### PR TITLE
Add LinkedIn brand-account amplification guidance to handbook

### DIFF
--- a/contents/handbook/content/linkedin.md
+++ b/contents/handbook/content/linkedin.md
@@ -41,6 +41,19 @@ Yes, I realize LinkedIn has a bad reputation, but it’s a popular channel with 
 
 > Thank you to <TeamMember name="Lucas Faria" photo /> for many of these tips.
 
+## Boosting posts from the PostHog brand account
+
+If you post PostHog-related content to LinkedIn more than once per week and **aren't scheduling it in advance**, please:
+
+- Ask Liam to add you as a content admin to the [PostHog LinkedIn page](https://www.linkedin.com/company/posthog/) if you aren't already.
+- Immediately after posting, switch your profile to the PostHog page and:
+  - React (like, love, insightful, etc.)
+  - Repost (the regular "Instantly bring [your] post to others' feeds" option)
+
+The first couple of hours of a LinkedIn post are critical algorithmically, so sharing from the company page early helps maximize reach.
+
+If you _are_ scheduling content, aim to engage from the brand account within ~an hour of the post going live (e.g. liking comments, adding the supporting article link as a comment). Liam will cover this when possible, but morning GMT posts may fall outside PST working hours.
+
 ## LinkedIn posters and their newsletters
 
 A primary way we use LinkedIn is to promote our newsletter, so here are some examples of people doing the same:

--- a/contents/handbook/content/linkedin.md
+++ b/contents/handbook/content/linkedin.md
@@ -45,7 +45,7 @@ Yes, I realize LinkedIn has a bad reputation, but it’s a popular channel with 
 
 If you post PostHog-related content to LinkedIn more than once per week and **aren't scheduling it in advance**, please:
 
-- Ask Liam to add you as a content admin to the [PostHog LinkedIn page](https://www.linkedin.com/company/posthog/) if you aren't already.
+- Ask <TeamMember name="Liam Graham" photo /> [Liam](https://posthog.com/community/profiles/44190) to add you as a content admin to the [PostHog LinkedIn page](https://www.linkedin.com/company/posthog/) if you aren't already.
 - Immediately after posting, switch your profile to the PostHog page and:
   - React (like, love, insightful, etc.)
   - Repost (the regular "Instantly bring [your] post to others' feeds" option)

--- a/contents/handbook/content/linkedin.md
+++ b/contents/handbook/content/linkedin.md
@@ -45,7 +45,7 @@ Yes, I realize LinkedIn has a bad reputation, but it’s a popular channel with 
 
 If you post PostHog-related content to LinkedIn more than once per week and **aren't scheduling it in advance**, please:
 
-- Ask <TeamMember name="Liam Graham" photo /> [Liam](https://posthog.com/community/profiles/44190) to add you as a content admin to the [PostHog LinkedIn page](https://www.linkedin.com/company/posthog/) if you aren't already.
+- Ask <TeamMember name="Liam Graham" photo /> to add you as a content admin to the [PostHog LinkedIn page](https://www.linkedin.com/company/posthog/) if you aren't already.
 - Immediately after posting, switch your profile to the PostHog page and:
   - React (like, love, insightful, etc.)
   - Repost (the regular "Instantly bring [your] post to others' feeds" option)


### PR DESCRIPTION
## Summary

- Adds a new section to the LinkedIn handbook page documenting the brand-account amplification workflow Liam shared in Slack.
- Covers the ask: content admins should repost/react from the PostHog page within the first hour of an unscheduled post to boost algorithmic reach.
- Notes the engagement window for scheduled posts and the PST/GMT timezone consideration.

## Test plan

- [ ] Preview `/handbook/content/linkedin` and confirm the new "Boosting posts from the PostHog brand account" section renders between the existing posting tips and the newsletters list.