### PR TITLE
docs: use VITE_ prefix instead of VITE_PUBLIC_ for env vars

### DIFF
--- a/contents/docs/integrate/_snippets/install-react.mdx
+++ b/contents/docs/integrate/_snippets/install-react.mdx
@@ -6,11 +6,11 @@ import InstallReactPackageManagers from "./install-react-package-managers.mdx"
 
 <InstallReactPackageManagers />
 
-2. Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, include `VITE_PUBLIC_` in their names ensures they are accessible in the frontend.
+2. Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, prefixing variable names with `VITE_` ensures they are accessible in the frontend.
 
 ```shell file=.env.local
-VITE_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
-VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+VITE_POSTHOG_TOKEN=<ph_project_token>
+VITE_POSTHOG_HOST=<ph_client_api_host>
 ```
 
 3. Integrate PostHog at the root of your app (such as `main.jsx` for Vite apps and `root.tsx` for React Router V7).
@@ -24,8 +24,8 @@ import App from './App.jsx'
 import posthog from 'posthog-js'; // +
 import { PostHogProvider } from '@posthog/react' // +
 
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, { // +
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST, // +
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+  api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '<ph_posthog_js_defaults>', // +
 }); // +
 

--- a/contents/docs/libraries/react-router/_snippets/step-env-variables.mdx
+++ b/contents/docs/libraries/react-router/_snippets/step-env-variables.mdx
@@ -1,7 +1,7 @@
-Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, including `VITE_PUBLIC_` in their names ensures they are accessible in the frontend.
+Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, prefixing variable names with `VITE_` ensures they are accessible in the frontend.
 
 ```shell file=.env.local
-VITE_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
-VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+VITE_POSTHOG_TOKEN=<ph_project_token>
+VITE_POSTHOG_HOST=<ph_client_api_host>
 ```
 

--- a/contents/docs/libraries/react-router/react-router-v6.mdx
+++ b/contents/docs/libraries/react-router/react-router-v6.mdx
@@ -114,8 +114,8 @@ import posthog from 'posthog-js'; // +
 import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react' // +
 
 // Initialize PostHog
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, { // +
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST, // +
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+  api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '2026-01-30', // +
 }); // +
 
@@ -205,8 +205,8 @@ Now that you've set up PostHog for React Router V7 in declarative mode, you can 
 To help PostHog track your user sessions across the client and server, you'll need to add the `__add_tracing_headers: ['your-backend-domain1.com', 'your-backend-domain2.com', ...]` option to your PostHog initialization:
 
 ```tsx
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30',
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +
 });

--- a/contents/docs/libraries/react-router/react-router-v7-data-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-data-mode.mdx
@@ -113,8 +113,8 @@ import Root, { RootErrorBoundary } from "./app/root";
 import posthog from 'posthog-js'; // +
 import { PostHogProvider } from '@posthog/react' // +
 
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, { // +
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30', // +
 }); // +
 
@@ -196,8 +196,8 @@ Now that you've set up PostHog for React Router V7 in data mode, you can continu
 To help PostHog track your user sessions across the client and server, you'll need to add the `__add_tracing_headers: ['your-backend-domain1.com', 'your-backend-domain2.com', ...]` option to your PostHog initialization:
 
 ```tsx
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30',
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +
 });

--- a/contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx
@@ -114,8 +114,8 @@ import posthog from 'posthog-js'; // +
 import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react' // +
 
 // Initialize PostHog
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, { // +
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST, // +
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+  api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '2026-01-30', // +
 }); // +
 
@@ -205,8 +205,8 @@ Now that you've set up PostHog for React Router V7 in declarative mode, you can 
 To help PostHog track your user sessions across the client and server, you'll need to add the `__add_tracing_headers: ['your-backend-domain1.com', 'your-backend-domain2.com', ...]` option to your PostHog initialization:
 
 ```tsx
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30',
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +
 });

--- a/contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx
@@ -135,8 +135,8 @@ import { HydratedRouter } from "react-router/dom";
 import posthog from 'posthog-js'; // +
 import { PostHogProvider } from '@posthog/react'  // +
 
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN, { // +
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST, // +
+posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+  api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '2026-01-30', // +
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +
 }); // +
@@ -240,8 +240,8 @@ export interface PostHogContext extends RouterContextProvider {
 }
 
 export const posthogMiddleware: Route.MiddlewareFunction = async ({ request, context }, next) => {
-  const posthog = new PostHog(process.env.VITE_PUBLIC_POSTHOG_TOKEN!, {
-    host: process.env.VITE_PUBLIC_POSTHOG_HOST!,
+  const posthog = new PostHog(process.env.VITE_POSTHOG_TOKEN!, {
+    host: process.env.VITE_POSTHOG_HOST!,
     flushAt: 1,
     flushInterval: 0,
   });

--- a/contents/tutorials/bootstrap-feature-flags-react.md
+++ b/contents/tutorials/bootstrap-feature-flags-react.md
@@ -35,8 +35,8 @@ Next, get your PostHog project token and instance address from the getting start
 
 ```bash
 # .env.local
