### PR TITLE
docs: update Java feature flag examples

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -166,7 +166,8 @@ end
 
 ```java
 PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("user_distinct_id");
-Object variant = flags.getFlag("experiment-feature-flag-key");
+Object flagValue = flags.getFlag("experiment-feature-flag-key");
+String variant = flagValue instanceof String ? (String) flagValue : "control";
 
 if ("variant-name".equals(variant)) {
     // Do something

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -165,8 +165,8 @@ end
 ```
 
 ```java
-Object flagValue = posthog.getFeatureFlag("user_distinct_id", "experiment-feature-flag-key", "control");
-String variant = flagValue instanceof String ? (String) flagValue : "control";
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("user_distinct_id");
+Object variant = flags.getFlag("experiment-feature-flag-key");
 
 if ("variant-name".equals(variant)) {
     // Do something

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -117,6 +117,7 @@ Search your codebase for the flag key as a string. Common SDK patterns:
 | Node | `evaluateFlags(...)` followed by `flags.isEnabled('key')` or `flags.getFlag('key')`, plus older `isFeatureEnabled('key')` and `getFeatureFlag('key')` calls |
 | Ruby | `evaluate_flags(...)` followed by `flags.enabled?('key')` or `flags.get_flag('key')`, plus older `is_feature_enabled('key')` and `get_feature_flag('key')` calls |
 | Go | `EvaluateFlags(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabled("key")` and `GetFeatureFlag("key")` calls |
+| Java | `evaluateFlags(...)` followed by `flags.isEnabled("key")` or `flags.getFlag("key")`, plus older `isFeatureEnabled("key")` and `getFeatureFlag("key")` calls |
 | PHP | `evaluateFlags(...)` followed by `$flags->isEnabled('key')` or `$flags->getFlag('key')`, plus older `isFeatureEnabled('key')` and `getFeatureFlag('key')` calls |
 | Other SDKs | Search for the flag key as a string literal |
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -227,17 +227,19 @@ await posthog.GetFeatureFlagAsync(
 ```
 
 ```java
-posthog.getFeatureFlag(
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "distinct_id_of_the_user",
-    "flag-key",
-    PostHogFeatureFlagOptions
-        .builder()
+    PostHogEvaluateFlagsOptions.builder()
         .personProperty("property_name", "value")
         .group("your_group_type", "your_group_id")
         .group("another_group_type", "another_group_id")
         .groupProperty("your_group_type", "group_property_name", "value")
         .groupProperty("another_group_type", "group_property_name", "another value")
-        .build());
+        .onlyEvaluateLocally(false) // Optional. Defaults to false. Set to true if you don't want PostHog to make a server request if it can't evaluate locally.
+        .build()
+);
+
+Object flagValue = flags.getFlag("flag-key");
 ```
 
 ```rust

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -567,10 +567,9 @@ flagValue := flags.GetFlag("feature-flag-key")
 ```
 
 ```java
-Object flagValue = posthog.getFeatureFlag(
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "user-distinct-id",
-    "feature-flag-key",
-    PostHogFeatureFlagOptions.builder()
+    PostHogEvaluateFlagsOptions.builder()
         .groups(Map.of("company", "company-123"))
         .personProperties(Map.of(
             "plan", "enterprise",
@@ -584,6 +583,8 @@ Object flagValue = posthog.getFeatureFlag(
         ))
         .build()
 );
+
+Object flagValue = flags.getFlag("feature-flag-key");
 ```
 
 </MultiLanguage>

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -570,17 +570,11 @@ flagValue := flags.GetFlag("feature-flag-key")
 PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "user-distinct-id",
     PostHogEvaluateFlagsOptions.builder()
-        .groups(Map.of("company", "company-123"))
-        .personProperties(Map.of(
-            "plan", "enterprise",
-            "company_size", "large"
-        ))
-        .groupProperties(Map.of(
-            "company", Map.of(
-                "plan", "enterprise",
-                "employee_count", 500
-            )
-        ))
+        .personProperty("plan", "enterprise")
+        .personProperty("company_size", "large")
+        .group("company", "company-123")
+        .groupProperty("company", "plan", "enterprise")
+        .groupProperty("company", "employee_count", 500)
         .build()
 );
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx
@@ -1,24 +1,129 @@
-### Boolean feature flags
+There are two steps to implement feature flags in Java:
+
+### Step 1: Evaluate flags once
+
+Call `posthog.evaluateFlags()` once for the user, then read values from the returned snapshot.
+
+#### Boolean feature flags
 
 ```java
-if (posthog.isFeatureEnabled("distinct_id_of_your_user", "flag-key")) {
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("distinct_id_of_your_user");
+
+if (flags.isEnabled("flag-key")) {
     // Do something differently for this user
 
     // Optional: fetch the payload
-    Object matchedFlagPayload = posthog.getFeatureFlagPayload("distinct_id_of_your_user", "flag-key");
+    String matchedFlagPayload = flags.getFlagPayload("flag-key");
 }
 ```
 
