### PR TITLE
Add /r/posthog-mcp landing page

### DIFF
--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -1,0 +1,426 @@
+import React, { useState, useEffect } from 'react'
+import SEO from 'components/seo'
+import ReaderView from 'components/ReaderView'
+import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
+import { CallToAction } from 'components/CallToAction'
+import { ProductScreenshot } from 'components/ProductScreenshot'
+import { ProductVideo } from 'components/ProductVideo'
+import Link from 'components/Link'
+import CloudinaryImage from 'components/CloudinaryImage'
+import { SingleCodeBlock } from 'components/CodeBlock'
+import ElevenLabsLogo from 'components/CustomerLogos/ElevenLabsLogo'
+import HeygenLogo from 'components/CustomerLogos/HeygenLogo'
+import ExaLogo from 'components/CustomerLogos/ExaLogo'
+
+export default function PostHogMCPLanding(): JSX.Element {
+    const [isIdle, setIsIdle] = useState(false)
+
+    useEffect(() => {
+        let idleTimer: ReturnType<typeof setTimeout>
+
+        const handleActivity = () => {
+            setIsIdle(false)
+            clearTimeout(idleTimer)
+            idleTimer = setTimeout(() => setIsIdle(true), 2000)
+        }
+
+        handleActivity()
+        window.addEventListener('pointermove', handleActivity)
+        window.addEventListener('keydown', handleActivity)
+
+        const scrollViewport = document.querySelector('[data-radix-scroll-area-viewport]')
+        scrollViewport?.addEventListener('scroll', handleActivity)
+
+        return () => {
+            clearTimeout(idleTimer)
+            window.removeEventListener('pointermove', handleActivity)
+            window.removeEventListener('keydown', handleActivity)
+            scrollViewport?.removeEventListener('scroll', handleActivity)
+        }
+    }, [])
+
+    return (
+        <>
+            <SEO
+                title="PostHog MCP - A product analyst that lives in your editor"
+                description="With PostHog MCP, your AI agents can grab session replays, summarize user behavior, build funnels, and turn bug reports into PRs, all from Claude Code, Cursor, Zed, or Windsurf. No per-seat pricing, no credit card."
+                noindex
+            />
+            <ReaderView
+                hideLeftSidebar
+                hideRightSidebar
+                hideTitle
+                title="PostHog MCP"
+                contentMaxWidthClass="max-w-5xl"
+                showQuestions={false}
+            >
+                <div className="grid grid-cols-1 @lg:grid-cols-[1.2fr_1fr] gap-10 items-center mb-6 max-w-7xl mx-auto">
+                    <div>
+                        <h1 className="text-3xl md:text-5xl !mb-4">PostHog MCP</h1>
+                        <p className="text-lg md:text-xl mb-6 text-secondary">
+                            A product analyst that lives in your editor. Ask anything.
+                        </p>
+                        <div className="flex flex-wrap gap-2 mb-6">
+                            <CallToAction type="primary" size="md" to="https://us.posthog.com/signup">
+                                Get started free
+                            </CallToAction>
+                            <CallToAction
+                                type="secondary"
+                                size="md"
+                                to="/docs/model-context-protocol"
+                                state={{ newWindow: true }}
+                            >
+                                Install MCP
+                            </CallToAction>
+                        </div>
+                        <p className="text-sm !mb-0 text-secondary">
+                            With{' '}
+                            <Link to="/docs/model-context-protocol" state={{ newWindow: true }}>
+                                PostHog MCP
+                            </Link>
+                            , your AI agents can grab session replays, summarize user behavior, and turn bug reports
+                            into PRs, all from Claude Code, Cursor, Zed, or Windsurf. Instead of manually searching for
+                            insights, building dashboards, and writing SQL queries, just ask your agent to use the
+                            PostHog MCP. No per-seat pricing, no credit card.
+                        </p>
+                    </div>
+                    <div>
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Group_143773_7436a145da.png"
+                            alt="PostHog MCP in your editor"
+                            className="w-full"
+                        />
+                    </div>
+                </div>
+
+                <div className="mb-12 max-w-7xl mx-auto">
+                    <div className="flex flex-wrap items-center gap-x-12 gap-y-6 text-primary dark:text-primary-dark">
+                        <ElevenLabsLogo className="fill-current object-contain max-w-full h-8" />
+                        <HeygenLogo className="fill-current object-contain max-w-full h-8" />
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/kilocode_logo_c58c88f029.webp"
+                            alt="Kilo Code"
+                            imgClassName="object-contain max-w-full h-8 w-auto"
+                        />
+                        <ExaLogo className="fill-current object-contain max-w-full h-8" />
+                    </div>
+                    <p className="text-xs mt-3 !mb-0">
+                        <span className="font-semibold">A few PostHog MCP customers.</span>
+                        <br />
+                        <span className="text-muted">
+                            (Yes they actually use us, no it's not just some random engineer who tried us out 2+ years
+                            ago.)
+                        </span>
+                    </p>
+                </div>
+
+                <div className={isIdle ? 'quest-idle' : ''}>
+                    <QuestLog
+                        firstSpeechBubble="Let's wire up your editor!"
+                        lastSpeechBubble="Time to start shipping!"
+                    >
+                        <QuestLogItem
+                            title="Start with the Wizard"
+                            subtitle="Set up PostHog in 8 minutes with the Wizard"
+                            icon="IconMagicWand"
+                        >
+                            <p>
+                                <strong>PostHog Wizard</strong> is an agentic CLI tool that installs and configures
+                                PostHog for you. The Wizard analyzes your codebase and automagically sets up the right
+                                tools, custom events, and dashboards for your product. All it takes is one line:
+                            </p>
+
+                            <SingleCodeBlock language="bash" showAskAI={false}>
+                                npx @posthog/wizard
+                            </SingleCodeBlock>
+
+                            <ProductVideo
+                                videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/mcp_session_replay_1080_de1089e7aa_ee24396774.mp4"
+                                videoDark={undefined}
+                                classes="rounded border border-primary"
+                                autoPlay={true}
+                            />
+
+                            <p>No schemas to design upfront. No data warehouse to set up.</p>
+
+                            <p className="text-secondary">
+                                <em>Prefer to manually set up PostHog in your codebase? Already using PostHog and want
+                                to wire it into your IDE?</em>
+                            </p>
+                            <p>
+                                You can still benefit from installing the MCP. Instead of using the Wizard, use the
+                                following in your terminal:
+                            </p>
+
+                            <SingleCodeBlock language="bash" showAskAI={false}>
+                                npx @posthog/wizard mcp add
+                            </SingleCodeBlock>
+
+                            <div className="mt-4">
+                                <CallToAction type="primary" size="md" to="https://us.posthog.com/signup">
+                                    Set up PostHog with AI
+                                </CallToAction>
+                            </div>
+                        </QuestLogItem>
+
+                        <QuestLogItem
+                            title="Talk to me, baby"
+                            subtitle="Natural language navigation"
+                            icon="IconChat"
+                        >
+                            <p>
+                                Once you connect the PostHog MCP server to Claude, Cursor, or whatever agent you
+                                already use, just ask a question. For example:
+                            </p>
+
+                            <ul>
+                                <li>
+                                    <em>"Why did sign-ups drop 12% last Tuesday?"</em>
+                                </li>
+                                <li>
+                                    <em>
+                                        "Build me a funnel from landing page to paid conversion, broken down by
+                                        marketing source."
+                                    </em>
+                                </li>
+                                <li>
+                                    <em>
+                                        "Show me warning and error logs from the last 24 hours, excluding debug noise."
+                                    </em>
+                                </li>
+                                <li>
+                                    <em>
+                                        "Create a feature flag called new-checkout-flow rolled out to 20% of users on
+                                        the pro plan."
+                                    </em>
+                                </li>
+                            </ul>
+
+                            <p>
+                                The agent pulls from your real events, builds the insight, and explains what it found.
+                                You stay in your IDE or CLI. No context switching, no dashboard archaeology.
+                            </p>
+
+                            <ProductVideo
+                                videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/mcp_session_replay_1080_de1089e7aa.mp4"
+                                videoDark={undefined}
+                                classes="rounded border border-primary"
+                                autoPlay={true}
+                            />
+
+                            <ul>
+                                <li>Works with Claude, Cursor, Windsurf, and any MCP-compatible client</li>
+                                <li>HogQL (our SQL) and the UI insight builder are there when you need them</li>
+                                <li>Full audit log of every query run on your data, by humans or agents</li>
+                            </ul>
+
+                            <div className="mt-4">
+                                <CallToAction
+                                    type="primary"
+                                    size="md"
+                                    to="/docs/model-context-protocol"
+                                    state={{ newWindow: true }}
+                                >
+                                    Connect the MCP server
+                                </CallToAction>
+                            </div>
+                        </QuestLogItem>
+
+                        <QuestLogItem
+                            title="See your product's performance"
+                            subtitle="Product analytics and insights"
+                            icon="IconGraph"
+                        >
+                            <p>
+                                The PostHog MCP server gives your AI coding agent direct access to PostHog analytics.
+                                Query trends, funnels, retention, and custom HogQL – all from your code editor.
+                            </p>
+
+                            <p>With the PostHog MCP, you can:</p>
+
+                            <ul>
+                                <li>
+                                    <strong>Check feature performance before making code changes</strong> – "How many
+                                    users are using the new search feature this week?"
+                                </li>
+                                <li>
+                                    <strong>Pull conversion rates into your workflow</strong> – "What's the funnel
+                                    conversion from signup to first project?"
+                                </li>
+                                <li>
+                                    <strong>Investigate metric changes</strong> – "Did the login success rate change
+                                    after last Tuesday's deploy?"
+                                </li>
+                                <li>
+                                    <strong>Build insights on demand</strong> – "Create a trend showing daily active
+                                    users broken down by plan. Then, create a report."
+                                </li>
+                            </ul>
+
+                            <ProductVideo
+                                videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/MCP_claude_chat_0633217f46.mp4"
+                                videoDark={undefined}
+                                classes="rounded border border-primary"
+                                autoPlay={true}
+                            />
+
+                            <div className="mt-4">
+                                <CallToAction
+                                    type="primary"
+                                    size="md"
+                                    to="/docs/product-analytics/build-insights-mcp"
+                                    state={{ newWindow: true }}
+                                >
+                                    MCP for Analytics
+                                </CallToAction>
+                            </div>
+                        </QuestLogItem>
+
+                        <QuestLogItem
+                            title="Triage issues, fix automatically"
+                            subtitle="Use PostHog's debugging tools to quickly find issues and get the context to fix them"
+                            icon="IconWarning"
+                        >
+                            <p>
+                                No more grep. No more searching through stack traces. No more comparing customer
+                                profiles to your logs.
+                            </p>
+
+                            <p>
+                                Instead, query your data warehouse tables, clickstream event data, errors, and more to
+                                answer tough questions using your actual data – events, warehouse tables, errors,
+                                recordings – in one place.
+                            </p>
+
+                            <p>With the PostHog MCP, you can:</p>
+
+                            <ul>
+                                <li>
+                                    <strong>Prioritize errors by any metric</strong> – "Which errors impact user
+                                    sign-ups the most?"
+                                </li>
+                                <li>
+                                    <strong>Get front-end context while investigating logs and errors</strong> – "Show
+                                    recordings from enterprise users in the last 24 hours."
+                                </li>
+                                <li>
+                                    <strong>Let PostHog surface errors that matter most</strong> – "What services are
+                                    logging errors? Search for error logs from the payments service."
+                                </li>
+                            </ul>
+
+                            <div className="mt-4">
+                                <CallToAction
+                                    type="primary"
+                                    size="md"
+                                    to="/docs/error-tracking/debug-errors-mcp"
+                                    state={{ newWindow: true }}
+                                >
+                                    Debug with MCP
+                                </CallToAction>
+                            </div>
+                        </QuestLogItem>
+
+                        <QuestLogItem
+                            title="Ship, measure, iterate"
+                            subtitle="Feature flags, experiments, and surveys on the same events"
+                            icon="IconRocket"
+                        >
+                            <p>
+                                You've found the problem. Now ship the fix behind a flag, measured, and A/B tested.
+                                Just ask your agent to do it.
+                            </p>
+
+                            <ProductScreenshot
+                                imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/feature_flags_claude_code_3eddf374a9.png"
+                                imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/feature_flags_claude_code_3eddf374a9.png"
+                                alt="Feature flags managed from Claude Code"
+                                classes="rounded"
+                                padding={false}
+                                zoom={undefined}
+                            />
+
+                            <p>With the PostHog MCP, you can:</p>
+
+                            <ul>
+                                <li>
+                                    <strong>Create flags while building features</strong> – "Create a flag called
+                                    new-search rolled out to 10% of users" as part of your development workflow.
+                                </li>
+                                <li>
+                                    <strong>Set up A/B tests in plain English</strong> – "Create an A/B test for the
+                                    new checkout flow with a 70/30 split. Use purchase_completed as the goal metric."
+                                </li>
+                                <li>
+                                    <strong>Get updates on experiments</strong> – "Is the dark-mode-test Experiment
+                                    statistically significant yet?"
+                                </li>
+                            </ul>
+
+                            <div className="mt-4">
+                                <CallToAction
+                                    type="primary"
+                                    size="md"
+                                    to="/docs/experiments/create-experiments-mcp"
+                                    state={{ newWindow: true }}
+                                >
+                                    Optimize with MCP
+                                </CallToAction>
+                            </div>
+                        </QuestLogItem>
+
+                        <QuestLogItem
+                            title="Use for free"
+                            subtitle="The PostHog MCP doesn't cost extra"
+                            icon="IconPiggyBank"
+                        >
+                            <p>
+                                PostHog is cheap. There's a generous free tier, no per-seat fees, and pricing is
+                                usage-based and published. More than 90% of companies use PostHog for free.
+                            </p>
+
+                            <p>
+                                Here's the kicker: <strong>using the PostHog MCP doesn't cost extra</strong>.
+                            </p>
+
+                            <h2>TL;DR 💸</h2>
+
+                            <ul>
+                                <li>No credit card required to start</li>
+                                <li>
+                                    <strong>PostHog MCP is included</strong> (no enterprise plan required)
+                                </li>
+                                <li>Set billing limits to avoid surprise charges</li>
+                                <li>
+                                    See our{' '}
+                                    <Link to="/pricing" state={{ newWindow: true }}>
+                                        pricing page
+                                    </Link>{' '}
+                                    for more up-to-date details
+                                </li>
+                            </ul>
+
+                            <hr className="my-6" />
+
+                            <p>That's it! You're ready to start integrating.</p>
+
+                            <div className="flex flex-wrap gap-2 mt-4">
+                                <CallToAction type="primary" size="md" to="https://us.posthog.com/signup">
+                                    Get started free
+                                </CallToAction>
+                                <CallToAction
+                                    type="secondary"
+                                    size="md"
+                                    to="/talk-to-a-human"
+                                    state={{ newWindow: true }}
+                                >
+                                    Talk to a human
+                                </CallToAction>
+                            </div>
+                        </QuestLogItem>
+                    </QuestLog>
+                </div>
+            </ReaderView>
+        </>
+    )
+}

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -54,7 +54,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                 contentMaxWidthClass="max-w-5xl"
                 showQuestions={false}
             >
