### PR TITLE
Link enterprise "Contact us" to /talk-to-a-human

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -3,7 +3,7 @@ import Tooltip from 'components/Tooltip'
 import { IconCopy, IconInfo, IconLightBulb } from '@posthog/icons'
 import Toggle from 'components/Toggle'
 import { calculatePrice, formatUSD } from '../PricingSlider/pricingSliderLogic'
-import { useStaticQuery } from 'gatsby'
+import { Link, useStaticQuery } from 'gatsby'
 import { allProductsData } from '../Pricing'
 import useProducts from 'hooks/useProducts'
 import { LogSlider, inverseCurve, sliderCurve } from '../PricingSlider/Slider'
@@ -436,6 +436,7 @@ export default function Tabbed() {
                         .map(({ type, name, description }) => {
                             const platformAddon = platformAddons.find((addon) => addon.type === type)
                             const checked = platformAddon?.checked
+                            const isEnterprise = type === 'enterprise'
                             return (
                                 <div key={type} className="grid grid-cols-6 gap-8 items-center">
                                     <div className="col-span-3 sm:col-span-4 flex items-center justify-between">
@@ -451,32 +452,49 @@ export default function Tabbed() {
                                                 </span>
                                             </Tooltip>
                                         </div>
-                                        <Toggle
-                                            checked={checked}
-                                            onChange={(checked) =>
-                                                setPlatformAddons(
-                                                    platformAddons.map((addon) => {
-                                                        if (addon.type === type) {
-                                                            return { ...addon, checked }
-                                                        }
-                                                        return addon
-                                                    })
-                                                )
-                                            }
-                                        />
+                                        {!isEnterprise && (
+                                            <Toggle
+                                                checked={checked}
+                                                onChange={(checked) =>
+                                                    setPlatformAddons(
+                                                        platformAddons.map((addon) => {
+                                                            if (addon.type === type) {
+                                                                return { ...addon, checked }
+                                                            }
+                                                            return addon
+                                                        })
+                                                    )
+                                                }
+                                            />
+                                        )}
                                     </div>
                                     <div className="col-span-3 sm:col-span-2 flex justify-between">
-                                        <div>
-                                            <strong className="text-[15px] md:text-base">
-                                                ${platformAddon.price.toLocaleString()}
-                                            </strong>
-                                            <span className="text-sm opacity-70">/mo</span>
-                                        </div>
-                                        <div className="text-right">
-                                            <p className={`font-semibold m-0 pr-3 ${checked ? '' : 'opacity-50'}`}>
-                                                ${checked ? platformAddon?.price : 0}
-                                            </p>
-                                        </div>
+                                        {isEnterprise ? (
+                                            <Link
+                                                to="/talk-to-a-human"
+                                                className="text-[15px] md:text-base font-bold"
+                                            >
+                                                Contact us
+                                            </Link>
+                                        ) : (
+                                            <>
+                                                <div>
+                                                    <strong className="text-[15px] md:text-base">
+                                                        ${platformAddon.price.toLocaleString()}
+                                                    </strong>
+                                                    <span className="text-sm opacity-70">/mo</span>
+                                                </div>
+                                                <div className="text-right">
+                                                    <p
+                                                        className={`font-semibold m-0 pr-3 ${
+                                                            checked ? '' : 'opacity-50'
+                                                        }`}
+                                                    >
+                                                        ${checked ? platformAddon?.price : 0}
+                                                    </p>
+                                                </div>
+                                            </>
+                                        )}
                                     </div>
                                 </div>
                             )

--- a/src/pages/platform-packages/index.tsx
+++ b/src/pages/platform-packages/index.tsx
@@ -113,7 +113,9 @@ export default function PlatformPackages() {
                                         {plan?.flat_rate && (
                                             <div className="flex items-baseline mt-auto">
                                                 {addon.type === 'enterprise' ? (
-                                                    <strong className="text-lg">Contact us</strong>
+                                                    <Link to="/talk-to-a-human" className="text-lg font-bold">
+                                                        Contact us
+                                                    </Link>
                                                 ) : (
                                                     <>
                                                         <strong className="text-lg">


### PR DESCRIPTION
## Summary

- On `/platform-packages`, the Enterprise card's "Contact us" was plain text — now links to `/talk-to-a-human`.
- On the `/pricing#calculator` Platform packages row, the Enterprise tier no longer shows a toggle or price. Its right-hand column is replaced with the same "Contact us" link.
- Other platform package rows (e.g. Teams) are unchanged: toggles still work and still contribute to the Estimated total.

## Test plan

- [x] Vercel preview: open `/platform-packages` → Enterprise card shows "Contact us" as a link that navigates to `/talk-to-a-human`.
- [x] Vercel preview: open `/pricing#calculator` → Platform packages section → Enterprise row has no toggle, and the right column shows "Contact us" linking to `/talk-to-a-human`.
- [x] Toggling other platform packages (e.g. Teams) still updates the Estimated total at the bottom of the calculator.
- [x] Layout holds when the calculator window is resized narrow.