### PR TITLE
feat(dpa): add Gen Z slang version to DPA generator

### DIFF
--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -263,6 +263,23 @@ function DpaGenerator() {
                                 <br />
                                 <div className="block text-sm opacity-75">Sing along while staying compliant</div>
                             </li>
+                            <li className="pl-7 relative">
+                                <input
+                                    type="radio"
+                                    id="genz"
+                                    name="mode"
+                                    value="genz"
+                                    className="absolute left-1 top-1"
+                                    onChange={handleModeChange}
+                                />
+                                <label className="font-semibold" htmlFor="genz">
+                                    Gen Z slang edition
+                                </label>
+                                <br />
+                                <div className="block text-sm opacity-75">
+                                    Compliance, but make it bestie energy
+                                </div>
+                            </li>
                         </ul>
                     </div>
                 </div>
@@ -666,6 +683,96 @@ function DpaGenerator() {
                                 <br />
                                 To protect and cherish, here and now.
                             </p>
+                            <div className="pb-16">
+                                <SignatureFields />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className={`${mode === 'genz' ? 'block' : 'hidden'} [&>p]:text-[15px] pb-4`}>
+                        <div className="bg-yellow/25 py-4 px-8 text-sm text-center -mx-8 border-t border-light">
+                            <strong>Notice:</strong> Vibes-only translation, bestie. Not legally binding on its own —
+                            you still need the real one from{' '}
+                            <a
+                                href={APP_LEGAL_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline font-semibold"
+                            >
+                                app.posthog.com/legal
+                            </a>{' '}
+                            for it to slap in court.
+                        </div>
+
+                        <div className="@container mx-auto max-w-3xl">
+                            <h2 className="pt-8 pb-0 mt-0">The DPA, but make it Gen Z 💅</h2>
+
+                            <p>
+                                okay bestie, let's get into it. this is the part where you and PostHog pinky-promise
+                                about your users' data. no cap, it's giving compliance era.
+                            </p>
+
+                            <h3>The vibe check (who's who)</h3>
+                            <p>
+                                <strong>You</strong> = the controller. main character energy, you call the shots on
+                                whose data gets processed and why.
+                                <br />
+                                <strong>Us (PostHog)</strong> = the processor. your ride-or-die bestie who handles the
+                                data exactly how you said, periodt.
+                            </p>
+
+                            <h3>The tea (what we're actually agreeing to)</h3>
+                            <p>
+                                You're trusting us with personal data, and we're not gonna do anything sus with it. We
+                                only process it for the reasons you tell us to, full stop. No side quests, no sneaky
+                                rebranding it as "ours." That'd be lowkey illegal and highkey not our vibe.
+                            </p>
+
+                            <h3>Security (because we're not mid)</h3>
+                            <p>
+                                We keep your data locked down: encryption in transit and at rest, access controls,
+                                regular security reviews, the whole rizz. SOC 2, ISO 27001, HIPAA — we understood the
+                                assignment.
+                            </p>
+
+                            <h3>If something goes sideways (the drama)</h3>
+                            <p>
+                                If there's a breach we'll let you know without delay. We're not gonna ghost you. You'll
+                                hear from us faster than a group chat finds out about a breakup, and we'll give you
+                                everything you need to handle your own notification duties.
+                            </p>
+
+                            <h3>Sub-processors (the supporting cast)</h3>
+                            <p>
+                                We work with a small lineup of other companies (cloud hosting, the usual suspects) to
+                                help run the platform. They're vetted, they're on the same vibe re: data protection,
+                                and we'll keep you posted if anyone new joins the cast.
+                            </p>
+
+                            <h3>International transfers (passport era)</h3>
+                            <p>
+                                If your data needs to cross borders, we use the proper Standard Contractual Clauses bc
+                                we're not trying to catch a regulator's smoke. EU to US? Bet. UK addendum? Slay. Swiss
+                                FDPA? We got that covered too.
+                            </p>
+
+                            <h3>Your rights, bestie</h3>
+                            <p>
+                                You can audit us, you can ask us to delete or return data, and you can ask us to help
+                                you answer data subject requests. Just hit us up — we'll cooperate because we have
+                                literally nothing to hide. It's giving open book.
+                            </p>
+
+                            <h3>When this ends (it's giving sunset)</h3>
+                            <p>
+                                When you stop using PostHog, we'll delete or return your data per your instructions. No
+                                keeping screenshots, no clinging to receipts. We move on like grown adults.
+                            </p>
+
+                            <p className="font-bold">
+                                Cool? Cool. Sign below and we're locked in 💯
+                            </p>
+
                             <div className="pb-16">
                                 <SignatureFields />
                             </div>


### PR DESCRIPTION
## Summary

Adds a fifth reading style to the DPA generator at `/dpa`, alongside the existing pretty / lawyer / fairytale / Taylor Swift variants.

The new "Gen Z slang edition" rewrites the DPA in zoomer-speak — covers the same eight sections a real DPA would (parties, scope, security, breach notification, sub-processors, international transfers, audit rights, termination) but with the bestie-energy tone.

Like the other novelty variants, it shows the same "preview only — generate the real one at app.posthog.com/legal" banner so nobody mistakes it for the countersigned version.

## Changes

- `src/pages/dpa.tsx`
  - New radio option in the reading-style picker
  - New conditional content block toggled by `mode === 'genz'`, reusing the shared `SignatureFields` component

## Test plan

- [ ] Visit `/dpa` locally, select "Gen Z slang edition", confirm the content renders and the other modes still toggle correctly
- [ ] Verify the disclaimer banner appears and the "Generate this DPA at app.posthog.com/legal" tooltip works on the signature fields
- [ ] Check responsive layout in a narrow window (container queries)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*