### PR TITLE
docs: clarifying on ambiguous feedback

### DIFF
--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -41,7 +41,7 @@ We know that giving feedback can sometimes be difficult, so here are a few tips 
 
 - Be as specific as you can with your feedback. An example can be helpful to give the recipient context. 
 
-- Do not give ambiguous or neutral feedback. Something that may have been intended as positive may be interpreted as negative, and vice-versa. This means you should prepare in advance, to avoid saying "I've got nothing to say, it's all going good".
+- Do not give ambiguous or neutral feedback. Something that may have been intended as positive may be interpreted as negative, and vice-versa.
 
 - Sometimes a question can be more useful if you feel you lack the full context. For example 'I've noticed that you sometimes do X. Can you explain to me what your thought process is when you are doing that?' 
 

--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -41,6 +41,8 @@ We know that giving feedback can sometimes be difficult, so here are a few tips 
 
 - Be as specific as you can with your feedback. An example can be helpful to give the recipient context. 
 
+- Do not give ambiguous or neutral feedback. Something that may have been intended as positive may be interpreted as negative, and vice-versa. This means you should prepare in advance, to avoid saying "I've got nothing to say, it's all going good".
+
 - Sometimes a question can be more useful if you feel you lack the full context. For example 'I've noticed that you sometimes do X. Can you explain to me what your thought process is when you are doing that?' 
 
 - If your feedback is about behavior, focus on the behavior itself and its impact on you, rather than attacking the person's character. For example 'When you do X, it makes me feel Y. Would you be willing to do Z instead?'


### PR DESCRIPTION
## Changes

Adds a new item to the "how to give feedback" section, clarifying that given feedback shouldn't be ambiguous.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
