### PR TITLE
Show 'Contact us' for Enterprise add-on price on platform packages page

### DIFF
--- a/src/pages/platform-packages/index.tsx
+++ b/src/pages/platform-packages/index.tsx
@@ -112,7 +112,7 @@ export default function PlatformPackages() {
                                         <p className="text-secondary mb-2">{addon.description}</p>
                                         {plan?.flat_rate && (
                                             <div className="flex items-baseline mt-auto">
-                                                {addon.name === 'Enterprise' ? (
+                                                {addon.type === 'enterprise' ? (
                                                     <strong className="text-lg">Contact us</strong>
                                                 ) : (
                                                     <>

--- a/src/pages/platform-packages/index.tsx
+++ b/src/pages/platform-packages/index.tsx
@@ -110,19 +110,20 @@ export default function PlatformPackages() {
                                     <div key={addon.name} className="">
                                         <h3 className="text-xl font-semibold mb-2 mt-0">{addon.name}</h3>
                                         <p className="text-secondary mb-2">{addon.description}</p>
-                                        {plan?.flat_rate &&
-                                            (addon.name === 'Enterprise' ? (
-                                                <div className="flex items-baseline mt-auto">
+                                        {plan?.flat_rate && (
+                                            <div className="flex items-baseline mt-auto">
+                                                {addon.name === 'Enterprise' ? (
                                                     <strong className="text-lg">Contact us</strong>
-                                                </div>
-                                            ) : (
-                                                <div className="flex items-baseline mt-auto">
-                                                    <strong className="text-lg">
-                                                        ${plan.unit_amount_usd.replace('.00', '')}
-                                                    </strong>
-                                                    <span className="text-sm opacity-60 ml-1">/mo</span>
-                                                </div>
-                                            ))}
+                                                ) : (
+                                                    <>
+                                                        <strong className="text-lg">
+                                                            ${plan.unit_amount_usd.replace('.00', '')}
+                                                        </strong>
+                                                        <span className="text-sm opacity-60 ml-1">/mo</span>
+                                                    </>
+                                                )}
+                                            </div>
+                                        )}
                                     </div>
                                 )
                             })}

--- a/src/pages/platform-packages/index.tsx
+++ b/src/pages/platform-packages/index.tsx
@@ -110,14 +110,19 @@ export default function PlatformPackages() {
                                     <div key={addon.name} className="">
                                         <h3 className="text-xl font-semibold mb-2 mt-0">{addon.name}</h3>
                                         <p className="text-secondary mb-2">{addon.description}</p>
-                                        {plan?.flat_rate && (
-                                            <div className="flex items-baseline mt-auto">
-                                                <strong className="text-lg">
-                                                    ${plan.unit_amount_usd.replace('.00', '')}
-                                                </strong>
-                                                <span className="text-sm opacity-60 ml-1">/mo</span>
-                                            </div>
-                                        )}
+                                        {plan?.flat_rate &&
+                                            (addon.name === 'Enterprise' ? (
+                                                <div className="flex items-baseline mt-auto">
+                                                    <strong className="text-lg">Contact us</strong>
+                                                </div>
+                                            ) : (
+                                                <div className="flex items-baseline mt-auto">
+                                                    <strong className="text-lg">
+                                                        ${plan.unit_amount_usd.replace('.00', '')}
+                                                    </strong>
+                                                    <span className="text-sm opacity-60 ml-1">/mo</span>
+                                                </div>
+                                            ))}
                                     </div>
                                 )
                             })}


### PR DESCRIPTION
## Summary

Temporarily replaces the $2,000/mo price for the Enterprise add-on on `/platform-packages` with "Contact us".

## Why

We want to experiment with pricing for the Enterprise add-on as we don't have very many people on it yet. While we figure this out, we need to make it temporarily "Contact us", and then we'll update it again once we've settled on a better pricing mechanism.

We're thinking of having this be on a sliding scale based on company size, since smaller companies don't see the value and larger companies see way more value from it than $2k/mo — but the final version is TBD while we figure this out.

## Test plan

- [x] Visit `/platform-packages` and confirm the Enterprise add-on shows "Contact us" instead of `$2,000/mo`
- [x] Confirm other add-ons (Teams, Boost) still show their flat rate pricing


---
_Generated by [Claude Code](https://claude.ai/code/session_01DEa7Dke8wc1D2dHsKk4kzp)_