### PR TITLE
Refresh support team page and share values/what-we-do via snippets

### DIFF
--- a/contents/handbook/support/_snippets/our-long-term-vision.mdx
+++ b/contents/handbook/support/_snippets/our-long-term-vision.mdx
@@ -1,0 +1,7 @@
+## Our long-term vision
+
+Support should be a competitive advantage for PostHog. Users choose us partly because they know they'll get exceptional support. They stay partly because they feel valued and helped. They recommend us partly because they've had great experiences with our team.
+
+As PostHog grows, we're scaling thoughtfully. We prioritize keeping the team technical, staying true to our values, and maintaining our user-first culture. We value attitude and aptitude over experience - we need people who can jump into the unknown and figure things out. We want to contribute code and build tools, while keeping quality and user-centricity at the core of everything we do.
+
+The benchmark we're aiming for: other companies should measure themselves against PostHog support - not because we answer tickets quickly, but because we genuinely help users succeed.

--- a/contents/handbook/support/_snippets/support-values.mdx
+++ b/contents/handbook/support/_snippets/support-values.mdx
@@ -1,0 +1,17 @@
+## Our values
+
+### Take ownership
+
+Own your work from start to finish. Be proactive and self-driven. Don't wait to be told what to do. When you see a problem, jump in and solve it. Be resourceful, curious, and hands-on. If something needs doing, figure it out and make it happen. Taking ownership means being accountable for outcomes, not just tasks.
+
+### Delight users
+
+Go beyond solving problems. Create moments that make users' days better. Be genuinely caring, reassuringly human, and empathetic in every interaction. Surprise users with your thoughtfulness and responsiveness. Bring positivity and warmth to technical conversations. When users walk away from an interaction with you, they should feel helped, valued, and hopefully a little bit delighted.
+
+### Stay humble
+
+Check your ego at the door. Take feedback as a gift and be open to learning from anyone, regardless of their experience level or role. Share knowledge freely with the team and communicate with transparency and honesty. We get better together by staying curious, admitting what we don't know, and helping each other grow. No one has all the answers, and that's okay.
+
+### Ship fixes
+
+Be deeply technical and hands-on. Don't just log bugs or pass tickets along - write the fix yourself. Raise PRs for docs improvements, patch code, and solve problems end-to-end. We're engineers who happen to do support, not support agents who escalate to engineers. If you can fix it, ship it. That's what makes PostHog support special.

--- a/contents/handbook/support/_snippets/what-makes-us-great.mdx
+++ b/contents/handbook/support/_snippets/what-makes-us-great.mdx
@@ -1,0 +1,3 @@
+## What makes us great
+
+We communicate clearly and don't hide behind jargon. We're relentlessly curious - pulling at every thread when investigating an issue, and seeing the bigger picture beyond the immediate problem. We're always looking for ways to improve, whether that's our processes, our docs, or our own skills. We're thorough without being slow, thoughtful without overthinking, and we genuinely care about getting things right for our users.

--- a/contents/handbook/support/_snippets/what-we-do.mdx
+++ b/contents/handbook/support/_snippets/what-we-do.mdx
@@ -1,0 +1,11 @@
+## What we do
+
+We help users through in-app support (which routes to Zendesk), community questions, and Slack channels for enterprise customers. But we don't stop at answering questions:
+
+- **Ship code:** We write and merge small bug fixes and improvements ourselves.
+- **Improve docs:** We contribute fixes, clarify sections, and add missing information.
+- **Build internal tools:** We create tools like HogHero for internal efficiency, SDK Doctor for proactive customer help, and automations to streamline our work.
+- **Share product feedback:** We surface patterns and pain points we see from users.
+- **Answer community questions:** We respond to questions in our community forums.
+
+We provide support Monday through Friday, 9am GMT to 5pm PST. We focus on being consistently excellent during our coverage hours, with clear expectations set for users.

--- a/contents/handbook/support/_snippets/what-we-do.mdx
+++ b/contents/handbook/support/_snippets/what-we-do.mdx
@@ -9,3 +9,10 @@ We help users through in-app support (which routes to Zendesk), community questi
 - **Answer community questions:** We respond to questions in our community forums.
 
 We provide support Monday through Friday, 9am GMT to 5pm PST. We focus on being consistently excellent during our coverage hours, with clear expectations set for users.
