### PR TITLE
docs(ios): correct iOS autocapture defaults

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -409,20 +409,22 @@ PostHog captures the following events:
 
 #### Configuring screen navigation autocapture
 
-Screen navigation autocapture is not enabled by default. You can enable it by setting `captureScreenViews` to `true` in the config.
+Screen navigation autocapture is **enabled by default**. You can disable it by setting `captureScreenViews` to `false` in the config.
 
-| Option                              | Description                                                                                     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `captureScreenViews`                | **Type:** `boolean`. When set to `true`, autocapture will capture screen views.                 |
-| `captureApplicationLifecycleEvents` | **Type:** `boolean`. When set to `true`, autocapture will capture application lifecycle events. |
+| Option                              | Description                                                                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `captureScreenViews`                | **Type:** `boolean`. **Default:** `true`. When `true`, autocapture will capture screen views (`$screen` events).                             |
+| `captureApplicationLifecycleEvents` | **Type:** `boolean`. **Default:** `true`. When `true`, autocapture will capture application lifecycle events (`Application Installed` etc.). |
+| `captureElementInteractions`        | **Type:** `boolean`. **Default:** `false`. When `true`, autocapture will capture element interactions (iOS / Mac Catalyst only).             |
 
-For example, your initialization code might look like this:
+For example, if you want to turn off the defaults and only enable element interactions, your initialization code might look like this:
 
 ```swift
 let config = PostHogConfig(apiKey: <ph_project_token>, host: <ph_client_api_host>)
 
-config.captureElementInteractions = true // Disabled by default
-config.captureApplicationLifecycleEvents = true // Disabled by default
+config.captureScreenViews = false                // Enabled by default
+config.captureApplicationLifecycleEvents = false // Enabled by default
+config.captureElementInteractions = true         // Disabled by default
 
 PostHogSDK.shared.setup(config)
 ```


### PR DESCRIPTION
## Problem

Closes #16182.

The iOS autocapture section of [/docs/product-analytics/autocapture](https://posthog.com/docs/product-analytics/autocapture) is wrong in two ways:

1. It says _"Screen navigation autocapture is not enabled by default."_
2. The Swift example comments `config.captureApplicationLifecycleEvents = true` as _"Disabled by default."_

Both contradict the [`posthog-ios` SDK defaults](https://github.com/PostHog/posthog-ios/blob/main/PostHog/PostHogConfig.swift):

```swift
@objc public var captureApplicationLifecycleEvents: Bool = true
@objc public var captureScreenViews: Bool = true

#if os(iOS) || targetEnvironment(macCatalyst)
    /// Default: false
    @objc public var captureElementInteractions: Bool = false
#endif
```

## Changes

- Flip the sentence to say screen navigation autocapture **is** enabled by default.
- Add a **Default** column to the options table.
- Document the previously-missing `captureElementInteractions` option (iOS / Mac Catalyst only, default `false`).
- Rework the Swift example to show how to turn the defaults off while enabling element interactions, with accurate inline comments.

## Preview

Before:

> Screen navigation autocapture is not enabled by default. You can enable it by setting `captureScreenViews` to `true` in the config.
>
> ```swift
> config.captureElementInteractions = true // Disabled by default
> config.captureApplicationLifecycleEvents = true // Disabled by default
> ```

After:

> Screen navigation autocapture is **enabled by default**. You can disable it by setting `captureScreenViews` to `false` in the config.
>
> ```swift
> config.captureScreenViews = false                // Enabled by default
> config.captureApplicationLifecycleEvents = false // Enabled by default
> config.captureElementInteractions = true         // Disabled by default
> ```