-### Multivariate feature flags
+#### Multivariate feature flags
 
 ```java
-if ("variant-key".equals(posthog.getFeatureFlag("distinct_id_of_your_user", "flag-key"))) { // replace 'variant-key' with the key of your variant
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("distinct_id_of_your_user");
+
+Object enabledVariant = flags.getFlag("flag-key");
+
+if ("variant-key".equals(enabledVariant)) { // replace "variant-key" with the key of your variant
     // Do something differently for this user
 
     // Optional: fetch the payload
-    Object matchedFlagPayload = posthog.getFeatureFlagPayload("distinct_id_of_your_user", "flag-key");
+    String matchedFlagPayload = flags.getFlagPayload("flag-key");
 }
 ```
+
+`flags.getFlag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `null` when the flag wasn't returned by the evaluation.
+
+> **Note:** `posthog.isFeatureEnabled()`, `posthog.getFeatureFlag()`, `posthog.getFeatureFlagPayload()`, and `capture(appendFeatureFlags = true)` still work during the migration period, but they're deprecated. Prefer `evaluateFlags()` for new code.
+
+import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-events.mdx"
+
+<IncludePropertyInEvents />
+
+There are two methods you can use to include feature flag information in your events:
+
+#### Method 1: Pass the evaluated flags snapshot to `capture()`
+
+Pass the same `flags` object that you used for branching. This attaches the exact flag values from that evaluation and doesn't make another `/flags` request.
+
+```java
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("distinct_id_of_your_user");
+
+if (flags.isEnabled("flag-key")) {
+    // Do something differently for this user
+}
+
+posthog.capture(
+    "distinct_id_of_your_user",
+    "event_name",
+    PostHogCaptureOptions.builder()
+        .flags(flags)
+        .build()
+);
+```
+
+By default, this attaches every flag in the snapshot using `$feature/<flag-key>` properties and `$active_feature_flags`.
+
+To reduce event property bloat, pass a filtered snapshot:
+
+```java
+// Attach only flags accessed with isEnabled() or getFlag() before this call
+posthog.capture(
+    "distinct_id_of_your_user",
+    "event_name",
+    PostHogCaptureOptions.builder()
+        .flags(flags.onlyAccessed())
+        .build()
+);
+
+// Attach only specific flags
+posthog.capture(
+    "distinct_id_of_your_user",
+    "event_name",
+    PostHogCaptureOptions.builder()
+        .flags(flags.only("checkout-flow", "new-dashboard"))
+        .build()
+);
+```
+
+`onlyAccessed()` is order-dependent. If you call it before accessing any flags with `isEnabled()` or `getFlag()`, no feature flag properties are attached.
+
+#### Method 2: Include the `$feature/feature_flag_name` property manually
+
+In the event properties, include `$feature/feature_flag_name: variant_key`:
+
+```java
+posthog.capture(
+    "distinct_id_of_your_user",
+    "event_name",
+    PostHogCaptureOptions.builder()
+        .property("$feature/feature-flag-key", "variant-key") // replace feature-flag-key with your flag key. Replace "variant-key" with the key of your variant
+        .build()
+);
+```
+
+### Evaluating only specific flags
+
+By default, `evaluateFlags()` evaluates every flag for the user. If you only need a few flags, pass `flagKeys` to request only those flags:
+
+```java
+import java.util.List;
+
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
+    "distinct_id_of_your_user",
+    PostHogEvaluateFlagsOptions.builder()
+        .flagKeys(List.of("checkout-flow", "new-dashboard"))
+        .build()
+);
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enables PostHog to know when a flag was accessed by a user and provide [analytics and insights](/docs/product-analytics/insights) on the flag. With `evaluateFlags()`, the SDK sends this event when you call `flags.isEnabled()` or `flags.getFlag()` for a flag.
+
+The SDK deduplicates these events per `(distinct_id, flag, value)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
+
+`flags.getFlagPayload()` doesn't send `$feature_flag_called` events and doesn't count as an access for `onlyAccessed()`.
 
 import JavaOverrideServerProperties from './override-server-properties/java.mdx'
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx
@@ -22,7 +22,8 @@ if (flags.isEnabled("flag-key")) {
 ```java
 PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("distinct_id_of_your_user");
 
