### PR TITLE
docs(llma): add Dedalus Labs and Cloudflare AI Gateway installation pages

### DIFF
--- a/contents/docs/llm-analytics/installation/cloudflare-ai-gateway.mdx
+++ b/contents/docs/llm-analytics/installation/cloudflare-ai-gateway.mdx
@@ -1,0 +1,42 @@
+---
+title: Cloudflare AI Gateway LLM analytics installation
+platformLogo: cloudflare
+showStepsToc: true
+tableOfContents: [
+    {
+        url: 'install-dependencies',
+        value: 'Install dependencies',
+        depth: 1,
+    },
+    {
+        url: 'set-up-opentelemetry-tracing',
+        value: 'Set up OpenTelemetry tracing',
+        depth: 1,
+    },
+    {
+        url: 'call-cloudflare-ai-gateway',
+        value: 'Call Cloudflare AI Gateway',
+        depth: 1,
+    },
+    {
+        url: 'verify-traces-and-generations',
+        value: 'Verify traces and generations',
+        depth: 1,
+    },
+]
+---
+
+<!--
+This page imports shared onboarding content from the main PostHog repo.
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/cloudflare-ai-gateway.tsx
+See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
+-->
+
+import { CloudflareAIGatewayInstallation } from 'onboarding/llm-analytics/cloudflare-ai-gateway.tsx'
+import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
+import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
+import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
+
+<OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
+    <CloudflareAIGatewayInstallation modifySteps={addNextStepsStep} />
+</OnboardingContentWrapper>

--- a/contents/docs/llm-analytics/installation/dedalus.mdx
+++ b/contents/docs/llm-analytics/installation/dedalus.mdx
@@ -1,0 +1,42 @@
+---
+title: Dedalus Labs LLM analytics installation
+platformLogo: dedalus
+showStepsToc: true
+tableOfContents: [
+    {
+        url: 'install-dependencies',
+        value: 'Install dependencies',
+        depth: 1,
+    },
+    {
+        url: 'set-up-opentelemetry-tracing',
+        value: 'Set up OpenTelemetry tracing',
+        depth: 1,
+    },
+    {
+        url: 'call-dedalus-labs',
+        value: 'Call Dedalus Labs',
+        depth: 1,
+    },
+    {
+        url: 'verify-traces-and-generations',
+        value: 'Verify traces and generations',
+        depth: 1,
+    },
+]
+---
+
+<!--
+This page imports shared onboarding content from the main PostHog repo.
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/dedalus.tsx
+See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
+-->
+
+import { DedalusInstallation } from 'onboarding/llm-analytics/dedalus.tsx'
+import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
+import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
+import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
+
+<OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
+    <DedalusInstallation modifySteps={addNextStepsStep} />
+</OnboardingContentWrapper>

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -33,6 +33,7 @@ export const LOGOS = {
     crewai: 'https://res.cloudinary.com/dmukukwp6/image/upload/crewai_67ee9f5eb6.svg',
     cloudflareR2: 'https://res.cloudinary.com/dmukukwp6/image/upload/r2_0d79d88d1f.svg',
     cloudfront: 'https://res.cloudinary.com/dmukukwp6/image/upload/Cloud_Front_76c0f62ab5.svg',
+    dedalus: 'https://res.cloudinary.com/dmukukwp6/image/upload/dedalus_labs_logo_e03bb97137.svg',
     deepseek: 'https://res.cloudinary.com/dmukukwp6/image/upload/deepseek_df02608124.svg',
     django: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/django.svg',
     docusaurus:

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5445,6 +5445,16 @@ export const docsMenu = {
                             icon: 'IconOpenRouter',
                         },
                         {
+                            name: 'Cloudflare AI Gateway',
+                            url: '/docs/llm-analytics/installation/cloudflare-ai-gateway',
+                            platformLogo: 'cloudflare',
+                        },
+                        {
+                            name: 'Dedalus Labs',
+                            url: '/docs/llm-analytics/installation/dedalus',
+                            platformLogo: 'dedalus',
+                        },
+                        {
                             name: 'DeepSeek',
                             url: '/docs/llm-analytics/installation/deepseek',
                             platformLogo: 'deepseek',


### PR DESCRIPTION
## Changes

Add installation pages and sidebar entries for Dedalus Labs and Cloudflare AI Gateway as LLM analytics providers.

- `contents/docs/llm-analytics/installation/dedalus.mdx` — wrapper page importing the shared `DedalusInstallation` component from the posthog repo.
- `contents/docs/llm-analytics/installation/cloudflare-ai-gateway.mdx` — same pattern for Cloudflare AI Gateway.
- `src/constants/logos.ts` — added `dedalus` logo URL.
- `src/navs/index.js` — added both providers to the LLM analytics installation sidebar.

Companion posthog repo PR: https://github.com/PostHog/posthog/pull/54663

Stacked on #16236.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`