### PR TITLE
docs: mention Gradle task config for Android mapping uploads

### DIFF
--- a/contents/docs/error-tracking/upload-mappings/android.mdx
+++ b/contents/docs/error-tracking/upload-mappings/android.mdx
@@ -41,6 +41,20 @@ plugins {
 }
 ```
 
+If you are running this in CI/CD, you can configure the CLI directly on the Gradle task instead of relying on `POSTHOG_CLI_HOST`, `POSTHOG_CLI_PROJECT_ID`, and `POSTHOG_CLI_API_KEY` environment variables:
+
+```kotlin
+import com.posthog.android.PostHogCliExecTask
+
+tasks.withType<PostHogCliExecTask> {
+    postHogHost = "https://eu.posthog.com"
+    postHogProjectId = "my-project-id"
+    postHogApiKey = "my-personal-api-key"
+}
+```
+
+You can also set `postHogExecutable` if you want to use a custom `posthog-cli` path.
+
 </Step>
 
 <StepVerifySymbolSetsUpload symbolType="mappings" />


### PR DESCRIPTION
## Changes

Adds an alternative Android error tracking setup path for customers using the `posthog-android` Gradle plugin in CI/CD.

- document configuring `PostHogCliExecTask` directly in `build.gradle.kts`
- show task-based equivalents for `POSTHOG_CLI_HOST`, `POSTHOG_CLI_PROJECT_ID`, and `POSTHOG_CLI_API_KEY`
- mention optional `postHogExecutable` support for custom CLI paths

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