-Object enabledVariant = flags.getFlag("flag-key");
+Object flagValue = flags.getFlag("flag-key");
+String enabledVariant = flagValue instanceof String ? (String) flagValue : null;
 
 if ("variant-key".equals(enabledVariant)) { // replace "variant-key" with the key of your variant
     // Do something differently for this user
@@ -34,7 +35,7 @@ if ("variant-key".equals(enabledVariant)) { // replace "variant-key" with the ke
 
 `flags.getFlag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `null` when the flag wasn't returned by the evaluation.
 
-> **Note:** `posthog.isFeatureEnabled()`, `posthog.getFeatureFlag()`, `posthog.getFeatureFlagPayload()`, and `capture(appendFeatureFlags = true)` still work during the migration period, but they're deprecated. Prefer `evaluateFlags()` for new code.
+> **Note:** `posthog.isFeatureEnabled()`, `posthog.getFeatureFlag()`, `posthog.getFeatureFlagPayload()`, and `PostHogCaptureOptions.builder().appendFeatureFlags(true)` still work during the migration period, but they're deprecated. Prefer `evaluateFlags()` for new code.
 
 import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-events.mdx"
 
@@ -107,12 +108,12 @@ posthog.capture(
 By default, `evaluateFlags()` evaluates every flag for the user. If you only need a few flags, pass `flagKeys` to request only those flags:
 
 ```java
-import java.util.List;
+import java.util.Arrays;
 
 PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "distinct_id_of_your_user",
     PostHogEvaluateFlagsOptions.builder()
-        .flagKeys(List.of("checkout-flow", "new-dashboard"))
+        .flagKeys(Arrays.asList("checkout-flow", "new-dashboard"))
         .build()
 );
 ```

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/java.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/java.mdx
@@ -3,20 +3,22 @@ import OverrideServerPropertiesIntro from './override-server-properties-intro.md
 <OverrideServerPropertiesIntro />
 
 ```java
-import com.posthog.server.PostHogFeatureFlagOptions;
+import com.posthog.server.PostHogEvaluateFlagsOptions;
 
-posthog.getFeatureFlag(
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "distinct_id_of_the_user",
-    "flag-key",
-    PostHogFeatureFlagOptions
-        .builder()
-        .defaultValue(false)
+    PostHogEvaluateFlagsOptions.builder()
         .group("your_group_type", "your_group_id")
         .group("another_group_type", "your_group_id")
         .groupProperty("your_group_type", "group_property_name", "value")
         .groupProperty("another_group_type", "group_property_name", "value")
         .personProperty("property_name", "value")
-        .build());
+        .build()
+);
+
+if (flags.isEnabled("flag-key")) {
+    // Do something differently for this user
+}
 ```
 
 import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -123,63 +123,9 @@ import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
 
 <FeatureFlagsLibsIntro />
 
-### Boolean feature flags
+import JavaFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx'
 
-```java
-boolean isEnabled = posthog.isFeatureEnabled("user_distinct_id", "use_optimized_query", false);
-if (isEnabled) {
-    // Do something differently for this user
-}
-```
-
-### Multivariate feature flags
-
-```java
-Object flagValue = posthog.getFeatureFlag("user_distinct_id", "recommendation_algorithm", "control");
-String algorithm = flagValue instanceof String ? (String) flagValue : "control";
-switch (algorithm) {
-    case "collaborative_filtering":
-        useCollaborativeFiltering();
-        break;
-    case "neural_network":
-        useNeuralNetwork();
-        break;
-    default:
-        useControlAlgorithm();
-}
-```
-
-### Feature flag payloads
-
-```java
-Object payload = posthog.getFeatureFlagPayload("user_distinct_id", "recommendation_algorithm");
-if (payload instanceof Map) {
-    Map<String, Object> config = (Map<String, Object>) payload;
-    String modelVersion = config.get("model_version") instanceof String
-        ? (String) config.get("model_version") : "v1.0";
-    boolean enableFallback = config.get("enable_fallback") instanceof Boolean
-        ? (Boolean) config.get("enable_fallback") : true;
-}
-```
-
-### Sending `$feature_flag_called` events
-
-Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send these events when:
-
-1. You call `posthog.getFeatureFlag()` or `posthog.isFeatureEnabled()`, AND
-2. It's a new user, or the value of the flag has changed.
-
-> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `getFeatureFlag` or `isFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
-
-You can control the automatic capture of `$feature_flag_called` events using the `sendFeatureFlagEvent` configuration option when initializing PostHog:
-
-```java
-PostHogConfig config = PostHogConfig
-    .builder(POSTHOG_API_KEY)
-    .host(POSTHOG_HOST)
-    .sendFeatureFlagEvent(false)  // Disable automatic feature flag events
-    .build();
-```
+<JavaFeatureFlagsCode />
 
 ### Local evaluation
 
@@ -213,62 +159,66 @@ PostHogConfig config = PostHogConfig
 
 For local evaluation to work, you must provide person properties, groups, or group properties that are used in your flag's [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions).
 
