### PR TITLE
fix: missing nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5263,6 +5263,12 @@ export const docsMenu = {
                     color: 'orange',
                 },
                 {
+                    name: 'GitHub integration',
+                    url: '/docs/support/github',
+                    icon: 'IconGitHub',
+                    color: 'orange',
+                },
+                {
                     name: 'Workflow automation',
                     url: '/docs/support/workflows',
                     icon: 'IconDecisionTree',


### PR DESCRIPTION
Missing nav item for github in support docs
