### PR TITLE
handbook: add SDK health checks and check slack history during account handover

### DIFF
--- a/contents/handbook/cs-and-onboarding/health-checks.md
+++ b/contents/handbook/cs-and-onboarding/health-checks.md
@@ -38,6 +38,14 @@ When Session replay is enabled it will capture all sessions by default.  As ever
 
 If a customer has Session replay enabled, log in as them and look at their session replay [settings](/docs/session-replay/how-to-control-which-sessions-you-record).  At a minimum we recommend setting the minimum duration to 2 seconds or more but there are other tuning options which they may also benefit from.
 
+## Are they running up-to-date SDKs?
+
+Outdated SDKs miss out on bug fixes, performance improvements, and new features. A customer using a three-year-old SDK will hit issues we've already solved, which can silently erode trust over time.
+
+Check SDK versions using [SDK Doctor](/docs/sdk-doctor) or in Metabase via the `Library version audit` table. At minimum, the SDK sending the bulk of their event volume shouldn't be more than 3 months behind the latest. Monthly updates are the best-practice habit to encourage. Some SDKs have breaking changes between versions, and if so, make sure you make the customer aware about the breaking change.
+
+A light nudge on this also doubles as a natural re-engagement touchpoint for customers you haven't spoken to in a while.
+
 ## Have they implemented tracking incorrectly?
 
 ### Calling identify too often

--- a/contents/handbook/cs-and-onboarding/lifecycle-csm.md
+++ b/contents/handbook/cs-and-onboarding/lifecycle-csm.md
@@ -26,6 +26,8 @@ Some key examples that really help with building trusts with your customers:
 
 - **Go beyond the basics**: In getting started with customers, you focused on getting to know your customers, understanding their business goals, helping with implementation, and optimizing their use. Now is a great time to focus on how you can help them optimize for success. This could be looking at how they're currently engaging with PostHog products, whether there are things they haven't done that might be helpful to implement. For example, have they set up custom tracking funnels for high value metrics, created alerts on customer actions to track, have they tried PostHog AI, or considered implementing other features to augment the data they have (such as error tracking to figure out why conversions drop off). This is a good opportunity to cross sell but also presents an opportunity to help customers understand where they can get more value out of PostHog.
 
+- **Regularly invite new users to the Slack channel**: The more people on the customer side who know you exist, the more of them will come to you when they hit PostHog issues. Monthly is a good cadence – Vitally can show you who's new.
+
 Establishing trust can take time, and your communication style and actions can play a significant role. It may be worth offering recurring calls with your champion to establish more face-to-face contact, as this can help you maintain an ongoing pulse on what's happening.
 
 ### Stage 3: Getting deeply embedded with customers

--- a/contents/handbook/growth/sales/account-allocation.md
+++ b/contents/handbook/growth/sales/account-allocation.md
@@ -189,6 +189,8 @@ The incoming TAM should prepare by reviewing the following in Vitally and SFDC b
 - [ ] **Usage metrics** – active users, project count, Feature Flag requests, Session Replay volume, insight/dashboard engagement
 - [ ] **Support history** – recent Zendesk tickets, tags, severity, resolution status
 - [ ] **Conversations & notes** – read all Vitally notes, meeting summaries, and conversation history
+- [ ] **Customer Slack channel** – scan the shared channel for who's actually active on the customer side, what issues have come up, and any open threads worth asking the previous owner about. This is often where the most useful context lives.
+- [ ] **Internal Slack discussions** – search our own Slack (outside the shared channel) for mentions of the customer. Engineering debates, pricing conversations, support escalations, and context from the previous owner often surface things that were never written down in Vitally.
 - [ ] **SFDC opportunity** – deal value, stage, next steps, close date
 - [ ] **Admin emails & user list** – identify who's active, who has admin access, what domains are in play
 - [ ] **The customer's product** – sign up or browse their website. Understand what they do and how they make money


### PR DESCRIPTION
Adds a few learnings to the handbook from [churn retro](https://posthog.slack.com/archives/C09HKF565MZ/p1776953235666959?thread_ts=1769013603.016309&cid=C09HKF565MZ):

- Added SDK version check to `health-checks`
- Added note on regularly inviting new users to the Slack channel in `lifecycle-csm`
- Two items around Slack research during handover in `account-allocation`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*