### PR TITLE
chore: fix example api keys

### DIFF
--- a/contents/docs/migrate/launchdarkly.mdx
+++ b/contents/docs/migrate/launchdarkly.mdx
@@ -103,7 +103,7 @@ import requests
 project_key = "default"
 environment_key = "test"
 ld_api_key = "fake-1a234567-89ab-cdef-1234-567890abcdef"
-ph_api_key = "phx_abc123def456ghi789jkl123mno456pqr789stu123vwx"
+ph_api_key = "<ph_personal_api_key>"
 ph_project_id = "12345"
 
 # Get LaunchDarkly experiments

--- a/contents/docs/migrate/statsig.mdx
+++ b/contents/docs/migrate/statsig.mdx
@@ -46,7 +46,7 @@ import requests
 
 console_key = 'console-a1B2c3D4e5F6g7H8i9J0k2L3M4N5o6P7Q8R9S0TUvWxYz'
 gates_url = 'https://statsigapi.net/console/v1/gates'
-ph_api_key = 'phx_1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0tuvwxyz'
+ph_api_key = '<ph_personal_api_key>'
 ph_project_id = '12345'
 
 headers = {
@@ -114,7 +114,7 @@ import requests
 
 console_key = 'console-a1B2c3D4e5F6g7H8i9J0k2L3M4N5o6P7Q8R9S0TUvWxYz'
 configs_url = 'https://statsigapi.net/console/v1/dynamic_configs'
-ph_api_key = 'phx_1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0tuvwxyz'
+ph_api_key = '<ph_personal_api_key>'
 ph_project_id = '12345'
 
 headers = {
@@ -216,7 +216,7 @@ import requests
 
 console_key = 'console-a1B2c3D4e5F6g7H8i9J0k2L3M4N5o6P7Q8R9S0TUvWxYz'
 experiments_url = 'https://statsigapi.net/console/v1/experiments'
-ph_api_key = 'phx_1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0tuvwxyz'
+ph_api_key = '<ph_personal_api_key>'
 ph_project_id = '12345'
 
 headers = {

--- a/contents/tutorials/api-get-insights-persons.mdx
+++ b/contents/tutorials/api-get-insights-persons.mdx
@@ -36,7 +36,7 @@ To create a personal API key in PostHog, click your avatar icon in the bottom le
 In "My settings," go to the ["Personal API Keys" tab](https://us.posthog.com/settings/user-api-keys) click "Create personal API key," add a name, and click "Create key." This creates a key and value in the table below. Make sure to save the value as it is only shown once, and you must create a new key if you lose it. The value looks like this:
 
 ```
-phx_IFdqdH62fKoax8x17bwu8gujE0tsTBZRvNmlMJ7eZxz
+<ph_personal_api_key>
 ```
 
 This key is then used either as a bearer token, in the request body, or in the query string to authenticate your request.

--- a/contents/tutorials/recharts.md
+++ b/contents/tutorials/recharts.md
@@ -65,7 +65,7 @@ function App() {
       const url = `https://us.posthog.com/api/projects/${projectId}/query/`;
       const headers = {
         "Content-Type": "application/json",
-        "Authorization": "Bearer phx_1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0tuvwxyz"
+        "Authorization": "Bearer <ph_personal_api_key>"
       };
   
       const payload = {
@@ -138,7 +138,7 @@ function App() {
       const url = `https://us.posthog.com/api/projects/${projectId}/query/`;
       const headers = {
         "Content-Type": "application/json",
-        "Authorization": "Bearer phx_1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0tuvwxyz"
+        "Authorization": "Bearer <ph_personal_api_key>"
       };
   
       const payload = {


### PR DESCRIPTION
## Changes

replaced example API keys with placeholders per style guide, they were raising some false positives in the context mill security scans