-VITE_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
-VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+VITE_POSTHOG_TOKEN=<ph_project_token>
+VITE_POSTHOG_HOST=<ph_client_api_host>
 ```
 
 Next, create your entry point for client-side rendering in `src/entry-client.jsx`:
@@ -50,12 +50,12 @@ import App from './App.jsx'
 import { PostHogProvider } from '@posthog/react'
 
 const options = {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
 }
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN} options={options}>
+    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
       <App />
     </PostHogProvider>
   </StrictMode>,
@@ -90,7 +90,7 @@ Once done, you can evaluate your flag in the `loaded()` method on initialization
 
 ```js
 const options = {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   loaded(ph) {
     console.log(ph.isFeatureEnabled('test-flag'))
   }
@@ -143,7 +143,7 @@ import App from './App'
 import { PostHogProvider } from '@posthog/react'
 
 const options = {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   loaded(ph) {
     console.log(ph.isFeatureEnabled('test-flag'))
   }
@@ -153,7 +153,7 @@ const options = {
 hydrateRoot(
   document.getElementById('root'),
   <StrictMode>
-    <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN} options={options}>
+    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
       <App />
     </PostHogProvider>
   </StrictMode>
@@ -206,9 +206,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Initialize PostHog client
 const client = new PostHog(
-  process.env.VITE_PUBLIC_POSTHOG_TOKEN,
+  process.env.VITE_POSTHOG_TOKEN,
   { 
-    host: process.env.VITE_PUBLIC_POSTHOG_HOST,
+    host: process.env.VITE_POSTHOG_HOST,
     personalApiKey: process.env.POSTHOG_PERSONAL_API_KEY // This one is server-only
   }
 );
@@ -262,7 +262,7 @@ In the route's `try` block, we'll get or create a distinct ID and use it to get 
 try {
   // Get or create distinct ID
   let distinctId = null;
-  const phCookie = req.cookies[`ph_${process.env.VITE_PUBLIC_POSTHOG_TOKEN}_posthog`];
+  const phCookie = req.cookies[`ph_${process.env.VITE_POSTHOG_TOKEN}_posthog`];
   if (phCookie) {
     distinctId = JSON.parse(phCookie)['distinct_id'];
   }
@@ -332,9 +332,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Initialize PostHog client
 const client = new PostHog(
-  process.env.VITE_PUBLIC_POSTHOG_TOKEN,
+  process.env.VITE_POSTHOG_TOKEN,
   { 
-    host: process.env.VITE_PUBLIC_POSTHOG_HOST,
+    host: process.env.VITE_POSTHOG_HOST,
     personalApiKey: process.env.POSTHOG_PERSONAL_API_KEY // This one is server-only
   }
 );
@@ -360,7 +360,7 @@ async function createServer() {
     try {
       // Get or create distinct ID
       let distinctId = null;
-      const phCookie = req.cookies[`ph_${process.env.VITE_PUBLIC_POSTHOG_TOKEN}_posthog`];
+      const phCookie = req.cookies[`ph_${process.env.VITE_POSTHOG_TOKEN}_posthog`];
       if (phCookie) {
         distinctId = JSON.parse(phCookie)['distinct_id'];
       }
@@ -451,7 +451,7 @@ const flagData = window.__FLAG_DATA__;
 const distinctId = window.__PH_DISTINCT_ID__;
 
 const options = {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   bootstrap: {
     distinctID: distinctId,
     featureFlags: flagData,


### PR DESCRIPTION
## Changes

The React and React Router docs prefix env vars with `VITE_PUBLIC_` (e.g. `VITE_PUBLIC_POSTHOG_TOKEN`). That isn't a Vite convention — Vite exposes any var starting with `VITE_` to the client. The extra `PUBLIC_` was a holdover from when we leaned on the word "public" to reassure folks about the project token (back when it was called `project_api_key`).

This drops `PUBLIC_` everywhere in the docs and fixes the explanatory sentence in the React / React Router install snippets that incorrectly implied `VITE_PUBLIC_` was the magic prefix making vars frontend-accessible.

Files touched:
- `contents/docs/integrate/_snippets/install-react.mdx`
- `contents/docs/libraries/react-router/_snippets/step-env-variables.mdx`
- `contents/docs/libraries/react-router/react-router-v6.mdx`
- `contents/docs/libraries/react-router/react-router-v7-data-mode.mdx`
- `contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx`
- `contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx`
- `contents/tutorials/bootstrap-feature-flags-react.md`

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)