### PR TITLE
docs: update Ruby SDK documentation

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
@@ -32,7 +32,7 @@ end
 
 `flags.get_flag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `nil` when the flag wasn't returned by the evaluation.
 
-> **Note:** `posthog.is_feature_enabled()`, `posthog.get_feature_flag()`, `posthog.get_feature_flag_payload()`, and `capture(send_feature_flags: true)` still work during the migration period, but they're deprecated. Prefer `evaluate_flags()` for new code.
+> **Note:** `posthog.is_feature_enabled()`, `posthog.get_feature_flag()`, `posthog.get_feature_flag_result()`, `posthog.get_feature_flag_payload()`, and `capture({ ..., send_feature_flags: true })` still work during the migration period, but they're deprecated. Prefer `evaluate_flags()` for new code.
 
 import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-events.mdx"
 
@@ -103,6 +103,28 @@ By default, `evaluate_flags()` evaluates every flag for the user. If you only ne
 flags = posthog.evaluate_flags(
     'distinct_id_of_your_user',
     flag_keys: ['checkout-flow', 'new-dashboard'],
+)
+```
+
+### Evaluating locally only
+
+If you want to skip the remote `/flags` request and only use locally cached definitions, pass `only_evaluate_locally: true`:
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    only_evaluate_locally: true,
+)
+```
+
+### Disabling GeoIP for flag evaluation
+
+Pass `disable_geoip: true` to disable GeoIP lookup for remote flag evaluation:
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    disable_geoip: true,
 )
 ```
 

--- a/contents/docs/libraries/ruby-on-rails.mdx
+++ b/contents/docs/libraries/ruby-on-rails.mdx
@@ -5,7 +5,7 @@ platformLogo: rails
 
 import AgentIntegrationSection from "../components/AgentIntegrationSection.mdx"
 
