### PR TITLE
Change language around add-ons and plans

### DIFF
--- a/contents/blog/the-posthog-array-1-41-0.md
+++ b/contents/blog/the-posthog-array-1-41-0.md
@@ -90,7 +90,7 @@ We've added a new page to the Data Management section which lists warnings relat
 
 Curious how well your apps are doing? Previously, you may have had to pour over the AWS logs, but now you can head to the new app metrics page to find out how many events an app has processed, how many retries were attempted and what errors may have occurred. Very handy. Want to take a look? Head to the apps page in your instance and click the chart symbol for any installed app.  
 
-App metrics are only available for users on Scale or Enterprise plans. 
+App metrics are only available for users on Scale or Enterprise add-ons. 
 
 > **Note:** Self-hosted users managing kafka separately should create a new topic `clickhouse_app_metrics` manually.
 

--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -110,7 +110,7 @@ python3 ./migrate.py \
 
 ### Migrating events between Cloud instances (e.g. US -> EU Cloud)
 
-You must raise a [support ticket in-app](https://us.posthog.com/home#supportModal) with the **Data pipelines** topic for the PostHog team to do this migration for you. This option is **only available to customers on the scale or enterprise plan** as it requires significant engineering time.  
+You must raise a [support ticket in-app](https://us.posthog.com/home#supportModal) with the **Data pipelines** topic for the PostHog team to do this migration for you. This option is **only available to customers on Scale or Enterprise add-ons** as it requires significant engineering time.  
 
 ## Switching tracking in your product
 


### PR DESCRIPTION
## Changes

Scale and Enterprise are add-ons, not plans

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
