### PR TITLE
docs: update SDK guidelines

### DIFF
--- a/contents/handbook/engineering/sdks/guidelines.md
+++ b/contents/handbook/engineering/sdks/guidelines.md
@@ -14,6 +14,8 @@ Most users never read every option. They install the package, copy the quickstar
 
 Good defaults matter more than lots of configuration. Capture the right context by default, batch sensibly, retry carefully, and avoid making users learn PostHog internals before they see value. Configuration is still important, but it should feel like customization rather than a requirement to get a safe baseline.
 
+A clean install should get developers to first value quickly: install the package, initialize PostHog, and capture a test event or evaluate a feature flag in a few minutes. Quickstarts should work from a new project without hidden setup.
+
 In general, features should be enabled by default unless there's a good reason not to, such as privacy risk, compatibility risk, performance risk, or platform limitations. Users should be able to opt in and out of features, and ideally high-level feature controls should also exist in PostHog project settings through remote config. When the reason is privacy-sensitive data, see [Treat privacy as a product feature](#treat-privacy-as-a-product-feature).
 
 ### Don't break the host application
@@ -21,6 +23,10 @@ In general, features should be enabled by default unless there's a good reason n
 The SDK should never be the reason a customer's app crashes, slows down dramatically, fails to build, or starts behaving strangely.
 
 Prefer graceful degradation over cleverness. If feature flag polling, replay capture, networking, storage, or background work fails, the app should keep running. In most cases, failing silently with useful debug logging is better than surprising the customer at runtime. The logger is our friend here: use it to explain what happened without making the host app pay for it.
+
+Silent failure is not always the right default. Initialization errors, invalid configuration, unsupported hosts, project token problems, and explicit customer-called APIs should surface clear, idiomatic errors when the customer can act on them.
+
+Retries and timeouts should be bounded, predictable, and documented. Avoid retry behavior that surprises customers, creates duplicate work, or hides persistent failures.
 
 If an SDK can't support a platform, framework version, or runtime, make that clear at install time or startup. Don't make customers discover it through confusing production errors.
 
@@ -84,6 +90,8 @@ SDK APIs live for a long time. Once a pattern is copied into thousands of apps, 
 
 Keep the public API small, boring, and hard to misuse. Use options objects for things likely to grow. Avoid exposing internal concepts unless customers need them. Public APIs and configuration options should be unique: don't offer two or more ways to do the same thing unless there's a strong compatibility reason. Duplicate paths confuse humans, documentation, support, and LLMs.
 
+Agents can help spec and drive SDK changes, especially repetitive cross-SDK work. Public APIs, configuration, defaults, and behavior that affects customers still need human review for ergonomics, platform fit, and long-term support cost.
+
 Be careful not to expand the public API by accident. Exported helpers, leaked internal types, undocumented options, and test-only hooks can become APIs customers depend on. Keep internals private where the platform enables it. If something is experimental, say so clearly and consider keeping it behind an internal API until we're confident it should be public.
 
 Prefer additive API changes over breaking ones. It's much easier to add a new method, option, or type than to remove one later. When you need a breaking change, respect the SDK's versioning scheme, make the migration obvious, document it clearly, and release it intentionally.
@@ -122,9 +130,13 @@ Prefer tests that match how customers use the SDK. Add small example apps where 
 
 An SDK without good docs is only half shipped. Keep the quickstart current, show idiomatic examples, and explain common production setup: flushing on shutdown, identifying users, using custom hosts, handling feature flags, and enabling debug logs.
 
+Each SDK should have a troubleshooting page for common install, build, configuration, network, and runtime errors.
+
 Examples should be boring, copy-pasteable, and close to how customers write real production code in that ecosystem.
 
 Public methods, configuration options, and types should have documentation comments in the platform's standard style, such as JSDoc, docstrings, KDoc, or Swift documentation comments. Write them for humans, but remember that LLMs and IDEs parse them too. A good comment explains what the method or option does, when to use it, defaults, side effects, and any privacy or performance caveats.
+
+The public API reference should be complete and current. It should cover public methods, types, configuration options, defaults, side effects, return values, errors, and examples where they help.
 
 ### Release like people depend on it
 


### PR DESCRIPTION
## Changes

Updates the SDK guidelines with a few additions from the SDK best practices review:

- Emphasizes quick time to first value from a clean install.
- Clarifies when SDKs should surface actionable errors instead of failing silently.
- Adds guidance that retry and timeout behavior should be bounded, predictable, and documented.
- Notes that agent-assisted SDK changes still need human review for public APIs and customer-facing behavior.
- Adds expectations for SDK troubleshooting pages and complete public API references.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
