### PR TITLE
docs(mcp): clarify LLM-backed tools incur PostHog AI usage

### DIFF
--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -6,7 +6,7 @@ import MCPClients from "./_snippets/mcp-clients.tsx"
 
 The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server enables your AI agents and tools to directly interact with PostHog's products.
 
-The PostHog MCP server is free to use – connecting to it and calling its tools doesn't incur any charges on your PostHog bill.
+Regular MCP usage is free – connecting to the server and calling its tools doesn't incur any charges on your PostHog bill. The exception is tools that use LLMs internally (like session recording summarization), which count toward your regular [PostHog AI usage](/docs/posthog-ai/pricing). These tools are only accessible if your organization owner has accepted [AI data processing](/docs/posthog-ai/allow-access).
 
 ## Server URL
 


### PR DESCRIPTION
## Problem

Follow-up to #16670. The current MCP overview page says the server is free, but doesn't mention that some tools (e.g. session recording summarization) call LLMs internally and count toward regular PostHog AI usage. It also doesn't mention that those tools are gated on the organization owner accepting AI data processing.

## Changes

Reworded the billing line on the MCP overview page to call out the LLM-backed tool exception and link to the [PostHog AI pricing](/docs/posthog-ai/pricing) and [AI data processing](/docs/posthog-ai/allow-access) pages.

## How did you test this code?

Visually confirmed the diff in `contents/docs/model-context-protocol/index.mdx` and verified both linked docs exist locally.

## Publish to changelog?

no