### PR TITLE
fix: iOS minimum duration wording

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -228,7 +228,7 @@ This mode is **more accurate** for filtering out short sessions, especially on s
 
 On iOS, minimum duration is enforced using **buffer length**, similar to web strict mode:
 
-- Replay events are buffered, and PostHog checks the duration of buffered replay data (from the oldest to newest buffered snapshot)
+- Snapshots are buffered, and PostHog checks the duration of buffered replay data (from the oldest to newest buffered snapshot)
 - Recording starts sending only after that buffered duration reaches the configured minimum duration
 - After this threshold is reached once in a session, new snapshots are sent normally for the rest of that session
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

Missed cause automerge from https://github.com/PostHog/posthog.com/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Amerged

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
