### PR TITLE
docs(dashboards): copying from one project to another

### DIFF
--- a/contents/docs/product-analytics/dashboards.mdx
+++ b/contents/docs/product-analytics/dashboards.mdx
@@ -24,7 +24,7 @@ export const dashboardfiltersDark =
 
 Dashboards are the easiest way to track all your most important product and performance metrics.
 
-Unlike [notebooks](/docs/notebooks), which are ideal for adhoc analysis of specific issues, dashboards are designed for tracking common metrics over time.
+Unlike [notebooks](/docs/notebooks), which are ideal for ad hoc analysis of specific issues, dashboards are designed for tracking common metrics over time.
 
 You can create a new dashboard from scratch, but we also offer numerous [dashboard templates](/templates) for tracking things like [website metrics](/templates/website-dashboard), [product health metrics](/templates/health-dashboard), and [metrics for large language models](/docs/llm-analytics).
 
@@ -57,8 +57,8 @@ Click any prompt to open [PostHog AI](/docs/posthog-ai) in the side panel with a
 
 You can organize dashboards into folders for easier navigation. There are two ways to move a dashboard into a folder:
 
-- **From the dashboards list page** - Click the **...** menu next to a dashboard and select **Move to another folder**.
-- **From an individual dashboard** - Use the sidebar to move it to a folder.
+- **From the dashboards list page** – Click the **...** menu next to a dashboard and select **Move to another folder**.
+- **From an individual dashboard** – Use the sidebar to move it to a folder.
 
 > **Note:** Moving a dashboard to a folder requires editor access.
 
@@ -137,7 +137,7 @@ You can do this in five ways:
 
 Once in edit mode, press 'E' again to save your changes and exit edit mode, or press 'Escape' to discard changes and exit.
 
-Tapping 'F' enables fullscreen mode.
+Tapping 'F' enables full-screen mode.
 
 > **Note:** On smaller screens, dashboard tiles are automatically stacked in a single column based on the desktop layout order. Layout editing (drag and resize) is only available on wider viewports.
 
@@ -154,8 +154,8 @@ These options require editor access to the insight.
 
 You can move or copy insight cards and text cards to other dashboards from the **⋯** menu on each card:
 
-- **Move to** - Moves the widget from the current dashboard to another dashboard. It's removed from the current dashboard.
-- **Copy to** - Copies the widget to another dashboard while keeping it on the current dashboard.
+- **Move to** – Moves the widget from the current dashboard to another dashboard. It's removed from the current dashboard.
+- **Copy to** – Copies the widget to another dashboard while keeping it on the current dashboard.
 
 Both options require editor access to the target dashboard.
 
@@ -177,11 +177,11 @@ Button tiles let you link to other pages within PostHog or external URLs. This i
 
 When creating a button tile, you can configure:
 
-- **URL** - The destination link. Use a path like `/dashboards` for internal PostHog pages, or a full URL like `https://example.com` for external sites.
-- **Button text** - The label displayed on the button.
-- **Placement** - Align the button to the left or right side of the tile.
-- **Style** - Choose between primary (filled) or secondary (outlined) button styles.
-- **Transparent background** - Toggle to remove the tile's background for a cleaner look.
+- **URL** – The destination link. Use a path like `/dashboards` for internal PostHog pages, or a full URL like `https://example.com` for external sites.
+- **Button text** – The label displayed on the button.
+- **Placement** – Align the button to the left or right side of the tile.
+- **Style** – Choose between primary (filled) or secondary (outlined) button styles.
+- **Transparent background** – Toggle to remove the tile's background for a cleaner look.
 
 ### Toggling labels and values on insights
 
@@ -221,9 +221,9 @@ For teams practicing infrastructure-as-code, you can manage PostHog dashboards a
 
 This enables:
 
-- **Version-controlled analytics** - Dashboard and insight definitions stored in git
-- **Consistent environments** - Deploy the same dashboards across projects
-- **CI/CD integration** - Automate analytics infrastructure alongside your application
+- **Version-controlled analytics** – Dashboard and insight definitions stored in git
+- **Consistent environments** – Deploy the same dashboards across projects
+- **CI/CD integration** – Automate analytics infrastructure alongside your application
 
 ### Exporting existing dashboards
 
@@ -231,10 +231,10 @@ To get started quickly, you can export your existing dashboards as Terraform cod
 
 You'll see a **Manage with Terraform** button on:
 
-- **Dashboard pages** - Exports the entire dashboard including all insights, dashboard layouts, alerts, and hog functions
-- **Insight detail pages** - Exports the individual insight with its associated alerts and hog functions
+- **Dashboard pages** – Exports the entire dashboard including all insights, dashboard layouts, alerts, and hog functions
+- **Insight detail pages** – Exports the individual insight with its associated alerts and hog functions
 
-Click the button to generate HCL code that you can copy directly into your Terraform configuration. This makes it easy to bring existing dashboards under version control without manually recreating them.
+Click the button to generate HCL code that you can copy directly into your Terraform configuration. This lets you bring existing dashboards under version control without manually recreating them.
 
 ### Installation
 

--- a/contents/docs/product-analytics/dashboards.mdx
+++ b/contents/docs/product-analytics/dashboards.mdx
@@ -62,9 +62,18 @@ You can organize dashboards into folders for easier navigation. There are two wa
 
 > **Note:** Moving a dashboard to a folder requires editor access.
 
-## Copying templates between projects
+## Copying dashboards and templates between projects
 
-You can copy project-scoped dashboard templates from one project to another within the same organization. This is useful when you want to reuse a template you've built without recreating it from scratch.
+You can copy dashboards and project-scoped dashboard templates from one project to another within the same organization. This is useful when you want to reuse work you've built without recreating it from scratch.
+
+To copy a dashboard:
+
+1. Go to [**Dashboards**](https://app.posthog.com/dashboard) and open the dashboard you want to copy.
+1. Open the actions sidebar.
+1. Click **Copy to another project**.
+1. Select the destination project.
+1. Configure the dependencies for the copy.
+1. Click **Copy**.
 
 To copy a template:
 
@@ -77,7 +86,7 @@ A few things to keep in mind:
 - Only project-scoped templates can be copied – global templates can't be copied this way.
 - The source and destination must be different projects in the same organization.
 - The copy is independent – changes to the original don't sync to the copy, and vice versa.
-- If a template with the same name already exists in the destination project, the copy is automatically renamed with a suffix like "(copy)", "(copy 2)", etc.
+- If a dashboard or template with the same name already exists in the destination project, the copy is automatically renamed with a suffix like "(copy)", "(copy 2)", etc.
 
 ## Dates and filters
 


### PR DESCRIPTION
## Changes

The feature flag `inter-project-transfers` is now rolled out to 100% of users so documenting this feature so that PostHog AI can instruct users on how to peform dashboard copies between projects.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
