### PR TITLE
fix(docs): use absolute path for PostHog Code link in MCP docs

### DIFF
--- a/contents/docs/model-context-protocol/_snippets/mcp-clients.tsx
+++ b/contents/docs/model-context-protocol/_snippets/mcp-clients.tsx
@@ -5,7 +5,7 @@ const MCPClients = () => {
     const codeEditors = [
         {
             label: 'PostHog Code',
-            url: 'docs/posthog-code',
+            url: '/docs/posthog-code',
             icon: 'IconPostHog',
         },
         {


### PR DESCRIPTION
## Changes

The PostHog Code entry in `contents/docs/model-context-protocol/_snippets/mcp-clients.tsx` used a relative path (`docs/posthog-code`) while every other entry in the same list uses an absolute path (`/docs/...`).

When rendered on `/docs/model-context-protocol`, the browser resolves the relative URL against the current path, producing `/docs/docs/posthog-code` — which 404s. Switching to `/docs/posthog-code` makes the link match the rest of the list and point at the actual docs page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*