### PR TITLE
docs(feature-flags): mark evaluation contexts as generally available

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -259,12 +259,6 @@ If you're not sure which runtime to use, you can use the following guidelines:
 
 ### Evaluation contexts (optional)
 
-<CalloutBox icon="IconWarning" title="Evaluation contexts are in alpha release" type="caution">
-
-Evaluation contexts are currently in alpha release. This feature may not be available in your PostHog instance yet. Contact support if you'd like early access.
-
-</CalloutBox>
-
 Evaluation contexts control where and when a feature flag evaluates at runtime. They have their own dedicated section on the feature flag page, separate from tags.
 
 Add contexts to describe where the flag is used in your application. Some common examples are:


### PR DESCRIPTION
## Summary

- Removes the alpha-release `CalloutBox` from `contents/docs/feature-flags/creating-feature-flags.mdx`. Evaluation contexts are now in general release.
- The main `contents/docs/feature-flags/evaluation-contexts.mdx` page already has `availability: full` and no beta markers, and a sweep across the other 10 docs that mention evaluation contexts found no other status caveats to update.