### PR TITLE
docs: update shared feature flag snapshot guidance

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -18,7 +18,7 @@ In your experiment, each user is randomly assigned to a variant (usually either 
 
 <CalloutBox icon="IconWarning" title="Only flag value access counts as an exposure" type="caution">
 
-You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. In server SDKs with snapshot APIs, use the snapshot value accessor like `flags.getFlag()` / `flags.get_flag()` / `flags.GetFlag()`. Other methods like `getAllFlags()`, `getFeatureFlags()`, or payload-only accessors do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
+You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. In server-side SDKs, use the `evaluateFlags` API to access flag values via `getFlag()` / `get_flag()`. Other methods like `getAllFlags()`, `getFeatureFlags()`, or payload-only accessors do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
 
 </CalloutBox>
 

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -16,9 +16,9 @@ Once you've created your experiment in PostHog, the next step is to add your cod
 
 In your experiment, each user is randomly assigned to a variant (usually either 'control' or 'test'). To check which variant a user has been assigned to, fetch the experiment feature flag. You can then customize their experience based on the value in the feature flag:
 
-<CalloutBox icon="IconWarning" title="Only getFeatureFlag() counts as an exposure" type="caution">
+<CalloutBox icon="IconWarning" title="Only flag value access counts as an exposure" type="caution">
 
-You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. Other methods like `getAllFlags()`, `getFeatureFlags()`, or `getFeatureFlagPayload()` alone do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
+You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. In server SDKs with snapshot APIs, use the snapshot value accessor like `flags.getFlag()` / `flags.get_flag()` / `flags.GetFlag()`. Other methods like `getAllFlags()`, `getFeatureFlags()`, or payload-only accessors do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
 
 </CalloutBox>
 

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -14,7 +14,7 @@ Exposures are the foundation of experiment analysis in PostHog. A user must be *
 
 An exposure occurs when a user encounters the part of your product where the experiment is running. This is the moment they become a participant in your experiment and start contributing to your metrics.
 
-**For most users**: If you're using PostHog feature flags with our SDKs, exposures are tracked automatically. When you call `getFeatureFlag()` or read a flag from a server-side snapshot with an accessor like `getFlag()`, `get_flag()`, or `GetFlag()`, PostHog sends a `$feature_flag_called` event with all the necessary properties. You don't need to do anything extra.
+**For most users**: If you're using PostHog feature flags with our SDKs, exposures are tracked automatically. When you call `getFeatureFlag()` or read a flag from a server-side `evaluateFlags` result, PostHog sends a `$feature_flag_called` event with all the necessary properties. You don't need to do anything extra.
 
 **Technical details**: PostHog considers a user exposed when it receives a `$feature_flag_called` event containing:
 - The property `$feature_flag` matching your experiment's flag key

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -14,7 +14,7 @@ Exposures are the foundation of experiment analysis in PostHog. A user must be *
 
 An exposure occurs when a user encounters the part of your product where the experiment is running. This is the moment they become a participant in your experiment and start contributing to your metrics.
 
-**For most users**: If you're using PostHog feature flags with our SDKs, exposures are tracked automatically. When you call `getFeatureFlag()`, PostHog sends a `$feature_flag_called` event with all the necessary properties. You don't need to do anything extra.
+**For most users**: If you're using PostHog feature flags with our SDKs, exposures are tracked automatically. When you call `getFeatureFlag()` or read a flag from a server-side snapshot with an accessor like `getFlag()`, `get_flag()`, or `GetFlag()`, PostHog sends a `$feature_flag_called` event with all the necessary properties. You don't need to do anything extra.
 
 **Technical details**: PostHog considers a user exposed when it receives a `$feature_flag_called` event containing:
 - The property `$feature_flag` matching your experiment's flag key
@@ -114,7 +114,7 @@ Users are analyzed based on the first variant they were exposed to, regardless o
 
 PostHog counts one exposure per user per variant in experiment results. Even if multiple `$feature_flag_called` events fire for the same user, they won't inflate your exposure counts or affect your results as long as the variant value is the same.
 
-The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs (Node, Python), dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy. As noted above, this doesn't affect experiment analysis.
+The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs, dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy. As noted above, this doesn't affect experiment analysis.
 
 ## Sample ratio mismatch detection
 

--- a/contents/docs/experiments/legacy-methodology.mdx
+++ b/contents/docs/experiments/legacy-methodology.mdx
@@ -78,7 +78,7 @@ The probability of a variant being the best is given by:
 
 > **Trend experiment exposure**
 >
-> Trend experiments compare counts of events. Since count data can refer to the total count of events or the number of unique users, we use a proxy metric to measure exposure. The number of times the `feature_flag_called` event returns control or test is used as the respective exposure for the variant. This event is sent automatically when you call `posthog.getFeatureFlag()` or read a flag value from a server-side snapshot with an accessor like `getFlag()`.
+> Trend experiments compare counts of events. Since count data can refer to the total count of events or the number of unique users, we use a proxy metric to measure exposure. The number of times the `feature_flag_called` event returns control or test is used as the respective exposure for the variant. This event is sent automatically when you call `posthog.getFeatureFlag()` or read a flag value from a server-side `evaluateFlags` result.
 >
 > Note that a variant showing fewer count data can still have a higher probability of being the best if its exposure is much smaller. This is because the relative exposure is taken into account when calculating probabilities.
 

--- a/contents/docs/experiments/legacy-methodology.mdx
+++ b/contents/docs/experiments/legacy-methodology.mdx
@@ -78,7 +78,7 @@ The probability of a variant being the best is given by:
 
 > **Trend experiment exposure**
 >
-> Trend experiments compare counts of events. Since count data can refer to the total count of events or the number of unique users, we use a proxy metric to measure exposure. The number of times the `feature_flag_called` event returns control or test is used as the respective exposure for the variant. This event is sent automatically when you call `posthog.getFeatureFlag()`.
+> Trend experiments compare counts of events. Since count data can refer to the total count of events or the number of unique users, we use a proxy metric to measure exposure. The number of times the `feature_flag_called` event returns control or test is used as the respective exposure for the variant. This event is sent automatically when you call `posthog.getFeatureFlag()` or read a flag value from a server-side snapshot with an accessor like `getFlag()`.
 >
 > Note that a variant showing fewer count data can still have a higher probability of being the best if its exposure is much smaller. This is because the relative exposure is taken into account when calculating probabilities.
 

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -141,7 +141,7 @@ Something changed in the evaluation inputs. Common causes: `identify()` called a
 
 The flag is being evaluated in a context you didn't expect. Server-side evaluation without bot filtering means bots are participants. `getAllFlags()` in your code means exposures aren't being recorded. Multiple SDKs evaluating the same flag with different distinct IDs means duplicate exposures.
 
-**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()`? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
+**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()` or a server-side snapshot value accessor like `getFlag()`? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
 
 ### Metric shows all "none" values with a property breakdown
 

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -141,7 +141,7 @@ Something changed in the evaluation inputs. Common causes: `identify()` called a
 
 The flag is being evaluated in a context you didn't expect. Server-side evaluation without bot filtering means bots are participants. `getAllFlags()` in your code means exposures aren't being recorded. Multiple SDKs evaluating the same flag with different distinct IDs means duplicate exposures.
 
-**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()` or a server-side snapshot value accessor like `getFlag()`? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
+**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()` or the server-side `evaluateFlags` API? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
 
 ### Metric shows all "none" values with a property breakdown
 

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -135,9 +135,10 @@ Update the list of flags to update and paste this prompt into any AI coding agen
 ```text
 Find and remove all references to these feature flags in the codebase.
 For each flag, search for all usages including isFeatureEnabled,
-getFeatureFlag, useFeatureFlag, evaluate_flags, is_enabled,
-get_flag, feature_enabled, and the flag key as a string literal
-in constants and configs.
+getFeatureFlag, useFeatureFlag, evaluateFlags, EvaluateFlags,
+evaluate_flags, IsEnabled, isEnabled, enabled?, is_enabled,
+getFlag, GetFlag, get_flag, get_feature_flag, feature_enabled,
+and the flag key as a string literal in constants and configs.
 
 ## Fully rolled out – remove the flag check, KEEP the enabled code path
 - new-checkout

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -20,7 +20,7 @@ We aim to be significantly cheaper than our competitors. Below are tips to reduc
 
 Feature flags are charged based on requests made to our `/flags` endpoint, which is used to evaluate feature flags for a given user. This endpoint is called in several scenarios:
 
-- When explicitly requesting feature flags via server-side SDK methods like `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()`
+- When explicitly requesting feature flags via server-side SDK methods like `evaluateFlags()`, `evaluate_flags()`, `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()`
 - When using client-side SDK methods like `onFeatureFlags()` or when flags are automatically fetched
 - Automatically on SDK initialization (unless disabled, see below)
 - When evaluating survey targeting, which checks **all active feature flags** in your project
@@ -29,7 +29,7 @@ Feature flags are charged based on requests made to our `/flags` endpoint, which
 
 For **client-side SDKs** (JavaScript, React Native), methods like `getFeatureFlag()` don't necessarily create billable events due to caching. Requests are made when the SDK initializes, when users are identified, or when `reloadFeatureFlags()` is called.
 
-For **server-side SDKs** (Node, Python, PHP, etc.), each call to `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()` makes a request to the `/flags` endpoint and incurs a billable event.
+For **server-side SDKs** (Node, Python, PHP, etc.), each call that evaluates flags, such as `evaluateFlags()`, `evaluate_flags()`, `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()`, makes a request to the `/flags` endpoint and incurs a billable event unless local evaluation resolves it.
 
 </CalloutBox>
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -80,7 +80,7 @@ import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-s
 
 ## Step 3: Evaluate your feature flag
 
-To evaluate the feature flag, call the flag evaluation method for your SDK. In Python, use `posthog.evaluate_flags()` once and read values from the returned snapshot with `flags.is_enabled()` or `flags.get_flag()`. The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
+To evaluate the feature flag, call the flag evaluation method for your SDK. In server SDKs with snapshot APIs, evaluate flags once and read values from the returned snapshot (for example, Python uses `posthog.evaluate_flags()` with `flags.is_enabled()` or `flags.get_flag()`). The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
 
 Then, by default, PostHog attempts to evaluate the flag locally using definitions it loads on initialization and at the `poll interval`. If this fails, PostHog then makes a server request to fetch the flag value.
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -80,7 +80,7 @@ import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-s
 
 ## Step 3: Evaluate your feature flag
 
-To evaluate the feature flag, call the flag evaluation method for your SDK. In server SDKs with snapshot APIs, evaluate flags once and read values from the returned snapshot (for example, Python uses `posthog.evaluate_flags()` with `flags.is_enabled()` or `flags.get_flag()`). The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
+To evaluate the feature flag, call the flag evaluation method for your SDK. In server-side APIs, evaluate flags once and read values from the returned snapshot. The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
 
 Then, by default, PostHog attempts to evaluate the flag locally using definitions it loads on initialization and at the `poll interval`. If this fails, PostHog then makes a server request to fetch the flag value.
 

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -458,7 +458,7 @@ No additional configuration is required on the client side.
 
 ## Server-side SDKs
 
-Server-side SDKs handle property overrides differently. Instead of persistent session-based overrides, you pass properties directly when evaluating each flag.
+Server-side SDKs handle property overrides differently. Instead of persistent session-based overrides, you pass properties directly when evaluating flags.
 
 <MultiLanguage selector="tabs">
 

--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -20,7 +20,7 @@ For example, if on refresh, you see 2 `/flags` requests per pageview and you hav
 
 ##### Without local evaluation 
 
-If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a request to get feature flags is made every time your backend evaluates flags. For example, in Python, each `posthog.evaluate_flags()` call makes one `/flags` request. Your estimated usage is based on how often you call this code.
+If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a request to get feature flags is made every time your backend evaluates flags. For example, each server-side snapshot evaluation call like `evaluateFlags()` or Python's `posthog.evaluate_flags()` makes one `/flags` request. Your estimated usage is based on how often you call this code.
 
 ##### With local evaluation
 


### PR DESCRIPTION
## Changes

Updates shared feature flag docs guidance for server-side snapshot/value accessor APIs, exposure tracking, and feature flag billing/local evaluation wording.\n\nThis is the base PR for the SDK-specific docs PRs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
