### PR TITLE
Add MCP tool callouts to API endpoint docs

### DIFF
--- a/gatsby/onPreBootstrap.ts
+++ b/gatsby/onPreBootstrap.ts
@@ -96,7 +96,7 @@ posthog.init("${process.env.GATSBY_POSTHOG_API_KEY}", {
 
     // Cache the data if successful
     if (!mcpToolsData.error && mcpToolsData.categories) {
-        await cache.set(MCP_TOOLS_CACHE_KEY, mcpToolsData.categories)
+        await cache.set(MCP_TOOLS_CACHE_KEY, mcpToolsData)
     }
 
     if (process.env.POSTHOG_APP_API_KEY && !(await cache.get(PAGEVIEW_CACHE_KEY))) {

--- a/gatsby/utils/fetchMCPTools.ts
+++ b/gatsby/utils/fetchMCPTools.ts
@@ -8,6 +8,8 @@ const MCP_TOOLS_URL =
 interface MCPTool {
     category?: string
     summary: string
+    description?: string
+    required_scopes?: string[]
 }
 
 interface ToolCategory {
@@ -18,10 +20,20 @@ interface ToolCategory {
     }>
 }
 
-export async function fetchAndProcessMCPTools(): Promise<{
+interface ToolByName {
+    summary: string
+    description?: string
+    category?: string
+    required_scopes?: string[]
+}
+
+export interface MCPToolsData {
     categories: ToolCategory[] | null
+    byName: Record<string, ToolByName> | null
     error: boolean
-}> {
+}
+
+export async function fetchAndProcessMCPTools(): Promise<MCPToolsData> {
     try {
         const response = await fetch(MCP_TOOLS_URL)
 
@@ -33,6 +45,7 @@ export async function fetchAndProcessMCPTools(): Promise<{
 
         // Process the tools into categories
         const toolCategories: Record<string, Array<{ name: string; summary: string }>> = {}
+        const byName: Record<string, ToolByName> = {}
 
         Object.entries(mcpTools).forEach(([toolName, toolDef]) => {
             const category = toolDef.category || 'Uncategorized'
@@ -43,6 +56,12 @@ export async function fetchAndProcessMCPTools(): Promise<{
                 name: toolName,
                 summary: toolDef.summary,
             })
+            byName[toolName] = {
+                summary: toolDef.summary,
+                description: toolDef.description,
+                category: toolDef.category,
+                required_scopes: toolDef.required_scopes,
+            }
         })
 
         // Sort tools within each category alphabetically
@@ -57,18 +76,20 @@ export async function fetchAndProcessMCPTools(): Promise<{
 
         return {
             categories: categoriesArray,
+            byName,
             error: false,
         }
     } catch (error) {
         console.error('Error fetching MCP tools:', error)
         return {
             categories: null,
+            byName: null,
             error: true,
         }
     }
 }
 
-export function writeMCPToolsToFile(data: { categories: ToolCategory[] | null; error: boolean }): void {
+export function writeMCPToolsToFile(data: MCPToolsData): void {
     const mcpToolsPath = path.resolve(__dirname, '../../src/data/mcp-tools.json')
     fs.mkdirSync(path.dirname(mcpToolsPath), { recursive: true })
     fs.writeFileSync(mcpToolsPath, JSON.stringify(data, null, 2))

--- a/scripts/generate-mcp-rest-mapping-candidates.js
+++ b/scripts/generate-mcp-rest-mapping-candidates.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 /*
  * One-shot helper to suggest entries for src/data/mcp-rest-mapping.json.
  *
@@ -40,10 +43,7 @@ function get(url, headers = {}) {
 }
 
 async function main() {
-    const [specBody, toolsBody] = await Promise.all([
-        get(SPEC_URL, { Accept: 'application/json' }),
-        get(TOOLS_URL),
-    ])
+    const [specBody, toolsBody] = await Promise.all([get(SPEC_URL, { Accept: 'application/json' }), get(TOOLS_URL)])
 
     let spec
     try {

--- a/scripts/generate-mcp-rest-mapping-candidates.js
+++ b/scripts/generate-mcp-rest-mapping-candidates.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/*
+ * One-shot helper to suggest entries for src/data/mcp-rest-mapping.json.
+ *
+ * Fetches the live OpenAPI spec and the MCP tool definitions, finds operationIds
+ * whose direct `_` → `-` transformation matches an existing MCP tool name, and
+ * prints a JSON blob of NEW candidates (i.e. not already in the mapping file).
+ *
+ * Output is meant to be reviewed by a human before pasting into the mapping
+ * file. The script never writes to the mapping file directly.
+ *
+ * Usage:
+ *   node scripts/generate-mcp-rest-mapping-candidates.js
+ *   node scripts/generate-mcp-rest-mapping-candidates.js --merge   # writes merged file
+ */
+
+const fs = require('fs')
+const path = require('path')
+const https = require('https')
+
+const SPEC_URL = process.env.POSTHOG_OPEN_API_SPEC_URL || 'https://app.posthog.com/api/schema/'
+const TOOLS_URL =
+    'https://raw.githubusercontent.com/PostHog/posthog/refs/heads/master/services/mcp/schema/tool-definitions-all.json'
+const MAPPING_FILE = path.resolve(__dirname, '../src/data/mcp-rest-mapping.json')
+
+function get(url, headers = {}) {
+    return new Promise((resolve, reject) => {
+        https
+            .get(url, { headers }, (res) => {
+                if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                    resolve(get(res.headers.location, headers))
+                    return
+                }
+                let body = ''
+                res.on('data', (c) => (body += c))
+                res.on('end', () => resolve(body))
+            })
+            .on('error', reject)
+    })
+}
+
+async function main() {
+    const [specBody, toolsBody] = await Promise.all([
+        get(SPEC_URL, { Accept: 'application/json' }),
+        get(TOOLS_URL),
+    ])
+
+    let spec
+    try {
+        spec = JSON.parse(specBody)
+    } catch {
+        console.error('Failed to parse OpenAPI spec as JSON. Try setting POSTHOG_OPEN_API_SPEC_URL to a JSON variant.')
+        process.exit(1)
+    }
+    const tools = JSON.parse(toolsBody)
+    const toolNames = new Set(Object.keys(tools))
+
+    const operationIds = []
+    for (const methods of Object.values(spec.paths || {})) {
+        for (const op of Object.values(methods)) {
+            if (op && typeof op === 'object' && op.operationId) {
+                operationIds.push(op.operationId)
+            }
+        }
+    }
+
+    const existing = fs.existsSync(MAPPING_FILE) ? JSON.parse(fs.readFileSync(MAPPING_FILE, 'utf8')) : {}
+
+    const candidates = {}
+    for (const opId of operationIds) {
+        const candidate = opId.replace(/_/g, '-')
+        if (toolNames.has(candidate) && !existing[opId]) {
+            candidates[opId] = [candidate]
+        }
+    }
+
+    console.log(`Spec ops: ${operationIds.length}`)
+    console.log(`MCP tools: ${toolNames.size}`)
+    console.log(`Existing mappings: ${Object.keys(existing).length}`)
+    console.log(`New direct-match candidates: ${Object.keys(candidates).length}`)
+    console.log('')
+
+    if (Object.keys(candidates).length === 0) {
+        console.log('No new candidates.')
+        return
+    }
+
+    if (process.argv.includes('--merge')) {
+        const merged = { ...existing, ...candidates }
+        const sorted = Object.fromEntries(Object.entries(merged).sort(([a], [b]) => a.localeCompare(b)))
+        fs.writeFileSync(MAPPING_FILE, JSON.stringify(sorted, null, 2) + '\n')
+        console.log(`Wrote ${Object.keys(merged).length} entries to ${MAPPING_FILE}`)
+    } else {
+        console.log('Candidate JSON (paste into src/data/mcp-rest-mapping.json after review):')
+        console.log(JSON.stringify(candidates, null, 2))
+        console.log('')
+        console.log('Or run with --merge to write directly.')
+    }
+}
+
+main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/src/components/Docs/MCPCallout.tsx
+++ b/src/components/Docs/MCPCallout.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import mcpRestMapping from '../../data/mcp-rest-mapping.json'
+import mcpToolsData from '../../data/mcp-tools.json'
+
+interface ToolByName {
+    summary: string
+    description?: string
+    category?: string
+    required_scopes?: string[]
+}
+
+interface MCPToolsData {
+    byName?: Record<string, ToolByName> | null
+    error?: boolean
+}
+
+interface MCPCalloutProps {
+    operationId: string
+}
+
+const MCPCallout: React.FC<MCPCalloutProps> = ({ operationId }) => {
+    const mapping = mcpRestMapping as Record<string, string[]>
+    const toolNames = mapping[operationId]
+    if (!toolNames || toolNames.length === 0) {
+        return null
+    }
+
+    const { byName } = mcpToolsData as MCPToolsData
+    const matched = toolNames
+        .map((name) => ({ name, info: byName?.[name] }))
+        .filter((t): t is { name: string; info: ToolByName } => Boolean(t.info))
+
+    if (matched.length === 0) {
+        return null
+    }
+
+    return (
+        <blockquote className="p-4 mb-4 rounded bg-accent border-l-4 border-yellow not-prose">
+            <p className="text-sm font-semibold mb-2">
+                Also available via the{' '}
+                <a href="/docs/model-context-protocol">PostHog MCP server</a>:
+            </p>
+            <ul className="m-0 p-0 list-none space-y-1">
+                {matched.map(({ name, info }) => (
+                    <li key={name} className="text-sm">
+                        <code>{name}</code>
+                        {info.summary ? <> — {info.summary}</> : null}
+                    </li>
+                ))}
+            </ul>
+        </blockquote>
+    )
+}
+
+export default MCPCallout

--- a/src/data/mcp-rest-mapping.json
+++ b/src/data/mcp-rest-mapping.json
@@ -1,413 +1,140 @@
 {
-  "activity_log_list": [
-    "activity-log-list"
-  ],
-  "advanced_activity_logs_list": [
-    "advanced-activity-logs-list"
-  ],
-  "alerts_list": [
-    "alerts-list"
-  ],
-  "annotations_create": [
-    "annotation-create"
-  ],
-  "annotations_destroy": [
-    "annotation-delete"
-  ],
-  "annotations_list": [
-    "annotations-list"
-  ],
-  "annotations_partial_update": [
-    "annotations-partial-update"
-  ],
-  "annotations_retrieve": [
-    "annotation-retrieve"
-  ],
-  "approval_policies_list": [
-    "approval-policies-list"
-  ],
-  "batch_exports_list": [
-    "batch-exports-list"
-  ],
-  "change_requests_list": [
-    "change-requests-list"
-  ],
-  "cohorts_add_persons_to_static_cohort_partial_update": [
-    "cohorts-add-persons-to-static-cohort-partial-update"
-  ],
-  "cohorts_create": [
-    "cohorts-create"
-  ],
-  "cohorts_list": [
-    "cohorts-list"
-  ],
-  "cohorts_partial_update": [
-    "cohorts-partial-update"
-  ],
-  "cohorts_retrieve": [
-    "cohorts-retrieve"
-  ],
-  "comments_list": [
-    "comments-list"
-  ],
-  "conversations_tickets_list": [
-    "conversations-tickets-list"
-  ],
-  "conversations_tickets_retrieve": [
-    "conversations-tickets-retrieve"
-  ],
-  "conversations_tickets_update": [
-    "conversations-tickets-update"
-  ],
-  "dashboards_create": [
-    "dashboard-create"
-  ],
-  "dashboards_destroy": [
-    "dashboard-delete"
-  ],
-  "dashboards_list": [
-    "dashboards-get-all"
-  ],
-  "dashboards_partial_update": [
-    "dashboard-update"
-  ],
-  "dashboards_retrieve": [
-    "dashboard-get"
-  ],
-  "data_warehouse_data_health_issues_retrieve": [
-    "data-warehouse-data-health-issues-retrieve"
-  ],
-  "docs_search": [
-    "docs-search"
-  ],
-  "early_access_feature_create": [
-    "early-access-feature-create"
-  ],
-  "early_access_feature_destroy": [
-    "early-access-feature-destroy"
-  ],
-  "early_access_feature_list": [
-    "early-access-feature-list"
-  ],
-  "early_access_feature_partial_update": [
-    "early-access-feature-partial-update"
-  ],
-  "early_access_feature_retrieve": [
-    "early-access-feature-retrieve"
-  ],
-  "error_tracking_assignment_rules_create": [
-    "error-tracking-assignment-rules-create"
-  ],
-  "error_tracking_assignment_rules_list": [
-    "error-tracking-assignment-rules-list"
-  ],
-  "error_tracking_grouping_rules_create": [
-    "error-tracking-grouping-rules-create"
-  ],
-  "error_tracking_grouping_rules_list": [
-    "error-tracking-grouping-rules-list"
-  ],
-  "error_tracking_issues_merge_create": [
-    "error-tracking-issues-merge-create"
-  ],
-  "error_tracking_issues_partial_update": [
-    "error-tracking-issues-partial-update"
-  ],
-  "error_tracking_issues_split_create": [
-    "error-tracking-issues-split-create"
-  ],
-  "error_tracking_suppression_rules_create": [
-    "error-tracking-suppression-rules-create"
-  ],
-  "error_tracking_suppression_rules_list": [
-    "error-tracking-suppression-rules-list"
-  ],
-  "error_tracking_symbol_sets_download_retrieve": [
-    "error-tracking-symbol-sets-download-retrieve"
-  ],
-  "error_tracking_symbol_sets_list": [
-    "error-tracking-symbol-sets-list"
-  ],
-  "error_tracking_symbol_sets_retrieve": [
-    "error-tracking-symbol-sets-retrieve"
-  ],
-  "event_definitions_list": [
-    "event-definitions-list"
-  ],
-  "experiment_saved_metrics_create": [
-    "experiment-saved-metrics-create"
-  ],
-  "experiment_saved_metrics_destroy": [
-    "experiment-saved-metrics-destroy"
-  ],
-  "experiment_saved_metrics_list": [
-    "experiment-saved-metrics-list"
-  ],
-  "experiment_saved_metrics_partial_update": [
-    "experiment-saved-metrics-partial-update"
-  ],
-  "experiment_saved_metrics_retrieve": [
-    "experiment-saved-metrics-retrieve"
-  ],
-  "experiments_create": [
-    "experiment-create"
-  ],
-  "experiments_partial_update": [
-    "experiment-update"
-  ],
-  "experiments_retrieve": [
-    "experiment-get"
-  ],
-  "external_data_schemas_incremental_fields_create": [
-    "external-data-schemas-incremental-fields-create"
-  ],
-  "external_data_schemas_list": [
-    "external-data-schemas-list"
-  ],
-  "external_data_schemas_partial_update": [
-    "external-data-schemas-partial-update"
-  ],
-  "external_data_schemas_retrieve": [
-    "external-data-schemas-retrieve"
-  ],
-  "external_data_sources_check_cdc_prerequisites_create": [
-    "external-data-sources-check-cdc-prerequisites-create"
-  ],
-  "external_data_sources_create": [
-    "external-data-sources-create"
-  ],
-  "external_data_sources_create_webhook_create": [
-    "external-data-sources-create-webhook-create"
-  ],
-  "external_data_sources_delete_webhook_create": [
-    "external-data-sources-delete-webhook-create"
-  ],
-  "external_data_sources_destroy": [
-    "external-data-sources-destroy"
-  ],
-  "external_data_sources_list": [
-    "external-data-sources-list"
-  ],
-  "external_data_sources_partial_update": [
-    "external-data-sources-partial-update"
-  ],
-  "external_data_sources_retrieve": [
-    "external-data-sources-retrieve"
-  ],
-  "external_data_sources_update_webhook_inputs_create": [
-    "external-data-sources-update-webhook-inputs-create"
-  ],
-  "external_data_sources_webhook_info_retrieve": [
-    "external-data-sources-webhook-info-retrieve"
-  ],
-  "feature_flags_activity_retrieve": [
-    "feature-flags-activity-retrieve"
-  ],
-  "feature_flags_create": [
-    "create-feature-flag"
-  ],
-  "feature_flags_destroy": [
-    "delete-feature-flag"
-  ],
-  "feature_flags_evaluation_reasons_retrieve": [
-    "feature-flags-evaluation-reasons-retrieve"
-  ],
-  "feature_flags_list": [
-    "feature-flag-get-all"
-  ],
-  "feature_flags_partial_update": [
-    "update-feature-flag"
-  ],
-  "feature_flags_retrieve": [
-    "feature-flag-get-definition"
-  ],
-  "feature_flags_status_retrieve": [
-    "feature-flags-status-retrieve"
-  ],
-  "feature_flags_test_evaluation_create": [
-    "feature-flags-test-evaluation-create"
-  ],
-  "feature_flags_user_blast_radius_create": [
-    "feature-flags-user-blast-radius-create"
-  ],
-  "hog_flows_logs_retrieve": [
-    "hog-flows-logs-retrieve"
-  ],
-  "hog_flows_metrics_retrieve": [
-    "hog-flows-metrics-retrieve"
-  ],
-  "insights_activity_retrieve": [
-    "insights-activity-retrieve"
-  ],
-  "insights_all_activity_retrieve": [
-    "insights-all-activity-retrieve"
-  ],
-  "insights_create": [
-    "insight-create"
-  ],
-  "insights_destroy": [
-    "insight-delete"
-  ],
-  "insights_list": [
-    "insights-list"
-  ],
-  "insights_partial_update": [
-    "insight-update"
-  ],
-  "insights_retrieve": [
-    "insight-get"
-  ],
-  "insights_trending_retrieve": [
-    "insights-trending-retrieve"
-  ],
-  "integrations_channels_retrieve": [
-    "integrations-channels-retrieve"
-  ],
-  "integrations_list": [
-    "integrations-list"
-  ],
-  "logs_alerts_create": [
-    "logs-alerts-create"
-  ],
-  "logs_alerts_destinations_create": [
-    "logs-alerts-destinations-create"
-  ],
-  "logs_alerts_destinations_delete_create": [
-    "logs-alerts-destinations-delete-create"
-  ],
-  "logs_alerts_destroy": [
-    "logs-alerts-destroy"
-  ],
-  "logs_alerts_events_list": [
-    "logs-alerts-events-list"
-  ],
-  "logs_alerts_list": [
-    "logs-alerts-list"
-  ],
-  "logs_alerts_partial_update": [
-    "logs-alerts-partial-update"
-  ],
-  "logs_alerts_retrieve": [
-    "logs-alerts-retrieve"
-  ],
-  "logs_alerts_simulate_create": [
-    "logs-alerts-simulate-create"
-  ],
-  "logs_services_create": [
-    "logs-services-create"
-  ],
-  "notebooks_create": [
-    "notebooks-create"
-  ],
-  "notebooks_destroy": [
-    "notebooks-destroy"
-  ],
-  "notebooks_list": [
-    "notebooks-list"
-  ],
-  "notebooks_partial_update": [
-    "notebooks-partial-update"
-  ],
-  "notebooks_retrieve": [
-    "notebooks-retrieve"
-  ],
-  "persons_cohorts_retrieve": [
-    "persons-cohorts-retrieve"
-  ],
-  "persons_list": [
-    "persons-list"
-  ],
-  "persons_retrieve": [
-    "persons-retrieve"
-  ],
-  "persons_values_retrieve": [
-    "persons-values-retrieve"
-  ],
-  "roles_list": [
-    "roles-list"
-  ],
-  "session_recording_playlists_list": [
-    "session-recording-playlists-list"
-  ],
-  "subscriptions_create": [
-    "subscriptions-create"
-  ],
-  "subscriptions_deliveries_list": [
-    "subscriptions-deliveries-list"
-  ],
-  "subscriptions_deliveries_retrieve": [
-    "subscriptions-deliveries-retrieve"
-  ],
-  "subscriptions_list": [
-    "subscriptions-list"
-  ],
-  "subscriptions_partial_update": [
-    "subscriptions-partial-update"
-  ],
-  "subscriptions_retrieve": [
-    "subscriptions-retrieve"
-  ],
-  "subscriptions_test_delivery_create": [
-    "subscriptions-test-delivery-create"
-  ],
-  "surveys_list": [
-    "surveys-get-all"
-  ],
-  "user_interview_topics_create": [
-    "user-interview-topics-create"
-  ],
-  "user_interview_topics_interviewees_create": [
-    "user-interview-topics-interviewees-create"
-  ],
-  "user_interview_topics_interviewees_destroy": [
-    "user-interview-topics-interviewees-destroy"
-  ],
-  "user_interview_topics_interviewees_list": [
-    "user-interview-topics-interviewees-list"
-  ],
-  "user_interview_topics_interviewees_partial_update": [
-    "user-interview-topics-interviewees-partial-update"
-  ],
-  "user_interview_topics_list": [
-    "user-interview-topics-list"
-  ],
-  "user_interview_topics_partial_update": [
-    "user-interview-topics-partial-update"
-  ],
-  "user_interview_topics_retrieve": [
-    "user-interview-topics-retrieve"
-  ],
-  "user_interviews_list": [
-    "user-interviews-list"
-  ],
-  "user_interviews_retrieve": [
-    "user-interviews-retrieve"
-  ],
-  "visual_review_repos_list": [
-    "visual-review-repos-list"
-  ],
-  "visual_review_repos_retrieve": [
-    "visual-review-repos-retrieve"
-  ],
-  "visual_review_runs_counts_retrieve": [
-    "visual-review-runs-counts-retrieve"
-  ],
-  "visual_review_runs_list": [
-    "visual-review-runs-list"
-  ],
-  "visual_review_runs_retrieve": [
-    "visual-review-runs-retrieve"
-  ],
-  "visual_review_runs_snapshot_history_list": [
-    "visual-review-runs-snapshot-history-list"
-  ],
-  "visual_review_runs_snapshots_list": [
-    "visual-review-runs-snapshots-list"
-  ],
-  "visual_review_runs_tolerated_hashes_list": [
-    "visual-review-runs-tolerated-hashes-list"
-  ],
-  "web_analytics_weekly_digest": [
-    "web-analytics-weekly-digest"
-  ]
+    "activity_log_list": ["activity-log-list"],
+    "advanced_activity_logs_list": ["advanced-activity-logs-list"],
+    "alerts_list": ["alerts-list"],
+    "annotations_create": ["annotation-create"],
+    "annotations_destroy": ["annotation-delete"],
+    "annotations_list": ["annotations-list"],
+    "annotations_partial_update": ["annotations-partial-update"],
+    "annotations_retrieve": ["annotation-retrieve"],
+    "approval_policies_list": ["approval-policies-list"],
+    "batch_exports_list": ["batch-exports-list"],
+    "change_requests_list": ["change-requests-list"],
+    "cohorts_add_persons_to_static_cohort_partial_update": ["cohorts-add-persons-to-static-cohort-partial-update"],
+    "cohorts_create": ["cohorts-create"],
+    "cohorts_list": ["cohorts-list"],
+    "cohorts_partial_update": ["cohorts-partial-update"],
+    "cohorts_retrieve": ["cohorts-retrieve"],
+    "comments_list": ["comments-list"],
+    "conversations_tickets_list": ["conversations-tickets-list"],
+    "conversations_tickets_retrieve": ["conversations-tickets-retrieve"],
+    "conversations_tickets_update": ["conversations-tickets-update"],
+    "dashboards_create": ["dashboard-create"],
+    "dashboards_destroy": ["dashboard-delete"],
+    "dashboards_list": ["dashboards-get-all"],
+    "dashboards_partial_update": ["dashboard-update"],
+    "dashboards_retrieve": ["dashboard-get"],
+    "data_warehouse_data_health_issues_retrieve": ["data-warehouse-data-health-issues-retrieve"],
+    "docs_search": ["docs-search"],
+    "early_access_feature_create": ["early-access-feature-create"],
+    "early_access_feature_destroy": ["early-access-feature-destroy"],
+    "early_access_feature_list": ["early-access-feature-list"],
+    "early_access_feature_partial_update": ["early-access-feature-partial-update"],
+    "early_access_feature_retrieve": ["early-access-feature-retrieve"],
+    "error_tracking_assignment_rules_create": ["error-tracking-assignment-rules-create"],
+    "error_tracking_assignment_rules_list": ["error-tracking-assignment-rules-list"],
+    "error_tracking_grouping_rules_create": ["error-tracking-grouping-rules-create"],
+    "error_tracking_grouping_rules_list": ["error-tracking-grouping-rules-list"],
+    "error_tracking_issues_merge_create": ["error-tracking-issues-merge-create"],
+    "error_tracking_issues_partial_update": ["error-tracking-issues-partial-update"],
+    "error_tracking_issues_split_create": ["error-tracking-issues-split-create"],
+    "error_tracking_suppression_rules_create": ["error-tracking-suppression-rules-create"],
+    "error_tracking_suppression_rules_list": ["error-tracking-suppression-rules-list"],
+    "error_tracking_symbol_sets_download_retrieve": ["error-tracking-symbol-sets-download-retrieve"],
+    "error_tracking_symbol_sets_list": ["error-tracking-symbol-sets-list"],
+    "error_tracking_symbol_sets_retrieve": ["error-tracking-symbol-sets-retrieve"],
+    "event_definitions_list": ["event-definitions-list"],
+    "experiment_saved_metrics_create": ["experiment-saved-metrics-create"],
+    "experiment_saved_metrics_destroy": ["experiment-saved-metrics-destroy"],
+    "experiment_saved_metrics_list": ["experiment-saved-metrics-list"],
+    "experiment_saved_metrics_partial_update": ["experiment-saved-metrics-partial-update"],
+    "experiment_saved_metrics_retrieve": ["experiment-saved-metrics-retrieve"],
+    "experiments_create": ["experiment-create"],
+    "experiments_partial_update": ["experiment-update"],
+    "experiments_retrieve": ["experiment-get"],
+    "external_data_schemas_incremental_fields_create": ["external-data-schemas-incremental-fields-create"],
+    "external_data_schemas_list": ["external-data-schemas-list"],
+    "external_data_schemas_partial_update": ["external-data-schemas-partial-update"],
+    "external_data_schemas_retrieve": ["external-data-schemas-retrieve"],
+    "external_data_sources_check_cdc_prerequisites_create": ["external-data-sources-check-cdc-prerequisites-create"],
+    "external_data_sources_create": ["external-data-sources-create"],
+    "external_data_sources_create_webhook_create": ["external-data-sources-create-webhook-create"],
+    "external_data_sources_delete_webhook_create": ["external-data-sources-delete-webhook-create"],
+    "external_data_sources_destroy": ["external-data-sources-destroy"],
+    "external_data_sources_list": ["external-data-sources-list"],
+    "external_data_sources_partial_update": ["external-data-sources-partial-update"],
+    "external_data_sources_retrieve": ["external-data-sources-retrieve"],
+    "external_data_sources_update_webhook_inputs_create": ["external-data-sources-update-webhook-inputs-create"],
+    "external_data_sources_webhook_info_retrieve": ["external-data-sources-webhook-info-retrieve"],
+    "feature_flags_activity_retrieve": ["feature-flags-activity-retrieve"],
+    "feature_flags_create": ["create-feature-flag"],
+    "feature_flags_destroy": ["delete-feature-flag"],
+    "feature_flags_evaluation_reasons_retrieve": ["feature-flags-evaluation-reasons-retrieve"],
+    "feature_flags_list": ["feature-flag-get-all"],
+    "feature_flags_my_flags_retrieve": ["feature-flags-my-flags-retrieve"],
+    "feature_flags_partial_update": ["update-feature-flag"],
+    "feature_flags_retrieve": ["feature-flag-get-definition"],
+    "feature_flags_status_retrieve": ["feature-flags-status-retrieve"],
+    "feature_flags_test_evaluation_create": ["feature-flags-test-evaluation-create"],
+    "feature_flags_user_blast_radius_create": ["feature-flags-user-blast-radius-create"],
+    "hog_flows_logs_retrieve": ["hog-flows-logs-retrieve"],
+    "hog_flows_metrics_retrieve": ["hog-flows-metrics-retrieve"],
+    "insights_activity_retrieve": ["insights-activity-retrieve"],
+    "insights_all_activity_retrieve": ["insights-all-activity-retrieve"],
+    "insights_create": ["insight-create"],
+    "insights_destroy": ["insight-delete"],
+    "insights_list": ["insights-list"],
+    "insights_partial_update": ["insight-update"],
+    "insights_retrieve": ["insight-get"],
+    "insights_trending_retrieve": ["insights-trending-retrieve"],
+    "integrations_channels_retrieve": ["integrations-channels-retrieve"],
+    "integrations_list": ["integrations-list"],
+    "logs_alerts_create": ["logs-alerts-create"],
+    "logs_alerts_destinations_create": ["logs-alerts-destinations-create"],
+    "logs_alerts_destinations_delete_create": ["logs-alerts-destinations-delete-create"],
+    "logs_alerts_destroy": ["logs-alerts-destroy"],
+    "logs_alerts_events_list": ["logs-alerts-events-list"],
+    "logs_alerts_list": ["logs-alerts-list"],
+    "logs_alerts_partial_update": ["logs-alerts-partial-update"],
+    "logs_alerts_retrieve": ["logs-alerts-retrieve"],
+    "logs_alerts_simulate_create": ["logs-alerts-simulate-create"],
+    "logs_services_create": ["logs-services-create"],
+    "notebooks_create": ["notebooks-create"],
+    "notebooks_destroy": ["notebooks-destroy"],
+    "notebooks_list": ["notebooks-list"],
+    "notebooks_partial_update": ["notebooks-partial-update"],
+    "notebooks_retrieve": ["notebooks-retrieve"],
+    "persons_cohorts_retrieve": ["persons-cohorts-retrieve"],
+    "persons_list": ["persons-list"],
+    "persons_retrieve": ["persons-retrieve"],
+    "persons_values_retrieve": ["persons-values-retrieve"],
+    "roles_list": ["roles-list"],
+    "session_recording_playlists_list": ["session-recording-playlists-list"],
+    "subscriptions_create": ["subscriptions-create"],
+    "subscriptions_deliveries_list": ["subscriptions-deliveries-list"],
+    "subscriptions_deliveries_retrieve": ["subscriptions-deliveries-retrieve"],
+    "subscriptions_list": ["subscriptions-list"],
+    "subscriptions_partial_update": ["subscriptions-partial-update"],
+    "subscriptions_retrieve": ["subscriptions-retrieve"],
+    "subscriptions_test_delivery_create": ["subscriptions-test-delivery-create"],
+    "surveys_list": ["surveys-get-all"],
+    "user_interview_topics_create": ["user-interview-topics-create"],
+    "user_interview_topics_interviewees_create": ["user-interview-topics-interviewees-create"],
+    "user_interview_topics_interviewees_destroy": ["user-interview-topics-interviewees-destroy"],
+    "user_interview_topics_interviewees_list": ["user-interview-topics-interviewees-list"],
+    "user_interview_topics_interviewees_partial_update": ["user-interview-topics-interviewees-partial-update"],
+    "user_interview_topics_list": ["user-interview-topics-list"],
+    "user_interview_topics_partial_update": ["user-interview-topics-partial-update"],
+    "user_interview_topics_retrieve": ["user-interview-topics-retrieve"],
+    "user_interviews_list": ["user-interviews-list"],
+    "user_interviews_retrieve": ["user-interviews-retrieve"],
+    "visual_review_repos_list": ["visual-review-repos-list"],
+    "visual_review_repos_retrieve": ["visual-review-repos-retrieve"],
+    "visual_review_runs_counts_retrieve": ["visual-review-runs-counts-retrieve"],
+    "visual_review_runs_list": ["visual-review-runs-list"],
+    "visual_review_runs_retrieve": ["visual-review-runs-retrieve"],
+    "visual_review_runs_snapshot_history_list": ["visual-review-runs-snapshot-history-list"],
+    "visual_review_runs_snapshots_list": ["visual-review-runs-snapshots-list"],
+    "visual_review_runs_tolerated_hashes_list": ["visual-review-runs-tolerated-hashes-list"],
+    "web_analytics_weekly_digest": ["web-analytics-weekly-digest"]
 }

--- a/src/data/mcp-rest-mapping.json
+++ b/src/data/mcp-rest-mapping.json
@@ -1,0 +1,413 @@
+{
+  "activity_log_list": [
+    "activity-log-list"
+  ],
+  "advanced_activity_logs_list": [
+    "advanced-activity-logs-list"
+  ],
+  "alerts_list": [
+    "alerts-list"
+  ],
+  "annotations_create": [
+    "annotation-create"
+  ],
+  "annotations_destroy": [
+    "annotation-delete"
+  ],
+  "annotations_list": [
+    "annotations-list"
+  ],
+  "annotations_partial_update": [
+    "annotations-partial-update"
+  ],
+  "annotations_retrieve": [
+    "annotation-retrieve"
+  ],
+  "approval_policies_list": [
+    "approval-policies-list"
+  ],
+  "batch_exports_list": [
+    "batch-exports-list"
+  ],
+  "change_requests_list": [
+    "change-requests-list"
+  ],
+  "cohorts_add_persons_to_static_cohort_partial_update": [
+    "cohorts-add-persons-to-static-cohort-partial-update"
+  ],
+  "cohorts_create": [
+    "cohorts-create"
+  ],
+  "cohorts_list": [
+    "cohorts-list"
+  ],
+  "cohorts_partial_update": [
+    "cohorts-partial-update"
+  ],
+  "cohorts_retrieve": [
+    "cohorts-retrieve"
+  ],
+  "comments_list": [
+    "comments-list"
+  ],
+  "conversations_tickets_list": [
+    "conversations-tickets-list"
+  ],
+  "conversations_tickets_retrieve": [
+    "conversations-tickets-retrieve"
+  ],
+  "conversations_tickets_update": [
+    "conversations-tickets-update"
+  ],
+  "dashboards_create": [
+    "dashboard-create"
+  ],
+  "dashboards_destroy": [
+    "dashboard-delete"
+  ],
+  "dashboards_list": [
+    "dashboards-get-all"
+  ],
+  "dashboards_partial_update": [
+    "dashboard-update"
+  ],
+  "dashboards_retrieve": [
+    "dashboard-get"
+  ],
+  "data_warehouse_data_health_issues_retrieve": [
+    "data-warehouse-data-health-issues-retrieve"
+  ],
+  "docs_search": [
+    "docs-search"
+  ],
+  "early_access_feature_create": [
+    "early-access-feature-create"
+  ],
+  "early_access_feature_destroy": [
+    "early-access-feature-destroy"
+  ],
+  "early_access_feature_list": [
+    "early-access-feature-list"
+  ],
+  "early_access_feature_partial_update": [
+    "early-access-feature-partial-update"
+  ],
+  "early_access_feature_retrieve": [
+    "early-access-feature-retrieve"
+  ],
+  "error_tracking_assignment_rules_create": [
+    "error-tracking-assignment-rules-create"
+  ],
+  "error_tracking_assignment_rules_list": [
+    "error-tracking-assignment-rules-list"
+  ],
+  "error_tracking_grouping_rules_create": [
+    "error-tracking-grouping-rules-create"
+  ],
+  "error_tracking_grouping_rules_list": [
+    "error-tracking-grouping-rules-list"
+  ],
+  "error_tracking_issues_merge_create": [
+    "error-tracking-issues-merge-create"
+  ],
+  "error_tracking_issues_partial_update": [
+    "error-tracking-issues-partial-update"
+  ],
+  "error_tracking_issues_split_create": [
+    "error-tracking-issues-split-create"
+  ],
+  "error_tracking_suppression_rules_create": [
+    "error-tracking-suppression-rules-create"
+  ],
+  "error_tracking_suppression_rules_list": [
+    "error-tracking-suppression-rules-list"
+  ],
+  "error_tracking_symbol_sets_download_retrieve": [
+    "error-tracking-symbol-sets-download-retrieve"
+  ],
+  "error_tracking_symbol_sets_list": [
+    "error-tracking-symbol-sets-list"
+  ],
+  "error_tracking_symbol_sets_retrieve": [
+    "error-tracking-symbol-sets-retrieve"
+  ],
+  "event_definitions_list": [
+    "event-definitions-list"
+  ],
+  "experiment_saved_metrics_create": [
+    "experiment-saved-metrics-create"
+  ],
+  "experiment_saved_metrics_destroy": [
+    "experiment-saved-metrics-destroy"
+  ],
+  "experiment_saved_metrics_list": [
+    "experiment-saved-metrics-list"
+  ],
+  "experiment_saved_metrics_partial_update": [
+    "experiment-saved-metrics-partial-update"
+  ],
+  "experiment_saved_metrics_retrieve": [
+    "experiment-saved-metrics-retrieve"
+  ],
+  "experiments_create": [
+    "experiment-create"
+  ],
+  "experiments_partial_update": [
+    "experiment-update"
+  ],
+  "experiments_retrieve": [
+    "experiment-get"
+  ],
+  "external_data_schemas_incremental_fields_create": [
+    "external-data-schemas-incremental-fields-create"
+  ],
+  "external_data_schemas_list": [
+    "external-data-schemas-list"
+  ],
+  "external_data_schemas_partial_update": [
+    "external-data-schemas-partial-update"
+  ],
+  "external_data_schemas_retrieve": [
+    "external-data-schemas-retrieve"
+  ],
+  "external_data_sources_check_cdc_prerequisites_create": [
+    "external-data-sources-check-cdc-prerequisites-create"
+  ],
+  "external_data_sources_create": [
+    "external-data-sources-create"
+  ],
+  "external_data_sources_create_webhook_create": [
+    "external-data-sources-create-webhook-create"
+  ],
+  "external_data_sources_delete_webhook_create": [
+    "external-data-sources-delete-webhook-create"
+  ],
+  "external_data_sources_destroy": [
+    "external-data-sources-destroy"
+  ],
+  "external_data_sources_list": [
+    "external-data-sources-list"
+  ],
+  "external_data_sources_partial_update": [
+    "external-data-sources-partial-update"
+  ],
+  "external_data_sources_retrieve": [
+    "external-data-sources-retrieve"
+  ],
+  "external_data_sources_update_webhook_inputs_create": [
+    "external-data-sources-update-webhook-inputs-create"
+  ],
+  "external_data_sources_webhook_info_retrieve": [
+    "external-data-sources-webhook-info-retrieve"
+  ],
+  "feature_flags_activity_retrieve": [
+    "feature-flags-activity-retrieve"
+  ],
+  "feature_flags_create": [
+    "create-feature-flag"
+  ],
+  "feature_flags_destroy": [
+    "delete-feature-flag"
+  ],
+  "feature_flags_evaluation_reasons_retrieve": [
+    "feature-flags-evaluation-reasons-retrieve"
+  ],
+  "feature_flags_list": [
+    "feature-flag-get-all"
+  ],
+  "feature_flags_partial_update": [
+    "update-feature-flag"
+  ],
+  "feature_flags_retrieve": [
+    "feature-flag-get-definition"
+  ],
+  "feature_flags_status_retrieve": [
+    "feature-flags-status-retrieve"
+  ],
+  "feature_flags_test_evaluation_create": [
+    "feature-flags-test-evaluation-create"
+  ],
+  "feature_flags_user_blast_radius_create": [
+    "feature-flags-user-blast-radius-create"
+  ],
+  "hog_flows_logs_retrieve": [
+    "hog-flows-logs-retrieve"
+  ],
+  "hog_flows_metrics_retrieve": [
+    "hog-flows-metrics-retrieve"
+  ],
+  "insights_activity_retrieve": [
+    "insights-activity-retrieve"
+  ],
+  "insights_all_activity_retrieve": [
+    "insights-all-activity-retrieve"
+  ],
+  "insights_create": [
+    "insight-create"
+  ],
+  "insights_destroy": [
+    "insight-delete"
+  ],
+  "insights_list": [
+    "insights-list"
+  ],
+  "insights_partial_update": [
+    "insight-update"
+  ],
+  "insights_retrieve": [
+    "insight-get"
+  ],
+  "insights_trending_retrieve": [
+    "insights-trending-retrieve"
+  ],
+  "integrations_channels_retrieve": [
+    "integrations-channels-retrieve"
+  ],
+  "integrations_list": [
+    "integrations-list"
+  ],
+  "logs_alerts_create": [
+    "logs-alerts-create"
+  ],
+  "logs_alerts_destinations_create": [
+    "logs-alerts-destinations-create"
+  ],
+  "logs_alerts_destinations_delete_create": [
+    "logs-alerts-destinations-delete-create"
+  ],
+  "logs_alerts_destroy": [
+    "logs-alerts-destroy"
+  ],
+  "logs_alerts_events_list": [
+    "logs-alerts-events-list"
+  ],
+  "logs_alerts_list": [
+    "logs-alerts-list"
+  ],
+  "logs_alerts_partial_update": [
+    "logs-alerts-partial-update"
+  ],
+  "logs_alerts_retrieve": [
+    "logs-alerts-retrieve"
+  ],
+  "logs_alerts_simulate_create": [
+    "logs-alerts-simulate-create"
+  ],
+  "logs_services_create": [
+    "logs-services-create"
+  ],
+  "notebooks_create": [
+    "notebooks-create"
+  ],
+  "notebooks_destroy": [
+    "notebooks-destroy"
+  ],
+  "notebooks_list": [
+    "notebooks-list"
+  ],
+  "notebooks_partial_update": [
+    "notebooks-partial-update"
+  ],
+  "notebooks_retrieve": [
+    "notebooks-retrieve"
+  ],
+  "persons_cohorts_retrieve": [
+    "persons-cohorts-retrieve"
+  ],
+  "persons_list": [
+    "persons-list"
+  ],
+  "persons_retrieve": [
+    "persons-retrieve"
+  ],
+  "persons_values_retrieve": [
+    "persons-values-retrieve"
+  ],
+  "roles_list": [
+    "roles-list"
+  ],
+  "session_recording_playlists_list": [
+    "session-recording-playlists-list"
+  ],
+  "subscriptions_create": [
+    "subscriptions-create"
+  ],
+  "subscriptions_deliveries_list": [
+    "subscriptions-deliveries-list"
+  ],
+  "subscriptions_deliveries_retrieve": [
+    "subscriptions-deliveries-retrieve"
+  ],
+  "subscriptions_list": [
+    "subscriptions-list"
+  ],
+  "subscriptions_partial_update": [
+    "subscriptions-partial-update"
+  ],
+  "subscriptions_retrieve": [
+    "subscriptions-retrieve"
+  ],
+  "subscriptions_test_delivery_create": [
+    "subscriptions-test-delivery-create"
+  ],
+  "surveys_list": [
+    "surveys-get-all"
+  ],
+  "user_interview_topics_create": [
+    "user-interview-topics-create"
+  ],
+  "user_interview_topics_interviewees_create": [
+    "user-interview-topics-interviewees-create"
+  ],
+  "user_interview_topics_interviewees_destroy": [
+    "user-interview-topics-interviewees-destroy"
+  ],
+  "user_interview_topics_interviewees_list": [
+    "user-interview-topics-interviewees-list"
+  ],
+  "user_interview_topics_interviewees_partial_update": [
+    "user-interview-topics-interviewees-partial-update"
+  ],
+  "user_interview_topics_list": [
+    "user-interview-topics-list"
+  ],
+  "user_interview_topics_partial_update": [
+    "user-interview-topics-partial-update"
+  ],
+  "user_interview_topics_retrieve": [
+    "user-interview-topics-retrieve"
+  ],
+  "user_interviews_list": [
+    "user-interviews-list"
+  ],
+  "user_interviews_retrieve": [
+    "user-interviews-retrieve"
+  ],
+  "visual_review_repos_list": [
+    "visual-review-repos-list"
+  ],
+  "visual_review_repos_retrieve": [
+    "visual-review-repos-retrieve"
+  ],
+  "visual_review_runs_counts_retrieve": [
+    "visual-review-runs-counts-retrieve"
+  ],
+  "visual_review_runs_list": [
+    "visual-review-runs-list"
+  ],
+  "visual_review_runs_retrieve": [
+    "visual-review-runs-retrieve"
+  ],
+  "visual_review_runs_snapshot_history_list": [
+    "visual-review-runs-snapshot-history-list"
+  ],
+  "visual_review_runs_snapshots_list": [
+    "visual-review-runs-snapshots-list"
+  ],
+  "visual_review_runs_tolerated_hashes_list": [
+    "visual-review-runs-tolerated-hashes-list"
+  ],
+  "web_analytics_weekly_digest": [
+    "web-analytics-weekly-digest"
+  ]
+}

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -16,6 +16,7 @@ import { InlineCode } from 'components/InlineCode'
 import { CallToAction } from 'components/CallToAction'
 import ReaderView from 'components/ReaderView'
 import { Heading } from 'components/Heading'
+import MCPCallout from 'components/Docs/MCPCallout'
 
 const mapVerbsColor = {
     get: 'blue',
@@ -661,6 +662,7 @@ export default function ApiEndpoint({ data }: { data: ApiEndpointData }): JSX.El
                                         <Heading id={pathID(item.httpVerb, item.pathName)} as="h2">
                                             {generateName(item)}
                                         </Heading>
+                                        <MCPCallout operationId={item.operationId} />
                                         {mdxNode?.body && (
                                             <div className="article-content">
                                                 <div className="text-primary">


### PR DESCRIPTION
## Summary

- Surfaces matching MCP tools on each REST API endpoint page so users discover the MCP equivalent without leaving the API reference.
- Enriches the MCP tools fetcher to emit a flat `byName` map (summary, description, category, required_scopes) alongside the existing categories shape, and caches the full payload in `onPreBootstrap`.
- Adds a seeded `src/data/mcp-rest-mapping.json` (137 entries — direct `_`→`-` matches plus verb-swap CRUD entries for feature flags, dashboards, insights, cohorts, experiments, annotations, surveys) and a helper script to regenerate candidates as the upstream tool list / OpenAPI spec evolve.
- Renders `<MCPCallout operationId={...} />` inside `ApiEndpoint.tsx` right after each endpoint heading; returns null when no mapping exists so unmapped endpoints stay clean.

## Test plan

- [ ] `pnpm clean && pnpm install && pnpm start`
- [ ] Visit `/docs/api/feature-flags` — each operation with a mapping entry should show a yellow-bordered callout above the description listing the matching MCP tool(s) with summaries and a link to `/docs/model-context-protocol`.
- [ ] Visit an endpoint with no mapping (e.g. a niche operation) and confirm no callout appears.
- [ ] Confirm `pnpm build` still completes without TypeScript errors.

Generated-By: PostHog Code
Task-Id: 5e7552fa-6b4b-4e3a-ba92-d71895b6f041