### PR TITLE
docs: explain Slackbot emoji cues in PostHog Code Slack docs

### DIFF
--- a/contents/docs/posthog-code/slack.mdx
+++ b/contents/docs/posthog-code/slack.mdx
@@ -54,6 +54,30 @@ Once the agent finishes, you can reply to it by sending a new message in the thr
 
 Right now, only the person that started a task can continue it in the thread. If you want to continue it yourself, you can start a new thread and pass the existing messages as context.
 
+## Emoji cues
+
+The bot signals where your request is in its lifecycle using reactions on your `@PostHog` message and emojis in its own replies. Glance at a busy channel and you can tell what's still in flight without opening every thread.
+
+Reactions on your mention message:
+
+| Emoji | What it means |
+|---|---|
+| `:seedling:` 🌱 | Saw your mention and is spinning up a new task |
+| `:eyes:` 👀 | Forwarding a follow-up to the running agent, or resuming a previous run |
+| `:hedgehog:` 🦔 | The agent finished and posted its reply in the thread |
+| `:x:` ❌ | Something went wrong - usually the sandbox stopped before the message could be delivered |
+
+A stale 🌱 or 👀 gets removed once the bot lands on a terminal 🦔 or ❌, so the reaction on your message always reflects the latest state.
+
+Emojis inside the bot's own messages:
+
+| Emoji | Where it shows up |
+|---|---|
+| `:hourglass_flowing_sand:` ⏳ | In the progress message while the agent works, next to the current stage |
+| `:rocket:` 🚀 | On the "Pull request opened" message once a PR is up |
+| `:hedgehog:` 🦔 | On the "Task completed" header (and when the sandbox is cleaned up afterwards) |
+| `:x:` ❌ | On the "Task failed" header when a run errors out |
+
 ## Routing rules and default repo
 
 If you work across many repos, you can teach the bot how to pick a repo intelligently. Run these as mentions:

--- a/contents/docs/posthog-code/slack.mdx
+++ b/contents/docs/posthog-code/slack.mdx
@@ -56,9 +56,7 @@ Right now, only the person that started a task can continue it in the thread. If
 
 ## Emoji cues
 
-The bot signals where your request is in its lifecycle using reactions on your `@PostHog` message and emojis in its own replies. Glance at a busy channel and you can tell what's still in flight without opening every thread.
-
-Reactions on your mention message:
+The bot reacts to your `@PostHog` message as it works through your request, so you can scan a busy channel and see what's still in flight without opening every thread:
 
 | Emoji | What it means |
 |---|---|
@@ -66,7 +64,6 @@ Reactions on your mention message:
 | 👀 `:eyes:` | Forwarding a follow-up to the running agent, or resuming a previous run |
 | 🦔 `:hedgehog:` | The agent finished and posted its reply in the thread |
 | ❌ `:x:` | Something went wrong – usually the sandbox stopped before the message could be delivered |
-
 
 ## Routing rules and default repo
 

--- a/contents/docs/posthog-code/slack.mdx
+++ b/contents/docs/posthog-code/slack.mdx
@@ -65,7 +65,7 @@ Reactions on your mention message:
 | `:seedling:` 🌱 | Saw your mention and is spinning up a new task |
 | `:eyes:` 👀 | Forwarding a follow-up to the running agent, or resuming a previous run |
 | `:hedgehog:` 🦔 | The agent finished and posted its reply in the thread |
-| `:x:` ❌ | Something went wrong - usually the sandbox stopped before the message could be delivered |
+| `:x:` ❌ | Something went wrong – usually the sandbox stopped before the message could be delivered |
 
 A stale 🌱 or 👀 gets removed once the bot lands on a terminal 🦔 or ❌, so the reaction on your message always reflects the latest state.
 
@@ -75,10 +75,10 @@ Emojis inside the bot's own messages:
 |---|---|
 | `:hourglass_flowing_sand:` ⏳ | In the progress message while the agent works, next to the current stage |
 | `:rocket:` 🚀 | On the final "Pull Request Created" message once the run completes with a PR (and on the follow-up "Pull request opened" message after the sandbox is cleaned up) |
