### PR TITLE
Blog: Why attacking your competitors online is dumb

### DIFF
--- a/contents/blog/why-attacking-competitors-is-dumb.md
+++ b/contents/blog/why-attacking-competitors-is-dumb.md
@@ -22,58 +22,53 @@ Let's say a competitor copies your feature. Let's say they lift your positioning
 
 Still don't do it.
 
-This isn't a moral argument. I'm not going to lecture you about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
+This isn't a moral argument - I'm not going to lecture you about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
 
-**Tl;dr:**
-1. Even when you're right, it usually backfires
-2. You're amplifying a competitor who may have far fewer users than you
-3. Most of your market didn't see the thing you're upset about
-4. There are more effective ways to compete
+**TL;DR:**
+- Even when you're right, it usually backfires
+- You're amplifying a competitor who may have far fewer users than you
+- Most of your market didn't see the thing you're upset about
+- There are more effective ways to compete
 
 ---
 
-## 1. You're only talking to your own fans
+## You're only talking to your own fans
 
-When you attack a competitor publicly, you reach two audiences: your fans, who already agree with you, and their fans, who will immediately get defensive.
+When you attack a competitor publicly, you reach two audiences: your fans, who already agree with you, and their fans, who will immediately get defensive. Your fans cheer. Their fans roll their eyes. The people actually evaluating their options - the ones who matter - are unlikely to switch to you because of a zinger of a tweet.
 
-Your fans cheer. Their fans roll their eyes. The people actually evaluating their options - the ones who matter - are unlikely to switch vendors because of a tweet.
-
-You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect - we've made loads of mistakes!
-
-Whatever you're accusing a competitor of - copying something, overstating a claim, making a bad call - there's a good chance you've done some version of it too, and someone will find it.
+You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect - we've made loads of mistakes! Whatever you're accusing a competitor of - copying something, overstating a claim, making a bad call - there's a good chance you've done some version of it too, and someone will find it.
 
 If you're open source, this gets even more awkward. PostHog is built on the work of many others, and we think others should be able to build on ours too. Attacking a competitor for being "inspired" by us kinda misses the point of open source.
 
-## 2. You're doing their marketing, with your audience
+## You're doing their marketing, with your audience
 
 PostHog has more users than most of our direct competitors. When we publicly name a competitor, we're lending them our audience - introducing thousands of developers to a product and telling them it's worth being upset about.
 
 So you fire off the tweet, they get more traction than they would have otherwise, their team screenshots it for the all-hands, and you've spent your energy on this instead of on your product.
 
-## 3. Most people didn't see the thing you're upset about
+## Most people didn't see the thing you're upset about
 
 If you're in a competitive market, you're probably monitoring it closely. Social listening, Google Alerts, the Slack channel where someone drops every mention. You are primed to notice competitor activity, and you see a lot of it.
 
-Your users are not doing this. Most of the market didn't see the post that's been annoying you since Tuesday. Most people aren't tracking the nuances of your competitive landscape at all. Nobody cares.
+Your users are not doing this. Most of the market didn't see the post that's been annoying you since Tuesday. Most people aren't tracking the nuances of your competitive landscape at all. [Nobody cares](https://www.youtube.com/watch?v=mmw2ub-o4gg).
 
 The urgency of wanting to respond scales with how much it bothered you, not with how many people actually saw it. Responding publicly does more to surface the original thing than to rebut it.
 
-## 4. What to do instead
+## What to do instead
 
 **Make fun of trends, not companies.** If something in your market is genuinely dumb, be funny and critical about that without naming anyone. The joke lands, people share it, and you haven't handed anyone ammunition.
 
 **Publish honest comparisons.** The instinct is to make yourself look great and them look bad. The better move is genuine honesty about tradeoffs - where you're stronger, where you're not, who each product is actually for. PostHog does this. It builds trust that no amount of positioning copy can buy, because it's harder to argue with.
 
-**Bid on their keywords.** Fully legitimate. If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did X.
+**Bid on their keywords.** Fully legitimate. If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did [thing].
 
