### PR TITLE
docs(toolbar): note that authorized URLs must match the site origin including the port

### DIFF
--- a/contents/docs/toolbar/index.mdx
+++ b/contents/docs/toolbar/index.mdx
@@ -40,6 +40,8 @@ With it, you can interact with elements to [create actions](/tutorials/how-to-ca
 3. Click **Save** and then **Launch**.
 4. A new window will open with toolbar on your website. Click on the toolbar to interact with it.
 
+> **Note:** The authorized URL must match your site's origin exactly, including the port. For example, if your local dev server runs on `http://localhost:3000`, authorize `http://localhost:3000` – not `http://localhost`. Likewise, if your production site runs on the default `http://example.com` (no port), authorize it without a port. Mismatching the port is a common reason the toolbar does not appear.
+
 <ProductVideo
     videoLight = {setupLight}
     videoDark = {setupDark}
@@ -179,6 +181,18 @@ if (toolbarJSON) {
 #### 2. The toolbar is being blocked by an ad blocker
 
 Ad blockers can block the toolbar from loading or displaying. Turning off your ad blocker should fix the issue in this case.
+
+#### 3. The authorized URL does not match your site's origin (including port)
+
+The toolbar only loads on pages whose origin is in the "Authorized URLs for Toolbar" list. Origins are compared by `protocol + host + port`, so a port mismatch is enough to silently prevent the toolbar from appearing.
+
+Common gotchas:
+
+- Authorized URL is `http://localhost` but your dev server runs on `http://localhost:3000` (or `:8080`, `:5173`, etc.). Fix: authorize the full URL with the port, e.g. `http://localhost:3000`.
+- Authorized URL is `https://example.com:443` but your site serves on `https://example.com` (default port, no explicit port in the URL bar). Fix: drop the explicit `:443`.
+- Authorized URL has a trailing path or query string. Only the origin (`protocol + host + port`) is used for matching; paths are ignored, but extra characters can still be confusing when debugging. Keep the entry as just the origin.
+
+If the toolbar still does not appear after confirming the origin, check the browser console for CSP or CORS errors (see the sections below).
 
 ### Toolbar authentication issue (with reverse proxy)
 


### PR DESCRIPTION
﻿## Problem

Users who add an entry to **"Authorized URLs for Toolbar"** that does not match their site's actual origin (specifically, the port) often see the toolbar silently fail to load. This has tripped up at least one user for ~1 hour of debugging (see #9789).

Looking at [`checkUrlIsAuthorized`](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts), matching uses `parsedUrl.protocol + '//' + parsedUrl.host`, and `URL.host` **includes the port** when one is present. So `http://localhost` and `http://localhost:3000` are not a match. The previous docs did not call this out.

## Fix

Adds two pieces of guidance to `contents/docs/toolbar/index.mdx`:

1. A short callout under **How to launch the toolbar** telling users the authorized URL must match the site origin exactly (including port), with a concrete local-dev example.
2. A troubleshooting entry (`#### 3. The authorized URL does not match your site's origin (including port)`) that lists the three most common mismatch shapes (missing port, explicit default port like `:443`, trailing path/query).

No behaviour changes -- docs only.

## Closes

Closes #9789.

## How I tested

- Read `authorizedUrlListLogic.ts` to confirm origin matching uses `protocol + host` (host includes port).
- Rendered the MDX locally to confirm the note and the new `####` heading sit in the expected positions within the toolbar page.
