### PR TITLE
docs: use app.posthog.com for remaining feature-preview links (partial #13516)

### DIFF
--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -158,7 +158,7 @@ Percentage thresholds are only available for relative alerts (as you need to com
 
 <CalloutBox icon="IconFlask" title="Feature preview" type="info">
 
-Anomaly detection alerts are in **beta**. To enable them, go to [Settings > Feature previews](https://us.posthog.com/settings/user-feature-previews) and toggle on **Anomaly Detection Alerts**.
+Anomaly detection alerts are in **beta**. To enable them, go to [Settings > Feature previews](https://app.posthog.com/settings/user-feature-previews) and toggle on **Anomaly Detection Alerts**.
 
 </CalloutBox>
 

--- a/contents/docs/cdp/sources/incoming-webhooks.mdx
+++ b/contents/docs/cdp/sources/incoming-webhooks.mdx
@@ -11,7 +11,7 @@ import { ProductScreenshot } from 'components/ProductScreenshot'
 
 <CalloutBox icon="IconInfo" title="Feature preview" type="caution">
 
-Incoming webhook sources are experimental and available behind a [feature preview](https://us.posthog.com/settings/user-feature-previews#cdp-hog-sources). For most use cases, we recommend using a [workflow with a webhook trigger](/docs/workflows/workflow-builder#webhook-triggers) combined with a **capture event** action instead — it's more flexible, doesn't require code, and gives you access to delays, branching, and other workflow features.
+Incoming webhook sources are experimental and available behind a [feature preview](https://app.posthog.com/settings/user-feature-previews#cdp-hog-sources). For most use cases, we recommend using a [workflow with a webhook trigger](/docs/workflows/workflow-builder#webhook-triggers) combined with a **capture event** action instead — it's more flexible, doesn't require code, and gives you access to delays, branching, and other workflow features.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Problem

Partial fix for #13516.

Issue #13516 reports that a "feature previews" link points to `us.posthog.com/settings/user-feature-previews`, which redirects EU users through the US region instead of keeping them on EU infra.

The originally-reported location (`/docs/discussion`) has already been updated, but two other docs pages still have the same broken pattern:

- `contents/docs/alerts/index.mdx` — Anomaly detection alerts beta callout
- `contents/docs/cdp/sources/incoming-webhooks.mdx` — Incoming webhook sources beta callout

Grep confirms the established convention: 14 other docs/handbook/teams pages already link to `app.posthog.com/settings/user-feature-previews` (region-neutral). These two were out of step.

```bash
# Before this PR
$ rg -l "us\.posthog\.com/settings/user-feature-previews" contents/
contents/docs/cdp/sources/incoming-webhooks.mdx
contents/docs/alerts/index.mdx

# After this PR
$ rg -l "us\.posthog\.com/settings/user-feature-previews" contents/
(no matches)

$ rg -l "app\.posthog\.com/settings/user-feature-previews" contents/ | wc -l
16
```

## Changes

Two-character change per file, `us.` → `app.`, nothing else.

## Test plan

- [x] `rg "us\.posthog\.com/settings/user-feature-previews" contents/` returns zero results after the change.
- [x] The two callout boxes still render the same link text (`feature preview` / `Settings > Feature previews`).
- [x] No other content on either page was touched.

## Notes

This is a partial fix of #13516 — the wider "`us.posthog.com` → region-neutral URL" sweep has ~50 other hits across `contents/docs/` for paths other than `user-feature-previews` (session replay settings, project settings, account settings, etc.). Happy to take that on as a follow-up if the maintainers want a sweeping PR; I kept this one minimal and grouped by URL pattern so it's easy to review.
