### PR TITLE
chore: trigger inkeep sync on PR merge

### DIFF
--- a/.github/workflows/inkeep-agent.yml
+++ b/.github/workflows/inkeep-agent.yml
@@ -1,6 +1,9 @@
 name: Inkeep Agent
 
 on:
+    pull_request:
+        types: [closed]
+
     issue_comment:
         types: [created]
 
@@ -19,9 +22,14 @@ permissions:
 jobs:
     trigger-agent:
         if: |
-            (github.event_name == 'issue_comment' &&  github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep')) ||
-            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@inkeep')) ||
-            (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@inkeep'))
+            !contains(github.event.pull_request.labels.*.name, 'skip-inkeep-docs') &&
+            !contains(github.event.issue.labels.*.name, 'skip-inkeep-docs') &&
+            (
+              (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.user.login != 'inkeep[bot]') ||
+              (github.event_name == 'issue_comment' &&  github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep')) ||
+              (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@inkeep')) ||
+              (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@inkeep'))
+            )
         runs-on: ubuntu-latest
         steps:
             - name: Trigger Inkeep Agent


### PR DESCRIPTION
## Changes

Mirrors the [posthog/posthog inkeep workflow](https://github.com/PostHog/posthog/blob/master/.github/workflows/inkeep-agent.yml) so docs/fix/feat/chore PRs kick off an inkeep sync as soon as they merge, rather than waiting for the scheduled 24h run.

Specifically:
- Adds a `pull_request: [closed]` trigger and a merge condition to the `trigger-agent` job (excluding `inkeep[bot]`-authored PRs to avoid loops on inkeep's own docs PRs).
- Adds a `skip-inkeep-docs` label as an escape hatch for PRs we don't want synced.
- Keeps the existing `pr-title-regex` (`^(feat|fix|docs|chore)(\(.+\))?:`), so only those PR types trigger a sync.
- Keeps the existing `@inkeep` comment/review triggers untouched.

No change to the inkeep agent action pin or the trigger URL secret.

## Checklist

N/A, this is a CI workflow change with no docs or content impact.
