### PR TITLE
docs: fix filter test users links

### DIFF
--- a/contents/docs/product-analytics/trends/filters.mdx
+++ b/contents/docs/product-analytics/trends/filters.mdx
@@ -98,8 +98,8 @@ Currently, inline filters only support with `AND` operations. If you want to inc
 
 Filter groups allow you to apply filters to **all series** within an insight. These filter groups are composed of a number of single filter, which can be combined in the following two ways:
 
--   `AND` - Events have to match _every_ filter within the group
--   `OR` - Events only have to match _a single_ filter within the group
+-   `AND` – Events have to match _every_ filter within the group
+-   `OR` – Events only have to match _a single_ filter within the group
 
 <ProductScreenshot
     imageLight = {filterGroupsLight} 
@@ -125,7 +125,7 @@ This option is useful for excluding events sent from local builds of your produc
     alt="Filtering internal and test users turned on"
 />
 
-Click on the settings icon to go to your project's [product analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) to customize the filters that are used.
+Click on the settings icon to go to your project's [Product Analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) to customize the filters that are used.
 
 ## Filtering by first event occurrence
 

--- a/contents/docs/product-analytics/trends/filters.mdx
+++ b/contents/docs/product-analytics/trends/filters.mdx
@@ -125,7 +125,7 @@ This option is useful for excluding events sent from local builds of your produc
     alt="Filtering internal and test users turned on"
 />
 
-Click on the settings icon to go to [your project settings](https://us.posthog.com/settings/project#internal-user-filtering) to customize the filters that are used.
+Click on the settings icon to go to your project's [product analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) to customize the filters that are used.
 
 ## Filtering by first event occurrence
 

--- a/contents/tutorials/filter-internal-users.mdx
+++ b/contents/tutorials/filter-internal-users.mdx
@@ -36,7 +36,7 @@ To make it easier to get accurate insights, PostHog includes tools to filter int
 
 ## Step 1: Navigate to project settings
 
-PostHog identifies internal users on a project-by-project basis, so head to [your project setting](https://us.posthog.com/settings/project#internal-user-filtering) to get started. If your PostHog instance spans multiple projects then you must repeat this tutorial for each project.
+PostHog identifies internal users on a project-by-project basis, so head to your project's [product analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) to get started. If your PostHog instance spans multiple projects then you must repeat this tutorial for each project.
 
 <ProductScreenshot
   imageLight={step1Light}

--- a/contents/tutorials/filter-internal-users.mdx
+++ b/contents/tutorials/filter-internal-users.mdx
@@ -32,11 +32,11 @@ When you’re investigating an insight, it’s important to make sure you’re l
 
 Filtering out these sorts of users can be especially important for large organizations where they may be hundreds, or thousands of internal team members using your product. It can also be important for early-stage organizations, where such users may make up a larger proportion of the total users due to the small sample size.
 
-To make it easier to get accurate insights, PostHog includes tools to filter internal users out — and here’s how to use them.
+To make it easier to get accurate insights, PostHog includes tools to filter internal users out – and here’s how to use them.
 
 ## Step 1: Navigate to project settings
 
-PostHog identifies internal users on a project-by-project basis, so head to your project's [product analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) to get started. If your PostHog instance spans multiple projects then you must repeat this tutorial for each project.
+PostHog identifies internal users on a project-by-project basis, so head to your project's [Product Analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) to get started. If your PostHog instance spans multiple projects then you must repeat this tutorial for each project.
 
 <ProductScreenshot
   imageLight={step1Light}
@@ -53,7 +53,7 @@ Any internal users you identify for a project will apply for _all_ users on that
 
 In project settings, scroll down to the ‘_Filter out internal and test users_’ section and click ‘_+ Add filter_’ to begin.
 
-Adding a filter here works exactly the same as it does when you add a filter to any other insight, with a list of available events, properties and cohorts to choose from as a base for your filter. You can add several filters at once, to create an inclusive list of ways to identify groups of internal users or beta testers.
+Adding a filter here works exactly the same as it does when you add a filter to any other insight, with a list of available events, properties, and cohorts to choose from as a base for your filter. You can add several filters at once, to create an inclusive list of ways to identify groups of internal users or beta testers.
 
 One of the easiest filters to create is to filter out internal users identified by their email address. We do this at PostHog, using the following filter to create insights based only on users who do not have a PostHog email address:
 

--- a/contents/tutorials/multiple-environments.md
+++ b/contents/tutorials/multiple-environments.md
@@ -102,7 +102,7 @@ Setting this up correctly prevents capturing non-production event data. It enabl
 
 The previous options capture data to separate projects or don’t capture data at all, but there is another option. This is to capture data normally and filter internal users from your analysis.
 
-PostHog provides a toggle to filter internal users (as defined by you) from your analysis and visualization. To set this up, go to [Project Settings](https://us.posthog.com/settings/project#internal-user-filtering) and scroll down to **Filter out internal and test users**. Here you can add filters to identify your internal users and events so that they can be removed from insights. This could include filters like: 
+PostHog provides a toggle to filter internal users (as defined by you) from your analysis and visualization. To set this up, go to your project's [product analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) and scroll down to **Filter out internal and test users**. Here you can add filters to identify your internal users and events so that they can be removed from insights. This could include filters like: 
 
 - `distinct ID does not contain your domain`
 - `host is not localhost`

--- a/contents/tutorials/multiple-environments.md
+++ b/contents/tutorials/multiple-environments.md
@@ -47,7 +47,7 @@ To copy or update a flag in another project:
 1. Navigate to the [feature flag](https://us.posthog.com/feature_flags) you want to copy.
 2. Select the `Projects` tab.
 3. Select the project you want to copy the flag to.
-4. Click `Copy` or `Update` - this depends on whether the flag already exists in the target project.
+4. Click `Copy` or `Update` – this depends on whether the flag already exists in the target project.
 5. View the table at the bottom to see the newly created or updated flag.
 
 <ProductScreenshot
@@ -102,7 +102,7 @@ Setting this up correctly prevents capturing non-production event data. It enabl
 
 The previous options capture data to separate projects or don’t capture data at all, but there is another option. This is to capture data normally and filter internal users from your analysis.
 
-PostHog provides a toggle to filter internal users (as defined by you) from your analysis and visualization. To set this up, go to your project's [product analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) and scroll down to **Filter out internal and test users**. Here you can add filters to identify your internal users and events so that they can be removed from insights. This could include filters like: 
+PostHog provides a toggle to filter internal users (as defined by you) from your analysis and visualization. To set this up, go to your project's [Product Analytics settings](https://us.posthog.com/settings/project-product-analytics#internal-user-filtering) and scroll down to **Filter out internal and test users**. Here you can add filters to identify your internal users and events so that they can be removed from insights. This could include filters like: 
 
 - `distinct ID does not contain your domain`
 - `host is not localhost`


### PR DESCRIPTION
## Changes

We've moved the internal user filtering options from the root of the project settings to the project's product analytics page, so update any links found that previously routed this way. This was causing PostHog AI to trip up redirecting users to a page that did not contain the option they were looking for.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
