### PR TITLE
docs: Rewrite LLM analytics skills store guide around native skill MCP tools

### DIFF
--- a/contents/docs/llm-analytics/skills-store.mdx
+++ b/contents/docs/llm-analytics/skills-store.mdx
@@ -1,30 +1,37 @@
 ---
-title: Using prompts as a shared skills store
+title: Using the PostHog skills store
 ---
 
-import PromptsAlpha from "./_snippets/prompts-alpha.mdx"
+Your team's coding agents (Claude Code, Cursor, Codex, Windsurf, and others) all support [MCP](/docs/model-context-protocol). PostHog's skills store gives you a centralized, versioned place to store and share reusable agent skills — following the [Agent Skills specification](https://agentskills.io/specification) — across any tool, for any team member.
 
-<PromptsAlpha />
+> **Shortcut: install the PostHog AI plugin.** The [PostHog AI plugin](https://github.com/PostHog/ai-plugin) ships an official [`skills-store` skill](https://github.com/PostHog/ai-plugin/tree/main/skills/skills-store) — maintained alongside the [canonical version in the PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/llm_analytics/skills/skills-store) — that teaches your agent exactly how to discover, load, create, and update skills via the PostHog MCP tools. Install the plugin in [Claude Code](/docs/model-context-protocol/claude-code), [Codex](/docs/model-context-protocol/codex), Cursor, or Gemini CLI and your agent already knows how to use the store. The rest of this guide covers the same concepts in case you want to understand what's happening under the hood or roll your own bridge.
 
-Your team's coding agents (Claude Code, Cursor, Codex, Windsurf, and others) all support [MCP](/docs/model-context-protocol). PostHog [Prompts](/docs/llm-analytics/prompts) combined with MCP gives you a centralized, versioned place to store and share reusable agent skills — across any tool, for any team member.
-
-## Why use prompts as a skills store?
+## Why use PostHog as your skills store?
 
 - **Works in any MCP-connected agent** — Claude Code, Cursor, Codex, Windsurf, VS Code, and more
 - **Centrally managed** — Update a skill once, every team member gets the latest version on their next fetch
-- **Full version history** — See exactly what changed between versions using the [diff view](/docs/llm-analytics/prompts#compare-versions)
+- **Full version history** — Every edit creates an immutable version, with `base_version` concurrency checks
+- **Bundled files** — Skills can include scripts, references, and assets alongside the instructions
+- **Progressive disclosure** — Agents list skills by description, load bodies on demand, and fetch bundled files only when needed
 - **No vendor lock-in** — Not tied to a specific agent or IDE
 - **Non-engineers can contribute** — Anyone on your team can create and maintain skills through the PostHog UI
-- **Skills evolve with proper versioning** — You or your agent can update skills, and every change is tracked
 
 ## How it works
 
-The pattern is simple:
+A PostHog skill follows the [Agent Skills specification](https://agentskills.io/specification): a body of instructions (the equivalent of a `SKILL.md`), plus optional bundled files, structured metadata, and an `allowed_tools` list.
 
-1. **PostHog Prompts** stores the skill content as versioned markdown
-2. **MCP prompt tools** (`prompt-get`, `prompt-list`) let agents fetch and run skills at runtime
+The MCP server exposes the skills store through a dedicated family of tools:
 
-When a team member wants to use a skill, they ask their agent to fetch it from PostHog via MCP. The agent reads the instructions and follows them. No local files to sync, no git repos to pull — just one source of truth.
+| Tool | Purpose |
+|------|---------|
+| `skill-list` | List all available skills (name + description only) |
+| `skill-get` | Fetch a skill by name — returns the body and a manifest of bundled files |
+| `skill-file-get` | Fetch a single bundled file by path (on demand) |
+| `skill-create` | Store a new skill, optionally with bundled files |
+| `skill-update` | Publish a new immutable version (with `base_version` for concurrency) |
+| `skill-duplicate` | Duplicate an existing skill under a new name |
+
+Agents use these with progressive disclosure: discover by description, fetch the body only when relevant, and pull individual files on demand — rather than loading everything up front.
 
 ## Prerequisites
 
@@ -33,36 +40,42 @@ When a team member wants to use a skill, they ask their agent to fetch it from P
 
 ## Step 1: Create a skill
 
-A skill is just a PostHog prompt that contains agent instructions instead of an LLM system prompt. Let's create one — a skill called `hog-release-notes` that writes release notes in PostHog's voice.
+Let's create a skill called `hog-release-notes` that writes release notes in PostHog's voice.
 
 ### Via the PostHog UI
 
-1. Navigate to **LLM analytics** > **Prompts**
-2. Click **New prompt**
+1. Navigate to **LLM analytics** > **Skills**
+2. Click **New skill**
 3. Name it `hog-release-notes`
-4. Paste your skill content (see example below)
-5. Click **Create prompt**
+4. Add a description that explains *when* to use the skill — this is what agents use to discover it
+5. Paste your skill body (see example below)
+6. Optionally add bundled files, `allowed_tools`, `license`, `compatibility`, or metadata
+7. Click **Create skill**
 
 ### Via MCP
 
 Ask your agent to create the skill:
 
 ```text
-Use the PostHog MCP prompt-create tool to create a prompt named
+Use the PostHog MCP skill-create tool to create a skill named
 "hog-release-notes" with the content I'll provide.
 ```
 
-Or call `prompt-create` directly:
+Or call `skill-create` directly:
 
+```json
+{
+  "name": "hog-release-notes",
+  "description": "Write PostHog release notes from recent merged changes. Use when the user asks to draft, generate, or update release notes.",
+  "body": "# Hog release notes writer\n\nYou write release notes for PostHog...",
+  "allowed_tools": ["Bash", "Read", "Grep"],
+  "metadata": { "author": "posthog", "category": "docs" }
+}
 ```
-Tool: prompt-create
-Name: hog-release-notes
-Content: (see example below)
-```
 
-### Example skill content
+### Example skill body
 
-A good skill gives the agent all the context it needs — where to find information, what format to use, and any project-specific knowledge. Here's what `hog-release-notes` might look like:
+A good skill body gives the agent all the context it needs — where to find information, what format to use, and any project-specific knowledge:
 
 ```markdown
 # Hog release notes writer
@@ -100,46 +113,62 @@ You write release notes for PostHog. Follow these rules.
 Write the release notes as markdown, ready to append to the changelog.
 ```
 
-Notice the skill includes everything the agent needs to work autonomously — where to look for changes, what's already published, and how to format the output. The more context you bake in, the less you need to explain each time you run it.
+The more context you bake into the body, the less you need to explain each time you run the skill.
+
+### Bundled files (optional)
+
+If your skill needs scripts, reference docs, or assets, include them in the same `skill-create` call:
+
+```json
+{
+  "name": "make-fractals",
+  "description": "Generate fractal images as PNGs. Use when the user asks to make, render, or visualize fractals.",
+  "body": "# make-fractals\n\nWhen to use... Workflow... Output contract...",
+  "compatibility": "Requires Python 3.10+ with Pillow and numpy",
+  "allowed_tools": ["Bash", "Write"],
+  "files": [
+    { "path": "scripts/mandelbrot.py", "content": "...", "content_type": "text/x-python" },
+    { "path": "references/primer.md", "content": "# Primer\n...", "content_type": "text/markdown" }
+  ]
+}
+```
+
+The body can reference bundled files by path. Agents pull them with `skill-file-get` only when they actually need them.
 
 ## Step 2: Use a skill from any agent
 
-Once a skill exists in PostHog, any team member with the MCP server configured can use it. No extra setup needed — just ask your agent. Since PostHog MCP is already connected, your agent can fetch and run skills directly.
+Once a skill exists in PostHog, any team member with the MCP server configured can use it.
 
 ### Discover available skills
 
 ```text
-Use PostHog MCP prompts to list all available skills.
+Use PostHog MCP to list available skills.
 ```
 
-This calls `prompt-list` and returns all prompts in your project.
+This calls `skill-list` and returns every skill's name + description — never the body. Agents pick the right skill from the description alone, without loading any bodies.
+
+You can also filter:
+
+```text
+Use PostHog MCP to search skills for "release notes".
+```
 
 ### Fetch and run a skill
 
 ```text
-Use PostHog MCP prompts to fetch "hog-release-notes" and follow its
+Use PostHog MCP to fetch "hog-release-notes" and follow its
 instructions to write release notes for the changes in my current branch.
 ```
 
-The agent calls `prompt-get` with the name `hog-release-notes`, receives the skill content, and follows the instructions — writing release notes based on your branch's changes.
+The agent calls `skill-get` with `skill_name: "hog-release-notes"`, receives the body + file manifest, reads the body as its system instructions, and gets to work — fetching any referenced bundled files via `skill-file-get` on demand.
 
-That's it. This works identically in Claude Code, Cursor, Codex, or any other MCP-connected agent. The skill lives in PostHog, not in any particular tool. You can also create and update skills the same way:
-
-```text
-Use PostHog MCP prompts to create a new skill called "review-api-pr"
-that reviews PRs against our API design guidelines.
-```
-
-```text
-Use PostHog MCP prompts to update "hog-release-notes" to add a
-"Breaking changes" section.
-```
+This works identically in Claude Code, Cursor, Codex, or any other MCP-connected agent. The skill lives in PostHog, not in any particular tool.
 
 ## Step 3: Set up a bridge skill (optional shortcut)
 
-Step 2 is all you need — but if your agent supports local slash commands (like Claude Code), you can optionally set up a bridge skill to make invocation a bit more convenient. Instead of typing "use PostHog MCP prompts to..." each time, you get a slash command.
+Step 2 is all you need. If you've installed the [PostHog AI plugin](https://github.com/PostHog/ai-plugin), you can skip this step entirely — the plugin's `skills-store` skill already provides the bridge.
 
-You create **one** generic bridge that can fetch and run any skill by name:
+Otherwise, if your agent supports local skills (like Claude Code's `.claude/skills/` directory), you can drop in a tiny DIY bridge that bootstraps into the PostHog skills store. You only need **one** generic bridge:
 
 ### Claude Code example
 
@@ -149,29 +178,24 @@ Create a file at `.claude/skills/posthog-skills-store/SKILL.md`:
 ---
 name: posthog-skills-store
 description: Access and run shared team skills stored in PostHog.
-  Use when the user asks to list, run, or manage PostHog skills/prompts.
-user-invocable: true
-allowed-tools: mcp__posthog__prompt-list, mcp__posthog__prompt-get,
-  mcp__posthog__prompt-create, mcp__posthog__prompt-update
+  Use when the user asks to list, browse, load, or manage PostHog
+  skills, or references "skills store" or "skill store".
+allowed-tools: mcp__posthog__skill-list, mcp__posthog__skill-get,
+  mcp__posthog__skill-file-get, mcp__posthog__skill-create,
+  mcp__posthog__skill-update, mcp__posthog__skill-duplicate
 ---
 
 # PostHog Skills Store
 
 Fetch the full instructions from PostHog:
 
-1. Call `prompt-get(name="posthog-skills-store")` to load the latest version
-2. Follow the instructions in the returned prompt
+1. Call `skill-get(skill_name="skills-store")` to load the latest version
+2. Follow the instructions in the returned body
 ```
 
-This bridge is intentionally thin — it just bootstraps into PostHog, where the real instructions live. Now team members can type things like:
+The bridge is intentionally thin — it just points at the canonical `skills-store` skill in PostHog, where the real instructions live. Updates to that remote skill automatically reach everyone on the team.
 
-```text
-/posthog-skills-store run hog-release-notes on my current branch
-/posthog-skills-store create a skill called "review-api-pr"
-/posthog-skills-store list all skills
-```
-
-One local file, unlimited remote skills. But again, this is purely a convenience — everything the bridge does, you can do by asking your agent to use PostHog MCP prompts directly.
+One local file, unlimited remote skills. But again, this is purely a convenience — everything the bridge does, you can do by asking your agent to use PostHog MCP skills directly.
 
 ## Example: a full session
 
@@ -180,21 +204,21 @@ Here's what using the skills store looks like in practice — from running a ski
 ### Running the skill
 
 ```text
-> Use PostHog MCP prompts to fetch "hog-release-notes" and generate
+> Use PostHog MCP to fetch "hog-release-notes" and generate
   release notes for the latest changes.
 
-Agent fetches the skill via prompt-get("hog-release-notes"), reads the
-instructions, checks the changelog, runs git log, reads PR descriptions,
-and drafts the release notes.
+Agent calls skill-get("hog-release-notes"), reads the body, checks
+the changelog, runs git log, reads PR descriptions, and drafts
+the release notes.
 
 ✓ Here are the release notes for the last two weeks:
 
-  ## Add prompt version diffing
-  You can now compare any two versions of a prompt side-by-side...
+  ## Add skill version diffing
+  You can now compare any two versions of a skill side-by-side...
   ...
 ```
 
-The agent had everything it needed — the skill told it where to find what's already published, how to discover what's new, and how to format the output.
+The agent had everything it needed — the body told it where to find what's already published, how to discover what's new, and how to format the output.
 
 ### Updating the skill mid-session
 
@@ -205,24 +229,24 @@ After reviewing the output, you decide the skill could be better:
   always include a fun hedgehog fact at the end of each set of
   release notes.
 
-Agent calls prompt-get("hog-release-notes") to fetch the current version,
-adds the new rule, then calls prompt-update with the updated content and
-base_version for conflict detection.
+Agent calls skill-get("hog-release-notes") to fetch the current version,
+adds the new rule to the body, then calls skill-update with the updated
+body and base_version for conflict detection.
 
 ✓ Updated "hog-release-notes" to version 2. Added rule:
   "End each set of release notes with a fun hedgehog fact."
 ```
 
-That's it — the skill is updated in PostHog. You can [review the diff](/docs/llm-analytics/prompts#compare-versions) in the PostHog UI to see exactly what changed.
+That's it — the skill is updated in PostHog. You can review the diff in the PostHog UI to see exactly what changed.
 
 ### A teammate benefits automatically
 
 The next day, a teammate runs the same skill from their own agent (Claude Code, Cursor, or anything with PostHog MCP):
 
 ```text
-> Use PostHog MCP prompts to run "hog-release-notes" for this week.
+> Use PostHog MCP to run "hog-release-notes" for this week.
 
-Agent fetches version 2 of the skill (the latest), follows the updated
+Agent calls skill-get and gets version 2 (the latest), follows the updated
 instructions, and includes a hedgehog fact at the end — without the
 teammate needing to know anything changed.
 ```
@@ -231,33 +255,49 @@ No sync, no PR, no "hey I updated the skill" message in Slack. The skill evolved
 
 ## Updating and versioning skills
 
-Skills are versioned just like any other PostHog prompt. Every edit creates a new immutable version.
+Every `skill-update` publishes a new immutable version.
 
 ### Edit a skill
 
-**Via the UI:** Open the prompt, click **Edit latest**, make changes, and click **Publish version**.
+**Via the UI:** open the skill, click **Edit latest**, make changes, and click **Publish version**.
 
-**Via MCP:** Ask your agent to update the skill:
+**Via MCP:** ask your agent to update it. Always fetch first so you have the current `base_version`:
 
 ```text
-Update the PostHog prompt "hog-release-notes" to also include
+Update the PostHog skill "hog-release-notes" to also include
 a "Known limitations" section in the release notes structure.
 ```
 
-This calls `prompt-update` and creates a new version.
+The agent calls `skill-get` to read the current version, then `skill-update` with the new body and `base_version`. Fields you don't pass are carried forward — if you don't send `files`, the existing bundle is preserved. If you do send `files`, they replace the previous version's bundle.
 
 ### Review changes
 
-Use the [Compare versions](/docs/llm-analytics/prompts#compare-versions) feature to see a diff between any two versions. This is especially useful when an agent has updated a skill — you can review exactly what it changed before the rest of your team picks it up.
+Use the compare view in the PostHog UI to see a diff between any two versions. This is especially useful when an agent has updated a skill — you can review exactly what it changed before the rest of your team picks it up.
 
 ### Automatic propagation
 
-Team members automatically get the latest version on their next fetch. No PRs, no syncing, no manual updates — just one source of truth in PostHog.
+Team members get the latest version on their next `skill-get`. No PRs, no syncing, no manual updates — just one source of truth in PostHog.
+
+## Porting a local skill
+
+To move a skill from a local `SKILL.md` directory (e.g. `~/.claude/skills/<name>/` with `scripts/`, `references/`, and `assets/` subdirs) into PostHog:
+
+1. Read the local `SKILL.md` — use its frontmatter for `name`, `description`, `license`, `compatibility`, `allowed_tools`, and `metadata`; the body after the frontmatter becomes `body`
+2. Walk the `scripts/`, `references/`, and `assets/` subdirs and collect each file as `{ path, content, content_type }`
+3. Call `skill-create` with everything in one shot — the skill lands at v1 with its full bundle
+
+The skill is then available to the whole team via `skill-get`.
+
+## Skills vs prompts
+
+PostHog also has a separate [prompts](/docs/llm-analytics/prompts) tool family (`prompt-list`, `prompt-get`, `prompt-create`, `prompt-update`) for plain single-text prompts — LLM system prompts, short reusable text, and anything the SDK fetches at runtime for generations. Skills are the right choice whenever the workflow needs structured metadata, bundled files, or an `allowed_tools` surface. When in doubt, use skills.
 
 ## Team workflow tips
 
 - **Use descriptive, kebab-case names** — `review-frontend-pr`, `write-api-docs`, `check-security-headers`
-- **Discover before you create** — Run `prompt-list` to see what skills your team already has before creating a duplicate
-- **Port local skills to PostHog** — If you have useful instructions saved locally, move them to PostHog so the whole team benefits
-- **Keep skills focused** — One task per skill. A skill that does "everything" is a skill that does nothing well
-- **Let agents update skills** — After an agent follows a skill, ask it to suggest improvements, then update the prompt via MCP
+- **Invest in descriptions** — discovery depends entirely on them; an agent decides whether to load your skill based on its description alone
+- **Discover before you create** — run `skill-list` to see what skills your team already has before creating a duplicate
+- **Port local skills to PostHog** — if you have useful `SKILL.md` files saved locally, move them (with their bundled files) to PostHog so the whole team benefits
+- **Keep skills focused** — one task per skill. A skill that does "everything" is a skill that does nothing well
+- **Don't preload bundled files** — let the agent fetch them on demand via `skill-file-get`; that's the whole point of progressive disclosure
+- **Let agents update skills** — after an agent follows a skill, ask it to suggest improvements, then update via `skill-update`

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5746,7 +5746,7 @@ export const docsMenu = {
                     },
                 },
                 {
-                    name: 'Prompts as a skills store',
+                    name: 'Skills store',
                     url: '/docs/llm-analytics/skills-store',
                     icon: 'IconStack',
                     color: 'blue',


### PR DESCRIPTION
## Summary

- Rewrites `contents/docs/llm-analytics/skills-store.mdx` around PostHog's native `skill-*` MCP tool family (following the [Agent Skills specification](https://agentskills.io/specification)) instead of the generic `prompt-*` tools. Covers progressive disclosure, bundled files, `allowed_tools`, metadata, `base_version` concurrency, and adds a "Skills vs prompts" section.
- Adds a top-of-page callout pointing to the official [`skills-store` skill](https://github.com/PostHog/ai-plugin/tree/main/skills/skills-store) shipped in the [PostHog AI plugin](https://github.com/PostHog/ai-plugin) (canonical source in the [PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/llm_analytics/skills/skills-store)), so readers can just install the plugin instead of rolling their own bridge.
- Renames the sidebar nav entry from "Prompts as a skills store" to "Skills store" in `src/navs/index.js`.

## Test plan

- [ ] Preview the rendered page and check that the callout, tool table, and code blocks look right
- [ ] Verify the sidebar entry reads "Skills store" under LLM analytics
- [ ] Confirm the links to the ai-plugin repo, monorepo skill, Claude Code install page, and Codex install page all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)