### PR TITLE
rename paid plans to "Cheaper" and "More expensive"

### DIFF
--- a/src/components/Pricing/OtherOptions/index.tsx
+++ b/src/components/Pricing/OtherOptions/index.tsx
@@ -38,7 +38,7 @@ interface ISection {
 
 const sections: ISection[] = [
     {
-        title: 'Enterprise',
+        title: 'More expensive',
         icon: <IconShield className="w-7 h-7" />,
         description: <EnterpriseDescription />,
         cta: {

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -44,7 +44,7 @@ const planSummary = [
         ],
     },
     {
-        title: 'Pay-as-you-go',
+        title: 'Cheaper',
         price: '$0',
         features: [
             'Generous free tier on all products',
@@ -59,7 +59,7 @@ const planSummary = [
         ],
     },
     {
-        title: 'Enterprise',
+        title: 'More expensive',
         price: 'Custom pricing',
         priceSubtitle: 'w/ fixed terms',
         features: [
@@ -100,7 +100,7 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => (
                 </ul>
                 <div className="mt-auto">
                     <PlanCTA
-                        type={planData.title === 'Pay-as-you-go' ? 'primary' : 'secondary'}
+                        type={planData.title === 'Cheaper' ? 'primary' : 'secondary'}
                         ctaText={planData.CTAText}
                         ctaLink={planData.CTALink}
                     />

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -112,7 +112,7 @@ const planSummary: PlanData[] = [
         intent: 'free' as const,
     },
     {
-        title: 'Pay-as-you-go',
+        title: 'Cheaper',
         subtitle: 'Usage-based pricing after free tier',
         pricePreface: 'Starts at',
         price: '$0',
@@ -280,7 +280,7 @@ export const PlanColumns: React.FC<PlanColumnsProps> = ({ billingProducts, highl
                             </div>
                             {/* Header */}
                             {mainPlans?.map((plan: BillingV2PlanType, idx: number) => {
-                                // Add border-r to the last plan column (Pay-as-you-go)
+                                // Add border-r to the last plan column (Cheaper)
                                 const isLast = idx === mainPlans.length - 1
                                 const planKey = plan.key || plan.plan_key || `plan-${idx}`
                                 return (

--- a/src/components/Pricing/Test/PricingHero.tsx
+++ b/src/components/Pricing/Test/PricingHero.tsx
@@ -196,7 +196,7 @@ const PricingHero = ({ activePlan, setActivePlan }: PricingHeroProps): JSX.Eleme
                                     : 'border-yellow bg-white dark:bg-white/5'
                             }`}
                         >
-                            <strong className="whitespace-nowrap">Pay-as-you-go</strong>
+                            <strong className="whitespace-nowrap">Cheaper</strong>
                             <span className="text-sm opacity-75 whitespace-nowrap">Usage-based pricing</span>
                         </button>
                     </li>

--- a/src/components/Products/Slides/PlanComparison/index.tsx
+++ b/src/components/Products/Slides/PlanComparison/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Tooltip from 'components/RadixUI/Tooltip'
 import { IconInfo } from '@posthog/icons'
 import useProduct from 'hooks/useProduct'
-import ScrollArea from "components/RadixUI/ScrollArea"
+import ScrollArea from 'components/RadixUI/ScrollArea'
 
 interface PlanComparisonProps {
     products: any[]
@@ -410,7 +410,7 @@ const PlanComparison: React.FC<PlanComparisonProps> = ({
                             <p className="text-secondary">No credit card required</p>
                         </div>
                         <div className="border-b border-primary">
-                            <strong>{paidPlan?.name || 'Pay-as-you-go'}</strong>
+                            <strong>{paidPlan?.name || 'Cheaper'}</strong>
                             <p className="text-secondary">Starts at $0/mo</p>
                         </div>
                         {/* Volume/Usage row - dynamically named based on unit */}
@@ -464,7 +464,9 @@ const PlanComparison: React.FC<PlanComparisonProps> = ({
                                             delay={0}
                                         >
                                             <div className="max-w-xs">
-                                                <p className="mb-0 text-[13px] leading-normal">{difference.description}</p>
+                                                <p className="mb-0 text-[13px] leading-normal">
+                                                    {difference.description}
+                                                </p>
                                             </div>
                                         </Tooltip>
                                     )}
@@ -485,7 +487,6 @@ const PlanComparison: React.FC<PlanComparisonProps> = ({
                                 </p>
                             </div>
                         )}
-
                     </div>
                     {productInfo?.customPricingContent && productInfo.customPricingContent}
                 </ScrollArea>


### PR DESCRIPTION
## Summary

- Renames the two paid plan tiers on `/pricing` (and elsewhere) to be honest about what differentiates them.
- Before: **Free** / **Pay-as-you-go** / **Enterprise**
- After: **Free** / **Cheaper** / **More expensive**

No pricing, features, or links change — just the labels. Tagging for vibe-check.

## Test plan

- [ ] `/pricing` hero plan toggle reads "Cheaper" instead of "Pay-as-you-go"
- [ ] `/pricing` plan columns render with new titles
- [ ] OtherOptions section shows "More expensive" instead of "Enterprise"
- [ ] Product page `<PlanComparison />` slides fall back to "Cheaper" when billing data is missing
- [ ] CTA styling on the cheaper column still resolves to primary (string comparison updated)

> ⚠️ Couldn't verify in browser — local Gatsby dev server crashed on Wistia video enrichment during onPreBootstrap (unrelated to this diff). Vercel preview will be the real check.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*