### PR TITLE
Add new feet pic to feet-pics page

### DIFF
--- a/src/pages/feet-pics/index.tsx
+++ b/src/pages/feet-pics/index.tsx
@@ -164,6 +164,21 @@ export default function FeetPics(): JSX.Element {
                         className={`size-24`}
                         orientation={isListLayout ? 'row' : 'column'}
                     ></AppLink>
+
+                    <AppLink
+                        label="employee #30264.jpg"
+                        Icon={
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/A004066_R1_19_6_8bd7f1c686.JPG"
+                                alt="employee #30264.jpg"
+                                className="w-full h-full object-cover"
+                                imgClassName="size-24"
+                            />
+                        }
+                        background="bg-primary"
+                        className={`size-24`}
+                        orientation={isListLayout ? 'row' : 'column'}
+                    ></AppLink>
                 </div>
             </Explorer>
         </>

--- a/src/pages/feet-pics/index.tsx
+++ b/src/pages/feet-pics/index.tsx
@@ -169,7 +169,7 @@ export default function FeetPics(): JSX.Element {
                         label="employee #30264.jpg"
                         Icon={
                             <CloudinaryImage
-                                src="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/A004066_R1_19_6_8bd7f1c686.JPG"
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/h_1000,c_limit,q_auto,f_auto/A004066_R1_19_6_8bd7f1c686.JPG"
                                 alt="employee #30264.jpg"
                                 className="w-full h-full object-cover"
                                 imgClassName="size-24"

--- a/src/pages/feet-pics/index.tsx
+++ b/src/pages/feet-pics/index.tsx
@@ -169,7 +169,7 @@ export default function FeetPics(): JSX.Element {
                         label="employee #30264.jpg"
                         Icon={
                             <CloudinaryImage
-                                src="https://res.cloudinary.com/dmukukwp6/image/upload/h_1000,c_limit,q_auto,f_auto/A004066_R1_19_6_8bd7f1c686.JPG"
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/a_90,h_1000,c_limit,q_auto,f_auto/A004066_R1_19_6_8bd7f1c686.JPG"
                                 alt="employee #30264.jpg"
                                 className="w-full h-full object-cover"
                                 imgClassName="size-24"


### PR DESCRIPTION
## Summary
- Adds a new entry to the `/feet-pics` Explorer page using the provided Cloudinary image.

## Test plan
- [ ] `pnpm start` and visit `/feet-pics` to verify the new tile appears alongside the existing ones in both grid and list layouts.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*