### PR TITLE
updated docs for iOS

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -409,7 +409,7 @@ PostHog captures the following events:
 
 #### Configuring screen navigation autocapture
 
-Screen navigation autocapture is not enabled by default. You can enable it by setting `captureScreenViews` to `true` in the config.
+Screen navigation autocapture is enabled by default via `captureScreenViews`. You can disable it by setting `captureScreenViews` to `false` in the config.
 
 | Option                              | Description                                                                                     |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Changes
Fixes #16182 

Corrected the iOS screen navigation autocapture section in `autocapture.mdx` to reflect that `captureScreenViews` defaults to `true` (not `false` as previously stated).

The fix aligns the autocapture docs with both the [iOS SDK configuration docs](https://posthog.com/docs/libraries/ios/configuration#all-configuration-options) and the [source code](https://github.com/PostHog/posthog-ios/blob/af5b8e4c1a8e68c1e99ccbb62521f35e3928eb8d/PostHog/PostHogConfig.swift#L63).

**Before:** "Screen navigation autocapture is not enabled by default. You can enable it by setting `captureScreenViews` to `true` in the config."

<img width="936" height="925" alt="image" src="https://github.com/user-attachments/assets/fc2f5eae-9049-49cc-95ee-07652da3fb6e" />


**After:** "Screen navigation autocapture is enabled by default via `captureScreenViews`. You can disable it by setting `captureScreenViews` to `false` in the config."

<img width="1141" height="920" alt="image" src="https://github.com/user-attachments/assets/74bf58ed-c9f7-4726-ac19-239ffb3788fe" />



## Checklist
- [ X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`