### PR TITLE
docs(mcp): add Streamable HTTP Node client snippet

### DIFF
--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -26,6 +26,49 @@ We're working on adding more supported tools to the wizard. If you're using anot
 
 <SharedContent />
 
+## Calling the MCP server from a Node client
+
+For custom integrations or scripting, you can talk to the MCP server directly from Node using the official MCP SDK's Streamable HTTP transport. Two things people commonly miss:
+
+- Your `Accept` header needs both `application/json` and `text/event-stream` -- the server returns JSON for normal request/response calls and upgrades to an SSE stream for longer-running tool invocations.
+- The SDK's `connect()` handles the full MCP lifecycle for you (`initialize` followed by the `notifications/initialized` notification), so you do not need to send those manually.
+
+```js
+// tools-list.mjs
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { URL } from 'node:url'
+
+const AUTH = process.env.POSTHOG_AUTH_HEADER // "Bearer phx_..."
+const MCP_URL = process.env.MCP_URL || 'https://mcp.posthog.com/mcp'
+
+if (!AUTH?.startsWith('Bearer ')) {
+    console.error('Set POSTHOG_AUTH_HEADER="Bearer phx_..."')
+    process.exit(1)
+}
+
+const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+    requestInit: {
+        headers: {
+            Authorization: AUTH,
+            Accept: 'application/json, text/event-stream',
+        },
+    },
+})
+
+const client = new Client({ name: 'example-node-client', version: '0.0.1' })
+
+await client.connect(transport)
+
+const { tools } = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+console.log('Tools:', tools.length)
+
+await client.close()
+```
+
+Create a [personal API key](/docs/api#personal-api-keys) with the scopes your MCP session needs and export it as `POSTHOG_AUTH_HEADER="Bearer phx_..."` before running the script.
+
 ## Next steps
 
 - [PostHog AI plugin](https://github.com/PostHog/ai-plugin): Install PostHog as a plugin for Claude Code, Codex, Cursor, and Gemini CLI


### PR DESCRIPTION
Closes PostHog/posthog.com#13594.

The reporter noticed `/docs/model-context-protocol` walks you through every editor/agent integration but never shows the Streamable HTTP transport directly from Node, which is what you reach for when you are building tooling (CI jobs, audit scripts, custom dashboards) around MCP. They also pointed at PostHog/posthog#41078 which already landed the same snippet as an internal README in the monorepo, so there is a known-working source of truth to copy from.

Added a "Calling the MCP server from a Node client" section between `<SharedContent />` and "Next steps" with:
- The two gotchas people hit the most: the `Accept: application/json, text/event-stream` requirement and the `connect()`-handles-the-`initialize`-then-`notifications/initialized`-lifecycle note.
- A self-contained `tools-list.mjs` example that reads a `Bearer` from env and lists the tools the server exposes (matches the script shipped in `products/mcp/README.md` modulo the filesystem-write boilerplate that makes sense in a repo README but not in the published docs).
- A pointer at personal API keys rather than inventing a scope name; tool scopes depend on which MCP tools the user invokes, so that feels like the right level of detail.

No existing sections changed.