+
+## What we don't do
+
+- **Route tickets:** We solve problems ourselves rather than passing them along.
+- **Hide behind processes:** We care more about outcomes than following rigid procedures.
+- **Work in silos:** We're integrated into product development and actively contribute to company discussions.
+- **Accept "that's not my job":** If we can help, we do. If we can't, we figure out who can and make the connection.

--- a/contents/handbook/support/_snippets/what-we-dont-do.mdx
+++ b/contents/handbook/support/_snippets/what-we-dont-do.mdx
@@ -1,6 +1,0 @@
-## What we don't do
-
-- **Route tickets:** We solve problems ourselves rather than passing them along.
-- **Hide behind processes:** We care more about outcomes than following rigid procedures.
-- **Work in silos:** We're integrated into product development and actively contribute to company discussions.
-- **Accept "that's not my job":** If we can help, we do. If we can't, we figure out who can and make the connection.

--- a/contents/handbook/support/_snippets/what-we-dont-do.mdx
+++ b/contents/handbook/support/_snippets/what-we-dont-do.mdx
@@ -1,0 +1,6 @@
+## What we don't do
+
+- **Route tickets:** We solve problems ourselves rather than passing them along.
+- **Hide behind processes:** We care more about outcomes than following rigid procedures.
+- **Work in silos:** We're integrated into product development and actively contribute to company discussions.
+- **Accept "that's not my job":** If we can help, we do. If we can't, we figure out who can and make the connection.

--- a/contents/handbook/support/support-team.md
+++ b/contents/handbook/support/support-team.md
@@ -4,6 +4,9 @@ sidebar: Handbook
 showTitle: true
 ---
 
+import SupportValues from './_snippets/support-values.mdx'
+import WhatWeDo from './_snippets/what-we-do.mdx'
+
 The <SmallTeam slug="support">support team</SmallTeam> exists to help our users succeed with PostHog, and we do that differently than most support teams.
 
 We're not a ticket-routing operation. We genuinely care about making our users' experience exceptional, which we do by being a deeply technical team that takes pride in solving problems ourselves. We write code, ship fixes, update docs, and build internal tooling to deliver that experience. We move fast, stay humble, and believe that great support is about empowering users, not just answering questions.
@@ -12,35 +15,9 @@ We're not a ticket-routing operation. We genuinely care about making our users' 
 
 We communicate clearly and don't hide behind jargon. We're relentlessly curious - pulling at every thread when investigating an issue, and seeing the bigger picture beyond the immediate problem. We're always looking for ways to improve, whether that's our processes, our docs, or our own skills. We're thorough without being slow, thoughtful without overthinking, and we genuinely care about getting things right for our users.
 
-## Our values
+<SupportValues />
 
-### Take ownership
-
-Own your work from start to finish. Be proactive and self-driven. Don't wait to be told what to do. When you see a problem, jump in and solve it. Be resourceful, curious, and hands-on. If something needs doing, figure it out and make it happen. Taking ownership means being accountable for outcomes, not just tasks.
-
-### Delight users
-
-Go beyond solving problems. Create moments that make users' days better. Be genuinely caring, reassuringly human, and empathetic in every interaction. Surprise users with your thoughtfulness and responsiveness. Bring positivity and warmth to technical conversations. When users walk away from an interaction with you, they should feel helped, valued, and hopefully a little bit delighted.
-
-### Stay humble
-
-Check your ego at the door. Take feedback as a gift and be open to learning from anyone, regardless of their experience level or role. Share knowledge freely with the team and communicate with transparency and honesty. We get better together by staying curious, admitting what we don't know, and helping each other grow. No one has all the answers, and that's okay.
-
-### Ship fixes
-
-Be deeply technical and hands-on. Don't just log bugs or pass tickets along - write the fix yourself. Raise PRs for docs improvements, patch code, and solve problems end-to-end. We're engineers who happen to do support, not support agents who escalate to engineers. If you can fix it, ship it. That's what makes PostHog support special.
-
-## What we do
-
-We help users through in-app support (which routes to Zendesk), community questions, and Slack channels for enterprise customers. But we don't stop at answering questions:
-
-- **Ship code:** We write and merge small bug fixes and improvements ourselves.
-- **Improve docs:** We contribute fixes, clarify sections, and add missing information.
-- **Build internal tools:** We create tools like HogHero for internal efficiency, SDK Doctor for proactive customer help, and automations to streamline our work.
-- **Share product feedback:** We surface patterns and pain points we see from users.
-- **Answer community questions:** We respond to questions in our community forums.
-
-We provide support Monday through Friday, 9am GMT to 5pm PST. We focus on being consistently excellent during our coverage hours, with clear expectations set for users.
+<WhatWeDo />
 
 ## What we don't do
 

