### PR TITLE
feat: offset pagination

### DIFF
--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -257,7 +257,7 @@ Bad names are generic and vague:
 
 ### 5. Use keyset pagination instead of OFFSET
 
-`OFFSET` pagination is **not supported** for programmatic requests on `/query` and is currently rejected with HTTP 400 for personal API keys. If you're paginating to export data, **stop and use [batch exports](/docs/cdp/batch-exports) instead** — `/query` is not a supported export path.
+`OFFSET` pagination is **not supported** for programmatic requests on `/query` and is currently rejected with HTTP 400 for personal API keys. If you're paginating to export data, **stop and use [batch exports](/docs/cdp/batch-exports) instead** – `/query` is not a supported export path.
 
 For ad-hoc paging, use keyset pagination on the table's sort column: `timestamp` for `events`, `id` for `persons`. Other columns (e.g. `created_at`) are not indexed for this and will be slow.
 

--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -255,52 +255,21 @@ Bad names are generic and vague:
 - `test`
 - `data`
 
-### 5. Use timestamp-based pagination instead of OFFSET
+### 5. Use keyset pagination instead of OFFSET
 
-`OFFSET` pagination is **not supported** for programmatic requests on `/query` — it currently returns HTTP 400 when authenticating with a personal API key, and we may reject it for other authentication methods (OAuth tokens, etc.) at any time. Use keyset pagination on `timestamp` instead.
+`OFFSET` pagination is **not supported** for programmatic requests on `/query` and is currently rejected with HTTP 400 for personal API keys. If you're paginating to export data, **stop and use [batch exports](/docs/cdp/batch-exports) instead** — `/query` is not a supported export path.
 
-This isn't only a restriction: keyset pagination is also dramatically more efficient on large tables like `events` and `query_log`, and scales better as your data grows.
+For ad-hoc paging, use keyset pagination on the table's sort column: `timestamp` for `events`, `id` for `persons`. Other columns (e.g. `created_at`) are not indexed for this and will be slow.
 
-**❌ Inefficient approach using OFFSET:**
 ```sql
--- First batch
-SELECT timestamp, event, distinct_id
-FROM events
-WHERE timestamp >= '2024-01-01'
-ORDER BY timestamp
-LIMIT 1000;
+-- ❌ Rejected
+SELECT * FROM events WHERE timestamp >= '2024-01-01'
+ORDER BY timestamp LIMIT 1000 OFFSET 1000;
 
--- Second batch
-SELECT timestamp, event, distinct_id
-FROM events
-WHERE timestamp >= '2024-01-01'
-ORDER BY timestamp
-LIMIT 1000 OFFSET 1000;  -- This gets slower with each page
+-- ✅ Keyset pagination
+SELECT * FROM events WHERE timestamp > '2024-01-01 12:34:56.789'
+ORDER BY timestamp LIMIT 1000;
 ```
-
-**✅ Efficient approach using timestamp pagination:**
-```sql
--- First batch
-SELECT timestamp, event, distinct_id
-FROM events
-WHERE timestamp >= '2024-01-01'
-ORDER BY timestamp
-LIMIT 1000;
-
--- Second batch (use timestamp of last event from previous batch)
-SELECT timestamp, event, distinct_id
-FROM events
-WHERE timestamp > '2024-01-01 12:34:56.789'  -- timestamp from last row of previous batch
-ORDER BY timestamp
-LIMIT 1000;
-```
-
-This approach is more efficient because:
-- **Constant performance**: Each query executes in similar time regardless of how many rows you've already retrieved
-- **Index-friendly**: Uses the timestamp index effectively for filtering
-- **Scalable**: Performance doesn't degrade as you paginate through millions of rows
-
-**For geeks:** OFFSET-based pagination gets progressively slower because the database must scan and skip all the offset rows for each query. With timestamp-based pagination, the database uses the timestamp index to directly jump to the right starting point, maintaining consistent performance across all pages.
 
 ### 6. Other SQL optimizations
 

--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -257,7 +257,7 @@ Bad names are generic and vague:
 
 ### 5. Use timestamp-based pagination instead of OFFSET
 
-`OFFSET` pagination is **not supported** on `/query` when authenticating with a personal API key — requests using it return HTTP 400. Use keyset pagination on `timestamp` instead.
+`OFFSET` pagination is **not supported** for programmatic requests on `/query` — it currently returns HTTP 400 when authenticating with a personal API key, and we may reject it for other authentication methods (OAuth tokens, etc.) at any time. Use keyset pagination on `timestamp` instead.
 
 This isn't only a restriction: keyset pagination is also dramatically more efficient on large tables like `events` and `query_log`, and scales better as your data grows.
 

--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -257,7 +257,9 @@ Bad names are generic and vague:
 
 ### 5. Use timestamp-based pagination instead of OFFSET
 
-When querying large datasets like `events` or `query_log` over multiple batches, avoid using `OFFSET` for pagination. Instead, use timestamp-based pagination, which is much more efficient and scales better.
+`OFFSET` pagination is **not supported** on `/query` when authenticating with a personal API key — requests using it return HTTP 400. Use keyset pagination on `timestamp` instead.
+
+This isn't only a restriction: keyset pagination is also dramatically more efficient on large tables like `events` and `query_log`, and scales better as your data grows.
 
 **❌ Inefficient approach using OFFSET:**
 ```sql

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -40,7 +40,7 @@ To create a query, you make a `POST` request to the `/api/projects/:project_id/q
 
 By default, API queries return up to 100 rows. If you specify your own `LIMIT`, you can return up to 50k rows per query.
 
