### PR TITLE
Update proxy path references in remix.mdx

### DIFF
--- a/contents/docs/advanced/proxy/remix.mdx
+++ b/contents/docs/advanced/proxy/remix.mdx
@@ -19,14 +19,14 @@ Remix resource routes are server-side endpoints that can handle any HTTP method.
 Here's the request flow:
 
 1. User triggers an event in your app
-2. Request goes to your domain (e.g., `yourdomain.com/ph/e`)
+2. Request goes to your domain (e.g., `yourdomain.com/yourpath/e`)
 3. Remix's resource route intercepts requests matching your proxy path
 4. The route fetches the response from PostHog's servers
 5. PostHog's response is returned to the user under your domain
 
 This works because the route runs server-side, so the browser only sees requests to your domain. Ad blockers that filter by domain won't block these requests.
 
-**Why splat routes?** The `$` in the filename creates a [splat route](https://remix.run/docs/en/main/file-conventions/routes#splat-routes) that matches any path after your prefix. This lets a single route handle all PostHog endpoints like `/ph/e`, `/ph/decide`, and `/ph/static/array.js`.
+**Why splat routes?** The `$` in the filename creates a [splat route](https://remix.run/docs/en/main/file-conventions/routes#splat-routes) that matches any path after your prefix. This lets a single route handle all PostHog endpoints like `/yourpath/e`, `/yourpath/decide`, and `/yourpath/static/array.js`.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ This guide requires a Remix project with a server runtime (Node.js, Deno, or Clo
 
 <Step title="Create the resource route">
 
-Create a file at `app/routes/ph.$.tsx`:
+Create a file at `app/routes/yourpath.$.tsx`:
 
 <MultiLanguage>
 
@@ -51,14 +51,14 @@ const ASSET_HOST = "us-assets.i.posthog.com"
 const posthogProxy = async (request: Request) => {
   const url = new URL(request.url)
   const pathname = url.pathname
-  const useAssetHost = pathname.startsWith("/ph/static/") || pathname.startsWith("/ph/array/")
+  const useAssetHost = pathname.startsWith("/yourpath/static/") || pathname.startsWith("/yourpath/array/")
   const hostname = useAssetHost ? ASSET_HOST : API_HOST
 
   const newUrl = new URL(url)
   newUrl.protocol = "https"
   newUrl.hostname = hostname
   newUrl.port = "443"
-  newUrl.pathname = newUrl.pathname.replace(/^\/ph/, "")
+  newUrl.pathname = newUrl.pathname.replace(/^\/yourpath/, "")
 
   const headers = new Headers(request.headers)
   headers.set("host", hostname)
@@ -101,14 +101,14 @@ const ASSET_HOST = "eu-assets.i.posthog.com"
 const posthogProxy = async (request: Request) => {
   const url = new URL(request.url)
   const pathname = url.pathname
-  const useAssetHost = pathname.startsWith("/ph/static/") || pathname.startsWith("/ph/array/")
+  const useAssetHost = pathname.startsWith("/yourpath/static/") || pathname.startsWith("/yourpath/array/")
   const hostname = useAssetHost ? ASSET_HOST : API_HOST
 
   const newUrl = new URL(url)
   newUrl.protocol = "https"
   newUrl.hostname = hostname
   newUrl.port = "443"
-  newUrl.pathname = newUrl.pathname.replace(/^\/ph/, "")
+  newUrl.pathname = newUrl.pathname.replace(/^\/yourpath/, "")
 
   const headers = new Headers(request.headers)
   headers.set("host", hostname)
@@ -164,14 +164,14 @@ In your application code, update your PostHog initialization:
 
 ```js file=US
 posthog.init('<ph_project_token>', {
-  api_host: '/ph',
+  api_host: '/yourpath',
   ui_host: 'https://us.posthog.com'
 })
 ```
 
 ```js file=EU
 posthog.init('<ph_project_token>', {
-  api_host: '/ph',
+  api_host: '/yourpath',
   ui_host: 'https://eu.posthog.com'
 })
 ```
@@ -196,7 +196,7 @@ Confirm events are flowing through your proxy:
 
 1. Open your browser's developer tools and go to the **Network** tab
 2. Navigate to your site or trigger an event
-3. Look for requests to your domain with your proxy path (e.g., `yourdomain.com/ph`)
+3. Look for requests to your domain with your proxy path (e.g., `yourdomain.com/yourpath`)
 4. Verify the response status is `200 OK`
 5. Check the [PostHog app](https://app.posthog.com) to confirm events appear in your activity feed
 
@@ -212,7 +212,7 @@ If you see errors, check [troubleshooting](#troubleshooting) below.
 
 If requests to your proxy path return 404:
 
-1. Verify your file is at `app/routes/ph.$.tsx` (the `$` is important)
+1. Verify your file is at `app/routes/yourpath.$.tsx` (the `$` is important)
 2. Check the file extension matches your project (`.tsx` for TypeScript, `.jsx` for JavaScript)
 3. Restart your dev server after creating the file
 


### PR DESCRIPTION
We've [learned from experience](https://posthog.slack.com/archives/C01FHN8DNN6/p1749668999952489) that suggestions we make / examples we use for reverse proxy naming will eventually be spotted and blocked by adblockers. e.g. `/ingest` was a suggestion that used to be in our docs and was later removed from our docs after we spotted it in adblocking/anti-tracking lists.

So, changing instance of this:
```
/ph
```

to this:
```
/yourpath
```