### PR TITLE
Achievement groups

### DIFF
--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -584,6 +584,21 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
 
     createTypes(
         `
+            type AchievementGroupIconAttributes {
+              url: String
+            }
+            type AchievementGroupIconData {
+              attributes: AchievementGroupIconAttributes
+            }
+            type AchievementGroupIcon {
+              data: AchievementGroupIconData
+            }
+            type AchievementGroup implements Node {
+              Title: String
+              description: String
+              tiered: Boolean
+              icon: AchievementGroupIcon
+            }
             type ShopifyCollection implements Node {
               handle: String!
               products: [ShopifyProduct!] @link(by: "shopifyId", from: "products.shopifyId")

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -1086,6 +1086,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
     const fetchAchievements = async () => {
         const query = qs.stringify({
             populate: ['icon', 'achievement_group.achievements.icon'],
+            publicationState: 'preview',
         })
         const { data } = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/achievements?${query}`).then((res) =>
             res.json()
@@ -1106,7 +1107,8 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
 
     const fetchAchievementGroups = async () => {
         const query = qs.stringify({
-            populate: ['achievements.icon'],
+            populate: ['achievements.icon', 'icon'],
+            publicationState: 'preview',
         })
         const { data } = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/achievement-groups?${query}`).then(
             (res) => res.json()

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1199,13 +1199,12 @@ const appSettings: AppSettings = {
         size: {
             min: {
                 width: 500,
-                height: 1000,
+                height: 650,
             },
             max: {
                 width: 500,
-                height: 1000,
+                height: 650,
             },
-            autoHeight: true,
         },
         position: {
             center: true,

--- a/src/pages/community/achievements.tsx
+++ b/src/pages/community/achievements.tsx
@@ -22,7 +22,17 @@ const profileHasAchievement = (profile, achievement) => {
     return profile?.achievements?.some((profileAchievement) => profileAchievement.achievement?.id === achievement.id)
 }
 
-const AchievementRow = ({ achievement, badge, achieved }: { achievement: any; badge?: string; achieved?: boolean }) => {
+const AchievementRow = ({
+    achievement,
+    badge,
+    achieved,
+    showCheck = true,
+}: {
+    achievement: any
+    badge?: string
+    achieved?: boolean
+    showCheck?: boolean
+}) => {
     return (
         <div className="flex items-end justify-between w-full">
             <span className="flex space-x-1">
@@ -46,25 +56,43 @@ const AchievementRow = ({ achievement, badge, achieved }: { achievement: any; ba
                 </span>
             </span>
             <p className="text-sm text-secondary m-0 flex space-x-1 items-center">
-                {achieved && <IconCheck className="size-3 text-green" />}
-                <span className={achieved ? 'text-green font-semibold' : ''}>
-                    {achievement.points} point{achievement.points === 1 ? '' : 's'}
-                </span>
+                {achieved && showCheck && <IconCheck className="size-3 text-green" />}
+                {achievement.points && (
+                    <span className={achieved ? 'text-green font-semibold' : ''}>
+                        {achievement.points} point{achievement.points === 1 ? '' : 's'}
+                    </span>
+                )}
             </p>
         </div>
     )
 }
 
 const AchievementGroupRow = ({ achievementGroup, profile }) => {
+    const groupHasIcon = !!achievementGroup.icon?.data?.attributes?.url
+    const tiered = achievementGroup.tiered
+    const achievements = groupHasIcon ? achievementGroup.achievements.data : achievementGroup.achievements.data.slice(1)
+    const allAchieved = achievementGroup.achievements.data.every((a) => profileHasAchievement(profile, a))
     return (
         <div className="text-left w-full">
-            <AchievementRow
-                achievement={achievementGroup.data[0].attributes}
-                badge="Level 1"
-                achieved={profileHasAchievement(profile, achievementGroup.data[0])}
-            />
+            {groupHasIcon ? (
+                <AchievementRow
+                    achievement={{
+                        title: achievementGroup.Title,
+                        description: achievementGroup.description,
+                        icon: achievementGroup.icon,
+                    }}
+                    achieved={allAchieved}
+                    showCheck={false}
+                />
+            ) : (
+                <AchievementRow
+                    achievement={achievementGroup.achievements.data[0].attributes}
+                    badge={tiered ? 'Level 1' : undefined}
+                    achieved={profileHasAchievement(profile, achievementGroup.achievements.data[0])}
+                />
+            )}
             <ul className="m-0 p-0 list-none mt-2 ml-[16px]">
-                {achievementGroup.data.slice(1).map((achievement, index) => (
+                {achievements.map((achievement, index) => (
                     <li
                         key={achievement.id}
                         className="mt-2 border-l border-primary relative pl-[16px] before:content-[''] before:absolute before:left-[-1px] before:-top-4 before:w-[32px] before:border-l before:h-[calc(50%+1rem)] before:border-b before:border-primary before:rounded-bl-md last:border-l-0 last:before:left-0"
@@ -72,7 +100,7 @@ const AchievementGroupRow = ({ achievementGroup, profile }) => {
                         <div className="relative">
                             <AchievementRow
                                 achievement={achievement.attributes}
-                                badge={`Level ${index + 2}`}
+                                badge={tiered ? `Level ${groupHasIcon ? index + 1 : index + 2}` : undefined}
                                 achieved={profileHasAchievement(profile, achievement)}
                             />
                         </div>
@@ -108,6 +136,16 @@ const Points = () => {
             }
             allAchievementGroup {
                 nodes {
+                    Title
+                    description
+                    tiered
+                    icon {
+                        data {
+                            attributes {
+                                url
+                            }
+                        }
+                    }
                     achievements {
                         data {
                             id
@@ -155,10 +193,7 @@ const Points = () => {
                                 key={achievement.id}
                             >
                                 {achievement.achievements ? (
-                                    <AchievementGroupRow
-                                        achievementGroup={achievement.achievements}
-                                        profile={profile}
-                                    />
+                                    <AchievementGroupRow achievementGroup={achievement} profile={profile} />
                                 ) : (
                                     <AchievementRow
                                         achievement={achievement}

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -1139,6 +1139,11 @@ export default function ProfilePage({ params }: PageProps) {
                             populate: {
                                 image: true,
                                 icon: true,
+                                achievement_group: {
+                                    populate: {
+                                        icon: true,
+                                    },
+                                },
                             },
                         },
                     },
@@ -1727,19 +1732,11 @@ export default function ProfilePage({ params }: PageProps) {
 
                             {profile.achievements?.length > 0 && (
                                 <Block title="Achievements" url={`/community/achievements`}>
-                                    <ul className="grid grid-cols-7 gap-2 m-0 p-0 list-none">
-                                        {profile.achievements.map(({ achievement, hidden, id }) => (
-                                            <li key={id} className="flex justify-center">
-                                                <Achievement
-                                                    {...achievement.data.attributes}
-                                                    id={id}
-                                                    hidden={hidden}
-                                                    profile={profile}
-                                                    mutate={mutate}
-                                                />
-                                            </li>
-                                        ))}
-                                    </ul>
+                                    <AchievementsGrid
+                                        achievements={profile.achievements}
+                                        profile={profile}
+                                        mutate={mutate}
+                                    />
                                 </Block>
                             )}
                             {isEditing && <BackgroundImageField setFieldValue={setFieldValue} values={values} />}
@@ -1863,6 +1860,116 @@ const TeamMembersList = ({ self, team }) => {
     )
 }
 
+const AchievementTooltipContent = ({ icon, title, description, iconSize = 'size-16' }) => (
+    <>
+        <div className="flex justify-center -mx-1.5 -mt-1 mb-2 py-2 bg-accent/50 rounded">
+            <img className={iconSize} src={icon} />
+        </div>
+        <h4 className="text-lg m-0">{title}</h4>
+        {description && <p className="m-0 mt-1 text-sm">{description}</p>}
+    </>
+)
+
+const AchievementGrouped = ({ items, profile, mutate }) => {
+    const groupData = items[0].achievement.data.attributes.achievement_group.data.attributes
+
+    if (groupData.tiered && items.length === 1) {
+        const { achievement, hidden, id } = items[0]
+        return (
+            <Achievement {...achievement.data.attributes} id={id} hidden={hidden} profile={profile} mutate={mutate} />
+        )
+    }
+
+    return (
+        <Tooltip
+            delay={0}
+            side="bottom"
+            trigger={
+                <span className="relative">
+                    <img className="w-full" src={groupData.icon?.data?.attributes?.url} />
+                    {items.length > 1 && (
+                        <span className="absolute -top-1 -right-1 bg-accent text-primary text-[10px] font-bold rounded-full size-4 flex items-center justify-center border border-primary">
+                            x{items.length}
+                        </span>
+                    )}
+                </span>
+            }
+        >
+            <div className="max-w-[220px] text-left">
+                <AchievementTooltipContent
+                    icon={groupData.icon?.data?.attributes?.url}
+                    title={groupData.Title}
+                    description={groupData.description}
+                    iconSize="size-24"
+                />
+                <div className="border-t border-primary mt-3 pt-2.5">
+                    <p className="text-xs font-semibold opacity-50 m-0 mb-2">Unlocked by</p>
+                    <ul className="m-0 p-0 list-none flex flex-col gap-2">
+                        {items.map(({ achievement, id }, index) => (
+                            <li key={id} className="relative flex items-center gap-2">
+                                <div className="size-7 flex-shrink-0 relative">
+                                    {index < items.length - 1 && (
+                                        <div className="absolute w-px h-full left-1/2 -translate-x-1/2 bg-border dark:bg-border-dark bottom-0 translate-y-1/2" />
+                                    )}
+                                    <img
+                                        className="size-full relative"
+                                        src={achievement.data.attributes.icon?.data?.attributes?.url}
+                                    />
+                                </div>
+                                <div>
+                                    <p className="text-xs font-semibold m-0 leading-tight">
+                                        {achievement.data.attributes.title}
+                                    </p>
+                                    {achievement.data.attributes.description && (
+                                        <p className="text-xs opacity-60 m-0 leading-tight mt-0.5">
+                                            {achievement.data.attributes.description}
+                                        </p>
+                                    )}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </Tooltip>
+    )
+}
+
+const AchievementsGrid = ({ achievements, profile, mutate }) => {
+    const groups = useMemo(() => {
+        const grouped = achievements.filter((item) => item.achievement?.data?.attributes?.achievement_group?.data)
+        return Object.groupBy(grouped, (item) => item.achievement.data.attributes.achievement_group.data.id)
+    }, [achievements])
+
+    return (
+        <ul className="grid grid-cols-7 gap-2 m-0 p-0 list-none">
+            {achievements.map(({ achievement, hidden, id }) => {
+                if (!achievement?.data) return null
+                const group = achievement.data.attributes?.achievement_group?.data
+                if (group) {
+                    if (groups[group.id][0].id !== id) return null
+                    return (
+                        <li key={`group-${group.id}`} className="flex justify-center">
+                            <AchievementGrouped items={groups[group.id]} profile={profile} mutate={mutate} />
+                        </li>
+                    )
+                }
+                return (
+                    <li key={id} className="flex justify-center">
+                        <Achievement
+                            {...achievement.data.attributes}
+                            id={id}
+                            hidden={hidden}
+                            profile={profile}
+                            mutate={mutate}
+                        />
+                    </li>
+                )
+            })}
+        </ul>
+    )
+}
+
 const Achievement = ({ title, description, image, icon, id, mutate, profile, ...other }) => {
     const { user, getJwt } = useUser()
     const [hidden, setHidden] = useState(other.hidden)
@@ -1923,12 +2030,8 @@ const Achievement = ({ title, description, image, icon, id, mutate, profile, ...
                 </ImageContainer>
             }
         >
-            <div className="max-w-[250px] text-left">
-                <div className="mb-4 -mx-2 -mt-2">
-                    <img src={image?.data?.attributes?.url} />
-                </div>
-                <h4 className="text-lg m-0">{title}</h4>
-                <p className="m-0 mt-1 text-sm mb-2">{description}</p>
+            <div className="max-w-[220px] text-left">
+                <AchievementTooltipContent icon={icon?.data?.attributes?.url} title={title} description={description} />
             </div>
         </Tooltip>
     )


### PR DESCRIPTION
## Changes

- Groups related achievements under a single icon on profiles
- Popover shows group info and individual achievements earned
- Tiered vs non-tiered groups display differently (levels/points vs flat)
- Adds missing fields to Gatsby schema

<img width="262" height="440" alt="Screenshot 2026-04-30 at 6 46 57 PM" src="https://github.com/user-attachments/assets/81c4d3b6-4db1-4454-870f-b010976c4af7" />

