### PR TITLE
Fix: profile icon click no longer navigates to app.posthog.com

### DIFF
--- a/src/components/RadixUI/MenuBar.tsx
+++ b/src/components/RadixUI/MenuBar.tsx
@@ -409,7 +409,7 @@ const MenuBar: React.FC<MenuBarProps> = ({
                                     : undefined
                             }
                             onClick={
-                                websiteMode
+                                websiteMode && showChevronDown && !menu.hideChevron
                                     ? () => {
                                           const url = menu.mobileLink || menu.items.find((item) => item.link)?.link
                                           if (url) {


### PR DESCRIPTION
## Summary

- Clicking the avatar/profile icon in the top-right taskbar was navigating to `https://app.posthog.com` instead of opening the account dropdown.
- Root cause: in `src/components/RadixUI/MenuBar.tsx`, the trigger's `onClick` walks `menu.items` and navigates to the first item with a `link` whenever `websiteMode` is true — regardless of whether the trigger is intended to be a nav link. The account menu's first linked item is "PostHog app", so every click on the avatar navigated to the app before the dropdown could open.
- Fix: gate the auto-navigate `onClick` by the same condition that controls the chevron rendering (`showChevronDown && !menu.hideChevron`). The chevron is the visual affordance for "this trigger doubles as a nav link" — so if no chevron is rendered, the trigger shouldn't auto-navigate either. The primary top-bar nav (which passes `showChevronDown={websiteMode}`) is unchanged; only triggers that never showed a chevron (account/avatar, and any other consumer that didn't opt in) stop auto-navigating.

## Test plan

- [ ] `pnpm start`, sign in to the community, click the avatar in the top-right — the account dropdown opens, no navigation occurs.
- [ ] Click "PostHog app" *inside* the dropdown — still navigates to `https://app.posthog.com`.
- [ ] Click the primary nav items (Product, Docs, etc.) in the top bar — still navigate on click as before.
- [ ] Sign out and click the avatar — dropdown opens, no navigation. "Sign in to the community" still works.
- [ ] Repeat on a narrow viewport (mobile layout) — `mobileLink` handling for the primary nav is unchanged.