### PR TITLE
docs: document open-in-posthog deep links for provisioning partners

### DIFF
--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -204,7 +204,7 @@ The `requires_auth` flow isn't only for first-time onboarding. Use the same hand
 
 For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. When the logged-in PostHog session matches the email you sent, PostHog completes the OAuth handshake and lands the user in their project.
 
-If the session is for a different PostHog account, PostHog currently drops the user back on their PostHog homepage without a helpful prompt. To make the mismatch case obvious before the click, surface the expected PostHog email in your own UI – for example, a button labeled _"Open in PostHog as user@example.com"_ or a small line of helper text. That gives users a chance to log out and switch accounts before getting confused.
+If the session is for a different PostHog account, PostHog shows an "Account mismatch" page with a one-click "Log out and continue as <expected email>" button that resumes the flow after re-login. To smooth this case even further – so users can self-diagnose before they click – consider also surfacing the expected PostHog email in your own UI, for example a button labeled _"Open in PostHog as user@example.com"_.
 
 ##### Don't link directly to project URLs
 

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -204,7 +204,7 @@ The `requires_auth` flow isn't only for first-time onboarding. Use the same hand
 
 For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. When the logged-in PostHog session matches the email you sent, PostHog completes the OAuth handshake and lands the user in their project.
 
-If the session is for a different PostHog account, PostHog shows an "Account mismatch" page with a one-click "Log out and continue as <expected email>" button that resumes the flow after re-login. To smooth this case even further – so users can self-diagnose before they click – consider also surfacing the expected PostHog email in your own UI, for example a button labeled _"Open in PostHog as user@example.com"_.
+If the session is for a different PostHog account, PostHog shows an "Account mismatch" page with a one-click `Log out and continue as <expected email>` button that resumes the flow after re-login. To smooth this case even further – so users can self-diagnose before they click – consider also surfacing the expected PostHog email in your own UI, for example a button labeled _"Open in PostHog as user@example.com"_.
 
 ##### Avoid linking directly to project URLs
 

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -198,17 +198,17 @@ sequenceDiagram
     PH-->>P: project token + host
 ```
 
-#### Open in PostHog buttons and other deep links
+#### Deep linking
 
-The `requires_auth` flow isn't only for first-time onboarding. Use the same handshake every time you want to deep-link a user from your own dashboard into PostHog (for example, an "Open in PostHog" button on their connected project).
+The `requires_auth` flow isn't only for first-time onboarding. Use the same handshake every time you want to deep-link a user from your own application into PostHog. A common case is an "Open in PostHog" button on the project a user has already connected: each click should run the handshake again, not point at a static PostHog URL.
 
 For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. When the logged-in PostHog session matches the email you sent, PostHog completes the OAuth handshake and lands the user in their project.
 
 If the session is for a different PostHog account, PostHog shows an "Account mismatch" page with a one-click "Log out and continue as <expected email>" button that resumes the flow after re-login. To smooth this case even further – so users can self-diagnose before they click – consider also surfacing the expected PostHog email in your own UI, for example a button labeled _"Open in PostHog as user@example.com"_.
 
-##### Don't link directly to project URLs
+##### Avoid linking directly to project URLs
 
-It's tempting to skip the handshake and point your button straight at `https://us.posthog.com/project/<id>`. Don't:
+Pointing a button straight at `https://us.posthog.com/project/<id>` skips the handshake and removes PostHog's ability to route the user safely:
 
 - If the user is logged into PostHog with a different email, they hit a permission error or 404 on a project their current account can't access.
 - If they're logged out, they get the generic PostHog login page with no context about which email to use.

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -198,6 +198,21 @@ sequenceDiagram
     PH-->>P: project token + host
 ```
 
+#### Open in PostHog buttons and other deep links
+
+The `requires_auth` flow isn't only for first-time onboarding. Use the same handshake every time you want to deep-link a user from your own dashboard into PostHog (for example, an "Open in PostHog" button on their connected project).
+
+For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. PostHog verifies the browser session matches the email you sent before completing the OAuth handshake.
+
+##### Don't link directly to project URLs
+
+It's tempting to skip the handshake and point your button straight at `https://us.posthog.com/project/<id>`. Don't:
+
+- If the user is logged into PostHog with a different email, they hit a permission error or 404 on a project their current account can't access, with no hint about which email they should be using.
+- If they're logged out, they get the generic PostHog login page with no context about which email to use.
+
+Going through `/account_requests` lets PostHog verify the logged-in user's email matches the one you sent. On mismatch, PostHog prompts them to log out and sign in with the right email before continuing.
+
 ### Step 2: Exchange the code for tokens
 
 Exchange the authorization code for an access token and refresh token. The token endpoint uses standard `application/x-www-form-urlencoded` encoding.

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -202,16 +202,18 @@ sequenceDiagram
 
 The `requires_auth` flow isn't only for first-time onboarding. Use the same handshake every time you want to deep-link a user from your own dashboard into PostHog (for example, an "Open in PostHog" button on their connected project).
 
-For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. PostHog verifies the browser session matches the email you sent before completing the OAuth handshake.
+For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. When the logged-in PostHog session matches the email you sent, PostHog completes the OAuth handshake and lands the user in their project.
+
+If the session is for a different PostHog account, PostHog currently drops the user back on their PostHog homepage without a helpful prompt. To make the mismatch case obvious before the click, surface the expected PostHog email in your own UI – for example, a button labeled _"Open in PostHog as user@example.com"_ or a small line of helper text. That gives users a chance to log out and switch accounts before getting confused.
 
 ##### Don't link directly to project URLs
 
 It's tempting to skip the handshake and point your button straight at `https://us.posthog.com/project/<id>`. Don't:
 
-- If the user is logged into PostHog with a different email, they hit a permission error or 404 on a project their current account can't access, with no hint about which email they should be using.
+- If the user is logged into PostHog with a different email, they hit a permission error or 404 on a project their current account can't access.
 - If they're logged out, they get the generic PostHog login page with no context about which email to use.
 
-Going through `/account_requests` lets PostHog verify the logged-in user's email matches the one you sent. On mismatch, PostHog prompts them to log out and sign in with the right email before continuing.
+Going through `/account_requests` keeps routing scoped to the email you sent.
 
 ### Step 2: Exchange the code for tokens
 


### PR DESCRIPTION
## Changes

Adds a subsection under [Step 1](https://posthog.com/docs/integrate/provisioning#step-1-create-an-account) of the Provisioning API docs covering how partners should build "Open in PostHog" buttons and other dashboard-to-PostHog deep links.

Two things the docs previously missed:

1. The `requires_auth` handshake isn't only for first-time onboarding – it's also the right primitive for recurring deep links from a partner UI.
2. The flow does an email-match check between the logged-in PostHog session and the email the partner sent. On mismatch, PostHog now renders a dedicated "Account mismatch" page (shipping in https://github.com/PostHog/posthog/pull/58880) with a one-click "Log out and continue as <expected email>" button.

Without these two pieces, partners end up hardcoding `us.posthog.com/project/<id>` URLs in their UI, which silently sends users to the wrong account or a 404.

## Dependency

This PR describes behavior that ships in https://github.com/PostHog/posthog/pull/58880. **Please don't merge until that PR is deployed**, otherwise the mismatch-page wording will be inaccurate (today the redirect goes to the homepage with no useful prompt).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links (no internal links added)
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)