### PR TITLE
docs: tweak provisioning API page voice and terminology

### DIFF
--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -3,9 +3,9 @@ title: Provisioning API
 sidebarTitle: Provisioning API
 ---
 
-If you're onboarding users from your own product into PostHog, this API lets you skip the signup page. Call three endpoints and you get back a project token, a personal API key, and a host URL – everything you need to start sending events on the user's behalf.
+If you're onboarding users from your own product into PostHog, this API lets you skip the signup form. Call three endpoints and you get back a project token, a personal API key, and a host URL – everything you need to start sending events into the user's project. The user still gets a welcome email with a link to set their password and access their dashboard.
 
-It's intended for partners and platform integrations. If you're integrating your own app with your own PostHog account, you probably want [OAuth](/docs/api/oauth) or a [personal API key](/docs/api) instead.
+It's intended for partners and platform integrations. If you're integrating your own app with your own PostHog account, you probably want [OAuth](/docs/api/oauth) or a [personal API key](/docs/api#private-endpoint-authentication) instead.
 
 Jump to the [full Node.js example](#full-example) to see the complete flow in code.
 
@@ -39,7 +39,7 @@ sequenceDiagram
 
 ### Host a CIMD metadata document
 
-PostHog uses [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) (CIMD) for partner registration. There's no signup form to fill out – you host a JSON document at an HTTPS URL on your domain, and that URL becomes your `client_id`. The first API call you make picks it up.
+PostHog uses [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) (CIMD) for partner registration. There's no signup form to fill out – you host a JSON document at an HTTPS URL on your domain, and that URL becomes your `client_id`.
 
 Create a JSON file at a stable HTTPS URL, for example `https://yourapp.com/.well-known/posthog-client.json`:
 
@@ -401,7 +401,7 @@ All provisioning endpoints are rate limited.
 - 100 new client registrations per hour globally
 - 5 new client registrations per domain per hour
 
-**Account requests** (per partner, per hour): defaults to 10/hour for new CIMD partners. Email **team-growth@posthog.com** if you need a higher limit for a real integration.
+**Account requests** (per partner, per hour): defaults to 10/hour for new CIMD partners. Email [team-growth@posthog.com](mailto:team-growth@posthog.com) if you need a higher limit for production use.
 
 ## Full example
 

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -3,8 +3,9 @@ title: Provisioning API
 sidebarTitle: Provisioning API
 ---
 
-The provisioning API lets partners create PostHog accounts and projects for their users programmatically.
-Instead of sending users to a signup page, you call three endpoints and get back a project API key, a personal API key, and a host URL - everything needed to start sending events.
+If you're onboarding users from your own product into PostHog, this API lets you skip the signup page. Call three endpoints and you get back a project token, a personal API key, and a host URL – everything you need to start sending events on the user's behalf.
+
+It's intended for partners and platform integrations. If you're integrating your own app with your own PostHog account, you probably want [OAuth](/docs/api/oauth) or a [personal API key](/docs/api) instead.
 
 Jump to the [full Node.js example](#full-example) to see the complete flow in code.
 
@@ -16,7 +17,7 @@ Your application is identified by a metadata document hosted on your domain.
 ```
 1. POST /account_requests  →  authorization code
 2. POST /oauth/token        →  access + refresh tokens
-3. POST /resources          →  project API key + host
+3. POST /resources          →  project token + host
 ```
 
 ```mermaid
@@ -31,16 +32,14 @@ sequenceDiagram
     PH-->>P: access_token + refresh_token
 
     P->>PH: POST /resources (Bearer token)
-    PH-->>P: project API key + host
+    PH-->>P: project token + host
 ```
 
 ## Set up as a partner
 
 ### Host a CIMD metadata document
 
-PostHog uses [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) (CIMD) for partner registration.
-Instead of a manual signup, you host a JSON document at an HTTPS URL on your domain.
-That URL becomes your `client_id`.
+PostHog uses [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) (CIMD) for partner registration. There's no signup form to fill out – you host a JSON document at an HTTPS URL on your domain, and that URL becomes your `client_id`. The first API call you make picks it up.
 
 Create a JSON file at a stable HTTPS URL, for example `https://yourapp.com/.well-known/posthog-client.json`:
 
@@ -169,7 +168,7 @@ sequenceDiagram
     PH-->>P: access_token + refresh_token
 
     P->>PH: POST /resources (Bearer token)
-    PH-->>P: project API key + host
+    PH-->>P: project token + host
 ```
 
 ### Step 2: Exchange the code for tokens
@@ -273,13 +272,13 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
 
 | Field | Description |
 |---|---|
-| `api_key` | The project API token - use this to initialize PostHog SDKs |
+| `api_key` | The project token (starts with `phc_`) – use this to initialize PostHog SDKs |
 | `host` | The API host (`https://us.posthog.com` or `https://eu.posthog.com`) |
-| `personal_api_key` | A personal API key scoped to this project - use this for the PostHog API |
+| `personal_api_key` | A personal API key scoped to this project – use this for the PostHog API |
 
 ### Rotate project credentials
 
-Rotate the project API token and create a new personal API key for an existing provisioned project:
+Rotate the project token and create a new personal API key for an existing provisioned project:
 
 ```bash
 curl -X POST https://us.posthog.com/api/agentic/provisioning/resources/12345/rotate_credentials \
@@ -349,11 +348,11 @@ The `scopes` field in the account request controls what permissions the access t
 
 When you provision a new account, the user receives:
 
-- **Welcome email** with a link to set their password
-- **Full dashboard access** at [us.posthog.com](https://us.posthog.com) (or [eu.posthog.com](https://eu.posthog.com) for EU)
-- **Free tier** with generous limits across all PostHog products - no credit card required
+- A welcome email with a link to set their password.
+- Full dashboard access at [us.posthog.com](https://us.posthog.com) (or [eu.posthog.com](https://eu.posthog.com) for EU).
+- The PostHog [free tier](/pricing) across all products – no credit card required.
 
-Your integration gets back the project API key and host needed to start sending events immediately.
+Your integration gets back the project token and host, so you can start sending events the moment the API call returns.
 
 ## Error handling
 
@@ -402,7 +401,7 @@ All provisioning endpoints are rate limited.
 - 100 new client registrations per hour globally
 - 5 new client registrations per domain per hour
 
-**Account requests** (per partner, per hour): defaults to 10/hour for new CIMD partners. Contact PostHog to increase this for higher-volume integrations.
+**Account requests** (per partner, per hour): defaults to 10/hour for new CIMD partners. Email **team-growth@posthog.com** if you need a higher limit for a real integration.
 
 ## Full example
 


### PR DESCRIPTION
## Changes

Voice and style-guide cleanup for [`/docs/integrate/provisioning`](https://posthog.com/docs/integrate/provisioning). The page was a recent addition (#16560) and read more like generic API reference than the rest of PostHog's docs. None of the API contract, payloads, or examples change.

**Style-guide violations**

- Replace `project API key` with `project token` everywhere – the [docs style guide](https://posthog.com/handbook/docs-and-wizard/docs-style-guide#keys-and-tokens) explicitly says: "Never call it `project API key`."
- Replace inline ` - ` separators with British-style en dashes (` – `) per the [content style guide](https://posthog.com/handbook/content/posthog-style-guide#use-british-style-en-dashes).

**Voice nudges (light, kept inside the same terse-reference register as `oauth.mdx` / `capture.mdx` – no forced quirk)**

- Tighten the intro: lead with the audience ("if you're onboarding users from your own product…") and add a one-line redirect for people who actually want OAuth or a personal API key instead.
- Add a small opinion to the CIMD blurb ("There's no signup form to fill out") since the [brand style guide](https://posthog.com/handbook/brand/style-guide#voice-and-tone) rewards being opinionated.
- Replace the vague "Contact PostHog" rate-limit footer with the `team-growth@posthog.com` email used in `oauth.mdx`.
- Drop the hedge-y "generous limits" wording in favor of a direct link to `/pricing`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a – no move)