### PR TITLE
docs: split agent-friendly SDKs into its own client libraries goal

### DIFF
--- a/contents/teams/client-libraries/objectives.mdx
+++ b/contents/teams/client-libraries/objectives.mdx
@@ -14,11 +14,17 @@ What we'll ship:
   * Don’t rely only on reactive feedback from unhappy users
   * Run surveys targeting those customers
 
-* AI improvements
-  * Leverage insights from the wizard team to understand what users are asking from SDKs
-  * Make working with AI to set up and extend SDK usage a smooth and delightful experience
+#### Goal 2: Agent-friendly SDKs (Driver: <TeamMember name="Dustin Byrne" /> <TeamMember name="Manoel Aranda Neto" />)
 
-#### Goal 2: PostHog libraries vNext (Driver: <TeamMember name="Ioannis Josephides" />)
+As more developers rely on AI agents to integrate PostHog products, our SDKs should be easy for agents to understand, configure, instrument, and extend correctly.
+
+What we'll ship:
+
+* Use insights from the wizard team to understand what users and agents are asking SDKs to do
+* Make SDK setup, instrumentation, and extension smooth for AI-assisted workflows
+* Reduce the ambiguity in our SDK interfaces, docs, and examples so agents can produce correct implementations more reliably
+
+#### Goal 3: PostHog libraries vNext (Driver: <TeamMember name="Ioannis Josephides" />)
 
 What we'll ship:
 
@@ -65,7 +71,7 @@ What we'll ship:
 * Flutter desktop support (Windows/Linux) (<TeamMember name="Ioannis Josephides" />)
   * https://github.com/PostHog/posthog-flutter/issues/51
 
-#### Goal 3: Maintaining the SDKs (Driver: <TeamMember name="Manoel Aranda Neto" />)
+#### Goal 4: Maintaining the SDKs (Driver: <TeamMember name="Manoel Aranda Neto" />)
 
 What we'll ship:
 
@@ -80,7 +86,7 @@ What we'll ship:
 * Migrate and consolidate `/decide`, `/flags`, and `/static/array.js` into a unified remote config (`/static/token/config`)
 * Document SDK design guidelines and best practices under the [SDK handbook page](/handbook/engineering/sdks) to help contributors avoid common pitfalls
 
-#### Goal 4: Logs for Mobile (Driver: <TeamMember name="Anna Garcia" />)
+#### Goal 5: Logs for Mobile (Driver: <TeamMember name="Anna Garcia" />)
 
 What we'll ship:
 


### PR DESCRIPTION
## Problem

The client libraries objectives document grouped AI-related SDK work under Goal 1, which made it harder to treat agent-friendly SDK improvements as a focused outcome of their own.

## Changes

- removed the "AI improvements" subsection from Goal 1 in `contents/teams/client-libraries/objectives.mdx`
- added a new standalone goal for agent-friendly SDKs
- assigned the new goal to Dustin Byrne and Manoel Aranda Neto
- rewrote the goal description so it covers AI-assisted integration across PostHog products, not just analytics
- renumbered the remaining goals

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
