### PR TITLE
docs: update Customer.io opt-outs doc with sync steps

### DIFF
--- a/contents/docs/workflows/import-customerio-optouts.mdx
+++ b/contents/docs/workflows/import-customerio-optouts.mdx
@@ -31,7 +31,7 @@ To create an App API key in Customer.io, go to **[Settings > Account Settings > 
 
 Click **Create New App API Key** and give it a descriptive name (e.g. "PostHog Import").
 
-<CalloutBox icon="IconInfo" title="Save your API key" type="action">
+<CalloutBox icon="IconWarning" title="Save your API key" type="caution">
 
 Save this API key securely – Customer.io only shows it once.
 

--- a/contents/docs/workflows/import-customerio-optouts.mdx
+++ b/contents/docs/workflows/import-customerio-optouts.mdx
@@ -3,33 +3,47 @@ title: "Import opt-out lists from Customer.io"
 showStepsToc: true
 ---
 
-In this guide we'll walk through importing your **opt-out lists from Customer.io** into PostHog. After following this guide, you will:
-- Create an API key in Customer.io
-- Export people with subscription preferences
-- Import opt-outs into PostHog
+In this guide we'll walk through importing your **opt-out lists from Customer.io** into PostHog and keeping them in sync.
+
+Go to your PostHog app and navigate to **Workflows > Opt-out list**. Click **Import from Customer.io**. 
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
+    classes="rounded"
+    alt="PostHog opt-out list page"
+/>
 
 <Steps>
 
-<Step title="Create an app API key in Customer.io" badge="required">
+<Step title="Import categories and global opt-outs" badge="required">
 
-First, you'll need to create an app API key in Customer.io. This key will be used later to import all categories and generally unsubscribed customers.
+This step imports all subscription topics and globally unsubscribed customers from Customer.io using an App API key.
 
-Go to **[Settings > Account Settings > App API Keys](https://fly.customer.io/settings/api_credentials?keyType=app)** in your Customer.io dashboard.
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step1_light_bf6fe10f61.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step1_dark_17eab665b2.png"
+    classes="rounded"
+    alt="Enter API key"
+/>
 
+To create an App API key in Customer.io, go to **[Settings > Account Settings > App API Keys](https://fly.customer.io/settings/api_credentials?keyType=app)** in your Customer.io dashboard. 
 
 Click **Create New App API Key** and give it a descriptive name (e.g. "PostHog Import").
 
-**Important**: Save this API key securely - you'll need it in step 3. Customer.io will only show it once.
+**Important**: Save this API key securely, Customer.io will only show it once.
+
+Go back to PostHog, paste the key into the first step, and click **Start import**. This will import:
+- All available categories from Customer.io
+- All customers who are generally unsubscribed (not subscribed to any category)
+
+Customer.io only supports importing globally unsubscribed users via API, so per-category opt-outs need to be imported through a CSV in the next step.
 
 </Step>
 
-<Step title="Export people with subscription preferences" badge="required">
+<Step title="Upload opt-out preferences CSV" badge="required">
 
-Now you need to export a CSV of people who have opted out of specific categories.
-
-Go to the **People** page in your Customer.io dashboard.
-
-To filter for people with subscription preferences:
+To get the CSV of people who have opted out of specific categories, go to the **People** page in Customer.io. Filter for people with subscription preferences:
 1. Click **conditions** at the top of the page
 2. Select `cio_subscription_preferences` from the dropdown
 3. Choose the **exists** operator
@@ -58,68 +72,72 @@ Now export this data:
     alt="Choosing export attributes"
 />
 
-Customer.io will send you an email with a download link for the CSV file. Download this file - you'll upload it to PostHog in the next step.
+Customer.io will send you an email with a download link for the CSV file.
 
-</Step>
-
-<Step title="Import into PostHog" badge="required">
-
-Go to your PostHog app and navigate to **Workflows > Opt-out list**.
+Back in PostHog, select the CSV and click **Upload & process CSV**.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_light_0f5a6142c2.png" 
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_dark_c964735a03.png" 
     classes="rounded"
-    alt="PostHog opt-out list page"
-/>
-
-Click **Import from Customer.io**.
-
-You'll see a two-step import process:
-
-### Step 1: Import via API key
-
-Enter the API key you created in step 1. This will import:
-- All available categories from Customer.io
-- All customers who are generally unsubscribed (not subscribed to any category)
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/4_18a3a268e3.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/4_18a3a268e3.png"
-    classes="rounded"
-    alt="Enter API key"
-/>
-
-Due to rate limiting, we need to import customers that opted out of certain categories through the CSV.
-
-### Step 2: Upload CSV
-
-Once step 1 is completed, you'll be prompted to upload the CSV file you downloaded in step 2.
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/5_076d8fa46c.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/5_076d8fa46c.png"
-    classes="rounded"
-    alt="Upload CSV file"
-/>
-
-1. Click **Choose file** and select the CSV you downloaded from Customer.io
-2. Click **Upload & process CSV**
-
-This will import customers who opted out of specific categories (those with granular subscription preferences).
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/6_d9c7957fcd.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/6_d9c7957fcd.png"
-    classes="rounded"
-    alt="Processing CSV"
+    alt="Upload CSV"
 />
 
 Once complete, you'll see a success message with a summary of imported opt-outs.
 
-Your Customer.io opt-out lists are now imported into PostHog. These users will automatically be excluded from all future workflow campaigns based on their preferences.
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_completed_light_2774421ebd.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_completed_dark_e54e84395f.png"
+    classes="rounded"
+    alt="CSV import complete"
+/>
+
+</Step>
+
+<Step title="Receive opt-out updates from Customer.io" badge="recommended">
+
+To keep opt-outs in sync, set up a [Reporting Webhook](https://docs.customer.io/integrations/api/webhooks/) so Customer.io notifies PostHog whenever someone unsubscribes or changes their topic preferences.
+
+Go to Customer.io and navigate to **Integrations > Add integration > Reporting webhook**. Paste the webhook URL from PostHog.
+
+Next, copy the webhook signing secret. It is used to verify that incoming webhooks are from your Customer.io account, unsigned webhooks are rejected.
+
+Back in PostHog, paste the signing secret and click **Enable sync**.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step3_light_2c23a92419.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step3_dark_c36c86c266.png"
+    classes="rounded"
+    alt="Inbound webhook sync enabled"
+/>
+
+Once enabled, PostHog automatically records opt-outs whenever:
+- A user globally unsubscribes or resubscribes in Customer.io
+- A user changes their per-topic subscription preferences in Customer.io
+
+</Step>
+
+<Step title="Send PostHog opt-out updates to Customer.io" badge="recommended">
+
+When users update their preferences through a PostHog-managed preferences page, you can automatically sync those changes back to Customer.io. This is useful if you haven't fully migrated your email campaigns to PostHog workflows.
+
+Only categories originally imported from Customer.io are synced back. 
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_light_ec05fee09f.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_dark_e4a42010f8.png"
+    classes="rounded"
+    alt="Outbound sync configuration in PostHog"
+/>
+
+To get your Customer.io Track API credentials, go to **Settings > API and webhook credentials > Track API Keys** and copy the **Site ID** and **Track API key**.
+
+Back in PostHog:
+1. Select your Customer.io **region** (US or EU) - this determines which Track API endpoint PostHog uses
+2. Enter your **Site ID**
+3. Enter your **Track API key**
+4. Click **Enable sync**
 
 </Step>
 
 </Steps>
-

--- a/contents/docs/workflows/import-customerio-optouts.mdx
+++ b/contents/docs/workflows/import-customerio-optouts.mdx
@@ -31,7 +31,7 @@ To create an App API key in Customer.io, go to **[Settings > Account Settings > 
 
 Click **Create New App API Key** and give it a descriptive name (e.g. "PostHog Import").
 
-**Important**: Save this API key securely, Customer.io will only show it once.
+**Important**: Save this API key securely – Customer.io only shows it once.
 
 Go back to PostHog, paste the key into the first step, and click **Start import**. This will import:
 - All available categories from Customer.io
@@ -100,7 +100,7 @@ To keep opt-outs in sync, set up a [Reporting Webhook](https://docs.customer.io/
 
 Go to Customer.io and navigate to **Integrations > Add integration > Reporting webhook**. Paste the webhook URL from PostHog.
 
-Next, copy the webhook signing secret. It is used to verify that incoming webhooks are from your Customer.io account, unsigned webhooks are rejected.
+Next, copy the webhook signing secret. It is used to verify that incoming webhooks are from your Customer.io account – unsigned webhooks are rejected.
 
 Back in PostHog, paste the signing secret and click **Enable sync**.
 
@@ -133,7 +133,7 @@ Only categories originally imported from Customer.io are synced back.
 To get your Customer.io Track API credentials, go to **Settings > API and webhook credentials > Track API Keys** and copy the **Site ID** and **Track API key**.
 
 Back in PostHog:
-1. Select your Customer.io **region** (US or EU) - this determines which Track API endpoint PostHog uses
+1. Select your Customer.io **region** (US or EU) – this determines which Track API endpoint PostHog uses
 2. Enter your **Site ID**
 3. Enter your **Track API key**
 4. Click **Enable sync**

--- a/contents/docs/workflows/import-customerio-optouts.mdx
+++ b/contents/docs/workflows/import-customerio-optouts.mdx
@@ -119,7 +119,7 @@ Once enabled, PostHog automatically records opt-outs whenever:
 
 <Step title="Send PostHog opt-out updates to Customer.io" badge="recommended">
 
-When users update their preferences through a PostHog-managed preferences page, you can automatically sync those changes back to Customer.io. This is useful if you haven't fully migrated your email campaigns to PostHog workflows.
+When users update their preferences through a PostHog-managed preferences page, you can automatically sync those changes back to Customer.io. This is useful if you haven't fully migrated your email campaigns to PostHog Workflows.
 
 Only categories originally imported from Customer.io are synced back.
 

--- a/contents/docs/workflows/import-customerio-optouts.mdx
+++ b/contents/docs/workflows/import-customerio-optouts.mdx
@@ -100,7 +100,7 @@ To keep opt-outs in sync, set up a [Reporting Webhook](https://docs.customer.io/
 
 Go to Customer.io and navigate to **Integrations > Add integration > Reporting webhook**. Paste the webhook URL from PostHog.
 
-Next, copy the webhook signing secret. It is used to verify that incoming webhooks are from your Customer.io account – unsigned webhooks are rejected.
+Next, copy the webhook signing secret. It's used to verify that incoming webhooks are from your Customer.io account – unsigned webhooks are rejected.
 
 Back in PostHog, paste the signing secret and click **Enable sync**.
 
@@ -121,14 +121,7 @@ Once enabled, PostHog automatically records opt-outs whenever:
 
 When users update their preferences through a PostHog-managed preferences page, you can automatically sync those changes back to Customer.io. This is useful if you haven't fully migrated your email campaigns to PostHog workflows.
 
-Only categories originally imported from Customer.io are synced back. 
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_light_ec05fee09f.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_dark_e4a42010f8.png"
-    classes="rounded"
-    alt="Outbound sync configuration in PostHog"
-/>
+Only categories originally imported from Customer.io are synced back.
 
 To get your Customer.io Track API credentials, go to **Settings > API and webhook credentials > Track API Keys** and copy the **Site ID** and **Track API key**.
 
@@ -137,6 +130,13 @@ Back in PostHog:
 2. Enter your **Site ID**
 3. Enter your **Track API key**
 4. Click **Enable sync**
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_light_ec05fee09f.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_dark_e4a42010f8.png"
+    classes="rounded"
+    alt="Outbound sync configuration in PostHog"
+/>
 
 </Step>
 

--- a/contents/docs/workflows/import-customerio-optouts.mdx
+++ b/contents/docs/workflows/import-customerio-optouts.mdx
@@ -5,13 +5,13 @@ showStepsToc: true
 
 In this guide we'll walk through importing your **opt-out lists from Customer.io** into PostHog and keeping them in sync.
 
-Go to your PostHog app and navigate to **Workflows > Opt-out list**. Click **Import from Customer.io**. 
+Go to your PostHog app and navigate to **Workflows > Opt-out list**. Click **Import from Customer.io**.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
-    classes="rounded"
-    alt="PostHog opt-out list page"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/3_9e79e42360.png"
+  classes="rounded"
+  alt="PostHog opt-out list page"
 />
 
 <Steps>
@@ -21,19 +21,24 @@ Go to your PostHog app and navigate to **Workflows > Opt-out list**. Click **Imp
 This step imports all subscription topics and globally unsubscribed customers from Customer.io using an App API key.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step1_light_bf6fe10f61.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step1_dark_17eab665b2.png"
-    classes="rounded"
-    alt="Enter API key"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step1_light_bf6fe10f61.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step1_dark_17eab665b2.png"
+  classes="rounded"
+  alt="Enter API key"
 />
 
-To create an App API key in Customer.io, go to **[Settings > Account Settings > App API Keys](https://fly.customer.io/settings/api_credentials?keyType=app)** in your Customer.io dashboard. 
+To create an App API key in Customer.io, go to **[Settings > Account Settings > App API Keys](https://fly.customer.io/settings/api_credentials?keyType=app)** in your Customer.io dashboard.
 
 Click **Create New App API Key** and give it a descriptive name (e.g. "PostHog Import").
 
-**Important**: Save this API key securely – Customer.io only shows it once.
+<CalloutBox icon="IconInfo" title="Save your API key" type="action">
+
+Save this API key securely – Customer.io only shows it once.
+
+</CalloutBox>
 
 Go back to PostHog, paste the key into the first step, and click **Start import**. This will import:
+
 - All available categories from Customer.io
 - All customers who are generally unsubscribed (not subscribed to any category)
 
@@ -44,21 +49,23 @@ Customer.io only supports importing globally unsubscribed users via API, so per-
 <Step title="Upload opt-out preferences CSV" badge="required">
 
 To get the CSV of people who have opted out of specific categories, go to the **People** page in Customer.io. Filter for people with subscription preferences:
+
 1. Click **conditions** at the top of the page
 2. Select `cio_subscription_preferences` from the dropdown
 3. Choose the **exists** operator
 4. Confirm your choice
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/1_a04d048af2.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/1_a04d048af2.png"
-    classes="rounded"
-    alt="Adding attribute filter for cio_subscription_preferences"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/1_a04d048af2.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/1_a04d048af2.png"
+  classes="rounded"
+  alt="Adding attribute filter for cio_subscription_preferences"
 />
 
 This will update the people list in the table below to show only those with subscription preferences.
 
 Now export this data:
+
 1. Click **Export to CSV** in the top right corner
 2. Click **Choose attributes**
 3. Select only these two attributes:
@@ -66,10 +73,10 @@ Now export this data:
    - `email` (make sure it's `email` and **not** `$email`)
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/2_0cf22e73b9.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/2_0cf22e73b9.png"
-    classes="rounded"
-    alt="Choosing export attributes"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/2_0cf22e73b9.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/2_0cf22e73b9.png"
+  classes="rounded"
+  alt="Choosing export attributes"
 />
 
 Customer.io will send you an email with a download link for the CSV file.
@@ -77,19 +84,19 @@ Customer.io will send you an email with a download link for the CSV file.
 Back in PostHog, select the CSV and click **Upload & process CSV**.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_light_0f5a6142c2.png" 
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_dark_c964735a03.png" 
-    classes="rounded"
-    alt="Upload CSV"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_light_0f5a6142c2.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_dark_c964735a03.png"
+  classes="rounded"
+  alt="Upload CSV"
 />
 
 Once complete, you'll see a success message with a summary of imported opt-outs.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_completed_light_2774421ebd.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_completed_dark_e54e84395f.png"
-    classes="rounded"
-    alt="CSV import complete"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_completed_light_2774421ebd.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step2_completed_dark_e54e84395f.png"
+  classes="rounded"
+  alt="CSV import complete"
 />
 
 </Step>
@@ -105,13 +112,14 @@ Next, copy the webhook signing secret. It's used to verify that incoming webhook
 Back in PostHog, paste the signing secret and click **Enable sync**.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step3_light_2c23a92419.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step3_dark_c36c86c266.png"
-    classes="rounded"
-    alt="Inbound webhook sync enabled"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step3_light_2c23a92419.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step3_dark_c36c86c266.png"
+  classes="rounded"
+  alt="Inbound webhook sync enabled"
 />
 
 Once enabled, PostHog automatically records opt-outs whenever:
+
 - A user globally unsubscribes or resubscribes in Customer.io
 - A user changes their per-topic subscription preferences in Customer.io
 
@@ -126,16 +134,17 @@ Only categories originally imported from Customer.io are synced back.
 To get your Customer.io Track API credentials, go to **Settings > API and webhook credentials > Track API Keys** and copy the **Site ID** and **Track API key**.
 
 Back in PostHog:
+
 1. Select your Customer.io **region** (US or EU) – this determines which Track API endpoint PostHog uses
 2. Enter your **Site ID**
 3. Enter your **Track API key**
 4. Click **Enable sync**
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_light_ec05fee09f.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_dark_e4a42010f8.png"
-    classes="rounded"
-    alt="Outbound sync configuration in PostHog"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_light_ec05fee09f.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/step4_dark_e4a42010f8.png"
+  classes="rounded"
+  alt="Outbound sync configuration in PostHog"
 />
 
 </Step>


### PR DESCRIPTION
## Changes

Updated the "Import opt-outs from Customer.io" doc to cover the two new steps in the reworked Customer.io integration:
- Step 3: Receive opt-out updates from Customer.io via a reporting webhook
- Step 4: Send PostHog preference changes back to Customer.io via the Track API                                                                                                     

Steps 1 and 2 (API key import and CSV upload) are mostly unchanged. Updated screenshots and minor copy tweaks. 

Related PRs: 
PostHog/posthog#54470
PostHog/posthog#54572

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
