### PR TITLE
Update iOS docs for project token config

### DIFF
--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -182,7 +182,7 @@ if (isTestEnv) {
 // Detect test/CI environment
 let isTestEnv = ProcessInfo.processInfo.environment["CI"] != nil
 
-let config = PostHogConfig(apiKey: "<ph_project_token>")
+let config = PostHogConfig(projectToken: "<ph_project_token>")
 
 if isTestEnv {
     config.preloadFeatureFlags = false

--- a/contents/docs/integrate/_snippets/code-variants/ios-swiftui.mdx
+++ b/contents/docs/integrate/_snippets/code-variants/ios-swiftui.mdx
@@ -10,11 +10,11 @@ struct YourGreatApp: App {
 
     init() {
         
-        let POSTHOG_API_KEY = "<ph_project_token>"
+        let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
         // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
         let POSTHOG_HOST = "<ph_client_api_host>"
         
-        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
+        let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
         PostHogSDK.shared.setup(config)
         
     }

--- a/contents/docs/integrate/_snippets/code-variants/ios-uikit.mdx
+++ b/contents/docs/integrate/_snippets/code-variants/ios-uikit.mdx
@@ -5,11 +5,11 @@ import UIKit
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        let POSTHOG_API_KEY = "<ph_project_token>"
+        let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
         // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
         let POSTHOG_HOST = "<ph_client_api_host>"
 
-        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
+        let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
         PostHogSDK.shared.setup(config)
 
         return true

--- a/contents/docs/integrate/_snippets/install-ios.mdx
+++ b/contents/docs/integrate/_snippets/install-ios.mdx
@@ -7,7 +7,7 @@ PostHog is available through [CocoaPods](http://cocoapods.org) or you can add it
 ### CocoaPods
 
 ```ruby file=Podfile
-pod "PostHog", "~> 3.0"
+pod "PostHog", ">= 3.56.0"
 ```
 
 ### Swift Package Manager
@@ -18,7 +18,7 @@ For a Swift Package Manager based project, add PostHog as a dependency in your `
 
 ```swift file=Package.swift
 dependencies: [
-  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0")
+  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.56.0")
 ],
 ```
 

--- a/contents/docs/integrate/_snippets/install-ios.mdx
+++ b/contents/docs/integrate/_snippets/install-ios.mdx
@@ -7,7 +7,7 @@ PostHog is available through [CocoaPods](http://cocoapods.org) or you can add it
 ### CocoaPods
 
 ```ruby file=Podfile
-pod "PostHog", ">= 3.56.0"
+pod "PostHog", "~> 3.56.0"
 ```
 
 ### Swift Package Manager

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
@@ -47,11 +47,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             object: nil
         )
 
-        let POSTHOG_API_KEY = "<ph_project_token>"
+        let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
         // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
         let POSTHOG_HOST = "https://us.i.posthog.com"
 
-        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
+        let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
 
         PostHogSDK.shared.setup(config)
 

--- a/contents/docs/libraries/ios/_snippets/autocapture-config-ios.mdx
+++ b/contents/docs/libraries/ios/_snippets/autocapture-config-ios.mdx
@@ -1,9 +1,9 @@
 ```swift file=AppDelegate.swift focusOnLines=7-14
-let POSTHOG_API_KEY = "<ph_project_token>"
+let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
 // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
 let POSTHOG_HOST = "<ph_client_api_host>"
 
-let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
+let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
 
 // capture screen views
 config.captureScreenViews = true 

--- a/contents/docs/libraries/ios/_snippets/autocapture.mdx
+++ b/contents/docs/libraries/ios/_snippets/autocapture.mdx
@@ -109,7 +109,7 @@ Interaction autocapture records when users interact with UI elements in your app
 Interaction autocapture is **not enabled by default**. You can enable it by setting `captureElementInteractions` to `true` in the config.
 
 ```swift
-let config = PostHogConfig(apiKey: <ph_project_token>, host: <ph_client_api_host>)
+let config = PostHogConfig(projectToken: <ph_project_token>, host: <ph_client_api_host>)
 config.captureElementInteractions = true // Disabled by default
 PostHogSDK.shared.setup(config)
 ```
@@ -125,7 +125,7 @@ This is captured as a `$rageclick` event. You can use this event to identify opp
 It is enabled by default (`rageClickConfig.enabled = true`).
 
 ```swift
-let config = PostHogConfig(apiKey: <ph_project_token>, host: <ph_client_api_host>)
+let config = PostHogConfig(projectToken: <ph_project_token>, host: <ph_client_api_host>)
 config.rageClickConfig.enabled = true // Enabled by default
 config.rageClickConfig.minimumTapCount = 3 // Optional, default is 3
 config.rageClickConfig.thresholdPoints = 30 // Optional, default is 30

--- a/contents/docs/libraries/ios/configuration.mdx
+++ b/contents/docs/libraries/ios/configuration.mdx
@@ -59,7 +59,7 @@ Since version 3.28.0, you can provide a `BeforeSendBlock` function when initiali
 <summary>Redact URLs in event properties</summary>
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 
 config.setBeforeSend { event in
     // Redact URLs
@@ -75,7 +75,7 @@ config.setBeforeSend { event in
 <summary>Redact sensitive information from event properties</summary>
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 
 config.setBeforeSend { event in
     // Redact sensitive information
@@ -93,7 +93,7 @@ config.setBeforeSend { event in
 <summary>Drop events by event name</summary>
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 
 config.setBeforeSend { event in
     // Drop all events named "Stale Event"
@@ -114,7 +114,7 @@ Sampling lets you choose to send only a percentage of events to PostHog. It is a
 <summary>Sample events by event name</summary>
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 
 config.setBeforeSend { event in
     // Sample 10% of Sampled Event events
@@ -138,7 +138,7 @@ config.setBeforeSend { event in
 You can provide an array of `BeforeSendBlock` functions to be called one after the other:
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 
 config.setBeforeSend(
     // First block: Drop all events named "Stale Event"
@@ -166,7 +166,7 @@ config.setBeforeSend(
 2. **Configure PostHog**: Use the same App Group identifier in all targets:
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 config.appGroupIdentifier = "group.com.yourcompany.yourapp"
 PostHogSDK.shared.setup(config)
 ```
@@ -192,7 +192,7 @@ Method swizzling is enabled by default, but can be disabled by setting the relev
 Since version 3.34.0, you can opt out of all swizzling using the `enableSwizzling` configuration option. When you disable swizzling, the SDK disables the features listed above. 
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_api_client_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
 config.enableSwizzling = false
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/libraries/ios/usage.mdx
+++ b/contents/docs/libraries/ios/usage.mdx
@@ -161,7 +161,7 @@ You can completely opt-out users from data capture. To do this, there are two op
 1. Opt users out by default by setting `optOut` to `true` in your PostHog config:
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_client_api_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
 config.optOut = true
 PostHogSDK.shared.setup(config)
 ```
@@ -229,7 +229,7 @@ If you're not seeing the expected events being captured, the feature flags being
 You can enable debug mode by setting the `debug` option to `true` in the `PostHogConfig` object. A common pattern is to set this to `true` in development environments only for local development.
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_client_api_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
 config.debug = true
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
@@ -10,7 +10,7 @@ For example:
 
 ```ios_swift
 let config = PostHogConfig(
-    apiKey: POSTHOG_API_KEY, 
+    projectToken: POSTHOG_PROJECT_TOKEN,
     host: POSTHOG_HOST
 )
 config.personProfiles = .identifiedOnly

--- a/contents/docs/product-analytics/_snippets/multilanguage/opt-out-default.mdx
+++ b/contents/docs/product-analytics/_snippets/multilanguage/opt-out-default.mdx
@@ -7,7 +7,7 @@ posthog.init('<ph_project_token>', {
 ```
 
 ```ios_swift        
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_client_api_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
 config.optOut = true
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -245,7 +245,7 @@ Autocaptured events display as the autocaptured interaction type in the [activit
 Interaction autocapture is **not enabled by default**. You can enable it by setting `captureElementInteractions` to `true` in the config.
 
 ```swift
-let config = PostHogConfig(apiKey: <ph_project_token>, host: <ph_client_api_host>)
+let config = PostHogConfig(projectToken: <ph_project_token>, host: <ph_client_api_host>)
 
 config.captureElementInteractions = true // Disabled by default
 
@@ -419,7 +419,7 @@ Screen navigation autocapture is not enabled by default. You can enable it by se
 For example, your initialization code might look like this:
 
 ```swift
-let config = PostHogConfig(apiKey: <ph_project_token>, host: <ph_client_api_host>)
+let config = PostHogConfig(projectToken: <ph_project_token>, host: <ph_client_api_host>)
 
 config.captureElementInteractions = true // Disabled by default
 config.captureApplicationLifecycleEvents = true // Disabled by default

--- a/contents/docs/product-analytics/installation/ios.mdx
+++ b/contents/docs/product-analytics/installation/ios.mdx
@@ -24,7 +24,7 @@ For Swift Package Manager projects, add PostHog to your `Package.swift` dependen
 
 ```swift file=Package.swift
 dependencies: [
-  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0")
+  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.56.0")
 ],
 ```
 
@@ -47,10 +47,10 @@ import PostHog
 @main
 struct YourGreatApp: App {
     init() {
-        let POSTHOG_API_KEY = "<ph_project_token>"
+        let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
         let POSTHOG_HOST = "<ph_client_api_host>" // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
 
-        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
+        let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
         PostHogSDK.shared.setup(config)
     }
 

--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -41,7 +41,7 @@ You can programmatically start and stop session recordings. See [how to control 
 ## Configuration options
 
 ```swift
-let config = PostHogConfig(apiKey: "<ph_project_token>")
+let config = PostHogConfig(projectToken: "<ph_project_token>")
 // Enable session recording. Requires enabling in your project settings as well.
 // Default is false.
 config.sessionReplay = true

--- a/contents/docs/session-replay/_snippets/ios-logging.mdx
+++ b/contents/docs/session-replay/_snippets/ios-logging.mdx
@@ -2,7 +2,7 @@ As console logs can contain sensitive information, we do not capture these logs 
 You can enable this feature from your client-side by setting `captureLogs = true` in our [iOS SDK config](/docs/session-replay/installation/ios#step-two-enable-session-recordings-in-your-project-settings).
 
 ```ios_swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_client_api_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
 config.sessionReplay = true
 // Remote configuration via project settings requires SDK version 3.41.1 or higher.
 config.sessionReplayConfig.captureLogs = true
@@ -19,7 +19,7 @@ PostHog iOS SDK allows you to customize how log messages are processed and categ
 This handler is called for each new line printed to the console. It receives the line's content and can return either a processed log entry with its severity level, or `nil` to skip the log entirely:
 
 ```ios_swift
-let config = PostHogConfig(apiKey: "<ph_project_token>", host: "<ph_client_api_host>")
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
 
 // Custom log processing and sanitization
 config.sessionReplayConfig.captureLogsConfig.logSanitizer = { output in

--- a/contents/docs/surveys/_snippets/ios-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/ios-surveys-installation.mdx
@@ -12,10 +12,10 @@ import IOSInstall from "../../integrate/_snippets/install-ios.mdx"
 To enable surveys in your iOS app, enable surveys in your PostHog configuration:
 
 ```swift
-let POSTHOG_API_KEY = "<ph_project_token>"
+let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
 // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
 let POSTHOG_HOST = "<ph_client_api_host>"
-let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
+let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
 
 // Surveys require iOS 15.0 or later
 if #available(iOS 15.0, *) {


### PR DESCRIPTION
## Changes

- Update official iOS docs snippets to use `POSTHOG_PROJECT_TOKEN` instead of `POSTHOG_API_KEY` / `POSTHOG_TOKEN`.
- Update iOS `PostHogConfig` examples to use the new `projectToken:` named parameter.
- Update iOS SDK installation snippets for CocoaPods and Swift Package Manager to use minimum version `3.56`, preserving each package manager's existing version precision and CocoaPods `~>` constraint syntax.

No screenshots needed; docs-only change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
