### PR TITLE
fix(nav): website-mode submenus drift right on wide viewports in Safari

### DIFF
--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -275,7 +275,6 @@ export default function TaskBarMenu() {
                 ref={taskbarRef}
                 id="taskbar"
                 data-scheme="primary"
-                data-menu-container
                 className={`w-full bg-accent/75 skin-classic:bg-accent wallpaper-keyboard-garden:dark:bg-black/15 backdrop-blur border-b border-primary top-0 pl-0.5 pr-2 ${
                     websiteMode ? 'sticky top-0 z-40' : 'bg-accent/75 z-50'
                 } ${rendered ? 'block' : 'hidden'}`}

--- a/src/components/Wrapper/index.tsx
+++ b/src/components/Wrapper/index.tsx
@@ -31,6 +31,7 @@ export default function Wrapper() {
     return (
         <div
             data-scheme="primary"
+            data-menu-container
             className={`${
                 websiteMode
                     ? 'max-w-7xl mx-auto border-x border-primary bg-primary shadow-xl min-h-screen'


### PR DESCRIPTION
## Changes

**Reproduces in Safari / iOS Safari.**
Chromium's `backdrop-filter` containing-block handling diverges from spec, so the bug doesn't surface on Chrome today - but the underlying positioning is fragile in both.

In website mode, top-level nav submenus (Product OS, Pricing, Docs, Library, Company) drift horizontally away from their trigger once the viewport is wider than `max-w-7xl` (1280px). The gap grows linearly with viewport width.

**Before / After (Safari, 2000px viewport):**

Before:

<img width="1979" height="750" alt="posthog-before" src="https://github.com/user-attachments/assets/0abe7908-66c8-4eac-aa6a-55339b236f5d" />

After:

<img width="1990" height="760" alt="posthog-after" src="https://github.com/user-attachments/assets/281525f2-a47f-4da6-9a70-d91939561386" />

**Problem:**
`#taskbar` has `backdrop-blur`, which per [spec](https://www.w3.org/TR/filter-effects-2/#BackdropFilterProperty)
  establishes a containing block for `position: fixed` descendants (same as `filter`/`transform`). Since `MenuBar` portals `Menubar.Content` into `#taskbar` via `[data-menu-container]`, Radix's viewport-relative coordinates get interpreted relative to the centered 1280px taskbar box instead - so each menu shifts right by `(viewport − 1280) / 2`.

**Fix:**
move `data-menu-container` up one level from `#taskbar` to `#app-container`, which doesn't create a containing block
(The Search `Popover` in the same TaskBar already portals to `document.body` and works - same idea.)

  ## Checklist

  - [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
  - [x] Words are spelled using American English
  - [x] Use relative URLs for internal links
  - [ ] I've checked the pages added or changed in the Vercel preview build
  - [ ] If I moved a page, I added a redirect in `vercel.json`
