### PR TITLE
docs(code): add open deeplink page for phc

### DIFF
--- a/src/pages/code/open.tsx
+++ b/src/pages/code/open.tsx
@@ -1,0 +1,46 @@
+import { CallToAction } from 'components/CallToAction'
+import Editor from 'components/Editor'
+import SEO from 'components/seo'
+import React, { useEffect } from 'react'
+
+const RELEASES_URL = 'https://github.com/PostHog/code/releases/latest'
+const SAFE_DEEP_LINK_PATH = /^[a-zA-Z0-9/_-]{1,128}$/
+
+export default function CodeOpenPage(): JSX.Element {
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search)
+        const raw = (params.get('to') || 'open').replace(/^\/+/, '')
+        const to = SAFE_DEEP_LINK_PATH.test(raw) ? raw : 'open'
+        window.location.href = `posthog-code://${to}`
+    }, [])
+
+    return (
+        <>
+            <SEO
+                title="Open PostHog Code"
+                description="Open the PostHog Code desktop app, or download it if you haven't yet."
+                noindex
+            />
+            <Editor slug="/code/open" maxWidth="100%" hasPadding={false}>
+                <div className="@container not-prose font-rounded">
+                    <div className="max-w-xl mx-auto px-4 @xl:px-8 py-16 text-center">
+                        <h1 className="text-3xl mb-3">Opening PostHog Code…</h1>
+                        <p className="mb-8 text-base leading-relaxed">
+                            Your browser should be asking to launch the app - say yes and you're in. If nothing's
+                            happening, download PostHog Code below.
+                        </p>
+
+                        <div className="flex flex-wrap gap-3 justify-center mb-6">
+                            <CallToAction type="primary" size="md" to={RELEASES_URL}>
+                                Download PostHog Code
+                            </CallToAction>
+                            <CallToAction type="secondary" size="md" to="/docs/posthog-code">
+                                Read the docs
+                            </CallToAction>
+                        </div>
+                    </div>
+                </div>
+            </Editor>
+        </>
+    )
+}


### PR DESCRIPTION
## Changes

adds `/code/open` as a deeplink to posthog code + download fallback

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`