### PR TITLE
Update 'Staff' level description in compensation.md

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -27,7 +27,7 @@ Very broadly, we think of the various levels as:
 - Junior: contributes to small or function-specific projects (note, we rarely hire people at this level)
 - Intermediate: owns small to medium sized projects
 - Senior: owns and drives large projects or a whole product, decides what needs to happen and does everything necessary to get that done
-- Staff: _consistently_ owns and drives large projects that impact the entire company, not just their product, team or even function; or posesses a uniquely honed and uniquely important skillset that posthog would struggle to replace.
+- Staff: _consistently_ owns and drives large projects that impact the entire company, not just their product, team or even function; or possesses a uniquely honed and uniquely important skillset that posthog would struggle to replace.
 - Director: someone who is operating at the highest levels, usually a member of the Blitzscale team and usually a manager of managers
 - Principal (same level as Director): same as Staff, but with extremely rare skills or operating at a very high level.
 

--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -27,7 +27,7 @@ Very broadly, we think of the various levels as:
 - Junior: contributes to small or function-specific projects (note, we rarely hire people at this level)
 - Intermediate: owns small to medium sized projects
 - Senior: owns and drives large projects or a whole product, decides what needs to happen and does everything necessary to get that done
-- Staff: same as senior, but also _consistently_ owns and drives large projects that impact the entire company, not just their product, team or even function.
+- Staff: _consistently_ owns and drives large projects that impact the entire company, not just their product, team or even function; or posesses a uniquely honed and uniquely important skillset that posthog would struggle to replace.
 - Director: someone who is operating at the highest levels, usually a member of the Blitzscale team and usually a manager of managers
 - Principal (same level as Director): same as Staff, but with extremely rare skills or operating at a very high level.
 


### PR DESCRIPTION
Clarified the definition of 'Staff' level by adding details about skillset and impact.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
