### PR TITLE
Fix API docs build failure

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -148,7 +148,7 @@ function pathID(verb, path) {
 
 function Params({ params, objects, object, depth = 0 }) {
     if (depth > 4) return null
-    if (object) {
+    if (object?.properties) {
         params = Object.entries(object.properties).map(([key, value]) => {
             return {
                 name: key,
@@ -382,6 +382,7 @@ function RequestExample({ name, item, objects, exampleLanguage, setExampleLangua
         const objectKey = item.requestBody.content?.['application/json']?.schema['$ref']?.split('/').at(-1)
         if (!objectKey) return null
         const object = objects.schemas[objectKey]
+        if (!object?.properties) return null
         params = Object.entries(object.properties).filter(
             ([name, schema]) => object.required?.indexOf(name) > -1 && !schema.readOnly
         )

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -317,6 +317,7 @@ function RequestBody({ item, objects }) {
         item.requestBody?.content?.['application/json']?.schema.items?.['$ref'].split('/').at(-1)
     if (!objectKey) return null
     const object = objects.schemas[objectKey]
+    if (!object?.properties) return null
 
     return (
         <div>
@@ -342,6 +343,7 @@ function ResponseBody({ item, objects }) {
         .at(-1)
     if (!objectKey) return null
     const object = objects.schemas[objectKey]
+    if (!object?.properties) return null
     const [showResponse, setShowResponse] = useState(false)
 
     return (


### PR DESCRIPTION
## Changes

- Some API schemas use `oneOf` instead of `properties` which is breaking builds
- Added null guards for `object.properties`
