### PR TITLE
Fix typo in home slides.tsx

### DIFF
--- a/src/components/Home/HeroCarousel/slides.tsx
+++ b/src/components/Home/HeroCarousel/slides.tsx
@@ -448,7 +448,7 @@ export const DebugFixSlide = () => {
         <div className="rounded pt-4 px-4 bg-primary">
             <h2 className="mt-0 mb-2">Triage issues, fix them automatically</h2>
             <p className="text-secondary text-sm">
-                Use PostHog's debugging tools to quickly find issues and the get context to fix them.
+                Use PostHog's debugging tools to quickly find issues and get the context to fix them.
             </p>
             <div className="bg-yellow/10 rounded px-3 border border-yellow mb-4">
                 <p className="text-secondary text-sm my-3">


### PR DESCRIPTION

## Changes

Fixed small typo on homepage 
"...quickly find issues and the get context..." to "...quickly find issues and get the context..."

## Checklist

- [x ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
