### PR TITLE
Add no-cache label support for deploy preview builds

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,7 +2,7 @@ name: Deploy preview to Cloudflare Pages
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened]
+        types: [opened, synchronize, reopened, labeled]
 
 concurrency:
     group: deploy-preview-${{ github.event.pull_request.number }}
@@ -62,6 +62,7 @@ jobs:
                   cache: 'pnpm'
 
             - name: Cache Gatsby
+              if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
               uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: |
@@ -70,6 +71,12 @@ jobs:
                   key: gatsby-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}
                   restore-keys: |
                       gatsby-${{ runner.os }}-
+
+            - name: Clean Gatsby cache
+              if: ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') }}
+              run: |
+                  echo "::warning::Gatsby cache skipped — 'no-cache' label detected. Running a clean build."
+                  rm -rf .cache public
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/contents/handbook/engineering/posthog-com/developing-the-website.md
+++ b/contents/handbook/engineering/posthog-com/developing-the-website.md
@@ -196,6 +196,8 @@ Everything else (apps, CDP, templates, jobs, API docs, SDK references, paginatio
 
 Pull request previews on Cloudflare Pages use the same minimal build as above: the workflow sets `GATSBY_MINIMAL=true` (see `.github/workflows/deploy-preview.yml`). That keeps preview builds fast.
 
+**Building without cache:** If a preview build is broken due to a stale Gatsby cache, add the `no-cache` label to the PR. This skips cache restore and runs a clean build from scratch. Remove the label when you're done to go back to cached builds.
+
 **Implications for content authors:**
 
 - **Post category indexes are not built** — Routes like `/tutorials`, `/blog`, and `/posts` are not generated in previews. Opening them can fail or show a broken page (for example a blank or error screen in the site shell). This is expected.


### PR DESCRIPTION
## Changes

- Adds support for a no-cache GitHub label that skips Gatsby cache and cleans .cache/public directories for a fresh deploy preview build