### PR TITLE
docs: remove beta status from CSP tracking page

### DIFF
--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: CSP Tracking (Beta)
+title: CSP Tracking
 sidebar: Docs
 showTitle: true
 ---
@@ -11,8 +11,6 @@ You can send reports of CSP rule violations to PostHog, which is useful for:
 * Warning when your website is under certain kinds of attack
 * Debugging problems when adding external scripts/media/etc to your site
 * Being confident that changes to your site haven't broken the loading of any resources
-
-> **Note:** CSP Tracking is currently in beta. Give feedback by [raising an issue](https://github.com/PostHog/posthog/issues/new?labels=feature%2Fcsp-tracking).
 
 ## Where do I start?
 


### PR DESCRIPTION
## Summary

- `/docs/csp-tracking` was still labeled as beta. Removed the `(Beta)` suffix from the frontmatter title and the in-body beta note.

## Test plan

- [ ] Verify the rendered page at `/docs/csp-tracking` no longer shows "Beta" in the H1 or the body