### PR TITLE
Remove ISO 27001 claim from DPA page

### DIFF
--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -731,7 +731,7 @@ function DpaGenerator() {
                             <h3>Security (because we're not mid)</h3>
                             <p>
                                 We keep your data locked down: encryption in transit and at rest, access controls,
-                                regular security reviews, the whole rizz. SOC 2, ISO 27001, HIPAA — we understood the
+                                regular security reviews, the whole rizz. SOC 2 and HIPAA — we understood the
                                 assignment.
                             </p>
 


### PR DESCRIPTION
## Summary

PostHog is not ISO 27001 certified, but the gen-z TL;DR section on `/dpa` claimed we were. Drops the mention so we don't overstate our certifications. SOC 2 and HIPAA stay since those are legit.

Reported by Fraser Hopper.

## Changes

- `src/pages/dpa.tsx`: changed "SOC 2, ISO 27001, HIPAA — we understood the assignment." to "SOC 2 and HIPAA — we understood the assignment."

## Test plan

- [ ] Visit `/dpa`, scroll to the gen-z TL;DR section, confirm the "Security (because we're not mid)" paragraph no longer mentions ISO 27001

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*