### PR TITLE
Update Q1 2026 objectives to Q2 2026 objectives

### DIFF
--- a/contents/teams/logs/objectives.mdx
+++ b/contents/teams/logs/objectives.mdx
@@ -1,23 +1,20 @@
-### Q1 2026 Objectives
+### Q2 2026 Objectives
 
-#### Have happy paying customers
-Motivation: Validate PMF - users want to pay for the service we provide, they aren’t just messing around with a free beta
+#### Product autonomy
 
-* Billing integration
-* GA Launch (finalise retention, pricing, start charging etc)
-* PostHog integrations (session replay logs, PostHogJS integration)
-* Platform Integrations (vercel, more generic api ingestions other than just otel)
+* Can use logs without the UI (e.g. via Max)
+* Detect and send interesting signals, e.g. anomaly detection, spikes, errors
+* APM
+* Traces
+* Metrics
+* Reduce migration blocker feedback to 0
 
-#### Launch AI MVP feature
-Generate buzz, set our product apart from everyone else,  *"We built a logging product where you don’t need to look at a log line ever again"*
+#### Table stakes
 
-* MVP Natural language log investigation, e.g. "Why did the capture service crash at 2pm on Tuesday?"
-
-#### Make Logs part of PostHog
-
-Logs is currently a very separate and isolated product and there’s a bunch of obvious integrations with other PostHog features, also makes a better case for *why PostHog for logs?*
-
-* Logs links from error tracking
-* Docs and easy default path for linking exception events to log resource
-* Tie into product analytics (e.g. view logs for specific distinct_ids)
-* Build logs panel into session replay view
+* Solid backups
+* Quota limits so complex queries don't impact other users (e.g. searching for "1" in team2)
+* Retention
+* Alerts
+* Saved views / dashboards
+* Context view
+* Archival storage?


### PR DESCRIPTION
## Changes

Updated the Logs team objectives document from Q1 2026 to Q2 2026 with revised priorities and focus areas.

**Key changes:**
- Renamed quarter from Q1 2026 to Q2 2026
- Replaced three Q1 objectives ("Have happy paying customers", "Launch AI MVP feature", "Make Logs part of PostHog") with two Q2 objectives:
  - **Product autonomy**: Focus on programmatic access, signal detection, APM/traces/metrics support, and reducing migration blockers
  - **Table stakes**: Core infrastructure work including backups, quota limits, retention, alerts, saved views, context view, and archival storage

This reflects a shift from customer validation and AI features toward building foundational product capabilities and integration depth.

## Checklist

- [x] I've read the docs and/or content style guides
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

https://claude.ai/code/session_019UgjyjZfVHXA7GTLT7HXNX