### PR TITLE
Fix last activity attribution to show latest replier in questions

### DIFF
--- a/src/components/Inbox/index.tsx
+++ b/src/components/Inbox/index.tsx
@@ -123,7 +123,8 @@ const QuestionRow = ({
     pinned = false,
 }: QuestionRowProps) => {
     const { subject, numReplies, activeAt, replies, profile, permalink, resolved } = question
-    const latestAuthor = replies?.data?.[replies.data.length - 1]?.profile || profile
+    const replyList = Object.values(replies || {})
+    const latestAuthor = (replyList[replyList.length - 1] as any)?.profile || profile
     const active = `/questions/${permalink}` === appWindowPath
 
     return (

--- a/src/components/Inbox/index.tsx
+++ b/src/components/Inbox/index.tsx
@@ -123,8 +123,9 @@ const QuestionRow = ({
     pinned = false,
 }: QuestionRowProps) => {
     const { subject, numReplies, activeAt, replies, profile, permalink, resolved } = question
-    const replyList = Object.values(replies || {})
-    const latestAuthor = (replyList[replyList.length - 1] as any)?.profile || profile
+    const replyList = Array.isArray(replies?.data) ? replies.data : Object.values(replies ?? {})
+    const lastReply = replyList[replyList.length - 1]
+    const latestAuthor = lastReply?.profile || lastReply?.attributes?.profile || profile
     const active = `/questions/${permalink}` === appWindowPath
 
     return (


### PR DESCRIPTION
## TL;DR

Fixed a bug where the "Last activity" attribution in the Questions inbox was showing the thread opener's name instead of the actual latest commenter's name when new replies were added.

## What changed?

- Changed from accessing `replies?.data?.[replies.data.length - 1]` to using `Object.values(replies || {})` to properly iterate through the replies collection
  - This ensures the most recent commenter's profile is displayed next to the "Last activity" timestamp, rather than defaulting to the original question author's profile

|Before|
|:---|
|<img width="1271" height="197" alt="Screenshot 2026-05-19 at 4 24 38 PM" src="https://github.com/user-attachments/assets/06a78bb2-d2c3-40cd-8a74-334778f72fbe" />|
|After|
|<img width="1050" height="243" alt="Screenshot 2026-05-19 at 4 18 11 PM" src="https://github.com/user-attachments/assets/1f54d2b0-ab65-44b8-983d-a8e3c45c3fb3" />|

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*