### PR TITLE
feat(feature-flags): add local-eval cost calculator to docs

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -56,6 +56,10 @@ Notice that PostHog is not involved at evaluation time. The tradeoff: **you are 
 
 Local evaluation is also more cost-effective: with remote evaluation, every flag check is a billable request, whereas local evaluation only bills for the periodic request to fetch flag definitions (counted as 10 flag requests each). For high-traffic services, this can significantly reduce your flag usage costs.
 
+Use this calculator to estimate your monthly cost and the savings from switching to local evaluation:
+
+<FeatureFlagCostCalculator />
+
 There are 3 steps to enable local evaluation:
 
 ## Step 1: Find your feature flags secure API key
@@ -73,10 +77,6 @@ By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in 
 > **Note:** For billing purposes, we count the request to fetch the feature flag definitions as being equivalent to `10 flags` requests.
 >
 > This is because one of these requests can compute feature flags for hundreds or thousands of users. It ensures local evaluation is priced fairly while remaining the most cost-effective option (by far!).
-
-Use this calculator to estimate your monthly cost and the savings from switching to local evaluation:
-
-<FeatureFlagCostCalculator />
 
 import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-secure-key.mdx"
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -74,6 +74,10 @@ By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in 
 >
 > This is because one of these requests can compute feature flags for hundreds or thousands of users. It ensures local evaluation is priced fairly while remaining the most cost-effective option (by far!).
 
+Use this calculator to estimate your monthly cost and the savings from switching to local evaluation:
+
+<FeatureFlagCostCalculator />
+
 import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-secure-key.mdx"
 
 <ConfigureFlagsSecureKey />

--- a/src/components/FeatureFlagCostCalculator/FeatureFlagCostCalculator.stories.tsx
+++ b/src/components/FeatureFlagCostCalculator/FeatureFlagCostCalculator.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { FeatureFlagCostCalculator } from './index'
+
+export default {
+    title: 'Components/FeatureFlagCostCalculator',
+    component: FeatureFlagCostCalculator,
+}
+
+export const Default = (): JSX.Element => (
+    <div className="max-w-2xl mx-auto p-6">
+        <FeatureFlagCostCalculator />
+    </div>
+)

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -62,8 +62,11 @@ const parseShorthand = (raw: string): number | null => {
     return Math.round(base * mult)
 }
 
+const fieldWrapperClassName =
+    'flex items-baseline gap-1 border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-32 focus-within:border-red dark:focus-within:border-yellow focus-within:bg-white dark:focus-within:bg-accent-dark'
+
 const inputClassName =
-    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-32 focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
+    'bg-transparent text-right font-code text-sm flex-1 min-w-0 focus:outline-none focus:ring-0 tabular-nums'
 
 const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
     <Tooltip content={tooltip} contentContainerClassName="max-w-xs" placement="top">
