### PR TITLE
Document phone setup to bypass DND for incident.io pages

### DIFF
--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -95,7 +95,7 @@ To get a calendar with all your on-call shifts from incident.io go to the [sched
 
 ### Make sure alerts can break through Do Not Disturb
 
-Unlike PagerDuty, the incident.io app does not configure these settings for you on install. By default your phone's Do Not Disturb, Sleep, or Focus mode will silence pages – including the middle-of-the-night ones. Configure both your phone and the incident.io contact so alerts always come through, even when you're not normally on call at night (you may still be escalated to).
+The incident.io app does not configure these settings for you on install. By default your phone's Do Not Disturb, Sleep, or Focus mode will silence pages. Configure both the incident.io app and phone contact so alerts always come through.
 
 #### iOS
 
@@ -103,7 +103,7 @@ Unlike PagerDuty, the incident.io app does not configure these settings for you 
 2. **Enable Emergency Bypass for that contact.** Open the `Contacts` app → `Lists` → `All Contacts`, find `incident.io On-call`, tap `Edit` → `Ringtone` → toggle on `Emergency Bypass`. Repeat for `Text Tone` so SMS pages also break through. On iOS 18+, edit from `All Contacts` rather than the auto-grouped "incident.io" section to avoid a known Apple bug.
 3. **Allow critical notifications.** `Settings` → `incident.io` → `Notifications` → enable `Critical Alerts`. These bypass silent and Focus mode for push notifications.
 4. **Allowlist incident.io in every Focus mode.** `Settings` → `Focus` → for each mode (Sleep, Do Not Disturb, Work, etc.) → `Apps` → add `incident.io` to the allowed list.
-5. **Watch for sound redirects.** Apple Watch pairing, AirPods Announce Notifications, and Screen Time can route incident.io alerts away from your phone speaker – disable the incident.io app in the Watch app's notification list and add incident.io to Screen Time's "Always Allowed" apps.
+5. **Optional: Watch for sound redirects.** Apple Watch pairing, AirPods Announce Notifications, and Screen Time can route incident.io alerts away from your phone speaker – disable the incident.io app in the Watch app's notification list and add incident.io to Screen Time's "Always Allowed" apps.
 
 #### Android
 

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -93,6 +93,29 @@ Before going on call, make sure you have the **Incident.io mobile app** [Android
 
 To get a calendar with all your on-call shifts from incident.io go to the [schedules section](https://app.incident.io/posthog/on-call/schedules), select `Sync calendar` at the top right and copy the link for the webcal feed. In google calendar, add a new calendar from URL and paste the link in there.
 
+### Make sure alerts can break through Do Not Disturb
+
+Unlike PagerDuty, the incident.io app does not configure these settings for you on install. By default your phone's Do Not Disturb, Sleep, or Focus mode will silence pages – including the middle-of-the-night ones. Configure both your phone and the incident.io contact so alerts always come through, even when you're not normally on call at night (you may still be escalated to).
+
+#### iOS
+
+1. **Save the incident.io On-call contact to your phone.** In the incident.io mobile app, go to `Settings` → `Contacts` and enable the toggle to add the contact to your address book.
+2. **Enable Emergency Bypass for that contact.** Open the `Contacts` app → `Lists` → `All Contacts`, find `incident.io On-call`, tap `Edit` → `Ringtone` → toggle on `Emergency Bypass`. Repeat for `Text Tone` so SMS pages also break through. On iOS 18+, edit from `All Contacts` rather than the auto-grouped "incident.io" section to avoid a known Apple bug.
+3. **Allow critical notifications.** `Settings` → `incident.io` → `Notifications` → enable `Critical Alerts`. These bypass silent and Focus mode for push notifications.
+4. **Whitelist incident.io in every Focus mode.** `Settings` → `Focus` → for each mode (Sleep, Do Not Disturb, Work, etc.) → `Apps` → add `incident.io` to the allowed list.
+5. **Watch for sound redirects.** Apple Watch pairing, AirPods Announce Notifications, and Screen Time can route incident.io alerts away from your phone speaker – disable the incident.io app in the Watch app's notification list and add incident.io to Screen Time's "Always Allowed" apps.
+
+#### Android
+
+Exact menu paths vary by manufacturer (Pixel, Samsung, OnePlus, etc.), but the same setup applies:
+
+1. **Grant Do Not Disturb access to the app.** Accept the prompt during incident.io onboarding, or set it manually via `Settings` → `Apps` → `incident.io` → `Special app access` → `Do Not Disturb access`.
+2. **Disable battery and sleep restrictions for the app.** `Settings` → `Apps` → `incident.io` → disable `Pause app activity if unused`, and set `App battery usage` to `Unrestricted`. Otherwise Android may kill the app in the background and you won't get paged.
+3. **Whitelist incident.io in each Do Not Disturb / Focus mode.** On Pixel/stock Android: `Settings` → `Sound & vibration` → `Do Not Disturb` → `Apps` → add `incident.io`. On Samsung: `Settings` → `Modes and routines` → each mode → `Allowed apps` → add `incident.io`.
+4. **Star the incident.io On-call contact and allow starred contacts to bypass DND.** Save and star/favorite the contact, then under `Do Not Disturb` → `People` (or `Exceptions`), allow `Calls` and `Messages` from `Starred contacts`. This lets the phone calls and SMS pages ring through.
+5. **Consider enabling Alarm-style notifications.** In the incident.io app's advanced settings, toggle `Alarm style notifications` and make sure alarms are allowed during Do Not Disturb – this routes pages through the alarm channel, which most phones treat as un-silenceable.
+
+> 💡 Test it! Once configured, put your phone into Do Not Disturb / Sleep mode and ask a teammate to send you a test page (or use the `Send test notification` button in the incident.io app). If you don't hear it, something still isn't right.
 
 ## Make sure your availability is up-to-date
 

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -102,7 +102,7 @@ Unlike PagerDuty, the incident.io app does not configure these settings for you 
 1. **Save the incident.io On-call contact to your phone.** In the incident.io mobile app, go to `Settings` → `Contacts` and enable the toggle to add the contact to your address book.
 2. **Enable Emergency Bypass for that contact.** Open the `Contacts` app → `Lists` → `All Contacts`, find `incident.io On-call`, tap `Edit` → `Ringtone` → toggle on `Emergency Bypass`. Repeat for `Text Tone` so SMS pages also break through. On iOS 18+, edit from `All Contacts` rather than the auto-grouped "incident.io" section to avoid a known Apple bug.
 3. **Allow critical notifications.** `Settings` → `incident.io` → `Notifications` → enable `Critical Alerts`. These bypass silent and Focus mode for push notifications.
-4. **Whitelist incident.io in every Focus mode.** `Settings` → `Focus` → for each mode (Sleep, Do Not Disturb, Work, etc.) → `Apps` → add `incident.io` to the allowed list.
+4. **Allowlist incident.io in every Focus mode.** `Settings` → `Focus` → for each mode (Sleep, Do Not Disturb, Work, etc.) → `Apps` → add `incident.io` to the allowed list.
 5. **Watch for sound redirects.** Apple Watch pairing, AirPods Announce Notifications, and Screen Time can route incident.io alerts away from your phone speaker – disable the incident.io app in the Watch app's notification list and add incident.io to Screen Time's "Always Allowed" apps.
 
 #### Android
@@ -111,7 +111,7 @@ Exact menu paths vary by manufacturer (Pixel, Samsung, OnePlus, etc.), but the s
 
 1. **Grant Do Not Disturb access to the app.** Accept the prompt during incident.io onboarding, or set it manually via `Settings` → `Apps` → `incident.io` → `Special app access` → `Do Not Disturb access`.
 2. **Disable battery and sleep restrictions for the app.** `Settings` → `Apps` → `incident.io` → disable `Pause app activity if unused`, and set `App battery usage` to `Unrestricted`. Otherwise Android may kill the app in the background and you won't get paged.
-3. **Whitelist incident.io in each Do Not Disturb / Focus mode.** On Pixel/stock Android: `Settings` → `Sound & vibration` → `Do Not Disturb` → `Apps` → add `incident.io`. On Samsung: `Settings` → `Modes and routines` → each mode → `Allowed apps` → add `incident.io`.
+3. **Allowlist incident.io in each Do Not Disturb / Focus mode.** On Pixel/stock Android: `Settings` → `Sound & vibration` → `Do Not Disturb` → `Apps` → add `incident.io`. On Samsung: `Settings` → `Modes and routines` → each mode → `Allowed apps` → add `incident.io`.
 4. **Star the incident.io On-call contact and allow starred contacts to bypass DND.** Save and star/favorite the contact, then under `Do Not Disturb` → `People` (or `Exceptions`), allow `Calls` and `Messages` from `Starred contacts`. This lets the phone calls and SMS pages ring through.
 5. **Consider enabling Alarm-style notifications.** In the incident.io app's advanced settings, toggle `Alarm style notifications` and make sure alarms are allowed during Do Not Disturb – this routes pages through the alarm channel, which most phones treat as un-silenceable.
 


### PR DESCRIPTION
## Changes

After getting paged overnight and having the alert silenced by iPhone Do Not Disturb, Raquel flagged that the incident.io mobile app — unlike PagerDuty — doesn't configure phone-side bypass settings on install. This adds a new `Set up your phone to bypass Do Not Disturb` section to the on-call rotation handbook page with step-by-step setup for both iOS (Emergency Bypass on the saved contact, Critical Alerts, Focus mode whitelisting) and Android (DND access, battery/sleep exceptions, per-mode app whitelisting, starred-contact rules, optional Alarm-style notifications).

Android paths are documented for both Pixel/stock and Samsung since they diverge meaningfully.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*