### PR TITLE
chore(team objectives): platform features Q2 2026 goals

### DIFF
--- a/contents/teams/platform-features/objectives.mdx
+++ b/contents/teams/platform-features/objectives.mdx
@@ -7,7 +7,16 @@
     - Explore platform addons midpoint options
     - Access control scopes
         - Destinations or Workflows
-        
+    - AI tools
+        - `auditing-instance-security` — guided posture review and prioritized hardening steps
+        - `enforcing-2fa-sso` — lock down auth org-wide before something bad happens
+        - `configuring-approval-policies` — add change-control gating to risky actions
+        - `reviewing-pending-approvals` — triage and decide on pending approval requests
+        - `setting-up-reminders` — offload recurring or time-based check-ins to PostHog
+        - `cleaning-up-unused-dashboards` — prune stale dashboards cluttering the workspace
+        - `discovering-value-add-features` — surface relevant capabilities the user doesn't yet know exist
+        - `reviewing-team-usage` — usage picture of a team for renewal / churn calls
+
 - Alex
     - Survey/experiment about white-labeling
     - Update the docs about the B2B2C case
@@ -15,6 +24,12 @@
     - Fix notebook papercuts
     - Help with data access control
     - SQL editor access control
+    - AI tools
+        - `invite-a-user` — get a teammate into the org without leaving chat
+        - `setting-up-saml` — wire up SSO end-to-end without misreading a doc
+        - `setting-up-reverse-proxy` — improve capture reliability and ad-blocker resistance
+        - `dumping-research-to-markdown` — turn a sprawling chat session into a clean notebook summary
+        - `running-notebook-analysis` — run a structured analysis (e.g. correlation) inside a notebook
 
 - Reece
     - Access control
@@ -25,6 +40,14 @@
         - Notifications
     - Expand project->project transfers to more resources
     - Help with notebook papercuts
+    - AI tools
+        - `granting-access` — bestow or inspect roles on people, projects, and resources
+        - `creating-access-rules` — carve out scoped project access for members or roles
+        - `auditing-permission-anomalies` — spot users whose access drifted broader than it should be
+        - `explaining-created-resources` — leave future readers context on agent-created resources
+        - `exploring-integrations` — discover and turn on the right integration for the user's stack
+        - `suggesting-resource-access` — recommend who should see a new resource so the user doesn't have to guess
+        - `sharing-with-roles` — hand a dashboard or insight to the right people in one step
 
 
 ### Q1 2026 objectives


### PR DESCRIPTION
## Problem

The platform features team page didn't break down which AI tools (PostHog AI / MCP skills) each engineer owns this quarter.

## Changes

- List AI tools each engineer owns under their Q2 2026 objectives

## How did you test this code?

- No automated tests
- Visually inspected the rendered MDX

## Publish to changelog?

no