@@ -110,7 +113,7 @@ const FieldRow = ({ title, tooltip, value, min, max, marks, scale, onChange, suf
                     <span className="truncate">{title}</span>
                     <InfoIcon tooltip={tooltip} />
                 </span>
-                <span className="flex items-center gap-1.5 shrink-0">
+                <span className={`${fieldWrapperClassName} shrink-0`}>
                     <input
                         type="text"
                         inputMode="numeric"
@@ -123,7 +126,7 @@ const FieldRow = ({ title, tooltip, value, min, max, marks, scale, onChange, suf
                         aria-label={title}
                         className={inputClassName}
                     />
-                    <span className="text-[13px] opacity-60 shrink-0 w-8 text-left">{suffix ?? ''}</span>
+                    {suffix && <span className="text-[13px] opacity-60 shrink-0">{suffix}</span>}
                 </span>
             </div>
             <div className="px-1 pb-5">

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -63,10 +63,10 @@ const parseShorthand = (raw: string): number | null => {
 }
 
 const fieldWrapperClassName =
-    'flex items-baseline gap-1 border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-32 focus-within:border-red dark:focus-within:border-yellow focus-within:bg-white dark:focus-within:bg-accent-dark'
+    'flex items-baseline gap-1 border border-primary hover:border-input-hover rounded-md py-1.5 px-3 w-32 bg-white dark:bg-accent-dark focus-within:border-red dark:focus-within:border-yellow'
 
 const inputClassName =
-    'bg-transparent text-right font-code text-sm flex-1 min-w-0 focus:outline-none focus:ring-0 tabular-nums'
+    'bg-transparent text-right text-sm flex-1 min-w-0 focus:outline-none focus:ring-0 tabular-nums'
 
 const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
     <Tooltip content={tooltip} contentContainerClassName="max-w-xs" placement="top">

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -63,10 +63,10 @@ const parseShorthand = (raw: string): number | null => {
 }
 
 const fieldWrapperClassName =
-    'flex items-baseline gap-1 border border-primary hover:border-input-hover rounded-md py-1.5 px-3 w-32 bg-white dark:bg-accent-dark focus-within:border-red dark:focus-within:border-yellow'
+    'flex items-center gap-1 border border-primary hover:border-input-hover rounded-md h-8 px-3 w-32 bg-white dark:bg-accent-dark focus-within:border-red dark:focus-within:border-yellow'
 
 const inputClassName =
-    'bg-transparent text-right text-sm flex-1 min-w-0 focus:outline-none focus:ring-0 tabular-nums'
+    'appearance-none border-0 bg-transparent p-0 text-right text-[14px] flex-1 min-w-0 focus:outline-none focus:ring-0 tabular-nums'
 
 const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
     <Tooltip content={tooltip} contentContainerClassName="max-w-xs" placement="top">

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -193,7 +193,6 @@ const CalculatorBody = (): JSX.Element => {
     const [serverCount, setServerCount] = useState<number>(DEFAULT_SERVER_COUNT)
     const [pollIntervalSec, setPollIntervalSec] = useState<number>(DEFAULT_POLL_INTERVAL_SEC)
     const [serverSidePct, setServerSidePct] = useState<number>(DEFAULT_SERVER_SHARE_PCT)
-    const [showAdvanced, setShowAdvanced] = useState<boolean>(false)
     const [tiers, setTiers] = useState<Tier[] | null>(null)
 
     useEffect(() => {
@@ -271,52 +270,41 @@ const CalculatorBody = (): JSX.Element => {
                 </div>
             )}
 
-            <button
-                type="button"
-                onClick={() => setShowAdvanced((v) => !v)}
-                className="mt-4 text-[13px] font-semibold opacity-75 hover:opacity-100 inline-flex items-center gap-1"
-                aria-expanded={showAdvanced}
-            >
-                <span className="inline-block w-3 text-center">{showAdvanced ? '−' : '+'}</span>
-                Local evaluation assumptions
-            </button>
-
-            {showAdvanced && (
-                <div className="mt-2 border-t border-light dark:border-dark divide-y divide-light dark:divide-dark">
-                    <FieldRow
-                        title="Server fleet size"
-                        tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
-                        value={serverCount}
-                        min={1}
-                        max={5000}
-                        marks={[1, 10, 100, 1000, 5000]}
-                        scale="log"
-                        onChange={setServerCount}
-                    />
-                    <FieldRow
-                        title="Poll interval"
-                        tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
-                        value={pollIntervalSec}
-                        min={10}
-                        max={3600}
-                        marks={[10, 30, 60, 300, 900, 3600]}
-                        scale="log"
-                        onChange={setPollIntervalSec}
-                        suffix="sec"
-                    />
-                    <FieldRow
-                        title="Server-side share"
-                        tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
-                        value={serverSidePct}
-                        min={0}
-                        max={100}
-                        marks={[0, 25, 50, 75, 100]}
-                        scale="linear"
-                        onChange={setServerSidePct}
-                        suffix="%"
-                    />
-                </div>
-            )}
+            <div className="mt-4 border-t border-light dark:border-dark divide-y divide-light dark:divide-dark">
+                <div className="pt-3 text-[13px] font-semibold opacity-75">Local evaluation assumptions</div>
+                <FieldRow
+                    title="Server fleet size"
+                    tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
+                    value={serverCount}
+                    min={1}
+                    max={5000}
+                    marks={[1, 10, 100, 1000, 5000]}
+                    scale="log"
+                    onChange={setServerCount}
+                />
+                <FieldRow
+                    title="Poll interval"
+                    tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
+                    value={pollIntervalSec}
+                    min={10}
+                    max={3600}
+                    marks={[10, 30, 60, 300, 900, 3600]}
+                    scale="log"
+                    onChange={setPollIntervalSec}
+                    suffix="sec"
+                />
+                <FieldRow
+                    title="Server-side share"
+                    tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
+                    value={serverSidePct}
+                    min={0}
+                    max={100}
+                    marks={[0, 25, 50, 75, 100]}
+                    scale="linear"
+                    onChange={setServerSidePct}
+                    suffix="%"
+                />
+            </div>
 
             {tiers === null && <div className="mt-3 text-[12px] opacity-60">Loading current pricing tiers…</div>}
         </div>

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { IconInfo } from '@posthog/icons'
-import Tooltip from 'components/RadixUI/Tooltip'
+import Tooltip from 'components/Tooltip'
+import Toggle from 'components/Toggle'
 import { LogSlider, LinearSlider, prettyInt } from 'components/Pricing/PricingSlider/Slider'
 
-type Mode = 'remote' | 'local'
 type Scale = 'log' | 'linear'
 
 type Tier = {
@@ -46,7 +46,8 @@ const clamp = (n: number, min: number, max: number): number => Math.max(min, Mat
 
 const parseShorthand = (raw: string): number | null => {
     const cleaned = raw
-        .replace(/[, _%s]/gi, '')
+        .replace(/[, _%]/g, '')
+        .replace(/s$/i, '')
         .trim()
         .toLowerCase()
     if (!cleaned) return null
@@ -58,50 +59,17 @@ const parseShorthand = (raw: string): number | null => {
 }
 
 const inputClassName =
-    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-28 focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
+    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-full max-w-[120px] focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
 
 const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
-    <Tooltip
-        side="top"
-        trigger={
-            <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
-                <IconInfo className="size-3.5 inline-block" />
-            </span>
-        }
-    >
-        <div className="max-w-xs text-sm">{tooltip}</div>
+    <Tooltip content={tooltip} contentContainerClassName="max-w-xs" placement="top">
+        <span className="inline-block opacity-60 hover:opacity-100 cursor-help relative -top-px">
+            <IconInfo className="size-4 inline-block" />
+        </span>
     </Tooltip>
 )
 
-const ModeToggle = ({ mode, onChange }: { mode: Mode; onChange: (m: Mode) => void }): JSX.Element => (
-    <div
-        role="radiogroup"
-        aria-label="Evaluation mode"
-        className="inline-flex p-0.5 rounded-full border border-light dark:border-dark bg-white dark:bg-accent-dark text-[12px] font-semibold"
-    >
-        {(['remote', 'local'] as Mode[]).map((option) => {
-            const checked = mode === option
-            return (
-                <button
-                    key={option}
-                    type="button"
-                    role="radio"
-                    aria-checked={checked}
-                    onClick={() => onChange(option)}
-                    className={`px-3 py-1 rounded-full transition-colors ${
-                        checked
-                            ? 'bg-red text-white'
-                            : 'text-primary/70 dark:text-primary-dark/70 hover:text-primary dark:hover:text-primary-dark'
-                    }`}
-                >
-                    {option === 'remote' ? 'Remote' : 'Local'}
-                </button>
-            )
-        })}
-    </div>
-)
-
-type NumericFieldProps = {
+type FieldRowProps = {
     title: string
     tooltip: string
     value: number
@@ -111,104 +79,75 @@ type NumericFieldProps = {
     scale: Scale
     onChange: (n: number) => void
     suffix?: string
-    formatDisplay?: (n: number) => string
 }
 
-const NumericField = ({
-    title,
-    tooltip,
-    value,
-    min,
-    max,
-    marks,
-    scale,
-    onChange,
-    suffix,
-    formatDisplay = prettyInt,
-}: NumericFieldProps): JSX.Element => {
-    const [draft, setDraft] = useState<string>(formatDisplay(value))
+const FieldRow = ({ title, tooltip, value, min, max, marks, scale, onChange, suffix }: FieldRowProps): JSX.Element => {
+    const [draft, setDraft] = useState<string>(prettyInt(value))
 
     useEffect(() => {
-        setDraft(formatDisplay(value))
-    }, [value, formatDisplay])
+        setDraft(prettyInt(value))
+    }, [value])
 
     const commit = (): void => {
         const parsed = parseShorthand(draft)
         if (parsed === null) {
-            setDraft(formatDisplay(value))
+            setDraft(prettyInt(value))
             return
         }
         const bounded = clamp(parsed, min, max)
         onChange(bounded)
-        setDraft(formatDisplay(bounded))
+        setDraft(prettyInt(bounded))
     }
 
     return (
-        <div>
-            <div className="flex items-center justify-between gap-2 mb-1.5">
-                <div className="flex items-baseline gap-1">
-                    <span className="text-[13px] font-semibold">{title}</span>
-                    <InfoIcon tooltip={tooltip} />
-                </div>
-                <div className="flex items-center gap-1">
-                    <input
-                        type="text"
-                        inputMode="numeric"
-                        value={draft}
-                        onChange={(e) => setDraft(e.target.value)}
-                        onBlur={commit}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
-                        }}
-                        aria-label={title}
-                        className={inputClassName}
-                    />
-                    {suffix && <span className="text-[13px] opacity-60">{suffix}</span>}
-                </div>
+        <div className="grid grid-cols-12 gap-x-4 items-center border-t border-light dark:border-dark py-4">
+            <div className="col-span-12 md:col-span-4 flex items-baseline gap-1">
+                <span className="text-[14px] font-semibold">{title}</span>
+                <InfoIcon tooltip={tooltip} />
             </div>
-            {scale === 'log' ? (
-                <LogSlider
-                    min={min}
-                    max={max}
-                    marks={marks}
-                    stepsInRange={200}
-                    value={Math.log(value)}
-                    onChange={(v) => onChange(clamp(Math.round(Math.exp(v)), min, max))}
+            <div className="col-span-8 md:col-span-5 pr-2">
+                {scale === 'log' ? (
+                    <LogSlider
+                        min={min}
+                        max={max}
+                        marks={marks}
+                        stepsInRange={200}
+                        value={Math.log(value)}
+                        onChange={(v) => onChange(clamp(Math.round(Math.exp(v)), min, max))}
+                    />
+                ) : (
+                    <LinearSlider
+                        min={min}
+                        max={max}
+                        marks={marks}
+                        stepsInRange={Math.max(100, max - min)}
+                        value={value}
+                        onChange={(v) => onChange(clamp(Math.round(v), min, max))}
+                    />
+                )}
+            </div>
+            <div className="col-span-4 md:col-span-3 flex items-center justify-end gap-1.5">
+                <input
+                    type="text"
+                    inputMode="numeric"
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onBlur={commit}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                    }}
+                    aria-label={title}
+                    className={inputClassName}
                 />
-            ) : (
-                <LinearSlider
-                    min={min}
-                    max={max}
-                    marks={marks}
-                    stepsInRange={Math.max(100, max - min)}
-                    value={value}
-                    onChange={(v) => onChange(clamp(Math.round(v), min, max))}
-                />
-            )}
+                {suffix && <span className="text-[13px] opacity-60 shrink-0">{suffix}</span>}
+            </div>
         </div>
     )
 }
 
-const ResultLine = ({
-    label,
-    value,
-    emphasis = false,
-}: {
-    label: string
-    value: string
-    emphasis?: boolean
-}): JSX.Element => (
-    <div className="flex items-baseline justify-between py-1">
-        <span className={emphasis ? 'text-[15px] font-semibold' : 'text-[13px]'}>{label}</span>
-        <span className={`font-code tabular-nums ${emphasis ? 'text-[15px] font-semibold' : 'text-[13px]'}`}>
-            {value}
-        </span>
-    </div>
-)
-
 const CalculatorBody = (): JSX.Element => {
     const [monthlyRequests, setMonthlyRequests] = useState<number>(1_000_000)
-    const [mode, setMode] = useState<Mode>('remote')
+    const [useLocal, setUseLocal] = useState<boolean>(false)
     const [serverCount, setServerCount] = useState<number>(10)
     const [pollIntervalSec, setPollIntervalSec] = useState<number>(30)
     const [serverSidePct, setServerSidePct] = useState<number>(50)
@@ -236,33 +175,46 @@ const CalculatorBody = (): JSX.Element => {
     const localCost = calculatePrice(mixedBillable, activeTiers)
     const savings = remoteCost - localCost
     const savingsPct = remoteCost > 0 ? Math.round((savings / remoteCost) * 100) : 0
-    const localCostsMore = mode === 'local' && localCost > remoteCost
+    const localCostsMore = useLocal && localCost > remoteCost
+    const headlineCost = useLocal ? localCost : remoteCost
 
     return (
-        <div className="border border-light dark:border-dark rounded-md p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
-            <div className="flex items-center justify-between flex-wrap gap-3 mb-5">
-                <h3 className="!my-0 !text-lg">Feature flag cost calculator</h3>
-                <ModeToggle mode={mode} onChange={setMode} />
+        <div className="not-prose my-8">
+            <div className="flex items-center justify-between gap-3 flex-wrap mb-1">
+                <h4 className="!mb-0 !text-xl">
+                    Estimate your monthly cost
+                    <span className="inline-block ml-1 relative -top-0.5">
+                        <InfoIcon tooltip="Estimates use current usage-based pricing tiers. Local evaluation polls count as 10 flag requests each." />
+                    </span>
+                </h4>
+                <Toggle
+                    label="Use local evaluation"
+                    position="left"
+                    checked={useLocal}
+                    onChange={setUseLocal}
+                    activeOpacity={false}
+                />
             </div>
+            <p className="text-sm opacity-75 mb-2">
+                Drag a slider or type a volume to see your monthly bill. Toggle local evaluation to compare against
+                remote-only.
+            </p>
 
-            <NumericField
-                title="Monthly flag requests"
-                tooltip="Total flag evaluation requests across all your apps per month. If unsure, estimate as daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b."
-                value={monthlyRequests}
-                min={REQUEST_MIN}
-                max={REQUEST_MAX}
-                marks={REQUEST_MARKS}
-                scale="log"
-                onChange={setMonthlyRequests}
-            />
+            <div className="border-b border-light dark:border-dark">
+                <FieldRow
+                    title="Monthly flag requests"
+                    tooltip="Total flag evaluation requests across all your apps per month. Estimate as daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b."
+                    value={monthlyRequests}
+                    min={REQUEST_MIN}
+                    max={REQUEST_MAX}
+                    marks={REQUEST_MARKS}
+                    scale="log"
+                    onChange={setMonthlyRequests}
+                />
 
-            {mode === 'local' && (
-                <div className="mt-6 pt-5 border-t border-light dark:border-dark">
-                    <div className="text-[11px] font-semibold uppercase tracking-wide opacity-60 mb-4">
-                        Local evaluation settings
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-5">
-                        <NumericField
+                {useLocal && (
+                    <>
+                        <FieldRow
                             title="Server fleet size"
                             tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
                             value={serverCount}
@@ -272,7 +224,7 @@ const CalculatorBody = (): JSX.Element => {
                             scale="log"
                             onChange={setServerCount}
                         />
-                        <NumericField
+                        <FieldRow
                             title="Poll interval"
                             tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
                             value={pollIntervalSec}
@@ -283,51 +235,53 @@ const CalculatorBody = (): JSX.Element => {
                             onChange={setPollIntervalSec}
                             suffix="sec"
                         />
-                        <div className="md:col-span-2">
-                            <NumericField
-                                title="Server-side share of requests"
-                                tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
-                                value={serverSidePct}
-                                min={0}
-                                max={100}
-                                marks={[0, 25, 50, 75, 100]}
-                                scale="linear"
-                                onChange={setServerSidePct}
-                                suffix="%"
-                            />
-                        </div>
-                    </div>
-                </div>
-            )}
-
-            <div className="mt-6 rounded-md bg-white dark:bg-dark border border-light dark:border-dark p-4">
-                <ResultLine
-                    label="Remote-only cost"
-                    value={`${formatUSD(remoteCost)} / mo`}
-                    emphasis={mode === 'remote'}
-                />
-                {mode === 'local' && (
-                    <>
-                        <ResultLine label="With local evaluation" value={`${formatUSD(localCost)} / mo`} emphasis />
-                        <ResultLine
-                            label="Estimated savings"
-                            value={
-                                savings > 0
-                                    ? `${formatUSD(savings)} / mo (${savingsPct}%)`
-                                    : savings < 0
-                                    ? `${formatUSD(-savings)} more / mo`
-                                    : '$0 / mo'
-                            }
+                        <FieldRow
+                            title="Server-side share of requests"
+                            tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
+                            value={serverSidePct}
+                            min={0}
+                            max={100}
+                            marks={[0, 25, 50, 75, 100]}
+                            scale="linear"
+                            onChange={setServerSidePct}
+                            suffix="%"
                         />
-                        <ResultLine label="Annualized savings" value={savings > 0 ? formatUSD(savings * 12) : '—'} />
                     </>
                 )}
             </div>
 
+            <div className="grid grid-cols-12 mt-4 bg-accent dark:bg-accent-dark rounded items-center">
+                <div className="col-span-12 md:col-span-7 p-4">
+                    <strong className="block">Monthly estimate</strong>
+                    <span className="text-sm opacity-75">
+                        {useLocal
+                            ? `${
+                                  savings > 0
+                                      ? `Save ${formatUSD(savings)}/mo (${savingsPct}%) vs remote`
+                                      : savings < 0
+                                      ? `${formatUSD(-savings)}/mo more than remote`
+                                      : 'Same cost as remote'
+                              }`
+                            : 'Remote evaluation — every flag check is a billable request'}
+                    </span>
+                </div>
+                <div className="col-span-12 md:col-span-5 p-4 md:text-right">
+                    <div className="flex md:justify-end items-baseline gap-1">
+                        <span className="text-2xl font-bold">{formatUSD(headlineCost)}</span>
+                        <span className="opacity-60 text-sm">/mo</span>
+                    </div>
+                    {useLocal && savings > 0 && (
+                        <div className="text-sm opacity-75">
+                            Remote-only: <span className="font-code">{formatUSD(remoteCost)}/mo</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+
             {localCostsMore && (
-                <div className="mt-4 p-3 rounded-md border border-yellow text-[13px] bg-yellow/10">
-                    <strong>Heads up:</strong> with these settings, local evaluation would cost <em>more</em> than
-                    remote. Try a larger poll interval or a smaller fleet.
+                <div className="mt-3 p-3 rounded border border-yellow text-[13px] bg-yellow/10">
+                    <strong>Heads up:</strong> with these settings, local evaluation costs <em>more</em> than remote.
+                    Try a larger poll interval or a smaller fleet.
                 </div>
             )}
 
@@ -341,8 +295,8 @@ export const FeatureFlagCostCalculator = (): JSX.Element | null => {
     useEffect(() => setMounted(true), [])
     if (!mounted) {
         return (
-            <div className="border border-light dark:border-dark rounded-md p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
-                <h3 className="!mt-0 !mb-4 !text-lg">Feature flag cost calculator</h3>
+            <div className="not-prose my-8">
+                <h4 className="!mb-2 !text-xl">Estimate your monthly cost</h4>
                 <div className="text-sm opacity-70">Loading…</div>
             </div>
         )

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -4,6 +4,7 @@ import Tooltip from 'components/RadixUI/Tooltip'
 import { LogSlider, LinearSlider, prettyInt } from 'components/Pricing/PricingSlider/Slider'
 
 type Mode = 'remote' | 'local'
+type Scale = 'log' | 'linear'
 
 type Tier = {
     up_to: number | null
@@ -41,32 +42,42 @@ const calculatePrice = (events: number, tiers: Tier[]): number => {
     return Math.round(total)
 }
 
-const Label = ({ title, value, tooltip }: { title: string; value: string; tooltip?: string }): JSX.Element => (
-    <div className="flex items-baseline justify-between mb-1">
-        <div className="flex items-baseline gap-1">
-            <span className="text-[13px] font-semibold">{title}</span>
-            {tooltip && (
-                <Tooltip
-                    side="top"
-                    trigger={
-                        <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
-                            <IconInfo className="size-3.5 inline-block" />
-                        </span>
-                    }
-                >
-                    <div className="max-w-xs text-sm">{tooltip}</div>
-                </Tooltip>
-            )}
-        </div>
-        <span className="text-[13px] font-mono tabular-nums opacity-80">{value}</span>
-    </div>
+const clamp = (n: number, min: number, max: number): number => Math.max(min, Math.min(max, n))
+
+const parseShorthand = (raw: string): number | null => {
+    const cleaned = raw
+        .replace(/[, _%s]/gi, '')
+        .trim()
+        .toLowerCase()
+    if (!cleaned) return null
+    const match = cleaned.match(/^(\d+(?:\.\d+)?)([kmb])?$/)
+    if (!match) return null
+    const base = parseFloat(match[1])
+    const mult = match[2] === 'k' ? 1_000 : match[2] === 'm' ? 1_000_000 : match[2] === 'b' ? 1_000_000_000 : 1
+    return Math.round(base * mult)
+}
+
+const inputClassName =
+    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-28 focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
+
+const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
+    <Tooltip
+        side="top"
+        trigger={
+            <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
+                <IconInfo className="size-3.5 inline-block" />
+            </span>
+        }
+    >
+        <div className="max-w-xs text-sm">{tooltip}</div>
+    </Tooltip>
 )
 
 const ModeToggle = ({ mode, onChange }: { mode: Mode; onChange: (m: Mode) => void }): JSX.Element => (
     <div
         role="radiogroup"
         aria-label="Evaluation mode"
-        className="inline-flex p-0.5 rounded-full border border-light dark:border-dark bg-light dark:bg-dark text-[12px] font-semibold"
+        className="inline-flex p-0.5 rounded-full border border-light dark:border-dark bg-white dark:bg-accent-dark text-[12px] font-semibold"
     >
         {(['remote', 'local'] as Mode[]).map((option) => {
             const checked = mode === option
@@ -90,22 +101,106 @@ const ModeToggle = ({ mode, onChange }: { mode: Mode; onChange: (m: Mode) => voi
     </div>
 )
 
-const parseRequests = (raw: string): number | null => {
-    const cleaned = raw.replace(/[, _]/g, '').trim().toLowerCase()
-    if (!cleaned) return null
-    const match = cleaned.match(/^(\d+(?:\.\d+)?)([kmb])?$/)
-    if (!match) return null
-    const base = parseFloat(match[1])
-    const mult = match[2] === 'k' ? 1_000 : match[2] === 'm' ? 1_000_000 : match[2] === 'b' ? 1_000_000_000 : 1
-    return Math.round(base * mult)
+type NumericFieldProps = {
+    title: string
+    tooltip: string
+    value: number
+    min: number
+    max: number
+    marks: number[]
+    scale: Scale
+    onChange: (n: number) => void
+    suffix?: string
+    formatDisplay?: (n: number) => string
 }
 
-const clamp = (n: number, min: number, max: number): number => Math.max(min, Math.min(max, n))
+const NumericField = ({
+    title,
+    tooltip,
+    value,
+    min,
+    max,
+    marks,
+    scale,
+    onChange,
+    suffix,
+    formatDisplay = prettyInt,
+}: NumericFieldProps): JSX.Element => {
+    const [draft, setDraft] = useState<string>(formatDisplay(value))
 
-const Row = ({ label, value, emphasis = false }: { label: string; value: string; emphasis?: boolean }): JSX.Element => (
+    useEffect(() => {
+        setDraft(formatDisplay(value))
+    }, [value, formatDisplay])
+
+    const commit = (): void => {
+        const parsed = parseShorthand(draft)
+        if (parsed === null) {
+            setDraft(formatDisplay(value))
+            return
+        }
+        const bounded = clamp(parsed, min, max)
+        onChange(bounded)
+        setDraft(formatDisplay(bounded))
+    }
+
+    return (
+        <div>
+            <div className="flex items-center justify-between gap-2 mb-1.5">
+                <div className="flex items-baseline gap-1">
+                    <span className="text-[13px] font-semibold">{title}</span>
+                    <InfoIcon tooltip={tooltip} />
+                </div>
+                <div className="flex items-center gap-1">
+                    <input
+                        type="text"
+                        inputMode="numeric"
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onBlur={commit}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                        }}
+                        aria-label={title}
+                        className={inputClassName}
+                    />
+                    {suffix && <span className="text-[13px] opacity-60">{suffix}</span>}
+                </div>
+            </div>
+            {scale === 'log' ? (
+                <LogSlider
+                    min={min}
+                    max={max}
+                    marks={marks}
+                    stepsInRange={200}
+                    value={Math.log(value)}
+                    onChange={(v) => onChange(clamp(Math.round(Math.exp(v)), min, max))}
+                />
+            ) : (
+                <LinearSlider
+                    min={min}
+                    max={max}
+                    marks={marks}
+                    stepsInRange={Math.max(100, max - min)}
+                    value={value}
+                    onChange={(v) => onChange(clamp(Math.round(v), min, max))}
+                />
+            )}
+        </div>
+    )
+}
+
+const ResultLine = ({
+    label,
+    value,
+    emphasis = false,
+}: {
+    label: string
+    value: string
+    emphasis?: boolean
+}): JSX.Element => (
     <div className="flex items-baseline justify-between py-1">
-        <span className={emphasis ? 'text-[15px] font-semibold' : 'text-[14px]'}>{label}</span>
-        <span className={`font-mono tabular-nums ${emphasis ? 'text-[15px] font-semibold' : 'text-[14px]'}`}>
+        <span className={emphasis ? 'text-[15px] font-semibold' : 'text-[13px]'}>{label}</span>
+        <span className={`font-code tabular-nums ${emphasis ? 'text-[15px] font-semibold' : 'text-[13px]'}`}>
             {value}
         </span>
     </div>
@@ -113,7 +208,6 @@ const Row = ({ label, value, emphasis = false }: { label: string; value: string;
 
 const CalculatorBody = (): JSX.Element => {
     const [monthlyRequests, setMonthlyRequests] = useState<number>(1_000_000)
-    const [requestsInput, setRequestsInput] = useState<string>(prettyInt(1_000_000))
     const [mode, setMode] = useState<Mode>('remote')
     const [serverCount, setServerCount] = useState<number>(10)
     const [pollIntervalSec, setPollIntervalSec] = useState<number>(30)
@@ -132,21 +226,6 @@ const CalculatorBody = (): JSX.Element => {
             .catch(() => setTiers(FALLBACK_TIERS))
     }, [])
 
-    const updateRequests = (n: number): void => {
-        const bounded = clamp(n, REQUEST_MIN, REQUEST_MAX)
-        setMonthlyRequests(bounded)
-        setRequestsInput(prettyInt(bounded))
-    }
-
-    const handleInputBlur = (): void => {
-        const parsed = parseRequests(requestsInput)
-        if (parsed === null) {
-            setRequestsInput(prettyInt(monthlyRequests))
-            return
-        }
-        updateRequests(parsed)
-    }
-
     const activeTiers = tiers ?? FALLBACK_TIERS
     const pollsPerServerMo = SECONDS_PER_MONTH / pollIntervalSec
     const localBillable = LOCAL_EVAL_MULTIPLIER * pollsPerServerMo * serverCount
@@ -160,118 +239,77 @@ const CalculatorBody = (): JSX.Element => {
     const localCostsMore = mode === 'local' && localCost > remoteCost
 
     return (
-        <div className="border border-light dark:border-dark rounded p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
+        <div className="border border-light dark:border-dark rounded-md p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
             <div className="flex items-center justify-between flex-wrap gap-3 mb-5">
                 <h3 className="!my-0 !text-lg">Feature flag cost calculator</h3>
                 <ModeToggle mode={mode} onChange={setMode} />
             </div>
 
-            <div>
-                <div className="flex items-baseline justify-between mb-1.5 gap-2">
-                    <div className="flex items-baseline gap-1">
-                        <span className="text-[13px] font-semibold">Monthly flag requests</span>
-                        <Tooltip
-                            side="top"
-                            trigger={
-                                <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
-                                    <IconInfo className="size-3.5 inline-block" />
-                                </span>
-                            }
-                        >
-                            <div className="max-w-xs text-sm">
-                                Total flag evaluation requests across all your apps per month. If unsure, estimate as
-                                daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b.
-                            </div>
-                        </Tooltip>
-                    </div>
-                    <input
-                        type="text"
-                        inputMode="numeric"
-                        value={requestsInput}
-                        onChange={(e) => setRequestsInput(e.target.value)}
-                        onBlur={handleInputBlur}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
-                        }}
-                        aria-label="Monthly flag requests"
-                        className="w-32 px-2 py-1 text-right text-[13px] font-mono tabular-nums rounded border border-light dark:border-dark bg-white dark:bg-accent-dark focus:outline-none focus:border-red"
-                    />
-                </div>
-                <LogSlider
-                    min={REQUEST_MIN}
-                    max={REQUEST_MAX}
-                    marks={REQUEST_MARKS}
-                    stepsInRange={200}
-                    value={Math.log(monthlyRequests)}
-                    onChange={(v) => updateRequests(Math.round(Math.exp(v)))}
-                />
-            </div>
+            <NumericField
+                title="Monthly flag requests"
+                tooltip="Total flag evaluation requests across all your apps per month. If unsure, estimate as daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b."
+                value={monthlyRequests}
+                min={REQUEST_MIN}
+                max={REQUEST_MAX}
+                marks={REQUEST_MARKS}
+                scale="log"
+                onChange={setMonthlyRequests}
+            />
 
             {mode === 'local' && (
-                <div className="mt-6 pt-4 border-t border-light dark:border-dark">
-                    <div className="text-[11px] font-semibold uppercase tracking-wide opacity-60 mb-3">
+                <div className="mt-6 pt-5 border-t border-light dark:border-dark">
+                    <div className="text-[11px] font-semibold uppercase tracking-wide opacity-60 mb-4">
                         Local evaluation settings
                     </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
-                        <div>
-                            <Label
-                                title="Server fleet size"
-                                value={prettyInt(serverCount)}
-                                tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
-                            />
-                            <LogSlider
-                                min={1}
-                                max={5000}
-                                marks={[1, 10, 100, 1000, 5000]}
-                                stepsInRange={200}
-                                value={Math.log(serverCount)}
-                                onChange={(v) => setServerCount(clamp(Math.round(Math.exp(v)), 1, 5000))}
-                            />
-                        </div>
-
-                        <div>
-                            <Label
-                                title="Poll interval"
-                                value={`${pollIntervalSec}s`}
-                                tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
-                            />
-                            <LogSlider
-                                min={10}
-                                max={3600}
-                                marks={[10, 30, 60, 300, 900, 3600]}
-                                stepsInRange={200}
-                                value={Math.log(pollIntervalSec)}
-                                onChange={(v) => setPollIntervalSec(clamp(Math.round(Math.exp(v)), 10, 3600))}
-                            />
-                        </div>
-
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-5">
+                        <NumericField
+                            title="Server fleet size"
+                            tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
+                            value={serverCount}
+                            min={1}
+                            max={5000}
+                            marks={[1, 10, 100, 1000, 5000]}
+                            scale="log"
+                            onChange={setServerCount}
+                        />
+                        <NumericField
+                            title="Poll interval"
+                            tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
+                            value={pollIntervalSec}
+                            min={10}
+                            max={3600}
+                            marks={[10, 30, 60, 300, 900, 3600]}
+                            scale="log"
+                            onChange={setPollIntervalSec}
+                            suffix="sec"
+                        />
                         <div className="md:col-span-2">
-                            <Label
+                            <NumericField
                                 title="Server-side share of requests"
-                                value={`${serverSidePct}%`}
                                 tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
-                            />
-                            <LinearSlider
+                                value={serverSidePct}
                                 min={0}
                                 max={100}
                                 marks={[0, 25, 50, 75, 100]}
-                                stepsInRange={100}
-                                value={serverSidePct}
-                                onChange={(v) => setServerSidePct(Math.round(v))}
+                                scale="linear"
+                                onChange={setServerSidePct}
+                                suffix="%"
                             />
                         </div>
                     </div>
                 </div>
             )}
 
-            <hr className="my-5 border-light dark:border-dark" />
-
-            <div>
-                <Row label="Remote-only cost" value={`${formatUSD(remoteCost)} / mo`} emphasis={mode === 'remote'} />
+            <div className="mt-6 rounded-md bg-white dark:bg-dark border border-light dark:border-dark p-4">
+                <ResultLine
+                    label="Remote-only cost"
+                    value={`${formatUSD(remoteCost)} / mo`}
+                    emphasis={mode === 'remote'}
+                />
                 {mode === 'local' && (
                     <>
-                        <Row label="With local evaluation" value={`${formatUSD(localCost)} / mo`} emphasis />
-                        <Row
+                        <ResultLine label="With local evaluation" value={`${formatUSD(localCost)} / mo`} emphasis />
+                        <ResultLine
                             label="Estimated savings"
                             value={
                                 savings > 0
@@ -281,19 +319,19 @@ const CalculatorBody = (): JSX.Element => {
                                     : '$0 / mo'
                             }
                         />
-                        <Row label="Annualized savings" value={savings > 0 ? formatUSD(savings * 12) : '—'} />
+                        <ResultLine label="Annualized savings" value={savings > 0 ? formatUSD(savings * 12) : '—'} />
                     </>
                 )}
-
-                {localCostsMore && (
-                    <div className="mt-4 p-3 rounded border border-yellow text-[13px] bg-yellow/10">
-                        <strong>Heads up:</strong> with these settings, local evaluation would cost <em>more</em> than
-                        remote. Try a larger poll interval or a smaller fleet.
-                    </div>
-                )}
-
-                {tiers === null && <div className="mt-3 text-[12px] opacity-60">Loading current pricing tiers…</div>}
             </div>
+
+            {localCostsMore && (
+                <div className="mt-4 p-3 rounded-md border border-yellow text-[13px] bg-yellow/10">
+                    <strong>Heads up:</strong> with these settings, local evaluation would cost <em>more</em> than
+                    remote. Try a larger poll interval or a smaller fleet.
+                </div>
+            )}
+
+            {tiers === null && <div className="mt-3 text-[12px] opacity-60">Loading current pricing tiers…</div>}
         </div>
     )
 }
@@ -303,7 +341,7 @@ export const FeatureFlagCostCalculator = (): JSX.Element | null => {
     useEffect(() => setMounted(true), [])
     if (!mounted) {
         return (
-            <div className="border border-light dark:border-dark rounded p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
+            <div className="border border-light dark:border-dark rounded-md p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
                 <h3 className="!mt-0 !mb-4 !text-lg">Feature flag cost calculator</h3>
                 <div className="text-sm opacity-70">Loading…</div>
             </div>

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { IconInfo } from '@posthog/icons'
 import Tooltip from 'components/Tooltip'
-import Toggle from 'components/Toggle'
 import { LogSlider, LinearSlider, prettyInt } from 'components/Pricing/PricingSlider/Slider'
 
 type Scale = 'log' | 'linear'
@@ -17,6 +16,11 @@ const LOCAL_EVAL_MULTIPLIER = 10
 const REQUEST_MIN = 1_000
 const REQUEST_MAX = 10_000_000_000
 const REQUEST_MARKS = [1_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 10_000_000_000]
+
+const DEFAULT_MONTHLY_REQUESTS = 10_000_000
+const DEFAULT_SERVER_COUNT = 5
+const DEFAULT_POLL_INTERVAL_SEC = 60
+const DEFAULT_SERVER_SHARE_PCT = 80
 
 const FALLBACK_TIERS: Tier[] = [
     { up_to: 1_000_000, unit_amount_usd: '0' },
@@ -59,7 +63,7 @@ const parseShorthand = (raw: string): number | null => {
 }
 
 const inputClassName =
-    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-full max-w-[120px] focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
+    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-24 focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
 
 const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
     <Tooltip content={tooltip} contentContainerClassName="max-w-xs" placement="top">
@@ -100,12 +104,29 @@ const FieldRow = ({ title, tooltip, value, min, max, marks, scale, onChange, suf
     }
 
     return (
-        <div className="grid grid-cols-12 gap-x-4 items-center border-t border-light dark:border-dark py-4">
-            <div className="col-span-12 md:col-span-4 flex items-baseline gap-1">
-                <span className="text-[14px] font-semibold">{title}</span>
-                <InfoIcon tooltip={tooltip} />
+        <div className="py-3">
+            <div className="flex items-baseline justify-between gap-3 mb-2">
+                <span className="text-[14px] font-semibold flex items-baseline gap-1 min-w-0">
+                    <span className="truncate">{title}</span>
+                    <InfoIcon tooltip={tooltip} />
+                </span>
+                <span className="flex items-center gap-1.5 shrink-0">
+                    <input
+                        type="text"
+                        inputMode="numeric"
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onBlur={commit}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                        }}
+                        aria-label={title}
+                        className={inputClassName}
+                    />
+                    {suffix && <span className="text-[13px] opacity-60 shrink-0">{suffix}</span>}
+                </span>
             </div>
-            <div className="col-span-8 md:col-span-5 pr-2">
+            <div className="px-1 pb-5">
                 {scale === 'log' ? (
                     <LogSlider
                         min={min}
@@ -126,31 +147,50 @@ const FieldRow = ({ title, tooltip, value, min, max, marks, scale, onChange, suf
                     />
                 )}
             </div>
-            <div className="col-span-4 md:col-span-3 flex items-center justify-end gap-1.5">
-                <input
-                    type="text"
-                    inputMode="numeric"
-                    value={draft}
-                    onChange={(e) => setDraft(e.target.value)}
-                    onBlur={commit}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
-                    }}
-                    aria-label={title}
-                    className={inputClassName}
-                />
-                {suffix && <span className="text-[13px] opacity-60 shrink-0">{suffix}</span>}
+        </div>
+    )
+}
+
+type CostCardProps = {
+    title: string
+    description: string
+    cost: number
+    accent: 'neutral' | 'best' | 'warning'
+    badge?: string
+}
+
+const CostCard = ({ title, description, cost, accent, badge }: CostCardProps): JSX.Element => {
+    const accentClass =
+        accent === 'best'
+            ? 'border-green/40 bg-green/5'
+            : accent === 'warning'
+            ? 'border-yellow/40 bg-yellow/10'
+            : 'border-light dark:border-dark bg-accent dark:bg-accent-dark'
+    return (
+        <div className={`flex-1 min-w-0 rounded border p-4 ${accentClass}`}>
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <strong className="text-[13px] uppercase tracking-wide opacity-75">{title}</strong>
+                {badge && (
+                    <span className="text-[11px] font-semibold px-1.5 py-0.5 rounded bg-green/20 text-green shrink-0">
+                        {badge}
+                    </span>
+                )}
             </div>
+            <div className="flex items-baseline gap-1 mb-2">
+                <span className="text-2xl font-bold tabular-nums">{formatUSD(cost)}</span>
+                <span className="opacity-60 text-sm">/mo</span>
+            </div>
+            <p className="text-[12px] opacity-75 m-0 leading-snug">{description}</p>
         </div>
     )
 }
 
 const CalculatorBody = (): JSX.Element => {
-    const [monthlyRequests, setMonthlyRequests] = useState<number>(1_000_000)
-    const [useLocal, setUseLocal] = useState<boolean>(false)
-    const [serverCount, setServerCount] = useState<number>(10)
-    const [pollIntervalSec, setPollIntervalSec] = useState<number>(30)
-    const [serverSidePct, setServerSidePct] = useState<number>(50)
+    const [monthlyRequests, setMonthlyRequests] = useState<number>(DEFAULT_MONTHLY_REQUESTS)
+    const [serverCount, setServerCount] = useState<number>(DEFAULT_SERVER_COUNT)
+    const [pollIntervalSec, setPollIntervalSec] = useState<number>(DEFAULT_POLL_INTERVAL_SEC)
+    const [serverSidePct, setServerSidePct] = useState<number>(DEFAULT_SERVER_SHARE_PCT)
+    const [showAdvanced, setShowAdvanced] = useState<boolean>(false)
     const [tiers, setTiers] = useState<Tier[] | null>(null)
 
     useEffect(() => {
@@ -175,113 +215,103 @@ const CalculatorBody = (): JSX.Element => {
     const localCost = calculatePrice(mixedBillable, activeTiers)
     const savings = remoteCost - localCost
     const savingsPct = remoteCost > 0 ? Math.round((savings / remoteCost) * 100) : 0
-    const localCostsMore = useLocal && localCost > remoteCost
-    const headlineCost = useLocal ? localCost : remoteCost
+    const localCheaper = savings > 0
+    const localCostsMore = savings < 0
+
+    const assumptions = `Assumes ${serverSidePct}% of evaluations server-side, ${serverCount} server${
+        serverCount === 1 ? '' : 's'
+    } polling every ${pollIntervalSec}s.`
 
     return (
-        <div className="not-prose my-8">
-            <div className="flex items-center justify-between gap-3 flex-wrap mb-1">
-                <h4 className="!mb-0 !text-xl">
+        <div className="not-prose my-8 @container border border-light dark:border-dark rounded-md p-4 md:p-5 bg-white/40 dark:bg-accent-dark/40">
+            <div className="mb-3">
+                <h4 className="!mb-1 !text-xl flex items-baseline gap-1">
                     Estimate your monthly cost
-                    <span className="inline-block ml-1 relative -top-0.5">
-                        <InfoIcon tooltip="Estimates use current usage-based pricing tiers. Local evaluation polls count as 10 flag requests each." />
-                    </span>
+                    <InfoIcon tooltip="Estimates use current usage-based pricing tiers. Local evaluation polls count as 10 flag requests each." />
                 </h4>
-                <Toggle
-                    label="Use local evaluation"
-                    position="left"
-                    checked={useLocal}
-                    onChange={setUseLocal}
-                    activeOpacity={false}
-                />
-            </div>
-            <p className="text-sm opacity-75 mb-2">
-                Drag a slider or type a volume to see your monthly bill. Toggle local evaluation to compare against
-                remote-only.
-            </p>
-
-            <div className="border-b border-light dark:border-dark">
-                <FieldRow
-                    title="Monthly flag requests"
-                    tooltip="Total flag evaluation requests across all your apps per month. Estimate as daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b."
-                    value={monthlyRequests}
-                    min={REQUEST_MIN}
-                    max={REQUEST_MAX}
-                    marks={REQUEST_MARKS}
-                    scale="log"
-                    onChange={setMonthlyRequests}
-                />
-
-                {useLocal && (
-                    <>
-                        <FieldRow
-                            title="Server fleet size"
-                            tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
-                            value={serverCount}
-                            min={1}
-                            max={5000}
-                            marks={[1, 10, 100, 1000, 5000]}
-                            scale="log"
-                            onChange={setServerCount}
-                        />
-                        <FieldRow
-                            title="Poll interval"
-                            tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
-                            value={pollIntervalSec}
-                            min={10}
-                            max={3600}
-                            marks={[10, 30, 60, 300, 900, 3600]}
-                            scale="log"
-                            onChange={setPollIntervalSec}
-                            suffix="sec"
-                        />
-                        <FieldRow
-                            title="Server-side share of requests"
-                            tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
-                            value={serverSidePct}
-                            min={0}
-                            max={100}
-                            marks={[0, 25, 50, 75, 100]}
-                            scale="linear"
-                            onChange={setServerSidePct}
-                            suffix="%"
-                        />
-                    </>
-                )}
+                <p className="text-sm opacity-75 m-0">
+                    See how local evaluation compares to remote at your traffic volume.
+                </p>
             </div>
 
-            <div className="grid grid-cols-12 mt-4 bg-accent dark:bg-accent-dark rounded items-center">
-                <div className="col-span-12 md:col-span-7 p-4">
-                    <strong className="block">Monthly estimate</strong>
-                    <span className="text-sm opacity-75">
-                        {useLocal
-                            ? `${
-                                  savings > 0
-                                      ? `Save ${formatUSD(savings)}/mo (${savingsPct}%) vs remote`
-                                      : savings < 0
-                                      ? `${formatUSD(-savings)}/mo more than remote`
-                                      : 'Same cost as remote'
-                              }`
-                            : 'Remote evaluation — every flag check is a billable request'}
-                    </span>
-                </div>
-                <div className="col-span-12 md:col-span-5 p-4 md:text-right">
-                    <div className="flex md:justify-end items-baseline gap-1">
-                        <span className="text-2xl font-bold">{formatUSD(headlineCost)}</span>
-                        <span className="opacity-60 text-sm">/mo</span>
-                    </div>
-                    {useLocal && savings > 0 && (
-                        <div className="text-sm opacity-75">
-                            Remote-only: <span className="font-code">{formatUSD(remoteCost)}/mo</span>
-                        </div>
-                    )}
-                </div>
+            <FieldRow
+                title="Monthly flag requests"
+                tooltip="Total flag evaluation requests across all your apps per month. Estimate as daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b."
+                value={monthlyRequests}
+                min={REQUEST_MIN}
+                max={REQUEST_MAX}
+                marks={REQUEST_MARKS}
+                scale="log"
+                onChange={setMonthlyRequests}
+            />
+
+            <div className="flex flex-col @md:flex-row gap-3 mt-2">
+                <CostCard
+                    title="Remote evaluation"
+                    description="Every flag check is a billable request."
+                    cost={remoteCost}
+                    accent={localCheaper ? 'neutral' : 'best'}
+                />
+                <CostCard
+                    title="Local evaluation"
+                    description={assumptions}
+                    cost={localCost}
+                    accent={localCheaper ? 'best' : localCostsMore ? 'warning' : 'neutral'}
+                    badge={localCheaper && savingsPct > 0 ? `Save ${savingsPct}%` : undefined}
+                />
             </div>
 
             {localCostsMore && (
                 <div className="mt-3 p-3 rounded border border-yellow text-[13px] bg-yellow/10">
-                    <strong>Heads up:</strong> with these settings, local evaluation costs <em>more</em> than remote.
-                    Try a larger poll interval or a smaller fleet.
+                    <strong>Heads up:</strong> at this volume, local evaluation costs <em>more</em>. Try a larger poll
+                    interval, a smaller fleet, or a higher server-side share below.
+                </div>
+            )}
+
+            <button
+                type="button"
+                onClick={() => setShowAdvanced((v) => !v)}
+                className="mt-4 text-[13px] font-semibold opacity-75 hover:opacity-100 inline-flex items-center gap-1"
+                aria-expanded={showAdvanced}
+            >
+                <span className="inline-block w-3 text-center">{showAdvanced ? '−' : '+'}</span>
+                Local evaluation assumptions
+            </button>
+
+            {showAdvanced && (
+                <div className="mt-2 border-t border-light dark:border-dark divide-y divide-light dark:divide-dark">
+                    <FieldRow
+                        title="Server fleet size"
+                        tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
+                        value={serverCount}
+                        min={1}
+                        max={5000}
+                        marks={[1, 10, 100, 1000, 5000]}
+                        scale="log"
+                        onChange={setServerCount}
+                    />
+                    <FieldRow
+                        title="Poll interval"
+                        tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
+                        value={pollIntervalSec}
+                        min={10}
+                        max={3600}
+                        marks={[10, 30, 60, 300, 900, 3600]}
+                        scale="log"
+                        onChange={setPollIntervalSec}
+                        suffix="sec"
+                    />
+                    <FieldRow
+                        title="Server-side share"
+                        tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
+                        value={serverSidePct}
+                        min={0}
+                        max={100}
+                        marks={[0, 25, 50, 75, 100]}
+                        scale="linear"
+                        onChange={setServerSidePct}
+                        suffix="%"
+                    />
                 </div>
             )}
 
@@ -295,7 +325,7 @@ export const FeatureFlagCostCalculator = (): JSX.Element | null => {
     useEffect(() => setMounted(true), [])
     if (!mounted) {
         return (
-            <div className="not-prose my-8">
+            <div className="not-prose my-8 border border-light dark:border-dark rounded-md p-4">
                 <h4 className="!mb-2 !text-xl">Estimate your monthly cost</h4>
                 <div className="text-sm opacity-70">Loading…</div>
             </div>

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -63,7 +63,7 @@ const parseShorthand = (raw: string): number | null => {
 }
 
 const inputClassName =
-    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-24 focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
+    'bg-transparent text-right font-code text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-2 w-32 focus:outline-none focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark tabular-nums'
 
 const InfoIcon = ({ tooltip }: { tooltip: string }): JSX.Element => (
     <Tooltip content={tooltip} contentContainerClassName="max-w-xs" placement="top">
@@ -123,7 +123,7 @@ const FieldRow = ({ title, tooltip, value, min, max, marks, scale, onChange, suf
                         aria-label={title}
                         className={inputClassName}
                     />
-                    {suffix && <span className="text-[13px] opacity-60 shrink-0">{suffix}</span>}
+                    <span className="text-[13px] opacity-60 shrink-0 w-8 text-left">{suffix ?? ''}</span>
                 </span>
             </div>
             <div className="px-1 pb-5">

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useState } from 'react'
+import { RadioGroup } from '@headlessui/react'
+import { IconInfo } from '@posthog/icons'
+import Tooltip from 'components/Tooltip'
+import { LogSlider, LinearSlider, prettyInt } from 'components/Pricing/PricingSlider/Slider'
+
+type Mode = 'remote' | 'local'
+
+type Tier = {
+    up_to: number | null
+    unit_amount_usd: string
+}
+
+const SECONDS_PER_MONTH = 30 * 24 * 60 * 60
+const LOCAL_EVAL_MULTIPLIER = 10
+
+const REQUEST_MIN = 1_000
+const REQUEST_MAX = 10_000_000_000
+const REQUEST_MARKS = [1_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 10_000_000_000]
+
+const FALLBACK_TIERS: Tier[] = [
+    { up_to: 1_000_000, unit_amount_usd: '0' },
+    { up_to: 2_000_000, unit_amount_usd: '0.0001' },
+    { up_to: 10_000_000, unit_amount_usd: '0.000045' },
+    { up_to: 50_000_000, unit_amount_usd: '0.000025' },
+    { up_to: null, unit_amount_usd: '0.00001' },
+]
+
+const formatUSD = (n: number): string =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n)
+
+const calculatePrice = (events: number, tiers: Tier[]): number => {
+    let total = 0
+    let counted = 0
+    for (const { up_to, unit_amount_usd } of tiers) {
+        const remaining = Math.max(events - counted, 0)
+        const inTier = up_to ? Math.min(remaining, up_to - counted) : remaining
+        total += inTier * parseFloat(unit_amount_usd)
+        counted = up_to ?? Number.MAX_SAFE_INTEGER
+        if (events <= counted) break
+    }
+    return Math.round(total)
+}
+
+const Label = ({ title, value, tooltip }: { title: string; value: string; tooltip?: string }): JSX.Element => (
+    <div className="flex items-baseline justify-between mb-1">
+        <div className="flex items-baseline gap-1">
+            <span className="text-[14px] font-semibold">{title}</span>
+            {tooltip && (
+                <Tooltip placement="top" content={() => <div className="max-w-xs text-sm">{tooltip}</div>}>
+                    <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
+                        <IconInfo className="size-4 inline-block" />
+                    </span>
+                </Tooltip>
+            )}
+        </div>
+        <span className="text-[14px] font-mono tabular-nums">{value}</span>
+    </div>
+)
+
+const Row = ({ label, value, emphasis = false }: { label: string; value: string; emphasis?: boolean }): JSX.Element => (
+    <div className="flex items-baseline justify-between py-1">
+        <span className={emphasis ? 'text-[15px] font-semibold' : 'text-[14px]'}>{label}</span>
+        <span className={`font-mono tabular-nums ${emphasis ? 'text-[15px] font-semibold' : 'text-[14px]'}`}>
+            {value}
+        </span>
+    </div>
+)
+
+const CalculatorBody = (): JSX.Element => {
+    const [monthlyRequests, setMonthlyRequests] = useState<number>(1_000_000)
+    const [mode, setMode] = useState<Mode>('remote')
+    const [serverCount, setServerCount] = useState<number>(10)
+    const [pollIntervalSec, setPollIntervalSec] = useState<number>(30)
+    const [serverSidePct, setServerSidePct] = useState<number>(50)
+    const [tiers, setTiers] = useState<Tier[] | null>(null)
+
+    useEffect(() => {
+        const url = `${process.env.BILLING_SERVICE_URL}/api/products-v2?display_friendly=true`
+        fetch(url)
+            .then((r) => r.json())
+            .then((data) => {
+                const ff = data.products?.find((p: { type: string }) => p.type === 'feature_flags')
+                const ffTiers = ff?.plans?.find((pl: { tiers?: Tier[] }) => pl.tiers)?.tiers as Tier[] | undefined
+                setTiers(ffTiers && ffTiers.length > 0 ? ffTiers : FALLBACK_TIERS)
+            })
+            .catch(() => setTiers(FALLBACK_TIERS))
+    }, [])
+
+    const activeTiers = tiers ?? FALLBACK_TIERS
+    const pollsPerServerMo = SECONDS_PER_MONTH / pollIntervalSec
+    const localBillable = LOCAL_EVAL_MULTIPLIER * pollsPerServerMo * serverCount
+    const serverFrac = serverSidePct / 100
+    const mixedBillable = monthlyRequests * (1 - serverFrac) + localBillable
+
+    const remoteCost = calculatePrice(monthlyRequests, activeTiers)
+    const localCost = calculatePrice(mixedBillable, activeTiers)
+    const savings = remoteCost - localCost
+    const savingsPct = remoteCost > 0 ? Math.round((savings / remoteCost) * 100) : 0
+    const localCostsMore = mode === 'local' && localCost > remoteCost
+
+    return (
+        <div className="border border-light dark:border-dark rounded p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
+            <h3 className="!mt-0 !mb-4 !text-lg">Feature flag cost calculator</h3>
+
+            <div className="space-y-5">
+                <div>
+                    <Label
+                        title="Monthly flag requests"
+                        value={prettyInt(monthlyRequests)}
+                        tooltip="Total flag evaluation requests across all your apps per month. If unsure, estimate as daily active users × ~5 evals/user × 30 days."
+                    />
+                    <LogSlider
+                        min={REQUEST_MIN}
+                        max={REQUEST_MAX}
+                        marks={REQUEST_MARKS}
+                        stepsInRange={200}
+                        value={Math.log(monthlyRequests)}
+                        onChange={(v) => setMonthlyRequests(Math.round(Math.exp(v)))}
+                    />
+                </div>
+
+                <div>
+                    <div className="text-[14px] font-semibold mb-2">Evaluation mode</div>
+                    <RadioGroup value={mode} onChange={setMode} className="flex gap-2">
+                        {(['remote', 'local'] as Mode[]).map((option) => (
+                            <RadioGroup.Option
+                                key={option}
+                                value={option}
+                                className={({ checked }) =>
+                                    `cursor-pointer flex-1 text-center py-2 px-3 rounded border text-[14px] ${
+                                        checked
+                                            ? 'bg-red text-white border-red'
+                                            : 'border-light dark:border-dark hover:border-red/50'
+                                    }`
+                                }
+                            >
+                                {option === 'remote' ? 'Remote' : 'Local'}
+                            </RadioGroup.Option>
+                        ))}
+                    </RadioGroup>
+                </div>
+
+                {mode === 'local' && (
+                    <div className="space-y-4 pl-3 border-l-2 border-red/30">
+                        <div>
+                            <Label
+                                title="Server fleet size"
+                                value={prettyInt(serverCount)}
+                                tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
+                            />
+                            <LinearSlider
+                                min={1}
+                                max={5000}
+                                marks={[1, 10, 100, 1000, 5000]}
+                                stepsInRange={500}
+                                value={serverCount}
+                                onChange={(v) => setServerCount(Math.round(v))}
+                            />
+                        </div>
+
+                        <div>
+                            <Label
+                                title="Poll interval (seconds)"
+                                value={`${pollIntervalSec}s`}
+                                tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
+                            />
+                            <LinearSlider
+                                min={10}
+                                max={3600}
+                                marks={[10, 30, 60, 300, 900, 3600]}
+                                stepsInRange={359}
+                                value={pollIntervalSec}
+                                onChange={(v) => setPollIntervalSec(Math.round(v))}
+                            />
+                        </div>
+
+                        <div>
+                            <Label
+                                title="Server-side share of requests"
+                                value={`${serverSidePct}%`}
+                                tooltip="Percentage of evaluations on your servers (eligible for local eval). Browser and mobile evaluations stay remote."
+                            />
+                            <LinearSlider
+                                min={0}
+                                max={100}
+                                marks={[0, 25, 50, 75, 100]}
+                                stepsInRange={100}
+                                value={serverSidePct}
+                                onChange={(v) => setServerSidePct(Math.round(v))}
+                            />
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            <hr className="my-5 border-light dark:border-dark" />
+
+            <div>
+                <Row label="Remote-only cost" value={`${formatUSD(remoteCost)} / mo`} emphasis={mode === 'remote'} />
+                {mode === 'local' && (
+                    <>
+                        <Row label="With local evaluation" value={`${formatUSD(localCost)} / mo`} emphasis />
+                        <Row
+                            label="Estimated savings"
+                            value={
+                                savings > 0
+                                    ? `${formatUSD(savings)} / mo (${savingsPct}%)`
+                                    : savings < 0
+                                    ? `${formatUSD(-savings)} more / mo`
+                                    : '$0 / mo'
+                            }
+                        />
+                        <Row label="Annualized savings" value={savings > 0 ? formatUSD(savings * 12) : '—'} />
+                    </>
+                )}
+
+                {localCostsMore && (
+                    <div className="mt-4 p-3 rounded border border-yellow text-[13px] bg-yellow/10">
+                        <strong>Heads up:</strong> with these settings, local evaluation would cost <em>more</em> than
+                        remote. Try a larger poll interval or a smaller fleet.
+                    </div>
+                )}
+
+                {tiers === null && <div className="mt-3 text-[12px] opacity-60">Loading current pricing tiers…</div>}
+            </div>
+        </div>
+    )
+}
+
+export const FeatureFlagCostCalculator = (): JSX.Element | null => {
+    const [mounted, setMounted] = useState(false)
+    useEffect(() => setMounted(true), [])
+    if (!mounted) {
+        return (
+            <div className="border border-light dark:border-dark rounded p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
+                <h3 className="!mt-0 !mb-4 !text-lg">Feature flag cost calculator</h3>
+                <div className="text-sm opacity-70">Loading…</div>
+            </div>
+        )
+    }
+    return <CalculatorBody />
+}
+
+export default FeatureFlagCostCalculator

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { RadioGroup } from '@headlessui/react'
 import { IconInfo } from '@posthog/icons'
 import Tooltip from 'components/RadixUI/Tooltip'
 import { LogSlider, LinearSlider, prettyInt } from 'components/Pricing/PricingSlider/Slider'
@@ -45,13 +44,13 @@ const calculatePrice = (events: number, tiers: Tier[]): number => {
 const Label = ({ title, value, tooltip }: { title: string; value: string; tooltip?: string }): JSX.Element => (
     <div className="flex items-baseline justify-between mb-1">
         <div className="flex items-baseline gap-1">
-            <span className="text-[14px] font-semibold">{title}</span>
+            <span className="text-[13px] font-semibold">{title}</span>
             {tooltip && (
                 <Tooltip
                     side="top"
                     trigger={
                         <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
-                            <IconInfo className="size-4 inline-block" />
+                            <IconInfo className="size-3.5 inline-block" />
                         </span>
                     }
                 >
@@ -59,9 +58,49 @@ const Label = ({ title, value, tooltip }: { title: string; value: string; toolti
                 </Tooltip>
             )}
         </div>
-        <span className="text-[14px] font-mono tabular-nums">{value}</span>
+        <span className="text-[13px] font-mono tabular-nums opacity-80">{value}</span>
     </div>
 )
+
+const ModeToggle = ({ mode, onChange }: { mode: Mode; onChange: (m: Mode) => void }): JSX.Element => (
+    <div
+        role="radiogroup"
+        aria-label="Evaluation mode"
+        className="inline-flex p-0.5 rounded-full border border-light dark:border-dark bg-light dark:bg-dark text-[12px] font-semibold"
+    >
+        {(['remote', 'local'] as Mode[]).map((option) => {
+            const checked = mode === option
+            return (
+                <button
+                    key={option}
+                    type="button"
+                    role="radio"
+                    aria-checked={checked}
+                    onClick={() => onChange(option)}
+                    className={`px-3 py-1 rounded-full transition-colors ${
+                        checked
+                            ? 'bg-red text-white'
+                            : 'text-primary/70 dark:text-primary-dark/70 hover:text-primary dark:hover:text-primary-dark'
+                    }`}
+                >
+                    {option === 'remote' ? 'Remote' : 'Local'}
+                </button>
+            )
+        })}
+    </div>
+)
+
+const parseRequests = (raw: string): number | null => {
+    const cleaned = raw.replace(/[, _]/g, '').trim().toLowerCase()
+    if (!cleaned) return null
+    const match = cleaned.match(/^(\d+(?:\.\d+)?)([kmb])?$/)
+    if (!match) return null
+    const base = parseFloat(match[1])
+    const mult = match[2] === 'k' ? 1_000 : match[2] === 'm' ? 1_000_000 : match[2] === 'b' ? 1_000_000_000 : 1
+    return Math.round(base * mult)
+}
+
+const clamp = (n: number, min: number, max: number): number => Math.max(min, Math.min(max, n))
 
 const Row = ({ label, value, emphasis = false }: { label: string; value: string; emphasis?: boolean }): JSX.Element => (
     <div className="flex items-baseline justify-between py-1">
@@ -74,6 +113,7 @@ const Row = ({ label, value, emphasis = false }: { label: string; value: string;
 
 const CalculatorBody = (): JSX.Element => {
     const [monthlyRequests, setMonthlyRequests] = useState<number>(1_000_000)
+    const [requestsInput, setRequestsInput] = useState<string>(prettyInt(1_000_000))
     const [mode, setMode] = useState<Mode>('remote')
     const [serverCount, setServerCount] = useState<number>(10)
     const [pollIntervalSec, setPollIntervalSec] = useState<number>(30)
@@ -92,6 +132,21 @@ const CalculatorBody = (): JSX.Element => {
             .catch(() => setTiers(FALLBACK_TIERS))
     }, [])
 
+    const updateRequests = (n: number): void => {
+        const bounded = clamp(n, REQUEST_MIN, REQUEST_MAX)
+        setMonthlyRequests(bounded)
+        setRequestsInput(prettyInt(bounded))
+    }
+
+    const handleInputBlur = (): void => {
+        const parsed = parseRequests(requestsInput)
+        if (parsed === null) {
+            setRequestsInput(prettyInt(monthlyRequests))
+            return
+        }
+        updateRequests(parsed)
+    }
+
     const activeTiers = tiers ?? FALLBACK_TIERS
     const pollsPerServerMo = SECONDS_PER_MONTH / pollIntervalSec
     const localBillable = LOCAL_EVAL_MULTIPLIER * pollsPerServerMo * serverCount
@@ -106,48 +161,58 @@ const CalculatorBody = (): JSX.Element => {
 
     return (
         <div className="border border-light dark:border-dark rounded p-5 my-6 bg-accent dark:bg-accent-dark not-prose">
-            <h3 className="!mt-0 !mb-4 !text-lg">Feature flag cost calculator</h3>
+            <div className="flex items-center justify-between flex-wrap gap-3 mb-5">
+                <h3 className="!my-0 !text-lg">Feature flag cost calculator</h3>
+                <ModeToggle mode={mode} onChange={setMode} />
+            </div>
 
-            <div className="space-y-5">
-                <div>
-                    <Label
-                        title="Monthly flag requests"
-                        value={prettyInt(monthlyRequests)}
-                        tooltip="Total flag evaluation requests across all your apps per month. If unsure, estimate as daily active users × ~5 evals/user × 30 days."
-                    />
-                    <LogSlider
-                        min={REQUEST_MIN}
-                        max={REQUEST_MAX}
-                        marks={REQUEST_MARKS}
-                        stepsInRange={200}
-                        value={Math.log(monthlyRequests)}
-                        onChange={(v) => setMonthlyRequests(Math.round(Math.exp(v)))}
+            <div>
+                <div className="flex items-baseline justify-between mb-1.5 gap-2">
+                    <div className="flex items-baseline gap-1">
+                        <span className="text-[13px] font-semibold">Monthly flag requests</span>
+                        <Tooltip
+                            side="top"
+                            trigger={
+                                <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
+                                    <IconInfo className="size-3.5 inline-block" />
+                                </span>
+                            }
+                        >
+                            <div className="max-w-xs text-sm">
+                                Total flag evaluation requests across all your apps per month. If unsure, estimate as
+                                daily active users × ~5 evals/user × 30 days. Accepts shorthand: 500k, 1m, 2.5b.
+                            </div>
+                        </Tooltip>
+                    </div>
+                    <input
+                        type="text"
+                        inputMode="numeric"
+                        value={requestsInput}
+                        onChange={(e) => setRequestsInput(e.target.value)}
+                        onBlur={handleInputBlur}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                        }}
+                        aria-label="Monthly flag requests"
+                        className="w-32 px-2 py-1 text-right text-[13px] font-mono tabular-nums rounded border border-light dark:border-dark bg-white dark:bg-accent-dark focus:outline-none focus:border-red"
                     />
                 </div>
+                <LogSlider
+                    min={REQUEST_MIN}
+                    max={REQUEST_MAX}
+                    marks={REQUEST_MARKS}
+                    stepsInRange={200}
+                    value={Math.log(monthlyRequests)}
+                    onChange={(v) => updateRequests(Math.round(Math.exp(v)))}
+                />
+            </div>
 
-                <div>
-                    <div className="text-[14px] font-semibold mb-2">Evaluation mode</div>
-                    <RadioGroup value={mode} onChange={setMode} className="flex gap-2">
-                        {(['remote', 'local'] as Mode[]).map((option) => (
-                            <RadioGroup.Option
-                                key={option}
-                                value={option}
-                                className={({ checked }) =>
-                                    `cursor-pointer flex-1 text-center py-2 px-3 rounded border text-[14px] ${
-                                        checked
-                                            ? 'bg-red text-white border-red'
-                                            : 'border-light dark:border-dark hover:border-red/50'
-                                    }`
-                                }
-                            >
-                                {option === 'remote' ? 'Remote' : 'Local'}
-                            </RadioGroup.Option>
-                        ))}
-                    </RadioGroup>
-                </div>
-
-                {mode === 'local' && (
-                    <div className="space-y-4 pl-3 border-l-2 border-red/30">
+            {mode === 'local' && (
+                <div className="mt-6 pt-4 border-t border-light dark:border-dark">
+                    <div className="text-[11px] font-semibold uppercase tracking-wide opacity-60 mb-3">
+                        Local evaluation settings
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
                         <div>
                             <Label
                                 title="Server fleet size"
@@ -157,7 +222,7 @@ const CalculatorBody = (): JSX.Element => {
                             <LinearSlider
                                 min={1}
                                 max={5000}
-                                marks={[1, 10, 100, 1000, 5000]}
+                                marks={[1, 100, 1000, 5000]}
                                 stepsInRange={500}
                                 value={serverCount}
                                 onChange={(v) => setServerCount(Math.round(v))}
@@ -166,21 +231,21 @@ const CalculatorBody = (): JSX.Element => {
 
                         <div>
                             <Label
-                                title="Poll interval (seconds)"
+                                title="Poll interval"
                                 value={`${pollIntervalSec}s`}
                                 tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
                             />
                             <LinearSlider
                                 min={10}
                                 max={3600}
-                                marks={[10, 30, 60, 300, 900, 3600]}
+                                marks={[10, 60, 300, 3600]}
                                 stepsInRange={359}
                                 value={pollIntervalSec}
                                 onChange={(v) => setPollIntervalSec(Math.round(v))}
                             />
                         </div>
 
-                        <div>
+                        <div className="md:col-span-2">
                             <Label
                                 title="Server-side share of requests"
                                 value={`${serverSidePct}%`}
@@ -196,8 +261,8 @@ const CalculatorBody = (): JSX.Element => {
                             />
                         </div>
                     </div>
-                )}
-            </div>
+                </div>
+            )}
 
             <hr className="my-5 border-light dark:border-dark" />
 

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -219,13 +219,13 @@ const CalculatorBody = (): JSX.Element => {
                                 value={prettyInt(serverCount)}
                                 tooltip="Number of server-side processes/pods running the PostHog SDK. Each polls independently."
                             />
-                            <LinearSlider
+                            <LogSlider
                                 min={1}
                                 max={5000}
-                                marks={[1, 100, 1000, 5000]}
-                                stepsInRange={500}
-                                value={serverCount}
-                                onChange={(v) => setServerCount(Math.round(v))}
+                                marks={[1, 10, 100, 1000, 5000]}
+                                stepsInRange={200}
+                                value={Math.log(serverCount)}
+                                onChange={(v) => setServerCount(clamp(Math.round(Math.exp(v)), 1, 5000))}
                             />
                         </div>
 
@@ -235,13 +235,13 @@ const CalculatorBody = (): JSX.Element => {
                                 value={`${pollIntervalSec}s`}
                                 tooltip="How often each server fetches fresh flag definitions. Lower = fresher flags but more billable polls."
                             />
-                            <LinearSlider
+                            <LogSlider
                                 min={10}
                                 max={3600}
-                                marks={[10, 60, 300, 3600]}
-                                stepsInRange={359}
-                                value={pollIntervalSec}
-                                onChange={(v) => setPollIntervalSec(Math.round(v))}
+                                marks={[10, 30, 60, 300, 900, 3600]}
+                                stepsInRange={200}
+                                value={Math.log(pollIntervalSec)}
+                                onChange={(v) => setPollIntervalSec(clamp(Math.round(Math.exp(v)), 10, 3600))}
                             />
                         </div>
 

--- a/src/components/FeatureFlagCostCalculator/index.tsx
+++ b/src/components/FeatureFlagCostCalculator/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { RadioGroup } from '@headlessui/react'
 import { IconInfo } from '@posthog/icons'
-import Tooltip from 'components/Tooltip'
+import Tooltip from 'components/RadixUI/Tooltip'
 import { LogSlider, LinearSlider, prettyInt } from 'components/Pricing/PricingSlider/Slider'
 
 type Mode = 'remote' | 'local'
@@ -47,10 +47,15 @@ const Label = ({ title, value, tooltip }: { title: string; value: string; toolti
         <div className="flex items-baseline gap-1">
             <span className="text-[14px] font-semibold">{title}</span>
             {tooltip && (
-                <Tooltip placement="top" content={() => <div className="max-w-xs text-sm">{tooltip}</div>}>
-                    <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
-                        <IconInfo className="size-4 inline-block" />
-                    </span>
+                <Tooltip
+                    side="top"
+                    trigger={
+                        <span className="inline-block p-0.5 opacity-60 hover:opacity-100 cursor-help relative -top-px">
+                            <IconInfo className="size-4 inline-block" />
+                        </span>
+                    }
+                >
+                    <div className="max-w-xs text-sm">{tooltip}</div>
                 </Tooltip>
             )}
         </div>

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -22,6 +22,7 @@ import { Drawer } from './components/Drawer'
 import { lib } from './components/Edition/lib'
 import { Emoji } from './components/Emoji'
 import { FeatureAvailability } from './components/FeatureAvailability'
+import { FeatureFlagCostCalculator } from './components/FeatureFlagCostCalculator'
 import FeatureOwnershipTable from './components/FeatureOwnershipTable'
 import { FormulaScreenshot } from './components/FormulaScreenshot'
 import { GDPRForm } from './components/GDPRForm'
@@ -94,6 +95,7 @@ export const shortcodes = {
     lib,
     Emoji,
     FeatureAvailability,
+    FeatureFlagCostCalculator,
     FormulaScreenshot,
     GDPRForm,
     HiddenSection,

--- a/src/mdxGlobalComponents.ts
+++ b/src/mdxGlobalComponents.ts
@@ -16,6 +16,7 @@ import { Step, Steps } from './components/Docs/Steps'
 import { ProductChangelog } from './components/Docs/ProductChangelog'
 import { Emoji } from './components/Emoji'
 import { FeatureAvailability } from './components/FeatureAvailability'
+import { FeatureFlagCostCalculator } from './components/FeatureFlagCostCalculator'
 import FeatureOwnershipTable from './components/FeatureOwnershipTable'
 import { FormulaScreenshot } from './components/FormulaScreenshot'
 import { GDPRForm } from './components/GDPRForm'
@@ -51,6 +52,7 @@ export const shortcodes = {
     CompensationCalculator,
     Emoji,
     FeatureAvailability,
+    FeatureFlagCostCalculator,
     FormulaScreenshot,
     ImageSlider,
     GDPRForm,


### PR DESCRIPTION
## Changes

Embeds an interactive calculator on `/docs/feature-flags/local-evaluation` that compares remote-only vs mixed local-eval monthly cost. Inputs: monthly requests, eval mode, server fleet size, poll interval, server-side share. Pulls live billing tiers with a hardcoded fallback.

Replaces #17004 (fork branch → same-repo branch so Vercel preview runs).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`