-**Correct factual errors privately if they actually matter.** "Hey, this isn't accurate, here's the data" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions - we have happily accepted PRs to our website to set the record straight.
+**Correct factual errors privately if they _actually_ matter.** "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions - we have happily accepted PRs to our website to set the record straight.
 
-But mostly: use the anger to outship them and build a better product.
+But mostly: use your anger to outship them and build a better product.
 
 ## Further reading
 
 - [How not to be boring](/blog/brand)
-- [How startup secondaries actually work](/blog/how-secondaries-actually-work)
-- [Making Claude Cowork actually useful](/blog/making-claude-cowork-actually-useful)
+- [40 things we’ve learned about marketing for developers](/newsletter/marketing-for-devs)
 
 <NewsletterForm />

--- a/contents/blog/why-attacking-competitors-is-dumb.md
+++ b/contents/blog/why-attacking-competitors-is-dumb.md
@@ -56,13 +56,17 @@ The urgency of wanting to respond scales with how much it bothered you, not with
 
 ## What to do instead
 
+I'll admit - we've got this wrong before. When we threw together [isgoogleanalyticsillegal.com](https://www.isgoogleanalyticsillegal.com/), it was meant to be tongue in cheek but we still got criticized for going directly after a competitor, which was fair. 
+
+This is what we try to do instead:
+
 **Make fun of trends, not companies.** If something in your market is genuinely dumb, be funny and critical about that without naming anyone. The joke lands, people share it, and you haven't handed anyone ammunition.
 
-**Publish honest comparisons.** The instinct is to make yourself look great and them look bad. The better move is genuine honesty about tradeoffs – where you're stronger, where you're not, who each product is actually for. PostHog does this. It builds trust that no amount of positioning copy can buy, because it's harder to argue with.
+**Publish detailed, honest comparisons.** The instinct is to make yourself look great and them look bad - lots of ticks for you, lots of crosses for them. The better move is genuine honesty about tradeoffs – where you're stronger, where you're not, who each product is actually for. PostHog does this, and I think it builds trust that no amount of positioning copy can buy. I'll admit we haven't always got this right, so where we have made factual errors, we do our best to fix them as quickly as possible when someone notices.
 
-**Bid on their keywords.** Fully legitimate. If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did [thing].
+**Bid on competitor keywords.** If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did [thing]. You know when someone asks in a forum 'what do you think about X?' and the response is 'I actually like Y'? This is the ads equivalent of that. 
 
-**Correct factual errors privately if they _actually_ matter.** "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions – we have happily accepted PRs to our website to set the record straight.
+**Correct factual errors privately if they _actually_ matter.** Contacting a competitors to say "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions – we have happily accepted PRs to our website to set the record straight!
 
 But mostly: use your anger to outship them and build a better product.
 

--- a/contents/blog/why-attacking-competitors-is-dumb.md
+++ b/contents/blog/why-attacking-competitors-is-dumb.md
@@ -18,25 +18,18 @@ tags:
   - Culture
 ---
 
-Let's say a competitor copies your feature. Let's say they lift your positioning, write a misleading comparison post, or just take a cheap shot at you on X. And let's say you're 'right' – they actually did the thing, and it's actually annoying.
+Let's say a competitor copies your feature. They lift your positioning, write a misleading comparison post, or just take a cheap shot at you on X. And let's say you're 'right' – they actually did the thing, and it's actually annoying.
 
 Still don't do it.
 
-This isn't a moral argument – I'm not going to lecture you about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
+This isn't a moral argument about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
 
-**TL;DR:**
-- Even when you're right, it usually backfires
-- You're amplifying a competitor who may have far fewer users than you
-- Most of your market didn't see the thing you're upset about
-- There are more effective ways to compete
-
----
 
 ## You're only talking to your own fans
 
 When you attack a competitor publicly, you reach two audiences: your fans, who already agree with you, and their fans, who will immediately get defensive. Your fans cheer. Their fans roll their eyes. The people actually evaluating their options – the ones who matter – are unlikely to switch to you because of a zinger of a tweet.
 
-You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect – we've made loads of mistakes! Whatever you're accusing a competitor of – copying something, overstating a claim, making a bad call – there's a good chance you've done some version of it too, and someone will find it.
+You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect and we've made loads of mistakes! Whatever you're accusing a competitor of, like copying something, overstating a claim, or making a bad call, there's a good chance you've done some version of it too, and someone will find it.
 
 If you're open source, this gets even more awkward. PostHog is built on the work of many others, and we think others should be able to build on ours too. Attacking a competitor for being "inspired" by us kinda misses the point of open source.
 
@@ -50,23 +43,23 @@ So you fire off the tweet, they get more traction than they would have otherwise
 
 If you're in a competitive market, you're probably monitoring it closely. Social listening, Google Alerts, the Slack channel where someone drops every mention. You are primed to notice competitor activity, and you see a lot of it.
 
-Your users are not doing this. Most of the market didn't see the post that's been annoying you since Tuesday. Most people aren't tracking the nuances of your competitive landscape at all. [Nobody cares](https://www.youtube.com/watch?v=mmw2ub-o4gg).
+Your users are not doing this. Most people didn't see the post that's been annoying you since Tuesday. They're not tracking the nuances of your competitive landscape at all. [Nobody cares](https://www.youtube.com/watch?v=mmw2ub-o4gg).
 
 The urgency of wanting to respond scales with how much it bothered you, not with how many people actually saw it. Responding publicly does more to surface the original thing than to rebut it.
 
 ## What to do instead
 
-I'll admit - we've got this wrong before. When we threw together [isgoogleanalyticsillegal.com](https://www.isgoogleanalyticsillegal.com/), it was meant to be tongue in cheek but we still got criticized for going directly after a competitor, which was fair. 
+I'll admit, we've got this wrong before. When we threw together [isgoogleanalyticsillegal.com](https://www.isgoogleanalyticsillegal.com/), it was meant to be tongue in cheek but we still got criticized for going directly after a competitor, which was fair. 
 
 This is what we try to do instead:
 
 **Make fun of trends, not companies.** If something in your market is genuinely dumb, be funny and critical about that without naming anyone. The joke lands, people share it, and you haven't handed anyone ammunition.
 
-**Publish detailed, honest comparisons.** The instinct is to make yourself look great and them look bad - lots of ticks for you, lots of crosses for them. The better move is genuine honesty about tradeoffs – where you're stronger, where you're not, who each product is actually for. PostHog does this, and I think it builds trust that no amount of positioning copy can buy. I'll admit we haven't always got this right, so where we have made factual errors, we do our best to fix them as quickly as possible when someone notices.
+**Publish detailed, honest comparisons.** The instinct is to make yourself look great and them look bad - lots of ticks for you, lots of crosses for them. The better move is genuine honesty about tradeoffs – where you're stronger, where you're not, who each product is actually for. PostHog does this, and I think it builds trust that no amount of positioning copy can buy. I'll admit we haven't always got this right, so where we have made factual errors, we fix them as quickly as possible when they're pointed out.
 
 **Bid on competitor keywords.** If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did [thing]. You know when someone asks in a forum 'what do you think about X?' and the response is 'I actually like Y'? This is the ads equivalent of that. 
 
-**Correct factual errors privately if they _actually_ matter.** Contacting a competitors to say "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions – we have happily accepted PRs to our website to set the record straight!
+**Correct factual errors privately if they _actually_ matter.** Contacting a competitor to say "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions. We have happily accepted PRs to our website to set the record straight!
 
 But mostly: use your anger to outship them and build a better product.
 

--- a/contents/blog/why-attacking-competitors-is-dumb.md
+++ b/contents/blog/why-attacking-competitors-is-dumb.md
@@ -18,11 +18,11 @@ tags:
   - Culture
 ---
 
-Let's say a competitor copies your feature. Let's say they lift your positioning, write a misleading comparison post, or just take a cheap shot at you on X. And let's say you're 'right' - they actually did the thing, and it's actually annoying.
+Let's say a competitor copies your feature. Let's say they lift your positioning, write a misleading comparison post, or just take a cheap shot at you on X. And let's say you're 'right' – they actually did the thing, and it's actually annoying.
 
 Still don't do it.
 
-This isn't a moral argument - I'm not going to lecture you about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
+This isn't a moral argument – I'm not going to lecture you about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
 
 **TL;DR:**
 - Even when you're right, it usually backfires
@@ -34,15 +34,15 @@ This isn't a moral argument - I'm not going to lecture you about keeping it clas
 
 ## You're only talking to your own fans
 
-When you attack a competitor publicly, you reach two audiences: your fans, who already agree with you, and their fans, who will immediately get defensive. Your fans cheer. Their fans roll their eyes. The people actually evaluating their options - the ones who matter - are unlikely to switch to you because of a zinger of a tweet.
+When you attack a competitor publicly, you reach two audiences: your fans, who already agree with you, and their fans, who will immediately get defensive. Your fans cheer. Their fans roll their eyes. The people actually evaluating their options – the ones who matter – are unlikely to switch to you because of a zinger of a tweet.
 
-You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect - we've made loads of mistakes! Whatever you're accusing a competitor of - copying something, overstating a claim, making a bad call - there's a good chance you've done some version of it too, and someone will find it.
+You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect – we've made loads of mistakes! Whatever you're accusing a competitor of – copying something, overstating a claim, making a bad call – there's a good chance you've done some version of it too, and someone will find it.
 
 If you're open source, this gets even more awkward. PostHog is built on the work of many others, and we think others should be able to build on ours too. Attacking a competitor for being "inspired" by us kinda misses the point of open source.
 
 ## You're doing their marketing, with your audience
 
-PostHog has more users than most of our direct competitors. When we publicly name a competitor, we're lending them our audience - introducing thousands of developers to a product and telling them it's worth being upset about.
+PostHog has more users than most of our direct competitors. When we publicly name a competitor, we're lending them our audience – introducing thousands of developers to a product and telling them it's worth being upset about.
 
 So you fire off the tweet, they get more traction than they would have otherwise, their team screenshots it for the all-hands, and you've spent your energy on this instead of on your product.
 
@@ -58,11 +58,11 @@ The urgency of wanting to respond scales with how much it bothered you, not with
 
 **Make fun of trends, not companies.** If something in your market is genuinely dumb, be funny and critical about that without naming anyone. The joke lands, people share it, and you haven't handed anyone ammunition.
 
-**Publish honest comparisons.** The instinct is to make yourself look great and them look bad. The better move is genuine honesty about tradeoffs - where you're stronger, where you're not, who each product is actually for. PostHog does this. It builds trust that no amount of positioning copy can buy, because it's harder to argue with.
+**Publish honest comparisons.** The instinct is to make yourself look great and them look bad. The better move is genuine honesty about tradeoffs – where you're stronger, where you're not, who each product is actually for. PostHog does this. It builds trust that no amount of positioning copy can buy, because it's harder to argue with.
 
 **Bid on their keywords.** Fully legitimate. If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did [thing].
 
-**Correct factual errors privately if they _actually_ matter.** "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions - we have happily accepted PRs to our website to set the record straight.
+**Correct factual errors privately if they _actually_ matter.** "Hey, this isn't accurate, it should be this" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions – we have happily accepted PRs to our website to set the record straight.
 
 But mostly: use your anger to outship them and build a better product.
 

--- a/contents/blog/why-attacking-competitors-is-dumb.md
+++ b/contents/blog/why-attacking-competitors-is-dumb.md
@@ -1,0 +1,79 @@
+---
+title: Why attacking your competitors online is dumb
+date: 2026-05-02
+author:
+  - charles-cook
+showTitle: true
+rootPage: /blog
+sidebar: Blog
+hideAnchor: true
+featuredImage: >-
+  https://res.cloudinary.com/dmukukwp6/image/upload/brand_startup_1aa2b151d6.png
+featuredImageType: full
+category: Startups
+tags:
+  - Guides
+  - Marketing
+  - Growth
+  - Culture
+---
+
+Let's say a competitor copies your feature. Let's say they lift your positioning, write a misleading comparison post, or just take a cheap shot at you on X. And let's say you're 'right' - they actually did the thing, and it's actually annoying.
+
+Still don't do it.
+
+This isn't a moral argument. I'm not going to lecture you about keeping it classy. I just think public competitor attacks never work, and there are much better places to put the energy.
+
+**Tl;dr:**
+1. Even when you're right, it usually backfires
+2. You're amplifying a competitor who may have far fewer users than you
+3. Most of your market didn't see the thing you're upset about
+4. There are more effective ways to compete
+
+---
+
+## 1. You're only talking to your own fans
+
+When you attack a competitor publicly, you reach two audiences: your fans, who already agree with you, and their fans, who will immediately get defensive.
+
+Your fans cheer. Their fans roll their eyes. The people actually evaluating their options - the ones who matter - are unlikely to switch vendors because of a tweet.
+
+You're also, the moment you go on the offensive, opening yourself up to scrutiny. We're not perfect - we've made loads of mistakes!
+
+Whatever you're accusing a competitor of - copying something, overstating a claim, making a bad call - there's a good chance you've done some version of it too, and someone will find it.
+
+If you're open source, this gets even more awkward. PostHog is built on the work of many others, and we think others should be able to build on ours too. Attacking a competitor for being "inspired" by us kinda misses the point of open source.
+
+## 2. You're doing their marketing, with your audience
+
+PostHog has more users than most of our direct competitors. When we publicly name a competitor, we're lending them our audience - introducing thousands of developers to a product and telling them it's worth being upset about.
+
+So you fire off the tweet, they get more traction than they would have otherwise, their team screenshots it for the all-hands, and you've spent your energy on this instead of on your product.
+
+## 3. Most people didn't see the thing you're upset about
+
+If you're in a competitive market, you're probably monitoring it closely. Social listening, Google Alerts, the Slack channel where someone drops every mention. You are primed to notice competitor activity, and you see a lot of it.
+
+Your users are not doing this. Most of the market didn't see the post that's been annoying you since Tuesday. Most people aren't tracking the nuances of your competitive landscape at all. Nobody cares.
+
+The urgency of wanting to respond scales with how much it bothered you, not with how many people actually saw it. Responding publicly does more to surface the original thing than to rebut it.
+
+## 4. What to do instead
+
+**Make fun of trends, not companies.** If something in your market is genuinely dumb, be funny and critical about that without naming anyone. The joke lands, people share it, and you haven't handed anyone ammunition.
+
+**Publish honest comparisons.** The instinct is to make yourself look great and them look bad. The better move is genuine honesty about tradeoffs - where you're stronger, where you're not, who each product is actually for. PostHog does this. It builds trust that no amount of positioning copy can buy, because it's harder to argue with.
+
+**Bid on their keywords.** Fully legitimate. If someone is searching for your competitor, you should be showing up. I know a lot of people think this doesn't work, but a) data disagrees with you, and b) sometimes we're reaching PostHog users who weren't aware we also did X.
+
+**Correct factual errors privately if they actually matter.** "Hey, this isn't accurate, here's the data" takes five minutes and either fixes it or motivates you when they are annoying about it. We have seen this succeed in both directions - we have happily accepted PRs to our website to set the record straight.
+
+But mostly: use the anger to outship them and build a better product.
+
+## Further reading
+
+- [How not to be boring](/blog/brand)
+- [How startup secondaries actually work](/blog/how-secondaries-actually-work)
+- [Making Claude Cowork actually useful](/blog/making-claude-cowork-actually-useful)
+
+<NewsletterForm />


### PR DESCRIPTION
## Summary

New blog post by Charles Cook arguing that publicly attacking competitors backfires, amplifies them to your own audience, and addresses problems most of the market never noticed - plus what to do instead.

- Frontmatter copied from the secondaries post (`how-secondaries-actually-work.md`), with category `Startups` and tags adjusted to fit (`Guides`, `Marketing`, `Growth`, `Culture`)
- Reused the `brand_startup_1aa2b151d6.png` artwork from James's "How not to be boring" post — closest thematic match for a brand/marketing strategy piece
- Added a "Further reading" section linking to related posts, matching the secondaries post's pattern

## Test plan

- [ ] Review copy for tone and accuracy
- [ ] Confirm the chosen featured image is appropriate, or swap for a preferred one
- [ ] Confirm tags/category are correct


---
_Generated by [Claude Code](https://claude.ai/code/session_018RqCeSJADSCVgGUsfDTAtN)_