### PR TITLE
Remove graphics team goals from Marketing Q2 objectives

### DIFF
--- a/contents/teams/marketing/objectives.mdx
+++ b/contents/teams/marketing/objectives.mdx
@@ -39,24 +39,6 @@ These are the primary goals the team is prioritizing this quarter.
 
 </details>
 
-<details>
-<summary>Vlogging our design work (Lottie)</summary>
-
-- **Rationale:** We do good art. Let's share it. 
-- **Things we could do:** Time-lapses. Livestreams. Videos. 
-- **We'll know we're successful when:** Lottie becomes an influencer. 
-
-</details>
-
-<details>
-<summary>Take our art into the real world (Heidi)</summary>
-
-- **Rationale:** Being weird helps us grow. 
-- **Things we could do:** Murals. Art objects. Exhibits. 
-- **We'll know we're successful when:** Non-users start noticing our stuff. 
-
-</details>
-
 ## Sidequests
 
 Sidequests are important areas of focus or things the team cares a lot about, but which aren't their primary goal.
@@ -85,10 +67,3 @@ Sidequests are important areas of focus or things the team cares a lot about, bu
 
 </details>
 
-<details>
-<summary>Keep the merch moving (Lottie)</summary>
-
-- **Rationale:** We're not quite a lifestyle brand yet. 
-- **Things we could do:** Finish the photoshoot and launch the merch.
-
-</details>


### PR DESCRIPTION
Removes the graphics-related goals (Lottie, Heidi) from the Marketing team's Q2 2026 objectives, leaving the remaining goals and sidequests intact.

Removed:
- "Vlogging our design work (Lottie)" — primary goal
- "Take our art into the real world (Heidi)" — primary goal
- "Keep the merch moving (Lottie)" — sidequest

Note: No goals attributed to Daniel were present in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1spCFtYgFHoovoybM5WQU)_