### PR TITLE
chore: move Inkeep PR reminders

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -51,21 +51,6 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-              with:
-                  fetch-depth: 0
-
-            - name: Detect docs-only changes
-              id: changed
-              env:
-                  BASE_REF: ${{ github.base_ref }}
-              run: |
-                  CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
-                  echo "Changed files: $CHANGED"
-                  if echo "$CHANGED" | grep -qvE '^(contents/docs/|src/navs/index\.js|vercel\.json)'; then
-                    echo "docs_only=false" >> $GITHUB_OUTPUT
-                  else
-                    echo "docs_only=true" >> $GITHUB_OUTPUT
-                  fi
 
             - name: Set up pnpm
               uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
@@ -93,7 +78,6 @@ jobs:
               run: pnpm build
               env:
                   GATSBY_MINIMAL: 'true'
-                  GATSBY_DOCS_ONLY: ${{ steps.changed.outputs.docs_only }}
                   CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
                   CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
 
@@ -125,6 +109,34 @@ jobs:
                       | Status | Details | Updated (UTC) |
                       |--------|---------|---------|
                       | 🟢 **Ready** | [View preview](${{ steps.deploy.outputs.deployment-url }}) | ${{ steps.timestamp-final.outputs.time }} |
+
+            - name: Notify reviewer on successful builds (Inkeep PRs only)
+              if: success() && contains(github.event.pull_request.user.login, 'inkeep')
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const pr = context.payload.pull_request;
+                      const reviewers = pr.requested_reviewers.map(r => `@${r.login}`).join(', ');
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: pr.number,
+                        body: `Hey ${reviewers}! This docs PR was generated for you by an agent. You're responsible for reviewing and merging it into production.\n\n1. Review and approve the PR\n2. Merge the PR\n   a. Check the preview env and CI build and merge it yourself\n   b. Enable auto-merge if you're confident in the changes`
+                      });
+
+            - name: Notify reviewer on build failure (Inkeep PRs only)
+              if: failure() && contains(github.event.pull_request.user.login, 'inkeep')
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const pr = context.payload.pull_request;
+                      const reviewers = pr.requested_reviewers.map(r => `@${r.login}`).join(', ');
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: pr.number,
+                        body: `Hey ${reviewers}! This docs PR was generated for you by an agent. You're responsible for reviewing and merging it into production.\n\nThe deploy preview failed to build. [View logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) to see what went wrong. If it looks like a flaky failure, re-run the workflow.`
+                      });
 
             - name: Comment on failure
               if: failure()

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -59,7 +59,6 @@ jobs:
               env:
                   BASE_REF: ${{ github.base_ref }}
               run: |
-                  git fetch origin "$BASE_REF" --depth=1
                   CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
                   echo "Changed files: $CHANGED"
                   if echo "$CHANGED" | grep -qvE '^(contents/docs/|src/navs/index\.js|vercel\.json)'; then

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -51,6 +51,22 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  fetch-depth: 0
+
+            - name: Detect docs-only changes
+              id: changed
+              env:
+                  BASE_REF: ${{ github.base_ref }}
+              run: |
+                  git fetch origin "$BASE_REF" --depth=1
+                  CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+                  echo "Changed files: $CHANGED"
+                  if echo "$CHANGED" | grep -qvE '^(contents/docs/|src/navs/index\.js|vercel\.json)'; then
+                    echo "docs_only=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "docs_only=true" >> $GITHUB_OUTPUT
+                  fi
 
             - name: Set up pnpm
               uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
@@ -78,6 +94,7 @@ jobs:
               run: pnpm build
               env:
                   GATSBY_MINIMAL: 'true'
+                  GATSBY_DOCS_ONLY: ${{ steps.changed.outputs.docs_only }}
                   CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
                   CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
 

--- a/.github/workflows/inkeep-agent.yml
+++ b/.github/workflows/inkeep-agent.yml
@@ -10,9 +10,6 @@ on:
     pull_request_review:
         types: [submitted]
 
-    pull_request:
-        types: [opened]
-
 permissions:
     contents: read
     pull-requests: write
@@ -20,25 +17,6 @@ permissions:
     id-token: write
 
 jobs:
