### PR TITLE
docs(logs): add iOS installation page

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -14,10 +14,14 @@ mdx = md
 BasedOnStyles = Vale, PostHogBase
 Vale.Spelling = NO
 Vale.Terms = warning
-# Ignore: import/export statements, fenced code blocks
+# Ignore: import/export statements, fenced code blocks, platformLogo
+# frontmatter values (asset key, must match the lowercase key in
+# src/constants/logos.ts e.g. `platformLogo: ios` -- prose `ios`
+# elsewhere in the file is still checked)
 BlockIgnores = (?s)```[^\n]*\n.*?\n>?\s*```, \
                (?m)^import\s+.*?from\s+['"].*?['"];?\s*$, \
-               (?m)^export\s+(const|let|var|function|class|default)\s+.*$
+               (?m)^export\s+(const|let|var|function|class|default)\s+.*$, \
+               (?m)^platformLogo:\s*\S+\s*$
 # Ignore: markdown link URLs, React component tags
 TokenIgnores = \]\((?:\\\)|[^\)])+\), \
                <[A-Z][\w.:-]*(?:\s+[^<>]*?)?\s*/?>

--- a/.vale.ini
+++ b/.vale.ini
@@ -14,14 +14,10 @@ mdx = md
 BasedOnStyles = Vale, PostHogBase
 Vale.Spelling = NO
 Vale.Terms = warning
-# Ignore: import/export statements, fenced code blocks, platformLogo
-# frontmatter values (asset key, must match the lowercase key in
-# src/constants/logos.ts e.g. `platformLogo: ios` -- prose `ios`
-# elsewhere in the file is still checked)
+# Ignore: import/export statements, fenced code blocks
 BlockIgnores = (?s)```[^\n]*\n.*?\n>?\s*```, \
                (?m)^import\s+.*?from\s+['"].*?['"];?\s*$, \
-               (?m)^export\s+(const|let|var|function|class|default)\s+.*$, \
-               (?m)^platformLogo:\s*\S+\s*$
+               (?m)^export\s+(const|let|var|function|class|default)\s+.*$
 # Ignore: markdown link URLs, React component tags
 TokenIgnores = \]\((?:\\\)|[^\)])+\), \
                <[A-Z][\w.:-]*(?:\s+[^<>]*?)?\s*/?>