--- a/contents/handbook/support/support-team.md
+++ b/contents/handbook/support/support-team.md
@@ -7,7 +7,6 @@ showTitle: true
 import WhatMakesUsGreat from './_snippets/what-makes-us-great.mdx'
 import SupportValues from './_snippets/support-values.mdx'
 import WhatWeDo from './_snippets/what-we-do.mdx'
-import WhatWeDontDo from './_snippets/what-we-dont-do.mdx'
 import OurLongTermVision from './_snippets/our-long-term-vision.mdx'
 
 The <SmallTeam slug="support">support team</SmallTeam> exists to help our users succeed with PostHog, and we do that differently than most support teams.
@@ -19,7 +18,5 @@ We're not a ticket-routing operation. We genuinely care about making our users' 
 <SupportValues />
 
 <WhatWeDo />
-
-<WhatWeDontDo />
 
 <OurLongTermVision />

--- a/contents/handbook/support/support-team.md
+++ b/contents/handbook/support/support-team.md
@@ -4,32 +4,22 @@ sidebar: Handbook
 showTitle: true
 ---
 
+import WhatMakesUsGreat from './_snippets/what-makes-us-great.mdx'
 import SupportValues from './_snippets/support-values.mdx'
 import WhatWeDo from './_snippets/what-we-do.mdx'
+import WhatWeDontDo from './_snippets/what-we-dont-do.mdx'
+import OurLongTermVision from './_snippets/our-long-term-vision.mdx'
 
 The <SmallTeam slug="support">support team</SmallTeam> exists to help our users succeed with PostHog, and we do that differently than most support teams.
 
 We're not a ticket-routing operation. We genuinely care about making our users' experience exceptional, which we do by being a deeply technical team that takes pride in solving problems ourselves. We write code, ship fixes, update docs, and build internal tooling to deliver that experience. We move fast, stay humble, and believe that great support is about empowering users, not just answering questions.
 
-## What makes us great
-
-We communicate clearly and don't hide behind jargon. We're relentlessly curious - pulling at every thread when investigating an issue, and seeing the bigger picture beyond the immediate problem. We're always looking for ways to improve, whether that's our processes, our docs, or our own skills. We're thorough without being slow, thoughtful without overthinking, and we genuinely care about getting things right for our users.
+<WhatMakesUsGreat />
 
 <SupportValues />
 
 <WhatWeDo />
 
-## What we don't do
+<WhatWeDontDo />
 
-- **Route tickets:** We solve problems ourselves rather than passing them along.
-- **Hide behind processes:** We care more about outcomes than following rigid procedures.
-- **Work in silos:** We're integrated into product development and actively contribute to company discussions.
-- **Accept "that's not my job":** If we can help, we do. If we can't, we figure out who can and make the connection.
-
-## Our long-term vision
-
-Support should be a competitive advantage for PostHog. Users choose us partly because they know they'll get exceptional support. They stay partly because they feel valued and helped. They recommend us partly because they've had great experiences with our team.
-
-As PostHog grows, we're scaling thoughtfully. We prioritize keeping the team technical, staying true to our values, and maintaining our user-first culture. We value attitude and aptitude over experience - we need people who can jump into the unknown and figure things out. We want to contribute code and build tools, while keeping quality and user-centricity at the core of everything we do.
-
-The benchmark we're aiming for: other companies should measure themselves against PostHog support - not because we answer tickets quickly, but because we genuinely help users succeed.
+<OurLongTermVision />

