### PR TITLE
docs(feature-flags): note searchable person picker for distinct_id targeting

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -122,6 +122,8 @@ Rollout percentages support decimal values with up to two decimal places of prec
 
 - If you enabled group analytics, you can target based on [group properties](/docs/product-analytics/group-analytics#how-to-set-group-properties).
 
+When you target a person property of `distinct_id equals`, the value field searches persons by name, email, or distinct_id, so you don't need to paste a raw ID. A person with multiple distinct_ids – for example an anonymous device ID plus an identified email – appears as a separate option per ID, so you can pick the specific one the SDK captures under. The stored filter value is still the literal distinct_id, so flag evaluation is unchanged.
+
 <ProductScreenshot
     imageLight={ReleaseConditionLight}
     imageDark={ReleaseConditionDark}

--- a/contents/docs/feature-flags/testing.mdx
+++ b/contents/docs/feature-flags/testing.mdx
@@ -19,7 +19,8 @@ To do this:
 2. Ensure the feature flag is enabled by checking the "Enable feature flag" box.
 3. Add a new condition set with the condition to `email = your_email@domain.com`. Set the rollout percentage for this set to 100%.
    
-   - in cases where `email` is not available (such as when your users are logged out), you can use a parameter like `utm_source` and append `?utm_source=your_variant_name` to your URL.
+   - You can also target with `distinct_id equals`. The value field searches persons by name, email, or distinct_id, which is useful when `email` isn't set as a person property but the user is identified.
+   - In cases where `email` is not available (such as when your users are logged out), you can use a parameter like `utm_source` and append `?utm_source=your_variant_name` to your URL.
 
 
 4. If it is a multivariant flag, set the optional override to the variant you want to assign these users to.


### PR DESCRIPTION
## Summary

Mirrors the UX improvement shipped in [PostHog/posthog#56090](https://github.com/PostHog/posthog/pull/56090): when filtering a feature flag release condition by `distinct_id equals`, the value field now searches persons by name, email, or distinct_id rather than requiring a raw UUID. A person with multiple distinct_ids appears as one option per ID.

The PR description in the product PR said "no doc changes needed", but it's a discoverability win worth a brief mention in two spots:

- **`creating-feature-flags.mdx`** – one-paragraph note in the *Release conditions* section explaining the search behavior and the multi-id rendering, plus a reassurance that flag evaluation semantics are unchanged (the stored value is still the literal distinct_id).
- **`testing.mdx`** – sub-bullet under *Method 1: Assign a user a specific flag value* pointing out that `distinct_id equals` is an alternative to `email = …` and that the picker is searchable.

No new pages, no redirects, no screenshot changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*