### PR TITLE
fix(blog-categories): sort category and tag dropdown entries alphabetically

### DIFF
--- a/src/components/Edition/Categories.tsx
+++ b/src/components/Edition/Categories.tsx
@@ -96,11 +96,17 @@ export default function Categories({ setSelectedCategories, selectedCategories, 
                         static
                         className="absolute grid gap-y-2 right-0 bg-accent p-2 border border-input rounded mt-1"
                     >
-                        {categories.map((category) => {
+                        {[...categories]
+                            .sort((a, b) =>
+                                (a?.attributes?.label ?? '').localeCompare(b?.attributes?.label ?? '')
+                            )
+                            .map((category) => {
                             const active = Object.keys(selectedCategories).some(
                                 (selectedCategory) => selectedCategory === category.attributes.label
                             )
-                            const tags = category.attributes.post_tags?.data
+                            const tags = [...(category.attributes.post_tags?.data ?? [])].sort((a, b) =>
+                                (a?.attributes?.label ?? '').localeCompare(b?.attributes?.label ?? '')
+                            )
                             return (
                                 <Menu.Item as="span" key={category.id}>
                                     <button


### PR DESCRIPTION
Fixes #13586.

The Categories dropdown used on blog / posts listing pages (`src/components/Edition/Categories.tsx`) renders categories and their nested tags in whatever order Strapi returns them. The reporter was hunting for `Heatmaps` which ended up near the bottom of a long, apparently random list.

Sort both the outer category list and the inner tag list alphabetically by their `label` using `localeCompare`. Uses a copy of each array (`[...categories]` / `[...(post_tags?.data ?? [])]`) so the original Strapi response order is not mutated.

### Before / after

- Before: order matches Strapi response (looks random to the user).
- After: categories and tags sort alphabetically `A -> Z`, so scanning for a known tag is predictable.

### Notes

- Locale-aware via `localeCompare` so tags with diacritics sort the same way the user types them.
- No data-fetch changes -- the fix is purely on the render path.
- Didn't touch other tag surfaces (the `Edition/Tags.tsx` slider / posts-menu nav) because those are manually ordered lists in source, not API-driven.