### PR TITLE
Clarify error tracking suppression billing

### DIFF
--- a/contents/docs/error-tracking/_snippets/suppression-rules.mdx
+++ b/contents/docs/error-tracking/_snippets/suppression-rules.mdx
@@ -1,4 +1,4 @@
-Autocaptured exceptions can be ignored client-side by [configuring suppression rules](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-suppression-rules) in PostHog settings. You can only filter based on the exception type and message attributes because the stack of an exception may still be minified client-side.
+[Suppression rules](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-suppression-rules) drop matching future exceptions before they are ingested as `$exception` events, so they can reduce your bill. Supported SDKs may apply rules client-side before sending exceptions to PostHog, and PostHog also applies them server-side before storing the event. They do not apply retroactively to exceptions already ingested. You can only filter based on the exception type and message attributes because the stack of an exception may still be minified client-side.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/suppression_rule_light_8db44eb6b1.png"

--- a/contents/docs/error-tracking/pricing.mdx
+++ b/contents/docs/error-tracking/pricing.mdx
@@ -19,12 +19,14 @@ We aim to be significantly cheaper than our competitors. Below are tips to reduc
 
 ## What contributes to your bill?
 
-Error tracking bills you based on the number of `$exception` events **_ingested_** by PostHog _each month_. This means if you send exception events to PostHog, they will be billed.
+Error tracking bills you based on the number of `$exception` events **_ingested_** by PostHog _each month_. This means if you send exception events to PostHog, they will be billed (events dropped before ingestion are not billed).
 
 This also means:
 - The total number of exceptions stored in PostHog does not contribute to your bill.
 - The number of [issues](/docs/error-tracking/issues-and-exceptions) in PostHog does not affect your bill, only the individual exception events that make up the issues.
-- Merging, resolving, and suppressing issues in PostHog does not reduce your bill.
+- Merging and resolving issues in PostHog do not reduce your bill.
+- Suppressing an issue only affects future matching exceptions. Once an issue is suppressed, future exceptions linked to that issue are not ingested or billed. Exceptions already ingested before suppression still count.
+- Suppression rules also apply to future exceptions. Matching exceptions are dropped before ingestion and are not billed.
 
 ## Prevent surprises with billing limits
 


### PR DESCRIPTION
## Summary
- Clarify that error tracking billing is based on ingested `` events
- Distinguish already-ingested exceptions from future exceptions dropped by issue suppression or suppression rules
- Note that suppression rules may run client-side in supported SDKs and server-side before storage

## Checks
- `git diff --check`
- markdownlint hook via commit