### PR TITLE
docs: Update Referral channel type classification

### DIFF
--- a/contents/docs/data/channel-type.mdx
+++ b/contents/docs/data/channel-type.mdx
@@ -96,7 +96,7 @@ These rules are applied in order, and the first one that matches is used to dete
 | Organic Social   | `utm_medium` matches our list of social mediums (e.g. `sm`, `social-media`, `social-network`)                                                     |
 | Organic Video    | `utm_medium` matches our list of video mediums (e.g. `video`)                                                                                     |
 | Affiliate        | `utm_medium` matches our list of affiliate mediums (e.g. `affiliate`)                                                                             |
-| Referral         | `utm_medium` matches our list of referral mediums (e.g. `referral`, `link`, `app`)                                                                |
+| Referral         | `utm_medium` matches our list of referral mediums (e.g. `referral`, `link`, `app`), or `referring_domain` is present and not `$direct` and no previous rule matched |
 | Email            | `utm_medium` matches our list of email mediums (e.g. `email`, `e_mail`, `e-mail`)                                                                 |
 | Display          | `utm_medium` matches our list of display mediums  (e.g. `display`, `cpm`, `interstitial`, `banner`)                                               |
 | Audio            | `utm_medium` matches our list of referral mediums (e.g. `audio`)                                                                                  |


### PR DESCRIPTION
## Summary
- Updates the Referral row in the channel type docs to include the fallback condition: sessions with a `referring_domain` present (and not `$direct`) that didn't match any other channel rule are also classified as Referral
- This reflects the actual classification logic in the codebase

## Test plan
- [ ] Verify the channel type table renders correctly on the docs page

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*