### PR TITLE
Document CUPED experiment settings

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -16,4 +16,4 @@ export TAILWIND_MODE=watch
 # Ensure .cache directory exists (Gatsby expects it before onPreBootstrap runs)
 mkdir -p .cache
 
-gatsby develop -H 0.0.0.0 -p 8001
+gatsby develop -H 0.0.0.0 -p "${PORT:-8001}"

--- a/contents/docs/experiments/cuped.mdx
+++ b/contents/docs/experiments/cuped.mdx
@@ -1,0 +1,21 @@
+---
+title: CUPED variance reduction
+---
+
+CUPED (Controlled-experiment Using Pre-Experiment Data) is an optional variance reduction method for experiment metrics. It uses each participant's behavior before exposure as a covariate when analyzing their behavior after exposure.
+
+The goal is to remove noise from baseline differences between participants. CUPED doesn't change who is included in the experiment or which post-exposure events count toward the metric. It adjusts the metric estimate used by the stats engine.
+
+## Why enable CUPED
+
+Enable CUPED when the metric is likely to correlate with past behavior, such as revenue, usage volume, or activity counts.
+
+When the pre-experiment data predicts the metric, CUPED can narrow confidence or credible intervals. This can help you detect smaller changes with the same experiment traffic.
+
+CUPED is less useful when participants have little historical data or when past behavior doesn't predict the metric you're testing.
+
+## Performance cost
+
+CUPED needs to scan both experiment-period data and pre-exposure data. This means it has a performance cost compared to analyzing the same metric without CUPED.
+
+Large experiments or long lookback windows can take longer to analyze because PostHog has to scan more data.

--- a/contents/docs/experiments/cuped.mdx
+++ b/contents/docs/experiments/cuped.mdx
@@ -2,20 +2,46 @@
 title: CUPED variance reduction
 ---
 
-CUPED (Controlled-experiment Using Pre-Experiment Data) is an optional variance reduction method for experiment metrics. It uses each participant's behavior before exposure as a covariate when analyzing their behavior after exposure.
+CUPED (Controlled-experiment Using Pre-Experiment Data) is an optional variance reduction method for experiment metrics. It uses participants' behavior before exposure to reduce noise in their post-exposure metric values.
 
-The goal is to remove noise from baseline differences between participants. CUPED doesn't change who is included in the experiment or which post-exposure events count toward the metric. It adjusts the metric estimate used by the stats engine.
+It doesn't change randomization, who is included, or which post-exposure events count. The stats engine adjusts the metric values before estimating the treatment effect, so the analysis can be more precise.
+
+## Configure CUPED
+
+Set a project-level default, then override it on individual Experiments when needed.
+
+The project-level setting controls the default for all Experiments in the project. When enabled there, CUPED applies unless an Experiment overrides it.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/cuped_settings_light_83441a9e3d.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/cuped_settings_dark_165511b27c.png"
+  classes="rounded"
+  alt="Project settings showing the default CUPED variance reduction configuration"
+/>
+
+To configure CUPED for a single Experiment, open its **Settings** tab. You can use the project default or override it for that Experiment.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/experiment_tab_settings_light_e6dee14069.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/experiment_tab_settings_dark_ff980b87e7.png"
+  classes="rounded"
+  alt="Experiment settings tab showing CUPED variance reduction configuration"
+/>
 
 ## Why enable CUPED
 
-Enable CUPED when the metric is likely to correlate with past behavior, such as revenue, usage volume, or activity counts.
+Enable CUPED when pre-exposure behavior is likely to predict the metric you're testing, such as revenue, usage volume, or activity counts. Stronger correlation means more variance reduction.
 
-When the pre-experiment data predicts the metric, CUPED can narrow confidence or credible intervals. This can help you detect smaller changes with the same experiment traffic.
+When that prediction is useful, CUPED narrows confidence or credible intervals. This can help you detect smaller effects, or reach the same decision with less traffic.
 
-CUPED is less useful when participants have little historical data or when past behavior doesn't predict the metric you're testing.
+For example, if revenue is the metric, two participants can have the same post-exposure revenue but different baselines. The participant who was low-revenue before exposure gets a higher adjusted metric than the participant who was already high-revenue before exposure. CUPED uses that baseline signal across randomized groups, so predictable differences between participants add less noise to the treatment estimate.
+
+CUPED is less useful when participants have little history or when past behavior doesn't predict the metric.
+
+If there isn't useful pre-exposure data, enabling CUPED usually has little or no effect on the result. The stats engine estimates that relationship; when it's weak, the adjustment is small. CUPED still compares the same randomized groups.
 
 ## Performance cost
 
