### PR TITLE
docs(web-analytics): add Live tab documentation

### DIFF
--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -1,0 +1,48 @@
+---
+title: Live
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of incoming traffic. Each request streams into the feed as PostHog ingests it, so you can watch what's happening on your site right now without re-running a query.
+
+> **Note:** Live is currently in alpha and available behind the **Web analytics bot analysis** feature flag. Behavior and column layout may change before general availability.
+
+## What it shows
+
+The Live tab is a continuously updating feed of recent events. Each row includes:
+
+- **Timestamp** — when the event was ingested
+- **Path** — the URL or pathname requested
+- **Traffic type** — `Regular`, `AI Agent`, `Bot`, or `Automation` (see [bot detection](/docs/web-analytics/bot-detection#traffic-types))
+- **Bot name** and **operator** — populated for non-human traffic (e.g. `GPTBot` / `OpenAI`)
+- **Country** and **device** — derived from the request
+
+Use the filter controls at the top of the tab to narrow the feed by traffic type, category, host, or path. Filters apply to the live stream so you can isolate exactly what you want to watch.
+
+## Filtering by traffic type
+
+The most common filter is **Traffic type**, which lets you isolate one slice of incoming requests:
+
+- **Regular** — only human visitors
+- **AI Agent** — AI crawlers, search bots, and assistants (GPTBot, ClaudeBot, etc.)
+- **Bot** — traditional crawlers and monitoring (Googlebot, Bingbot, Pingdom)
+- **Automation** — HTTP clients and headless browsers (curl, Puppeteer)
+
+For aggregated bot dashboards (top crawlers, most-crawled paths, per-bot trends), use the [Bot analytics tab](/docs/web-analytics/bot-detection#bot-analytics-tab) instead — Live is for watching the stream as it happens.
+
+## Limitations
+
+- **Recent traffic only** — Live shows events from roughly the last few minutes. For longer windows use the main web analytics dashboard or [Product Analytics](/docs/product-analytics).
+- **Sampling** — high-volume sites may see the feed sampled to keep the stream readable. Aggregate dashboards are unaffected.
+- **No historical scroll** — Live is a stream, not a paginated table. Use the events explorer or SQL editor to look further back.
+
+## Related
+
+- [Bot detection](/docs/web-analytics/bot-detection) — how PostHog classifies bot, AI agent, and automation traffic
+- [Web analytics dashboard](/docs/web-analytics/dashboard) — aggregated views over longer time ranges
+- [Troubleshooting](/docs/web-analytics/troubleshooting) — when events aren't showing up

--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -8,41 +8,53 @@ availability:
   enterprise: full
 ---
 
-The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of incoming traffic. Each request streams into the feed as PostHog ingests it, so you can watch what's happening on your site right now without re-running a query.
+The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of what's happening on your site right now — how many users are active, what pages they're on, where they came from, and what they're doing. Each request streams into the feed as PostHog ingests it, so you can watch traffic as it arrives instead of re-running a query.
 
 > **Note:** Live is currently in alpha. Behavior and column layout may change before general availability.
 
+"Real-time" here means data that's a few seconds to a few minutes old. True zero-latency analytics is rare and usually unnecessary — what matters is that the feed is fresh enough to act on.
+
 ## What it shows
 
-The Live tab is a continuously updating feed of recent events. Each row includes:
+Live is a continuously updating feed of recent events. Each row includes:
 
 - **Timestamp** — when the event was ingested
 - **Path** — the URL or pathname requested
-- **Traffic type** — `Regular`, `AI Agent`, `Bot`, or `Automation` (see [bot detection](/docs/web-analytics/bot-detection#traffic-types))
-- **Bot name** and **operator** — populated for non-human traffic (e.g. `GPTBot` / `OpenAI`)
+- **Referrer** and **UTM parameters** — where the visitor came from
 - **Country** and **device** — derived from the request
 
-Use the filter controls at the top of the tab to narrow the feed by traffic type, category, host, or path. Filters apply to the live stream so you can isolate exactly what you want to watch.
+Use the filter controls at the top of the tab to narrow the feed by host, path, referrer, or any other property. Filters apply to the live stream so you can isolate exactly what you want to watch.
 
-## Filtering by traffic type
+## When to use Live
 
-The most common filter is **Traffic type**, which lets you isolate one slice of incoming requests:
+Live is for the moments when "right now" matters more than "this week". Reach for it when you're:
 
-- **Regular** — only human visitors
-- **AI Agent** — AI crawlers, search bots, and assistants (GPTBot, ClaudeBot, etc.)
-- **Bot** — traditional crawlers and monitoring (Googlebot, Bingbot, Pingdom)
-- **Automation** — HTTP clients and headless browsers (curl, Puppeteer)
+- **Shipping a launch** — watch traffic land on a new page or product as you announce it on Hacker News, Product Hunt, or a launch email.
+- **Running a paid campaign** — see whether ad spend is converting into real visits within minutes, not the next morning.
+- **Deploying frequently** — if you ship multiple times a day, Live lets you catch regressions before your users do.
+- **Monitoring product-led signups** — see which pages activated users are on right now, useful for PLG flows where active-user signal matters.
+- **Verifying an install** — drop the PostHog snippet onto a site, hit a few pages yourself, and confirm events arrive within seconds.
 
-For aggregated bot dashboards (top crawlers, most-crawled paths, per-bot trends), use the [Bot analytics tab](/docs/web-analytics/bot-detection#bot-analytics-tab) instead — Live is for watching the stream as it happens.
+## Live vs. the rest of web analytics
+
+Most analytics work splits into "right now" and "what happened" — Live and the rest of [web analytics](/docs/web-analytics/dashboard) cover the two ends of that split.
+
+| | Live | Web analytics dashboard |
+|---|---|---|
+| **Latency** | Seconds | Query-time, cached |
+| **Time range** | Last few minutes | Hours, days, months |
+| **Best for** | Launches, campaigns, monitoring, debugging | Trend analysis, reports, retrospectives |
+| **Aggregations** | Stream of individual events | Visitors, sessions, paths, sources |
+
+For deeper analysis (funnels, retention, breakdowns), use [Product Analytics](/docs/product-analytics) or the [SQL editor](/docs/sql).
 
 ## Limitations
 
-- **Recent traffic only** — Live shows events from roughly the last few minutes. For longer windows use the main web analytics dashboard or [Product Analytics](/docs/product-analytics).
+- **Recent traffic only** — Live shows events from roughly the last few minutes. For longer windows use the main web analytics dashboard.
 - **Sampling** — high-volume sites may see the feed sampled to keep the stream readable. Aggregate dashboards are unaffected.
 - **No historical scroll** — Live is a stream, not a paginated table. Use the events explorer or SQL editor to look further back.
 
 ## Related
 
-- [Bot detection](/docs/web-analytics/bot-detection) — how PostHog classifies bot, AI agent, and automation traffic
 - [Web analytics dashboard](/docs/web-analytics/dashboard) — aggregated views over longer time ranges
 - [Troubleshooting](/docs/web-analytics/troubleshooting) — when events aren't showing up

--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -10,7 +10,7 @@ availability:
 
 The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of incoming traffic. Each request streams into the feed as PostHog ingests it, so you can watch what's happening on your site right now without re-running a query.
 
-> **Note:** Live is currently in alpha and available behind the **Web analytics bot analysis** feature flag. Behavior and column layout may change before general availability.
+> **Note:** Live is currently in alpha. Behavior and column layout may change before general availability.
 
 ## What it shows
 

--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of what's happening on your site right now: how many users are active, what pages they're on, where they came from, and what they're doing. Live shows events as they arrive, while PostHog is still processing, enriching, and storing them.
+The **Live** tab in [Web Analytics](/docs/web-analytics/dashboard) is a real-time view of what's happening on your site right now: how many users are active, what pages they're on, where they came from, and what they're doing. Live shows events as they arrive, while PostHog is still processing, enriching, and storing them.
 
 > **Note:** Live is currently in alpha. Behavior and column layout may change before general availability.
 
@@ -33,11 +33,11 @@ Use Live when you're:
 - **Watching active users** – see which pages signed-in users are on right now.
 - **Verifying an install** – drop the PostHog snippet onto a site, hit a few pages yourself, and confirm events arrive within seconds.
 
-## Live vs. the rest of web analytics
+## Live vs. the rest of Web Analytics
 
-Most analytics work splits into "right now" and "what happened". Live covers the first; the rest of [web analytics](/docs/web-analytics/dashboard) covers the second.
+Most analytics work splits into "right now" and "what happened". Live covers the first; the rest of [Web Analytics](/docs/web-analytics/dashboard) covers the second.
 
-| | Live | Web analytics dashboard |
+| | Live | Web Analytics dashboard |
 |---|---|---|
 | **Latency** | Seconds | Query-time, cached |
 | **Time range** | Last few minutes | Hours, days, months |
@@ -48,11 +48,11 @@ For deeper analysis like funnels, retention, or breakdowns, use [Product Analyti
 
 ## Limitations
 
-- **Recent traffic only** – Live shows events from roughly the last few minutes. For longer windows, use the main web analytics dashboard.
+- **Recent traffic only** – Live shows events from roughly the last few minutes. For longer windows, use the main Web Analytics dashboard.
 - **Sampling** – high-volume sites may see the feed sampled to keep the stream readable. Aggregate dashboards are unaffected.
 - **No historical scroll** – Live is a stream, not a paginated table. Use the events explorer or SQL editor to look further back.
 
 ## Related
 
-- [Web analytics dashboard](/docs/web-analytics/dashboard) – aggregated views over longer time ranges
+- [Web Analytics dashboard](/docs/web-analytics/dashboard) – aggregated views over longer time ranges
 - [Troubleshooting](/docs/web-analytics/troubleshooting) – when events aren't showing up

--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -8,36 +8,34 @@ availability:
   enterprise: full
 ---
 
-The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of what's happening on your site right now — how many users are active, what pages they're on, where they came from, and what they're doing. Each request streams into the feed as PostHog ingests it, so you can watch traffic as it arrives instead of re-running a query.
+The **Live** tab in [web analytics](/docs/web-analytics/dashboard) is a real-time view of what's happening on your site right now: how many users are active, what pages they're on, where they came from, and what they're doing. Live shows events as they arrive, while PostHog is still processing, enriching, and storing them.
 
 > **Note:** Live is currently in alpha. Behavior and column layout may change before general availability.
-
-"Real-time" here means data that's a few seconds to a few minutes old. True zero-latency analytics is rare and usually unnecessary — what matters is that the feed is fresh enough to act on.
 
 ## What it shows
 
 Live is a continuously updating feed of recent events. Each row includes:
 
-- **Timestamp** — when the event was ingested
-- **Path** — the URL or pathname requested
-- **Referrer** and **UTM parameters** — where the visitor came from
-- **Country** and **device** — derived from the request
+- **Timestamp** – when the event was ingested
+- **Path** – the URL or pathname requested
+- **Referrer** and **UTM parameters** – where the visitor came from
+- **Country** and **device** – derived from the request
 
 Use the filter controls at the top of the tab to narrow the feed by host, path, referrer, or any other property. Filters apply to the live stream so you can isolate exactly what you want to watch.
 
 ## When to use Live
 
-Live is for the moments when "right now" matters more than "this week". Reach for it when you're:
+Use Live when you're:
 
-- **Shipping a launch** — watch traffic land on a new page or product as you announce it on Hacker News, Product Hunt, or a launch email.
-- **Running a paid campaign** — see whether ad spend is converting into real visits within minutes, not the next morning.
-- **Deploying frequently** — if you ship multiple times a day, Live lets you catch regressions before your users do.
-- **Monitoring product-led signups** — see which pages activated users are on right now, useful for PLG flows where active-user signal matters.
-- **Verifying an install** — drop the PostHog snippet onto a site, hit a few pages yourself, and confirm events arrive within seconds.
+- **Shipping a launch** – watch traffic land on a new page or product as you announce it on Hacker News, Product Hunt, or a launch email.
+- **Running a paid campaign** – see whether ad spend converts to real visits within minutes, not the next morning.
+- **Deploying frequently** – if you ship multiple times a day, Live helps you catch regressions before your users do.
+- **Watching active users** – see which pages signed-in users are on right now.
+- **Verifying an install** – drop the PostHog snippet onto a site, hit a few pages yourself, and confirm events arrive within seconds.
 
 ## Live vs. the rest of web analytics
 
-Most analytics work splits into "right now" and "what happened" — Live and the rest of [web analytics](/docs/web-analytics/dashboard) cover the two ends of that split.
+Most analytics work splits into "right now" and "what happened". Live covers the first; the rest of [web analytics](/docs/web-analytics/dashboard) covers the second.
 
 | | Live | Web analytics dashboard |
 |---|---|---|
@@ -46,15 +44,15 @@ Most analytics work splits into "right now" and "what happened" — Live and the
 | **Best for** | Launches, campaigns, monitoring, debugging | Trend analysis, reports, retrospectives |
 | **Aggregations** | Stream of individual events | Visitors, sessions, paths, sources |
 
-For deeper analysis (funnels, retention, breakdowns), use [Product Analytics](/docs/product-analytics) or the [SQL editor](/docs/sql).
+For deeper analysis like funnels, retention, or breakdowns, use [Product Analytics](/docs/product-analytics) or the [SQL editor](/docs/sql).
 
 ## Limitations
 
-- **Recent traffic only** — Live shows events from roughly the last few minutes. For longer windows use the main web analytics dashboard.
-- **Sampling** — high-volume sites may see the feed sampled to keep the stream readable. Aggregate dashboards are unaffected.
-- **No historical scroll** — Live is a stream, not a paginated table. Use the events explorer or SQL editor to look further back.
+- **Recent traffic only** – Live shows events from roughly the last few minutes. For longer windows, use the main web analytics dashboard.
+- **Sampling** – high-volume sites may see the feed sampled to keep the stream readable. Aggregate dashboards are unaffected.
+- **No historical scroll** – Live is a stream, not a paginated table. Use the events explorer or SQL editor to look further back.
 
 ## Related
 
-- [Web analytics dashboard](/docs/web-analytics/dashboard) — aggregated views over longer time ranges
-- [Troubleshooting](/docs/web-analytics/troubleshooting) — when events aren't showing up
+- [Web analytics dashboard](/docs/web-analytics/dashboard) – aggregated views over longer time ranges
+- [Troubleshooting](/docs/web-analytics/troubleshooting) – when events aren't showing up

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3728,6 +3728,16 @@ export const docsMenu = {
                     color: 'orange',
                 },
                 {
+                    name: 'Live',
+                    url: '/docs/web-analytics/live',
+                    icon: 'IconLive',
+                    color: 'red',
+                    badge: {
+                        title: 'Alpha',
+                        className: 'uppercase !bg-red/10 !text-red !dark:text-white !dark:bg-red/50',
+                    },
+                },
+                {
                     name: 'Conversion goals',
                     url: '/docs/web-analytics/conversion-goals',
                     icon: 'IconFunnels',


### PR DESCRIPTION
## Summary

Adds `contents/docs/web-analytics/live.mdx` documenting the **Live** tab in web analytics — a real-time view of incoming traffic.

Covers what the feed shows, traffic-type filtering (Regular / AI Agent / Bot / Automation), limitations (recent traffic only, possible sampling, no historical scroll), and links to bot detection and the main dashboard.

Marked **alpha** behind the **Web analytics bot analysis** feature flag.

## Things to verify before merging

- [ ] Confirm column list (timestamp, path, traffic type, bot name/operator, country, device) matches the actual UI
- [ ] Confirm the filter controls section is accurate (which dimensions can you filter by?)
- [ ] Confirm the sampling behavior on high-volume sites — softening or removing if not actually how it works
- [ ] Sidebar entry not added \u2014 \`src/navs/index.js\` left untouched per ask-first rule. Likely placement: under **Web analytics** after **Bot detection**.

## Test plan

- [ ] Run dev server and visit \`/docs/web-analytics/live\`
- [ ] Cross-links to bot detection and dashboard resolve