### PR TITLE
Clarify that steps are based on peers in similar roles

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -44,7 +44,7 @@ Within each level, we believe there's a place to have incremental steps to allow
 
 With exception of team members at the very beginning of their career or where it is their first time in this type of role, we hire into the *Established* step by default. This will give everyone the opportunity to be set up for success and leave enough room for salary increases, without the need to move up in seniority. 
 
-Here's [how to move from one step or level to another](/handbook/people/career-progression).
+At pay review time, we compare your step to peers in similar roles at PostHog and decide whether to bump it up. Here's [how to move from one step or level to another](/handbook/people/career-progression).
 
 ### Benchmark
  


### PR DESCRIPTION
## Changes


I described this at the all hands but realised it wasn't explicitly mentioned in our handbook

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
