### PR TITLE
Update PHP SDK documentation

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -305,7 +305,7 @@ posthog.load_feature_flags()
 ```
 
 ```php
-PostHog::loadFlags()
+PostHog::getClient()->loadFlags()
 ```
 
 ```java

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -45,10 +45,10 @@ func main() {
 ```
 
 ```php
-PostHog::init("<ph_project_token>",
-  ['host' => '<ph_client_api_host>'],
-  null, // or custom http client
- 'your feature flags secure API key from step 1'
+PostHog::init(
+    '<ph_project_token>',
+    ['host' => '<ph_client_api_host>'],
+    personalAPIKey: 'your feature flags secure API key from step 1'
 );
 // NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialize the posthog client
 ```

--- a/contents/docs/integrate/_snippets/install-php.mdx
+++ b/contents/docs/integrate/_snippets/install-php.mdx
@@ -1,15 +1,7 @@
-Add the following to `composer.json`:
-```json
-{
-    "require": {
-        "posthog/posthog-php": "3.0.*"
-    }
-}
-```
-And then install the dependencies with the command:
+Install the package with Composer:
 
 ```bash
-composer install
+composer require posthog/posthog-php
 ```
 
 In your app, set your project token before making any calls.
@@ -20,6 +12,6 @@ PostHog\PostHog::init("<ph_project_token>",
 );
 ```
 
-> **Note:** As a rule of thumb, we do not recommend having API keys or tokens in plaintext. Setting it as an environment variable is best.
+> **Note:** As a rule of thumb, we do not recommend having API keys or tokens in plaintext. Setting them as environment variables is best. The PHP SDK reads `POSTHOG_API_KEY` and `POSTHOG_HOST` when you omit the project token or host.
 
 You can find your project token and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
@@ -32,6 +32,8 @@ if ($enabledVariant === 'variant-key') { // replace 'variant-key' with the key o
 
 `$flags->getFlag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `null` when the flag wasn't returned by the evaluation.
 
+You can also call `$flags->getKeys()` to list the evaluated flag keys, or `$flags->getEventProperties()` to get the `$feature/<flag-key>` and `$active_feature_flags` properties that would be attached to a captured event.
+
 > **Note:** `PostHog::isFeatureEnabled()`, `PostHog::getFeatureFlag()`, `PostHog::getFeatureFlagPayload()`, and `capture(['send_feature_flags' => true])` still work during the migration period, but they're deprecated. Prefer `evaluateFlags()` for new code.
 
 import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-events.mdx"
@@ -106,11 +108,27 @@ $flags = PostHog::evaluateFlags(
 );
 ```
 
+### Optional evaluation parameters
+
+`evaluateFlags()` also accepts optional parameters for local evaluation and GeoIP behavior:
+
+```php
+$flags = PostHog::evaluateFlags(
+    distinctId: 'distinct_id_of_your_user',
+    groups: ['company' => 'company_id_in_your_db'],
+    personProperties: ['plan' => 'pro'],
+    groupProperties: ['company' => ['employees' => 11]],
+    onlyEvaluateLocally: false, // Defaults to false. Set to true to avoid a remote fallback.
+    disableGeoip: false, // Defaults to false. Set to true to disable GeoIP enrichment during remote evaluation.
+    flagKeys: ['checkout-flow', 'new-dashboard'],
+);
+```
+
 ### Sending `$feature_flag_called` events
 
 Capturing `$feature_flag_called` events enables PostHog to know when a flag was accessed by a user and provide [analytics and insights](/docs/product-analytics/insights) on the flag. With `evaluateFlags()`, the SDK sends this event when you call `$flags->isEnabled()` or `$flags->getFlag()` for a flag.
 
-The SDK deduplicates these events per `(distinct_id, flag, value)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
+The SDK deduplicates these events per `(flag key, distinct_id)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
 
 `$flags->getFlagPayload()` doesn't send `$feature_flag_called` events and doesn't count as an access for `onlyAccessed()`.
 

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -37,7 +37,19 @@ import PHPSendEvents from '../../integrate/send-events/_snippets/send-events-php
 
 ## Person profiles and properties
 
-The PHP SDK captures identified events by default. These create [person profiles](/docs/data/persons). To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+The PHP SDK captures identified events by default. These create [person profiles](/docs/data/persons). To set [person properties](/docs/data/user-properties), call `identify` with the user's distinct ID and properties:
+
+```php
+PostHog::identify([
+    'distinctId' => 'distinct_id',
+    'properties' => [
+        'email' => 'max@example.com',
+        'name' => 'Max Hedgehog',
+    ],
+]);
+```
+
+You can also include person properties when capturing an event:
 
 ```php
 PostHog::capture([
@@ -99,6 +111,16 @@ import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-
 
 <LocalEvaluationIntro />
 
+To load feature flag definitions for local evaluation, initialize the SDK with your feature flags secure API key as `personalAPIKey`:
+
+```php
+PostHog::init(
+    '<ph_project_token>',
+    ['host' => '<ph_client_api_host>'],
+    personalAPIKey: 'your feature flags secure API key'
+);
+```
+
 For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation).
 
 ### Experiments (A/B tests)
@@ -152,6 +174,38 @@ PostHog::capture([
 ]);
 ```
 
+## Request context
+
+Use request context to apply a distinct ID, session ID, and common properties to all captures inside a callback. This is useful when connecting frontend activity to backend events, session replay, and error tracking.
+
+```php
+PostHog::withContext([
+    'distinctId' => 'user_distinct_id',
+    'sessionId' => 'session_id_from_frontend',
+    'properties' => [
+        '$current_url' => 'https://example.com/account',
+    ],
+], function () {
+    PostHog::capture([
+        'event' => 'backend_event',
+    ]);
+});
+```
+
+You can extract PostHog context from frontend tracing headers with `contextFromHeaders()`:
+
+```php
+$context = PostHog::contextFromHeaders($_SERVER);
+
+PostHog::withContext($context, function () {
+    PostHog::capture([
+        'event' => 'backend_event',
+    ]);
+});
+```
+
+Call `PostHog::getContext()` to read the currently active context. Pass `['fresh' => true]` as the third argument to `withContext()` if you don't want to inherit any existing context.
+
 ## Error tracking
 
 The PHP SDK supports both manual exception capture and opt-in automatic error tracking.
@@ -194,15 +248,30 @@ All possible options below:
 
 | Attribute                 | Description   |
 | ------------------------- | ------------- |
-| `host`<br/><br/>**Type:** String<br/>**Default:** `app.posthog.com` | URL of your PostHog instance. |
-| `ssl`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Whether to use SSL for API requests or not |
-| `timeout`<br/><br/>**Type:** Integer<br/>**Default:** `10000` | Request timeout in milliseconds |
-| `verify_batch_events_request`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Whether to verify successful delivery of batch events (true, synchronous) or fire and forget (false, asynchronous) with the `lib_curl` consumer |
-| `feature_flag_request_timeout_ms`<br/><br/>**Type:** Integer<br/>**Default:** `3000` | Request timeout for feature flags in milliseconds |
-| `maximum_backoff_duration`<br/><br/>**Type:** Integer<br/>**Default:** `10000` | Request retry backoff. Retries will stop after this duration is hit |
-| `consumer`<br/><br/>**Type:** String<br/>**Default:** `lib_curl` | One of `socket`, `file`, `lib_curl`, and `fork_curl`. Determines what transport option to use for analytics capture. [More details here](https://github.com/PostHog/posthog-php/blob/master/lib/Consumer/File.php) |
-| `debug`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Output debug logs or not |
-| `error_tracking`<br/><br/>**Type:** Array<br/>**Default:** `[]` | Enables automatic error tracking and related options such as `context_provider`, `excluded_exceptions`, and `max_frames`. [See the setup guide](/docs/error-tracking/installation/php). |
+| `host`<br/><br/>**Type:** String<br/>**Default:** `us.i.posthog.com` | URL of your PostHog instance. |
+| `ssl`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Whether to use SSL for API requests or not. If `host` includes `http://` or `https://`, the SDK infers this option unless you set it explicitly. |
+| `timeout`<br/><br/>**Type:** Integer<br/>**Default:** `10000` | Request timeout in milliseconds. |
+| `verify_batch_events_request`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Whether to verify successful delivery of batch events (true, synchronous) or fire and forget (false, asynchronous) with the `lib_curl` consumer. |
+| `feature_flag_request_timeout_ms`<br/><br/>**Type:** Integer<br/>**Default:** `3000` | Request timeout for feature flags in milliseconds. |
+| `maximum_backoff_duration`<br/><br/>**Type:** Integer<br/>**Default:** `10000` | Request retry backoff. Retries stop after this duration is hit. |
+| `consumer`<br/><br/>**Type:** String<br/>**Default:** `lib_curl` | One of `socket`, `file`, `lib_curl`, and `fork_curl`. Determines what transport option to use for analytics capture. |
+| `debug`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Output debug logs or not. |
+| `max_queue_size`<br/><br/>**Type:** Integer<br/>**Default:** `1000` | Maximum number of events to queue before rejecting new events. Applies to queued consumers. |
+| `batch_size`<br/><br/>**Type:** Integer<br/>**Default:** `100` | Number of queued events to send in each batch. Applies to queued consumers. |
+| `compress_request`<br/><br/>**Type:** Boolean/String<br/>**Default:** `false` | Whether to gzip batch request payloads. |
+| `error_handler`<br/><br/>**Type:** Callable<br/>**Default:** `null` | Callback invoked for SDK transport errors. |
+| `filename`<br/><br/>**Type:** String<br/>**Default:** `sys_get_temp_dir() . '/posthog.log'` | File path used when `consumer` is set to `file`. |
+| `error_tracking`<br/><br/>**Type:** Array<br/>**Default:** `[]` | Enables automatic error tracking. See the options below or the [PHP error tracking setup guide](/docs/error-tracking/installation/php). |
+
+### Error tracking options
+
+| Attribute | Description |
+| --------- | ----------- |
+| `enabled`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Enables automatic error tracking handlers. Manual `captureException` works regardless. |
+| `capture_errors`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | When enabled, captures PHP errors and fatal shutdown errors in addition to uncaught exceptions. |
+| `excluded_exceptions`<br/><br/>**Type:** Array of class strings<br/>**Default:** `[]` | Throwable classes to skip during automatic capture. |
+| `max_frames`<br/><br/>**Type:** Integer<br/>**Default:** `20` | Maximum number of stack frames included in `$exception_list`. |
+| `context_provider`<br/><br/>**Type:** Callable or `null`<br/>**Default:** `null` | Callback that returns `distinctId` and extra event properties for automatic captures. |
 
 ## Debug mode
 


### PR DESCRIPTION
## Changes

follow up https://github.com/PostHog/posthog-php/pull/144

- Update PHP SDK docs for Composer installation, environment-based initialization, and current configuration defaults.
- Document `identify`, request context helpers, local evaluation setup, and feature flag evaluation options.
- Update PHP local evaluation examples to use the current client API and named `personalAPIKey` argument.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
