### PR TITLE
Add Discord goal to Q2 IRL Events objectives

### DIFF
--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -49,6 +49,30 @@ These are the primary goals the team is prioritizing this quarter.
 </details> 
 
 <details> 
+<summary>Test Discord as a live channel for builder community engagement</summary>
+
+**Owner:** <TeamMember name="Kliment Minchev" photo /> <TeamMember name="Daniel Zaltsman" photo /> 
+
+**Motivation:** Before committing to a broader community strategy or hire, we'll be running disciplined experiments to learn whether Discord generates genuine, durable participation — not just sign-ups — and whether PostHog can sustain it without over-investing upfront.
+
+**What we'll ship:**
+- Server structure and channel architecture (purpose-built, not default Discord layout)
+- Onboarding flow that clearly sets expectations on what the space is and isn't for
+- Handbook bot for self-serve answers
+- PostHog API integration to link Discord handles to PostHog user accounts where possible
+- Bi-weekly virtual events (session replay parties, product demos, mini talks) to give members a reason to show up
+- Pulse survey cadence for members who stick around past week 2
+- Lightweight moderation playbook and role system based on engagement level
+
+**We'll know we're successful when:**
+- DAU/MAU ratio reaches or exceeds 20% (the benchmark for a default-alive community)
+- At least 25% of new members send 3 or more messages within their first two weeks
+- We can point to at least one meaningful signal we couldn't have gotten elsewhere — a product insight, a super-user, a cross-user collaboration, or a partner co-event lead
+- The team feels like it's worth continuing, not just maintaining
+
+</details>
+
+<details> 
 <summary>Build a global, self-sustaining builder groups network</summary>
 
 **Owner:**<TeamMember name="Kliment Minchev" photo />

--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -49,7 +49,7 @@ These are the primary goals the team is prioritizing this quarter.
 </details> 
 
 <details> 
-<summary>Test Discord as a live channel for builder community engagement</summary>
+<summary>Test [Discord](https://discord.gg/6b8upjDs) as a live channel for builder community engagement</summary>
 
 **Owner:** <TeamMember name="Kliment Minchev" photo /> <TeamMember name="Daniel Zaltsman" photo /> 
 


### PR DESCRIPTION
## Changes

* Adds a new Q2 objective to team IRL objectives
* Introduces Discord as a live channel experiment for builder community engagement

Related to [community thread](https://github.com/PostHog/requests-for-comments-internal/pull/1051)

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
