### PR TITLE
docs(mcp): clarify MCP server is free to use

### DIFF
--- a/contents/docs/model-context-protocol/_snippets/shared.mdx
+++ b/contents/docs/model-context-protocol/_snippets/shared.mdx
@@ -1,7 +1,5 @@
 import MCPTools from "../../../../src/components/Docs/MCPTools";
 
-The PostHog MCP server is free to use – connecting to it and calling its tools doesn't incur any charges on your PostHog bill.
-
 Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review tool calls before executing them.
 
 <details>

--- a/contents/docs/model-context-protocol/_snippets/shared.mdx
+++ b/contents/docs/model-context-protocol/_snippets/shared.mdx
@@ -1,5 +1,7 @@
 import MCPTools from "../../../../src/components/Docs/MCPTools";
 
+The PostHog MCP server is free to use – connecting to it and calling its tools doesn't incur any charges on your PostHog bill.
+
 Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review tool calls before executing them.
 
 <details>

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -6,6 +6,8 @@ import MCPClients from "./_snippets/mcp-clients.tsx"
 
 The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server enables your AI agents and tools to directly interact with PostHog's products.
 
+The PostHog MCP server is free to use – connecting to it and calling its tools doesn't incur any charges on your PostHog bill.
+
 ## Server URL
 
 `https://mcp.posthog.com/mcp`


### PR DESCRIPTION
## Problem

Users connecting to the PostHog MCP server have no clear signal in the docs about whether using it incurs additional charges. This caused confusion about pricing.

## Changes

Added a one-line note to the shared MCP docs snippet stating that the MCP server is free to use and that calling its tools doesn't incur charges. Because the snippet is rendered on the main MCP index page and every client integration page (Cursor, Claude Code, Claude Desktop, Codex, VS Code, Windsurf, Zed, Replit, Lovable, v0), the clarification is visible everywhere users encounter MCP setup instructions.

## How did you test this code?

Visually confirmed the diff renders cleanly above the existing prompt-injection warning in `contents/docs/model-context-protocol/_snippets/shared.mdx`.

## Publish to changelog?

no