### PR TITLE
Removed goals for team members no longer present after the :axe:

### DIFF
--- a/contents/teams/analytics-platform/objectives.mdx
+++ b/contents/teams/analytics-platform/objectives.mdx
@@ -16,7 +16,6 @@ Improve the reliability of our system to leave a better experience for our custo
 - Stability improvements to better deal with degraded infrastructure
 - A 99.95% success rate for our background jobs over the last 28 days rolling
 - Anomaly detection to proactively spot regressions
-- Add sensible usage limits to everything we own <TeamMember name="Andy Zhao" photo />
 
 #### [AI-first support for our owned components](https://github.com/PostHog/posthog/issues/51814) <TeamMember name="Vasco de Krijger" photo />
 
@@ -26,19 +25,3 @@ Move along with the market to increase AI adoption and support.
 - AI suggestions during creation
 - Improved AI onboarding
 - Investigate ways to deal with adjusted usage patterns from AI
-
-#### [Revenue analytics as a platform](https://github.com/PostHog/posthog/issues/51804) <TeamMember name="Arthur Moreira de Deus" photo />
-
-Unlock the value of revenue analytics by making its data more easily available across PostHog.
-
-- Opinionated way of linking revenue data to customers (persons/groups)
-- Fix major accuracy issues (figures not matching Stripe)
-- Build insights from revenue analytics data
-
-#### [Reposition group analytics](https://github.com/PostHog/posthog/issues/48828) <TeamMember name="Arthur Moreira de Deus" photo /> and <TeamMember name="Mike Warren" photo />
-
-Group analytics pricing is not transparent and the value proposition is frequently misunderstood with cohorts.
-
-- Pricing RFC and actionables (e.g. change billing metric, adjust unit price)
-- Update docs to reflect the product key value driver
-- Announce new pricing (with marketing)


### PR DESCRIPTION
## Changes

This PR removes goals from team members that moved on to #team-query-performance after the 🪓 from our team offsite in 🇵🇹 . 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
