### PR TITLE
docs: clarify urgency criteria for feature requests

### DIFF
--- a/contents/handbook/cs-and-onboarding/feature-requests.md
+++ b/contents/handbook/cs-and-onboarding/feature-requests.md
@@ -4,17 +4,20 @@ sidebar: Handbook
 showTitle: true
 ---
 
-When working with our customers, they will occasionally ask for features which aren't in the product yet. We won't build a niche feature for a single big customer, but if we can see a request being of benefit to multiple customers, we should capture, track and feed it back to our product teams.
+When working with our customers, they will occasionally ask for features which aren't in the product yet. We won't build a niche feature for a single big customer, but if we can see a request being of benefit to multiple customers, we should capture, track, and feed it back to our product teams.
 
-# Urgent vs Non-urgent requests
+# Urgent vs non-urgent requests
 
-If a customer is at risk of churn, or otherwise unhappy about the missing feature, then we should communicate this to the relevant team in their Slack channel (usually #team-xyz). Adding in the urgency, ARR and tagging the team lead is a good approach here to get some focus.  Remember that you still own the customer and may need to follow up with product teams to get the right level of focus as they don't have all of the customer context that you do.  Don't create false urgency where there is none - we only want to use this approach when things are _actually_ urgent.
+Urgency is a context-driven measure of risk.  A feature request could be defined as _urgent_ if a customer is at risk of churn or otherwise uphappy about the missing feature.  Equally, a feature request from a newly onboarded customer can also serve as a great way to build a solid foundation of trust and showcase how we work at PostHog.  
 
-For non-urgent requests we should capture them in Vitally using the process on this page, and then share them with the teams in their Slack channels ahead of quarterly planning.
+If we determine a feature request to be truly urgent, then we should communicate this to the relevant team in their Slack channel (usually #team-xyz). Adding the urgency, ARR, and tagging the team lead is a good approach to get some focus.  Remember that you still own the customer and may need to follow up with product teams as they don't have the same customer context that you do.  If you are unsure about how urgent a feature request may be, ask in the team Slack channel. Don't create false urgency where there is none. 
+
+For non-urgent requests, we should capture them in Vitally using the process on this page, and then share them with the teams in their Slack channels ahead of quarterly planning.
 
 # Tracking feature requests in Vitally
 
-## Current Feature Request List
+## Current feature request list
+
 We track feature requests a custom object in Vitally. You can see the current list of feature requests <PrivateLink url="https://posthog.vitally-eu.io/hubs/152ccd4c-c7b2-4508-865b-b08fea5c3dc6/413939d5-0d20-40d5-963e-5987dcbae345">here</PrivateLink>. It's filterable by team, and shows the accounts and combined ARR of those accounts who have asked for the feature. There's also a <PrivateLink url="https://posthog.vitally-eu.io/hubs/152ccd4c-c7b2-4508-865b-b08fea5c3dc6/a5747096-f417-4536-9ca3-4a1d0ef09534">Kanban board view</PrivateLink> which helps you track the progress of requests.
 
 ## Adding a customer to an existing request

--- a/contents/handbook/cs-and-onboarding/feature-requests.md
+++ b/contents/handbook/cs-and-onboarding/feature-requests.md
@@ -8,7 +8,7 @@ When working with our customers, they will occasionally ask for features which a
 
 # Urgent vs non-urgent requests
 
-Urgency is a context-driven measure of risk.  A feature request could be defined as _urgent_ if a customer is at risk of churn or otherwise uphappy about the missing feature.  Equally, a feature request from a newly onboarded customer can also serve as a great way to build a solid foundation of trust and showcase how we work at PostHog.  
+Urgency is a context-driven measure of risk.  A feature request could be defined as _urgent_ if a customer is at risk of churn or otherwise unhappy about the missing feature.  Equally, a feature request from a newly onboarded customer can also serve as a great way to build a solid foundation of trust and showcase how we work at PostHog.  
 
 If we determine a feature request to be truly urgent, then we should communicate this to the relevant team in their Slack channel (usually #team-xyz). Adding the urgency, ARR, and tagging the team lead is a good approach to get some focus.  Remember that you still own the customer and may need to follow up with product teams as they don't have the same customer context that you do.  If you are unsure about how urgent a feature request may be, ask in the team Slack channel. Don't create false urgency where there is none. 
 


### PR DESCRIPTION
## Changes

Rewrites the "Urgent vs non-urgent requests" section of the feature-requests handbook page to frame urgency as context-driven, with newly onboarded customers as a second valid trigger. Sentence-cases headings, fixes a couple of comma/spelling issues.

## Checklist

- [x] I've read the docs/content style guides
- [x] American English
- [x] Relative URLs for internal links
- [x] Checked Vercel preview build
- [x] No moved pages