### PR TITLE
docs(self-host): add info about smokescreen and SSRFs

### DIFF
--- a/contents/docs/self-host/configure/securing-posthog.mdx
+++ b/contents/docs/self-host/configure/securing-posthog.mdx
@@ -58,15 +58,15 @@ openssl rand -hex 32
 
 This `SECRET_KEY` must be passed to PostHog as an environment variable.
 
-## SSRF Protection
+## SSRF protection
 
-PostHog has several features that make outbound HTTP requests to URLs supplied (directly or indirectly) by users – for example, webhooks and integrations. Without egress filtering, attackers can abuse these features to perform Server-Side Request Forgery (SSRF) attacks against your own internal network (cloud metadata endpoints, internal services, private IP ranges, and so on).
+PostHog has several features – such as webhooks and integrations – that make outbound HTTP requests to URLs supplied (directly or indirectly) by users. Without egress filtering, attackers can abuse these features to perform Server-Side Request Forgery (SSRF) attacks against your own internal network (the cloud metadata service, other internal hosts, private IP ranges, and so on).
 
 PostHog Cloud routes these outbound requests through [Stripe's Smokescreen](https://github.com/stripe/smokescreen), an HTTP proxy that enforces an allowlist at the network layer and rejects connections to private, loopback, link-local, and other sensitive address ranges. This is an infrastructure-level control and is **not part of the self-hosted PostHog deployment**.
 
 If you self-host PostHog, you're responsible for providing your own egress protection. Recommended options:
 
 - Run [Smokescreen](https://github.com/stripe/smokescreen) (or a similar egress proxy) yourself and route PostHog's outbound traffic through it.
-- Restrict outbound traffic from the PostHog containers at the firewall, security group, or VPC level so that internal IP ranges and cloud metadata endpoints (for example `169.254.169.254`) are unreachable.
+- Restrict outbound traffic from the PostHog containers at the firewall, security group, or VPC level so that internal IP ranges and the cloud metadata service (for example `169.254.169.254`) are unreachable.
 
-Without any of these controls in place, your PostHog instance can reach sensitive internal IPs.
+Without any of these controls in place, your PostHog instance can reach sensitive internal IP addresses.

--- a/contents/docs/self-host/configure/securing-posthog.mdx
+++ b/contents/docs/self-host/configure/securing-posthog.mdx
@@ -58,15 +58,15 @@ openssl rand -hex 32
 
 This `SECRET_KEY` must be passed to PostHog as an environment variable.
 
-## SSRF protection (egress filtering)
+## SSRF Protection
 
-PostHog has several features that make outbound HTTP requests to URLs supplied (directly or indirectly) by users — for example webhooks and (many) integrations. Without egress filtering, these features can be abused to perform Server-Side Request Forgery (SSRF) attacks against your own internal network (cloud metadata endpoints, internal services, private IP ranges, and so on).
+PostHog has several features that make outbound HTTP requests to URLs supplied (directly or indirectly) by users – for example, webhooks and integrations. Without egress filtering, attackers can abuse these features to perform Server-Side Request Forgery (SSRF) attacks against your own internal network (cloud metadata endpoints, internal services, private IP ranges, and so on).
 
-On PostHog Cloud, all outbound traffic is routed through [Stripe's Smokescreen](https://github.com/stripe/smokescreen), an HTTP proxy that enforces an allow/deny list at the network layer and rejects connections to private, loopback, link-local, and other sensitive address ranges. This is an infrastructure-level control and is **not part of the self-hosted PostHog deployment**.
+PostHog Cloud routes these outbound requests through [Stripe's Smokescreen](https://github.com/stripe/smokescreen), an HTTP proxy that enforces an allowlist at the network layer and rejects connections to private, loopback, link-local, and other sensitive address ranges. This is an infrastructure-level control and is **not part of the self-hosted PostHog deployment**.
 
-If you self-host PostHog, you are responsible for providing your own egress protection. Recommended options:
+If you self-host PostHog, you're responsible for providing your own egress protection. Recommended options:
 
 - Run [Smokescreen](https://github.com/stripe/smokescreen) (or a similar egress proxy) yourself and route PostHog's outbound traffic through it.
 - Restrict outbound traffic from the PostHog containers at the firewall, security group, or VPC level so that internal IP ranges and cloud metadata endpoints (for example `169.254.169.254`) are unreachable.
 
-Without any of these controls in place, your PostHog instance might be able to communicate to sensitive IPs.
+Without any of these controls in place, your PostHog instance can reach sensitive internal IPs.

--- a/contents/docs/self-host/configure/securing-posthog.mdx
+++ b/contents/docs/self-host/configure/securing-posthog.mdx
@@ -57,3 +57,16 @@ openssl rand -hex 32
 ```
 
 This `SECRET_KEY` must be passed to PostHog as an environment variable.
+
+## SSRF protection (egress filtering)
+
+PostHog has several features that make outbound HTTP requests to URLs supplied (directly or indirectly) by users — for example webhooks and (many) integrations. Without egress filtering, these features can be abused to perform Server-Side Request Forgery (SSRF) attacks against your own internal network (cloud metadata endpoints, internal services, private IP ranges, and so on).
+
+On PostHog Cloud, all outbound traffic is routed through [Stripe's Smokescreen](https://github.com/stripe/smokescreen), an HTTP proxy that enforces an allow/deny list at the network layer and rejects connections to private, loopback, link-local, and other sensitive address ranges. This is an infrastructure-level control and is **not part of the self-hosted PostHog deployment**.
+
+If you self-host PostHog, you are responsible for providing your own egress protection. Recommended options:
+
+- Run [Smokescreen](https://github.com/stripe/smokescreen) (or a similar egress proxy) yourself and route PostHog's outbound traffic through it.
+- Restrict outbound traffic from the PostHog containers at the firewall, security group, or VPC level so that internal IP ranges and cloud metadata endpoints (for example `169.254.169.254`) are unreachable.
+
+Without any of these controls in place, your PostHog instance might be able to communicate to sensitive IPs.


### PR DESCRIPTION
## Changes

Add information about our smokescreen deployment and SSRF risks on self-hosted instances.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
