### PR TITLE
docs: fix Ruby error tracking examples

### DIFF
--- a/contents/docs/error-tracking/capture.mdx
+++ b/contents/docs/error-tracking/capture.mdx
@@ -58,7 +58,7 @@ You can also manually call the exception capture method.
 
 <CalloutBox icon="IconWarning" title="Always use captureException()" type="warning">
 
-Never manually capture `$exception` events using `posthog.capture('$exception', {...})`. Always use `posthog.captureException(error)` instead - it handles the correct event format, stack trace processing, and source map integration automatically.
+Never manually capture `$exception` events using `posthog.capture('$exception', {...})`. Always use `posthog.captureException(error)` instead – it handles the correct event format, stack trace processing, and source map integration automatically.
 
 </CalloutBox>
 
@@ -94,8 +94,8 @@ posthog.capture_exception(
 ```ruby
 posthog.capture_exception(
   e,
-  distinct_id: 'user_distinct_id',
-  properties: {
+  'user_distinct_id',
+  {
     custom_property: 'custom_value',
     custom_list: ['custom_value_1', 'custom_value_2']
   }
@@ -275,8 +275,8 @@ begin
 rescue => e
   posthog.capture_exception(
     e,
-    distinct_id: 'user_123',
-    properties: {
+    'user_123',
+    {
       subscription_id: subscription_id,
       # You can also *optionally* override generated properties like fingerprint
       '$exception_fingerprint': 'CustomExceptionGroup'

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -205,8 +205,8 @@ begin
 rescue => e
   posthog.capture_exception(
     e,
-    distinct_id: 'user_distinct_id',
-    properties: {
+    'user_distinct_id',
+    {
       custom_property: 'custom_value'
     }
   )
@@ -216,18 +216,18 @@ end
 The `capture_exception` method accepts the following parameters:
 
 | Parameter | Type | Description |
-|-----------|------|-------------|
+| --------- | ---- | ----------- |
 | `exception` | `Exception` | The exception object to capture (required) |
 | `distinct_id` | `String` | The distinct ID of the user (optional) |
-| `properties` | `Hash` | Additional properties to attach to the exception event (optional) |
+| `additional_properties` | `Hash` | Additional properties to attach to the exception event (optional) |
 
 You can also override the [fingerprint](/docs/error-tracking/fingerprints) to customize how exceptions are grouped into issues:
 
 ```ruby
 posthog.capture_exception(
   e,
-  distinct_id: 'user_distinct_id',
-  properties: {
+  'user_distinct_id',
+  {
     '$exception_fingerprint': 'CustomExceptionGroup'
   }
 )


### PR DESCRIPTION
## Summary
- Update Ruby Error Tracking examples in `capture.mdx` and the Ruby library docs to use the current `capture_exception(exception, distinct_id, additional_properties)` positional signature.
- Rename the third parameter in the Ruby library docs table to `additional_properties`.
- Fix a Vale punctuation issue in touched copy.

## Testing
- `git diff --check`
- `pnpm exec prettier --check contents/docs/error-tracking/capture.mdx contents/docs/libraries/ruby/index.mdx`
- `, vale --minAlertLevel=error contents/docs/error-tracking/capture.mdx contents/docs/libraries/ruby/index.mdx`
- `NODE_OPTIONS=--max-old-space-size=8192 /nix/store/c5rhp8fwf3zhrwqs1hg3x23346al7g1a-nodejs-22.22.1/bin/corepack pnpm run build:minimal`

Companion onboarding source PR: https://github.com/PostHog/posthog/pull/59082