### PR TITLE
Recommend Hogpatch or Hedge House for offsites and onboarding

### DIFF
--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -36,12 +36,13 @@ Typical agenda:
 
 We want to try to encourage small teams to get together once each year. These are more focused on work and on creating strong bonds within teams. Ideally they are spaced appropriately through the year in relation to the all-company offsite.
 
+With very few exceptions, team offsites should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](#hedge-house) in London. Both are designed for it, remove most of the planning friction, and you'll always overlap with other PostHog teams — which is way better for cross-team collaboration than going somewhere new.
+
 Planning a small team offsite? Kendal’s got you covered.
 Here’s how it works:
 
-- The team lead should message Kendal with their proposed dates and location.
-- Kendal will then go away and find suitable accommodation for the group.
-- Once that’s sorted, she’ll:
+- The team lead should message Kendal with their proposed dates.
+- Kendal will then:
   - Create a Slack channel for the offsite (use `#offsite-[team]-[month]-[year]-[where]`) and add everyone who’s going.
   - Set up the offsite budget in Brex.
   - Update the team’s Canvas with:
@@ -61,7 +62,6 @@ Some guidelines:
 - If the number of attendees is >10 actively consider if Kendal should be attending so there is a person attending whose only focus is making sure it goes well and everyone else can focus on the work of the offsite.
 - Specify offsite start and end times down to the hour, for clarity and efficient use of everyone's time.
 - These offsites don't happen very often and involve a lot of travel, so make sure you make the most out of it by having an agenda and an idea of what you want to achieve _before_ the start of the trip. Also, it's a good idea to have an expectation-setting session (can be async in a Figjam) to ensure everyone is on the same page about what the outcome/output of the offsite should be.
-- Choose a location that minimises layovers for attendees.
 - Make it very clear who is participating in each session. Sessions / activities require full participation from attendees, especially for the likes of a hackathon given it runs over multiple days. Ideally one person should be responsible for the agenda and run a kick-off at the start of the hackathon.
 - You should do a [360 degree feedback session](/handbook/people/feedback#ground-rules). It can feel uncomfortable doing these, but almost everyone who's done one at PostHog has come out feeling better and with a whole host of things they can improve. These are best in person.
     - This can work better over a shared cooked meal or takeaway in the accommodation rather than a noisy restaurant, particularly for people who might be anxious about the format or the feedback.
@@ -89,15 +89,13 @@ You should assign someone on the small team to be responsible for planning the o
 
 ## Hedge House
 
-PostHog runs two Hedge Houses in the UK - a small one in Cambridge and a larger one in London. They are actual houses (yes, with a few bedrooms attached!) designed for small teams to run their offsites, host in-person onboardings, or come together for larger internal events like hackathons. Anyone at PostHog is welcome to use them as much as they like. We'd recommend using the Hedge House for small team offsites if you are in Europe as it removes a lot of the friction of finding somewhere new, and they're genuinely great places to get work done at a very high standard.
+PostHog runs two Hedge Houses in the UK - a small one in Cambridge and a larger one in London. They are actual houses (yes, with a few bedrooms attached!) designed for small teams to run their offsites, host in-person onboardings, or come together for larger internal events like hackathons. Anyone at PostHog is welcome to use them as much as they like — alongside [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco, these are our recommended spots for team offsites and in-person onboarding.
 
 ### Cambridge
 Message <TeamMember name="Kendal Ijeh" photo /> to check availability or make a booking at the Cambridge Hedge House.
 
 ### London
 Our light-filled, studious office is a reliable homebase between Farringdon and Barbican. It’s entirely ours, open 24/7 and the perfect place to stay if you're visiting from abroad.  Use the [Hedge House London](https://posthog.slack.com/archives/D0AAA9M06R2) slack tool to see the full address, book a room and/or desk, plus see who else will be there during the week you visit. This means you can easily self-serve, but ask <TeamMember name="Kendal Ijeh" photo /> with any questions.
-
-> If you're planning an offsite or onboarding in San Francisco, [Hogpatch](https://posthog.com/handbook/people/hogpatch-operations) is the perfect spot to focus, talk to users and get product feedback.
 
 ## London hotel recommendations
 

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -36,7 +36,14 @@ Typical agenda:
 
 We want to try to encourage small teams to get together once each year. These are more focused on work and on creating strong bonds within teams. Ideally they are spaced appropriately through the year in relation to the all-company offsite.
 
-With very few exceptions, team offsites should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](#hedge-house) in London. Both are designed for it, remove most of the planning friction, and you'll always overlap with other PostHog teams — which is way more fun, and means you'll meet more people.
+We want team offsites to be social events and encourage you to optimize offsites for meeting as many colleagues as is reasonably possible, even if it means spending more money or travelling further. [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](#hedge-house) in London should be the default choice, because:
+
+- They're places where there are already a lot of PostHog people that you can hang out with. The more we have random cross-polination, the more ambitious ideas we'll come up with
+- If most teams do their offsites there, you're much more likely to run into even more people
+- We've put a lot of money and effort into making Hogpatch and Hedge House beautiful spaces that you want to work from
+- SF has the benefit of being the epicenter of everything happening in tech, and we have lots of YC founders working out of Hogpatch who you can meet and learn from
+
+You can still grab an AirBnB in any of these places to have more team time if you prefer, over a hotel.
 
 Planning a small team offsite? Kendal’s got you covered.
 Here’s how it works:

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -34,7 +34,7 @@ Typical agenda:
 
 ## Small team offsites
 
-We want to try to encourage small teams to get together once each year. These are more focused on work and on creating strong bonds within teams. Ideally they are spaced appropriately through the year in relation to the all-company offsite.
+We want to try to encourage small teams to get together once each year. Ideally they are spaced appropriately through the year in relation to the all-company offsite.
 
 We want team offsites to be social events and encourage you to optimize offsites for meeting as many colleagues as is reasonably possible, even if it means spending more money or travelling further. [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](#hedge-house) in London should be the default choice, because:
 
@@ -43,7 +43,9 @@ We want team offsites to be social events and encourage you to optimize offsites
 - We've put a lot of money and effort into making Hogpatch and Hedge House beautiful spaces that you want to work from
 - SF has the benefit of being the epicenter of everything happening in tech, and we have lots of YC founders working out of Hogpatch who you can meet and learn from
 
-You can still grab an AirBnB in any of these places to have more team time if you prefer, over a hotel.
+We prefer AirBnBs over hotels, to give your team even more time to hang out, but this is not mandatory.
+
+If you do decide to do a small team offsite somewhere outside of these two hubs, let Kendal know why. That way we can figure out how to make going to the hubs more appealing, or perhaps open new hubs.
 
 Planning a small team offsite? Kendal’s got you covered.
 Here’s how it works:
@@ -96,7 +98,7 @@ You should assign someone on the small team to be responsible for planning the o
 
 ## Hedge House
 
-PostHog runs two Hedge Houses in the UK - a small one in Cambridge and a larger one in London. They are actual houses (yes, with a few bedrooms attached!) designed for small teams to run their offsites, host in-person onboardings, or come together for larger internal events like hackathons. Anyone at PostHog is welcome to use them as much as they like — alongside [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco, these are where you should do team offsites and in-person onboarding.
+PostHog runs two Hedge Houses in the UK - a small one in Cambridge and a larger one in London. They are actual houses (yes, with a few bedrooms attached!) designed for small teams to run their offsites, host in-person onboardings, or come together for larger internal events like hackathons. Anyone at PostHog is welcome to use them as much as they like — alongside [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco, these are where you should default to doing team offsites and in-person onboarding.
 
 ### Cambridge
 Message <TeamMember name="Kendal Ijeh" photo /> to check availability or make a booking at the Cambridge Hedge House.

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -36,7 +36,7 @@ Typical agenda:
 
 We want to try to encourage small teams to get together once each year. These are more focused on work and on creating strong bonds within teams. Ideally they are spaced appropriately through the year in relation to the all-company offsite.
 
-With very few exceptions, team offsites should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](#hedge-house) in London. Both are designed for it, remove most of the planning friction, and you'll always overlap with other PostHog teams — which is way better for cross-team collaboration than going somewhere new.
+With very few exceptions, team offsites should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](#hedge-house) in London. Both are designed for it, remove most of the planning friction, and you'll always overlap with other PostHog teams — which is way more fun, and means you'll meet more people.
 
 Planning a small team offsite? Kendal’s got you covered.
 Here’s how it works:
@@ -89,7 +89,7 @@ You should assign someone on the small team to be responsible for planning the o
 
 ## Hedge House
 
-PostHog runs two Hedge Houses in the UK - a small one in Cambridge and a larger one in London. They are actual houses (yes, with a few bedrooms attached!) designed for small teams to run their offsites, host in-person onboardings, or come together for larger internal events like hackathons. Anyone at PostHog is welcome to use them as much as they like — alongside [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco, these are our recommended spots for team offsites and in-person onboarding.
+PostHog runs two Hedge Houses in the UK - a small one in Cambridge and a larger one in London. They are actual houses (yes, with a few bedrooms attached!) designed for small teams to run their offsites, host in-person onboardings, or come together for larger internal events like hackathons. Anyone at PostHog is welcome to use them as much as they like — alongside [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco, these are where you should do team offsites and in-person onboarding.
 
 ### Cambridge
 Message <TeamMember name="Kendal Ijeh" photo /> to check availability or make a booking at the Cambridge Hedge House.

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -43,7 +43,7 @@ Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner w
 
 ## In-person onboarding
 
-Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. With very few exceptions, in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way more fun, and means you'll meet more people. Regardless of location, everyone should have their own bedroom.
+Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. With very few exceptions (visa issues or excessive travel time), in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way more fun, and means you'll meet more people. Regardless of location, everyone should have their own bedroom.
 
 In these cases, the process is:
 

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -43,7 +43,7 @@ Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner w
 
 ## In-person onboarding
 
-Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. We encourage team leads to consider the Hedgehouse as a location for in-person onboarding. Regardless of location, everyone should have their own bedroom.
+Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. With very few exceptions, in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way better for cross-team collaboration than going somewhere new. Regardless of location, everyone should have their own bedroom.
 
 In these cases, the process is:
 

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -43,7 +43,7 @@ Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner w
 
 ## In-person onboarding
 
-Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. With very few exceptions, in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way better for cross-team collaboration than going somewhere new. Regardless of location, everyone should have their own bedroom.
+Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. With very few exceptions, in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way more fun, and means you'll meet more people. Regardless of location, everyone should have their own bedroom.
 
 In these cases, the process is:
 


### PR DESCRIPTION
## Summary
why?
- These locations are well known, easy to get to, and the minimum amount of time and money is wasted
- There are almost always other people at these locations, giving you more exposure to posthog people. In person time is precious so if you can combine it with meeting other people, even better.

## Test plan
- [ ] Review the wording matches the rest of the handbook's tone
- [ ] Check the anchor link to `#hedge-house` resolves correctly on the rendered offsites page