-PostHog makes it easy to get data about traffic and usage of your Ruby on Rails app. Integrating PostHog enables analytics, custom events capture, feature flags, and automatic exception tracking.
+PostHog makes it easy to get data about traffic and usage of your Ruby on Rails app. Integrating PostHog enables analytics, custom event capture, feature flags, and automatic exception tracking.
 
 This guide walks you through integrating PostHog into your Rails app using the [posthog-rails gem](https://github.com/PostHog/posthog-ruby/tree/main/posthog-rails).
 
@@ -17,6 +17,7 @@ This guide walks you through integrating PostHog into your Rails app using the [
 - **ActiveJob instrumentation** – Tracks background job exceptions
 - **User context** – Automatically associates exceptions with the current user
 - **Smart filtering** – Excludes common Rails exceptions (404s, etc.) by default
+- **Request context** – Adds request metadata and optional PostHog tracing header identity/session context to captured events
 - **Rails 7.0+ error reporter** – Integrates with Rails' built-in error reporting
 
 ## Installation
@@ -52,12 +53,28 @@ This creates `config/initializers/posthog.rb` with sensible defaults and documen
 
 ## Configuration
 
-The generated initializer includes all available options:
+`PostHog.init` creates a single client instance used across your app. Avoid creating multiple `PostHog::Client` instances with the same API key, as this can cause dropped events and inconsistent behavior.
+
+The generated initializer includes the most common options:
 
 ```ruby file=config/initializers/posthog.rb
+# Rails-specific configuration
+PostHog::Rails.configure do |config|
+  config.auto_capture_exceptions = true           # Enable automatic exception capture (default: false)
+  config.report_rescued_exceptions = true         # Report exceptions Rails rescues (default: false)
+  config.auto_instrument_active_job = true        # Instrument background jobs (default: false)
+  config.use_tracing_headers = true               # Use PostHog tracing headers for identity/session context (default: true)
+  config.capture_user_context = true              # Include authenticated user info in exceptions (default: true)
+  config.current_user_method = :current_user      # Method to get current user (default: :current_user)
+  config.user_id_method = nil                     # Method to get ID from user object (default: auto-detect)
+
+  # Add additional exceptions to ignore
+  config.excluded_exceptions = ['MyCustomError']
+end
+
 # Core PostHog client initialization
 PostHog.init do |config|
-  # Required: Your PostHog API key
+  # Required: Your PostHog project API key
   config.api_key = '<ph_project_token>'
 
   # Optional: Your PostHog instance URL
@@ -66,22 +83,32 @@ PostHog.init do |config|
   # Optional: Personal API key for feature flags
   config.personal_api_key = 'phx_xxxxxxxxx'
 
+  # Maximum number of events to queue before dropping (default: 10000)
+  config.max_queue_size = 10_000
+
+  # Send events synchronously on the calling thread (default: false)
+  config.sync_mode = false
+
+  # Feature flags polling interval in seconds (default: 30)
+  config.feature_flags_polling_interval = 30
+
+  # Feature flag request timeout in seconds (default: 3)
+  config.feature_flag_request_timeout_seconds = 3
+
   # Error callback to detect misconfiguration
   config.on_error = proc { |status, msg|
     Rails.logger.error("PostHog error: #{msg}")
   }
-end
 
-# Rails-specific configuration
-PostHog::Rails.configure do |config|
-  config.auto_capture_exceptions = true           # Enable automatic exception capture
-  config.report_rescued_exceptions = true         # Report exceptions Rails rescues
-  config.auto_instrument_active_job = true        # Instrument background jobs
-  config.capture_user_context = true              # Include user info in exceptions
-  config.current_user_method = :current_user      # Method to get current user
+  # Before-send callback to modify or drop events
+  config.before_send = proc { |event|
+    event[:properties] ||= {}
+    event[:properties]['environment'] = Rails.env
+    event
+  }
 
-  # Add additional exceptions to ignore
-  config.excluded_exceptions = ['MyCustomError']
+  # Disable network calls in test mode
+  config.test_mode = true if Rails.env.test?
 end
 ```
 
@@ -111,21 +138,37 @@ You can find your project token and instance address in [your project settings](
 Track custom events anywhere in your Rails app:
 
 ```ruby
-# Track an event
-PostHog.capture(
+PostHog.capture({
   distinct_id: current_user.id,
   event: 'post_created',
   properties: { title: @post.title }
-)
+})
+```
 
-# Identify a user
-PostHog.identify(
+Identify a user and set their person properties:
+
+```ruby
+PostHog.identify({
   distinct_id: current_user.id,
   properties: {
     email: current_user.email,
     plan: current_user.plan
   }
-)
+})
+```
+
+The Rails integration delegates methods like `capture`, `identify`, `alias`, `group_identify`, `evaluate_flags`, `capture_exception`, `flush`, and `shutdown` to the initialized `PostHog::Client`.
+
+## Request context
+
+PostHog Rails automatically applies request-scoped context to events captured during web requests. Request metadata such as `$current_url`, `$request_method`, `$request_path`, `$user_agent`, and `$ip` is added to event properties.
+
+When `use_tracing_headers` is enabled, PostHog tracing headers (`X-PostHog-Distinct-Id` and `X-PostHog-Session-Id`) are also used as default `distinct_id` and `$session_id` values. Explicit `distinct_id` and properties passed to `PostHog.capture` always take precedence.
+
+Disable tracing header identity/session capture if you do not want client-supplied tracing headers used for server-side events. Request metadata is still captured:
+
+```ruby
+PostHog::Rails.config.use_tracing_headers = false
 ```
 
 ## Error tracking
@@ -145,6 +188,8 @@ class PostsController < ApplicationController
 end
 ```
 
+`report_rescued_exceptions` controls whether exceptions Rails rescues (for example, exceptions rendered by Rails error pages) are captured. Enable it along with `auto_capture_exceptions` for complete error visibility, or leave it disabled to capture only unhandled exceptions.
+
 ### Manual exception capture
 
 You can also manually capture exceptions:
@@ -154,6 +199,19 @@ PostHog.capture_exception(
   exception,
   current_user.id,
   { custom_property: 'value' }
+)
+```
+
+If you evaluated feature flags for the request, pass the same snapshot to include matching flag properties on the exception event:
+
+```ruby
+flags = PostHog.evaluate_flags(current_user.id)
+
+PostHog.capture_exception(
+  exception,
+  current_user.id,
+  { custom_property: 'value' },
+  flags: flags
 )
 ```
 
@@ -173,21 +231,35 @@ end
 
 #### Associating jobs with users
 
-By default, PostHog extracts a `distinct_id` from job arguments by looking for a `user_id` key:
+By default, PostHog extracts a `distinct_id` from job arguments by looking for a `user_id` key in hash arguments:
 
 ```ruby
 # PostHog will automatically use options[:user_id] as the distinct_id
 ProcessOrderJob.perform_later(order.id, user_id: current_user.id)
 ```
 
-For more control, use the `posthog_distinct_id` class method:
+For more control, use the `posthog_distinct_id` class method. The proc or block receives the same arguments as `perform`:
 
 ```ruby
 class SendWelcomeEmailJob < ApplicationJob
-  posthog_distinct_id ->(user, options) { user.id }
+  posthog_distinct_id ->(user, _options) { user.id }
 
   def perform(user, options = {})
     UserMailer.welcome(user).deliver_now
+  end
+end
+```
+
+You can also use a block:
+
+```ruby
+class ProcessOrderJob < ApplicationJob
+  posthog_distinct_id do |_order, notify_user_id|
+    notify_user_id
+  end
+
+  def perform(order, notify_user_id)
+    # Process the order...
   end
 end
 ```
@@ -205,11 +277,13 @@ end
 Rails.error.record(exception, context: { user_id: current_user.id })
 ```
 
-PostHog automatically extracts the user's distinct ID from `user_id` or `distinct_id` in the context hash.
+PostHog automatically extracts the user's distinct ID from `user_id` or `distinct_id` in the context hash. Other context keys are included as properties on the exception event.
 
 ### User context
 
-PostHog Rails automatically captures user information from your controllers. If your user method has a different name, configure it:
+PostHog Rails automatically captures authenticated user information from your controllers for exceptions. Authenticated Rails user context takes precedence over client-supplied tracing headers for exception identity.
+
+If your user method has a different name, configure it:
 
 ```ruby
 PostHog::Rails.config.current_user_method = :logged_in_user
@@ -217,11 +291,15 @@ PostHog::Rails.config.current_user_method = :logged_in_user
 
 #### User ID extraction
 
-By default, PostHog Rails auto-detects the user's distinct ID by trying these methods:
+By default, PostHog Rails auto-detects the user's distinct ID by trying these methods in order:
 
 1. `posthog_distinct_id` – Define this on your User model for full control
 2. `distinct_id` – Common analytics convention
 3. `id` – Standard ActiveRecord primary key
+4. `pk` – Primary key alias
+5. `uuid` – For UUID-based primary keys
+
+It also checks hash-like users for `id`, `pk`, and `uuid` keys.
 
 You can configure a specific method:
 
@@ -246,9 +324,16 @@ The following exceptions are not reported by default (common 4xx errors):
 - `AbstractController::ActionNotFound`
 - `ActionController::BadRequest`
 - `ActionController::InvalidAuthenticityToken`
+- `ActionController::InvalidCrossOriginRequest`
+- `ActionController::MethodNotAllowed`
+- `ActionController::NotImplemented`
+- `ActionController::ParameterMissing`
 - `ActionController::RoutingError`
 - `ActionController::UnknownFormat`
+- `ActionController::UnknownHttpMethod`
+- `ActionDispatch::Http::Parameters::ParseError`
 - `ActiveRecord::RecordNotFound`
+- `ActiveRecord::RecordNotUnique`
 
 Add more with:
 
@@ -258,18 +343,43 @@ PostHog::Rails.config.excluded_exceptions = ['MyException']
 
 ## Feature flags
 
-Use feature flags in your Rails app:
+Evaluate flags once for the current user, then read values from the returned snapshot:
 
 ```ruby
 class PostsController < ApplicationController
   def show
-    if PostHog.is_feature_enabled('new-post-design', current_user.id)
+    flags = PostHog.evaluate_flags(current_user.id)
+
+    if flags.enabled?('new-post-design')
       render 'posts/show_new'
     else
       render 'posts/show'
     end
   end
 end
+```
+
+For multivariate flags and experiments, use `get_flag`:
+
+```ruby
+flags = PostHog.evaluate_flags(current_user.id)
+variant = flags.get_flag('checkout-experiment')
+
+if variant == 'test'
+  # Do something differently
+end
+```
+
+When capturing an event after branching on a flag, pass the same `flags` snapshot so the event includes the exact flag values used by your code:
+
+```ruby
+flags = PostHog.evaluate_flags(current_user.id)
+
+PostHog.capture({
+  distinct_id: current_user.id,
+  event: 'checkout_started',
+  flags: flags.only_accessed
+})
 ```
 
 For local evaluation, ensure you've set `personal_api_key`:
@@ -280,13 +390,16 @@ config.personal_api_key = Rails.application.credentials.posthog[:personal_api_ke
 
 See our [Ruby SDK docs](/docs/libraries/ruby#local-evaluation) for details on local evaluation with Puma and Unicorn servers.
 
+> **Note:** `PostHog.is_feature_enabled`, `PostHog.get_feature_flag`, `PostHog.get_feature_flag_result`, `PostHog.get_feature_flag_payload`, and `PostHog.capture({ ..., send_feature_flags: true })` still work during the migration period, but they're deprecated. Prefer `PostHog.evaluate_flags` for new code.
+
 ## Testing
 
-In your test environment, disable PostHog or use test mode:
+In your test environment, disable network calls with test mode:
 
 ```ruby file=config/environments/test.rb
 PostHog.init do |config|
-  config.test_mode = true  # Events are queued but not sent
+  config.api_key = '<ph_project_token>'
+  config.test_mode = true
 end
 ```
 
@@ -306,23 +419,33 @@ end
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `api_key` | String | **required** | Your PostHog project token |
-| `host` | String | `https://us.i.posthog.com` | PostHog instance URL |
-| `personal_api_key` | String | `nil` | For feature flag evaluation |
-| `test_mode` | Boolean | `false` | Don't send events (for testing) |
-| `on_error` | Proc | `nil` | Error callback |
+| `api_key` | String | **required** | Your PostHog project token. |
+| `host` | String | `https://us.i.posthog.com` | Fully qualified PostHog API host. |
+| `personal_api_key` | String | `nil` | Personal API key for local feature flag evaluation and remote config payloads. |
+| `max_queue_size` | Integer | `10000` | Maximum number of events to keep in the async queue before dropping new events. |
+| `test_mode` | Boolean | `false` | Keep events queued and do not send them. Useful for tests. |
+| `sync_mode` | Boolean | `false` | Send events synchronously on the calling thread. |
+| `on_error` | Proc | no-op | Callback called as `on_error.call(status, error)`. |
+| `feature_flags_polling_interval` | Integer | `30` | Seconds between local feature flag definition polls. |
+| `feature_flag_request_timeout_seconds` | Integer | `3` | Timeout, in seconds, for feature flag requests. |
+| `before_send` | Proc | `nil` | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or `nil` to drop the event. |
+
+The `PostHog.init` block supports the options above. Less common core options like `batch_size`, `disable_singleton_warning`, `skip_ssl_verification`, and the experimental `flag_definition_cache_provider` can be passed as an options hash to `PostHog.init(...)`; see the [Ruby SDK docs](/docs/libraries/ruby#configuration) for details.
 
 ### Rails-specific options
 
+Configure these via `PostHog::Rails.configure` or `PostHog::Rails.config`:
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `auto_capture_exceptions` | Boolean | `false` | Automatically capture exceptions |
-| `report_rescued_exceptions` | Boolean | `false` | Report exceptions Rails rescues |
-| `auto_instrument_active_job` | Boolean | `false` | Instrument ActiveJob |
-| `capture_user_context` | Boolean | `true` | Include user info |
-| `current_user_method` | Symbol | `:current_user` | Controller method for user |
-| `user_id_method` | Symbol | `nil` | Method to extract ID from user object |
-| `excluded_exceptions` | Array | `[]` | Additional exceptions to ignore |
+| `auto_capture_exceptions` | Boolean | `false` | Automatically capture exceptions. |
+| `report_rescued_exceptions` | Boolean | `false` | Report exceptions Rails rescues. |
+| `auto_instrument_active_job` | Boolean | `false` | Capture ActiveJob exceptions with job context. |
+| `excluded_exceptions` | Array | `[]` | Additional exception class names to ignore. |
+| `use_tracing_headers` | Boolean | `true` | Use `X-PostHog-Distinct-Id` and `X-PostHog-Session-Id` as request-scoped defaults. |
+| `capture_user_context` | Boolean | `true` | Include authenticated user info in exceptions. |
+| `current_user_method` | Symbol | `:current_user` | Controller method used to fetch the current user. |
+| `user_id_method` | Symbol | `nil` | Method used to extract the distinct ID from the user object. Auto-detects when nil. |
 
 ## Troubleshooting
 
@@ -335,7 +458,7 @@ end
    => true
    ```
 
-2. Check your excluded exceptions list
+2. Check your excluded exceptions list.
 3. Verify middleware is installed:
    ```ruby
    Rails.application.middleware
@@ -343,9 +466,9 @@ end
 
 ### User context not working
 
-1. Verify `current_user_method` matches your controller method
-2. Check that the user object responds to `posthog_distinct_id`, `distinct_id`, or `id`
-3. If using a custom identifier, set `PostHog::Rails.config.user_id_method = :your_method`
+1. Verify `current_user_method` matches your controller method.
+2. Check that the user object responds to `posthog_distinct_id`, `distinct_id`, `id`, `pk`, or `uuid`.
+3. If using a custom identifier, set `PostHog::Rails.config.user_id_method = :your_method`.
 
 ### Feature flags not working
 

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -19,11 +19,73 @@ The `posthog-ruby` library provides tracking functionality on the server-side fo
 
 It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.
 
+> **Use a single client instance (singleton)** — Create the PostHog client once and reuse it throughout your application. Multiple client instances with the same API key can cause dropped events and inconsistent behavior. The SDK logs a warning if it detects multiple instances.
+
 ## Installation
 
 import RubyInstall from '../../integrate/_snippets/install-ruby.mdx'
 
 <RubyInstall />
+
+## Configuration
+
+Initialize the client with your project token before making any calls:
+
+```ruby
+require 'posthog'
+
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  host: '<ph_client_api_host>',
+  on_error: Proc.new { |status, msg| print msg }
+})
+```
+
+Available client options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `api_key` | String | **required** | Your PostHog project token. |
+| `host` | String | `https://us.i.posthog.com` | Fully qualified PostHog API host. Include the protocol, for example `https://us.i.posthog.com` or `https://eu.i.posthog.com`. |
+| `personal_api_key` | String | `nil` | Personal API key. Required for local feature flag evaluation and remote config payloads. |
+| `max_queue_size` | Integer | `10000` | Maximum number of events to keep in the async queue before dropping new events. |
+| `batch_size` | Integer | `100` | Maximum number of events to send in one async batch. |
+| `test_mode` | Boolean | `false` | Keep events queued and do not send them. Useful for tests. |
+| `sync_mode` | Boolean | `false` | Send events synchronously on the calling thread. Useful in forking environments like Sidekiq and Resque. |
+| `on_error` | Proc | no-op | Callback called as `on_error.call(status, error)` for API or serialization errors. |
+| `feature_flags_polling_interval` | Integer | `30` | Seconds between local feature flag definition polls. |
+| `feature_flag_request_timeout_seconds` | Integer | `3` | Timeout, in seconds, for feature flag requests. |
+| `before_send` | Proc | `nil` | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or `nil` to drop the event. |
+| `disable_singleton_warning` | Boolean | `false` | Suppress warnings about multiple clients with the same API key. Use only when you intentionally need multiple clients. |
+| `skip_ssl_verification` | Boolean | `false` | Disable SSL certificate verification. Intended only for local development or custom deployments. |
+| `flag_definition_cache_provider` | Object | `nil` | Experimental provider for distributed feature flag definition caching. See [distributed flag definition caching](#distributed-flag-definition-caching). |
+
+### Filtering or modifying events before sending
+
+Use `before_send` to add, modify, or drop events immediately before the SDK queues or sends them:
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  before_send: Proc.new do |event|
+    event[:properties] ||= {}
+    event[:properties]['environment'] = ENV['RACK_ENV']
+
+    # Return nil to drop the event
+    event[:properties]['internal_user'] == true ? nil : event
+  end
+})
+```
+
+### Flushing and shutting down
+
+For short-lived scripts, call `flush` before the process exits. Call `shutdown` when your application is stopping to flush pending events and stop background resources.
+
+```ruby
+posthog.capture({ distinct_id: 'user_123', event: 'script_finished' })
+posthog.flush
+posthog.shutdown
+```
 
 ## Identifying users
 
@@ -31,25 +93,51 @@ import IdentifyBackendCallout from '../../_snippets/identify-backend-callout.mdx
 
 <IdentifyBackendCallout />
 
+Identify a user and set their person properties with `identify`:
+
+```ruby
+posthog.identify({
+  distinct_id: 'distinct_id_of_your_user',
+  properties: {
+    email: 'john@doe.com',
+    pro_user: false
+  }
+})
+```
+
 ## Capturing events
 
 import RubySendEvents from '../../integrate/send-events/_snippets/send-events-ruby.mdx'
 
 <RubySendEvents />
 
+`capture` accepts these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `distinct_id` | String | The user ID. If omitted, framework integrations can provide request context; otherwise the SDK generates a UUID and marks the event as personless. |
+| `event` | String | Event name. Required. |
+| `properties` | Hash | Event properties. |
+| `groups` | Hash | Group analytics mapping from group type to group key. |
+| `timestamp` | Time | When the event occurred. Defaults to the current time. |
+| `message_id` | String | Optional message ID. |
+| `uuid` | String | Optional event UUID used for deduplication. Must be a valid UUID. |
+| `flags` | `PostHog::FeatureFlagEvaluations` | Snapshot returned by `evaluate_flags`. Adds `$feature/<key>` and `$active_feature_flags` properties without another `/flags` request. |
+| `send_feature_flags` | Boolean, Hash, or `PostHog::SendFeatureFlagsOptions` | Deprecated. Prefer passing `flags:` from `evaluate_flags`. |
+
 ## Person profiles and properties
 
 The Ruby SDK captures identified events by default. These create [person profiles](/docs/data/persons). To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```ruby
-posthog.capture(
+posthog.capture({
     distinct_id: 'distinct_id',
     event: 'event_name',
     properties: {
         '$set': { name: 'Max Hedgehog' },
         '$set_once': { initial_url: '/blog' }
     }
-)
+})
 ```
 
 For more details on the difference between `$set` and `$set_once`, see our [person properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
@@ -57,13 +145,13 @@ For more details on the difference between `$set` and `$set_once`, see our [pers
 To capture [anonymous events](/docs/data/anonymous-vs-identified-events) without person profiles, set the event's `$process_person_profile` property to `false`:
 
 ```ruby
-posthog.capture(
+posthog.capture({
     distinct_id: 'distinct_id',
     event: 'event_name',
     properties: {
         '$process_person_profile': false
     }
-)
+})
 ```
 
 ## Alias
@@ -73,10 +161,10 @@ Sometimes, you want to assign multiple distinct IDs to a single user. This is he
 In this case, you can use `alias` to assign another distinct ID to the same user.
 
 ```ruby
-posthog.alias(
-  distinct_id: "distinct_id",
-  alias: "alias_id"
-)
+posthog.alias({
+  distinct_id: 'distinct_id',
+  alias: 'alias_id'
+})
 ```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
@@ -91,6 +179,18 @@ import RubyFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/f
 
 <RubyFeatureFlagsCode />
 
+### Legacy single-flag methods
+
+The following methods are still available during the migration period, but are deprecated. Prefer `evaluate_flags` for new code.
+
+| Method | Replacement |
+|--------|-------------|
+| `posthog.is_feature_enabled(flag_key, distinct_id, ...)` | `posthog.evaluate_flags(distinct_id, ...).enabled?(flag_key)` |
+| `posthog.get_feature_flag(flag_key, distinct_id, ...)` | `posthog.evaluate_flags(distinct_id, ...).get_flag(flag_key)` |
+| `posthog.get_feature_flag_payload(flag_key, distinct_id, ...)` | `posthog.evaluate_flags(distinct_id, ...).get_flag_payload(flag_key)` |
+| `posthog.get_feature_flag_result(flag_key, distinct_id, ...)` | `posthog.evaluate_flags(distinct_id, ...)` and read `get_flag` / `get_flag_payload` |
+| `posthog.capture({ ..., send_feature_flags: true })` | `posthog.capture({ ..., flags: flags })` |
+
 ### Local Evaluation
 
 import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-intro.mdx"
@@ -101,32 +201,59 @@ For details on how to implement local evaluation, see our [local evaluation guid
 
 #### Evaluating feature flags locally in unicorn server
 
-If you have `preload_app true` in your unicorn config, you can use the [`after_fork`](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) hook (which is part of the unicorn's configuration) to enable the feature flag cache to receive the updates from posthog dashboard.
+If you have `preload_app true` in your unicorn config, you can use the [`after_fork`](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) hook (which is part of the unicorn's configuration) to enable the feature flag cache to receive the updates from PostHog.
 
 ```ruby
-after_fork do |server, worker|
-  $posthog = PostHog::Client.new(
+after_fork do |_server, _worker|
+  $posthog = PostHog::Client.new({
     api_key: '<ph_project_token>',
-    personal_api_key: '<ph_personal_api_key>'
+    personal_api_key: '<ph_personal_api_key>',
     host: '<ph_client_api_host>',
     on_error: Proc.new { |status, msg| print msg }
-  )
+  })
 end
 ```
 
 #### Evaluating feature flags locally in a Puma server
 
-If you use Puma with multiple workers, you can use the `on_worker_boot` hook (which is part of the Puma's configuration) to enable the feature flag cache to receive the updates from PostHog.
+If you use Puma with multiple workers, you can use the `on_worker_boot` hook (which is part of Puma's configuration) to enable the feature flag cache to receive updates from PostHog.
 
 ```ruby
 on_worker_boot do
-  $posthog = PostHog::Client.new(
+  $posthog = PostHog::Client.new({
     api_key: '<ph_project_token>',
-    personal_api_key: '<ph_personal_api_key>'
+    personal_api_key: '<ph_personal_api_key>',
     host: '<ph_client_api_host>',
     on_error: Proc.new { |status, msg| print msg }
-  )
+  })
 end
+```
+
+### Distributed flag definition caching
+
+`flag_definition_cache_provider` is an experimental API for sharing locally evaluated feature flag definitions across multiple workers or processes. The provider object must implement:
+
+- `flag_definitions` – returns cached definitions as a hash with `:flags`, `:group_type_mapping`, and `:cohorts`, or `nil` if empty.
+- `should_fetch_flag_definitions?` – returns `true` if this process should fetch fresh definitions from PostHog.
+- `on_flag_definitions_received(data)` – stores freshly fetched definitions.
+- `shutdown` – releases locks or other resources.
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  personal_api_key: '<ph_personal_api_key>',
+  flag_definition_cache_provider: my_cache_provider
+})
+```
+
+Because this API is experimental, it may change in future minor versions.
+
+### Remote config payloads
+
+Use `get_remote_config_payload` to fetch the decrypted remote config payload for a flag. This requires `personal_api_key`.
+
+```ruby
+payload = posthog.get_remote_config_payload('flag-key')
 ```
 
 ## Experiments (A/B tests)
@@ -148,9 +275,9 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics) guide for more information.
 
-> **Note:**  This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
 
--   Capture an event and associate it with a group
+Capture an event and associate it with a group:
 
 ```ruby
 posthog.capture({
@@ -159,30 +286,28 @@ posthog.capture({
     properties: {
         movie_id: '123',
         category: 'romcom'
-    }
+    },
     groups: {
         'company': 'company_id_in_your_db'
     }
 })
 ```
 
--   Update properties on a group
+Update properties on a group:
 
 ```ruby
-posthog.group_identify(
-  {
-    group_type: "company",
-    group_key: "company_id_in_your_db",
-    properties: {
-      name: "Awesome Inc."
-    }
+posthog.group_identify({
+  group_type: 'company',
+  group_key: 'company_id_in_your_db',
+  properties: {
+    name: 'Awesome Inc.'
   }
-)
+})
 ```
 
 The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
-If the optional `distinct_id` is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`.
+If the optional `distinct_id` is not provided in the group identify call, it defaults to `$#{group_type}_#{group_key}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`.
 
 ## Exception capture
 
@@ -194,14 +319,12 @@ The [posthog-rails](/docs/libraries/ruby-on-rails) gem provides automatic except
 
 </CalloutBox>
 
-For non-Rails Ruby applications, you can manually capture exceptions:
-
-To capture exceptions, use the `capture_exception` method:
+For non-Rails Ruby applications, you can manually capture exceptions with `capture_exception`:
 
 ```ruby
 begin
   # Code that might raise an exception
-  raise StandardError, "Something went wrong"
+  raise StandardError, 'Something went wrong'
 rescue => e
   posthog.capture_exception(
     e,
@@ -217,9 +340,10 @@ The `capture_exception` method accepts the following parameters:
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `exception` | `Exception` | The exception object to capture (required) |
-| `distinct_id` | `String` | The distinct ID of the user (optional) |
-| `additional_properties` | `Hash` | Additional properties to attach to the exception event (optional) |
+| `exception` | `Exception`, `String`, or exception-like object | The exception to capture. Required. |
+| `distinct_id` | `String` | The distinct ID of the user. Optional; request context can provide a default, otherwise the SDK generates a UUID. |
+| `additional_properties` | `Hash` | Additional properties to attach to the exception event. Optional. |
+| `flags` | `PostHog::FeatureFlagEvaluations` | Optional keyword argument. Adds the same feature flag properties as `capture({ flags: flags })`. |
 
 You can also override the [fingerprint](/docs/error-tracking/fingerprints) to customize how exceptions are grouped into issues:
 
@@ -235,7 +359,30 @@ posthog.capture_exception(
 
 ## Debug mode
 
-The Ruby SDK debug logs by default. The log level by default is set to `WARN`. You can change it to `DEBUG` if you want to debug the client by running `posthog.logger.level = Logger::DEBUG`, where `posthog` is your initialized `PostHog::Client` instance.
+The Ruby SDK logs warnings by default. You can change the log level to `DEBUG` to debug the client:
+
+```ruby
+posthog.logger.level = Logger::DEBUG
+```
+
+You can also replace the SDK logger globally:
+
+```ruby
+PostHog::Logging.logger = Rails.logger
+```
+
+## Test helpers
+
+When `test_mode: true`, events remain queued. You can inspect and clear the queue in tests:
+
+```ruby
+posthog = PostHog::Client.new({ api_key: '<ph_project_token>', test_mode: true })
+posthog.capture({ distinct_id: 'user_123', event: 'test_event' })
+
+posthog.queued_messages
+posthog.dequeue_last_message
+posthog.clear
+```
 
 ## Thank you
 


### PR DESCRIPTION
## Changes

**Problem**

follow up https://github.com/PostHog/posthog-ruby/pull/149

Ruby and Rails docs were missing newer SDK configuration options, request context behavior, and the `evaluate_flags` migration path.

**Changes**

- Expanded Ruby SDK configuration docs with client options, singleton guidance, `before_send`, flushing/shutdown, and test helpers.
- Updated feature flag docs to prefer `evaluate_flags`, document local-only evaluation, GeoIP disabling, remote config payloads, and legacy API replacements.
- Refreshed Rails docs with request context, tracing headers, error capture details, ActiveJob user association, and updated configuration tables.

No screenshots or screen recordings — documentation-only change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
