### PR TITLE
chore: revert gatsby-source-git default branch to master

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -395,7 +395,7 @@ module.exports = {
             options: {
                 name: `posthog-main-repo`,
                 remote: `https://github.com/posthog/posthog.git`,
-                branch: process.env.GATSBY_POSTHOG_BRANCH || 'docs/otel-onboarding-docs',
+                branch: process.env.GATSBY_POSTHOG_BRANCH || 'master',
                 patterns: ['docs/published/**', 'docs/onboarding/**'],
             },
         },

--- a/gatsby/onPreBootstrap.ts
+++ b/gatsby/onPreBootstrap.ts
@@ -17,7 +17,7 @@ const BRANCH_MANIFEST_FILE = path.join(GATSBY_SOURCE_GIT_CACHE_DIR, '.branch-man
  * This prevents stale docs from being served when switching GATSBY_POSTHOG_BRANCH.
  */
 function invalidateGitCacheIfBranchChanged(): void {
-    const currentBranch = process.env.GATSBY_POSTHOG_BRANCH || 'docs/otel-onboarding-docs'
+    const currentBranch = process.env.GATSBY_POSTHOG_BRANCH || 'master'
 
     // Read the stored branch from the manifest file
     let storedBranch: string | null = null


### PR DESCRIPTION
## Changes

Reverts the default `gatsby-source-git` branch from `docs/otel-onboarding-docs` back to `master` in both `gatsby-config.js` and `gatsby/onPreBootstrap.ts`. This was temporarily changed for the OTel onboarding docs work and needs to be reset now that the docs have been merged.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`