### PR TITLE
docs(client-libraries): add Goal 4 Log for Mobile

### DIFF
--- a/contents/teams/client-libraries/objectives.mdx
+++ b/contents/teams/client-libraries/objectives.mdx
@@ -82,11 +82,10 @@ What we'll ship:
 
 #### Goal 4: Logs for Mobile (Driver: <TeamMember name="Anna Garcia" />)
 
-https://github.com/PostHog/posthog/issues/40528
-
 What we'll ship:
 
-* Add support for collecting and sending app-side logs from Android
-* Add support for collecting and sending app-side logs from iOS
-* Add support for collecting and sending app-side logs from Flutter
-* Add support for collecting and sending app-side logs from React Native
+* [Add support for collecting and sending app-side logs](https://github.com/PostHog/posthog/issues/40528)
+  * Add support for collecting and sending app-side logs from Android
+  * Add support for collecting and sending app-side logs from iOS
+  * Add support for collecting and sending app-side logs from Flutter
+  * Add support for collecting and sending app-side logs from React Native

--- a/contents/teams/client-libraries/objectives.mdx
+++ b/contents/teams/client-libraries/objectives.mdx
@@ -79,3 +79,14 @@ What we'll ship:
   * https://github.com/PostHog/requests-for-comments-internal/pull/1036
 * Migrate and consolidate `/decide`, `/flags`, and `/static/array.js` into a unified remote config (`/static/token/config`)
 * Document SDK design guidelines and best practices under the [SDK handbook page](/handbook/engineering/sdks) to help contributors avoid common pitfalls
+
+#### Goal 4: Log for Mobile (Driver: <TeamMember name="Anna Garcia" />)
+
+https://github.com/PostHog/posthog/issues/40528
+
+What we'll ship:
+
+* Add support for collecting and sending app-side logs from Android
+* Add support for collecting and sending app-side logs from iOS
+* Add support for collecting and sending app-side logs from Flutter
+* Add support for collecting and sending app-side logs from React Native

--- a/contents/teams/client-libraries/objectives.mdx
+++ b/contents/teams/client-libraries/objectives.mdx
@@ -80,7 +80,7 @@ What we'll ship:
 * Migrate and consolidate `/decide`, `/flags`, and `/static/array.js` into a unified remote config (`/static/token/config`)
 * Document SDK design guidelines and best practices under the [SDK handbook page](/handbook/engineering/sdks) to help contributors avoid common pitfalls
 
-#### Goal 4: Log for Mobile (Driver: <TeamMember name="Anna Garcia" />)
+#### Goal 4: Logs for Mobile (Driver: <TeamMember name="Anna Garcia" />)
 
 https://github.com/PostHog/posthog/issues/40528
 


### PR DESCRIPTION
## Summary
- Adds Goal 4 "Log for Mobile" to the Client Libraries Q2 2026 objectives, per [this comment](https://github.com/PostHog/posthog/issues/54405#issuecomment-4242473323).
- Lists Android, iOS, Flutter, and React Native app-side log collection as deliverables.

## Test plan
- [ ] Preview builds render the new Goal 4 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)