-                <div className="grid grid-cols-1 @lg:grid-cols-[1.2fr_1fr] gap-10 items-center mb-6 max-w-7xl mx-auto">
+                <div className="grid grid-cols-1 @lg:grid-cols-[1.2fr_1fr] gap-10 items-start mb-6 max-w-7xl mx-auto">
                     <div>
                         <h1 className="text-3xl md:text-5xl !mb-4">PostHog MCP</h1>
                         <p className="text-lg md:text-xl mb-6 text-secondary">
@@ -115,10 +115,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                 </div>
 
                 <div className={isIdle ? 'quest-idle' : ''}>
-                    <QuestLog
-                        firstSpeechBubble="Let's wire up your editor!"
-                        lastSpeechBubble="Time to start shipping!"
-                    >
+                    <QuestLog firstSpeechBubble="Let's wire up your editor!" lastSpeechBubble="Time to start shipping!">
                         <QuestLogItem
                             title="Start with the Wizard"
                             subtitle="Set up PostHog in 8 minutes with the Wizard"
@@ -144,8 +141,10 @@ export default function PostHogMCPLanding(): JSX.Element {
                             <p>No schemas to design upfront. No data warehouse to set up.</p>
 
                             <p className="text-secondary">
-                                <em>Prefer to manually set up PostHog in your codebase? Already using PostHog and want
-                                to wire it into your IDE?</em>
+                                <em>
+                                    Prefer to manually set up PostHog in your codebase? Already using PostHog and want
+                                    to wire it into your IDE?
+                                </em>
                             </p>
                             <p>
                                 You can still benefit from installing the MCP. Instead of using the Wizard, use the
@@ -163,14 +162,10 @@ export default function PostHogMCPLanding(): JSX.Element {
                             </div>
                         </QuestLogItem>
 
-                        <QuestLogItem
-                            title="Talk to me, baby"
-                            subtitle="Natural language navigation"
-                            icon="IconChat"
-                        >
+                        <QuestLogItem title="Talk to me, baby" subtitle="Natural language navigation" icon="IconChat">
                             <p>
-                                Once you connect the PostHog MCP server to Claude, Cursor, or whatever agent you
-                                already use, just ask a question. For example:
+                                Once you connect the PostHog MCP server to Claude, Cursor, or whatever agent you already
+                                use, just ask a question. For example:
                             </p>
 
                             <ul>
@@ -327,8 +322,8 @@ export default function PostHogMCPLanding(): JSX.Element {
                             icon="IconRocket"
                         >
                             <p>
-                                You've found the problem. Now ship the fix behind a flag, measured, and A/B tested.
-                                Just ask your agent to do it.
+                                You've found the problem. Now ship the fix behind a flag, measured, and A/B tested. Just
+                                ask your agent to do it.
                             </p>
 
                             <ProductScreenshot
@@ -348,8 +343,8 @@ export default function PostHogMCPLanding(): JSX.Element {
                                     new-search rolled out to 10% of users" as part of your development workflow.
                                 </li>
                                 <li>
-                                    <strong>Set up A/B tests in plain English</strong> – "Create an A/B test for the
-                                    new checkout flow with a 70/30 split. Use purchase_completed as the goal metric."
+                                    <strong>Set up A/B tests in plain English</strong> – "Create an A/B test for the new
+                                    checkout flow with a 70/30 split. Use purchase_completed as the goal metric."
                                 </li>
                                 <li>
                                     <strong>Get updates on experiments</strong> – "Is the dark-mode-test Experiment

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -54,7 +54,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                 contentMaxWidthClass="max-w-5xl"
                 showQuestions={false}
             >
-                <div className="grid grid-cols-1 @lg:grid-cols-[1.2fr_1fr] gap-10 items-start mb-6 max-w-7xl mx-auto">
+                <div className="grid grid-cols-1 @lg:grid-cols-[1.2fr_1fr] gap-10 items-center mb-6 max-w-7xl mx-auto">
                     <div>
                         <h1 className="text-3xl md:text-5xl !mb-4">PostHog MCP</h1>
                         <p className="text-lg md:text-xl mb-6 text-secondary">
@@ -88,7 +88,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                         <CloudinaryImage
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Group_143773_7436a145da.png"
                             alt="PostHog MCP in your editor"
-                            className="w-full"
+                            className="w-full max-w-[260px] mx-auto"
                         />
                     </div>
                 </div>

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -84,11 +84,11 @@ export default function PostHogMCPLanding(): JSX.Element {
                             PostHog MCP. No per-seat pricing, no credit card.
                         </p>
                     </div>
-                    <div>
+                    <div className="flex justify-center">
                         <CloudinaryImage
-                            src="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Group_143773_7436a145da.png"
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/Group_143773_7436a145da_622d666c76.png"
                             alt="PostHog MCP in your editor"
-                            className="w-full max-w-[260px] mx-auto"
+                            className="w-full max-w-[350px] mx-auto"
                         />
                     </div>
                 </div>

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -210,12 +210,16 @@ export default function PostHogMCPLanding(): JSX.Element {
                                 <li>Full audit log of every query run on your data, by humans or agents</li>
                             </ul>
 
+                            <p>
+                                If you use any of the following PostHog products, chances are you're going to love our
+                                MCP.
+                            </p>
+
                             <ProductList
                                 className="grid gap-4 grid-cols-2 not-prose"
                                 urlPrefix="/docs/"
                                 products={[
                                     'product_analytics',
-                                    'web_analytics',
                                     'session_replay',
                                     'feature_flags',
                                     'experiments',
@@ -224,10 +228,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                                     'llm_analytics',
                                     'data_warehouse',
                                     'cdp',
-                                    'revenue_analytics',
                                     'logs',
-                                    'workflows',
-                                    'endpoints',
                                 ]}
                             />
 

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -120,7 +120,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                             title="Start with the Wizard"
                             subtitle="Set up PostHog in 8 minutes with the Wizard"
                             title="Install the MCP with the Wizard"
-                            subtitle="Automatica setup with one command"
+                            subtitle="Automatic setup with one command"
                             icon="IconMagicWand"
                         >
                             <p>

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -75,14 +75,13 @@ export default function PostHogMCPLanding(): JSX.Element {
                             </CallToAction>
                         </div>
                         <p className="text-sm !mb-0 text-secondary">
-                            With{' '}
+                            With the{' '}
                             <Link to="/docs/model-context-protocol" state={{ newWindow: true }}>
                                 PostHog MCP
                             </Link>
-                            , your AI agents can grab session replays, summarize user behavior, and turn bug reports
-                            into PRs, all from Claude Code, Cursor, Zed, or Windsurf. Instead of manually searching for
-                            insights, building dashboards, and writing SQL queries, just ask your agent to use the
-                            PostHog MCP. No per-seat pricing, no credit card.
+                            , your agents become PostHog geniuses. Instead of manually searching for insights, data, or
+                            trends in the PostHog user interface, just ask your agent to use the PostHog MCP. Works with
+                            Cursor, Codex, Claude Code, Windsurf, VS Code, and others.
                         </p>
                     </div>
                     <div className="flex justify-center">
@@ -123,13 +122,13 @@ export default function PostHogMCPLanding(): JSX.Element {
                             icon="IconMagicWand"
                         >
                             <p>
-                                <strong>PostHog Wizard</strong> is an agentic CLI tool that installs and configures
-                                PostHog for you. The Wizard analyzes your codebase and automagically sets up the right
-                                tools, custom events, and dashboards for your product. All it takes is one line:
+                                <strong>PostHog Wizard</strong> is an agentic CLI tool that installs and configures the
+                                PostHog MCP for you. The Wizard analyzes your codebase and automagically sets up the
+                                right tools, custom events, and dashboards for your product. All it takes is one line:
                             </p>
 
                             <SingleCodeBlock language="bash" showAskAI={false}>
-                                npx @posthog/wizard
+                                npx @posthog/wizard mcp add
                             </SingleCodeBlock>
 
                             <ProductVideo
@@ -139,34 +138,17 @@ export default function PostHogMCPLanding(): JSX.Element {
                                 autoPlay={true}
                             />
 
-                            <p>No schemas to design upfront. No data warehouse to set up.</p>
-
-                            <p className="text-secondary">
-                                <em>
-                                    Prefer to manually set up PostHog in your codebase? Already using PostHog and want
-                                    to wire it into your IDE?
-                                </em>
-                            </p>
-                            <p>
-                                You can still benefit from installing the MCP. Instead of using the Wizard, use the
-                                following in your terminal:
-                            </p>
-
-                            <SingleCodeBlock language="bash" showAskAI={false}>
-                                npx @posthog/wizard mcp add
-                            </SingleCodeBlock>
-
                             <div className="mt-4">
                                 <CallToAction type="primary" size="md" to="https://us.posthog.com/signup">
-                                    Set up PostHog with AI
+                                    Start cooking with our MCP
                                 </CallToAction>
                             </div>
                         </QuestLogItem>
 
                         <QuestLogItem title="Talk to me, baby" subtitle="Natural language navigation" icon="IconChat">
                             <p>
-                                Once you connect the PostHog MCP server to Claude, Cursor, or whatever agent you already
-                                use, just ask a question. For example:
+                                Once you connect to the PostHog MCP server, see how Hogpilled your agent has become. For
+                                example:
                             </p>
 
                             <ul>
@@ -210,10 +192,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                                 <li>Full audit log of every query run on your data, by humans or agents</li>
                             </ul>
 
-                            <p>
-                                If you use any of the following PostHog products, chances are you're going to love our
-                                MCP.
-                            </p>
+                            <p>If you use any of the following PostHog products, you're going to love our MCP.</p>
 
                             <ProductList
                                 className="grid gap-4 grid-cols-2 not-prose"
@@ -239,7 +218,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                                     to="/docs/model-context-protocol"
                                     state={{ newWindow: true }}
                                 >
-                                    Connect the MCP server
+                                    Get your agents Hogpilled
                                 </CallToAction>
                             </div>
                         </QuestLogItem>
@@ -289,7 +268,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                                     to="/docs/product-analytics/build-insights-mcp"
                                     state={{ newWindow: true }}
                                 >
-                                    MCP for Analytics
+                                    Deploy MCP for Analytics
                                 </CallToAction>
                             </div>
                         </QuestLogItem>

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -8,6 +8,7 @@ import { ProductVideo } from 'components/ProductVideo'
 import Link from 'components/Link'
 import CloudinaryImage from 'components/CloudinaryImage'
 import { SingleCodeBlock } from 'components/CodeBlock'
+import ProductList from 'components/ProductList'
 import ElevenLabsLogo from 'components/CustomerLogos/ElevenLabsLogo'
 import HeygenLogo from 'components/CustomerLogos/HeygenLogo'
 import ExaLogo from 'components/CustomerLogos/ExaLogo'
@@ -117,8 +118,6 @@ export default function PostHogMCPLanding(): JSX.Element {
                 <div className={isIdle ? 'quest-idle' : ''}>
                     <QuestLog firstSpeechBubble="Let's wire up your editor!" lastSpeechBubble="Time to start shipping!">
                         <QuestLogItem
-                            title="Start with the Wizard"
-                            subtitle="Set up PostHog in 8 minutes with the Wizard"
                             title="Install the MCP with the Wizard"
                             subtitle="Automatic setup with one command"
                             icon="IconMagicWand"
@@ -210,6 +209,27 @@ export default function PostHogMCPLanding(): JSX.Element {
                                 <li>HogQL (our SQL) and the UI insight builder are there when you need them</li>
                                 <li>Full audit log of every query run on your data, by humans or agents</li>
                             </ul>
+
+                            <ProductList
+                                className="grid gap-4 grid-cols-2 not-prose"
+                                urlPrefix="/docs/"
+                                products={[
+                                    'product_analytics',
+                                    'web_analytics',
+                                    'session_replay',
+                                    'feature_flags',
+                                    'experiments',
+                                    'error_tracking',
+                                    'surveys',
+                                    'llm_analytics',
+                                    'data_warehouse',
+                                    'cdp',
+                                    'revenue_analytics',
+                                    'logs',
+                                    'workflows',
+                                    'endpoints',
+                                ]}
+                            />
 
                             <div className="mt-4">
                                 <CallToAction

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -119,6 +119,8 @@ export default function PostHogMCPLanding(): JSX.Element {
                         <QuestLogItem
                             title="Start with the Wizard"
                             subtitle="Set up PostHog in 8 minutes with the Wizard"
+                            title="Install the MCP with the Wizard"
+                            subtitle="Automatica setup with one command"
                             icon="IconMagicWand"
                         >
                             <p>


### PR DESCRIPTION
## Summary

Adds an unlisted paid-search landing page at /r/posthog-mcp for PostHog MCP, following the quest-log format used by /r/error-tracking and /r/session-replay.

Hero pitches PostHog MCP as "a product analyst that lives in your editor".

The quest log walks through six steps:

1. Start with the Wizard
2. Talk to me, baby (natural language navigation)
3. See your product's performance (product analytics)
4. Triage issues, fix automatically (debugging)
5. Ship, measure, iterate (flags + experiments)
6. Use for free (pricing)

Customer logos: ElevenLabs, Heygen, Kilo Code, Exa.

## Help wanted

The hero has visible whitespace below the description before the customer logos that /r/session-replay does not have. The CSS is byte-for-byte identical to session-replay's hero, so the difference is the image itself: this page uses a roughly square asset (Group_143773.png) while session-replay uses a wide one (presentation_55bc6acecd.png). With items-center, the tall square image stretches the grid row past the text column height, leaving a gap. Tried capping at max-w-[260px] mx-auto with no visible effect. Looking for a developer to suggest a cleaner fix or swap in a wider hero asset.

## Test plan

- [ ] Vercel preview renders /r/posthog-mcp without console errors
- [ ] All six quest items render with correct copy and CTAs
- [ ] Hero image, three Cloudinary videos, and feature flags screenshot load
- [ ] No regression on /r/error-tracking or /r/session-replay