-    reviewer-reminder:
-        if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'inkeep[bot]'
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Post reviewer reminder
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      const pr = context.payload.pull_request;
-                      const reviewers = pr.requested_reviewers.map(r => `@${r.login}`).join(', ');
-
-                      await github.rest.issues.createComment({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: pr.number,
-                        body: `Hey ${reviewers}! This docs PR was generated for you by an agent. You're responsible for reviewing and merging it into production.\n\n1. Review and approve the PR\n2. Merge the PR\n   a. Check the preview env and CI build and merge it yourself\n   b. Enable auto-merge if you're confident in the changes`
-                      });
-
     trigger-agent:
         if: |
             (github.event_name == 'issue_comment' &&  github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep')) ||

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -16,11 +16,6 @@ export { onPreBootstrap } from './gatsby/onPreBootstrap'
 export const onCreatePage: GatsbyNode['onCreatePage'] = async ({ page, actions }) => {
     const { createPage, deletePage } = actions
 
-    if (process.env.GATSBY_DOCS_ONLY === 'true' && !page.path.startsWith('/docs/')) {
-        deletePage(page)
-        return
-    }
-
     // Add build time to credits page using environment variable
     if (page.path === '/credits/') {
         // Use Vercel's VERCEL_ENV variable or current time as fallback

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -16,6 +16,11 @@ export { onPreBootstrap } from './gatsby/onPreBootstrap'
 export const onCreatePage: GatsbyNode['onCreatePage'] = async ({ page, actions }) => {
     const { createPage, deletePage } = actions
 
+    if (process.env.GATSBY_DOCS_ONLY === 'true' && !page.path.startsWith('/docs/')) {
+        deletePage(page)
+        return
+    }
+
     // Add build time to credits page using environment variable
     if (page.path === '/credits/') {
         // Use Vercel's VERCEL_ENV variable or current time as fallback

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -9,9 +9,10 @@ const Slugger = require('github-slugger')
 const markdownLinkExtractor = require('markdown-link-extractor')
 
 const isMinimalBuild = process.env.GATSBY_MINIMAL === 'true'
+const isDocsOnlyBuild = process.env.GATSBY_DOCS_ONLY === 'true'
 
 export const createPages: GatsbyNode['createPages'] = async ({ actions: { createPage }, graphql }) => {
-    if (isMinimalBuild) {
+    if (isMinimalBuild || isDocsOnlyBuild) {
         return createMinimalPages({ createPage, graphql })
     }
 
@@ -1242,10 +1243,13 @@ async function createMinimalPages({
     }
 
     createHandbookPreviewPosts(data.docs.nodes, 'docs', { name: 'Docs', url: '/docs' })
-    createHandbookPreviewPosts(data.handbook.nodes, 'handbook', { name: 'Handbook', url: '/handbook' })
-    createHandbookPreviewPosts(data.productEngineerHandbook.nodes, 'product-engineer', {
-        name: 'Product Engineer Handbook',
-        url: '/product-engineer',
-    })
-    createBlogPreviewPosts(data.posts.nodes)
+
+    if (!isDocsOnlyBuild) {
+        createHandbookPreviewPosts(data.handbook.nodes, 'handbook', { name: 'Handbook', url: '/handbook' })
+        createHandbookPreviewPosts(data.productEngineerHandbook.nodes, 'product-engineer', {
+            name: 'Product Engineer Handbook',
+            url: '/product-engineer',
+        })
+        createBlogPreviewPosts(data.posts.nodes)
+    }
 }

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -9,10 +9,9 @@ const Slugger = require('github-slugger')
 const markdownLinkExtractor = require('markdown-link-extractor')
 
 const isMinimalBuild = process.env.GATSBY_MINIMAL === 'true'
-const isDocsOnlyBuild = process.env.GATSBY_DOCS_ONLY === 'true'
 
 export const createPages: GatsbyNode['createPages'] = async ({ actions: { createPage }, graphql }) => {
-    if (isMinimalBuild || isDocsOnlyBuild) {
+    if (isMinimalBuild) {
         return createMinimalPages({ createPage, graphql })
     }
 
@@ -1244,12 +1243,10 @@ async function createMinimalPages({
 
     createHandbookPreviewPosts(data.docs.nodes, 'docs', { name: 'Docs', url: '/docs' })
 
-    if (!isDocsOnlyBuild) {
-        createHandbookPreviewPosts(data.handbook.nodes, 'handbook', { name: 'Handbook', url: '/handbook' })
-        createHandbookPreviewPosts(data.productEngineerHandbook.nodes, 'product-engineer', {
-            name: 'Product Engineer Handbook',
-            url: '/product-engineer',
-        })
-        createBlogPreviewPosts(data.posts.nodes)
-    }
+    createHandbookPreviewPosts(data.handbook.nodes, 'handbook', { name: 'Handbook', url: '/handbook' })
+    createHandbookPreviewPosts(data.productEngineerHandbook.nodes, 'product-engineer', {
+        name: 'Product Engineer Handbook',
+        url: '/product-engineer',
+    })
+    createBlogPreviewPosts(data.posts.nodes)
 }


### PR DESCRIPTION
on Inkeep-generated PRs the bot is the author, so reviewers don't get notified when deploy previews are ready. there's a lot of stale PRs sitting unreviewed. originally I thought making the build faster would help, but that's not the issue, it's the ownership

changes:
- moved reviewer reminder comment into `deploy-preview.yml` to fire after successful deploy
- added failure notification so reviewers are looped in if the build breaks
- both notifications only fire on Inkeep PRs!!!

<details>
<summary>Previous changes/description</summary>
## Changes

**_I am proposing to add a `GATSBY_DOCS_ONLY` build mode to speed up preview deploys for docs PRs_**

the problem: every PR builds the entire site, even with `GATSBY_MINIMAL=true`. for PRs that only touch docs, slow builds are _one_ contributing factor to stale agent-generated docs PRs not getting merged (one factor among many that I am addressing this quarter!)

this change:
- CI workflow changes to detect whether a PR only touches docs by looking for PRs with changes to ONLY `contents/docs` AND `src/navs/index.js` for sidebar nav, `vercel.json` for redirects 

> _please opine if you feel strongly about any of these files being included, i'm on the fence about vercel.json because our Inkeep agent isn't allowed to touch that_

- doesn't affect PRs that touch more than docs 

## Testing

i tested locally:
- cold docs only build: 376s
- docs-only build w/ cache: 164s
- previous minimal build: 15 min

CI _should_ improve further over the local numbers

to test locally:

`NODE_OPTIONS='--max_old_space_size=8192' GATSBY_DOCS_ONLY=true pnpm build`
</details>