### PR TITLE
docs: fix angular snippet code duplication

### DIFF
--- a/contents/docs/integrate/_snippets/install-angular.mdx
+++ b/contents/docs/integrate/_snippets/install-angular.mdx
@@ -26,17 +26,14 @@ Generate environment files for your project with `ng g environments`. Configure 
 
   ```ts file=posthog.service.ts
   // src/app/services/posthog.service.ts
-  import { DestroyRef, Injectable, NgZone } from "@angular/core";
+  import { Injectable, NgZone } from "@angular/core";
   import posthog from "posthog-js";
   import { environment } from "../../environments/environment";
-  import { Router } from "@angular/router";
 
   @Injectable({ providedIn: "root" })
   export class PosthogService {
     constructor(
       private ngZone: NgZone,
-      private router: Router,
-      private destroyRef: DestroyRef,
     ) {
       this.initPostHog();
     }

--- a/contents/docs/libraries/angular.mdx
+++ b/contents/docs/libraries/angular.mdx
@@ -174,12 +174,11 @@ app.get('**', async (req, res, next) => {
 
   const distinctId = getDistinctIdFromCookie(headers.cookie);
   let isFeatureEnabled = false;
+  
   const client = new PostHog(
-      const client = new PostHog(
-          environment.posthogKey,
-          { host: environment.posthogHost }
-      )
-  )
+      environment.posthogKey,
+      { host: environment.posthogHost }
+  );
 
   if (distinctId) {
     client.capture({

--- a/contents/docs/libraries/angular.mdx
+++ b/contents/docs/libraries/angular.mdx
@@ -99,13 +99,10 @@ To use PostHog with Angular server-side rendering (SSR), you need to:
 Update your `posthog.service.ts` to restrict the initialization of the PostHog web JS client to the client-side. The web SDK uses methods that are not available on the server side, so we need to check if we're on the client side before initializing PostHog.
 
 ```ts file=posthog.service.ts focusOnLines=5-21
-import { DestroyRef, Injectable, NgZone, Inject } from "@angular/core";
+import { Injectable, NgZone, Inject } from "@angular/core";
 import posthog from "posthog-js";
 import { environment } from "../../environments/environment";
-import { Router } from "@angular/router";
 
-import { isPlatformBrowser } from "@angular/common"; // +
-import { PLATFORM_ID } from "@angular/core"; // +
 import { isPlatformBrowser } from "@angular/common"; // +
 import { PLATFORM_ID } from "@angular/core"; // +
 
@@ -113,8 +110,6 @@ import { PLATFORM_ID } from "@angular/core"; // +
 export class PosthogService {
   constructor(
     private ngZone: NgZone,
-    private router: Router,
-    private destroyRef: DestroyRef,
     @Inject(PLATFORM_ID) private platformId: Object // +
   ) {
     // Only initialize PostHog in browser environment
@@ -181,9 +176,9 @@ app.get('**', async (req, res, next) => {
   let isFeatureEnabled = false;
   const client = new PostHog(
       const client = new PostHog(
-      environment.posthogKey,
-      { host: environment.posthogHost }
-  )
+          environment.posthogKey,
+          { host: environment.posthogHost }
+      )
   )
 
   if (distinctId) {


### PR DESCRIPTION
## Changes

Remove duplicated lines from the Angular installation snippet, and remove uneeded imports to the minimum required.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
