### PR TITLE
Blog: Why we made chat our default UI

### DIFF
--- a/contents/blog/8-learnings-from-1-year-of-agents-posthog-ai.mdx
+++ b/contents/blog/8-learnings-from-1-year-of-agents-posthog-ai.mdx
@@ -19,7 +19,7 @@ tags:
 
 Today we launch **PostHog AI, the AI agent built into PostHog**. A year in the making, we've gone a long way from our first chat prototype made over a hackathon. It all started with just one tool: "create trends chart" - and no real [agentic capabilities](https://simonwillison.net/2025/Sep/18/agents/).
 
-Now, PostHog AI can access your data and setup via dozens of tools, and works tirelessly in a loop until it achieves the task you give it. Like a product analyst, it creates multi-step analyses of product usage, writes SQL queries, sets up new feature flags and experiments, digs into impactful errors - and more, all across PostHog. Thanks to a thorough beta period, it's already [used by thousands of users weekly](https://posthog.com/customers/rayfit).
+Now, PostHog AI can access your data and setup via dozens of tools, and works tirelessly in a loop until it achieves the task you give it. Like a product analyst, it creates multi-step analyses of product usage, writes SQL queries, sets up new feature flags and experiments, digs into impactful errors - and more, all across PostHog. Thanks to a thorough beta period, it's already [used by thousands of users weekly](/customers/rayfit).
 
 The road here has been full of adventures. Agents are paradoxical: some say [agent design is hard](https://lucumr.pocoo.org/2025/11/21/agents-are-hard/), and they're right! Others say [it's incredibly easy to build one](https://fly.io/blog/everyone-write-an-agent/) – weirdly that's true at the same time.
 

--- a/contents/blog/best-inapp-survey-tools.mdx
+++ b/contents/blog/best-inapp-survey-tools.mdx
@@ -101,7 +101,7 @@ This means you can do more than just collect feedback. When a user submits an NP
 
 [Surveys](/docs/surveys) in PostHog support web and mobile apps, can be triggered by events or feature flags, and include [templates for NPS, PMF, CSAT, and more](/templates). This lets teams get very granular with when and how to send surveys to users, and do complex analysis with other product tools.
 
-PostHog is also investing heavily in [AI features](/ai). Built-in AI summaries and the ability to get deeper survey analysis in the PostHog AI chat interface are both currently in Beta.
+PostHog is also investing heavily in [AI features](/ai). Built-in AI summaries and the ability to get deeper survey analysis in the [PostHog AI chat](/blog/why-chat) interface are both currently in Beta.
 
 The free tier includes 1,500 responses per month with no credit card required.
 

--- a/contents/blog/why-chat.md
+++ b/contents/blog/why-chat.md
@@ -1,0 +1,83 @@
+---
+title: Why we made chat our default UI
+date: 2026-04-17
+author:
+  - ian-vanagas
+featuredImageType: full
+featuredImage: >-
+  https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2026_04_17_at_11_06_36_2x_7007f77b71.png
+tags:
+  - Inside PostHog
+---
+
+"What can I help you with today?"
+
+It's what any business would ask a customer walking into their shop, so why is it so controversial when a piece of software does it?
+
+Companies like Linear, Attio, and us (PostHog) have all made an [AI chat](/ai) the default homepage experience recently and some are not happy about it.
+
+![Complaints](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Clean_Shot_2026_04_17_at_11_14_10_2x_b8266e901c.png)
+
+Although we can't speak for the other companies, we can talk about our thinking. 
+
+## We're shipping fast
+
+PostHog is getting more powerful. We're adding more products and more features. We had 48 [changelog-worthy](/changelog) updates in March. LLMs are increasing the velocity at which we can do this. 
+
+This is great because it's helping us provide every tool engineers need to build successful products. We can offer more of the products and features they need, have more of their data in one place (great for AI-powered analysis), and offer each of those products cheaper than competitors.
+
+But this growth causes two problems:
+
+1. There's a limited amount of room on the screen to put all of these products and features. 
+2. Users have a limited amount of time and attention to learn the usage and best practices of these products too. 
+
+The combination of these creates the complaint that PostHog is "too complicated" and our UI is "too cluttered."
+
+On top of this, the more we ship and the better products get, the further away PostHog gets from "just" being a product analytics tool as it once was. 48.5% of active PostHog users in the last 30 days didn't use product analytics. They rely on [session replay](/session-replay), [web analytics](/web-analytics), [feature flags](/feature-flags), [error tracking](/error-tracking), or any of our other tools. 
+
+Simply, we're outgrowing the default of having a product analytics dashboard as the homepage.
+
+## Welcome to the agent-first present
+
+People come to PostHog to get what they want done so they can go back to building. One way they do that most efficiently is [through agents](/newsletter/building-ai-agents). 
+
+More and more people are using PostHog in an agent-first way. 55% of dashboards, 28% of insights, 26% of experiments, and 13% of feature flags created in the last 7 days were done through agents.
+
+![Dashboards created](https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Clean_Shot_2026_04_17_at_11_12_09_2x_0748d14ed3.png)
+
+For many people, chat has become the default way they are developing software. This has two consequences:
+
+1. Going back to click around a UI feels like the past. They want to use natural language to get the insights as well as create and modify flags, experiments, surveys, and more.
+2. We need to focus more of our efforts on improving the [agent-first](/newsletter/agent-first-product-engineering) experience. 
+
+Having the chat as the homepage supports both of these. It's a new way of interacting with software, but one people seemingly want. Focusing more on it, and having more users use it, makes it better, and that improves our other agentic surfaces (like [MCP](/docs/model-context-protocol)).
+
+It also helps us solve the two problems caused by our growth. An agent can figure out what products to use and know the best practices of using them. Users get their simpler UI as a chat is a lot simpler than the existing PostHog UI.
+
+## What making chat default is not
+
+There is a lot of theories of why a company would do this that need debunking. Making the chat the default is not:
+
+- **A loss of vision.** For us, we see this as a core part of our AI-first vision. Chat is the best format for interacting with agents right now and more people want to interact with PostHog through agents. 
+
+- **A complete replacement.** The underlying UI is there and is still the primary way of interacting with every product. A lot of PostHog is visual in a way that text cannot represent. You can always change it back. 
+
+- **Faster for everything.** We fully realize that in lots of circumstances, having a UI is better. We fully expect product experts to still use the UI. Chat is faster when you're not fully familiar with the UI.
+
+- **Going to have 100% approval.** PostHog as a whole isn't perfect. We'll continue to iterate and improve. 
+
+- **Completely unique.** Other companies have done this before us. We're not claiming this is a genius new UI paradigm we've invented, just one that works for a lot of people.
+
+- **Just "chat with your data."** Although the primary way people use chat is querying their data and doing analysis, you can use many of our products and features through PostHog AI. We're aiming for all of them.
+
+## Chat is a step towards the future
+
+We're seeing good results from doing this so far. Only 6% of homepage visitors clicked a dashboard link while 12% chat with AI. On top of this, only 2% of people over 30 days have put the default dashboard back within one hour of visiting. 
+
+More importantly, we're not done.
+
+Not just in the "feature completeness" sense, but in a broader mission sense. We're working towards product autonomy, enabling PostHog to improve your product automatically. 
+
+This will work towards solving one of the final complaints: that a chat requires users to know what they want. Product autonomy aims to turn product data into improvements. Being able to guide this through chat is a critical part in helping it succeed.
+
+The chat you see now is just a start.

--- a/contents/blog/why-chat.md
+++ b/contents/blog/why-chat.md
@@ -1,6 +1,6 @@
 ---
 title: Why we made chat our default UI
-date: 2026-04-17
+date: 2026-04-22
 author:
   - ian-vanagas
 featuredImageType: full

--- a/contents/blog/why-chat.md
+++ b/contents/blog/why-chat.md
@@ -18,66 +18,52 @@ Companies like Linear, Attio, and us (PostHog) have all made an [AI chat](/ai) t
 
 ![Complaints](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Clean_Shot_2026_04_17_at_11_14_10_2x_b8266e901c.png)
 
-Although we can't speak for the other companies, we can talk about our thinking. 
+We're seeing good results from doing this so far. Only 6% of homepage visitors clicked a dashboard link while 12% chat with AI. On top of this, only 2% of people over 30 days have put the default dashboard back within one hour of visiting.
 
-## We're shipping fast
+To go further, we're explaining why we made this change and what we're doing to support it.
 
-PostHog is getting more powerful. We're adding more products and more features. We had 48 [changelog-worthy](/changelog) updates in March. LLMs are increasing the velocity at which we can do this. 
+## Our existing default doesn't make sense anymore
 
-This is great because it's helping us provide every tool engineers need to build successful products. We can offer more of the products and features they need, have more of their data in one place (great for AI-powered analysis), and offer each of those products cheaper than competitors.
+PostHog started as an "open source product analytics tool" but has grown to be much more. 48.5% of active PostHog users in the last 30 days didn't even use product analytics. They rely on [session replay](/session-replay), [web analytics](/web-analytics), [feature flags](/feature-flags), [error tracking](/error-tracking), or any of our other tools. 
 
-But this growth causes two problems:
+This is great as it shows we're making progress towards our mission of providing every tool engineers need to build successful products. We're sure aiming for it. We had 48 [changelog-worthy](/changelog) updates in March and LLMs are increasing the velocity at which we can ship new features.
 
-1. There's a limited amount of room on the screen to put all of these products and features. 
-2. Users have a limited amount of time and attention to learn the usage and best practices of these products too. 
+But this shift and growth causes three problems:
 
-The combination of these creates the complaint that PostHog is "too complicated" and our UI is "too cluttered."
+1. Defaulting to a product analytics dashboard doesn't make sense for ~50% of our users.
+2. There's a limited amount of room on the screen to put all of these products and features. 
+3. Users have a limited amount of time and attention to learn the usage and best practices of these products too. 
 
-On top of this, the more we ship and the better products get, the further away PostHog gets from "just" being a product analytics tool as it once was. 48.5% of active PostHog users in the last 30 days didn't use product analytics. They rely on [session replay](/session-replay), [web analytics](/web-analytics), [feature flags](/feature-flags), [error tracking](/error-tracking), or any of our other tools. 
+The combination of these creates the complaint that PostHog is "too complicated" and our UI is "too cluttered." Our [Platform UX team](/teams/platform-ux) is working on this, and we also have an exec leading a project on fixing "papercuts," 51 of which have been fixed in the last 2 weeks.
 
-Simply, we're outgrowing the default of having a product analytics dashboard as the homepage.
+But we're also being helped by the biggest shift in how we build software: agents.
 
 ## Welcome to the agent-first present
 
-People come to PostHog to get what they want done so they can go back to building. One way they do that most efficiently is [through agents](/newsletter/building-ai-agents). 
+People come to PostHog to get what they want done so they can go back to building. One way they do that most efficiently is [through agents](/newsletter/building-ai-agents).
 
 More and more people are using PostHog in an agent-first way. 55% of dashboards, 28% of insights, 26% of experiments, and 13% of feature flags created in the last 7 days were done through agents.
 
 ![Dashboards created](https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Clean_Shot_2026_04_17_at_11_12_09_2x_0748d14ed3.png)
 
-For many people, chat has become the default way they are developing software. This has two consequences:
+Agents are helping people with the complexity of using all software, PostHog included. When they work well, they are a solution to all three of our problems:
 
-1. Going back to click around a UI feels like the past. They want to use natural language to get the insights as well as create and modify flags, experiments, surveys, and more.
-2. We need to focus more of our efforts on improving the [agent-first](/newsletter/agent-first-product-engineering) experience. 
+1. A chat-based agent provide a much simpler UI. Users can use natural language to get the insights as well as create and modify flags, experiments, surveys, and more.
+2. Agents can be set up with the [right tools and skills](/newsletter/agent-first-product-engineering) to figure out what products to use and know the best practices of using them.
+3. Because they can use all of our products and features, a chat-based agent is more relevant to more of our users than a product analytics dashboard is.
 
-Having the chat as the homepage supports both of these. It's a new way of interacting with software, but one people seemingly want. Focusing more on it, and having more users use it, makes it better, and that improves our other agentic surfaces (like [MCP](/docs/model-context-protocol)).
+The key bit is *when they work well*. Many people have had bad experiences with these chat-based agents, which is where resentment comes from. We've done a lot of work and testing and had enough positive feedback to be confident in ours though.
 
-It also helps us solve the two problems caused by our growth. An agent can figure out what products to use and know the best practices of using them. Users get their simpler UI as a chat is a lot simpler than the existing PostHog UI.
+Making chat the default also helps us make improvements faster. More usage means more feedback, and the better tools and skills we build thanks to this feedback then spill over to our other agentic surfaces (like [MCP](/docs/model-context-protocol)).
 
-## What making chat default is not
+## Chat has it's own challenges but is a step towards the future
 
-There is a lot of theories of why a company would do this that need debunking. Making the chat the default is not:
+Chat has it's own challenges.
 
-- **A loss of vision.** For us, we see this as a core part of our AI-first vision. Chat is the best format for interacting with agents right now and more people want to interact with PostHog through agents. 
+First, it's not faster for everything. Each product's UI still exists, is still the primary way of interacting with it, and is still being improved. Experts will still use the UI and we'll continue to build for them.
 
-- **A complete replacement.** The underlying UI is there and is still the primary way of interacting with every product. A lot of PostHog is visual in a way that text cannot represent. You can always change it back. 
+Second, it's not clear what a chat can do for you. A UI provides immediate value because it shows you what you can do. Although a chat can give hints, it requires users to know what they want. It's like a restaurant without a menu.
 
-- **Faster for everything.** We fully realize that in lots of circumstances, having a UI is better. We fully expect product experts to still use the UI. Chat is faster when you're not fully familiar with the UI.
+This problem is trickier but we're working on it too. The solution is not to just give more hints, but to autonomously make improvements to your product. You guide this via chat, but there will be less of you "needing to know what you want" and more of PostHog knowing what to do. 
 
-- **Going to have 100% approval.** PostHog as a whole isn't perfect. We'll continue to iterate and improve. 
-
-- **Completely unique.** Other companies have done this before us. We're not claiming this is a genius new UI paradigm we've invented, just one that works for a lot of people.
-
-- **Just "chat with your data."** Although the primary way people use chat is querying their data and doing analysis, you can use many of our products and features through PostHog AI. We're aiming for all of them.
-
-## Chat is a step towards the future
-
-We're seeing good results from doing this so far. Only 6% of homepage visitors clicked a dashboard link while 12% chat with AI. On top of this, only 2% of people over 30 days have put the default dashboard back within one hour of visiting. 
-
-More importantly, we're not done.
-
-Not just in the "feature completeness" sense, but in a broader mission sense. We're working towards product autonomy, enabling PostHog to improve your product automatically. 
-
-This will work towards solving one of the final complaints: that a chat requires users to know what they want. Product autonomy aims to turn product data into improvements. Being able to guide this through chat is a critical part in helping it succeed.
-
-The chat you see now is just a start.
+We're excited to show you more of this soon. The chat you see now is just a start.

--- a/contents/blog/why-chat.md
+++ b/contents/blog/why-chat.md
@@ -12,13 +12,13 @@ tags:
 
 "What can I help you with today?"
 
-It's what any business would ask a customer walking into their shop, so why is it so controversial when a piece of software does it?
+It's what most businesses would ask when a customer walks into their shop, so why is it so controversial when a piece of software does it?
 
-Companies like Linear, Attio, and us (PostHog) have all made an [AI chat](/ai) the default homepage experience recently and some are not happy about it.
+Companies like Linear, Attio, and PostHog have all made [AI chat](/ai) the default homepage experience recently – and developers have opinions.
 
 ![Complaints](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Clean_Shot_2026_04_17_at_11_14_10_2x_b8266e901c.png)
 
-We're seeing good results from doing this so far. Only 6% of homepage visitors clicked a dashboard link while 12% chat with AI. On top of this, only 2% of people over 30 days have put the default dashboard back within one hour of visiting.
+Not everyone is happy about it, but our data shows promising results so far. Only 6% of homepage visitors clicked a dashboard link while 12% chat with AI. On top of this, only 2% of people over 30 days have put the default dashboard back within one hour of visiting.
 
 To go further, we're explaining why we made this change and what we're doing to support it.
 
@@ -26,15 +26,15 @@ To go further, we're explaining why we made this change and what we're doing to 
 
 PostHog started as an "open source product analytics tool" but has grown to be much more. 48.5% of active PostHog users in the last 30 days didn't even use product analytics. They rely on [session replay](/session-replay), [web analytics](/web-analytics), [feature flags](/feature-flags), [error tracking](/error-tracking), or any of our other tools. 
 
-This is great as it shows we're making progress towards our mission of providing every tool engineers need to build successful products. We're sure aiming for it. We had 48 [changelog-worthy](/changelog) updates in March and LLMs are increasing the velocity at which we can ship new features.
+This is great as it shows we're making progress towards our mission of providing every tool engineers need to build successful products. We sure are aiming for it. We had 48 [changelog-worthy](/changelog) updates in March, and LLMs are increasing the velocity at which we can ship new features.
 
 But this shift and growth causes three problems:
 
 1. Defaulting to a product analytics dashboard doesn't make sense for ~50% of our users.
-2. There's a limited amount of room on the screen to put all of these products and features. 
+2. There isn't enough room on the screen to put all of these products and features. 
 3. Users have a limited amount of time and attention to learn the usage and best practices of these products too. 
 
-The combination of these creates the complaint that PostHog is "too complicated" and our UI is "too cluttered." Our [Platform UX team](/teams/platform-ux) is working on this, and we also have an exec leading a project on fixing "papercuts," 51 of which have been fixed in the last 2 weeks.
+As a result, a common complaint we've been hearing is that PostHog is "too complicated" and our UI is "too cluttered." Our [Platform UX team](/teams/platform-ux) is working on this and we also have an exec leading a project on fixing "papercuts," 51 of which have been fixed in the last 2 weeks.
 
 But we're also being helped by the biggest shift in how we build software: agents.
 

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -27,7 +27,7 @@ Like everyone else, our AI journey started with a chatbot. From the first “you
 
 Our beloved hedgehog, Max, was the face that greeted you at every AI interaction. It kept learning, and eventually grew into a very capable product assistant. We learned a lot about [building AI-powered features](/newsletter/building-ai-features) along the way. 
 
-**The problem:** Even as we added AI capabilities across the platform, people still thought of Max AI as "the chat bot." The broader vision (AI woven through every product) wasn’t landing.
+**The problem:** Even as we added AI capabilities across the platform, people still thought of Max AI as "the [chat bot](/blog/why-chat)." The broader vision (AI woven through every product) wasn’t landing.
 
 We didn't want to be another company with [hand-wavy marketing](https://posthog.com/newsletter/marketing-for-devs) like “it's not just a chat bot, it's… [insert amazing AI capability here]”, which meant we needed to rethink how we positioned our AI capabilities in the minds of our users.  
 

--- a/contents/newsletter/building-ai-features.md
+++ b/contents/newsletter/building-ai-features.md
@@ -37,7 +37,7 @@ You don’t need to reinvent the wheel.
 
 A bunch of smart people have already figured out [effective AI patterns](/newsletter/agent-first-product-engineering) you can copy. These have the advantage of being [UX patterns](/newsletter/vibe-designing) that users are familiar with, while also being functionality AI is actually good at.
 
-First is the classic “chat with your docs/data/PDF.” AI is great at search and summarization, and can use this to build reports and recommendations.
+First is the classic “[chat](/blog/why-chat) with your docs/data/PDF.” AI is great at search and summarization, and can use this to build reports and recommendations.
 
 ![Intercom's Fin](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/6d97f7ea_c67e_4805_a1fa_ea8b7eda825a_676x487_04ace87dcc.png)
 


### PR DESCRIPTION
## Changes

Topical blog on making chat our default UI, addressing complaints and setting up our broader product autonomy vision. 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