-CUPED needs to scan both experiment-period data and pre-exposure data. This means it has a performance cost compared to analyzing the same metric without CUPED.
+CUPED scans data from the experiment period and the pre-exposure window. This means it has a performance cost compared to analyzing the same metric without CUPED.
 
-Large experiments or long lookback windows can take longer to analyze because PostHog has to scan more data.
+Large tests or long look-back windows can take longer to analyze. Use the look-back window setting to control how much pre-exposure data PostHog scans.

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -4,7 +4,7 @@ title: Bayesian statistics
 
 PostHog's Bayesian analysis engine provides a statistically rigorous yet user-friendly approach to experimentation. Instead of p-values and confidence intervals, it calculates the **probability that one variant is better than another** and directly answers the question: "Should I ship this change?"
 
-For example, instead of saying "statistically significant at p < 0.05," you get intuitive statements like: 
+For example, instead of saying "statistically significant at p < 0.05," you get intuitive statements like:
 
 > "There's a 96% chance that variant B increases conversion rate."
 
@@ -60,6 +60,8 @@ These sufficient statistics contain all the information needed to calculate mean
 
 For mean metrics, extreme outliers can skew results. PostHog optionally applies winsorization by clamping values to percentile-based bounds. Values below the lower percentile (e.g., 1st percentile) are replaced with the lower bound, and values above the upper percentile (e.g., 99th percentile) are replaced with the upper bound. No data is excluded; all users remain in the calculation. This makes results more robust to data entry errors or extreme edge cases. The percentile bounds are [configured per metric](https://posthog.com/docs/experiments/metrics#outlier-handling) when setting up the experiment.
 
+You can also enable [CUPED variance reduction](/docs/experiments/cuped) to reduce noise by accounting for pre-exposure behavior.
+
 ### Step 2: Data quality validation
 
 Before analysis proceeds, the engine validates the data quality based on metric type:
@@ -71,7 +73,7 @@ Before analysis proceeds, the engine validates the data quality based on metric 
 - **Minimum conversions**: At least 5 conversions per variant
 - **Normal approximation validity**: Both `n × p > 5` and `n × (1-p) > 5` must be satisfied, where `n` is the number of users and `p` is the conversion rate. This ensures the normal approximation to the binomial distribution is accurate.
 
-**Mean and ratio metrics only:**  
+**Mean and ratio metrics only:**
 - **Non-zero baseline**: The control variant must have a non-zero mean (needed for relative difference calculations like "20% increase")
 
 If any validation fails, the analysis stops and returns appropriate error messages instead of potentially misleading results.

--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -58,6 +58,8 @@ These sufficient statistics contain all the information needed to calculate mean
 
 For mean metrics, extreme outliers can skew results. PostHog optionally applies winsorization by clamping values to percentile-based bounds. Values below the lower percentile (e.g., 1st percentile) are replaced with the lower bound, and values above the upper percentile (e.g., 99th percentile) are replaced with the upper bound. No data is excluded; all users remain in the calculation. This makes results more robust to data entry errors or extreme edge cases. The percentile bounds are configured per metric when setting up the experiment.
 
+You can also enable [CUPED variance reduction](/docs/experiments/cuped) to reduce noise by accounting for pre-exposure behavior.
+
 ### Step 2: Data quality validation
 
 Before analysis proceeds, the engine validates the data quality based on metric type:
@@ -69,7 +71,7 @@ Before analysis proceeds, the engine validates the data quality based on metric 
 - **Minimum conversions**: At least 5 conversions per variant
 - **Normal approximation validity**: For proportions, both `np ≥ 5` and `n(1-p) ≥ 5` are required for the t-test to be valid
 
-**Mean and ratio metrics only:**  
+**Mean and ratio metrics only:**
 - **Non-zero baseline**: The control variant must have a non-zero mean (needed for relative difference calculations like "20% increase")
 
 If any validation fails, the analysis stops and returns appropriate error messages instead of potentially misleading results.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4498,6 +4498,12 @@ export const docsMenu = {
                     color: 'blue',
                 },
                 {
+                    name: 'CUPED',
+                    url: '/docs/experiments/cuped',
+                    icon: 'IconCalculator',
+                    color: 'orange',
+                },
+                {
                     name: 'Holdouts',
                     url: '/docs/experiments/holdouts',
                     icon: 'IconPeople',


### PR DESCRIPTION
Documents CUPED configuration for experiments, including team defaults and experiment-level overrides.

Also, add support for `PORT` variable so one can easily run on a different port to not conflict with temporal services that runs on the same port.