### PR TITLE
fix(replay): update replay doc to show how to redact urls

### DIFF
--- a/contents/docs/session-replay/_snippets/web-network.mdx
+++ b/contents/docs/session-replay/_snippets/web-network.mdx
@@ -64,6 +64,8 @@ And we redact bodies if we believe they contain
 
 ## How to register a callback to inspect and redact each network request
 
+> **Note:** This callback also runs against the page URL captured in the session snapshot (the URL shown in the replay player), not only network request URLs. See [URL redaction](/docs/session-replay/privacy#url-redaction) in the privacy docs.
+
 ```js-web
 posthog.init('<ph_project_token>', {
     session_recording: {

--- a/contents/docs/session-replay/_snippets/web-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/web-privacy.mdx
@@ -120,7 +120,7 @@ Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/
 
 ## URL redaction
 
-Session replay captures the page URL shown in the replay player URL bar and timeline. Query strings can include sensitive data such as auth tokens or user identifiers. To redact them, provide a `maskCapturedNetworkRequestFn` callback — the same callback used for [network capture](/docs/session-replay/network-recording#how-to-register-a-callback-to-inspect-and-redact-each-network-request) also runs against the page URL captured in the snapshot, so a single configuration covers both surfaces.
+Session replay captures the page URL shown in the replay player URL bar and timeline. Query strings can include sensitive data such as auth tokens or user identifiers. To redact them, provide a `maskCapturedNetworkRequestFn` callback, the same callback used for [network capture](/docs/session-replay/network-recording#how-to-register-a-callback-to-inspect-and-redact-each-network-request) also runs against the page URL captured in the snapshot, so a single configuration covers both surfaces.
 
 ```js-web
 posthog.init('<ph_project_token>', {

--- a/contents/docs/session-replay/_snippets/web-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/web-privacy.mdx
@@ -118,6 +118,28 @@ To do so, you should add the CSS class name `ph-no-capture` to elements which sh
 
 Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/autocapture) events from being captured from that element.
 
+## URL redaction
+
+Session replay captures the page URL shown in the replay player URL bar and timeline. Query strings can include sensitive data such as auth tokens or user identifiers. To redact them, provide a `maskCapturedNetworkRequestFn` callback — the same callback used for [network capture](/docs/session-replay/network-recording#how-to-register-a-callback-to-inspect-and-redact-each-network-request) also runs against the page URL captured in the snapshot, so a single configuration covers both surfaces.
+
+```js-web
+posthog.init('<ph_project_token>', {
+    session_recording: {
+        maskCapturedNetworkRequestFn: (request) => {
+            if (request.name) {
+                // Redact specific query params
+                request.name = request.name.replace(/([?&](token|auth|email)=)[^&]+/g, '$1[REDACTED]')
+                // Or strip the query string entirely:
+                // request.name = request.name.split('?')[0]
+            }
+            return request
+        },
+    },
+})
+```
+
+The callback runs in the browser, so redacted values never leave the user's device.
+
 ## Common example configs
 
 ### Maximum privacy - mask everything

--- a/src/components/Squeak/components/TopicSelector.tsx
+++ b/src/components/Squeak/components/TopicSelector.tsx
@@ -28,7 +28,7 @@ export const TopicSelector = (props: TopicSelectorProps) => {
                 Add topics
             </Popover.Button>
 
-            <Popover.Panel className="fixed z-[9999] text-black mb-0 w-64 top-[5vh] h-[90vh] px-4 mt-3 transform sm:px-0 overflow-y-scroll overscroll-contain bg-white dark:bg-accent-dark rounded border border-primary shadow-sm">
+            <Popover.Panel className="fixed z-[9999] text-black mb-0 w-64 top-[5vh] h-[90vh] px-4 mt-3 transform sm:px-0 overflow-y-scroll overflow-x-hidden overscroll-contain bg-white dark:bg-accent-dark rounded border border-primary shadow-sm">
                 <ol className="list-none p-0 m-0">
                     {data?.map((topic) => {
                         const isSelected = question?.attributes?.topics?.data?.find((t) => t.id === topic.id)
@@ -45,7 +45,7 @@ export const TopicSelector = (props: TopicSelectorProps) => {
                                         <div className="flex-shrink-0 h-5 w-5" />
                                     )}
                                     <div
-                                        className={`flex-shrink-0 flex items-center justify-center rounded-md whitespace-nowrap ${
+                                        className={`min-w-0 flex items-center justify-center rounded-md ${
                                             isSelected && 'font-bold'
                                         }`}
                                     >


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*
We should emphasize that we can already do url redacting for replays on our docs, it's a useful privacy feature.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
