### PR TITLE
docs(hobby-installer): Set  correct download url for the hobby-installer

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -25,7 +25,7 @@ We're exploring a new version for our self-hosting deployment via a TUI binary. 
 If you wanna opt-in, you can download and run the binary from our GitHub.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/posthog/posthog/rafa/hobby-deployment-goes-woke/bin/posthog-hobby -o hobby-installer
+curl -OfsSL https://github.com/PostHog/posthog/releases/download/hobby-latest/hobby-installer
 chmod +x hobby-installer
 ./hobby-installer
 ```


### PR DESCRIPTION
It seems that the download url for the binary points to an old branch. 404 now.

## Changes

Update the url of the installer to the correct one.


## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [X] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`


cc/ @pauldambra 