### PR TITLE
Add post-mortem process to hiring documentation

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -448,3 +448,37 @@ Currently, we are hiring a lot – aiming to go from ~96 people to ~185 by the e
 ## Internships
 
 We regularly receive enthusiastic requests from students about internships, which we're always flattered by. Currently, we don't offer internships, placements or work experience - we’re a bit too scrappy to do them well right now. Once you ~~escape college/university~~ graduate, you're welcome to apply to full time roles via our [careers page](/careers). Your details will then go straight through to our hiring team (who _are_ real humans, not AI) and you'll hear back from us shortly after.
+
+## Post-mortems
+
+We won't get every hiring decision right. So when we do let somebody go in their probation period, or shortly after, we need to try and figure out what went wrong. This is why we hold post-mortems, these are not massive inquests into who is to blame, these are figuring out one or two high leverage things that we can introduce to the hiring process to improve it going forward. 
+
+### The Process
+
+#### Pre-work
+
+The process will be owned by the talent partner that was responsible for the hire. It will also include the blitzscale team member and the team lead involved, where the team lead was not involved in the hiring process we will include the other main person involved in the hiring process. 
+
+The talent partner should create a private slack channel (mainly out of respect to the colleague who has left, the main results will be shared publicly) with everybody involved and share all the feedback from the hiring process. The Blitzscale member will share all the relevant feedback the team member received that led them to failing their probation. Once this is shared the following work should be prepped before the post-mortem call. The talent partner can share a google doc so everybody has access.
+
+- each interviewer involved should review the signals that they saw in the process and they discounted, any why. ~3 bullets is enough
+- each interviewer involved should also write the signals that were missed in the process, if any. 
+- talent partner prepares ~3 bullets for where in the process is meant to catch the reasons the person failed their probation.
+
+The pre-work here is the most important part, the call shouldn't happen without this being done. 
+
+#### The Post-mortem call
+
+The talent partner should remind everybody that we are here to fix the process, not re-litigate the decision or apportion any blame. 
+
+The first 10-12 minutes are about discusssing the pre-work and trying to answer two questions:- 
+
+- what did we see but discount?
+- what were we not even looking for that we should have been?
+
+Once agreed the second half should be focused on agreeing one or two fixes to the process that can be shipped. Try to avoid creating long lists as this is harder to implement.
+
+#### post post-mortem call
+
+The talent partner should write up the post-mortem and share it in the #team-talent channel cross-posting to #tell-posthog-anything. They should then update any handbook pages about the process and be sure to share any findings with the relevant interviewing channels like #technical-interviewers. 
+

--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -464,6 +464,9 @@ The talent partner should create a private slack channel (mainly out of respect 
 - each interviewer involved should review the signals that they saw in the process and they discounted, any why. ~3 bullets is enough
 - each interviewer involved should also write the signals that were missed in the process, if any. 
 - talent partner prepares ~3 bullets for where in the process is meant to catch the reasons the person failed their probation.
+- The team lead should also take time to consider the onboarding process and how that went
+    - Did the in-person onboarding happen? Was it successful?
+    - What potential flaws in their onboarding could have been improved?
 
 The pre-work here is the most important part, the call shouldn't happen without this being done. 
 


### PR DESCRIPTION
Added a section on post-mortems to the hiring process documentation, detailing the process, pre-work, and follow-up actions.