--- a/contents/teams/support/index.mdx
+++ b/contents/teams/support/index.mdx
@@ -3,39 +3,25 @@ title: Support
 template: team
 ---
 
-## Values
+import SupportValues from '../../handbook/support/_snippets/support-values.mdx'
+import WhatWeDo from '../../handbook/support/_snippets/what-we-do.mdx'
 
-### 1. Being hands-on is the best way to be helpful
+<SupportValues />
 
-It'd be very easy for us to say that we only handle support – that things like bug fixes, docs updates, and content aren't our job. We want to avoid doing that. If helping anyone – whether a colleague or customer – is within our capabilities then we'll jump in. Sometimes we'll jump in anyway. 
-
-### 2. Process shouldn't come above anything else
-
-We're constantly improving our processes to make them more performant and scalable. But if process gets in the way of delighting a user, accelerating a project, or otherwise Doing Good Things, then it's a bad process. It's better to break a rule than break a user's trust.
-  
-### 3. It's not just about the tickets
-
-We care about solving tickets, but they aren't the be-all and end-all. We don't judge individual performance based just on how many tickets someone answers, and we regularly ship big-picture work that involves putting tickets aside temporarily - and we think that's OK. 
-
-## Responsibilities
-
-- Handling customer support tickets
-- Facilitating the success of our users
+<WhatWeDo />
 
 ## Metrics we care about
 