-| `:hedgehog:` 🦔 | On the "Task Completed" header when a run finishes without a PR, and on the "Sandbox stopped" header when a run is cancelled |
+| `:hedgehog:` 🦔 | On the "Task Completed" header when a run finishes without a PR, and on the "Sandbox stopped" header when a run is canceled |
 | `:x:` ❌ | On the "Task Failed" header when a run errors out |
 
-The very first in-thread notification when a PR is opened mid-run is plain text - the 🚀 only shows up on the final completion or post-cleanup message.
+The very first in-thread notification when a PR is opened mid-run is plain text – the 🚀 only shows up on the final completion or post-cleanup message.
 
 ## Routing rules and default repo
 

--- a/contents/docs/posthog-code/slack.mdx
+++ b/contents/docs/posthog-code/slack.mdx
@@ -62,23 +62,11 @@ Reactions on your mention message:
 
 | Emoji | What it means |
 |---|---|
-| `:seedling:` 🌱 | Saw your mention and is spinning up a new task |
-| `:eyes:` 👀 | Forwarding a follow-up to the running agent, or resuming a previous run |
-| `:hedgehog:` 🦔 | The agent finished and posted its reply in the thread |
-| `:x:` ❌ | Something went wrong – usually the sandbox stopped before the message could be delivered |
+| 🌱 `:seedling:` | Saw your mention and is spinning up a new task |
+| 👀 `:eyes:` | Forwarding a follow-up to the running agent, or resuming a previous run |
+| 🦔 `:hedgehog:` | The agent finished and posted its reply in the thread |
+| ❌ `:x:` | Something went wrong – usually the sandbox stopped before the message could be delivered |
 
-A stale 🌱 or 👀 gets removed once the bot lands on a terminal 🦔 or ❌, so the reaction on your message always reflects the latest state.
-
-Emojis inside the bot's own messages:
-
-| Emoji | Where it shows up |
-|---|---|
-| `:hourglass_flowing_sand:` ⏳ | In the progress message while the agent works, next to the current stage |
-| `:rocket:` 🚀 | On the final "Pull Request Created" message once the run completes with a PR (and on the follow-up "Pull request opened" message after the sandbox is cleaned up) |
-| `:hedgehog:` 🦔 | On the "Task Completed" header when a run finishes without a PR, and on the "Sandbox stopped" header when a run is canceled |
-| `:x:` ❌ | On the "Task Failed" header when a run errors out |
-
-The very first in-thread notification when a PR is opened mid-run is plain text – the 🚀 only shows up on the final completion or post-cleanup message.
 
 ## Routing rules and default repo
 

--- a/contents/docs/posthog-code/slack.mdx
+++ b/contents/docs/posthog-code/slack.mdx
@@ -74,9 +74,11 @@ Emojis inside the bot's own messages:
 | Emoji | Where it shows up |
 |---|---|
 | `:hourglass_flowing_sand:` ⏳ | In the progress message while the agent works, next to the current stage |
-| `:rocket:` 🚀 | On the "Pull request opened" message once a PR is up |
-| `:hedgehog:` 🦔 | On the "Task completed" header (and when the sandbox is cleaned up afterwards) |
-| `:x:` ❌ | On the "Task failed" header when a run errors out |
+| `:rocket:` 🚀 | On the final "Pull Request Created" message once the run completes with a PR (and on the follow-up "Pull request opened" message after the sandbox is cleaned up) |
+| `:hedgehog:` 🦔 | On the "Task Completed" header when a run finishes without a PR, and on the "Sandbox stopped" header when a run is cancelled |
+| `:x:` ❌ | On the "Task Failed" header when a run errors out |
+
+The very first in-thread notification when a PR is opened mid-run is plain text - the 🚀 only shows up on the final completion or post-cleanup message.
 
 ## Routing rules and default repo
 


### PR DESCRIPTION
## Changes

Adds an "Emoji cues" section to `/docs/posthog-code/slack` that explains the emojis the PostHog Code Slackbot uses as it works through a request (🌱 → 👀 → 🦔 / ❌) 

The set of emojis and their meanings was sourced from the Slack mention workflow and the slack thread handler in `PostHog/posthog`, so what's documented matches what the bot actually does today.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*