### PR TITLE
Add cost warnings to proxy documentation pages

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -28,7 +28,7 @@ If you use a self-hosted proxy, PostHog can't help troubleshoot configuration is
 
 </CalloutBox>
 
-Proxied traffic — events, session recordings, feature flags, and SDK assets — flows through your provider and counts against their bandwidth and request quotas. On platforms that bill egress or function invocations (Vercel, Netlify, CloudFront, Railway), this can add up for high-traffic sites. The [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) avoids these costs entirely.
+Proxied traffic – events, session recordings, feature flags, and SDK assets – flows through your provider and counts against their bandwidth and request quotas. On platforms that bill egress or function invocations (Vercel, Netlify, CloudFront, Railway), this can add up for high-traffic sites. The [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) avoids these costs entirely.
 
 Choose your platform and follow the setup guide:
 

--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -28,6 +28,8 @@ If you use a self-hosted proxy, PostHog can't help troubleshoot configuration is
 
 </CalloutBox>
 
+Proxied traffic — events, session recordings, feature flags, and SDK assets — flows through your provider and counts against their bandwidth and request quotas. On platforms that bill egress or function invocations (Vercel, Netlify, CloudFront, Railway), this can add up for high-traffic sites. The [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) avoids these costs entirely.
+
 Choose your platform and follow the setup guide:
 
 <ProxyPlatforms />

