### PR TITLE
chore(flags): update local evaluation endpoint URL

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -36,7 +36,7 @@ sequenceDiagram
 
 Every flag check is a network round trip. PostHog already has all the data it needs, so you just pass the flag key and a user ID.
 
-With local evaluation, the SDK periodically fetches **flag definitions** from PostHog's `/api/feature_flag/local_evaluation` endpoint in the background. When you check a flag, **you provide the properties** and the SDK evaluates locally — no round trip:
+With local evaluation, the SDK periodically fetches **flag definitions** from PostHog's `/flags/definitions` endpoint in the background. When you check a flag, **you provide the properties** and the SDK evaluates locally — no round trip:
 
 ```mermaid
 sequenceDiagram
@@ -44,7 +44,7 @@ sequenceDiagram
     participant SDK as PostHog SDK
     participant PH as PostHog
     Note over SDK,PH: Background (every 30s)
-    SDK->>PH: GET /local_evaluation
+    SDK->>PH: GET /flags/definitions
     PH-->>SDK: Flag definitions
     Note over App,SDK: At evaluation time
     App->>SDK: flag key + person properties + group properties


### PR DESCRIPTION
## Changes

Updated the local evaluation docs to reference the new `/flags/definitions` endpoint instead of the old `/api/feature_flag/local_evaluation`. The server-side SDKs have been migrated to poll this new endpoint.

Two references updated in `contents/docs/feature-flags/local-evaluation/index.mdx`:
- Inline text mentioning the endpoint URL
- Mermaid sequence diagram showing the polling request

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`