-- [CSAT responses and user comments](https://us.posthog.com/project/2/surveys/018d1739-070f-0000-e5e7-60d9e66cb429)
-- [Escalation rates and ticket performance for other teams](https://posthoghelp.zendesk.com/explore/dashboard/precanned/00ED29FD6878842D011808EA714C5F470227102AAEF5CC3C1C706E448CF61B73)
+- [Support overview dashboard](https://us.posthog.com/project/2/dashboard/250270)
+- [PRs merged by the support team](https://us.posthog.com/project/2/dashboard/1358749)
 
 ## How we work
 
-<p>We work in weekly sprints. You can find what we're working on in the <PrivateLink url="https://github.com/PostHog/company-internal/issues">company-internal</PrivateLink> repo, where we put together a planning issue for each sprint.</p>
+<p>We work in bi-weekly sprints, with a sprint planning meeting every two weeks. You can find what we're working on in the <PrivateLink url="https://github.com/PostHog/company-internal/issues">company-internal</PrivateLink> repo, where we put together a planning issue for each sprint.</p>
 
 Like other teams, we plan our goals quarterly. Every goal gets assigned an owner who then puts an issue together outlining some of their ideas and steps towards that goal. These issues go [in the Meta repo](https://github.com/PostHog/meta/issues/).
 
-When we plan product launches or widescale user messaging activities, we begin by drafting a plan [in the Meta repo](https://github.com/PostHog/meta/issues/). There's a template for messaging activities if other teams want to request work. 
-
-Every week, on Monday morning, we put together a weekly report on the main support metrics for the Exec team, which is posted in the #team-exec Slack channel along with comments from CSAT surveys. Every two weeks we post a summary report in #tell-posthog-anything containing a bit more context and highlights. 
+Every week, on Monday morning, we put together a weekly report on the main support metrics for the Blitzscale team, which is posted in the #team-blitzscale Slack channel along with comments from CSAT surveys.
 
 ## Slack channel
 

--- a/contents/teams/support/index.mdx
+++ b/contents/teams/support/index.mdx
@@ -6,7 +6,6 @@ template: team
 import WhatMakesUsGreat from '../../handbook/support/_snippets/what-makes-us-great.mdx'
 import SupportValues from '../../handbook/support/_snippets/support-values.mdx'
 import WhatWeDo from '../../handbook/support/_snippets/what-we-do.mdx'
-import WhatWeDontDo from '../../handbook/support/_snippets/what-we-dont-do.mdx'
 import OurLongTermVision from '../../handbook/support/_snippets/our-long-term-vision.mdx'
 
 <WhatMakesUsGreat />
@@ -14,8 +13,6 @@ import OurLongTermVision from '../../handbook/support/_snippets/our-long-term-vi
 <SupportValues />
 
 <WhatWeDo />
-
-<WhatWeDontDo />
 
 <OurLongTermVision />
 

--- a/contents/teams/support/index.mdx
+++ b/contents/teams/support/index.mdx
@@ -3,17 +3,21 @@ title: Support
 template: team
 ---
 
+import WhatMakesUsGreat from '../../handbook/support/_snippets/what-makes-us-great.mdx'
 import SupportValues from '../../handbook/support/_snippets/support-values.mdx'
 import WhatWeDo from '../../handbook/support/_snippets/what-we-do.mdx'
+import WhatWeDontDo from '../../handbook/support/_snippets/what-we-dont-do.mdx'
+import OurLongTermVision from '../../handbook/support/_snippets/our-long-term-vision.mdx'
+
+<WhatMakesUsGreat />
 
 <SupportValues />
 
 <WhatWeDo />
 
-## Metrics we care about
+<WhatWeDontDo />
 
-- [Support overview dashboard](https://us.posthog.com/project/2/dashboard/250270)
-- [PRs merged by the support team](https://us.posthog.com/project/2/dashboard/1358749)
+<OurLongTermVision />
 
 ## How we work
 
@@ -21,7 +25,10 @@ import WhatWeDo from '../../handbook/support/_snippets/what-we-do.mdx'
 
 Like other teams, we plan our goals quarterly. Every goal gets assigned an owner who then puts an issue together outlining some of their ideas and steps towards that goal. These issues go [in the Meta repo](https://github.com/PostHog/meta/issues/).
 
-Every week, on Monday morning, we put together a weekly report on the main support metrics for the Blitzscale team, which is posted in the #team-blitzscale Slack channel along with comments from CSAT surveys.
+Every week, on Monday morning, we put together a weekly report on the main support metrics for the Blitzscale team, which is posted in the #team-blitzscale Slack channel along with comments from CSAT surveys. The report is put together from the metrics we care about:
+
+- [Support overview dashboard](https://us.posthog.com/project/2/dashboard/250270)
+- [PRs merged by the support team](https://us.posthog.com/project/2/dashboard/1358749)
 
 ## Slack channel
 


### PR DESCRIPTION
## Summary

The support team page (`/teams/support`) had drifted out of date relative to the support handbook. This PR brings it back in sync, and makes the team page mirror most of the **Support team overview** handbook page from a single shared source so the two can't drift again.

- **Single source of truth via snippets** — the shared sections now live in `contents/handbook/support/_snippets/` and are imported by both the handbook overview page and `/teams/support` (following the existing `_snippets` import pattern):
  - `what-makes-us-great.mdx`
  - `support-values.mdx`
  - `what-we-do.mdx`
  - `our-long-term-vision.mdx`
- **Team page now mirrors the overview** — renders What makes us great, Values, What we do, What we don't do, and Our long-term vision (the handbook's intro paragraph is intentionally left off the team page).
- **Values refreshed** — replaced the outdated values ("Being hands-on…", "Process shouldn't…", "It's not just about the tickets") with the current four: Take ownership, Delight users, Stay humble, Ship fixes.
- **How we work** — bi-weekly sprints + planning meeting (kept company-internal repo + quarterly goals); the weekly report now goes to the **Blitzscale** team / **#team-blitzscale** and is described as built from the metrics we care about, with the two dashboards listed directly underneath. Removed the separate "Metrics we care about" section, the no-longer-done biweekly highlights report, and a stale messaging-activities paragraph.
- **Slack channel** — unchanged (already current).

Editing any snippet now updates both pages automatically.

## Test plan

- [x] On the Vercel preview, open **`/teams/support`** and confirm the full overview (What makes us great → Long-term vision) renders under the "Handbook" section, followed by How we work (with the two dashboards under the weekly-report sentence) and the Slack channel.
- [x] Open **`/handbook/support/support-team`** and confirm the same shared sections render identically.
- [x] Confirm the dashboard links resolve, and that no stray pages were generated for the `_snippets` files.
