### PR TITLE
docs(logs): add 'Set up alerts' entry to navigation menu

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6701,6 +6701,12 @@ export const docsMenu = {
                     color: 'blue',
                 },
                 {
+                    name: 'Set up alerts',
+                    url: '/docs/logs/alerts',
+                    icon: 'IconBell',
+                    color: 'red',
+                },
+                {
                     name: 'PostHog AI',
                 },
                 {


### PR DESCRIPTION
## Changes

Adds a "Set up alerts" navigation item to the Logs section of the docs menu, linking to `/docs/logs/alerts` with a bell icon.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`