### PR TITLE
docs: clarify social referral guidance in hiring handbook

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -249,7 +249,7 @@ You will sometimes get people emailing or messaging you on LinkedIn asking to ch
 
 The referral bonus for social referrals is $500, and we again match any amount you choose to give this to charity.
 
-If you are consistently posting about jobs to your networks and people apply after seeing those posts, those count as social referrals if they use your referral links. [Create your referral links in Ashby](https://app.ashbyhq.com/referrals/links) and you can use those when linking to job ads on LinkedIn or other platforms.
+If you are consistently posting about jobs to your networks, please note that Ashby does not currently support referral links in a way that lets us reliably track those applications as social referrals. If someone reaches out after seeing your post and you want them to count as a social referral, ask them not to apply directly yet. Instead, submit them through the [Ashby referral page](https://app.ashbyhq.com/referrals).
 
 #### Family referral
 


### PR DESCRIPTION
## Problem

The hiring handbook said employees could create Ashby referral links for job posts and have applicants count as social referrals through those links. That is not how Ashby works, so the current guidance is misleading for anyone sharing roles through their network.

## Changes

- updated the social referral section in `contents/handbook/people/hiring-process/index.mdx`
- removed the incorrect instruction to create referral links in Ashby for social posts
- clarified that social referrals should be submitted through the Ashby referral page instead of relying on referral-link tracking

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`