### PR TITLE
Preflight external links and open iframeable sites in a PostHog window

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -81,6 +81,11 @@ jobs:
                   CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
                   CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
 
+            # Wrangler bundles repo-root `functions/` into the Pages Worker when cwd is the repo root
+            # (see deploy step `workingDirectory`). Fail here if Functions do not compile, before upload.
+            - name: Bundle Cloudflare Pages Functions (verify)
+              run: pnpm exec wrangler pages functions build --project-directory . --outdir /tmp/cf-pages-functions-check
+
             - name: Deploy to Cloudflare Pages
               id: deploy
               uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
@@ -88,6 +93,7 @@ jobs:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   packageManager: pnpm
+                  workingDirectory: .
                   command: pages deploy public --project-name=posthog-preview --branch=pr-${{ github.event.pull_request.number }}
 
             - name: Get timestamp (final)

--- a/api/check-iframe.js
+++ b/api/check-iframe.js
@@ -1,0 +1,136 @@
+/**
+ * Preflight check: given a URL, return whether the target site permits being
+ * embedded in an iframe from posthog.com. Used by the Link component to decide
+ * whether to enable the "Open in new PostHog window" option for external links.
+ */
+
+const TIMEOUT_MS = 5000
+const EMBED_ORIGIN = 'https://posthog.com'
+
+function isPrivateHost(hostname) {
+    if (!hostname) return true
+    const lower = hostname.toLowerCase()
+    if (lower === 'localhost' || lower === '0.0.0.0' || lower.endsWith('.local') || lower.endsWith('.internal')) {
+        return true
+    }
+    const v4 = lower.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
+    if (v4) {
+        const a = parseInt(v4[1], 10)
+        const b = parseInt(v4[2], 10)
+        if (a === 0 || a === 10 || a === 127) return true
+        if (a === 169 && b === 254) return true
+        if (a === 172 && b >= 16 && b <= 31) return true
+        if (a === 192 && b === 168) return true
+    }
+    if (lower === '::1' || lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80:')) {
+        return true
+    }
+    return false
+}
+
+function parseFrameAncestors(csp) {
+    if (!csp) return null
+    const directive = csp
+        .split(';')
+        .map((d) => d.trim())
+        .find((d) => /^frame-ancestors\b/i.test(d))
+    if (!directive) return null
+    return directive
+        .replace(/^frame-ancestors/i, '')
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((s) => s.replace(/^['"]|['"]$/g, '').toLowerCase())
+}
+
+function frameAncestorsAllow(sources) {
+    if (!sources || sources.length === 0) return false
+    if (sources.includes("'none'")) return false
+    if (sources.some((s) => s === '*' || s === 'https:' || s === 'http:')) {
+        return true
+    }
+    return sources.some((s) => {
+        if (s === EMBED_ORIGIN || s === 'posthog.com') return true
+        if (s === '*.posthog.com' || s === 'https://*.posthog.com') return true
+        return false
+    })
+}
+
+function isBlocking(xfo, csp) {
+    const ancestors = parseFrameAncestors(csp)
+    if (ancestors) {
+        return !frameAncestorsAllow(ancestors)
+    }
+    if (xfo) {
+        const value = xfo.toLowerCase().trim().split(',')[0].trim()
+        if (value === 'deny' || value === 'sameorigin') return true
+        if (value.startsWith('allow-from')) {
+            const allowed = value.replace('allow-from', '').trim()
+            return allowed !== EMBED_ORIGIN && !allowed.endsWith('.posthog.com')
+        }
+    }
+    return false
+}
+
+async function fetchWithMethod(url, method, signal) {
+    return fetch(url, {
+        method,
+        redirect: 'follow',
+        signal,
+        headers: {
+            'User-Agent': 'PostHog-IframeCheck/1.0 (+https://posthog.com)',
+            Accept: 'text/html,*/*',
+        },
+    })
+}
+
+const handler = async (req, res) => {
+    res.setHeader('Cache-Control', 'public, max-age=3600, s-maxage=3600')
+
+    const url = req.query?.url
+    if (!url || typeof url !== 'string') {
+        return res.status(400).json({ error: 'url query param required' })
+    }
+
+    let parsed
+    try {
+        parsed = new URL(url)
+    } catch {
+        return res.status(400).json({ error: 'invalid url' })
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return res.status(200).json({ allowed: false, reason: 'unsupported-protocol' })
+    }
+    if (isPrivateHost(parsed.hostname)) {
+        return res.status(200).json({ allowed: false, reason: 'private-host' })
+    }
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+    try {
+        let response
+        try {
+            response = await fetchWithMethod(parsed.toString(), 'HEAD', controller.signal)
+            if (response.status === 405 || response.status === 501) {
+                response = await fetchWithMethod(parsed.toString(), 'GET', controller.signal)
+            }
+        } catch {
+            response = await fetchWithMethod(parsed.toString(), 'GET', controller.signal)
+        }
+
+        const xfo = response.headers.get('x-frame-options')
+        const csp = response.headers.get('content-security-policy')
+        const blocked = isBlocking(xfo, csp)
+        return res.status(200).json({
+            allowed: !blocked,
+            reason: blocked ? (parseFrameAncestors(csp) ? 'frame-ancestors' : 'x-frame-options') : undefined,
+        })
+    } catch (err) {
+        return res.status(200).json({ allowed: false, reason: 'fetch-failed' })
+    } finally {
+        clearTimeout(timer)
+    }
+}
+
+export default handler

--- a/api/check-iframe.js
+++ b/api/check-iframe.js
@@ -2,135 +2,16 @@
  * Preflight check: given a URL, return whether the target site permits being
  * embedded in an iframe from posthog.com. Used by the Link component to decide
  * whether to enable the "Open in new PostHog window" option for external links.
+ *
+ * Vercel: this file. Cloudflare PR previews: `functions/api/check-iframe.js` (shared logic in `lib/`).
  */
 
-const TIMEOUT_MS = 5000
-const EMBED_ORIGIN = 'https://posthog.com'
-
-function isPrivateHost(hostname) {
-    if (!hostname) return true
-    const lower = hostname.toLowerCase()
-    if (lower === 'localhost' || lower === '0.0.0.0' || lower.endsWith('.local') || lower.endsWith('.internal')) {
-        return true
-    }
-    const v4 = lower.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
-    if (v4) {
-        const a = parseInt(v4[1], 10)
-        const b = parseInt(v4[2], 10)
-        if (a === 0 || a === 10 || a === 127) return true
-        if (a === 169 && b === 254) return true
-        if (a === 172 && b >= 16 && b <= 31) return true
-        if (a === 192 && b === 168) return true
-    }
-    if (lower === '::1' || lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80:')) {
-        return true
-    }
-    return false
-}
-
-function parseFrameAncestors(csp) {
-    if (!csp) return null
-    const directive = csp
-        .split(';')
-        .map((d) => d.trim())
-        .find((d) => /^frame-ancestors\b/i.test(d))
-    if (!directive) return null
-    return directive
-        .replace(/^frame-ancestors/i, '')
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean)
-        .map((s) => s.replace(/^['"]|['"]$/g, '').toLowerCase())
-}
-
-function frameAncestorsAllow(sources) {
-    if (!sources || sources.length === 0) return false
-    if (sources.includes("'none'")) return false
-    if (sources.some((s) => s === '*' || s === 'https:' || s === 'http:')) {
-        return true
-    }
-    return sources.some((s) => {
-        if (s === EMBED_ORIGIN || s === 'posthog.com') return true
-        if (s === '*.posthog.com' || s === 'https://*.posthog.com') return true
-        return false
-    })
-}
-
-function isBlocking(xfo, csp) {
-    const ancestors = parseFrameAncestors(csp)
-    if (ancestors) {
-        return !frameAncestorsAllow(ancestors)
-    }
-    if (xfo) {
-        const value = xfo.toLowerCase().trim().split(',')[0].trim()
-        if (value === 'deny' || value === 'sameorigin') return true
-        if (value.startsWith('allow-from')) {
-            const allowed = value.replace('allow-from', '').trim()
-            return allowed !== EMBED_ORIGIN && !allowed.endsWith('.posthog.com')
-        }
-    }
-    return false
-}
-
-async function fetchWithMethod(url, method, signal) {
-    return fetch(url, {
-        method,
-        redirect: 'follow',
-        signal,
-        headers: {
-            'User-Agent': 'PostHog-IframeCheck/1.0 (+https://posthog.com)',
-            Accept: 'text/html,*/*',
-        },
-    })
-}
+import { runIframePreflight } from '../lib/iframe-preflight.js'
 
 const handler = async (req, res) => {
     res.setHeader('Cache-Control', 'public, max-age=3600, s-maxage=3600')
-
-    const url = req.query?.url
-    if (!url || typeof url !== 'string') {
-        return res.status(400).json({ error: 'url query param required' })
-    }
-
-    let parsed
-    try {
-        parsed = new URL(url)
-    } catch {
-        return res.status(400).json({ error: 'invalid url' })
-    }
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return res.status(200).json({ allowed: false, reason: 'unsupported-protocol' })
-    }
-    if (isPrivateHost(parsed.hostname)) {
-        return res.status(200).json({ allowed: false, reason: 'private-host' })
-    }
-
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
-
-    try {
-        let response
-        try {
-            response = await fetchWithMethod(parsed.toString(), 'HEAD', controller.signal)
-            if (response.status === 405 || response.status === 501) {
-                response = await fetchWithMethod(parsed.toString(), 'GET', controller.signal)
-            }
-        } catch {
-            response = await fetchWithMethod(parsed.toString(), 'GET', controller.signal)
-        }
-
-        const xfo = response.headers.get('x-frame-options')
-        const csp = response.headers.get('content-security-policy')
-        const blocked = isBlocking(xfo, csp)
-        return res.status(200).json({
-            allowed: !blocked,
-            reason: blocked ? (parseFrameAncestors(csp) ? 'frame-ancestors' : 'x-frame-options') : undefined,
-        })
-    } catch (err) {
-        return res.status(200).json({ allowed: false, reason: 'fetch-failed' })
-    } finally {
-        clearTimeout(timer)
-    }
+    const result = await runIframePreflight(req.query?.url)
+    return res.status(result.status).json(result.json)
 }
 
 export default handler

--- a/functions/api/check-iframe.js
+++ b/functions/api/check-iframe.js
@@ -1,0 +1,16 @@
+import { runIframePreflight } from '../../lib/iframe-preflight.js'
+
+const CACHE = 'public, max-age=3600, s-maxage=3600'
+const JSON_HEADERS = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': CACHE,
+}
+
+export async function onRequestGet({ request }) {
+    const url = new URL(request.url).searchParams.get('url')
+    const result = await runIframePreflight(url)
+    return new Response(JSON.stringify(result.json), {
+        status: result.status,
+        headers: JSON_HEADERS,
+    })
+}

--- a/lib/iframe-preflight.js
+++ b/lib/iframe-preflight.js
@@ -1,0 +1,137 @@
+/**
+ * Shared iframe embed preflight for posthog.com (Vercel /api and Cloudflare Pages Functions).
+ */
+
+const TIMEOUT_MS = 5000
+const EMBED_ORIGIN = 'https://posthog.com'
+
+function isPrivateHost(hostname) {
+    if (!hostname) return true
+    const lower = hostname.toLowerCase()
+    if (lower === 'localhost' || lower === '0.0.0.0' || lower.endsWith('.local') || lower.endsWith('.internal')) {
+        return true
+    }
+    const v4 = lower.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
+    if (v4) {
+        const a = parseInt(v4[1], 10)
+        const b = parseInt(v4[2], 10)
+        if (a === 0 || a === 10 || a === 127) return true
+        if (a === 169 && b === 254) return true
+        if (a === 172 && b >= 16 && b <= 31) return true
+        if (a === 192 && b === 168) return true
+    }
+    if (lower === '::1' || lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80:')) {
+        return true
+    }
+    return false
+}
+
+function parseFrameAncestors(csp) {
+    if (!csp) return null
+    const directive = csp
+        .split(';')
+        .map((d) => d.trim())
+        .find((d) => /^frame-ancestors\b/i.test(d))
+    if (!directive) return null
+    return directive
+        .replace(/^frame-ancestors/i, '')
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((s) => s.replace(/^['"]|['"]$/g, '').toLowerCase())
+}
+
+function frameAncestorsAllow(sources) {
+    if (!sources || sources.length === 0) return false
+    if (sources.includes("'none'")) return false
+    if (sources.some((s) => s === '*' || s === 'https:' || s === 'http:')) {
+        return true
+    }
+    return sources.some((s) => {
+        if (s === EMBED_ORIGIN || s === 'posthog.com') return true
+        if (s === '*.posthog.com' || s === 'https://*.posthog.com') return true
+        return false
+    })
+}
+
+function isBlocking(xfo, csp) {
+    const ancestors = parseFrameAncestors(csp)
+    if (ancestors) {
+        return !frameAncestorsAllow(ancestors)
+    }
+    if (xfo) {
+        const value = xfo.toLowerCase().trim().split(',')[0].trim()
+        if (value === 'deny' || value === 'sameorigin') return true
+        if (value.startsWith('allow-from')) {
+            const allowed = value.replace('allow-from', '').trim()
+            return allowed !== EMBED_ORIGIN && !allowed.endsWith('.posthog.com')
+        }
+    }
+    return false
+}
+
+async function fetchWithMethod(url, method, signal) {
+    return fetch(url, {
+        method,
+        redirect: 'follow',
+        signal,
+        headers: {
+            'User-Agent': 'PostHog-IframeCheck/1.0 (+https://posthog.com)',
+            Accept: 'text/html,*/*',
+        },
+    })
+}
+
+/**
+ * @param {string | null | undefined} urlParam raw `url` query value
+ * @returns {Promise<{ status: number, json: Record<string, unknown> }>}
+ */
+export async function runIframePreflight(urlParam) {
+    const url = urlParam
+    if (!url || typeof url !== 'string') {
+        return { status: 400, json: { error: 'url query param required' } }
+    }
+
+    let parsed
+    try {
+        parsed = new URL(url)
+    } catch {
+        return { status: 400, json: { error: 'invalid url' } }
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return { status: 200, json: { allowed: false, reason: 'unsupported-protocol' } }
+    }
+    if (isPrivateHost(parsed.hostname)) {
+        return { status: 200, json: { allowed: false, reason: 'private-host' } }
+    }
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+    try {
+        let response
+        try {
+            response = await fetchWithMethod(parsed.toString(), 'HEAD', controller.signal)
+            if (response.status === 405 || response.status === 501) {
+                response = await fetchWithMethod(parsed.toString(), 'GET', controller.signal)
+            }
+        } catch {
+            response = await fetchWithMethod(parsed.toString(), 'GET', controller.signal)
+        }
+
+        const xfo = response.headers.get('x-frame-options')
+        const csp = response.headers.get('content-security-policy')
+        const blocked = isBlocking(xfo, csp)
+        return {
+            status: 200,
+            json: {
+                allowed: !blocked,
+                reason: blocked ? (parseFrameAncestors(csp) ? 'frame-ancestors' : 'x-frame-options') : undefined,
+            },
+        }
+    } catch {
+        return { status: 200, json: { allowed: false, reason: 'fetch-failed' } }
+    } finally {
+        clearTimeout(timer)
+    }
+}

--- a/lib/iframe-preflight.js
+++ b/lib/iframe-preflight.js
@@ -1,5 +1,8 @@
 /**
  * Shared iframe embed preflight for posthog.com (Vercel /api and Cloudflare Pages Functions).
+ *
+ * Lives server-side because browsers cannot read framing headers on cross-origin responses
+ * (see comment on `fetchIframeStatus` in `src/components/Link/index.tsx`).
  */
 
 const TIMEOUT_MS = 5000

--- a/src/components/Browser/index.tsx
+++ b/src/components/Browser/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { IconExternal, IconRefresh, IconX } from '@posthog/icons'
 import { useApp } from '../../context/App'
 import { useWindow } from '../../context/Window'
@@ -10,24 +10,50 @@ interface BrowserProps {
     minimal?: boolean
 }
 
+// Defence-in-depth: only allow http/https URLs to reach `href` / iframe `src`.
+// Anything else (javascript:, data:, vbscript:, file:, etc.) returns null.
+function sanitizeHttpUrl(input: string): { href: string; host: string; pathAndRest: string } | null {
+    try {
+        const parsed = new URL(input)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+        const href = parsed.toString()
+        return {
+            href,
+            host: parsed.host,
+            pathAndRest: parsed.pathname + parsed.search + parsed.hash,
+        }
+    } catch {
+        return null
+    }
+}
+
 export default function Browser({ url }: BrowserProps): JSX.Element {
     const { appWindow } = useWindow()
     const { setWindowTitle, closeWindow } = useApp()
     const [iframeKey, setIframeKey] = useState(0)
 
-    const displayHost = (() => {
-        try {
-            return new URL(url).host
-        } catch {
-            return url
-        }
-    })()
+    const safeUrl = useMemo(() => sanitizeHttpUrl(url), [url])
 
     useEffect(() => {
         if (appWindow) {
-            setWindowTitle(appWindow, displayHost)
+            setWindowTitle(appWindow, safeUrl?.host || 'Browser')
         }
-    }, [appWindow, displayHost])
+    }, [appWindow, safeUrl?.host])
+
+    if (!safeUrl) {
+        return (
+            <div
+                data-app="Browser"
+                data-scheme="primary"
+                className="@container w-full h-full flex items-center justify-center bg-primary p-6 text-center text-secondary"
+            >
+                <div>
+                    <p className="mb-2 font-semibold text-primary">Can't open this link in a PostHog window.</p>
+                    <p className="text-sm">Only http(s) URLs can be embedded.</p>
+                </div>
+            </div>
+        )
+    }
 
     return (
         <div
@@ -45,11 +71,11 @@ export default function Browser({ url }: BrowserProps): JSX.Element {
                     <IconRefresh className="size-4" />
                 </button>
                 <div className="flex-1 truncate text-sm font-mono px-2 py-1 rounded bg-primary border border-primary text-primary">
-                    <span className="text-secondary">{displayHost}</span>
-                    <span className="text-muted">{url.slice(url.indexOf(displayHost) + displayHost.length)}</span>
+                    <span className="text-secondary">{safeUrl.host}</span>
+                    <span className="text-muted">{safeUrl.pathAndRest}</span>
                 </div>
                 <a
-                    href={url}
+                    href={safeUrl.href}
                     target="_blank"
                     rel="noopener noreferrer"
                     title="Open in browser tab"
@@ -71,11 +97,11 @@ export default function Browser({ url }: BrowserProps): JSX.Element {
             </div>
             <iframe
                 key={iframeKey}
-                src={url}
+                src={safeUrl.href}
                 className="flex-1 w-full bg-white"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
                 referrerPolicy="no-referrer-when-downgrade"
-                title={displayHost}
+                title={safeUrl.host}
             />
         </div>
     )

--- a/src/components/Browser/index.tsx
+++ b/src/components/Browser/index.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react'
+import { IconExternal, IconRefresh, IconX } from '@posthog/icons'
+import { useApp } from '../../context/App'
+import { useWindow } from '../../context/Window'
+
+interface BrowserProps {
+    url: string
+    location?: { pathname: string }
+    newWindow?: boolean
+    minimal?: boolean
+}
+
+export default function Browser({ url }: BrowserProps): JSX.Element {
+    const { appWindow } = useWindow()
+    const { setWindowTitle, closeWindow } = useApp()
+    const [iframeKey, setIframeKey] = useState(0)
+
+    const displayHost = (() => {
+        try {
+            return new URL(url).host
+        } catch {
+            return url
+        }
+    })()
+
+    useEffect(() => {
+        if (appWindow) {
+            setWindowTitle(appWindow, displayHost)
+        }
+    }, [appWindow, displayHost])
+
+    return (
+        <div
+            data-app="Browser"
+            data-scheme="primary"
+            className="@container w-full h-full flex flex-col min-h-1 bg-primary"
+        >
+            <div className="flex items-center gap-2 px-2 py-1.5 border-b border-primary bg-accent">
+                <button
+                    type="button"
+                    onClick={() => setIframeKey((k) => k + 1)}
+                    title="Reload"
+                    className="p-1 rounded hover:bg-input-bg text-secondary hover:text-primary"
+                >
+                    <IconRefresh className="size-4" />
+                </button>
+                <div className="flex-1 truncate text-sm font-mono px-2 py-1 rounded bg-primary border border-primary text-primary">
+                    <span className="text-secondary">{displayHost}</span>
+                    <span className="text-muted">{url.slice(url.indexOf(displayHost) + displayHost.length)}</span>
+                </div>
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Open in browser tab"
+                    className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded text-secondary hover:text-primary hover:bg-input-bg"
+                >
+                    <IconExternal className="size-4" />
+                    <span className="hidden @md:inline">Open in tab</span>
+                </a>
+                {appWindow && (
+                    <button
+                        type="button"
+                        onClick={() => closeWindow(appWindow)}
+                        title="Close"
+                        className="p-1 rounded hover:bg-input-bg text-secondary hover:text-primary"
+                    >
+                        <IconX className="size-4" />
+                    </button>
+                )}
+            </div>
+            <iframe
+                key={iframeKey}
+                src={url}
+                className="flex-1 w-full bg-white"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
+                referrerPolicy="no-referrer-when-downgrade"
+                title={displayHost}
+            />
+        </div>
+    )
+}

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -14,6 +14,13 @@ type IframeStatus = 'unknown' | 'checking' | 'allowed' | 'blocked'
 const iframeStatusCache = new Map<string, 'allowed' | 'blocked'>()
 const iframeStatusInflight = new Map<string, Promise<'allowed' | 'blocked'>>()
 
+/**
+ * We call our own `/api/check-iframe` instead of `fetch`ing the external URL in the browser
+ * because `X-Frame-Options` and `Content-Security-Policy: frame-ancestors` are not exposed
+ * to cross-origin JavaScript: they are not CORS-safelisted response headers, and
+ * `fetch(..., { mode: "no-cors" })` only yields an opaque response with no readable headers.
+ * A same-origin endpoint that performs the HEAD/GET server-side is the reliable way to read them.
+ */
 function isCheckableHttpUrl(url: string): boolean {
     try {
         const u = new URL(url)

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,23 +1,66 @@
 import { TooltipContent, TooltipContentProps } from 'components/GlossaryElement'
 import Tooltip from 'components/Tooltip'
 import { Link as GatsbyLink } from 'gatsby'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import usePostHog from '../../hooks/usePostHog'
 import { IconArrowUpRight } from '@posthog/icons'
 import ContextMenu, { ContextMenuItemProps } from 'components/RadixUI/ContextMenu'
 import { useApp } from '../../context/App'
 import { useWindow } from '../../context/Window'
+import Browser from 'components/Browser'
+
+type IframeStatus = 'unknown' | 'checking' | 'allowed' | 'blocked'
+
+const iframeStatusCache = new Map<string, 'allowed' | 'blocked'>()
+const iframeStatusInflight = new Map<string, Promise<'allowed' | 'blocked'>>()
+
+function isCheckableHttpUrl(url: string): boolean {
+    try {
+        const u = new URL(url)
+        return u.protocol === 'http:' || u.protocol === 'https:'
+    } catch {
+        return false
+    }
+}
+
+function fetchIframeStatus(url: string): Promise<'allowed' | 'blocked'> {
+    const cached = iframeStatusCache.get(url)
+    if (cached) return Promise.resolve(cached)
+    const inflight = iframeStatusInflight.get(url)
+    if (inflight) return inflight
+    const request = fetch(`/api/check-iframe?url=${encodeURIComponent(url)}`)
+        .then((r) => (r.ok ? r.json() : { allowed: false }))
+        .then((d: { allowed?: boolean }): 'allowed' | 'blocked' => (d?.allowed ? 'allowed' : 'blocked'))
+        .catch((): 'allowed' | 'blocked' => 'blocked')
+        .then((status) => {
+            iframeStatusCache.set(url, status)
+            iframeStatusInflight.delete(url)
+            return status
+        })
+    iframeStatusInflight.set(url, request)
+    return request
+}
 
 // Helper function to create standard context menu items
-const createStandardMenuItems = (url: string, state?: any, isExternal = false): ContextMenuItemProps[] => {
+const createStandardMenuItems = (
+    url: string,
+    state?: any,
+    isExternal = false,
+    canOpenExternalInWindow = false,
+    openExternalInWindow?: () => void
+): ContextMenuItemProps[] => {
     const fullUrl = url?.startsWith('/') ? `https://posthog.com${url}` : url
 
     return [
         {
             type: 'item',
-            disabled: isExternal,
+            disabled: isExternal && !canOpenExternalInWindow,
             children: isExternal ? (
-                <span>Open in new PostHog window</span>
+                canOpenExternalInWindow ? (
+                    <span onClick={openExternalInWindow}>Open in new PostHog window</span>
+                ) : (
+                    <span>Open in new PostHog window</span>
+                )
             ) : (
                 <Link to={url} state={{ ...state, newWindow: true }} contextMenu={false}>
                     Open in new PostHog window
@@ -111,7 +154,7 @@ export default function Link({
     ...other
 }: Props): JSX.Element {
     const { appWindow } = useWindow()
-    const { posthogInstance, compact } = useApp()
+    const { posthogInstance, compact, addWindow } = useApp()
     const posthog = usePostHog()
     const locationHref = appWindow?.element?.props?.location?.href
     const initialUrl = to || href
@@ -163,11 +206,69 @@ export default function Link({
         !internal || !!external || !!externalNoIcon || (url && !url.startsWith('/') && !url.includes('posthog.com'))
     )
 
+    const checkableExternalUrl = isExternal && url && isCheckableHttpUrl(url) ? url : null
+    const [iframeStatus, setIframeStatus] = useState<IframeStatus>(() =>
+        checkableExternalUrl ? iframeStatusCache.get(checkableExternalUrl) || 'unknown' : 'unknown'
+    )
+    const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    useEffect(() => {
+        if (!checkableExternalUrl) {
+            setIframeStatus('unknown')
+            return
+        }
+        const cached = iframeStatusCache.get(checkableExternalUrl)
+        if (cached) setIframeStatus(cached)
+    }, [checkableExternalUrl])
+
+    useEffect(
+        () => () => {
+            if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current)
+        },
+        []
+    )
+
+    const handlePreflightHover = () => {
+        if (!checkableExternalUrl) return
+        if (iframeStatus !== 'unknown') return
+        if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current)
+        hoverTimerRef.current = setTimeout(() => {
+            setIframeStatus('checking')
+            fetchIframeStatus(checkableExternalUrl).then(setIframeStatus)
+        }, 150)
+    }
+
+    const handlePreflightLeave = () => {
+        if (hoverTimerRef.current) {
+            clearTimeout(hoverTimerRef.current)
+            hoverTimerRef.current = null
+        }
+    }
+
+    const openExternalInWindow = checkableExternalUrl
+        ? () => {
+              addWindow(
+                  <Browser
+                      url={checkableExternalUrl}
+                      location={{ pathname: `browser:${checkableExternalUrl}` }}
+                      key={`browser:${checkableExternalUrl}`}
+                      newWindow
+                  />
+              )
+          }
+        : undefined
+
     // Create context menu items
     const menuItems =
         contextMenu && url
             ? [
-                  ...createStandardMenuItems(url, state, isExternal),
+                  ...createStandardMenuItems(
+                      url,
+                      state,
+                      isExternal,
+                      iframeStatus === 'allowed' && !!openExternalInWindow,
+                      openExternalInWindow
+                  ),
                   ...(customMenuItems.length > 0 ? [{ type: 'separator' as const }, ...customMenuItems] : []),
               ]
             : []
@@ -207,6 +308,8 @@ export default function Link({
                 <a
                     rel="noopener noreferrer"
                     onClick={handleClick}
+                    onMouseEnter={handlePreflightHover}
+                    onMouseLeave={handlePreflightLeave}
                     {...other}
                     href={url}
                     className={`${className} group`}
@@ -260,6 +363,8 @@ export default function Link({
                 <a
                     rel="noopener noreferrer"
                     onClick={handleClick}
+                    onMouseEnter={handlePreflightHover}
+                    onMouseLeave={handlePreflightLeave}
                     {...other}
                     href={url}
                     className={`${className} group`}

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1043,6 +1043,22 @@ const appSettings: AppSettings = {
             center: true,
         },
     },
+    browser: {
+        size: {
+            min: {
+                width: 600,
+                height: 500,
+            },
+            max: {
+                width: 1100,
+                height: 800,
+            },
+            fixed: false,
+        },
+        position: {
+            center: true,
+        },
+    },
     'media-upload': {
         size: {
             min: {
@@ -1689,6 +1705,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
     }
 
     function getKey(key: string) {
+        if (key?.startsWith('browser:')) return 'browser'
         const experiment = appSettings[key]?.experiment
         if (!experiment?.flag) return key
         const assignedVariant = posthog?.getFeatureFlag?.(experiment?.flag)


### PR DESCRIPTION
## Summary

Today, when you right-click an external link on posthog.com, "Open in new PostHog window" is unconditionally disabled, because most external sites refuse to be embedded in an iframe. Per Michael's Slack idea, we can be smarter:

1. **On hover, preflight the link** — a tiny serverless function checks the target's `X-Frame-Options` and `Content-Security-Policy: frame-ancestors` server-side.
2. **If the site allows being framed by posthog.com**, the menu item is enabled. Clicking it opens the URL inside a new browser-like window in the OS UI (rather than a separate browser tab).

Sites that block iframing (most of them — Google, GitHub, Twitter…) keep the existing disabled state, so the menu layout stays consistent (Cory's concern).

### Pieces

- **`api/check-iframe.js`** — serverless preflight. HEAD request (falls back to GET on 405/501), 5s timeout, follows redirects, refuses private/loopback hosts (SSRF guard), 1h `s-maxage` cache. Parses `frame-ancestors` and `X-Frame-Options` (DENY / SAMEORIGIN / ALLOW-FROM) and replies `{ allowed, reason? }`.
- **`src/components/Browser/index.tsx`** — minimal browser-style chrome with reload, URL display, "open in tab", close, and a sandboxed iframe (`allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads`; no `allow-top-navigation`).
- **`src/components/Link/index.tsx`** — on `mouseenter` of an external `<a>`, a 150ms-debounced preflight fires. Results are cached in a module-level `Map<url, status>` so subsequent hovers and other Link instances pointing at the same URL skip the fetch. When `iframeStatus === 'allowed'`, the menu item becomes a `<span onClick>` that calls `addWindow(<Browser url={...} />)`. Otherwise the existing disabled state stands.
- **`src/context/App.tsx`** — a `browser` app setting (600×500 min, 1100×800 max, centered) plus a `getKey` mapping so `browser:<url>` element keys (unique per URL → unique window) resolve to the shared sizing/position config.

### Notes / trade-offs

- The preflight only fires for `http(s)://` external links — mailto:, tel:, javascript:, posthog.com URLs, and internal Gatsby links are unaffected.
- Hover-only triggering means keyboard-only users opening the context menu via Shift+F10 will see the disabled state. Acceptable for now; can be extended to `onFocus` / `onContextMenu` if needed.
- In Gatsby dev (no Vercel functions), `/api/check-iframe` 404s and the option stays disabled — matches existing behavior.
- `allow-same-origin` in the sandbox is intentional: cross-origin iframes don't gain anything dangerous from it, and many sites break without it. `allow-top-navigation` is **not** set, so embedded pages can't escape to `window.top`.

## Test plan

- [ ] In production (or `vercel dev`), hover a link to a known iframe-friendly site → right-click → "Open in new PostHog window" is enabled → click it → Browser window opens with the page rendered in an iframe.
- [ ] Hover a link to a site that sets `X-Frame-Options: DENY` (e.g. github.com) → option stays disabled.
- [ ] Hover a link to a site with `Content-Security-Policy: frame-ancestors 'none'` (e.g. twitter.com) → option stays disabled.
- [ ] Hover the same external URL twice in one session → second hover does not refetch (Map cache hit).
- [ ] Hover many external links quickly while moving the mouse past them — confirm the 150ms debounce prevents request floods.
- [ ] `curl /api/check-iframe?url=http://localhost:3000` → returns `{ allowed: false, reason: "private-host" }`.
- [ ] `curl /api/check-iframe?url=not-a-url` → 400.
- [ ] Reload button inside the Browser window remounts the iframe (key bump).
- [ ] Open two different external URLs in PostHog windows → each gets its own window (unique `browser:<url>` keys).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*