### PR TITLE
chore(cdp): callout globals available to transformations

### DIFF
--- a/contents/docs/cdp/transformations/customizing-transformations.md
+++ b/contents/docs/cdp/transformations/customizing-transformations.md
@@ -4,17 +4,26 @@ showTitle: true
 ---
 We've got a great library to get you started with the most common transformation needs. If you want to go further, you can write your own using our [Hog](/docs/hog) programming language.
 
-## Event object
+## Available globals
 
-During ingestion, transformations only have access to the event object. Here's the structure of the event object available in transformations:
+Because transformations execute _before_ events are fully ingested and processed, they only receive the `event` and `project` globals. Unlike [realtime destinations](/docs/cdp/destinations/customizing-destinations), transformations do **not** have access to `person` or `groups` — person profiles and group associations haven't been resolved at this point in the pipeline.
+
+Here's the structure of the globals available in transformations:
 
 ```ts
 {
-    uuid: string // The unique ID of the event
-    event: string // The event name (e.g. $pageview)
-    distinct_id: string // The distinct_id of the identity that created the event
-    properties: Record<string, any> // All event properties
-    timestamp: string
+    event: {
+        uuid: string // The unique ID of the event
+        event: string // The event name (e.g. $pageview)
+        distinct_id: string // The distinct_id of the identity that created the event
+        properties: Record<string, any> // All event properties
+        timestamp: string
+    }
+    project: {
+        id: number // The ID of the PostHog project
+        name: string // The name of the PostHog project
+        url: string // A URL to view it in PostHog
+    }
 }
 ```
 
@@ -160,4 +169,4 @@ For more details and inspiration, you can always view the source code of any tra
 
 - **No external calls:** Transformations cannot make HTTP calls or access external services. They can only modify the event object directly.
 
-- **Focus on the event:** Remember that you only have access to the event object during ingestion. You cannot access person profiles, groups, or any other PostHog data.
+- **Focus on the event:** Remember that you only have access to the `event` and `project` globals during ingestion. You cannot access person profiles, groups, or any other PostHog data, since transformations run before events are fully ingested and processed. If you need person or group data, use a [realtime destination](/docs/cdp/destinations) instead.

--- a/contents/docs/cdp/transformations/index.md
+++ b/contents/docs/cdp/transformations/index.md
@@ -20,6 +20,12 @@ Need more flexibility? Our [custom transformations](/docs/cdp/transformations/cu
 
 **Note**: Transformations don't apply to exceptions we capture as part of error tracking. If you need to run transformation against your exception data, please [let us know in-app](https://us.posthog.com#panel=support%3Afeedback%3Aerror_tracking%3Alow%3Atrue).
 
+## Available globals
+
+Transformations run during ingestion, _before_ events are fully ingested and processed. As a result, they only receive the `event` and `project` globals. They do **not** have access to the `person` or `groups` globals that [realtime destinations](/docs/cdp/destinations) can use, since person profiles and group associations haven't been resolved yet at the point a transformation executes.
+
+If your logic depends on person properties or group data, use a [realtime destination](/docs/cdp/destinations) instead.
+
 ## Filtering
 
 Filters enable you to target your transformations, affecting only the kinds of events you chose. Filter by event type, properties, or any SQL statement you can come up with.


### PR DESCRIPTION
## Changes

Context: https://posthog.slack.com/archives/C06GG249PR6/p1777485006873609

Updating docs to call out which globals are available in transformations compared to realtime destinations (and why)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
