### PR TITLE
Add guidelines for handling customer issues in Slack

### DIFF
--- a/contents/handbook/growth/sales/how-we-work.md
+++ b/contents/handbook/growth/sales/how-we-work.md
@@ -281,3 +281,24 @@ To add Pylon to your customer channel:
 Once enabled, you can add the :ticket: emoji to a Slack thread to create a new Ticket in Zendesk.  Customers can also do this.  Make sure that a Group and Severity are selected or the ticket won't be routed properly.
 
 > It's your job to ensure your customer issues are resolved, make sure you follow up with Support and Engineering if you feel like the issue isn't getting the right level of attention.
+
+### Handling business-impacting customer issues in Slack
+
+Sometimes, a customer Slack thread becomes more than a normal product question. For example, ingestion lag might affect advertising workflows, feature flag reliability might affect releases or experiments, or session replay might raise a privacy concern.
+
+When this happens:
+
+- Acknowledge the specific business impact.
+- Separate immediate mitigation from the longer-term fix.
+- Be clear about what we know and what we do not know.
+- Avoid promising timelines or product changes unless they are confirmed.
+- Ask for the operational details needed to help.
+- Pull in Support, Engineering, or the relevant product team early.
+
+Do not ask the customer to prove that the issue matters. If they say it is business-impacting, treat it that way. Ask for the details needed to reduce the impact.
+
+Examples:
+
+- If ingestion lag affects ad platforms, ask which destinations, events, cohorts, or person properties are affected, and whether they are used for bidding, retargeting, suppression, reporting, or lifecycle campaigns.
+- If session replay might capture passports, licenses, payment details, or other sensitive data, treat it as privacy-critical. Do not recommend recording the flow unless masking or pause/resume behaviour is verified.
+- If feature flags are unreliable, first understand how the customer uses them: rollouts, kill switches, entitlements, A/B tests, holdouts, or remote config. Then review fallback values, local evaluation where appropriate, and whether old flags can be cleaned up.


### PR DESCRIPTION
## What changed

Added a short section to the Sales "How we work" page on handling business-impacting customer issues in Slack, inspired by the tricky customer situation task during SuperDay.

## Why

The page already explains how Sales works with customers in Slack and how to route issues through Pylon/Zendesk. 

I thought it would be useful to add lightweight guidance for higher-impact situations where a customer issue affects production workflows, privacy, advertising, or feature flag reliability.

## Changes

*Additional section describing how to structure communication during a critical client situation*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
