### PR TITLE
chore: move LLM gateway ownership to LLM gateway team

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -211,7 +211,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'llm-gateway': {
         feature: 'LLM gateway',
-        owner: ['posthog-ai'],
+        owner: ['llm-gateway'],
         label: false,
     },
     'live-events': {


### PR DESCRIPTION
## Changes

Updates the feature ownership entry for the LLM gateway in `src/hooks/useFeatureOwnership.tsx` so the new LLM gateway team owns it instead of PostHog AI.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in \`vercel.json\`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*