### PR TITLE
docs: add FAQ on EU Cloudflare edge routing for managed proxy

### DIFF
--- a/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
+++ b/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
@@ -110,3 +110,20 @@ You have two options:
 2. **Disable zone hold** (not recommended): Zone holds are typically enabled for security reasons. Disabling them may expose your domain to certain risks. Only consider this if you understand the security implications for your organization.
 
 For most users with Cloudflare Enterprise, option 1 (setting up your own Cloudflare Worker proxy) is the recommended approach.
+
+### For EU Cloud, is managed reverse proxy traffic guaranteed to terminate only at EU Cloudflare edges?
+
+Not strictly guaranteed, but in practice this is usually the case. Cloudflare uses [anycast routing](https://developers.cloudflare.com/support/troubleshooting/general-troubleshooting/geographic-traffic-routing/) to terminate connections at the data center closest to the end user, so requests from users in Europe almost always land on EU edges. There are two caveats:
+
+- If your user is physically outside Europe, their request will terminate at a non-EU edge.
+- If the nearest Cloudflare data center is overloaded or unavailable, traffic may be routed to another region.
+
+We do not enable [Regional Services or the Data Localization Suite](https://developers.cloudflare.com/data-localization/) on the managed reverse proxy, so EU-only edge termination is not contractually enforced.
+
+That said, the managed reverse proxy is designed so that **no request content is stored at the edge**, regardless of which data center terminates the connection:
+
+- The Cloudflare Workers we use to forward traffic to our ingestion pipeline do not log requests.
+- Request caching is not enabled.
+- Cloudflare has confirmed to us that they do not retain request logs for this traffic either.
+
+Once traffic reaches PostHog, it is ingested into the region you selected (EU or US Cloud). If strict EU-only termination at the edge is a hard requirement for your compliance posture, we recommend setting up a [self-hosted proxy](/docs/advanced/proxy) on infrastructure you control instead.


### PR DESCRIPTION
## Summary

Adds a new FAQ entry to the managed reverse proxy docs answering a recurring customer question: for EU Cloud, is managed reverse proxy traffic guaranteed to terminate only at EU Cloudflare edges?

The new entry explains:
- Cloudflare anycast routing means EU users almost always hit EU edges, but it isn't contractually guaranteed (Regional Services / Data Localization Suite are not enabled).
- The two caveats: non-EU users and overloaded edges.
- No request content is stored at the edge regardless of region — the forwarding Workers don't log, caching is off, and Cloudflare has confirmed they don't retain request logs either.
- Pointer to self-hosted proxy for customers who need strict EU-only edge termination as a hard requirement.

Context: Zendesk ticket #57504.

## Test plan

- [ ] Render the page locally and confirm the FAQ entry appears under `## FAQ` on `/docs/advanced/proxy/managed-reverse-proxy`
- [ ] Verify the inline links to the Cloudflare docs and `/docs/advanced/proxy` resolve

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*