-For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is not supported for programmatic requests and is currently rejected with HTTP 400 for personal API keys. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) — `/query` is not a supported export path.
+For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is not supported for programmatic requests and is currently rejected with HTTP 400 for personal API keys. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) – `/query` is not a supported export path.
 
 </CalloutBox>
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -18,7 +18,7 @@ The `/query` endpoint is intended for ad-hoc analytics and embedded use cases. I
 
 - **Bulk or recurring exports of `events`, `persons`, or `query_log` are not supported** over `/query`. Use [batch exports](/docs/cdp/batch-exports) for ETL, data warehouse syncs, and any integration that pulls more than a few thousand rows on a schedule.
 - **Third-party connectors must use [batch exports](/docs/cdp/batch-exports)**, not `/query`. Connectors built on `/query` are not supported and will be rate-limited or rejected.
-- **`OFFSET` pagination is not supported with personal API keys** and will return HTTP 400. If you need to page through results, use keyset pagination on `timestamp` (see [below](#5-use-timestamp-based-pagination-instead-of-offset)).
+- **`OFFSET` pagination is not supported for programmatic requests** (personal API keys, OAuth tokens, and similar). It currently returns HTTP 400 for personal API keys, and we may reject it for other authentication methods at any time. Use keyset pagination on `timestamp` instead (see [below](#5-use-timestamp-based-pagination-instead-of-offset)).
 - We **reserve the right to rate-limit, restrict, or reject** queries that look like exports, including without prior notice. Pipelines built on `/query` may break at any time.
 - Use [real-time destinations](/docs/cdp/destinations) for sending data to Slack, webhooks, etc.
 - Use [materialized views](/docs/data-warehouse/views/materialize) for expensive recurring aggregations. You can [query these through SQL](#2-materialize-a-view-for-the-data-you-need) and get faster results.
@@ -40,7 +40,7 @@ To create a query, you make a `POST` request to the `/api/projects/:project_id/q
 
 By default, API queries return up to 100 rows. If you specify your own `LIMIT`, you can return up to 50k rows per query.
 
-For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is rejected with HTTP 400 when authenticating with a personal API key. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) — `/query` is not a supported export path.
+For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is not supported for programmatic requests and is currently rejected with HTTP 400 for personal API keys. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) — `/query` is not a supported export path.
 
 </CalloutBox>
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -12,10 +12,18 @@ API queries enable you to query your data in PostHog. This is useful for:
 - Building [embedded analytics](/tutorials/embedded-analytics). 
 - Pulling aggregated PostHog data into your own or other apps.
 
-> **When should you _not_ use API queries?**
-> 1. When you want to export large amounts of data. Use [batch exports](/docs/cdp/batch-exports) instead.
-> 2. When you want to send data to destinations like Slack or webhooks immediately. Use [real-time destinations](/docs/cdp/destinations) instead.
-> 3. If you need data from long-running queries with high memory usage at regular intervals. In this case, you should use [materialized views](/docs/data-warehouse/views/materialize) with a schedule instead. You can [query these through SQL](#2-materialize-a-view-for-the-data-you-need) and get faster results.
+<CalloutBox icon="IconWarning" type="caution" title="The /query endpoint is not for exports">
+
+The `/query` endpoint is intended for ad-hoc analytics and embedded use cases. It is **not a supported export mechanism**.
+
+- **Bulk or recurring exports of `events`, `persons`, or `query_log` are not supported** over `/query`. Use [batch exports](/docs/cdp/batch-exports) for ETL, data warehouse syncs, and any integration that pulls more than a few thousand rows on a schedule.
+- **Third-party connectors must use [batch exports](/docs/cdp/batch-exports)**, not `/query`. Connectors built on `/query` are not supported and will be rate-limited or rejected.
+- **`OFFSET` pagination is not supported with personal API keys** and will return HTTP 400. If you need to page through results, use keyset pagination on `timestamp` (see [below](#5-use-timestamp-based-pagination-instead-of-offset)).
+- We **reserve the right to rate-limit, restrict, or reject** queries that look like exports, including without prior notice. Pipelines built on `/query` may break at any time.
+- Use [real-time destinations](/docs/cdp/destinations) for sending data to Slack, webhooks, etc.
+- Use [materialized views](/docs/data-warehouse/views/materialize) for expensive recurring aggregations. You can [query these through SQL](#2-materialize-a-view-for-the-data-you-need) and get faster results.
+
+</CalloutBox>
 
 ## Prerequisites
 
@@ -30,7 +38,9 @@ To create a query, you make a `POST` request to the `/api/projects/:project_id/q
 
 <CalloutBox icon="IconInfo" type="fyi" title="Query limits">
 
-By default, API queries return up to 100 rows. If you specify your own `LIMIT` value, you can return up to 50k rows per query before we suggest [paginating](#5-use-timestamp-based-pagination-instead-of-offset).
+By default, API queries return up to 100 rows. If you specify your own `LIMIT`, you can return up to 50k rows per query.
+
+For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is rejected with HTTP 400 when authenticating with a personal API key. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) — `/query` is not a supported export path.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes
Mention that we do not support offset pagination on the /query endpoint with personal api keys.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
