### PR TITLE
docs(feature-flags): remove mixed targeting local-eval restriction

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -332,7 +332,6 @@ Local evaluation is not possible for flags that:
 2. Are linked to an [early access feature](/docs/feature-flags/early-access-feature-management)
 3. Depend on [static cohorts](/docs/data/cohorts#static-cohorts)
 4. Use the `is_not_set` property operator, since local evaluation can only check properties you provide — it can't determine whether a property is absent on a person.
-5. Use [mixed targeting](/docs/feature-flags/user-and-group-targeting#mixed-targeting) (the "User & Group" match mode), which combines user-level and group-level conditions in a single flag.
 
 ### Dynamic cohort restrictions
 


### PR DESCRIPTION
## Summary

Reverts #16561. Mixed targeting (the "User & Group" match mode) is now supported in local evaluation, so the restriction note is no longer accurate.