### PR TITLE
Revert PR #16443: error tracking settings URL update

### DIFF
--- a/contents/docs/error-tracking/_snippets/suppression-rules.mdx
+++ b/contents/docs/error-tracking/_snippets/suppression-rules.mdx
@@ -1,8 +1,8 @@
-Autocaptured exceptions can be ignored client-side by configuring suppression rules in [error tracking settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-suppression-rules). You can only filter based on the exception type and message attributes because the stack of an exception may still be minified client-side.
+Autocaptured exceptions can be ignored client-side by [configuring suppression rules](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-suppression-rules) in PostHog settings. You can only filter based on the exception type and message attributes because the stack of an exception may still be minified client-side.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/suppression_rule_light_8db44eb6b1.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/suppression_rule_dark_5972d57398.png"
-  alt="Issue suppression rules"
-  classes="rounded"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/suppression_rule_light_8db44eb6b1.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/suppression_rule_dark_5972d57398.png"
+    alt="Issue suppression rules"
+    classes="rounded"
 />

--- a/contents/docs/error-tracking/alerts.mdx
+++ b/contents/docs/error-tracking/alerts.mdx
@@ -6,13 +6,13 @@ To stay on top of issues, you can set up alerts. These enable you to post to Sla
 
 ## Issue created or reopened
 
