### PR TITLE
docs(feature-flags): note mixed targeting isn't locally evaluable

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -332,6 +332,7 @@ Local evaluation is not possible for flags that:
 2. Are linked to an [early access feature](/docs/feature-flags/early-access-feature-management)
 3. Depend on [static cohorts](/docs/data/cohorts#static-cohorts)
 4. Use the `is_not_set` property operator, since local evaluation can only check properties you provide — it can't determine whether a property is absent on a person.
+5. Use [mixed targeting](/docs/feature-flags/user-and-group-targeting#mixed-targeting) (the "User & Group" match mode), which combines user-level and group-level conditions in a single flag.
 
 ### Dynamic cohort restrictions
 


### PR DESCRIPTION
## Summary

Adds a bullet to the [local evaluation restrictions](https://posthog.com/docs/feature-flags/local-evaluation#restriction-on-local-evaluation) calling out that flags using mixed targeting (the "User & Group" match mode) can't be locally evaluated, with a link to the [mixed targeting section](/docs/feature-flags/user-and-group-targeting#mixed-targeting) of the targeting doc.

## Test plan

- [ ] Page renders with the new bullet under "General restrictions"
- [ ] Internal link to `/docs/feature-flags/user-and-group-targeting#mixed-targeting` resolves

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*