### PR TITLE
Update web script reference in Site-apps section

### DIFF
--- a/contents/docs/site-apps/index.md
+++ b/contents/docs/site-apps/index.md
@@ -10,7 +10,7 @@ Site apps enable you to easily add functionality to your site without extra code
 
 ## Enabling apps
 
-Head to **Data pipelines** and click the [Site apps](https://app.posthog.com/apps) tab. Here you can install official PostHog apps by clicking **+ New site-app**.
+Head to the [**Web scripts** app](https://app.posthog.com/web-scripts). Here you can install official PostHog apps by clicking **+ New Web script**.
 
 ## Available site apps
 


### PR DESCRIPTION
This hadn't been updated since they moved out of the Destinations screen.

## Changes

Corrected the link and reference to the Web Scripts app view in PostHog. 

## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
