### PR TITLE
Fix link in Discord goal summary

### DIFF
--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -49,11 +49,11 @@ These are the primary goals the team is prioritizing this quarter.
 </details> 
 
 <details> 
-<summary>Test [Discord](https://discord.gg/6b8upjDs) as a live channel for builder community engagement</summary>
+<summary>Test Discord as an online channel for builder community engagement</summary>
 
 **Owner:** <TeamMember name="Kliment Minchev" photo /> <TeamMember name="Daniel Zaltsman" photo /> 
 
-**Motivation:** Before committing to a broader community strategy or hire, we'll be running disciplined experiments to learn whether Discord generates genuine, durable participation — not just sign-ups — and whether PostHog can sustain it without over-investing upfront.
+**Motivation:** Before committing to a broader community strategy or hire, we'll be running disciplined experiments to learn whether [Discord](https://discord.gg/6b8upjDs) generates genuine, durable participation — not just sign-ups — and whether PostHog can sustain it without over-investing upfront.
 
 **What we'll ship:**
 - Server structure and channel architecture (purpose-built, not default Discord layout)


### PR DESCRIPTION
## Changes
Removes the inline link from the objectives header.

<img width="798" height="63" alt="image" src="https://github.com/user-attachments/assets/3700b0ad-d6ab-44a1-b953-4598c5080c42" />


## Changes
- Convert header text to plain text
- Moved the link into the body where appropriate

## Notes
Follow-up to #16458 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
