### PR TITLE
Update PHP group identify docs

### DIFF
--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -118,7 +118,7 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 ### Group analytics
 
-Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). This feature requires a posthog-php version of `2.1.0` or above. Read the [group analytics guide](/docs/product-analytics/group-analytics) for more information.
+Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). This feature requires version `2.1.0` or above of the PHP SDK. Read the [group analytics guide](/docs/product-analytics/group-analytics) for more information.
 
 > **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
 

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -70,7 +70,7 @@ PostHog::capture([
 
 ## Alias
 
-Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
 
 In this case, you can use `alias` to assign another distinct ID to the same user.
 
@@ -118,31 +118,39 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 ### Group analytics
 
-Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). This feature requires a posthog-php version of `2.1.0` or above. Read the [Group Analytics](/docs/user-guides/group-analytics) guide for more information.
+Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). This feature requires a posthog-php version of `2.1.0` or above. Read the [group analytics guide](/docs/product-analytics/group-analytics) for more information.
 
-> **Note:**  This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
 
--   Capture an event and associate it with a group
-
-```php
-PostHog::capture([
-    'distinctId' => 'user_distinct_id',
-    'event' => 'some_event',
-    '$groups' => ['company' => 'company_id_in_your_db']
-]);
-```
-
--   Update properties on a group
+To create a group or update its properties, use `groupIdentify`:
 
 ```php
 PostHog::groupIdentify([
     'groupType' => 'company',
     'groupKey' => 'company_id_in_your_db',
-    'properties' => ['name' => 'Awesome Inc.', 'employees' => 11]
+    'properties' => [
+        'name' => 'Awesome Inc.',
+        'employees' => 11,
+    ],
+    // Optional distinct ID to associate this event with an existing person.
+    // Requires posthog-php 4.4.0 or later.
+    'distinctId' => 'user_distinct_id'
 ]);
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
+`name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID is used instead.
+
+If the optional `distinctId` parameter is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior results in each group appearing as a separate person in PostHog. To avoid this, use a consistent `distinctId`, such as `group_identifier`, or a real user distinct ID.
+
+Once a group is created, you can use the `capture` method and pass in the `groups` parameter to capture an event with group analytics.
+
+```php
+PostHog::capture([
+    'distinctId' => 'user_distinct_id',
+    'event' => 'some_event',
+    'groups' => ['company' => 'company_id_in_your_db']
+]);
+```
 
 ## Error tracking
 


### PR DESCRIPTION
## Changes

- Update the PHP library group analytics docs to match the Node docs structure.
- Document the optional `distinctId` parameter for `PostHog::groupIdentify()` and explain the default synthetic distinct ID behavior.
- Use the `groups` capture parameter in the group analytics example.

SDK PR: https://github.com/PostHog/posthog-php/pull/141

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