--- a/contents/docs/integrate/_snippets/install-ios.mdx
+++ b/contents/docs/integrate/_snippets/install-ios.mdx
@@ -7,7 +7,7 @@ PostHog is available through [CocoaPods](http://cocoapods.org) or you can add it
 ### CocoaPods
 
 ```ruby file=Podfile
-pod "PostHog", "~> 3.56.0"
+pod "PostHog", "~> 3.58.0"
 ```
 
 ### Swift Package Manager
@@ -18,7 +18,7 @@ For a Swift Package Manager based project, add PostHog as a dependency in your `
 
 ```swift file=Package.swift
 dependencies: [
-  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.56.0")
+  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.58.0")
 ],
 ```
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -15,6 +15,7 @@ features:
   surveys: true
   llmAnalytics: false
   errorTracking: true
+  logs: true
 ---
 
 import IOSInstall from '../../integrate/_snippets/install-ios.mdx'

--- a/contents/docs/logs/installation/ios.mdx
+++ b/contents/docs/logs/installation/ios.mdx
@@ -27,7 +27,7 @@ If you haven't installed `posthog-ios` yet, follow the steps below. For full det
 
 <Step title="Configure logs in your PostHogConfig" badge="required">
 
-Add a `logs` block on the `PostHogConfig` instance you pass to `setup`. All fields are optional; defaults are tuned for mobile (cellular bandwidth, battery, OS lifecycle).
+Configure Logs through `config.logs` before calling `setup(_:)`. All fields are optional; defaults are tuned for mobile (cellular bandwidth, battery, OS lifecycle).
 
 ```swift
 import PostHog

--- a/contents/docs/logs/installation/ios.mdx
+++ b/contents/docs/logs/installation/ios.mdx
@@ -1,5 +1,5 @@
 ---
-title: iOS logs installation
+title: iOS Logs installation
 sidebarTitle: iOS
 platformLogo: ios
 showStepsToc: true
@@ -9,7 +9,7 @@ import { Steps, Step } from 'components/Docs/Steps'
 import IOSInstall from '../../integrate/_snippets/install-ios.mdx'
 import LogsNextSteps from './_snippets/logs-next-steps.mdx'
 
-The PostHog iOS SDK has built-in support for capturing structured logs from iOS, macOS, tvOS, watchOS, and visionOS apps. The SDK handles OTLP encoding, batching, on-disk persistence across app restarts, and lifecycle integration. You just call `PostHogSDK.shared.captureLog(...)` or `PostHogSDK.shared.logger?.{trace,debug,info,warn,error,fatal}(...)`.
+The PostHog iOS SDK has built-in support for capturing structured Logs from iOS, macOS, tvOS, watchOS, and visionOS apps. The SDK handles OTLP encoding, batching, on-disk persistence across app restarts, and lifecycle integration. You just call `PostHogSDK.shared.captureLog(...)` or `PostHogSDK.shared.logger?.{trace,debug,info,warn,error,fatal}(...)`.
 
 > **Manual capture only.** Logs are emitted by your code. The SDK does not autocapture system log streams (`os_log`, `Logger`, `print`).
 
@@ -40,7 +40,7 @@ config.logs.serviceVersion = "1.2.3"      // OTLP service.version
 PostHogSDK.shared.setup(config)
 ```
 
-These resource attributes are snapshotted at `setup(_:)` and apply to every batch. Mutating `config.logs` after `setup` has no effect.
+These resource attributes are captured at `setup(_:)` and apply to every batch. Mutating `config.logs` after `setup` has no effect.
 
 </Step>
 
@@ -66,9 +66,9 @@ PostHogSDK.shared.captureLog(
 
 Available severity levels: `.trace`, `.debug`, `.info`, `.warn`, `.error`, `.fatal`.
 
-Records are buffered, batched, persisted to disk, and flushed automatically – every 30 seconds, when the buffer hits the threshold, on app backgrounding, or on `PostHogSDK.shared.flush()`. `flush()` drains events, session replay, and logs together.
+Records are buffered, batched, persisted to disk, and flushed automatically – every 30 seconds, when the buffer hits the threshold, when the app moves to the background, or on `PostHogSDK.shared.flush()`. `flush()` drains events, Session Replay, and Logs together.
 
-Each record is automatically tagged with the user's distinct ID, session ID, current screen, app foreground/background state, and active feature flags at the moment of capture.
+Each record is automatically tagged with the current distinct ID, session ID, current screen, app foreground/background state, and active Feature Flags at the moment of capture.
 
 </Step>
 
@@ -85,7 +85,7 @@ Each record is automatically tagged with the user's distinct ID, session ID, cur
 You should see your record arrive within a few seconds.
 
 <CallToAction type="primary" to="https://app.posthog.com/logs">
-View your logs in PostHog
+View your Logs in PostHog
 </CallToAction>
 
 </Step>
@@ -122,7 +122,7 @@ Full configuration reference:
 | `rateCapMaxLogs` | `500` | Max records per `rateCapWindowSeconds` window. Set to `0` to disable. |
 | `rateCapWindowSeconds` | `10` | Rate-cap tumbling window length |
 
-All of the above are snapshotted at `setup(_:)`; mutating them later has no effect. Defaults are tuned for cellular-aware mobile apps. Raise `rateCapMaxLogs` and `maxBufferSize` for high-volume scenarios.
+All of the above are captured at `setup(_:)`; mutating them later has no effect. Defaults are tuned for cellular-aware mobile apps. Raise `rateCapMaxLogs` and `maxBufferSize` for high-volume scenarios.
 
 </Step>
 
@@ -145,7 +145,7 @@ config.logs.setBeforeSend({ record in
 })
 ```
 
-Pass an array (or variadic list) of blocks to compose a chain – evaluated left-to-right. Returning `nil` from any block short-circuits and drops the record. Setting `record.body` to an empty string also drops the record.
+Pass an array (or a comma-separated list) of blocks to compose a chain – evaluated left-to-right. Returning `nil` from any block short-circuits and drops the record. Setting `record.body` to an empty string also drops the record.
 
 From Objective-C, wrap each closure in a `BoxedBeforeSendLogBlock`:
 

--- a/contents/docs/logs/installation/ios.mdx
+++ b/contents/docs/logs/installation/ios.mdx
@@ -1,0 +1,164 @@
+---
+title: iOS logs installation
+sidebarTitle: iOS
+platformLogo: ios
+showStepsToc: true
+---
+
+import { Steps, Step } from 'components/Docs/Steps'
+import IOSInstall from '../../integrate/_snippets/install-ios.mdx'
+import LogsNextSteps from './_snippets/logs-next-steps.mdx'
+
+The PostHog iOS SDK has built-in support for capturing structured logs from iOS, macOS, tvOS, watchOS, and visionOS apps. The SDK handles OTLP encoding, batching, on-disk persistence across app restarts, and lifecycle integration. You just call `PostHogSDK.shared.captureLog(...)` or `PostHogSDK.shared.logger?.{trace,debug,info,warn,error,fatal}(...)`.
+
+> **Manual capture only.** Logs are emitted by your code. The SDK does not autocapture system log streams (`os_log`, `Logger`, `print`).
+
+> **Minimum version:** `posthog-ios@3.58.0` or later. Run `pod update PostHog` (CocoaPods) or update the package version in Xcode (Swift Package Manager).
+
+<Steps>
+
+<Step title="Install posthog-ios" badge="required">
+
+If you haven't already, install and initialize `posthog-ios` using the steps below. For full details, see the [iOS SDK guide](/docs/libraries/ios).
+
+<IOSInstall />
+
+</Step>
+
+<Step title="Configure logs in your PostHogConfig" badge="required">
+
+Add a `logs` block on the `PostHogConfig` instance you pass to `setup`. All fields are optional; defaults are tuned for mobile (cellular bandwidth, battery, OS lifecycle).
+
+```swift
+import PostHog
+
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
+config.logs.serviceName = "my-app"        // OTLP service.name – shown in the Logs UI
+config.logs.environment = "production"    // OTLP deployment.environment
+config.logs.serviceVersion = "1.2.3"      // OTLP service.version
+
+PostHogSDK.shared.setup(config)
+```
+
+These resource attributes are snapshotted at `setup(_:)` and apply to every batch. Mutating `config.logs` after `setup` has no effect.
+
+</Step>
+
+<Step title="Capture logs" badge="required">
+
+Use `PostHogSDK.shared.logger` for the per-level convenience API, or `PostHogSDK.shared.captureLog` for full control over level, attributes, and trace context.
+
+```swift
+// Per-level convenience methods – Optional, since logger is created at setup
+PostHogSDK.shared.logger?.info("checkout completed", attributes: ["order_id": "ord_789", "amount_cents": 4999])
+PostHogSDK.shared.logger?.warn("payment retry", attributes: ["attempt": 2])
+PostHogSDK.shared.logger?.error("payment failed", attributes: ["code": "E001"])
+
+// Lower-level API for custom severity / trace context
+PostHogSDK.shared.captureLog(
+    "checkout failed",
+    level: .error,
+    attributes: ["order_id": "ord_789", "step": "auth"],
+    traceId: "4bf92f3577b34da6a3ce929d0e0e4736",  // optional W3C trace context (32 hex chars)
+    spanId: "00f067aa0ba902b7"                    // optional W3C span (16 hex chars)
+)
+```
+
+Available severity levels: `.trace`, `.debug`, `.info`, `.warn`, `.error`, `.fatal`.
+
+Records are buffered, batched, persisted to disk, and flushed automatically – every 30 seconds, when the buffer hits the threshold, on app backgrounding, or on `PostHogSDK.shared.flush()`. `flush()` drains events, session replay, and logs together.
+
+Each record is automatically tagged with the user's distinct ID, session ID, current screen, app foreground/background state, and active feature flags at the moment of capture.
+
+</Step>
+
+<Step title="Test your setup" badge="recommended">
+
+1. Capture a test log from your app:
+   ```swift
+   PostHogSDK.shared.logger?.info("hello from iOS")
+   PostHogSDK.shared.flush()
+   ```
+2. Open the [PostHog Logs UI](https://app.posthog.com/logs).
+3. Filter by `service.name = 'my-app'` (or whatever value you set above).
+
+You should see your record arrive within a few seconds.
+
+<CallToAction type="primary" to="https://app.posthog.com/logs">
+View your logs in PostHog
+</CallToAction>
+
+</Step>
+
+<Step title="Tune buffering, rate cap, and resource attributes" badge="optional">
+
+The `logs` config has knobs for high-volume apps:
+
+```swift
+let config = PostHogConfig(projectToken: "<ph_project_token>")
+config.logs.serviceName = "my-app"
+config.logs.flushIntervalSeconds = 5            // default 30
+config.logs.maxBufferSize = 200                 // default 1000
+config.logs.maxBatchSize = 50                   // default 50
+config.logs.flushAt = 20                        // default 20
+config.logs.rateCapMaxLogs = 5000               // default 500
+config.logs.rateCapWindowSeconds = 60           // default 10
+config.logs.resourceAttributes = ["host.name": "device-01"]
+PostHogSDK.shared.setup(config)
+```
+
+Full configuration reference:
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `serviceName` | bundle identifier | OTLP `service.name` resource attribute |
+| `serviceVersion` | `CFBundleShortVersionString` | OTLP `service.version` resource attribute |
+| `environment` | `nil` | OTLP `deployment.environment` resource attribute |
+| `resourceAttributes` | `[:]` | Extra OTLP resource attributes (SDK keys win on collision) |
+| `flushIntervalSeconds` | `30` | Periodic flush interval |
+| `flushAt` | `20` | Buffer threshold that triggers an automatic flush |
+| `maxBatchSize` | `50` | Max records per outbound POST (halved on 413) |
+| `maxBufferSize` | `1000` | Max records held on disk before FIFO eviction |
+| `rateCapMaxLogs` | `500` | Max records per `rateCapWindowSeconds` window. Set to `0` to disable. |
+| `rateCapWindowSeconds` | `10` | Rate-cap tumbling window length |
+
+All of the above are snapshotted at `setup(_:)`; mutating them later has no effect. Defaults are tuned for cellular-aware mobile apps. Raise `rateCapMaxLogs` and `maxBufferSize` for high-volume scenarios.
+
+</Step>
+
+<Step title="Filter or redact with beforeSend" badge="optional">
+
+`beforeSend` runs synchronously before the rate cap, so dropped records don't consume the per-window budget. Use it for redaction, sampling, or filtering by level. Each block receives a mutable `PostHogLogRecord` and returns either the (possibly mutated) record or `nil` to drop it.
+
+```swift
+config.logs.setBeforeSend({ record in
+    // Drop debug logs in production
+    if record.level == .debug { return nil }
+
+    // Redact secrets in the body
+    record.body = record.body.replacingOccurrences(
+        of: #"api_key=\S+"#,
+        with: "api_key=[REDACTED]",
+        options: .regularExpression
+    )
+    return record
+})
+```
+
+Pass an array (or variadic list) of blocks to compose a chain – evaluated left-to-right. Returning `nil` from any block short-circuits and drops the record. Setting `record.body` to an empty string also drops the record.
+
+From Objective-C, wrap each closure in a `BoxedBeforeSendLogBlock`:
+
+```objc
+[posthogConfig.logs setBeforeSend:@[
+    [[BoxedBeforeSendLogBlock alloc] initWithBlock:^PostHogLogRecord * _Nullable(PostHogLogRecord * record) {
+        return [record.body containsString:@"secret"] ? nil : record;
+    }]
+]];
+```
+
+</Step>
+
+<LogsNextSteps />
+
+</Steps>

--- a/contents/docs/logs/installation/ios.mdx
+++ b/contents/docs/logs/installation/ios.mdx
@@ -19,7 +19,7 @@ The PostHog iOS SDK has built-in support for capturing structured Logs from iOS,
 
 <Step title="Install posthog-ios" badge="required">
 
-If you haven't already, install and initialize `posthog-ios` using the steps below. For full details, see the [iOS SDK guide](/docs/libraries/ios).
+If you haven't installed `posthog-ios` yet, follow the steps below. For full details, see the [iOS SDK guide](/docs/libraries/ios).
 
 <IOSInstall />
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6646,6 +6646,7 @@ export const docsMenu = {
                         { name: 'Next.js', url: '/docs/logs/installation/nextjs' },
                         { name: 'JavaScript (web)', url: '/docs/logs/installation/javascript' },
                         { name: 'React Native', url: '/docs/logs/installation/react-native' },
+                        { name: 'iOS', url: '/docs/logs/installation/ios' },
                         { name: 'Datadog', url: '/docs/logs/installation/datadog' },
                         { name: 'Other', url: '/docs/logs/installation/other' },
                     ],


### PR DESCRIPTION
## Summary

Adds an iOS installation walkthrough for the new Logs feature shipping in `posthog-ios@3.58.0` ([PostHog/posthog-ios#592](https://github.com/PostHog/posthog-ios/pull/592)).

Covers:
- `PostHogConfig.logs` setup (snapshotted at `setup(_:)`)
- `PostHogSDK.shared.captureLog` and `PostHogSDK.shared.logger?.{trace,debug,info,warn,error,fatal}`
- All six severity levels + W3C trace context (`traceId`/`spanId`)
- Auto-attached context (distinct id, session, screen, app state, feature flags)
- Buffering / rate-cap / resource-attribute tuning with a full defaults table
- `beforeSend` filter chain in both Swift and Objective-C

Adds the page to the **Logs > Install logging client** sidebar between React Native and Datadog.

## Test plan

- [x] Build the docs site locally and visit \`/docs/logs/installation/ios\`
- [x] Confirm the page renders, all code blocks have correct syntax highlighting (\`swift\`, \`objc\`), and the next-steps snippet appears
- [x] Confirm the new "iOS" entry shows up in the Logs install sidebar
- [x] Visit \`/docs/logs/installation\` and confirm the iOS platform tile appears in the auto-generated platforms list