### PR TITLE
Add SEO metadata to add-ons page

### DIFF
--- a/src/pages/addons.tsx
+++ b/src/pages/addons.tsx
@@ -2,6 +2,7 @@ import CloudinaryImage from 'components/CloudinaryImage'
 import React from 'react'
 import { pricingMenu } from '../navs'
 import Layout from 'components/Layout'
+import SEO from 'components/seo'
 import { IconAdvanced } from '@posthog/icons'
 import useProducts from 'components/Pricing/Products'
 import { PricingTiers } from 'components/Pricing/Plans'
@@ -104,6 +105,10 @@ const Addons = (): JSX.Element => {
 
     return (
         <Layout parent={pricingMenu}>
+            <SEO
+                title="Add-ons - PostHog"
+                description="Specialized functionality like data pipelines and person profiles, so you never pay for things you don't need."
+            />
             <section className="xl:w-11/12 mx-auto px-4 md:px-8 2xl:px-12 py-8 relative">
                 <div className="flex flex-col-reverse md:flex-row gap-4">
                     <div className="flex-1">


### PR DESCRIPTION
## Changes

Added SEO component to the add-ons page (`src/pages/addons.tsx`) with appropriate title and description metadata. This improves search engine optimization for the add-ons pricing page.

The SEO component includes:
- **Title**: "Add-ons - PostHog"
- **Description**: "Specialized functionality like data pipelines and person profiles, so you never pay for things you don't need."

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

https://claude.ai/code/session_01VosStwmvJKFCmmRCGeLutB