### PR TITLE
docs(dotnet): rename ProjectApiKey to ProjectToken

### DIFF
--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -69,7 +69,7 @@ posthog = Posthog('<ph_project_token>',
 // api key in a secrets manager.
 var client = new PostHogClient(
     new PostHogOptions {
-        ProjectApiKey = "<ph_project_token>",
+        ProjectToken = "<ph_project_token>",
         PersonalApiKey = "your feature flags secure API key from step 1"
     });
 ```

--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -26,7 +26,7 @@ Make sure to configure PostHog with your project token, instance address, and op
 ```json
 {
   "PostHog": {
-    "ProjectApiKey": "<ph_project_token>",
+    "ProjectToken": "<ph_project_token>",
     "HostUrl": "<ph_client_api_host>"
   }
 }
@@ -150,7 +150,7 @@ If you're not using dependency injection, you can create a static instance of th
 using PostHog;
 
 public static readonly PostHogClient PostHog = new(new PostHogOptions {
-    ProjectApiKey = "<ph_project_token>",
+    ProjectToken = "<ph_project_token>",
     HostUrl = new Uri("<ph_client_api_host>"),
     PersonalApiKey = Environment.GetEnvironmentVariable(
       "PostHog__PersonalApiKey")


### PR DESCRIPTION
## Summary
- The .NET SDK renamed the `ProjectApiKey` option to `ProjectToken`
- Updates the two .NET docs snippets (`install-dotnet.mdx`, `configure-flags-secure-key.mdx`) to match
- `PersonalApiKey` is unchanged; tutorials/guides are intentionally out of scope

## Test plan
- [ ] Verify the .NET install snippet renders correctly on `/docs/libraries/dotnet`
- [ ] Verify the feature-flags secure-key snippet renders correctly where it's included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

follow up https://github.com/PostHog/posthog-dotnet/pull/183