### PR TITLE
fix(customers): update UK Government note to reflect current monarch

### DIFF
--- a/src/hooks/useCustomers.tsx
+++ b/src/hooks/useCustomers.tsx
@@ -928,7 +928,7 @@ const CUSTOMER_DATA: Record<string, BaseCustomer> = {
         toolsUsed: [], // TODO: Add toolsUsed
         // industries: [], // TODO: Add industries
         // users: [], // TODO: Add users
-        notes: 'Most popular country with a Queen',
+        notes: 'Most popular country with a King',
         logo: UKGovtLogo,
         featured: true,
         height: 9,


### PR DESCRIPTION
Fixes #16381.

useCustomers.tsx described the UK Government as *'Most popular country with a Queen'*. Charles III has been on the throne since September 2022, so the note no longer matches reality. This PR swaps Queen for King -- smallest possible change, same tone, works for any reader unfamiliar with the joke.

### Change
- src/hooks/useCustomers.tsx (line 931)
  - Before: `notes: 'Most popular country with a Queen'`
  - After:  `notes: 'Most popular country with a King'`

Technically Queen Consort Camilla still qualifies, but the original gag reads cleaner with the reigning monarch, and the issue author explicitly pointed at September 2022 as the break date. Happy to swap to Queen Consort or King Consort-free alt if you prefer.