### PR TITLE
docs: update Laravel PHP SDK guide

### DIFF
--- a/contents/docs/libraries/laravel.md
+++ b/contents/docs/libraries/laravel.md
@@ -3,15 +3,27 @@ title: Laravel
 platformLogo: laravel
 ---
 
-PostHog makes it easy to get data about traffic and usage of your Laravel app. Integrating PostHog enables analytics, custom events capture, feature flags, and more.
-
-This guide walks you through integrating PostHog into your Laravel app using the [PHP SDK](/docs/libraries/php).
+PostHog integrates with Laravel through the [PostHog PHP SDK](/docs/libraries/php). This page covers Laravel-specific setup. For SDK features such as event capture, identifying users, feature flags, group analytics, and configuration options, see the [PHP SDK docs](/docs/libraries/php).
 
 ## Installation
 
-First, ensure [Composer](https://getcomposer.org/) is installed. Then run `composer require posthog/posthog-php` to install PostHog’s PHP SDK.
+Install the PHP SDK as described in the [PHP installation guide](/docs/libraries/php#installation), then add your project token and host to `.env`:
 
-Next, initialize PostHog in the `boot` method of `app/Providers/AppServiceProvider.php`:
+```bash file=.env
+POSTHOG_API_KEY=<ph_project_token>
+POSTHOG_HOST=<ph_client_api_host>
+```
+
+Add PostHog to Laravel's services config:
+
+```php file=config/services.php
+'posthog' => [
+    'api_key' => env('POSTHOG_API_KEY'),
+    'host' => env('POSTHOG_HOST', 'https://us.i.posthog.com'),
+],
+```
+
+Initialize PostHog in the `boot` method of `app/Providers/AppServiceProvider.php`:
 
 ```php file=app/Providers/AppServiceProvider.php
 <?php
@@ -25,45 +37,101 @@ class AppServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        if (! config('services.posthog.api_key')) {
+            return;
+        }
+
         PostHog::init(
-            '<ph_project_token>',
+            config('services.posthog.api_key'),
             [
-                'host' => '<ph_client_api_host>'
+                'host' => config('services.posthog.host'),
             ]
         );
     }
 }
 ```
 
-You can find your project token and instance address in [your project settings](https://us.posthog.com/project/settings). 
+## Request context middleware
 
-## Usage
+Client SDKs such as [PostHog JS](/docs/libraries/js) can send tracing headers to your Laravel backend. The PHP SDK can read `X-PostHog-Distinct-Id` and `X-PostHog-Session-Id` headers and apply them to events captured during the request. Add middleware like this:
 
-To access your PostHog client anywhere in your app, import `use PostHog\PostHog;` and call `PostHog::method_name`. For example, below is how to capture an event in a simple route:
-
-```php file=routes/web.php
+```php file=app/Http/Middleware/PostHogRequestContext.php
 <?php
 
-use Illuminate\Support\Facades\Route;
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
 use PostHog\PostHog;
+use Symfony\Component\HttpFoundation\Response;
 
-Route::get('/', function () {
-    PostHog::capture([
-        'distinctId' => 'distinct_id_of_your_user',
-        'event' => 'route_called'
-    ]);
+final class PostHogRequestContext
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! config('services.posthog.api_key')) {
+            return $next($request);
+        }
 
-    return view('welcome');
-});
+        $context = PostHog::contextFromHeaders($request->headers->all());
+
+        $context['properties'] = array_merge(
+            $context['properties'] ?? [],
+            array_filter([
+                '$current_url' => $request->fullUrl(),
+                '$request_method' => $request->method(),
+                '$request_path' => $request->getPathInfo(),
+                '$user_agent' => $request->userAgent(),
+                '$ip' => $request->ip(),
+            ], static fn ($value): bool => $value !== null && $value !== '')
+        );
+
+        return PostHog::withContext(
+            $context,
+            static fn (): Response => $next($request),
+            ['fresh' => true]
+        );
+    }
+}
 ```
+
+Register this middleware using your Laravel version's normal middleware registration.
+
+## Error tracking in Laravel
+
+The PHP SDK supports [error tracking](/docs/libraries/php#error-tracking), but Laravel handles most request exceptions before they become uncaught PHP exceptions. Capture Laravel-reported exceptions explicitly.
+
+In Laravel 11 and later, add a report callback in `bootstrap/app.php`:
+
+```php file=bootstrap/app.php
+use Illuminate\Foundation\Configuration\Exceptions;
+use PostHog\PostHog;
+use Throwable;
+
+->withExceptions(function (Exceptions $exceptions): void {
+    $exceptions->report(function (Throwable $e): void {
+        if (! config('services.posthog.api_key')) {
+            return;
+        }
+
+        PostHog::captureException(
+            $e,
+            auth()->id() !== null ? (string) auth()->id() : null,
+            [
+                '$current_url' => request()->fullUrl(),
+                '$request_method' => request()->method(),
+            ]
+        );
+    });
+})
+```
+
+For older Laravel versions, call `PostHog::captureException()` from your exception handler's `report` method.
+
+## Long-running processes
+
+In normal PHP request lifecycles, queued events flush when the client is destroyed. In long-running Laravel processes such as queue workers, Horizon, or Octane, call `PostHog::flush()` after capturing important events or at the end of a job/request.
 
 ## Next steps
 
-For any technical questions for how to integrate specific PostHog features into Laravel (such as analytics, feature flags, A/B testing, etc.), have a look at our [PHP SDK docs](/docs/libraries/php).
-
-Alternatively, the following tutorials can help you get started:
-
-- [How to set up analytics in Laravel](/tutorials/laravel-analytics)
-- [How to set up feature flags in Laravel](/tutorials/laravel-feature-flags)
-- [How to set up A/B tests in Laravel](/tutorials/laravel-ab-tests)
-
+See the [PHP SDK docs](/docs/libraries/php) for usage examples and the full API reference.


### PR DESCRIPTION
## Changes

Updates the Laravel library docs to:

- Clarify that Laravel integrates through the PostHog PHP SDK and link to the PHP SDK docs for shared API details.
- Document environment variables and Laravel services config initialization.
- Add request context middleware for applying PostHog tracing headers from client SDKs such as PostHog JS, without including a frontend setup example.
- Add Laravel exception reporting guidance and a note about flushing in long-running processes.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