--- a/contents/docs/advanced/proxy/cloudflare.mdx
+++ b/contents/docs/advanced/proxy/cloudflare.mdx
@@ -10,6 +10,12 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Cloudflare Workers has no egress fees and includes a generous free tier (100,000 requests/day), which makes it one of the cheaper self-hosted options for proxying PostHog. Every proxied event, session recording chunk, feature flag poll, and SDK asset request counts toward your [Workers request quota](https://developers.cloudflare.com/workers/platform/pricing/), so monitor usage if you expect to exceed the free tier on high-traffic sites.
+
+</CalloutBox>
+
 This guide shows you how to use [Cloudflare](https://www.cloudflare.com/) as a reverse proxy for PostHog.
 
 ## Prerequisites

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through CloudFront, which bills both [per-GB data transfer out and per-request](https://aws.amazon.com/cloudfront/pricing/). Session recordings are the biggest driver (often 1–5 MB per session) and can make CloudFront costs significant on high-traffic sites.
+Proxying routes all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – through CloudFront, which bills both [per-GB data transfer out and per-request](https://aws.amazon.com/cloudfront/pricing/). Session recordings are the biggest driver (often 1–5 MB per session) and can make CloudFront costs significant on high-traffic sites.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through CloudFront, which bills both [per-GB data transfer out and per-request](https://aws.amazon.com/cloudfront/pricing/). Session recordings are the biggest driver (often 1–5 MB per session) and can make CloudFront costs significant on high-traffic sites.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to configure [AWS CloudFront](https://docs.aws.amazon.com/cloudfront/) as a reverse proxy for PostHog.
 
 ## Why CloudFront needs custom configuration

--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through Netlify, which bills it against your plan's [bandwidth quota with overage fees](https://www.netlify.com/pricing/). Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
+Proxying routes all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – through Netlify, which bills it against your plan's [bandwidth quota with overage fees](https://www.netlify.com/pricing/). Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through Netlify, which bills it against your plan's [bandwidth quota with overage fees](https://www.netlify.com/pricing/). Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [Netlify redirects](https://docs.netlify.com/routing/redirects/) as a reverse proxy for PostHog.
 
 ## How it works

--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-The proxy file runs on every matching request, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through it. On Vercel, each invocation counts as an [Edge Request](https://vercel.com/docs/pricing) in addition to the data transfer; other hosts bill it against their compute and bandwidth quotas. Session recordings amplify this (often 1–5 MB per session) and can quickly push a plan over its limits on high-traffic sites.
+The proxy file runs on every matching request, so all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – passes through it. On Vercel, each invocation counts as an [Edge Request](https://vercel.com/docs/pricing) in addition to the data transfer; other hosts bill it against their compute and bandwidth quotas. Session recordings amplify this (often 1–5 MB per session) and can quickly push a plan over its limits on high-traffic sites.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+The proxy file runs on every matching request, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through it. On Vercel, each invocation counts as an [Edge Request](https://vercel.com/docs/pricing) in addition to the data transfer; other hosts bill it against their compute and bandwidth quotas. Session recordings amplify this (often 1–5 MB per session) and can quickly push a plan over its limits on high-traffic sites.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [Next.js proxy](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) (formerly middleware) as a reverse proxy for PostHog.
 
 <CalloutBox icon="IconInfo" title="Next.js 16 renamed middleware to proxy" type="fyi">

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Rewrites route all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through your Next.js server. On Vercel, this counts toward [Fast Data Transfer and Edge Requests](https://vercel.com/docs/pricing); on other hosts it counts against their bandwidth and compute quotas. Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [Next.js rewrites](https://nextjs.org/docs/app/api-reference/next-config-js/rewrites) as a reverse proxy for PostHog.
 
 <iframe

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Rewrites route all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through your Next.js server. On Vercel, this counts toward [Fast Data Transfer and Edge Requests](https://vercel.com/docs/pricing); on other hosts it counts against their bandwidth and compute quotas. Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
+Rewrites route all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – through your Next.js server. On Vercel, this counts toward [Fast Data Transfer and Edge Requests](https://vercel.com/docs/pricing); on other hosts it counts against their bandwidth and compute quotas. Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/nuxt.mdx
+++ b/contents/docs/advanced/proxy/nuxt.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Server routes run on the server, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through your Nuxt deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
+Server routes run on the server, so all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – passes through your Nuxt deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/nuxt.mdx
+++ b/contents/docs/advanced/proxy/nuxt.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Server routes run on the server, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through your Nuxt deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [Nuxt server routes](https://nuxt.com/docs/guide/directory-structure/server) as a reverse proxy for PostHog.
 
 ## How it works

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through your Railway service, which bills [egress per-GB](https://railway.app/pricing) on usage-based plans. Session recordings are the biggest driver (often 1–5 MB per session) and can make Railway costs noticeable on high-traffic sites.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to deploy a PostHog reverse proxy on [Railway](https://railway.app/).
 
 ## How it works

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through your Railway service, which bills [egress per-GB](https://railway.app/pricing) on usage-based plans. Session recordings are the biggest driver (often 1–5 MB per session) and can make Railway costs noticeable on high-traffic sites.
+Proxying routes all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – through your Railway service, which bills [egress per-GB](https://railway.app/pricing) on usage-based plans. Session recordings are the biggest driver (often 1–5 MB per session) and can make Railway costs noticeable on high-traffic sites.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/remix.mdx
+++ b/contents/docs/advanced/proxy/remix.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Resource routes run on the server, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through your Remix deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [Remix resource routes](https://remix.run/docs/en/main/guides/resource-routes) as a reverse proxy for PostHog.
 
 ## How it works

--- a/contents/docs/advanced/proxy/remix.mdx
+++ b/contents/docs/advanced/proxy/remix.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Resource routes run on the server, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through your Remix deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
+Resource routes run on the server, so all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – passes through your Remix deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+The `handle` hook runs on every request, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through your SvelteKit deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [SvelteKit server hooks](https://kit.svelte.dev/docs/hooks#server-hooks) as a reverse proxy for PostHog.
 
 ## How it works

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-The `handle` hook runs on every request, so all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — passes through your SvelteKit deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
+The `handle` hook runs on every request, so all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – passes through your SvelteKit deployment. Costs depend on where it's hosted: serverless platforms like Vercel or Netlify bill this as bandwidth and function invocations, which can add up on high-traffic sites, especially because session recordings are often 1–5 MB each.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -10,6 +10,14 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <ProxyCallout />
 
+<CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
+
+Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through Vercel, which bills it as [Fast Data Transfer and Edge Requests](https://vercel.com/docs/pricing). Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
+
+To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
+
+</CalloutBox>
+
 This guide shows you how to use [Vercel rewrites](https://vercel.com/docs/projects/project-configuration#rewrites) as a reverse proxy for PostHog.
 
 ## How it works

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -12,7 +12,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 
 <CalloutBox icon="IconInfo" title="Data transfer costs" type="fyi">
 
-Proxying routes all PostHog traffic — events, session recordings, feature flag polls, and SDK assets — through Vercel, which bills it as [Fast Data Transfer and Edge Requests](https://vercel.com/docs/pricing). Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
+Proxying routes all PostHog traffic – events, session recordings, feature flag polls, and SDK assets – through Vercel, which bills it as [Fast Data Transfer and Edge Requests](https://vercel.com/docs/pricing). Session recordings are the biggest driver (often 1–5 MB per session) and can consume a plan quickly on high-traffic sites.
 
 To avoid these costs, use the [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) (free for PostHog Cloud users) or a provider without egress fees like [Cloudflare Workers](/docs/advanced/proxy/cloudflare).
 


### PR DESCRIPTION
## Changes

Added cost warning callout boxes to all proxy documentation pages to inform users about potential data transfer and request billing implications when using third-party proxy providers.

**Pages updated:**
- CloudFront, Netlify, Next.js (rewrites), Next.js (middleware), Nuxt, Railway, Remix, SvelteKit, and Vercel proxy guides: Added warnings about egress fees and request billing specific to each platform
- Cloudflare Workers guide: Added note highlighting its cost advantages (no egress fees, generous free tier)
- Main proxy overview page: Added introductory paragraph about traffic costs and recommendation to use managed reverse proxy

Each warning callout:
- Explains what traffic flows through the proxy (events, session recordings, feature flags, SDK assets)
- Describes the specific billing model for that platform
- Highlights session recordings as the primary cost driver (1–5 MB per session)
- Recommends the managed reverse proxy (free for PostHog Cloud) or Cloudflare Workers as cost-effective alternatives

## Checklist

- [x] I've read the docs style guide
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] Added consistent messaging across all proxy documentation pages

https://claude.ai/code/session_01AENxqDUqS68HsyggC1FQrm