### PR TITLE
Update proxy path from '/ph' to '/yourpath'

### DIFF
--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -32,7 +32,7 @@ Next.js rewrites map incoming request paths to different destinations. When you 
 Here's the request flow:
 
 1. User triggers an event in your app
-2. Request goes to your domain (e.g., `yourdomain.com/ph`)
+2. Request goes to your domain (e.g., `yourdomain.com/yourpath`)
 3. Next.js matches the request against your rewrite rules
 4. Next.js fetches the response from PostHog's servers
 5. Next.js returns PostHog's response under your domain
@@ -65,15 +65,15 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/ph/static/:path*',
+        source: '/yourpath/static/:path*',
         destination: 'https://us-assets.i.posthog.com/static/:path*',
       },
       {
-        source: '/ph/array/:path*',
+        source: '/yourpath/array/:path*',
         destination: 'https://us-assets.i.posthog.com/array/:path*',
       },
       {
-        source: '/ph/:path*',
+        source: '/yourpath/:path*',
         destination: 'https://us.i.posthog.com/:path*',
       },
     ]
@@ -93,7 +93,7 @@ Here's what each part does:
 - The third rewrite routes all other requests to PostHog's main API. This handles event capture, Feature flags, and session recordings.
 - `skipTrailingSlashRedirect` prevents Next.js from redirecting URLs with trailing slashes. PostHog's API uses trailing slashes (like `/e/`), and without this setting, Next.js would redirect them and break event capture.
 
-The static and array rewrites must come before the catch-all. Next.js evaluates rewrites in order, so if the catch-all rule came first, it would match `/ph/static/*` and `/ph/array/*` before the specific rules.
+The static and array rewrites must come before the catch-all. Next.js evaluates rewrites in order, so if the catch-all rule came first, it would match `/yourpath/static/*` and `/yourpath/array/*` before the specific rules.
 
 See [Next.js rewrites documentation](https://nextjs.org/docs/app/api-reference/next-config-js/rewrites) for more details.
 
@@ -107,14 +107,14 @@ In your application code, update your PostHog initialization to use your proxy p
 
 ```js file=US
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
-  api_host: '/ph',
+  api_host: '/yourpath',
   ui_host: 'https://us.posthog.com'
 })
 ```
 
 ```js file=EU
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
-  api_host: '/ph',
+  api_host: '/yourpath',
   ui_host: 'https://eu.posthog.com'
 })
 ```
@@ -137,7 +137,7 @@ Confirm events are flowing through your proxy:
 
 1. Open your browser's developer tools and go to the **Network** tab
 2. Navigate to your site or trigger an event
-3. Look for requests to your domain with your proxy path (e.g., `yourdomain.com/ph`)
+3. Look for requests to your domain with your proxy path (e.g., `yourdomain.com/yourpath`)
 4. Verify the response status is `200 OK`
 5. Check the [PostHog app](https://app.posthog.com) to confirm events appear in your activity feed
 


### PR DESCRIPTION
We've [learned from experience](https://posthog.slack.com/archives/C01FHN8DNN6/p1749668999952489) that suggestions we make/examples we use for reverse proxy naming will eventually be spotted and blocked by adblockers. e.g. `/ingest` was a suggestion that used to be in our docs and was later removed from our docs after we spotted it in adblocking/anti-tracking lists.

So, changing instance of this:

```
/ph
```

to this:

```
/yourpath
```