### PR TITLE
Add Richard's foot x-ray to /feet-pics

### DIFF
--- a/src/pages/feet-pics/index.tsx
+++ b/src/pages/feet-pics/index.tsx
@@ -149,6 +149,21 @@ export default function FeetPics(): JSX.Element {
                         className={`size-24`}
                         orientation={isListLayout ? 'row' : 'column'}
                     ></AppLink>
+
+                    <AppLink
+                        label="broken bone (real).jpg"
+                        Icon={
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/h_1000,c_limit,q_auto,f_auto/IMG_7213_487294168e.jpg"
+                                alt="broken bone (real).jpg"
+                                className="w-full h-full object-cover"
+                                imgClassName="size-24"
+                            />
+                        }
+                        background="bg-primary"
+                        className={`size-24`}
+                        orientation={isListLayout ? 'row' : 'column'}
+                    ></AppLink>
                 </div>
             </Explorer>
         </>


### PR DESCRIPTION
## Summary

- Adds a new entry to `/feet-pics` for Richard's recent urgent care appearance (4 hours, 3 x-rays, 1 broken bone — solid opener for 2026)
- File labeled `broken bone (real).jpg`, image hosted on Cloudinary

## Test plan

- [ ] Visit `/feet-pics` in dev and confirm the new tile renders alongside the existing 5
- [ ] Toggle between grid and list layouts to verify orientation handling
- [ ] Confirm Eli's record is still safe

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*