### PR TITLE
Use connector because it's easier and more reliable

### DIFF
--- a/contents/docs/model-context-protocol/claude-desktop.mdx
+++ b/contents/docs/model-context-protocol/claude-desktop.mdx
@@ -14,24 +14,20 @@ The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables C
 
 The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
 
-## Quick install
+## The PostHog connector (recommended)
 
-The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP server directly into Claude Desktop:
+You can install the PostHog MCP directly into Claude Desktop using the [PostHog connector](https://claude.ai/directory/connectors/posthog).
 
-```bash
-npx @posthog/wizard mcp add
-```
+1. Visit the [PostHog connector](https://claude.ai/directory/connectors/posthog) page in the Claude connector directory.
+2. Click **Connect** to add the connector to your Claude Desktop.
+3. When prompted, sign in to PostHog to finish authentication.
 
-## Manual setup
-
-1. Open [Claude Desktop](http://claude.ai/download) and navigate to **Settings > Developer**
-2. Click **Edit Config** to open the configuration file
-3. Update `claude_desktop_config.json` with the following configuration:
+After that, PostHog MCP tools are available in Claude Desktop wherever that connector is supported.
 
 <MCPConfigSnippet variant="claude-desktop" />
 
-4. **Save** the configuration file and **restart Claude Desktop**
-5. The MCP server should show as **PostHog** in your list of Connectors found in **Settings > Connectors**
+4. **Save** the configuration file and **restart Claude Desktop**.
+5. The MCP server should show as **PostHog** under **Settings → Connectors** in the app.
 
 When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
 

--- a/contents/docs/model-context-protocol/claude-desktop.mdx
+++ b/contents/docs/model-context-protocol/claude-desktop.mdx
@@ -8,13 +8,7 @@ import SharedContent from "./_snippets/shared.mdx"
 
 The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Claude Desktop to directly interact with your PostHog data – managing feature flags, querying analytics, investigating errors, and more.
 
-## Server URL
-
-`https://mcp.posthog.com/mcp`
-
-The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
-
-## The PostHog connector (recommended)
+## The PostHog connector
 
 You can install the PostHog MCP directly into Claude Desktop using the [PostHog connector](https://claude.ai/directory/connectors/posthog).
 
@@ -23,12 +17,5 @@ You can install the PostHog MCP directly into Claude Desktop using the [PostHog 
 3. When prompted, sign in to PostHog to finish authentication.
 
 After that, PostHog MCP tools are available in Claude Desktop wherever that connector is supported.
-
-<MCPConfigSnippet variant="claude-desktop" />
-
-4. **Save** the configuration file and **restart Claude Desktop**.
-5. The MCP server should show as **PostHog** under **Settings → Connectors** in the app.
-
-When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
 
 <SharedContent />


### PR DESCRIPTION
## Changes

We have an official connector that has many fewer strings attached and is more reliable than mcp-remote. Which is [buggy](https://www.reddit.com/r/ClaudeAI/comments/1qvs2kd/connecting_claude_desktop_to_a_remote_mcp_server/) on claude desktop.
