### PR TITLE
Clarify org access suspension process in billing.md

### DIFF
--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -83,7 +83,7 @@ Reach out to all active users on the account, and let them know that access will
 
 #### Step 3 - Suspending user access
 
-To prevent users from being able to log in you need to go to the Django admin panel for their organization, then for each user account listed there open the user, uncheck the `Is Active` box and then save the user.
+To prevent users from being able to log in you need to go to the Django admin panel for their organization, then set the "Active" field to "No", with the reason selected from the dropdown: "Access revoked due to an unpaid balance." Then, hit save.
 
 After completing this, email or Slack all users in the organization letting them know that access has been suspended and what they can do to rectify the situation.  Also make it clear that if this isn't resolved within the next 7 days we will revert them back to the Free tier and they be subjected to the usage limits of that tier (e.g. they are likely to lose tracking data).
 


### PR DESCRIPTION
Updated instructions for suspending user access to specify setting the 'Active' field to 'No' with a reason for unpaid balance.