### PR TITLE
docs: add Flutter to session replay minimum duration supported SDKs

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -211,6 +211,7 @@ Supported on the following SDKs:
 - **Web:** posthog-js 1.291.0+
 - **iOS:** 3.53.0+
 - **Android:** 3.44.0+
+- **Flutter:** 5.24.3+
 
 <ProductScreenshot
   imageLight={ImgMinDurationLight}
@@ -275,9 +276,9 @@ This mode is **more accurate** for filtering out short sessions, especially on s
 - **Use legacy mode** if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes
 - **Use strict mode** if you want to ensure you only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users
 
-### iOS and Android behavior
+### iOS, Android, and Flutter behavior
 
-On iOS and Android, minimum duration is enforced using **buffer length**, similar to web strict mode:
+On iOS, Android, and Flutter, minimum duration is enforced using **buffer length**, similar to web strict mode:
 
 - Snapshots are buffered, and PostHog checks the duration of buffered replay data (from the oldest to newest buffered snapshot)
 - Recording starts sending only after that buffered duration reaches the configured minimum duration


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

Adds Flutter to the **Minimum duration** section of the session replay docs.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
