### PR TITLE
ci(security): pin semgrep image to 1.163.0

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -33,7 +33,7 @@ jobs:
     semgrep-js:
         runs-on: ubuntu-latest
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -57,7 +57,7 @@ jobs:
     semgrep-general:
         runs-on: ubuntu-latest
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout


### PR DESCRIPTION
We were using an unpinned image.