### PR TITLE
docs(feature-flags): note cron schedules drift to UTC after first run

### DIFF
--- a/contents/docs/feature-flags/scheduled-flag-changes.mdx
+++ b/contents/docs/feature-flags/scheduled-flag-changes.mdx
@@ -102,6 +102,8 @@ Here are some common examples:
 
 > **Note:** Only standard 5-field cron expressions are supported. Six-field expressions (with seconds) are not allowed.
 
+> **Note:** The first run of a recurring cron schedule fires in your project's timezone, but subsequent runs are currently computed in UTC. This means schedules can drift relative to your project timezone across daylight-saving transitions. If precise wall-clock timing matters for every run, prefer one-time schedules or paired daily presets until full project-timezone cron support ships.
+
 ## Schedule changes with MCP
 
 You can also schedule flag changes programmatically using the [PostHog MCP server](/docs/feature-flags/create-flags-mcp#scheduled-change-tools). This enables AI coding agents to create, list, update, and delete scheduled changes directly from your code editor.


### PR DESCRIPTION
## Summary

- Adds a caveat to `contents/docs/feature-flags/scheduled-flag-changes.mdx` under **Custom cron expressions** noting that the first run of a recurring cron schedule fires in the project's timezone but subsequent runs are currently computed in UTC, so schedules drift across DST transitions.
- Recommends one-time schedules or paired daily presets as a workaround until full project-timezone cron support ships.

## Why

[PostHog/posthog#56078](https://github.com/PostHog/posthog/pull/56078) fixed scheduled flag changes to use the project timezone end-to-end on the frontend save/load/display path. The existing **Timezones** section on this page (added in #16200) is now accurate for one-time schedules. The PR explicitly called out one known follow-up left out of scope: `compute_next_run_cron` in `posthog/tasks/process_scheduled_changes.py` still computes recurring cron next-runs in UTC. This note surfaces that gap so users picking weekday-style crons (e.g., `0 9 * * 1-5`) aren't surprised when the first run lands in project-local time and subsequent runs drift.