### PR TITLE
Remove product tour mentions from blog

### DIFF
--- a/contents/blog/best-pendo-alternatives.mdx
+++ b/contents/blog/best-pendo-alternatives.mdx
@@ -17,11 +17,11 @@ seo:
 
 import { ProductComparisonTable } from 'components/ProductComparisonTable'
 
-[Pendo](/blog/posthog-vs-pendo) is a popular product experience platform — and a good one. Its combination of in-app guides, product analytics, feedback collection, and roadmap tools has made it a go-to for product managers looking to drive adoption without engineering support.
+[Pendo](/blog/posthog-vs-pendo) is a popular product experience platform – and a good one. Its combination of in-app guides, product analytics, feedback collection, and roadmap tools has made it a go-to for product managers looking to drive adoption without engineering support.
 
 But Pendo isn't the right fit for every team. Maybe you need feature flags, A/B testing, or error tracking that Pendo doesn't offer. Maybe you want transparent, usage-based pricing instead of opaque quotes that [average ~$48k/year](https://www.vendr.com/buyer-guides/pendo). Or maybe you're an engineering-led team that wants SQL access, open-source code, and a platform that goes beyond in-app guides.
 
-In this guide, we compare the best Pendo alternatives — from all-in-one platforms that combine analytics with experimentation and developer tools, to focused digital adoption platforms for enterprise onboarding.
+In this guide, we compare the best Pendo alternatives – from all-in-one platforms that combine analytics with experimentation and developer tools, to focused digital adoption platforms for enterprise onboarding.
 
 ## 1. PostHog
 
@@ -50,7 +50,7 @@ Typical PostHog users are engineers, founders, and product managers at startups 
 
 - **Feature flags:** Rollout features safely with local evaluation (for faster performance) and JSON payloads.
 
-- **Workflows:** Automate messaging based on user behavior — trigger emails, Slack messages, or webhooks when users complete (or don't complete) key actions.
+- **Workflows:** Automate messaging based on user behavior – trigger emails, Slack messages, or webhooks when users complete (or don't complete) key actions.
 
 ### How does PostHog compare to Pendo?
 
@@ -81,7 +81,7 @@ Both PostHog and Pendo are multi-product companies covering many use cases. Pend
 
 - PostHog includes feature flags, A/B testing, and experiments natively; Pendo doesn't offer any of these.
 - PostHog includes error tracking and developer-focused LLM observability (traces, costs, latency); Pendo offers Agent Analytics for measuring AI agent adoption and user success, but has no error tracking.
-- Pendo has a visual drag-and-drop editor for tooltips, product tours, and onboarding walkthroughs; PostHog doesn't have in-app guide tooling yet ([product tours](/docs/product-tours/start-here) are currently in alpha).
+- Pendo has a visual drag-and-drop editor for tooltips, product tours, and onboarding walkthroughs; PostHog doesn't have in-app guide tooling.
 - Pendo includes product validation, roadmap planning, and feedback collection (via Pendo Listen); PostHog covers feedback through surveys and automated messaging through Workflows.
 - PostHog supports SQL access for custom queries; Pendo does not.
 - Pendo includes session replay only on Core plans and above; PostHog includes replay on all plans including free.
@@ -184,7 +184,7 @@ While Pendo focuses both on internal and external use cases, Whatfix focuses pri
 - Both offer in-app guides, tooltips, and onboarding walkthroughs with no-code editors.
 - Both include product analytics with trends, funnels, and retention analysis.
 - Both support event autocapture for tracking user behavior.
-- Both require sales conversations for pricing — neither publishes transparent pricing.
+- Both require sales conversations for pricing – neither publishes transparent pricing.
 - Both are closed-source, cloud-only platforms.
 
 </details>
@@ -349,7 +349,7 @@ Like Whatfix, WalkMe focuses on internal analytics and use cases. Its integratio
 - Both offer in-app guides, tooltips, and onboarding walkthroughs.
 - Both include analytics for tracking user engagement and adoption.
 - Both support enterprise integrations with tools like Salesforce.
-- Both require sales conversations for pricing — neither is self-serve.
+- Both require sales conversations for pricing – neither is self-serve.
 - Both are closed-source, cloud-only platforms.
 
 </details>
@@ -739,7 +739,7 @@ Yes, but it's limited. Pendo Free is capped at 500 MAUs with data sampling and P
 <details>
 <summary>Can PostHog replace Pendo?</summary>
 
-**Yes, for most use cases.** PostHog covers product analytics, session replay, surveys, and user feedback. The main gap is in-app guides — Pendo has a visual editor for tooltips, product tours, and onboarding walkthroughs that PostHog doesn't offer. PostHog does include [Surveys](/surveys) for collecting feedback and [Workflows](/workflows) for automated messaging, but if visual in-app guidance is critical, you may need a dedicated tool like Appcues alongside PostHog.
+**Yes, for most use cases.** PostHog covers product analytics, session replay, surveys, and user feedback. The main gap is in-app guides – Pendo has a visual editor for tooltips, product tours, and onboarding walkthroughs that PostHog doesn't offer. PostHog does include [Surveys](/surveys) for collecting feedback and [Workflows](/workflows) for automated messaging, but if visual in-app guidance is critical, you may need a dedicated tool like Appcues alongside PostHog.
 
 </details>
 
@@ -760,7 +760,7 @@ No. Pendo does not offer error tracking or crash reporting. If you need to monit
 <details>
 <summary>Does Pendo have LLM observability?</summary>
 
-Pendo offers Agent Analytics for tracking AI agent adoption, conversation effectiveness, and user success — but it's aimed at product managers measuring business impact, not engineers debugging LLM performance. **PostHog's** [LLM observability](/llm-analytics) is developer-focused, tracking traces, token costs, latency, and model performance across your AI stack.
+Pendo offers Agent Analytics for tracking AI agent adoption, conversation effectiveness, and user success – but it's aimed at product managers measuring business impact, not engineers debugging LLM performance. **PostHog's** [LLM observability](/llm-analytics) is developer-focused, tracking traces, token costs, latency, and model performance across your AI stack.
 
 </details>
 

--- a/contents/blog/best-product-analytics-tools-for-startups.mdx
+++ b/contents/blog/best-product-analytics-tools-for-startups.mdx
@@ -216,7 +216,7 @@ Use the [pricing calculator](/pricing) to estimate costs based on your actual vo
 <summary>PostHog is not for you if... </summary>
 
 - Your team is entirely non-technical – PMs who need point-and-click everything may find the learning curve steep
-- You *only* need in-app guides and onboarding flows ([Product Tours](/docs/product-tours/start-here) are still in alpha)
+- You *only* need in-app guides and onboarding flows
 - You want a warehouse-native analytics tool that sits on top of your existing BigQuery, Snowflake, or Databricks setup – PostHog has its own [data warehouse](/docs/data-warehouse) and can sync data in and out, but it's not designed to be a query layer for an external warehouse you already own
 - You want a [dedicated mobile analytics platform](/blog/best-mobile-app-analytics-tools) – PostHog has mobile SDKs and [mobile replay](/docs/session-replay), but you might be bettter served by a tool with deeper mobile-specific features
 

--- a/contents/blog/posthog-vs-fullstory.mdx
+++ b/contents/blog/posthog-vs-fullstory.mdx
@@ -80,7 +80,7 @@ This comparison will compare all available features, regardless of pricing tier.
         {
             label: 'In-app guides',
             description: 'Product tours and in-app messaging',
-            values: ['Alpha', true],
+            values: [false, true],
         },
         'platform.deployment.open_source',
     ]}

--- a/contents/blog/posthog-vs-pendo.mdx
+++ b/contents/blog/posthog-vs-pendo.mdx
@@ -46,7 +46,7 @@ Pendo now includes session replay and user engagement on higher tiers, but still
 
 ### 2. PostHog is built for engineers
 
-We built PostHog for product and engineering teams — especially [engineers with a product focus](/product-engineer/what-is-a-product-engineer). As such, PostHog includes many powerful features that aren't available in tools like Pendo, which are built for more general audiences. It also means you get support from the engineers who _actually build the product_, [extensively documented APIs](/docs/api), and a [SQL query builder](/docs/product-analytics/sql), so you can analyze data how you want.
+We built PostHog for product and engineering teams – especially [engineers with a product focus](/product-engineer/what-is-a-product-engineer). As such, PostHog includes many powerful features that aren't available in tools like Pendo, which are built for more general audiences. It also means you get support from the engineers who _actually build the product_, [extensively documented APIs](/docs/api), and a [SQL query builder](/docs/product-analytics/sql), so you can analyze data how you want.
 
 ### 3. Transparent pricing, generous free tiers
 
@@ -60,7 +60,7 @@ We also default to charging as little as possible while still making a sensible 
 
 ## Comparing PostHog and Pendo
 
-**Pendo** has four pricing tiers — Free, Base, Core, and Ultimate. Pendo's Free plan is limited to 500 monthly active users and doesn't include session replays.
+**Pendo** has four pricing tiers – Free, Base, Core, and Ultimate. Pendo's Free plan is limited to 500 monthly active users and doesn't include session replays.
 
 **PostHog** uses usage-based pricing with a generous free tier – no credit card required, and unlimited teammates on every plan. Every month, you get 1 million events, 5,000 session replays, 1 million feature flag requests, and more for free. After that, you only pay for what you use, and pricing gets cheaper at scale.
 
@@ -158,7 +158,7 @@ Pendo is built around in-app guides, tooltips, onboarding flows, and collecting 
 
 [**Workflows**](/docs/workflows) is PostHog's no-code automation builder for sending behavior-triggered messages and actions. You can send emails, Slack messages, and SMS (via Twilio), add delays and branching logic, split audiences, and trigger any CDP destination – all based on live product events. Think onboarding drip campaigns, milestone notifications, or Slack alerts when a user hits a key event.
 
-The biggest difference is that Pendo provides tooltips and product tours, which can be set up using its drag-and-drop editor without engineering support. PostHog doesn't offer in-app guides (yet, it's currently in alpha) — instead, it covers user engagement through [Surveys](/surveys) for targeted feedback and [Workflows](/workflows) for behavior-triggered messaging, with deeper integration into your product data.
+The biggest difference is that Pendo provides tooltips and product tours, which can be set up using its drag-and-drop editor without engineering support. PostHog doesn't offer in-app guides – instead, it covers user engagement through [Surveys](/surveys) for targeted feedback and [Workflows](/workflows) for behavior-triggered messaging, with deeper integration into your product data.
 
 ### CDP and integrations
 
