### PR TITLE
feat(api-docs): show prev/next buttons above endpoint list

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -647,6 +647,17 @@ export default function ApiEndpoint({ data }: { data: ApiEndpointData }): JSX.El
 
                     <Endpoints paths={paths} containerRef={contentContainerRef} />
 
+                    {(previousURL || nextURL) && (
+                        <div className="mt-8 flex gap-4">
+                            {previousURL && (
+                                <CallToAction to={previousURL} type="outline">
+                                    ← Previous page
+                                </CallToAction>
+                            )}
+                            {nextURL && <CallToAction to={nextURL}>Next page →</CallToAction>}
+                        </div>
+                    )}
+
                     {items.map((item, index) => {
                         const mdxNode = allMdx.nodes?.find((node) => node.slug.split('/').pop() === item.operationId)
 


### PR DESCRIPTION
## Changes

Mirrors the existing bottom pagination at the top so it's clear there are more pages when the endpoint list is long. It's not clear that this is even paginated unless you reach the bottom.

<img width="1708" height="938" alt="image" src="https://github.com/user-attachments/assets/a1b9e54c-788c-4fb9-b12b-e1edcc618fdf" />

<img width="1707" height="982" alt="image" src="https://github.com/user-attachments/assets/1ad51559-1c20-4e6a-9d39-eb0f39c934c9" />

<img width="1713" height="869" alt="image" src="https://github.com/user-attachments/assets/c649b30d-af0a-4ac6-9e0a-1f4cfbf4600b" />

Generated-By: PostHog Code
Task-Id: 753a8de5-7de5-4dde-93d9-b87a9044f519

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
