### PR TITLE
docs(mcp): remove deprecated mcp-eu URLs from per-client MCP pages

### DIFF
--- a/contents/docs/model-context-protocol/claude-code.mdx
+++ b/contents/docs/model-context-protocol/claude-code.mdx
@@ -10,10 +10,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables C
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 

--- a/contents/docs/model-context-protocol/claude-desktop.mdx
+++ b/contents/docs/model-context-protocol/claude-desktop.mdx
@@ -10,10 +10,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables C
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 

--- a/contents/docs/model-context-protocol/codex.mdx
+++ b/contents/docs/model-context-protocol/codex.mdx
@@ -10,10 +10,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables C
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 

--- a/contents/docs/model-context-protocol/cursor.mdx
+++ b/contents/docs/model-context-protocol/cursor.mdx
@@ -10,10 +10,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables C
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -8,10 +8,9 @@ The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/intro
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install using the PostHog wizard
 

--- a/contents/docs/model-context-protocol/vscode.mdx
+++ b/contents/docs/model-context-protocol/vscode.mdx
@@ -12,10 +12,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables V
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 

--- a/contents/docs/model-context-protocol/windsurf.mdx
+++ b/contents/docs/model-context-protocol/windsurf.mdx
@@ -10,10 +10,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables W
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 

--- a/contents/docs/model-context-protocol/zed.mdx
+++ b/contents/docs/model-context-protocol/zed.mdx
@@ -10,10 +10,9 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Z
 
 ## Server URL
 
-| Region | URL |
-|--------|-----|
-| **US** (default) | `https://mcp.posthog.com/mcp` |
-| **EU** | `https://mcp-eu.posthog.com/mcp` |
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
 ## Quick install
 


### PR DESCRIPTION
## Changes

Removes `https://mcp-eu.posthog.com/mcp` references from the per-client MCP setup pages. The OAuth proxy at `oauth.posthog.com` handles region routing automatically, so users don't need a separate EU URL.

### History

- [#15410](https://github.com/PostHog/posthog.com/pull/15410) originally removed the EU region callout from the MCP index page with the rationale that `oauth.posthog.com` handles region routing.
- [#15595](https://github.com/PostHog/posthog.com/pull/15595) split that single page into individual per-client pages and (unintentionally) reintroduced a US/EU server URL table on each one.

This PR finishes the cleanup by replacing the two-row region table on each client page with a single URL and a note explaining that the auth server handles region routing.

### Files changed

- `index.mdx`
- `claude-code.mdx`
- `claude-desktop.mdx`
- `codex.mdx`
- `cursor.mdx`
- `vscode.mdx`
- `windsurf.mdx`
- `zed.mdx`

Each now shows:

```
## Server URL

`https://mcp.posthog.com/mcp`

The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
```

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A - no pages moved)