### PR TITLE
Clarify handling of active customer leads in Vitally

### DIFF
--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -177,6 +177,7 @@ These mostly come into the sales inbox rather than the contact form. Whilst ther
 -   Make sure all new leads are contacted within 24 hours.
 -   Keep all lead information up-to-date and accurate in Salesforce.
 -   Periodically review lead statuses and update them as needed.
+-   If you are actively working an existing customer as a lead make sure you add yourself as the Account Executive in Vitally (to avoid double assignment).
 
 ## Handling time off (PTO)
 


### PR DESCRIPTION
Added a note about updating account assignments in Vitally for active leads.

## Changes

Made it clear that TAE and TAMs should assign themselves as AE in Vitally when working leads (so they don't keep getting flagged for assignment in my account allocation review).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
