### PR TITLE
docs(vue-js): document environment-specific PostHog setup for Vue

### DIFF
--- a/contents/docs/libraries/vue-js/index.mdx
+++ b/contents/docs/libraries/vue-js/index.mdx
@@ -26,6 +26,40 @@ import VueSetup from "../../integrate/_snippets/vuejs/vue-setup.mdx"
 
 <VueSetup />
 
+## Environment-specific tracking
+
+You usually don't want to send development or test traffic to your PostHog project. There are two common ways to scope PostHog to production in Vue:
+
+**Guard `posthog.init` on an environment flag.** Vite exposes `import.meta.env.PROD` (true only in `vite build` output), and Vue CLI / Nuxt expose `process.env.NODE_ENV`:
+
+```ts
+// src/main.ts (Vite + Vue 3)
+if (import.meta.env.PROD) {
+  posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST,
+    defaults: '2026-01-30',
+  })
+}
+```
+
+**Or initialize once and opt out per-environment** so the instance still exists for consumer code but does not send events:
+
+```ts
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
+  defaults: '2026-01-30',
+  opt_out_capturing_by_default: !import.meta.env.PROD,
+  loaded: (ph) => {
+    if (import.meta.env.DEV) ph.debug()
+  },
+})
+```
+
+With the second approach, `posthog.capture()` calls made from components are no-ops in development while still type-checking and running through your plugin layer, so you don't need `if (PROD)` checks sprinkled across components. Swap `import.meta.env` for `process.env` if you're on Vue CLI or Nuxt.
+
+Using different PostHog projects per environment -- staging vs production -- is just a matter of binding `VITE_POSTHOG_TOKEN` (or `NUXT_PUBLIC_POSTHOG_KEY`) to different project tokens in your `.env.production` / `.env.staging` files.
+
+
 ## Identifying users
 
 import IdentifyFrontendCallout from '../../_snippets/identify-frontend-callout.mdx'


### PR DESCRIPTION
Fixes #13513.

Adds a short `## Environment-specific tracking` section to the Vue.js SDK guide covering the two most common setups:

1. **Guard `posthog.init` on `import.meta.env.PROD`** (Vite / Vue CLI 5+) so PostHog isn't loaded at all in development.
2. **Initialize once and `opt_out_capturing_by_default`** based on the environment flag, so `posthog.capture()` calls throughout components stay type-safe but no-op outside production.

Both snippets use `import.meta.env` to match the existing `composition-install.mdx` snippet, and I note that Vue CLI / Nuxt users should swap to `process.env.NODE_ENV` / `NUXT_PUBLIC_POSTHOG_KEY`.

The section also mentions the simpler *per-environment token* approach via `.env.production` / `.env.staging`, which was the implicit ask from the feedback link.

### Why both patterns?

I hesitated between recommending one pattern, but the two have different trade-offs:

- `if (PROD) posthog.init(...)` keeps the `posthog` import unused in dev bundles -- good for bundle size, cleaner devtools.
- `opt_out_capturing_by_default` lets feature code still call `posthog.capture()` / `posthog.isFeatureEnabled()` without guards and keeps the API surface consistent across environments.

I didn't introduce an `active` flag or a new wrapper file because the SDK already exposes `opt_out_capturing_by_default` natively. Happy to trim to one pattern or add a callout if you'd prefer.