@@ -242,7 +242,7 @@ Regulatory compliance can be a critical need for many teams, especially if they 
 
 Pendo and PostHog both support a variety of tracking and implementation options to get your data into their platform. Both platforms enable you to create tracked events manually, as well as offering autocapture to help you get started quickly.
 
-Autocapture is preferred by many users because it's faster to set up, but some argue that it creates too much noise or cost to be useful. We disagree, and it's why PostHog gives you your first million events for free, every month — so you can capture events without worrying about these issues. [It's something we feel quite strongly about](/blog/is-autocapture-still-bad).
+Autocapture is preferred by many users because it's faster to set up, but some argue that it creates too much noise or cost to be useful. We disagree, and it's why PostHog gives you your first million events for free, every month – so you can capture events without worrying about these issues. [It's something we feel quite strongly about](/blog/is-autocapture-still-bad).
 
 <p>
 <ProductComparisonTable
@@ -328,7 +328,7 @@ PostHog supports [a wide range of client and server libraries](/docs/libraries),
 
 **PostHog** is an all-in-one platform built for engineers, combining product analytics with [web analytics](/web-analytics), [session replay](/session-replay), [feature flags](/feature-flags), [A/B testing](/experiments), [error tracking](/error-tracking), [LLM observability](/llm-analytics), [surveys](/surveys), [workflows](/workflows), a built-in [data warehouse](/data-warehouse), and more.
 
-The key difference is focus: **Pendo** is optimized for non-technical PMs who want to create in-app guides and collect feedback without code. **PostHog** is optimized for engineering-led teams who want to measure, experiment, and ship — all from one platform.
+The key difference is focus: **Pendo** is optimized for non-technical PMs who want to create in-app guides and collect feedback without code. **PostHog** is optimized for engineering-led teams who want to measure, experiment, and ship – all from one platform.
 
 </details>
 
@@ -344,7 +344,7 @@ Pendo is a good fit if your team's primary goal is driving feature adoption and 
 <details>
 <summary>Who is PostHog useful for?</summary>
 
-**PostHog** is built primarily for engineers, technical product managers, and product-focused engineering teams. Beyond product analytics, PostHog includes [PostHog AI](/ai), [feature flags](/feature-flags), [A/B testing](/experiments), [session replays](/session-replay) with console logs and network monitoring, [error tracking](/error-tracking), [LLM observability](/llm-analytics), [surveys](/surveys), [logs](/logs), [workflows](/workflows) for automated messaging, and a built-in [data warehouse](/data-warehouse) — all with SQL access and extensive APIs.
+**PostHog** is built primarily for engineers, technical product managers, and product-focused engineering teams. Beyond product analytics, PostHog includes [PostHog AI](/ai), [feature flags](/feature-flags), [A/B testing](/experiments), [session replays](/session-replay) with console logs and network monitoring, [error tracking](/error-tracking), [LLM observability](/llm-analytics), [surveys](/surveys), [logs](/logs), [workflows](/workflows) for automated messaging, and a built-in [data warehouse](/data-warehouse) – all with SQL access and extensive APIs.
 
 PostHog is a good fit if your team wants a single platform that covers the full build-measure-learn cycle: ship with feature flags, track with analytics, debug with replays and error tracking, iterate with experiments...
 
@@ -353,18 +353,18 @@ PostHog is a good fit if your team wants a single platform that covers the full 
 <details>
 <summary>How much does Pendo cost?</summary>
 
-Pendo uses MAU-based (monthly active users) pricing across four tiers — Free, Base, Core, and Ultimate — but doesn't publish prices publicly. You need to contact their sales team for a quote.
+Pendo uses MAU-based (monthly active users) pricing across four tiers – Free, Base, Core, and Ultimate – but doesn't publish prices publicly. You need to contact their sales team for a quote.
 
 The **Free** tier supports up to 500 MAUs with basic analytics, in-app guides, and branded NPS surveys. **Base** adds one integration and expanded analytics. **Core** adds session replay. **Ultimate** adds NPS (unbranded), product discovery, journey orchestration, and data synchronization. Some features like Pendo Listen (feedback) and additional integrations are available as paid add-ons on lower tiers.
 
-Based on third-party data from Vendr and customer reports, typical Pendo costs range from around $15,000 to $140,000+ per year depending on MAU count, features, and contract terms. Paid plans are annual only — Pendo doesn't offer monthly billing.
+Based on third-party data from Vendr and customer reports, typical Pendo costs range from around $15,000 to $140,000+ per year depending on MAU count, features, and contract terms. Paid plans are annual only – Pendo doesn't offer monthly billing.
 
 </details>
 
 <details>
 <summary>How much does PostHog cost?</summary>
 
-PostHog uses transparent, usage-based [pricing](/pricing). It's free to get started — no credit card required — and every month you get generous free allowances including 1 million analytics events, 5,000 session replays, and 1 million feature flag requests.
+PostHog uses transparent, usage-based [pricing](/pricing). It's free to get started – no credit card required – and every month you get generous free allowances including 1 million analytics events, 5,000 session replays, and 1 million feature flag requests.
 
 After the free tier, you pay only for what you use, and pricing gets cheaper at scale. You can set billing limits per product to avoid surprises, and all pricing is public on the [pricing page](/pricing). Volume discounts and [startup credits of $50k](/startups) are available. In practice, more than 90% of PostHog users stay on the free tier.
 
@@ -373,7 +373,7 @@ After the free tier, you pay only for what you use, and pricing gets cheaper at 
 <details>
 <summary>Do Pendo and PostHog offer free trials?</summary>
 
-**Pendo** offers a free tier (Pendo Free) rather than a time-limited trial. It supports up to 500 MAUs with basic analytics, in-app guides, and branded NPS surveys. Once you exceed 500 MAUs, you can no longer create guides or segments, and usage data is sampled. Pendo does not offer free trials of its paid plans — you need to contact sales.
+**Pendo** offers a free tier (Pendo Free) rather than a time-limited trial. It supports up to 500 MAUs with basic analytics, in-app guides, and branded NPS surveys. Once you exceed 500 MAUs, you can no longer create guides or segments, and usage data is sampled. Pendo does not offer free trials of its paid plans – you need to contact sales.
 
 **PostHog** is free to start with no restrictions on features or time. All users get 1 million events, 5,000 session replays, and 1 million feature flag requests free every month. You can set billing limits to keep usage within the free allowance indefinitely, and there's no Pendo-style branding on free accounts. Adding a credit card unlocks advanced features like correlation analysis and lifecycle insights while still staying on the free tier.
 
@@ -393,23 +393,23 @@ No. Pendo doesn't offer native feature flags, A/B testing, or experimentation. I
 
 No. Pendo doesn't offer error tracking, crash monitoring, or exception handling. You'd need a separate tool like Sentry or Bugsnag for this.
 
-**PostHog** includes native [error tracking](/error-tracking) that connects exceptions and stack traces directly to session replays, user behavior, and feature flag changes — so you can see exactly what a user was doing when an error occurred and whether a specific release caused it.
+**PostHog** includes native [error tracking](/error-tracking) that connects exceptions and stack traces directly to session replays, user behavior, and feature flag changes – so you can see exactly what a user was doing when an error occurred and whether a specific release caused it.
 
 </details>
 
 <details>
 <summary>Does Pendo have LLM observability?</summary>
 
-Pendo offers Agent Analytics for tracking AI agent adoption, conversation effectiveness, and user success — but it's aimed at product managers measuring business impact, not engineers debugging LLM performance.
+Pendo offers Agent Analytics for tracking AI agent adoption, conversation effectiveness, and user success – but it's aimed at product managers measuring business impact, not engineers debugging LLM performance.
 
 **PostHog's** [LLM observability](/llm-analytics) is developer-focused, tracking traces, token costs, latency, and model performance across your AI stack.
 
 </details>
 
 <details>
-<summary>Which has better session replay — PostHog or Pendo?</summary>
+<summary>Which has better session replay – PostHog or Pendo?</summary>
 
-**PostHog** has stronger session replay for developers. Beyond watching user sessions, it includes console logs, network request monitoring, a DOM explorer, and performance metrics — so you can debug issues, not just observe behavior. Replays also link directly to error tracking and feature flag evaluations, so you can see exactly what went wrong and which variant a user was on.
+**PostHog** has stronger session replay for developers. Beyond watching user sessions, it includes console logs, network request monitoring, a DOM explorer, and performance metrics – so you can debug issues, not just observe behavior. Replays also link directly to error tracking and feature flag evaluations, so you can see exactly what went wrong and which variant a user was on.
 
 **Pendo** includes session replay on Core plans and above, focused on understanding user journeys alongside in-app guide performance. It doesn't include developer debugging tools. Pendo's free tier doesn't include replay at all; PostHog's free tier includes 5,000 replays/month.
 

--- a/src/hooks/competitorData/posthog.tsx
+++ b/src/hooks/competitorData/posthog.tsx
@@ -281,7 +281,7 @@ export const posthog = {
             },
         },
         product_tours: {
-            available: 'Private alpha',
+            available: false,
         },
         feature_flags: {
             available: true,


### PR DESCRIPTION
## Changes

Switch PostHog availability to 'false' and removes alpha mentions