### PR TITLE
fix(elixir): loosen dep specifier to ~> 2.0

### DIFF
--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -5,7 +5,7 @@ The package can be installed by adding `posthog` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:posthog, "~> 2.2.0"}
+    {:posthog, "~> 2.0"}
   ]
 end
 ```


### PR DESCRIPTION
## Changes

Bump the Elixir SDK version specifier in the shared install snippet from `~> 2.2.0` to `~> 2.0`.

### Why

In Elixir's Mix, `~> 2.2.0` (three parts) resolves to `>= 2.2.0 and < 2.3.0`, pinning installs to the 2.2.x patch series. The latest release on Hex.pm is `2.6.0`, so customers following the current snippet end up on `2.2.0`.

`~> 2.0` (two parts) resolves to `>= 2.0.0 and < 3.0.0`, allowing all 2.x minor releases. This matches the upstream [posthog-elixir README](https://github.com/PostHog/posthog-elixir#getting-started).

### Scope

This snippet is imported by:

- `/docs/libraries/elixir` (via `contents/docs/libraries/elixir/index.mdx`)
- `/docs/feature-flags/installation/elixir` (via `contents/docs/feature-flags/installation/elixir.mdx`)
- `/docs/product-analytics/installation/elixir` (this page actually imports the in-app onboarding from PostHog/posthog, which is being fixed in a parallel PR)

### Related

- PostHog/posthog PR: `fix(onboarding): align elixir snippet with v2 SDK` on branch `fix/elixir-onboarding-config` fixes the same version-pinning issue plus an `api_url` → `api_host` config key fix in the in-app onboarding snippet.

There's also a corresponding / related fix on the main PostHog repo:
https://github.com/PostHog/posthog/pull/55435

## Checklist

- [x] I've read the docs style guide
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build (agent-authored, please verify)
- [x] No page was moved, no redirect needed