-To alert when an issue is created or reopened, go to [error tracking settings](https://app.posthog.com/settings/environment-error-tracking#error-tracking-alerting) and click **Alerting**. This shows you a list of existing alerts. Clicking **New notification** brings you to a page to create a new one.
+To alert when an issue is created or reopened, go to [error tracking's configuration page](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-alerting) and click **Alerting**. This shows you a list of existing alerts. Clicking **New notification** brings you to a page to create a new one.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/error_alerts_create_light_1a05deef21.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/error_alerts_create_dark_7585087b18.png"
-  alt="Error tracking alerting"
-  classes="rounded"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/error_alerts_create_light_1a05deef21.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/error_alerts_create_dark_7585087b18.png"
+    alt="Error tracking alerting"
+    classes="rounded"
 />
 
 Choosing an option brings you to a page to configure the alert. This may require setting up the Slack integration or pasting in a webhook URL. Once done, you can test the alert by clicking **Test function** and then finalize by clicking **Create & enable**.
@@ -26,10 +26,10 @@ This will then send alerts to your chosen destination when an issue is created o
 You can filter an alert based on the properties of an issue. This is useful for notifying a specific team when they have been auto assigned an issue using [auto assignment rules](/docs/error-tracking/managing-issues#auto-assignment-rules).
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_light_e575af6512.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_dark_9a8907af03.png"
-  alt="Error tracking alert assignee filtering"
-  classes="rounded"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_light_e575af6512.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_dark_9a8907af03.png"
+    alt="Error tracking alert assignee filtering"
+    classes="rounded"
 />
 
 ## Spike alerts
@@ -61,7 +61,7 @@ Check out our [real time destinations docs](/docs/cdp/destinations) for more inf
 
 ### Trend alerts
 
-You can also visualize your `$exception` events using [trends](/docs/product-analytics/trends/overview). Once you create a trend insight, click the **Alerts** button at the top of the insight and then **New alert**.
+You can also visualize your `$exception` events using [trends](/docs/product-analytics/trends/overview). Once you create a trend insight, click the **Alerts** button at the top of the insight and then **New alert**. 
 
 Here you can set alerts for event volume value, increase, or decrease.
 
@@ -74,10 +74,10 @@ Here you can set alerts for event volume value, increase, or decrease.
 
 This sends an email notification to the user you choose. Check out our [alerts docs](/docs/alerts) for more information.
 
-import { CalloutBox } from "components/Docs/CalloutBox";
+import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Can't find your alert?" type="fyi">
 
-If you'd like a destination to be added that we don't yet support, [let us know in-app](https://app.posthog.com/#panel=support%3Afeedback%3Aerror_tracking%3A%3Afalse).
+  If you'd like a destination to be added that we don't yet support, [let us know in-app](https://app.posthog.com/#panel=support%3Afeedback%3Aerror_tracking%3A%3Afalse).
 
 </CalloutBox>

--- a/contents/docs/error-tracking/pricing.mdx
+++ b/contents/docs/error-tracking/pricing.mdx
@@ -4,14 +4,14 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog Error Tracking comes with a generous free tier and transparent, usage-based pricing. Our large free tier means more than 90% of companies _use PostHog for free_.
+PostHog Error Tracking comes with a generous free tier and transparent, usage-based pricing. Our large free tier means more than 90% of companies *use PostHog for free*.
 
 No credit card is required to get started. You can also set billing limits to avoid any surprise
 charges.
 
 Error Tracking is billed by the number of `$exception` events you capture. The price per event changes based on your usage. You can estimate your costs using our pricing calculator below or by visiting our [pricing page](/pricing) for a more detailed breakdown.
 
-import Pricing from "components/Pricing/PricingCalculator/SingleProduct.tsx";
+import Pricing from 'components/Pricing/PricingCalculator/SingleProduct.tsx'
 
 <Pricing productType="error_tracking" />
 
@@ -22,7 +22,6 @@ We aim to be significantly cheaper than our competitors. Below are tips to reduc
 Error tracking bills you based on the number of `$exception` events **_ingested_** by PostHog _each month_. This means if you send exception events to PostHog, they will be billed.
 
 This also means:
-
 - The total number of exceptions stored in PostHog does not contribute to your bill.
 - The number of [issues](/docs/error-tracking/issues-and-exceptions) in PostHog does not affect your bill, only the individual exception events that make up the issues.
 - Merging, resolving, and suppressing issues in PostHog does not reduce your bill.
@@ -37,7 +36,7 @@ The best way to reduce your bill is to reduce the number of `$exception` events 
 
 ### Configure exception autocapture
 
-By default, we capture all unhandled errors and rejections. This can capture more than you need. To reduce which exceptions that are captured, you can configure which types of exceptions are autocaptured in the JS SDK config like this:
+By default, we capture all unhandled errors and rejections. This can capture more than you need. To reduce which exceptions that are captured, you can configure which types of exceptions are autocaptured in the JS SDK config like this: 
 
 ```json
 {
@@ -49,22 +48,22 @@ By default, we capture all unhandled errors and rejections. This can capture mor
 }
 ```
 
-Alternatively, you can disable exception autocapture completely in your [error tracking settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-exception-autocapture).
+Alternatively, you can disable exception autocapture completely in your [project settings](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-exception-autocapture).
 
 ### Suppression rules
 
-import SuppressionRules from "./_snippets/suppression-rules.mdx";
+import SuppressionRules from './_snippets/suppression-rules.mdx'
 
 <SuppressionRules />
 
 ### Burst protection
 
-import BurstProtection from "./_snippets/burst-protection.mdx";
+import BurstProtection from './_snippets/burst-protection.mdx'
 
 <BurstProtection />
 
 ### Using the `before_send` hook
 
-import BeforeSendHook from "./_snippets/before-send-hook.mdx";
+import BeforeSendHook from './_snippets/before-send-hook.mdx'
 
 <BeforeSendHook />

--- a/contents/docs/error-tracking/spikes.mdx
+++ b/contents/docs/error-tracking/spikes.mdx
@@ -2,7 +2,7 @@
 title: Detect spikes in exception volume
 ---
 
-import { CalloutBox } from "components/Docs/CalloutBox";
+import { CalloutBox } from 'components/Docs/CalloutBox'
 
 Spike detection automatically monitors each issue for sudden increases in exception volume, so you can catch regressions and incidents the moment they happen — without manually watching dashboards.
 
@@ -11,10 +11,10 @@ Spike detection automatically monitors each issue for sudden increases in except
 PostHog continuously tracks the exception rate for every issue using a rolling baseline. Every hour, we measure activity in 5-minute buckets. When the current bucket's exception count exceeds the baseline by a configurable **multiplier**, we emit a spike event for that issue.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T15_25_15_975_Z_bd4e418d5c.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T15_24_52_984_Z_ce05d97ce6.png"
-  alt="How spike detection works"
-  classes="rounded"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T15_25_15_975_Z_bd4e418d5c.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T15_24_52_984_Z_ce05d97ce6.png"
+    alt="How spike detection works"
+    classes="rounded"
 />
 
 ### Baseline calculation
@@ -25,23 +25,23 @@ If an issue is too new or hasn't had enough activity to establish a meaningful b
 
 ## Configuring spike detection
 
-You can configure spike detection in the [error tracking settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-spike-detection).
+You can configure spike detection in the [error tracking configuration page](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-spike-detection).
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T12_43_56_983_Z_9b524d4498.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T12_42_39_103_Z_77b881e459.png"
-  alt="Spike detection chart"
-  classes="rounded"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T12_43_56_983_Z_9b524d4498.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_03_11_T12_42_39_103_Z_77b881e459.png"
+    alt="Spike detection chart"
+    classes="rounded"
 />
 
 The following options are available:
 
-| Option                | Description                                                                                                                                                                        |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Minimum threshold** | Issues with fewer occurrences than this value in a 5-minute bucket will never trigger a spike. This prevents noise from low-volume issues.                                         |
-| **Multiplier**        | How many times the current bucket must exceed the baseline for the spike to fire. A higher multiplier means only more dramatic surges trigger an alert.                            |
-| **Snooze duration**   | After a spike fires for an issue, you won't be notified again for this many minutes — even if the issue continues spiking. This prevents alert fatigue during sustained incidents. |
+| Option | Description |
+| --- | --- |
+| **Minimum threshold** | Issues with fewer occurrences than this value in a 5-minute bucket will never trigger a spike. This prevents noise from low-volume issues. |
+| **Multiplier** | How many times the current bucket must exceed the baseline for the spike to fire. A higher multiplier means only more dramatic surges trigger an alert. |
+| **Snooze duration** | After a spike fires for an issue, you won't be notified again for this many minutes — even if the issue continues spiking. This prevents alert fatigue during sustained incidents. |
 
 ## Getting notified about spikes
 
-You can set up alerts to be notified when a spike occurs. Head to the [error tracking settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-spike-detection) to configure notifications to Slack, Discord, Teams, HTTP Webhook and more
+You can set up alerts to be notified when a spike occurs. Head to the [alerts tab](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-spike-detection) to configure notifications to Slack, Discord, Teams, HTTP Webhook and more

--- a/contents/docs/error-tracking/troubleshooting.mdx
+++ b/contents/docs/error-tracking/troubleshooting.mdx
@@ -13,16 +13,16 @@ This page covers troubleshooting for Error Tracking. For setup, see the [install
 If PostHog isn't capturing errors:
 
 1. Use the [SDK Doctor](/docs/sdk-doctor) to verify your SDKs are updated to the latest version
-2. Verify **exception capture** is enabled in your [error tracking settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-exception-autocapture)
+2. Verify **exception capture** is enabled on the [**Configuration** page](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-exception-autocapture) in Error Tracking
 3. Only unhandled exceptions auto-capture. For caught errors, use `posthog.captureException()`:
 
-   ```js
-   try {
-     // code that errors
-   } catch (error) {
-     posthog.captureException(error);
-   }
-   ```
+    ```js
+    try {
+        // code that errors
+    } catch (error) {
+        posthog.captureException(error)
+    }
+    ```
 
 4. Wait a few minutes and check [Error Tracking in the PostHog app](https://app.posthog.com/error_tracking). Issues may take a few minutes to update after ingesting new error events
 
@@ -30,9 +30,9 @@ If PostHog isn't capturing errors:
 
 If stack traces show minified code instead of original source:
 
-1. Verify source maps are uploaded to the correct project by navigating to your [error tracking settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-symbol-sets). You'll see warnings for missing symbol sets
+1. Verify source maps are uploaded to the correct project by navigating to [Error Tracking](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-symbol-sets). You'll see warnings for missing symbol sets
 2. Source map paths must match your production bundle URLs exactly
-3. Upload source maps _before_ deploying code that references them
+3. Upload source maps *before* deploying code that references them
 
 See the [source maps guide](/docs/error-tracking/upload-source-maps/) for upload instructions.
 
@@ -68,18 +68,18 @@ This happens when you reject a promise with a string instead of an `Error` objec
 
 ```js file=Without stack trace
 new Promise((resolve, reject) => {
-  reject("Something went wrong"); // String has no stack trace
+  reject('Something went wrong'); // String has no stack trace
 });
 
-Promise.reject("Something went wrong");
+Promise.reject('Something went wrong');
 ```
 
 ```js file=With stack trace
 new Promise((resolve, reject) => {
-  reject(new Error("Something went wrong")); // Error includes stack trace
+  reject(new Error('Something went wrong')); // Error includes stack trace
 });
 
-Promise.reject(new Error("Something went wrong"));
+Promise.reject(new Error('Something went wrong'));
 ```
 
 </MultiLanguage>
@@ -87,10 +87,11 @@ Promise.reject(new Error("Something went wrong"));
 For third-party libraries that reject with strings, wrap the rejection:
 
 ```js
-somePromise().catch((err) => {
-  posthog.captureException(new Error(err));
-  throw err;
-});
+somePromise()
+  .catch(err => {
+    posthog.captureException(new Error(err))
+    throw err
+  })
 ```
 
 ## 'Minified React error' with no stack trace
@@ -108,6 +109,7 @@ To debug:
 3. Watch [session recordings](/docs/session-replay) to see what user actions triggered the error, then reproduce in development
 4. Use a development build which includes full error messages. Only use this for debugging, not production
 
+
 ## Symbol set upload skipped as already present
 
 If the CLI reports `Server returned 0 upload keys (1 skipped as already present)`, it means a symbol set with the same chunk ID already exists on the server. This happens when your bundle content hasn't changed between builds — the chunk ID is derived from the bundle's content hash, so identical code produces identical IDs.
@@ -115,15 +117,15 @@ If the CLI reports `Server returned 0 upload keys (1 skipped as already present)
 To force a fresh upload:
 
 1. Make a real change to your application code (not just a whitespace change), or
-2. Delete the existing symbol set in the [error tracking symbol sets settings](https://us.posthog.com/settings/environment-error-tracking#error-tracking-symbol-sets) UI and rerun the build
+2. Delete the existing symbol set in the [Error Tracking Symbol Sets](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-symbol-sets) UI and rerun the build
 
 ## Grouping or assignment rules disabled
 
-Rules can become disabled if PostHog encounters a processing error while evaluating the rule during exception ingestion. When a rule is disabled, a banner appears in the [error tracking settings](https://us.posthog.com/settings/environment-error-tracking) showing the error message.
+Rules can become disabled if PostHog encounters a processing error while evaluating the rule during exception ingestion. When a rule is disabled, a banner appears in the [Error Tracking **Configuration** tab](https://us.posthog.com/error_tracking) showing the error message.
 
 To fix and re-enable a disabled rule:
 
-1. Go to your [custom grouping rules](/docs/error-tracking/grouping-issues#custom-grouping-rule) or [auto assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment) in your [error tracking settings](https://us.posthog.com/settings/environment-error-tracking)
+1. Go to your [custom grouping rules](/docs/error-tracking/grouping-issues#custom-grouping-rule) or [auto assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment) in the **Configuration** tab
 2. Find the rule with the disabled banner and review the error message
 3. Edit the rule to correct the configuration issue
 4. Save the rule – this automatically re-enables it
@@ -133,10 +135,10 @@ If the error persists after editing, reach out to support.
 ## Solved community questions
 
 <SolvedQuestions
-  topicLabel="Error Tracking"
-  pinnedQuestions={[
-    "code-variables-for-external-libraries-for-python",
-    "trouble-setting-up-source-map-in-vite-react",
-    "webpack-turbopack-plugin-getting-sourcemaps-uploaded-to-vercel",
-  ]}
+    topicLabel="Error Tracking"
+    pinnedQuestions={[
+        'code-variables-for-external-libraries-for-python',
+        'trouble-setting-up-source-map-in-vite-react',
+        'webpack-turbopack-plugin-getting-sourcemaps-uploaded-to-vercel'
+    ]}
 />


### PR DESCRIPTION
## Changes

- Reverts PR [#16443](https://github.com/PostHog/posthog.com/pull/16443).
- Restores the previous Error Tracking docs links from centralized settings URLs back to the prior configuration URLs.
- Reverted files:
  - `contents/docs/error-tracking/_snippets/suppression-rules.mdx`
  - `contents/docs/error-tracking/alerts.mdx`
  - `contents/docs/error-tracking/pricing.mdx`
  - `contents/docs/error-tracking/spikes.mdx`
  - `contents/docs/error-tracking/troubleshooting.mdx`

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

Related PR: https://github.com/PostHog/posthog/pull/55225