-Use `PostHogFeatureFlagOptions` to provide these properties:
+Use `PostHogEvaluateFlagsOptions` to provide these properties:
 
 **Basic flag evaluation:**
 ```java
-boolean isEnabled = posthog.isFeatureEnabled("distinct-id", "flag-key");
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("distinct-id");
+boolean isEnabled = flags.isEnabled("flag-key");
 ```
 
 **With person properties:**
 ```java
-PostHogFeatureFlagOptions options = PostHogFeatureFlagOptions
-    .builder()
-    .defaultValue(false)
-    .personProperty("plan", "premium")
-    .personProperty("email", "my-user@example.com")
-    .build();
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
+    "distinct-id",
+    PostHogEvaluateFlagsOptions.builder()
+        .personProperty("plan", "premium")
+        .personProperty("email", "my-user@example.com")
+        .build()
+);
 
-boolean isEnabled = posthog.isFeatureEnabled("distinct-id", "flag-key", options);
+boolean isEnabled = flags.isEnabled("flag-key");
 ```
 
 **With groups:**
 ```java
-PostHogFeatureFlagOptions options = PostHogFeatureFlagOptions
-    .builder()
-    .defaultValue(false)
-    .group("company", "company_id_in_your_db")
-    .build();
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
+    "distinct-id",
+    PostHogEvaluateFlagsOptions.builder()
+        .group("company", "company_id_in_your_db")
+        .build()
+);
 
-boolean isEnabled = posthog.isFeatureEnabled("distinct-id", "flag-key", options);
+boolean isEnabled = flags.isEnabled("flag-key");
 ```
 
 **With group properties:**
 ```java
-PostHogFeatureFlagOptions options = PostHogFeatureFlagOptions
-    .builder()
-    .defaultValue(false)
-    .group("company", "company_id_in_your_db")
-    .groupProperty("company", "industry", "technology")
-    .groupProperty("company", "employees", 500)
-    .build();
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
+    "distinct-id",
+    PostHogEvaluateFlagsOptions.builder()
+        .group("company", "company_id_in_your_db")
+        .groupProperty("company", "industry", "technology")
+        .groupProperty("company", "employees", 500)
+        .build()
+);
 
-boolean isEnabled = posthog.isFeatureEnabled("distinct-id", "flag-key", options);
+boolean isEnabled = flags.isEnabled("flag-key");
 ```
 
 **Multivariate flags:**
 ```java
-PostHogFeatureFlagOptions options = PostHogFeatureFlagOptions
-    .builder()
-    .defaultValue("control")
-    .personProperty("plan", "premium")
-    .group("company", "company_id_in_your_db")
-    .groupProperty("company", "industry", "technology")
-    .build();
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
+    "distinct-id",
+    PostHogEvaluateFlagsOptions.builder()
+        .personProperty("plan", "premium")
+        .group("company", "company_id_in_your_db")
+        .groupProperty("company", "industry", "technology")
+        .build()
+);
 
-Object flagValue = posthog.getFeatureFlag("distinct-id", "algorithm", options);
-String algorithm = flagValue instanceof String ? (String) flagValue : "control";
-switch (algorithm) {
+Object algorithm = flags.getFlag("algorithm");
+switch (String.valueOf(algorithm)) {
     case "neural_network":
         useNeuralNetwork();
         break;
@@ -316,8 +266,9 @@ Cached results are stored per distinct ID and flag key combination. When a cache
 Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code:
 
 ```java
-Object flagValue = posthog.getFeatureFlag("user_distinct_id", "recommendation_algorithm", "control");
-String variant = flagValue instanceof String ? (String) flagValue : "control";
+PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("user_distinct_id");
+Object variant = flags.getFlag("recommendation_algorithm");
+
 if ("neural_network".equals(variant)) {
     // Do something differently for this user
 }

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -217,8 +217,10 @@ PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
         .build()
 );
 
-Object algorithm = flags.getFlag("algorithm");
-switch (String.valueOf(algorithm)) {
+Object flagValue = flags.getFlag("algorithm");
+String algorithm = flagValue instanceof String ? (String) flagValue : "control";
+
+switch (algorithm) {
     case "neural_network":
         useNeuralNetwork();
         break;
@@ -267,7 +269,8 @@ Since [experiments](/docs/experiments/start-here) use feature flags, the code fo
 
 ```java
 PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags("user_distinct_id");
-Object variant = flags.getFlag("recommendation_algorithm");
+Object flagValue = flags.getFlag("recommendation_algorithm");
+String variant = flagValue instanceof String ? (String) flagValue : "control";
 
 if ("neural_network".equals(variant)) {
     // Do something differently for this user


### PR DESCRIPTION
## Changes

Updates Java feature flag docs examples to use the new `evaluateFlags` snapshot API where applicable.
## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
