### PR TITLE
docs(error-tracking): bump iOS minimum CLI version to 0.7.7

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/ios.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/ios.mdx
@@ -9,7 +9,7 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
 <CalloutBox icon="IconInfo" title="CLI version requirement" type="action">
 
-A minimum CLI version of [0.7.5](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.5) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of Error Tracking's features.
+A minimum CLI version of [0.7.7](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.7) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of Error Tracking's features.
 
 </CalloutBox>
 


### PR DESCRIPTION
posthog-ios build-tools/upload-symbols.sh now enforces MIN_POSTHOG_CLI_VERSION=0.7.7 (since posthog-ios#558). Updating the docs callout to match.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
