### PR TITLE
docs: update Python SDK examples

### DIFF
--- a/contents/docs/libraries/python/_snippets/contexts.mdx
+++ b/contents/docs/libraries/python/_snippets/contexts.mdx
@@ -60,7 +60,7 @@ with new_context():
 You can disable this nesting behavior by passing `fresh=True` to `new_context`:
 
 ```python
-from posthog import new_context
+from posthog import new_context, tag
 
 with new_context(fresh=True):
     tag("some-key", "value-2")
@@ -98,7 +98,7 @@ You can read more about identifying users in the [user identification documentat
 
 ### Contexts and sessions
 
-Contexts can be associated with a session ID by calling `posthog.set_context_session`. Session IDs must be UUIDv7 strings.
+Contexts can be associated with a session ID by calling `posthog.set_context_session`. When linking backend events to frontend sessions, use the session ID from the frontend SDK (PostHog session IDs are UUIDv7 strings).
 
 ```python
 from posthog import new_context, set_context_session
@@ -148,7 +148,7 @@ with new_context(capture_exceptions=False):
 
 ### Decorating functions
 
-The SDK exposes a function decorator. It takes the same arguments as `new_context` and provides a handy way to mark a whole function as being in a new context. For example:
+The SDK exposes a function decorator. It takes the same `fresh` and `capture_exceptions` arguments as `new_context` and provides a handy way to mark a whole function as being in a new context. For example:
 
 ```python
 from posthog import scoped, identify_context

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -171,7 +171,7 @@ posthog = Posthog("<ph_project_token>", enable_exception_autocapture=True, ...)
 You can also manually capture exceptions using the `capture_exception` method:
 
 ```python
-posthog.capture_exception(e, 'user_distinct_id', properties=additional_properties)
+posthog.capture_exception(e, distinct_id='user_distinct_id', properties=additional_properties)
 ```
 
 Contexts automatically capture exceptions thrown inside them, unless disable it by passing `capture_exceptions=False` to `new_context()`.


### PR DESCRIPTION
## Changes

follow up https://github.com/PostHog/posthog-python/pull/581

- Update Python SDK docs examples for context snippets and exception capture.
- Clarify context session guidance for linking backend events to frontend sessions.
- Keep the GeoIP `disable_geoip=True|False` example compact to show users pass one value or the other.

_No screenshots or screen recordings; docs-only changes._

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
