### PR TITLE
docs(experiments, feature-flags): enrich existing docs with experiment guidance

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -18,7 +18,7 @@ In your experiment, each user is randomly assigned to a variant (usually either 
 
 <CalloutBox icon="IconWarning" title="Only getFeatureFlag() counts as an exposure" type="caution">
 
-You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. Other methods like `getAllFlags()`, `getFeatureFlags()`, or `getFeatureFlagPayload()` alone do **not** record an [exposure event](/docs/experiments/exposures) — users evaluated with those methods won't be included in your experiment results.
+You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. Other methods like `getAllFlags()`, `getFeatureFlags()`, or `getFeatureFlagPayload()` alone do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
 
 </CalloutBox>
 

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -8,11 +8,19 @@ availability:
     enterprise: full
 ---
 
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
 Once you've created your experiment in PostHog, the next step is to add your code.
 
 ## Fetch the feature flag
 
 In your experiment, each user is randomly assigned to a variant (usually either 'control' or 'test'). To check which variant a user has been assigned to, fetch the experiment feature flag. You can then customize their experience based on the value in the feature flag:
+
+<CalloutBox icon="IconWarning" title="Only getFeatureFlag() counts as an exposure" type="caution">
+
+You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. Other methods like `getAllFlags()`, `getFeatureFlags()`, or `getFeatureFlagPayload()` alone do **not** record an [exposure event](/docs/experiments/exposures) — users evaluated with those methods won't be included in your experiment results.
+
+</CalloutBox>
 
 <MultiLanguage>
 

--- a/contents/docs/experiments/analyzing-results.mdx
+++ b/contents/docs/experiments/analyzing-results.mdx
@@ -142,7 +142,7 @@ Use this chart to:
 
 When all your primary metrics show green (positive) significance for a variant:
 - You have strong evidence that the variant improves your key metrics
-- Consider the magnitude of improvement – even statistically significant changes might not be practically significant
+- Consider the magnitude of improvement. Even statistically significant changes might not be practically significant
 - Review secondary metrics to ensure no unexpected negative impacts
 
 ### Mixed results
@@ -161,26 +161,32 @@ It's common to see some metrics improve while others decline. When this happens:
 
 ### Reading the pattern across metrics
 
-At the default 95% confidence level, any single metric has a 5% chance of showing a significant result even when nothing real changed. Your other metrics help you judge whether a result is real or noise — but only if they're related to each other and to your hypothesis.
+At the default 95% confidence level, any single metric has a 5% chance of showing a significant result even when nothing real changed. Your other metrics help you judge whether a result is real or noise, but only if they're related to each other and to your hypothesis.
 
-**Metrics that support each other (good).** You're testing a new onboarding flow. Your metrics:
-- Onboarding completion rate (primary)
-- Time to first key action
-- 7-day retention
-- Support tickets in first week
+**Metrics that support each other.** You're testing a new onboarding flow:
 
-Completion rate is significantly up. Time to first action is down. Retention is slightly up but not significant. Support tickets are flat. This is a coherent story — users are completing onboarding faster and sticking around. You can trust the primary result because the surrounding metrics all point the same direction.
+| Metric | Result |
+| --- | --- |
+| Onboarding completion rate (primary) | Significant increase ↑ |
+| Time to first key action | Significant decrease ↓ |
+| 7-day retention | Slight increase, not significant |
+| Support tickets in first week | Flat, not significant |
 
-**Metrics that can't help you (bad).** Same experiment, but your metrics are:
-- Onboarding completion rate (primary)
-- Total pageviews
-- Pricing page visits
-- Blog bounce rate
-- API calls made
+This is a coherent story. Users are completing onboarding faster and sticking around. You can trust the primary result because the surrounding metrics all point the same direction.
 
-Completion rate is significantly up — but the other four metrics have nothing to do with onboarding. They can't confirm or contradict the primary result. If completion rate lit up by chance, you'd have no way to tell. And if blog bounce rate also happens to show significance, that's almost certainly noise, but it might look tempting to claim your onboarding change also "improved content engagement."
+**Metrics that can't help you.** Same experiment, but your metrics are:
 
-**The takeaway:** Choose metrics that form a system around your hypothesis. When they agree, you have strong evidence. When one stands alone, be skeptical — especially if it's a metric you weren't focused on. If a surprising result looks compelling, run a follow-up experiment with that metric as the primary.
+| Metric | Result |
+| --- | --- |
+| Onboarding completion rate (primary) | Significant increase ↑ |
+| Total pageviews | Not significant |
+| Pricing page visits | Not significant |
+| Blog bounce rate | Significant decrease ↓ |
+| API calls made | Not significant |
+
+Completion rate is significantly up, but the other four metrics have nothing to do with onboarding. They can't confirm or contradict the primary result. If completion rate lit up by chance, you'd have no way to tell. And if blog bounce rate also happens to show significance, that's almost certainly noise, but it might look tempting to claim your onboarding change also "improved content engagement."
+
+**The takeaway:** Choose metrics that form a system around your hypothesis. When they agree, you have strong evidence. When one stands alone, be skeptical, especially if it's a metric you weren't focused on. If a surprising result looks compelling, run a follow-up experiment with that metric as the primary.
 
 ### No significant results
 
@@ -188,7 +194,7 @@ If your experiment shows no significant differences:
 - **Check sample size**: You might need more data. Use the sample size calculator to estimate required duration
 - **Verify implementation**: Ensure the variants are actually different and the tracking is working correctly
 - **Consider effect size**: The actual difference might be too small to detect with your current sample size
-- **Learn from it**: Not all experiments win – this is valuable information about what doesn't move the needle
+- **Learn from it**: Not all experiments win. This is valuable information about what doesn't move the needle
 
 ## Funnel metrics analysis
 

--- a/contents/docs/experiments/analyzing-results.mdx
+++ b/contents/docs/experiments/analyzing-results.mdx
@@ -172,7 +172,7 @@ At the default 95% confidence level, any single metric has a 5% chance of showin
 Completion rate is significantly up. Time to first action is down. Retention is slightly up but not significant. Support tickets are flat. This is a coherent story — users are completing onboarding faster and sticking around. You can trust the primary result because the surrounding metrics all point the same direction.
 
 **Metrics that can't help you (bad).** Same experiment, but your metrics are:
-- Onboarding completion rate
+- Onboarding completion rate (primary)
 - Total pageviews
 - Pricing page visits
 - Blog bounce rate

--- a/contents/docs/experiments/analyzing-results.mdx
+++ b/contents/docs/experiments/analyzing-results.mdx
@@ -150,7 +150,7 @@ When all your primary metrics show green (positive) significance for a variant:
 It's common to see some metrics improve while others decline. When this happens:
 
 1. **Prioritize your primary metric**: Focus on the metric you defined as most important when setting up the experiment
-2. **Understand the trade-offs**: 
+2. **Understand the trade-offs**:
    - Is a 5% increase in conversion worth a 2% decrease in average order value?
    - Does improved engagement justify slightly lower retention?
 3. **Dig deeper with analytics**:
@@ -158,6 +158,29 @@ It's common to see some metrics improve while others decline. When this happens:
    - Use [Session replays](/docs/session-replay) to see how users interact differently with each variant
    - Create [Cohorts](/docs/data/cohorts) of users from each variant for further analysis
 4. **Consider the user journey**: Sometimes negative changes in one metric lead to positive downstream effects
+
+### Reading the pattern across metrics
+
+At the default 95% confidence level, any single metric has a 5% chance of showing a significant result even when nothing real changed. Your other metrics help you judge whether a result is real or noise — but only if they're related to each other and to your hypothesis.
+
+**Metrics that support each other (good).** You're testing a new onboarding flow. Your metrics:
+- Onboarding completion rate (primary)
+- Time to first key action
+- 7-day retention
+- Support tickets in first week
+
+Completion rate is significantly up. Time to first action is down. Retention is slightly up but not significant. Support tickets are flat. This is a coherent story — users are completing onboarding faster and sticking around. You can trust the primary result because the surrounding metrics all point the same direction.
+
+**Metrics that can't help you (bad).** Same experiment, but your metrics are:
+- Onboarding completion rate
+- Total pageviews
+- Pricing page visits
+- Blog bounce rate
+- API calls made
+
+Completion rate is significantly up — but the other four metrics have nothing to do with onboarding. They can't confirm or contradict the primary result. If completion rate lit up by chance, you'd have no way to tell. And if blog bounce rate also happens to show significance, that's almost certainly noise, but it might look tempting to claim your onboarding change also "improved content engagement."
+
+**The takeaway:** Choose metrics that form a system around your hypothesis. When they agree, you have strong evidence. When one stands alone, be skeptical — especially if it's a metric you weren't focused on. If a surprising result looks compelling, run a follow-up experiment with that metric as the primary.
 
 ### No significant results
 

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -111,9 +111,9 @@ Users are analyzed based on the first variant they were exposed to, regardless o
 
 ## Exposure deduplication
 
-PostHog counts one exposure per user per variant in experiment results — even if multiple `$feature_flag_called` events fire for the same user, they won't inflate your exposure counts or affect your results as long as the variant value is the same.
+PostHog counts one exposure per user per variant in experiment results. Even if multiple `$feature_flag_called` events fire for the same user, they won't inflate your exposure counts or affect your results as long as the variant value is the same.
 
-The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs (Node, Python), dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy — but as noted above, this doesn't affect experiment analysis.
+The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs (Node, Python), dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy. As noted above, this doesn't affect experiment analysis.
 
 ## Sample ratio mismatch detection
 

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -109,6 +109,12 @@ Users exposed to multiple variants are completely removed from the experiment an
 ### Use first seen variant
 Users are analyzed based on the first variant they were exposed to, regardless of subsequent exposures. This maximizes sample size but may introduce some noise into your results.
 
+## Exposure deduplication
+
+PostHog counts one exposure per user per variant in experiment results — even if multiple `$feature_flag_called` events fire for the same user, they won't inflate your exposure counts or affect your results as long as the variant value is the same.
+
+The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs (Node, Python), dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy — but as noted above, this doesn't affect experiment analysis.
+
 ## Sample ratio mismatch detection
 
 Sample ratio mismatch (SRM) is an automatic check that compares your actual user distribution across variants against your configured split percentages. PostHog uses a chi-squared statistical test to detect when the observed distribution is significantly different from what's expected.

--- a/contents/docs/experiments/managing-lifecycle.mdx
+++ b/contents/docs/experiments/managing-lifecycle.mdx
@@ -24,6 +24,8 @@ Beyond this, we recommend:
 
 4. Archiving the experiment.
 
+5. Disabling the feature flag once the winning variant is hardcoded in your application and the flag check has been removed from your code. Every active flag counts toward your [feature flag billing](/docs/feature-flags/cutting-costs), even if it's rolled out to 100% and no longer doing anything useful.
+
 Remember, experimentation is an iterative process. Each experiment teaches you something about your users, even when results aren't what you expected.
 
 ### Ending an already rolled out experiment

--- a/contents/docs/experiments/metrics.mdx
+++ b/contents/docs/experiments/metrics.mdx
@@ -95,7 +95,7 @@ Common use cases:
 
 ## Outlier handling
 
-You can limit the impact of extreme values by clamping metric data at specified percentile thresholds using configurable lower and upper bounds. Values below the lower bound are replaced with the lower bound value, and values above the upper bound are replaced with the upper bound value. No data is excluded — all users remain in the calculation.
+You can limit the impact of extreme values by clamping metric data at specified percentile thresholds using configurable lower and upper bounds. Values below the lower bound are replaced with the lower bound value, and values above the upper bound are replaced with the upper bound value. No data is excluded, and all users remain in the calculation.
 
 This technique is commonly known as **Winsorization** and is especially useful for metrics with highly skewed distributions, such as revenue or total event counts, where a small subset of users can produce unusually high values that distort overall results.
 
@@ -161,13 +161,13 @@ The control (baseline) is always shown in gray. Other bars will be green or red�
 
 ## What "sum" actually computes
 
-When you select an event property and choose "sum" as the aggregation, PostHog computes the **mean of per-user totals**, not a raw sum across all events. For example, if user A has $50 in revenue and user B has $10, the result is ($50 + $10) / 2 = $30 — not $60.
+When you select an event property and choose "sum" as the aggregation, PostHog computes the **mean of per-user totals**, not a raw sum across all events. For example, if user A has $50 in revenue and user B has $10, the result is ($50 + $10) / 2 = $30, not $60.
 
 Experiments always compare per-user values between variants, so there's no raw total view. If you need raw totals, use a [trends insight](/docs/product-analytics/trends) outside the experiment.
 
 ## Set an explicit conversion window
 
-If you don't set a conversion window, trend metrics count conversions from exposure through the experiment end date with no upper bound. This means a user who converts 45 days after exposure is counted the same as one who converts in 5 minutes. Set a window that matches your product's natural conversion cycle — if users typically convert within a week, use a 7-day window.
+If you don't set a conversion window, trend metrics count conversions from exposure through the experiment end date with no upper bound. This means a user who converts 45 days after exposure is counted the same as one who converts in 5 minutes. Set a window that matches your product's natural conversion cycle. If users typically convert within a week, use a 7-day window.
 
 Two other behaviors to know:
 

--- a/contents/docs/experiments/metrics.mdx
+++ b/contents/docs/experiments/metrics.mdx
@@ -159,6 +159,21 @@ The width of the bar represents uncertainty. A narrower bar means we're more con
 
 The control (baseline) is always shown in gray. Other bars will be green or red—or even a mix—depending on whether the change is positive or negative.
 
+## What "sum" actually computes
+
+When you select an event property and choose "sum" as the aggregation, PostHog computes the **mean of per-user totals**, not a raw sum across all events. For example, if user A has $50 in revenue and user B has $10, the result is ($50 + $10) / 2 = $30 — not $60.
+
+Experiments always compare per-user values between variants, so there's no raw total view. If you need raw totals, use a [trends insight](/docs/product-analytics/trends) outside the experiment.
+
+## Set an explicit conversion window
+
+If you don't set a conversion window, trend metrics count conversions from exposure through the experiment end date with no upper bound. This means a user who converts 45 days after exposure is counted the same as one who converts in 5 minutes. Set a window that matches your product's natural conversion cycle — if users typically convert within a week, use a 7-day window.
+
+Two other behaviors to know:
+
+- **Conversions count from first exposure.** Metric events are only counted if they happen after the user's first exposure. If a user is re-exposed later (e.g., flag evaluated from both web and server SDK), the end of the window extends from that later exposure, but earlier conversions are still included.
+- **The window extends past the experiment end date.** A 7-day window on an experiment ending March 1 counts conversions through March 8 for users exposed on March 1.
+
 ## Shared metrics
 
 Create a shared metric to easily reuse a funnel or a trend metric across experiments. This is ideal for key company metrics like conversion, revenue, churn, and more.

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -243,7 +243,7 @@ With 5 metrics, the chance that *at least one* produces a false positive is abou
 
 ### More metrics can help — if they're planned
 
-This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but one out of five other metrics lights up as significant while the rest show nothing, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
+This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but _only_ one of five supporting metrics improve with it, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
 
 But this only works if your metrics form a coherent set tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power — you're just giving yourself more chances to find something to cherry-pick.
 

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -253,4 +253,4 @@ But this only works if you intentionally choose related metrics tied to your hyp
 
 **When reading results,** look at the full pattern across metrics, not individual ones in isolation. A coherent story across multiple metrics is strong evidence. A single significant metric with no supporting signal from the others is worth skepticism.
 
-**If something unexpected is significant,** don't ship based on the surprise. Design a follow-up experiment with that metric as the primary. If the effect replicates, it's real.
+**If an unexpected metric shows significant change,** don't ship based on that metric alone. Design a follow-up experiment with that metric as the primary. If the effect replicates, it's real.

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -234,3 +234,23 @@ When testing multiple variants (A/B/C/D tests):
 - The chance to win is calculated for each variant vs. control
 - No correction for multiple comparisons
 - This is philosophically consistent: each comparison stands on its own
+
+## Multiple metrics and false positives
+
+At the default 95% confidence level, there's a 5% chance that any single metric shows a significant result when nothing actually changed — the statistical engine itself can produce a false signal from random noise. Think of it like rolling a die: each metric is an independent roll, and each one has a small chance of landing on "significant" by chance.
+
+With 5 metrics, the chance that *at least one* produces a false positive is about 23%. With 10 metrics, it's 40%. PostHog tests each metric independently and doesn't adjust for this — each result stands on its own.
+
+### More metrics can help — if they're planned
+
+This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but one out of five other metrics lights up as significant while the rest show nothing, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
+
+But this only works if your metrics form a coherent set tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power — you're just giving yourself more chances to find something to cherry-pick.
+
+### How to use this in practice
+
+**Before launching,** make sure each metric is tied to your hypothesis and has clear success criteria. Decide which metric is your primary decision-driver, and which are secondary (providing context, not driving the ship/kill decision).
+
+**When reading results,** look at the full pattern across metrics, not individual ones in isolation. A coherent story across multiple metrics is strong evidence. A single significant metric with no supporting signal from the others is worth skepticism.
+
+**If something unexpected is significant,** don't ship based on the surprise. Design a follow-up experiment with that metric as the primary. If the effect replicates, it's real.

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -58,7 +58,7 @@ These sufficient statistics contain all the information needed to calculate mean
 
 #### Outlier handling (winsorization)
 
-For mean metrics, extreme outliers can skew results. PostHog optionally applies winsorization by clamping values to percentile-based bounds — values below the lower percentile (e.g., 1st percentile) are replaced with the lower bound, and values above the upper percentile (e.g., 99th percentile) are replaced with the upper bound. No data is excluded; all users remain in the calculation. This makes results more robust to data entry errors or extreme edge cases. The percentile bounds are [configured per metric](https://posthog.com/docs/experiments/metrics#outlier-handling) when setting up the experiment.
+For mean metrics, extreme outliers can skew results. PostHog optionally applies winsorization by clamping values to percentile-based bounds. Values below the lower percentile (e.g., 1st percentile) are replaced with the lower bound, and values above the upper percentile (e.g., 99th percentile) are replaced with the upper bound. No data is excluded; all users remain in the calculation. This makes results more robust to data entry errors or extreme edge cases. The percentile bounds are [configured per metric](https://posthog.com/docs/experiments/metrics#outlier-handling) when setting up the experiment.
 
 ### Step 2: Data quality validation
 
@@ -237,15 +237,15 @@ When testing multiple variants (A/B/C/D tests):
 
 ## Multiple metrics and false positives
 
-At the default 95% confidence level, there's a 5% chance that any single metric shows a significant result when nothing actually changed — the statistical engine itself can produce a false signal from random noise. Think of it like rolling a die: each metric is an independent roll, and each one has a small chance of landing on "significant" by chance.
+At the default 95% confidence level, there's a 5% chance that any single metric shows a significant result when nothing actually changed. The statistical engine itself can produce a false signal from random noise. Think of it like rolling a die: each metric is an independent roll, and each one has a small chance of landing on "significant" by chance.
 
-With 5 metrics, the chance that *at least one* produces a false positive is about 23%. With 10 metrics, it's 40%. PostHog tests each metric independently and doesn't adjust for this — each result stands on its own.
+With 5 metrics, the chance that *at least one* produces a false positive is about 23%. With 10 metrics, it's 40%. PostHog tests each metric independently and doesn't adjust for this, so each result stands on its own.
 
-### More metrics can help — if they're planned
+### More metrics can help, if they're planned
 
 This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but _only_ one of five supporting metrics improve with it, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
 
-But this only works if you intentionally choose related metrics tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power – you're just giving yourself more chances to find something to cherry-pick.
+But this only works if you intentionally choose related metrics tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power. You're just giving yourself more chances to find something to cherry-pick.
 
 ### How to use this in practice
 

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -245,7 +245,7 @@ With 5 metrics, the chance that *at least one* produces a false positive is abou
 
 This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but _only_ one of five supporting metrics improve with it, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
 
-But this only works if your metrics form a coherent set tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power — you're just giving yourself more chances to find something to cherry-pick.
+But this only works if you intentionally choose related metrics tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power – you're just giving yourself more chances to find something to cherry-pick.
 
 ### How to use this in practice
 

--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -252,7 +252,7 @@ With 5 metrics, the chance that *at least one* produces a false positive is abou
 
 This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but _only_ one of five supporting metrics improve with it, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
 
-But this only works if your metrics form a coherent set tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power — you're just giving yourself more chances to find something to cherry-pick.
+But this only works if you intentionally choose related metrics tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power – you're just giving yourself more chances to find something to cherry-pick.
 
 ### How to use this in practice
 

--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -241,3 +241,23 @@ When testing multiple variants (A/B/C/D tests):
 - The p-value and confidence interval are calculated for each variant vs. control
 - No correction for multiple comparisons is applied by default
 - Each comparison uses the same α = 0.05 significance level
+
+## Multiple metrics and false positives
+
+At the default significance level (α = 0.05), there's a 5% chance that any single metric shows a significant result when nothing actually changed — the statistical engine itself can produce a false signal from random noise. Think of it like rolling a die: each metric is an independent roll, and each one has a small chance of landing on "significant" by chance.
+
+With 5 metrics, the chance that *at least one* produces a false positive is about 23%. With 10 metrics, it's 40%. PostHog tests each metric independently and doesn't adjust for this — each result stands on its own.
+
+### More metrics can help — if they're planned
+
+This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but one out of five other metrics lights up as significant while the rest show nothing, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
+
+But this only works if your metrics form a coherent set tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power — you're just giving yourself more chances to find something to cherry-pick.
+
+### How to use this in practice
+
+**Before launching,** make sure each metric is tied to your hypothesis and has clear success criteria. Decide which metric is your primary decision-driver, and which are secondary (providing context, not driving the ship/kill decision).
+
+**When reading results,** look at the full pattern across metrics, not individual ones in isolation. A coherent story across multiple metrics is strong evidence. A single significant metric with no supporting signal from the others is worth skepticism.
+
+**If something unexpected is significant,** don't ship based on the surprise. Design a follow-up experiment with that metric as the primary. If the effect replicates, it's real.

--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -250,7 +250,7 @@ With 5 metrics, the chance that *at least one* produces a false positive is abou
 
 ### More metrics can help — if they're planned
 
-This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but one out of five other metrics lights up as significant while the rest show nothing, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
+This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but _only_ one of five supporting metrics improve with it, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
 
 But this only works if your metrics form a coherent set tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power — you're just giving yourself more chances to find something to cherry-pick.
 

--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -56,7 +56,7 @@ These sufficient statistics contain all the information needed to calculate mean
 
 #### Outlier handling (winsorization)
 
-For mean metrics, extreme outliers can skew results. PostHog optionally applies winsorization by clamping values to percentile-based bounds — values below the lower percentile (e.g., 1st percentile) are replaced with the lower bound, and values above the upper percentile (e.g., 99th percentile) are replaced with the upper bound. No data is excluded; all users remain in the calculation. This makes results more robust to data entry errors or extreme edge cases. The percentile bounds are configured per metric when setting up the experiment.
+For mean metrics, extreme outliers can skew results. PostHog optionally applies winsorization by clamping values to percentile-based bounds. Values below the lower percentile (e.g., 1st percentile) are replaced with the lower bound, and values above the upper percentile (e.g., 99th percentile) are replaced with the upper bound. No data is excluded; all users remain in the calculation. This makes results more robust to data entry errors or extreme edge cases. The percentile bounds are configured per metric when setting up the experiment.
 
 ### Step 2: Data quality validation
 
@@ -244,15 +244,15 @@ When testing multiple variants (A/B/C/D tests):
 
 ## Multiple metrics and false positives
 
-At the default significance level (α = 0.05), there's a 5% chance that any single metric shows a significant result when nothing actually changed — the statistical engine itself can produce a false signal from random noise. Think of it like rolling a die: each metric is an independent roll, and each one has a small chance of landing on "significant" by chance.
+At the default significance level (α = 0.05), there's a 5% chance that any single metric shows a significant result when nothing actually changed. The statistical engine itself can produce a false signal from random noise. Think of it like rolling a die: each metric is an independent roll, and each one has a small chance of landing on "significant" by chance.
 
-With 5 metrics, the chance that *at least one* produces a false positive is about 23%. With 10 metrics, it's 40%. PostHog tests each metric independently and doesn't adjust for this — each result stands on its own.
+With 5 metrics, the chance that *at least one* produces a false positive is about 23%. With 10 metrics, it's 40%. PostHog tests each metric independently and doesn't adjust for this, so each result stands on its own.
 
-### More metrics can help — if they're planned
+### More metrics can help, if they're planned
 
 This doesn't mean fewer metrics is better. Multiple well-chosen metrics actually help you cross-check results. If your change improves conversion but _only_ one of five supporting metrics improve with it, that pattern tells you the one outlier is likely noise. The other metrics gave you the context to see that.
 
-But this only works if you intentionally choose related metrics tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power – you're just giving yourself more chances to find something to cherry-pick.
+But this only works if you intentionally choose related metrics tied to your hypothesis. If you add 10 unrelated metrics with no plan, you lose that cross-checking power. You're just giving yourself more chances to find something to cherry-pick.
 
 ### How to use this in practice
 

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -36,7 +36,7 @@ However, if you insist on doing this (for example, you don't want to make code c
 
 ## How do I run a second experiment using the same feature flag as the first experiment?
 
-This is similar to running an experiment using an [existing feature flag](#how-do-i-use-an-existing-feature-flag-in-an-experiment). If you want to re-run an experiment (using the same feature flag key) while preserving the previous experiment results, delete the existing feature flag (not the experiment) and use the same key in the new experiment.
+End the first experiment, then create a new experiment and select the existing flag. You can also duplicate the experiment, which preserves your metric setup and lets you choose between reusing the same flag, selecting a different existing flag, or creating a new one.
 
 ## Why am I getting a feature flag validation error when creating an experiment?
 
@@ -108,6 +108,46 @@ You can check your current exposure count on the experiment results page. If you
 - Verify your feature flag implementation.
 - Consider increasing your feature flag's rollout percentage.
 - Ensure your exposure events are firing correctly.
+
+## Diagnosing sample ratio mismatch (SRM)
+
+When PostHog flags SRM on your experiment, check these causes in order — they're ranked by frequency:
+
+1. **Bot traffic.** Bots that trigger server-side flag evaluations are full experiment participants. They hash deterministically into one variant, skewing the split. Fix: enable the CDP Bot Filter Transformation in Settings → Data pipeline → Transformations.
+
+2. **Flag condition changes.** Did someone modify the flag's release conditions or rollout percentage after launch? Check the flag's activity log. Even API-level changes count — the UI locks experiment-linked flags, but the API doesn't enforce the same restrictions.
+
+3. **Identity fragmentation.** The same real user with two unlinked distinct IDs appears as two participants, potentially in different variants. Check your `identify()` flow. See [identity resolution](/docs/product-analytics/identity-resolution).
+
+4. **SDK dedup cache overflow.** Server-side SDKs (Node, Python) dedup exposure events in-memory with a 50,000 entry cache. If your server handles more than 50k distinct flag+value combinations between restarts, earlier entries are evicted and those users may fire duplicate exposures.
+
+5. **Normal early variance.** With fewer than ~1,000 exposures, a 55/45 split on a 50/50 experiment is statistically normal. Hash-based randomization converges with larger samples. If SRM fires early and your sample is small, wait.
+
+## Common issues and self-diagnosis
+
+### Users appearing in both control and test
+
+This is an identity problem. The user has two distinct IDs that haven't been linked. PostHog sees two separate persons, each correctly assigned a variant.
+
+**Check:** Are you calling `identify()` before or after the flag evaluation? Is the same stable ID used in every SDK that evaluates this flag? Did you call `reset()` somewhere that fragmented the session?
+
+### Variant flipped mid-session
+
+Something changed in the evaluation inputs. Common causes: `identify()` called after the flag was already evaluated with an anonymous ID. SDK cache cleared (by `reset()`, page reload without [bootstrapping](/docs/feature-flags/bootstrapping), or server restart). Release conditions modified on the flag while the experiment was running.
+
+**Check:** Pull both `$feature_flag_called` events for the user and compare the `distinct_id`, timestamp, and person properties.
+
+### Unexpected exposure numbers
+
+The flag is being evaluated in a context you didn't expect. Server-side evaluation without bot filtering means bots are participants. `getAllFlags()` in your code means exposures aren't being recorded. Multiple SDKs evaluating the same flag with different distinct IDs means duplicate exposures.
+
+**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()`? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
+
+### Metric shows all "none" values with a property breakdown
+
+The property doesn't exist on the event you're measuring.
+
+**Check:** Go to Data Management → Events → click the event → Properties tab. If your property isn't listed, your instrumentation needs to include it.
 
 ## Solved community questions
 

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -42,7 +42,7 @@ End the first experiment, then create a new experiment and select the existing f
 
 Experiments require feature flags to meet specific requirements. You may see validation errors if your feature flag doesn't meet them:
 
-- **"Feature flag must have at least 2 variants (control and at least one test variant)"**: Experiments need at least two variants – a `control` and at least one test variant. Single-variant flags cannot be used for experiments.
+- **"Feature flag must have at least 2 variants (control and at least one test variant)"**: Experiments need at least two variants: a `control` and at least one test variant. Single-variant flags cannot be used for experiments.
 
 - **"Feature flag must have a variant with key 'control'"**: One of your variants must have the key `control`. This is used as the baseline for comparison.
 
@@ -111,11 +111,11 @@ You can check your current exposure count on the experiment results page. If you
 
 ## Diagnosing sample ratio mismatch (SRM)
 
-When PostHog flags SRM on your experiment, check these causes in order — they're ranked by frequency:
+When PostHog flags SRM on your experiment, check these causes in order. They're ranked by frequency:
 
 1. **Bot traffic.** Bots that trigger server-side flag evaluations are full experiment participants. They hash deterministically into one variant, skewing the split. Fix: enable the CDP Bot Filter Transformation in Settings → Data pipeline → Transformations.
 
-2. **Flag condition changes.** Did someone modify the flag's release conditions or rollout percentage after launch? Check the flag's activity log. Even API-level changes count — the UI locks experiment-linked flags, but the API doesn't enforce the same restrictions.
+2. **Flag condition changes.** Did someone modify the flag's release conditions or rollout percentage after launch? Check the flag's activity log. Even API-level changes count. The UI locks experiment-linked flags, but the API doesn't enforce the same restrictions.
 
 3. **Identity fragmentation.** The same real user with two unlinked distinct IDs appears as two participants, potentially in different variants. Check your `identify()` flow. See [identity resolution](/docs/product-analytics/identity-resolution).
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -205,6 +205,10 @@ Start at 5-10% of users, monitor metrics, then gradually increase. This is a [ph
 
 [Feature flag dependencies](/docs/feature-flags/dependencies) let one flag's activation depend on another flag's state – useful for enabling complex features only after foundational components are active, or running Experiments only on users with specific features enabled. Keep dependency chains simple and avoid circular dependencies.
 
+### Be careful with "Latest" person properties
+
+PostHog automatically creates person properties like "Latest Current URL" and "Latest Referring Domain" — these are derived from the corresponding event properties (like `$current_url`) and update every time a new event comes in. If you target a flag on one of these, the flag value can change with every new event. If you need to target based on a value like this, capture it once as a stable person property (e.g., `first_landing_page` via `$set_once`) and target that instead.
+
 ### Reducing your bill
 
 Stale flags are the most common source of unnecessary cost. Beyond cleaning up flags, see our [dedicated guide to cutting costs](/docs/feature-flags/cutting-costs) for estimating and reducing your feature flag bill.

--- a/contents/docs/feature-flags/device-bucketing.mdx
+++ b/contents/docs/feature-flags/device-bucketing.mdx
@@ -127,6 +127,12 @@ with new_context():
 - `posthog.reset()` keeps `$device_id`. Device-bucketed flags stay stable even after logout.
 - `posthog.reset(true)` creates a new `$device_id`. Use this on shared devices or kiosks when each session should be treated as a new device.
 
+## Device bucketing for experiments
+
+For experiments that span the anonymous-to-identified transition (signup flows, pre-login landing pages), device bucketing is the recommended approach over [flag persistence across authentication](/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps-optional).
+
+**Why:** Flag persistence across authentication requires a database lookup on every flag evaluation, doesn't support local evaluation, and has a known issue where flag values can change after `identify()` despite persistence being enabled (posthog-js [#2623](https://github.com/PostHog/posthog-js/issues/2623)). Device bucketing has none of these costs — the `$device_id` stays constant across the anonymous → identified transition, so the hash input doesn't change and the variant stays consistent.
+
 ## Further reading
 
 - [Creating feature flags](/docs/feature-flags/creating-feature-flags)

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -86,6 +86,20 @@ Then, by default, PostHog attempts to evaluate the flag locally using definition
 
 You can disable this behavior by setting `onlyEvaluateLocally` to `true`. In this case, PostHog will **only** attempt to evaluate the flag locally, and return `undefined` / `None` / `nil` if it was unable to.
 
+### Cold start and fallback defaults
+
+When the SDK first starts, it needs up to one polling interval (30 seconds by default) to fetch flag definitions. During this window, local evaluation returns `undefined` / `None` because no definitions are loaded yet. Use per-flag defaults to control what users see during this period:
+
+```javascript
+// Without a default, undefined is falsy — users see nothing
+const variant = posthog.getFeatureFlag('checkout-redesign') || false
+
+// With a per-flag default, you control the experience
+const variant = posthog.getFeatureFlag('checkout-redesign') ?? 'control'
+```
+
+If you deploy frequently or have many short-lived workers, consider using a [shared flag definition cache](/docs/feature-flags/local-evaluation/distributed-environments) so definitions survive restarts and the cold start window is eliminated.
+
 <MultiLanguage>
 
 ```node

--- a/contents/docs/feature-flags/troubleshooting.mdx
+++ b/contents/docs/feature-flags/troubleshooting.mdx
@@ -206,6 +206,41 @@ import PostHogBillableUsageTemplate from "../_snippets/posthog-billable-usage-te
 
 <PostHogBillableUsageTemplate />
 
+## Server-side SDK gotchas
+
+### Async compatibility (Python / FastAPI)
+
+The `posthog-python` SDK is synchronous — it uses the `requests` library internally. In async Python web frameworks (FastAPI, Starlette), calling SDK methods directly blocks the event loop. Under concurrent load, a single slow PostHog call (e.g., 3-second timeout during an outage) blocks all other requests.
+
+**Fix:** Wrap SDK calls in `asyncio.to_thread()`:
+
+```python
+import asyncio
+from posthog import Posthog
+
+posthog_client = Posthog('phc_xxx', host='https://us.i.posthog.com')
+
+async def get_flags(distinct_id, properties=None):
+    return await asyncio.to_thread(
+        posthog_client.get_all_flags_and_payloads,
+        distinct_id,
+        person_properties=properties,
+    )
+```
+
+### Payload format differs between SDKs
+
+The Python SDK returns flag payloads as JSON strings — you need to parse them yourself:
+
+```python
+result = posthog_client.get_all_flags_and_payloads('user-123')
+# result['featureFlagPayloads']['my-flag'] is '{"color": "blue"}' — a string
+import json
+payload = json.loads(result['featureFlagPayloads']['my-flag'])
+```
+
+The Node SDK automatically parses payloads into objects — no manual parsing needed.
+
 ## Solved community questions
 
 <SolvedQuestions


### PR DESCRIPTION
## Changes

Enriches 12 existing docs pages with codebase-verified experiment guidance. All claims were verified against the PostHog codebase before writing. No pages moved, no new pages created — purely additive to existing content.

**Experiments docs:**
- **exposures.mdx** — Exposure deduplication behavior, reuse-flag warning
- **metrics.mdx** — What "sum" actually computes (mean of per-user totals), conversion window behavior
- **statistics-bayesian.mdx** — Multiple metrics and false positives (with cross-checking insight)
- **statistics-frequentist.mdx** — Same, with p-value framing
- **analyzing-results.mdx** — Reading patterns across metrics with worked good/bad examples
- **troubleshooting.mdx** — SRM diagnostic checklist (ranked by frequency), common self-diagnosis issues, corrected flag reuse guidance
- **adding-experiment-code.mdx** — Callout that only `getFeatureFlag()` records exposure
- **managing-lifecycle.mdx** — Flag cleanup after experiments (billing impact)

**Feature flags docs:**
- **best-practices.mdx** — "Latest" person properties warning
- **device-bucketing.mdx** — Recommend over flag persistence across auth for experiments
- **local-evaluation/index.mdx** — Cold start behavior and per-flag defaults
- **troubleshooting.mdx** — Async Python/FastAPI gotcha, payload format differences between SDKs

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`