### PR TITLE
docs(product-analytics): subscriptions are now free-tier

### DIFF
--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -6,9 +6,18 @@ availability:
   free: partial
   selfServe: full
   enterprise: full
+  features:
+    alerts:
+      free: 'Up to 5'
+      selfServe: true
+      boost: true
+      scale: true
+      enterprise: true
 ---
 
 Alerts enable you to monitor your [insights](/product-analytics) and get notified when something important changes. You can set fixed thresholds (e.g., notify me when unique visitors exceed 5,000) or use [anomaly detection](#anomaly-detection) to automatically flag unusual patterns in your data.
+
+<FeatureAvailability availability={_frontmatter.availability.features.alerts} />
 
 Currently, alerts are supported on all [trends](/docs/product-analytics/trends).
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -6,18 +6,9 @@ availability:
   free: partial
   selfServe: full
   enterprise: full
-  features:
-    alerts:
-      free: 'Up to 5'
-      selfServe: true
-      boost: true
-      scale: true
-      enterprise: true
 ---
 
 Alerts enable you to monitor your [insights](/product-analytics) and get notified when something important changes. You can set fixed thresholds (e.g., notify me when unique visitors exceed 5,000) or use [anomaly detection](#anomaly-detection) to automatically flag unusual patterns in your data.
-
-<FeatureAvailability availability={_frontmatter.availability.features.alerts} />
 
 Currently, alerts are supported on all [trends](/docs/product-analytics/trends).
 

--- a/contents/docs/product-analytics/subscriptions.mdx
+++ b/contents/docs/product-analytics/subscriptions.mdx
@@ -3,7 +3,7 @@ title: Subscriptions
 availability:
   features:
     subscriptions:
-      free: true
+      free: 'Up to 5'
       selfServe: true
       boost: true
       scale: true
@@ -29,8 +29,6 @@ export const slackAddDark =
 Subscriptions enable you to send [insights](/docs/product-analytics/insights) or [dashboards](/docs/product-analytics/dashboards) to your email or Slack on a regular basis.
 
 <FeatureAvailability availability={_frontmatter.availability.features.subscriptions} />
-
-The free plan includes up to 5 subscriptions. Paid plans have no limit.
 
 > **Looking to subscribe to events or actions?** See our [realtime destination docs](/docs/cdp/destinations) to learn how to send event or action data to webhooks, Slack, and more.
 

--- a/contents/docs/product-analytics/subscriptions.mdx
+++ b/contents/docs/product-analytics/subscriptions.mdx
@@ -3,7 +3,7 @@ title: Subscriptions
 availability:
   features:
     subscriptions:
-      free: false
+      free: true
       selfServe: true
       boost: true
       scale: true
@@ -29,6 +29,8 @@ export const slackAddDark =
 Subscriptions enable you to send [insights](/docs/product-analytics/insights) or [dashboards](/docs/product-analytics/dashboards) to your email or Slack on a regular basis.
 
 <FeatureAvailability availability={_frontmatter.availability.features.subscriptions} />
+
+The free plan includes up to 5 subscriptions. Paid plans have no limit.
 
 > **Looking to subscribe to events or actions?** See our [realtime destination docs](/docs/cdp/destinations) to learn how to send event or action data to webhooks, Slack, and more.
 

--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -4,21 +4,28 @@ import CheckIcon from '../../images/check.svg'
 import XIcon from '../../images/x.svg'
 import Tooltip from 'components/Tooltip'
 
+// A tier is either available (true) / unavailable (false), or available with a
+// caveat described inline (e.g. "Up to 5") so limited tiers don't read as unlimited.
+type TierAvailability = boolean | string
+
 type FeatureAvailabilityProps = {
     availability:
         | {
-              openSource?: boolean
-              free: boolean
-              selfServe: boolean
-              boost?: boolean
-              scale?: boolean
-              enterprise: boolean
+              openSource?: TierAvailability
+              free: TierAvailability
+              selfServe: TierAvailability
+              boost?: TierAvailability
+              scale?: TierAvailability
+              enterprise: TierAvailability
           }
         | boolean
 }
 
-const renderAvailabilityIcon = (isAvailable: boolean) => {
-    return isAvailable ? (
+const renderAvailability = (availability: TierAvailability) => {
+    if (typeof availability === 'string') {
+        return <span className="text-sm font-semibold mr-2">{availability}</span>
+    }
+    return availability ? (
         <img src={CheckIcon} alt="Available" className="h-4 w-4 mr-2" aria-hidden="true" />
     ) : (
         <img src={XIcon} alt="Not available" className="h-4 w-4 mr-2" aria-hidden="true" />
@@ -113,25 +120,21 @@ export function FeatureAvailability({ availability }: FeatureAvailabilityProps):
                     </h5>
                 </div>
 
-                {diffOpenSource ? renderAvailabilityIcon(availability.openSource || false) : null}
+                {diffOpenSource ? renderAvailability(availability.openSource || false) : null}
 
-                {renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.free)}
+                {renderAvailability(typeof availability === 'boolean' ? availability : availability.free)}
 
-                {renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.selfServe)}
+                {renderAvailability(typeof availability === 'boolean' ? availability : availability.selfServe)}
 
                 {typeof availability === 'object' &&
                     'boost' in availability &&
-                    renderAvailabilityIcon(
-                        typeof availability === 'boolean' ? availability : availability.boost || false
-                    )}
+                    renderAvailability(typeof availability === 'boolean' ? availability : availability.boost || false)}
 
                 {typeof availability === 'object' &&
                     'scale' in availability &&
-                    renderAvailabilityIcon(
-                        typeof availability === 'boolean' ? availability : availability.scale || false
-                    )}
+                    renderAvailability(typeof availability === 'boolean' ? availability : availability.scale || false)}
 
-                {renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.enterprise)}
+                {renderAvailability(typeof availability === 'boolean' ? availability : availability.enterprise)}
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem

Insight & dashboard subscriptions are moving to the free tier ([PostHog/posthog#59624](https://github.com/PostHog/posthog/pull/59624), [PostHog/billing#1922](https://github.com/PostHog/billing/pull/1922)). The docs still listed subscriptions as unavailable on the free plan — and once marked available, the `<FeatureAvailability>` widget would render the free tier as a plain checkmark, implying it's unlimited when the free plan is actually capped at 5 subscriptions.

## Changes

- Set `availability.subscriptions.free` so the free plan shows subscriptions as included.
- Teach the `<FeatureAvailability>` widget to render a per-tier caveat string inline (e.g. `Up to 5`) instead of only a boolean check/x icon, so a limited tier no longer reads as unlimited. Existing boolean consumers (`sso.mdx`, `funnels.mdx`) are unchanged.
- Set the free tier to `Up to 5` in `subscriptions.mdx`. The free column now reads "Up to 5"; paid tiers keep their checkmarks.

The previous prose note ("the free plan includes up to 5 subscriptions") was dropped since the widget now carries that information directly.

Preview: https://b6f97c2e.posthog-preview.pages.dev/docs/product-analytics/subscriptions

<img width="933" height="407" alt="CleanShot 2026-05-27 at 12 41 12" src="https://github.com/user-attachments/assets/272f52ab-136d-4e92-9163-cf546553d5c1" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`


