### PR TITLE
Add warning about changing feature flag bucketing methods

### DIFF
--- a/contents/docs/feature-flags/stable-identity-for-flags.mdx
+++ b/contents/docs/feature-flags/stable-identity-for-flags.mdx
@@ -111,9 +111,7 @@ To guarantee consistency across platforms for Experiments, evaluate flags on you
 | Quick fix, minimal code changes | Device bucketing |
 | Can't change identity flow at all | Experience continuity |
 
-<CalloutBox type="warning">
-<strong>Warning: Changing bucketing method re-evaluates users</strong>
-
+<CalloutBox type="warning" title="Warning: Changing bucketing method re-evaluates users">
 If you change a flag's bucketing method (from `device_id` to `person` or vice versa), all users will be re-evaluated against the new bucketing option. This can cause the flag to evaluate to a different value for existing users, potentially disrupting their experience or corrupting experiment data. Plan changes carefully and consider the impact on active experiments.
 </CalloutBox>
 

--- a/contents/docs/feature-flags/stable-identity-for-flags.mdx
+++ b/contents/docs/feature-flags/stable-identity-for-flags.mdx
@@ -43,6 +43,12 @@ Hashes on `$device_id` instead of `distinct_id`. Since the device ID doesn't cha
 
 See [Device bucketing](/docs/feature-flags/device-bucketing) for setup.
 
+<CalloutBox type="warning">
+**Warning: Changing bucketing method re-evaluates users**
+
+If you change a flag's bucketing method (from `device_id` to `person` or vice versa), all users will be re-evaluated against the new bucketing option. This can cause the flag to evaluate to a different value for existing users, potentially disrupting their experience or corrupting experiment data. Plan changes carefully and consider the impact on active experiments.
+</CalloutBox>
+
 | | Device bucketing | Experience continuity |
 |---|---|---|
 | Database cost | None | Read on every evaluation, write on first identify |

--- a/contents/docs/feature-flags/stable-identity-for-flags.mdx
+++ b/contents/docs/feature-flags/stable-identity-for-flags.mdx
@@ -43,12 +43,6 @@ Hashes on `$device_id` instead of `distinct_id`. Since the device ID doesn't cha
 
 See [Device bucketing](/docs/feature-flags/device-bucketing) for setup.
 
-<CalloutBox type="warning">
-**Warning: Changing bucketing method re-evaluates users**
-
-If you change a flag's bucketing method (from `device_id` to `person` or vice versa), all users will be re-evaluated against the new bucketing option. This can cause the flag to evaluate to a different value for existing users, potentially disrupting their experience or corrupting experiment data. Plan changes carefully and consider the impact on active experiments.
-</CalloutBox>
-
 | | Device bucketing | Experience continuity |
 |---|---|---|
 | Database cost | None | Read on every evaluation, write on first identify |
@@ -116,6 +110,12 @@ To guarantee consistency across platforms for Experiments, evaluate flags on you
 | Maximum debuggability and control | Server-side local eval with explicit stable ID |
 | Quick fix, minimal code changes | Device bucketing |
 | Can't change identity flow at all | Experience continuity |
+
+<CalloutBox type="warning">
+<strong>Warning: Changing bucketing method re-evaluates users</strong>
+
+If you change a flag's bucketing method (from `device_id` to `person` or vice versa), all users will be re-evaluated against the new bucketing option. This can cause the flag to evaluate to a different value for existing users, potentially disrupting their experience or corrupting experiment data. Plan changes carefully and consider the impact on active experiments.
+</CalloutBox>
 
 ## Further reading
 


### PR DESCRIPTION
## Problem

Users need to understand the risks when changing a feature flag's bucketing method (from device_id to person or vice versa). Currently, there's no warning about how this change can cause users to be re-evaluated and potentially receive different flag values.

## Changes

- Added a warning callout in the device bucketing section explaining that changing bucketing methods re-evaluates users
- Warns about potential disruption to user experience and experiment data corruption
- Advises careful planning for changes to active experiments

## How did you test this code?

- Verified the CalloutBox component renders correctly with warning styling
- Confirmed the warning is positioned appropriately in the device bucketing section