### PR TITLE
docs: update Python feature flag examples

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -115,9 +115,10 @@ if (variant === 'variant-name') {
 ```
 
 ```python
-variant = posthog.get_feature_flag('experiment-feature-flag-key', 'user_distinct_id')
+flags = posthog.evaluate_flags("user_distinct_id")
+variant = flags.get_flag("experiment-feature-flag-key")
 
-if variant == 'variant-name':
+if variant == "variant-name":
     # Do something
 ```
 

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -16,9 +16,9 @@ Once you've created your experiment in PostHog, the next step is to add your cod
 
 In your experiment, each user is randomly assigned to a variant (usually either 'control' or 'test'). To check which variant a user has been assigned to, fetch the experiment feature flag. You can then customize their experience based on the value in the feature flag:
 
-<CalloutBox icon="IconWarning" title="Only getFeatureFlag() counts as an exposure" type="caution">
+<CalloutBox icon="IconWarning" title="Only flag value access counts as an exposure" type="caution">
 
-You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. Other methods like `getAllFlags()`, `getFeatureFlags()`, or `getFeatureFlagPayload()` alone do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
+You must use `getFeatureFlag()` (or its framework equivalent like `useFeatureFlagVariantKey()`) to check variants. In server SDKs with snapshot APIs, use the snapshot value accessor like `flags.getFlag()` / `flags.get_flag()` / `flags.GetFlag()`. Other methods like `getAllFlags()`, `getFeatureFlags()`, or payload-only accessors do **not** record an [exposure event](/docs/experiments/exposures). Users evaluated with those methods won't be included in your experiment results.
 
 </CalloutBox>
 

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -14,7 +14,7 @@ Exposures are the foundation of experiment analysis in PostHog. A user must be *
 
 An exposure occurs when a user encounters the part of your product where the experiment is running. This is the moment they become a participant in your experiment and start contributing to your metrics.
 
-**For most users**: If you're using PostHog feature flags with our SDKs, exposures are tracked automatically. When you call `getFeatureFlag()`, PostHog sends a `$feature_flag_called` event with all the necessary properties. You don't need to do anything extra.
+**For most users**: If you're using PostHog feature flags with our SDKs, exposures are tracked automatically. When you call `getFeatureFlag()` or read a flag from a server-side snapshot with an accessor like `getFlag()`, `get_flag()`, or `GetFlag()`, PostHog sends a `$feature_flag_called` event with all the necessary properties. You don't need to do anything extra.
 
 **Technical details**: PostHog considers a user exposed when it receives a `$feature_flag_called` event containing:
 - The property `$feature_flag` matching your experiment's flag key
@@ -114,7 +114,7 @@ Users are analyzed based on the first variant they were exposed to, regardless o
 
 PostHog counts one exposure per user per variant in experiment results. Even if multiple `$feature_flag_called` events fire for the same user, they won't inflate your exposure counts or affect your results as long as the variant value is the same.
 
-The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs (Node, Python), dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy. As noted above, this doesn't affect experiment analysis.
+The SDKs also deduplicate on the sending side. In the browser, dedup persists across sessions via localStorage. In server-side SDKs, dedup is in-memory and resets on server restart, so a user may fire a new event after a deploy. As noted above, this doesn't affect experiment analysis.
 
 ## Sample ratio mismatch detection
 

--- a/contents/docs/experiments/holdouts.mdx
+++ b/contents/docs/experiments/holdouts.mdx
@@ -72,11 +72,12 @@ if (typeof variant === 'string' && variant.startsWith('holdout-')) {
 ```
 
 ```python
-variant = posthog.get_feature_flag('experiment-feature-flag', 'user-id')
+flags = posthog.evaluate_flags("user-id")
+variant = flags.get_flag("experiment-feature-flag")
 
-if isinstance(variant, str) and variant.startswith('holdout-'):
+if isinstance(variant, str) and variant.startswith("holdout-"):
     # User is in a holdout group - show them the default experience
-elif variant == 'test':
+elif variant == "test":
     # User is in the test variant
 else:
     # User is in control or flag is disabled

--- a/contents/docs/experiments/legacy-methodology.mdx
+++ b/contents/docs/experiments/legacy-methodology.mdx
@@ -78,7 +78,7 @@ The probability of a variant being the best is given by:
 
 > **Trend experiment exposure**
 >
-> Trend experiments compare counts of events. Since count data can refer to the total count of events or the number of unique users, we use a proxy metric to measure exposure. The number of times the `feature_flag_called` event returns control or test is used as the respective exposure for the variant. This event is sent automatically when you call `posthog.getFeatureFlag()`.
+> Trend experiments compare counts of events. Since count data can refer to the total count of events or the number of unique users, we use a proxy metric to measure exposure. The number of times the `feature_flag_called` event returns control or test is used as the respective exposure for the variant. This event is sent automatically when you call `posthog.getFeatureFlag()` or read a flag value from a server-side snapshot with an accessor like `getFlag()`.
 >
 > Note that a variant showing fewer count data can still have a higher probability of being the best if its exposure is much smaller. This is because the relative exposure is taken into account when calculating probabilities.
 

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -141,7 +141,7 @@ Something changed in the evaluation inputs. Common causes: `identify()` called a
 
 The flag is being evaluated in a context you didn't expect. Server-side evaluation without bot filtering means bots are participants. `getAllFlags()` in your code means exposures aren't being recorded. Multiple SDKs evaluating the same flag with different distinct IDs means duplicate exposures.
 
-**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()`? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
+**Check:** Search your codebase for every place the flag key appears. Is every evaluation using `getFeatureFlag()` or a server-side snapshot value accessor like `getFlag()`? Is the distinct ID consistent? Is bot traffic filtered? See [which SDK methods trigger exposure](/docs/experiments/exposures#which-sdk-methods-trigger-exposure).
 
 ### Metric shows all "none" values with a property breakdown
 

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -135,7 +135,9 @@ Update the list of flags to update and paste this prompt into any AI coding agen
 ```text
 Find and remove all references to these feature flags in the codebase.
 For each flag, search for all usages including isFeatureEnabled,
-getFeatureFlag, useFeatureFlag, feature_enabled, and the flag key
+getFeatureFlag, useFeatureFlag, evaluateFlags, EvaluateFlags,
+evaluate_flags, IsEnabled, isEnabled, enabled?, is_enabled,
+getFlag, GetFlag, get_flag, feature_enabled, and the flag key
 as a string literal in constants and configs.
 
 ## Fully rolled out – remove the flag check, KEEP the enabled code path

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -113,7 +113,7 @@ Search your codebase for the flag key as a string. Common SDK patterns:
 | Language | Patterns to search for |
 | --- | --- |
 | JavaScript/TypeScript | `isFeatureEnabled('key')`, `getFeatureFlag('key')`, `useFeatureFlag('key')` |
-| Python | `feature_enabled('key')`, `get_feature_flag('key')` |
+| Python | `evaluate_flags(...)` followed by `flags.is_enabled('key')` or `flags.get_flag('key')`, plus older `feature_enabled('key')` and `get_feature_flag('key')` calls |
 | Ruby | `is_feature_enabled('key')`, `get_feature_flag('key')` |
 | Go | `IsFeatureEnabled("key")`, `GetFeatureFlag("key")` |
 | Other SDKs | Search for the flag key as a string literal |

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -20,7 +20,7 @@ We aim to be significantly cheaper than our competitors. Below are tips to reduc
 
 Feature flags are charged based on requests made to our `/flags` endpoint, which is used to evaluate feature flags for a given user. This endpoint is called in several scenarios:
 
-- When explicitly requesting feature flags via server-side SDK methods like `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()`
+- When explicitly requesting feature flags via server-side SDK methods like `evaluateFlags()`, `evaluate_flags()`, `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()`
 - When using client-side SDK methods like `onFeatureFlags()` or when flags are automatically fetched
 - Automatically on SDK initialization (unless disabled, see below)
 - When evaluating survey targeting, which checks **all active feature flags** in your project
@@ -29,7 +29,7 @@ Feature flags are charged based on requests made to our `/flags` endpoint, which
 
 For **client-side SDKs** (JavaScript, React Native), methods like `getFeatureFlag()` don't necessarily create billable events due to caching. Requests are made when the SDK initializes, when users are identified, or when `reloadFeatureFlags()` is called.
 
-For **server-side SDKs** (Node, Python, PHP, etc.), each call to `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()` makes a request to the `/flags` endpoint and incurs a billable event.
+For **server-side SDKs** (Node, Python, PHP, etc.), each call that evaluates flags, such as `evaluateFlags()`, `evaluate_flags()`, `getFeatureFlag()`, `getAllFlags()`, or `isFeatureEnabled()`, makes a request to the `/flags` endpoint and incurs a billable event unless local evaluation resolves it.
 
 </CalloutBox>
 

--- a/contents/docs/feature-flags/device-bucketing.mdx
+++ b/contents/docs/feature-flags/device-bucketing.mdx
@@ -101,11 +101,8 @@ const variant = await posthog.getFeatureFlag(
 ```
 
 ```python
-variant = posthog.get_feature_flag(
-    "signup-flow-experiment",
-    "user_123",
-    device_id=device_id,
-)
+flags = evaluate_flags("user_123", device_id=device_id)
+variant = flags.get_flag("signup-flow-experiment")
 ```
 
 </MultiLanguage>
@@ -119,7 +116,8 @@ from posthog import get_feature_flag, new_context, set_context_device_id
 
 with new_context():
     set_context_device_id(device_id)
-    variant = get_feature_flag("signup-flow-experiment", "user_123")
+    flags = evaluate_flags("user_123")
+    variant = flags.get_flag("signup-flow-experiment")
 ```
 
 ## Shared devices and `reset()`

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -80,7 +80,7 @@ import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-s
 
 ## Step 3: Evaluate your feature flag
 
-To evaluate the feature flag, call any of the flag related methods, like `getFeatureFlag` or `getAllFlags`, as you normally would. The only difference is that you must provide any `person properties`, `groups` or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
+To evaluate the feature flag, call the flag evaluation method for your SDK. In server SDKs with snapshot APIs, evaluate flags once and read values from the returned snapshot. The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
 
 Then, by default, PostHog attempts to evaluate the flag locally using definitions it loads on initialization and at the `poll interval`. If this fails, PostHog then makes a server request to fetch the flag value.
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -177,21 +177,22 @@ enabledVariant, err := client.GetFeatureFlag(
 ```
 
 ```python
-posthog.get_feature_flag(
-    'flag-key',
-    'distinct_id_of_the_user',
+flags = posthog.evaluate_flags(
+    "distinct_id_of_the_user",
     # Include any person properties, groups, or group properties required to evaluate the flag
-    person_properties={'property_name': 'value'},
+    person_properties={"property_name": "value"},
     groups={
-        'your_group_type': 'your_group_id',
-        'another_group_type': 'another_group_id'
+        "your_group_type": "your_group_id",
+        "another_group_type": "another_group_id",
     },
     group_properties={
-        'your_group_type': {'group_property_name': 'value'},
-        'another_group_type': {'group_property_name': 'another value'}
+        "your_group_type": {"group_property_name": "value"},
+        "another_group_type": {"group_property_name": "another value"},
     },
-    only_evaluate_locally=False # Optional. Defaults to False. Set to True if you don't want PostHog to make a server request if it can't evaluate locally
+    only_evaluate_locally=False,  # Optional. Defaults to False. Set to True if you don't want PostHog to make a server request if it can't evaluate locally.
 )
+
+flag_value = flags.get_flag("flag-key")
 ```
 
 ```php

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -485,23 +485,24 @@ const flagValue = await client.getFeatureFlag(
 ```
 
 ```python
-flag_value = posthog.get_feature_flag(
-    'feature-flag-key',
-    'user-distinct-id',
+flags = posthog.evaluate_flags(
+    "user-distinct-id",
     person_properties={
-        'plan': 'enterprise',
-        'company_size': 'large'
+        "plan": "enterprise",
+        "company_size": "large",
     },
     groups={
-        'company': 'company-123'
+        "company": "company-123",
     },
     group_properties={
-        'company': {
-            'plan': 'enterprise',
-            'employee_count': 500
-        }
-    }
+        "company": {
+            "plan": "enterprise",
+            "employee_count": 500,
+        },
+    },
 )
+
+flag_value = flags.get_flag("feature-flag-key")
 ```
 
 ```php

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -458,7 +458,7 @@ No additional configuration is required on the client side.
 
 ## Server-side SDKs
 
-Server-side SDKs handle property overrides differently. Instead of persistent session-based overrides, you pass properties directly when evaluating each flag.
+Server-side SDKs handle property overrides differently. Instead of persistent session-based overrides, you pass properties directly when evaluating flags.
 
 <MultiLanguage selector="tabs">
 

--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -20,7 +20,7 @@ For example, if on refresh, you see 2 `/flags` requests per pageview and you hav
 
 ##### Without local evaluation 
 
-If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a request to get feature flags is made every time you call `posthog.get_feature_flag()` on your backend. Your estimated usage will be however many times you are calling this code.
+If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a request to get feature flags is made every time your backend evaluates flags. For example, each server-side snapshot evaluation call like `evaluateFlags()` or `evaluate_flags()` makes one `/flags` request. Your estimated usage is based on how often you call this code.
 
 ##### With local evaluation
 

--- a/contents/docs/feature-flags/snippets/groups-flags-python.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-python.mdx
@@ -1,8 +1,0 @@
-Update [posthog-python](/docs/integrate/server/python) to version 1.4.3 or above to make use of the new functionality.
-
-To check a flag that's matching by companies, specify groups in relevant call:
-
-```python
-if posthog.feature_enabled("new-groups-feature", "user_distinct_id", groups={"company": "id:5"}):
-    # do something
-```

--- a/contents/docs/feature-flags/targeting-groups.md
+++ b/contents/docs/feature-flags/targeting-groups.md
@@ -91,11 +91,11 @@ from posthog import Posthog
 posthog = Posthog('<ph_project_token>', host='<ph_client_api_host>')
 
 posthog.capture(
-  "canada-cloud-1", 
-  "server_identify", 
-  {
-    "server_id": "canada-cloud-1"
-  }
+    "server_identify",
+    distinct_id="canada-cloud-1",
+    properties={
+        "server_id": "canada-cloud-1",
+    },
 )
 ```
 
@@ -108,14 +108,15 @@ from posthog import Posthog
 
 posthog = Posthog('<ph_project_token>', host='<ph_client_api_host>')
 
-posthog.feature_enabled('server-rollout', 'canada-cloud-1')
+flags = posthog.evaluate_flags("canada-cloud-1")
+flags.is_enabled("server-rollout")
 ```
 
 Now, you can target your server with feature flags. You can use a similar workflow with services, machines, or devices as well as any of our other [backend SDKs](/docs/libraries) or even our [API](/docs/api).
 
 ### One-time property value
 
-A common pattern we use for many of our site apps is show a feature, set a property on the user once the "business code" executes, and check for that property to not show again. This pattern is useful if you want interactions with features or services to only happen once.
+A common pattern we use for many of our site apps is to show a feature, set a property on the user once the "business code" executes, and check for that property to not show again. This pattern is useful if you want interactions with features or services to only happen once.
 
 > 📖 Read a full implementation of this in "[How to set up one-time feature flags](/tutorials/one-time-feature-flags)."
 
@@ -128,25 +129,22 @@ from posthog import Posthog
 
 posthog = Posthog('<ph_project_token>', host='<ph_client_api_host>')
 
-is_first_interaction = posthog.feature_enabled(
-  'first-interaction', 
-  'ian@posthog.com'
-)
+flags = posthog.evaluate_flags("ian@posthog.com")
+is_first_interaction = flags.is_enabled("first-interaction")
 
-if (is_first_interaction):
-	# Do cool stuff here
-	
-	posthog.capture(
-    'did_cool_stuff',
-    'ian@posthog.com',
-    {
-      'is_first_interaction': False
-    }
-  )
+if is_first_interaction:
+    # Do cool stuff here
 
+    posthog.capture(
+        "did_cool_stuff",
+        distinct_id="ian@posthog.com",
+        properties={
+            "is_first_interaction": False,
+        },
+    )
 ```
 
-The flag now returns `false` meaning the user gets a different experience on all subsequent interactions.
+The flag now returns `false`, meaning the user gets a different experience on all subsequent interactions.
 
 ## Further reading
 

--- a/contents/docs/feature-flags/troubleshooting.mdx
+++ b/contents/docs/feature-flags/troubleshooting.mdx
@@ -156,7 +156,7 @@ If your flag is returning false and you expect it to return another value, check
 
 - The flag is enabled, rolled out, and has the correct release conditions.
 
-- You are evaluating the flag with all the information and arguments it needs in the correct order. For example, in Python, you need both the flag key and distinct ID to call `feature_enabled()`.
+- You are evaluating the flag with all the information and arguments it needs. For example, in Python, call `evaluate_flags()` with the distinct ID, then pass the flag key to `flags.is_enabled()` or `flags.get_flag()`.
 
 - Your flags are loaded before you evaluate them. Test this by evaluating the flag in the `onFeatureFlags()` callback.
 

--- a/contents/docs/feature-flags/user-and-group-targeting.mdx
+++ b/contents/docs/feature-flags/user-and-group-targeting.mdx
@@ -182,24 +182,25 @@ const flagValue = await posthog.getFeatureFlag(
 ```
 
 ```python
-flag_value = posthog.get_feature_flag(
-    'mixed-rollout-flag',
-    'user_123',
+flags = posthog.evaluate_flags(
+    "user_123",
     person_properties={
-        'email': 'jane@acme.com',
-        'role': 'admin'
+        "email": "jane@acme.com",
+        "role": "admin",
     },
     groups={
-        'company': 'company_abc'
+        "company": "company_abc",
     },
     group_properties={
-        'company': {
-            'name': 'Acme Inc',
-            'plan': 'enterprise',
-            'industry': 'tech'
-        }
-    }
+        "company": {
+            "name": "Acme Inc",
+            "plan": "enterprise",
+            "industry": "tech",
+        },
+    },
 )
+
+flag_value = flags.get_flag("mixed-rollout-flag")
 ```
 
 </MultiLanguage>

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python-set-send-feature-flags-to-true.mdx
@@ -1,41 +1,21 @@
-The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. This parameter controls whether feature flag information is sent with the event.
-
-#### Basic usage
-
-Setting `send_feature_flags` to `True` will include feature flag information with the event:
+`capture(send_feature_flags=True)` is a legacy way to attach feature flag properties to captured events. For new Python code, prefer evaluating flags once with `evaluate_flags()` and passing the returned snapshot to `capture()` with `flags=flags`.
 
 ```python
+flags = posthog.evaluate_flags("distinct_id_of_your_user")
+
 posthog.capture(
-    distinct_id="distinct_id_of_the_user",
-    event='event_name',
-    send_feature_flags=True
+    "event_name",
+    distinct_id="distinct_id_of_your_user",
+    flags=flags,
 )
 ```
 
-## Advanced usage (v6.3.0+)
-
-As of version 6.3.0, `send_feature_flags` can also accept a dictionary for more granular control:
+If you're maintaining existing code, `send_feature_flags=True` continues to work during the migration period:
 
 ```python
 posthog.capture(
+    "event_name",
     distinct_id="distinct_id_of_the_user",
-    event='event_name',
-    send_feature_flags={
-        'only_evaluate_locally': True,
-        'person_properties': {'plan': 'premium'},
-        'group_properties': {'org': {'tier': 'enterprise'}}
-    }
+    send_feature_flags=True,
 )
 ```
-
-#### Performance considerations
-
-- **With local evaluation**: When [local evaluation](/docs/feature-flags/local-evaluation) is configured, setting `send_feature_flags: True` will **not** make additional server requests. Instead, it uses the locally cached feature flags, and it provides an interface for including person and/or group properties needed to evaluate the flags in the context of the event, if required.
-
-- **Without local evaluation**: PostHog will make an additional request to fetch feature flag information before capturing the event, which adds delay.
-
-#### Breaking change in v6.3.0
-
-Prior to version 6.3.0, feature flags were automatically sent with events when using local evaluation, even when `send_feature_flags` was not explicitly set. This behavior has been **removed** in v6.3.0 to be more predictable and explicit.
-
-If you were relying on this automatic behavior, you must now explicitly set `send_feature_flags=True` to continue sending feature flags with your events.

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
@@ -1,28 +1,36 @@
-There are 2 steps to implement feature flags in Python:
+There are two steps to implement feature flags in Python:
 
-### Step 1: Evaluate the feature flag value
+### Step 1: Evaluate flags once
+
+Call `posthog.evaluate_flags()` once for the user, then read values from the returned snapshot.
 
 #### Boolean feature flags
 
 ```python
-is_my_flag_enabled = posthog.feature_enabled('flag-key', 'distinct_id_of_your_user')
+flags = posthog.evaluate_flags("distinct_id_of_your_user")
 
-if is_my_flag_enabled:
+if flags.is_enabled("flag-key"):
     # Do something differently for this user
     # Optional: fetch the payload
-    matched_flag_payload = posthog.get_feature_flag_payload('flag-key', 'distinct_id_of_your_user')
+    matched_flag_payload = flags.get_flag_payload("flag-key")
 ```
 
 #### Multivariate feature flags
 
 ```python
-enabled_variant = posthog.get_feature_flag('flag-key', 'distinct_id_of_your_user')
+flags = posthog.evaluate_flags("distinct_id_of_your_user")
 
-if enabled_variant == 'variant-key': # replace 'variant-key' with the key of your variant
+enabled_variant = flags.get_flag("flag-key")
+
+if enabled_variant == "variant-key":  # replace "variant-key" with the key of your variant
     # Do something differently for this user
     # Optional: fetch the payload
-    matched_flag_payload = posthog.get_feature_flag_payload('flag-key', 'distinct_id_of_your_user')
+    matched_flag_payload = flags.get_flag_payload("flag-key")
 ```
+
+`flags.get_flag()` returns the variant string for multivariate flags, `True` for enabled boolean flags, `False` for disabled flags, and `None` when the flag wasn't returned by the evaluation.
+
+> **Note:** `posthog.feature_enabled()`, `posthog.get_feature_flag()`, `posthog.get_feature_flag_payload()`, and `capture(send_feature_flags=True)` still work during the migration period, but they're deprecated. Prefer `evaluate_flags()` for new code.
 
 import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-events.mdx"
 
@@ -30,54 +38,79 @@ import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-
 
 There are two methods you can use to include feature flag information in your events:
 
-#### Method 1: Include the `$feature/feature_flag_name` property
+#### Method 1: Pass the evaluated flags snapshot to `capture()`
 
- In the event properties, include `$feature/feature_flag_name: variant_key`:
+Pass the same `flags` object that you used for branching. This attaches the exact flag values from that evaluation and doesn't make another `/flags` request.
+
+```python
+flags = posthog.evaluate_flags("distinct_id_of_your_user")
+
+if flags.is_enabled("flag-key"):
+    # Do something differently for this user
+    pass
+
+posthog.capture(
+    "event_name",
+    distinct_id="distinct_id_of_your_user",
+    flags=flags,
+)
+```
+
+By default, this attaches every flag in the snapshot using `$feature/<flag-key>` properties and `$active_feature_flags`.
+
+To reduce event property bloat, pass a filtered snapshot:
+
+```python
+# Attach only flags accessed with is_enabled() or get_flag() before this call
+posthog.capture(
+    "event_name",
+    distinct_id="distinct_id_of_your_user",
+    flags=flags.only_accessed(),
+)
+
+# Attach only specific flags
+posthog.capture(
+    "event_name",
+    distinct_id="distinct_id_of_your_user",
+    flags=flags.only(["checkout-flow", "new-dashboard"]),
+)
+```
+
+`only_accessed()` is order-dependent. If you call it before accessing any flags with `is_enabled()` or `get_flag()`, no feature flag properties are attached.
+
+#### Method 2: Include the `$feature/feature_flag_name` property manually
+
+In the event properties, include `$feature/feature_flag_name: variant_key`:
 
 ```python
 posthog.capture(
     "event_name",
     distinct_id="distinct_id_of_the_user",
     properties={
-        "$feature/feature-flag-key": "variant-key"  # replace feature-flag-key with your flag key. Replace 'variant-key' with the key of your variant
+        # Replace feature-flag-key with your flag key and "variant-key" with the key of your variant
+        "$feature/feature-flag-key": "variant-key",
     },
 )
 ```
 
-#### Method 2: Set `send_feature_flags` to `true`
+### Evaluating only specific flags
 
-import PythonSetSendFeatureFlagsTrue from "./feature-flags-code-python-set-send-feature-flags-to-true.mdx"
-
-<PythonSetSendFeatureFlagsTrue />
-
-### Fetching all flags for a user
-
-You can fetch all flag values for a single user by calling `get_all_flags()` or `get_all_flags_and_payloads()`.
-
-This is useful when you need to fetch multiple flag values and don't want to make multiple requests.
+By default, `evaluate_flags()` evaluates every flag for the user. If you only need a few flags, pass `flag_keys` to request only those flags:
 
 ```python
-posthog.get_all_flags('distinct_id_of_your_user')
-posthog.get_all_flags_and_payloads('distinct_id_of_your_user')
+flags = posthog.evaluate_flags(
+    "distinct_id_of_your_user",
+    flag_keys=["checkout-flow", "new-dashboard"],
+)
 ```
 
 ### Sending `$feature_flag_called` events
 
-Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
+Capturing `$feature_flag_called` events enables PostHog to know when a flag was accessed by a user and provide [analytics and insights](/docs/product-analytics/insights) on the flag. With `evaluate_flags()`, the SDK sends this event when you call `flags.is_enabled()` or `flags.get_flag()` for a flag.
 
-1. You call `posthog.get_feature_flag()` or `posthog.feature_enabled()`, AND
-2. It's a new user, or the value of the flag has changed.
+The SDK deduplicates these events per `(distinct_id, flag, value)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
 
-> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `get_feature_flag` or `feature_enabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
-
-You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
-
-To disable it, set the `send_feature_flag_events` argument in your function call, like so:
-
-```python
-is_my_flag_enabled = posthog.feature_enabled('flag-key', 'distinct_id_of_your_user', send_feature_flag_events=False)
-# will not send `$feature_flag_called` events
-```
+`flags.get_flag_payload()` doesn't send `$feature_flag_called` events and doesn't count as an access for `only_accessed()`.
 
 import PythonOverrideServerProperties from './override-server-properties/python.mdx'
 
@@ -85,36 +118,12 @@ import PythonOverrideServerProperties from './override-server-properties/python.
 
 ### Request timeout
 
-You can configure the `feature_flags_request_timeout_seconds` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked in the case when PostHog's servers are too slow to respond. By default, this is set at 3 seconds.
+You can configure the `feature_flags_request_timeout_seconds` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
 
 ```python
-posthog = Posthog('<ph_project_token>',
-    host='<ph_client_api_host>'
-    feature_flags_request_timeout_seconds=3 // Time in second. Default is 3
+posthog = Posthog(
+    "<ph_project_token>",
+    host="<ph_client_api_host>",
+    feature_flags_request_timeout_seconds=3,  # Time in seconds. Defaults to 3.
 )
-```
-
-### Error handling
-
-When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
-
-```python
-def handle_feature_flag(client, flag_key, distinct_id):
-    try:
-        is_enabled = client.is_feature_enabled(flag_key, distinct_id)
-        print(f"Feature flag '{flag_key}' for user '{distinct_id}' is {'enabled' if is_enabled else 'disabled'}")
-        return is_enabled
-    except Exception as e:
-        print(f"Error fetching feature flag '{flag_key}': {str(e)}")
-        raise e
-
-# Usage example
-try:
-    flag_enabled = handle_feature_flag(client, 'new-feature', 'user-123')
-    if flag_enabled:
-        # Implement new feature logic
-    else:
-        # Implement old feature logic
-except Exception as e:
-    # Handle the error at a higher level
 ```

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/python.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/python.mdx
@@ -3,18 +3,21 @@ import OverrideServerPropertiesIntro from './override-server-properties-intro.md
 <OverrideServerPropertiesIntro />
 
 ```python
-posthog.get_feature_flag(
-    'flag-key',
-    'distinct_id_of_the_user',
-    person_properties={'property_name': 'value'},
+flags = posthog.evaluate_flags(
+    "distinct_id_of_the_user",
+    person_properties={"property_name": "value"},
     groups={
-        'your_group_type': 'your_group_id',
-        'another_group_type': 'your_group_id'},
+        "your_group_type": "your_group_id",
+        "another_group_type": "your_group_id",
+    },
     group_properties={
-        'your_group_type': {'group_property_name': 'value'},
-        'another_group_type': {'group_property_name': 'value'}
+        "your_group_type": {"group_property_name": "value"},
+        "another_group_type": {"group_property_name": "value"},
     },
 )
+
+if flags.is_enabled("flag-key"):
+    # Do something differently for this user
 ```
 
 import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -145,9 +145,10 @@ In multi-worker or edge environments, you can implement custom caching for flag 
 Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code:
 
 ```python
-variant = posthog.get_feature_flag('experiment-feature-flag-key', 'user_distinct_id')
+flags = posthog.evaluate_flags("user_distinct_id")
+variant = flags.get_flag("experiment-feature-flag-key")
 
-if variant == 'variant-name':
+if variant == "variant-name":
     # Do something
 ```
 

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -684,7 +684,12 @@ if (posthog.isFeatureEnabled('new-groups-feature')) {
 ```
 
 ```python
-if posthog.feature_enabled("new-groups-feature", "user_distinct_id", groups={"company": "company_id_in_your_db"}):
+flags = posthog.evaluate_flags(
+    "user_distinct_id",
+    groups={"company": "company_id_in_your_db"},
+)
+
+if flags.is_enabled("new-groups-feature"):
     # Do something
 ```
 


### PR DESCRIPTION
## Changes

Updates Python feature flag docs examples to use the new evaluated-flags snapshot API where applicable.\n\nStacked on #16715; review this PR against `docs/evaluate-flags-shared` for the SDK-specific diff.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
