### PR TITLE
Marketing: add Lizzie's Q2 2026 objective + sidequest

### DIFF
--- a/contents/teams/marketing/objectives.mdx
+++ b/contents/teams/marketing/objectives.mdx
@@ -39,6 +39,15 @@ These are the primary goals the team is prioritizing this quarter.
 
 </details>
 
+<details>
+<summary>Get ready to launch Managed Warehouse (Lizzie)</summary>
+
+- **Rationale:** We want users to know something big is coming.
+- **Things we could do:** Start building authority and excitement for Managed Warehouse.
+- **We'll know we're successful when:** People are asking when they can get their hands on the warehouse.
+
+</details>
+
 ## Sidequests
 
 Sidequests are important areas of focus or things the team cares a lot about, but which aren't their primary goal.
@@ -64,6 +73,14 @@ Sidequests are important areas of focus or things the team cares a lot about, bu
 
 - **Rationale:** Headless usage is increasingly common. 
 - **Things we could do:** Put MCP and Skills out there as tier-1 features.
+
+</details>
+
+<details>
+<summary>Support data stack growth (Lizzie)</summary>
+
+- **Rationale:** Our users are building their data infrastructure now.
+- **Things we could do:** Shout about new data sources and Endpoints.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Adds **Get ready to launch Managed Warehouse (Lizzie)** to the Q2 2026 objectives on `/teams/marketing`.
- Adds **Support data stack growth (Lizzie)** to the Sidequests section.

Both follow the existing `<details>`/`<summary>` dropdown format used elsewhere in `contents/teams/marketing/objectives.mdx`.

## Test plan

- [ ] Confirm preview deploy renders both new dropdowns on `/teams/marketing`.
- [ ] Confirm bold labels (Rationale / Things we could do / We'll know we're successful when) match surrounding entries.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*