### PR TITLE
Updated product team page (added Ruby Childs, assigned to experiments…

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -79,12 +79,19 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend>Product teams with no PM currently</legend>
+<legend><TeamMember name="Ruby Childs" photo /></legend>
 
--   <SmallTeam slug="conversations" />
 -   <SmallTeam slug="experiments" />
 -   <SmallTeam slug="feature-flags" />
 -   <SmallTeam slug="flags-platform" />
+
+
+</fieldset>
+
+<fieldset>
+<legend>Product teams with no PM currently</legend>
+
+-   <SmallTeam slug="conversations" />
 
 </fieldset>
 
@@ -114,5 +121,5 @@ In Q2 2026, we are working on the following themes:
 
 “Business-as-usual” themes:
 
-- Make sure we standardise best practices & share knowledge as a group of 5 (soon to be 7) without central leadership, and without adding bureaucracy & friction
+- Make sure we standardise best practices & share knowledge as a group of 6 (soon to be 7) without central leadership, and without adding bureaucracy & friction
 - Use our PM brownbags to share how we use AI to be more effective


### PR DESCRIPTION
## Changes

1. Added a new fieldset for Ruby Childs (lines 81-89) with three small-team assignments:
- experiments
- feature-flags
- flags-platform

2. Removed those three teams from the "Product teams with no PM currently" fieldset — conversations is now the only team without a PM.
3. Updated the group size from "as a group of 5 (soon to be 7)" to "as a group of 6 (soon to be 7)" (line 117).

<img width="1021" height="687" alt="Screenshot 2026-04-28 at 1 18 05 AM" src="https://github.com/user-attachments/assets/4f3ea469-e2f0-4065-9981-64e3491bafb0" />

## Checklist

- [X ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [X] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [N/A] If I moved a page, I added a redirect in `vercel.json`
