### PR TITLE
docs: add manual escalation flow to on-call rotation handbook

### DIFF
--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -24,6 +24,30 @@ Every team has 2 schedules in [incident.io](https://app.incident.io/posthog/on-c
 * `Support: {team}`
     - This is a weekly or bi-weekly rotation (teams can decide) that covers both who is assigned to the [support hero rotation](/handbook/engineering/operations/support-hero) as well as the out of-hours-escalation for the extreme case
 
+### Manual escalation schedules
+
+In addition to the regular on-call schedules, every team has a manual escalation schedule in incident.io:
+* `Escalation: {team}`
+    - This is the "everything is broken" escalation path for critical out-of-hours emergencies
+    - **Everyone relevant on the team should be on this schedule** - it's not a rotation like regular on-call
+    - There should be no gaps in coverage since this is the last resort when normal escalation paths fail
+    - This schedule is triggered manually by whoever is handling an incident when they need additional help
+
+#### When to use manual escalation
+
+Manual escalation should be used when:
+* The primary on-call person is unresponsive or unavailable
+* The situation is critical and requires immediate additional expertise
+* You're the on-call responder and need help from a specific team outside normal working hours
+
+#### How to trigger manual escalation
+
+1. From within an incident in incident.io, use the escalation options to page the relevant `Escalation: {team}` schedule
+2. This will notify all members on that escalation schedule simultaneously
+3. Any available team member can then respond and assist with the incident
+
+> 💡 Manual escalation is a safety net, not a shortcut. Always try the normal escalation paths first before manually escalating to an entire team.
+
 ### Global on-call schedule
 
 [Schedule in incident.io](https://app.incident.io/posthog/on-call/schedules/01K7PNGFNP8ZZSCSTBXKPVWVAZ)

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -26,9 +26,10 @@ Every team has 2 schedules in [incident.io](https://app.incident.io/posthog/on-c
 
 ### Manual escalation schedules
 
-In addition to the regular on-call schedules, every team has a manual escalation schedule in incident.io:
+In addition to the regular on-call schedules, teams that own production-critical services have a manual escalation schedule in incident.io:
 * `Escalation: {team}`
     - This is the "everything is broken" escalation path for critical out-of-hours emergencies
+    - Only teams that own production-critical services are required to have this schedule - other teams don't need one
     - **Everyone relevant on the team should be on this schedule** - it's not a rotation like regular on-call
     - There should be no gaps in coverage since this is the last resort when normal escalation paths fail
     - This schedule is triggered manually by whoever is handling an incident when they need additional help


### PR DESCRIPTION
Explains the manual escalation schedules in incident.io - used for
critical out-of-hours emergencies when normal on-call isn't responding.

https://claude.ai/code/session_01EKJ5r3wc7yvGTxL5mobnb2## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
