### PR TITLE
docs: document the deep_links primitive for provisioning partners

### DIFF
--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -198,23 +198,6 @@ sequenceDiagram
     PH-->>P: project token + host
 ```
 
-#### Deep linking
-
-The `requires_auth` flow isn't only for first-time onboarding. Use the same handshake every time you want to deep-link a user from your own application into PostHog. A common case is an "Open in PostHog" button on the project a user has already connected: each click should run the handshake again, not point at a static PostHog URL.
-
-For each click, your backend calls `/account_requests` with the user's email, then you redirect them to the returned `requires_auth.url`. When the logged-in PostHog session matches the email you sent, PostHog completes the OAuth handshake and lands the user in their project.
-
-If the session is for a different PostHog account, PostHog shows an "Account mismatch" page with a one-click `Log out and continue as <expected email>` button that resumes the flow after re-login. To smooth this case even further – so users can self-diagnose before they click – consider also surfacing the expected PostHog email in your own UI, for example a button labeled _"Open in PostHog as user@example.com"_.
-
-##### Avoid linking directly to project URLs
-
-Pointing a button straight at `https://us.posthog.com/project/<id>` skips the handshake and removes PostHog's ability to route the user safely:
-
-- If the user is logged into PostHog with a different email, they hit a permission error or 404 on a project their current account can't access.
-- If they're logged out, they get the generic PostHog login page with no context about which email to use.
-
-Going through `/account_requests` keeps routing scoped to the email you sent.
-
 ### Step 2: Exchange the code for tokens
 
 Exchange the authorization code for an access token and refresh token. The token endpoint uses standard `application/x-www-form-urlencoded` encoding.
@@ -319,6 +302,53 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
 | `api_key` | The project token (starts with `phc_`) – use this to initialize PostHog SDKs |
 | `host` | The API host (`https://us.posthog.com` or `https://eu.posthog.com`) |
 | `personal_api_key` | A personal API key scoped to this project – use this for the PostHog API |
+
+### Deep linking
+
+For recurring deep links from your application into PostHog – the most common case is an "Open in PostHog" button on a user's connected project – use the deep-link endpoint. Each call returns a short-lived, single-use URL that logs the user into their PostHog project on click. There's no consent screen and no email-mismatch friction: the URL mints a fresh PostHog session for the right user, overriding any other session the browser happens to have.
+
+```bash
+curl -X POST https://us.posthog.com/api/agentic/provisioning/deep_links \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer phx_abc123..." \
+  -H "API-Version: 0.1d" \
+  -d '{
+    "purpose": "dashboard"
+  }'
+```
+
+Authenticate with the `access_token` you got from [Step 2](#step-2-exchange-the-code-for-tokens) – the same Bearer credential you use for `/resources`. The token is scoped to a single team, so the resulting deep link lands the user in the correct project.
+
+**Request fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `purpose` | string | No | What the deep link should land on. Currently only `dashboard` is supported. Defaults to `dashboard`. |
+
+**Response:**
+
+```json
+{
+  "purpose": "dashboard",
+  "url": "https://us.posthog.com/agentic/login?token=...&team_id=12345",
+  "expires_at": "2026-05-20T21:00:00Z"
+}
+```
+
+The returned `url` is valid for 10 minutes and can only be opened once. Use it as the `href` for the "Open in PostHog" button. Don't cache the URL across renders – generate a fresh one per click so the token stays valid.
+
+#### Requires a trusted partner record
+
+This endpoint is gated on the `provisioning_can_issue_deep_links` flag on your partner record, which is only enabled for partners admin-onboarded by PostHog. If you get a `deep_links_not_enabled` 403, ask PostHog to enable it for your CIMD app.
+
+#### Avoid linking directly to project URLs
+
+Pointing a button straight at `https://us.posthog.com/project/<id>` skips the deep-link handshake and removes PostHog's ability to log the user in correctly:
+
+- If the user is logged into PostHog with a different email, they hit a permission error or 404 on a project their current account can't access.
+- If they're logged out, they get the generic PostHog login page with no context about which email to use.
+
+Going through `/deep_links` mints a session for the right user every time.
 
 ### Rotate project credentials
 


### PR DESCRIPTION
## Changes

Fixes the deep-linking guidance for provisioning partners. The previous version (added in [#16870](https://github.com/PostHog/posthog.com/pull/16870)) recommended calling \`/account_requests\` per click for recurring \"Open in PostHog\" buttons – but that's the onboarding primitive. Partners following it (Insforge in particular) ended up bouncing every click through the authorize page even for already-linked users.

The right primitive is \`/deep_links\`, which:
- Takes the Bearer \`access_token\` the partner already got from Step 2
- Returns a single-use, 10-minute URL that logs the user into their PostHog project on click
- Forcibly mints a fresh PostHog session, overriding any other session in the browser (no consent screen, no mismatch friction)

Replaces the misleading \"Deep linking\" subsection under Step 1 with a dedicated top-level section after Step 3 covering the endpoint shape, the trusted-partner gate (\`provisioning_can_issue_deep_links\`), and the anti-pattern of hardcoding project URLs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in \`vercel.json\` (no page moved)