### PR TITLE
Add Product Galaxy — 3D map of how PostHog products fit together

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
         "react-country-flag": "^3.0.2",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
+        "react-force-graph-3d": "^1.29.1",
         "react-github-btn": "^1.2.1",
         "react-helmet": "^5.2.1",
         "react-input-autosize": "^3.0.0",
@@ -214,6 +215,7 @@
         "swr": "^2.0.0",
         "tailwind-merge": "^2.0.0",
         "tailwindcss-animated": "^1.1.2",
+        "three": "^0.169.0",
         "tsparticles-preset-stars": "^2.11.0",
         "turndown": "^7.2.2",
         "typescript": "^4.0.2",
@@ -247,6 +249,7 @@
         "@types/react-input-autosize": "^2.2.4",
         "@types/react-scroll": "^1.8.7",
         "@types/react-simple-maps": "^3.0.6",
+        "@types/three": "^0.169.0",
         "@typescript-eslint/parser": "^4.5.0",
         "autoprefixer": "^10.4.7",
         "babel-loader": "^8.2.2",
@@ -275,13 +278,10 @@
     "resolutions": {
         "undici": "5.26.3"
     },
-    "lint-staged": {
-        "*.{html,js,ts,tsx,json,yml,css,scss}": "prettier --write",
-        "*.{js,ts,tsx}": "eslint",
-        "*.{md,mdx}": "markdownlint-cli2 --fix"
-    },
-    "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",
     "pnpm": {
+        "overrides": {
+            "@types/d3-dispatch": "3.0.6"
+        },
         "onlyBuiltDependencies": [
             "@parcel/watcher",
             "core-js",
@@ -302,5 +302,11 @@
             "sharp",
             "tsparticles-engine"
         ]
-    }
+    },
+    "lint-staged": {
+        "*.{html,js,ts,tsx,json,yml,css,scss}": "prettier --write",
+        "*.{js,ts,tsx}": "eslint",
+        "*.{md,mdx}": "markdownlint-cli2 --fix"
+    },
+    "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   undici: 5.26.3
+  '@types/d3-dispatch': 3.0.6
 
 importers:
 
@@ -416,6 +417,9 @@ importers:
       react-dropzone:
         specifier: ^14.2.3
         version: 14.3.8(react@18.3.1)
+      react-force-graph-3d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@18.3.1)
       react-github-btn:
         specifier: ^1.2.1
         version: 1.4.0(react@18.3.1)
@@ -539,6 +543,9 @@ importers:
       tailwindcss-animated:
         specifier: ^1.1.2
         version: 1.1.2(tailwindcss@3.4.17)
+      three:
+        specifier: ^0.169.0
+        version: 0.169.0
       tsparticles-preset-stars:
         specifier: ^2.11.0
         version: 2.12.0
@@ -633,6 +640,9 @@ importers:
       '@types/react-simple-maps':
         specifier: ^3.0.6
         version: 3.0.6
+      '@types/three':
+        specifier: ^0.169.0
+        version: 0.169.0
       '@typescript-eslint/parser':
         specifier: ^4.5.0
         version: 4.33.0(eslint@7.32.0)(typescript@4.9.5)
@@ -751,6 +761,10 @@ importers:
         version: 7.2.3
 
 packages:
+
+  3d-force-graph@1.80.0:
+    resolution: {integrity: sha512-tzI353gW1nXPpnC7VTa3JjMg+3cp77qOLUFO0vucPTfF+q5R6sQsNsIqVTbRIb7RSypn14nBa4yfkOe9ThxASw==}
+    engines: {node: '>=12'}
 
   '@algolia/cache-browser-local-storage@4.25.2':
     resolution: {integrity: sha512-tA1rqAafI+gUdewjZwyTsZVxesl22MTgLWRKt1+TBiL26NiKx7SjRqTI3pzm8ngx1ftM5LSgXkVIgk2+SRgPTg==}
@@ -1006,11 +1020,6 @@ packages:
 
   '@babel/parser@7.28.4':
     resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5352,6 +5361,12 @@ packages:
   '@turist/time@0.0.2':
     resolution: {integrity: sha512-qLOvfmlG2vCVw5fo/oz8WAZYlpe5a5OurgTj3diIxJCdjRHpapC+vQCz3er9LV79Vcat+DifBjeAhOAdmndtDQ==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -5409,8 +5424,8 @@ packages:
   '@types/d3-delaunay@6.0.4':
     resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
 
-  '@types/d3-dispatch@3.0.7':
-    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+  '@types/d3-dispatch@3.0.6':
+    resolution: {integrity: sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
@@ -5775,6 +5790,9 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/styled-components@5.1.34':
     resolution: {integrity: sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==}
 
@@ -5786,6 +5804,9 @@ packages:
 
   '@types/tapable@1.0.12':
     resolution: {integrity: sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==}
+
+  '@types/three@0.169.0':
+    resolution: {integrity: sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==}
 
   '@types/tmp@0.0.33':
     resolution: {integrity: sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==}
@@ -5823,6 +5844,9 @@ packages:
 
   '@types/webpack@4.41.40':
     resolution: {integrity: sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5889,6 +5913,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/webpack-asset-relocator-loader@1.7.3':
     resolution: {integrity: sha512-vizrI18v8Lcb1PmNNUBz7yxPxxXoOeuaVEjTG9MjvDrphjiSxFZrRJ5tIghk+qdLFRCXI5HBCshgobftbmrC5g==}
@@ -6042,11 +6067,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -6451,6 +6477,10 @@ packages:
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
 
   acorn-globals@6.0.0:
     resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}
@@ -8170,6 +8200,9 @@ packages:
     resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
     engines: {node: '>=12'}
 
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
   d3-brush@3.0.0:
     resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
     engines: {node: '>=12'}
@@ -8223,6 +8256,10 @@ packages:
     resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
     engines: {node: '>=12'}
 
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
   d3-force@3.0.0:
     resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
@@ -8248,6 +8285,9 @@ packages:
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
 
   d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
@@ -8355,6 +8395,10 @@ packages:
   dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
+
+  data-bind-mapper@1.0.3:
+    resolution: {integrity: sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==}
+    engines: {node: '>=12'}
 
   data-urls@2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
@@ -9519,6 +9563,10 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
 
   flush-write-stream@1.1.1:
     resolution: {integrity: sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==}
@@ -11230,6 +11278,10 @@ packages:
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jest-changed-files@27.5.1:
     resolution: {integrity: sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -11545,6 +11597,10 @@ packages:
   junk@3.1.0:
     resolution: {integrity: sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==}
     engines: {node: '>=8'}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   katex@0.16.25:
     resolution: {integrity: sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==}
@@ -11867,9 +11923,6 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -12291,6 +12344,9 @@ packages:
 
   mermaid@11.11.0:
     resolution: {integrity: sha512-9lb/VNkZqWTRjVgCV+l1N+t4kyi94y+l5xrmBmbbxZYkfRl5hEDaTPMOcaWKCl1McG8nBEaMlWwkcAEEgjhBgg==}
+
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -12840,6 +12896,21 @@ packages:
 
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
+  ngraph.events@1.4.0:
+    resolution: {integrity: sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==}
+
+  ngraph.forcelayout@3.3.1:
+    resolution: {integrity: sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==}
+
+  ngraph.graph@20.1.2:
+    resolution: {integrity: sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==}
+
+  ngraph.merge@1.0.0:
+    resolution: {integrity: sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==}
+
+  ngraph.random@1.2.0:
+    resolution: {integrity: sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -14025,9 +14096,6 @@ packages:
   probe-image-size@7.2.3:
     resolution: {integrity: sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==}
 
-  probe-image-size@7.3.0:
-    resolution: {integrity: sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==}
-
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -14430,6 +14498,12 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
+  react-force-graph-3d@1.29.1:
+    resolution: {integrity: sha512-5Vp+PGpYnO+zLwgK2NvNqdXHvsWLrFzpDfJW1vUA1twjo9SPvXqfUYQrnRmAbD+K2tOxkZw1BkbH31l5b4TWHg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-github-btn@1.4.0:
     resolution: {integrity: sha512-lV4FYClAfjWnBfv0iNlJUGhamDgIq6TayD0kPZED6VzHWdpcHmPfsYOZ/CFwLfPv4Zp+F4m8QKTj0oy2HjiGXg==}
     peerDependencies:
@@ -14501,6 +14575,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -16187,6 +16267,24 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  three-forcegraph@1.43.4:
+    resolution: {integrity: sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      three: '>=0.118.3'
+
+  three-render-objects@1.42.0:
+    resolution: {integrity: sha512-KYfkPrYGEbIK8ChFocWqOF1aAN80FBUBWVYB8mB2oBpVuVN+52FvvngVYB5ieFANQu7Rt21rPYZ/xKaAgVWWRQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      three: '>=0.179'
+
+  three@0.169.0:
+    resolution: {integrity: sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==}
+
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
+
   throat@6.0.2:
     resolution: {integrity: sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==}
 
@@ -16223,6 +16321,9 @@ packages:
 
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
@@ -16964,15 +17065,17 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -17598,6 +17701,14 @@ packages:
 
 snapshots:
 
+  3d-force-graph@1.80.0:
+    dependencies:
+      accessor-fn: 1.5.3
+      kapsule: 1.16.3
+      three: 0.184.0
+      three-forcegraph: 1.43.4(three@0.184.0)
+      three-render-objects: 1.42.0(three@0.184.0)
+
   '@algolia/cache-browser-local-storage@4.25.2':
     dependencies:
       '@algolia/cache-common': 4.25.2
@@ -17920,7 +18031,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -18121,10 +18232,6 @@ snapshots:
   '@babel/parser@7.28.4':
     dependencies:
       '@babel/types': 7.28.4
-
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.3':
     dependencies:
@@ -19773,14 +19880,14 @@ snapshots:
   '@graphql-tools/optimize@1.4.0(graphql@15.10.1)':
     dependencies:
       graphql: 15.10.1
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@15.10.1)':
     dependencies:
       '@ardatan/relay-compiler': 12.0.0(graphql@15.10.1)
       '@graphql-tools/utils': 9.2.1(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.4.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -24024,6 +24131,10 @@ snapshots:
 
   '@turist/time@0.0.2': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.4
@@ -24091,7 +24202,7 @@ snapshots:
 
   '@types/d3-delaunay@6.0.4': {}
 
-  '@types/d3-dispatch@3.0.7': {}
+  '@types/d3-dispatch@3.0.6': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
@@ -24190,7 +24301,7 @@ snapshots:
       '@types/d3-color': 3.1.3
       '@types/d3-contour': 3.0.6
       '@types/d3-delaunay': 6.0.4
-      '@types/d3-dispatch': 3.0.7
+      '@types/d3-dispatch': 3.0.6
       '@types/d3-drag': 3.0.7
       '@types/d3-dsv': 3.0.7
       '@types/d3-ease': 3.0.2
@@ -24497,6 +24608,8 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/styled-components@5.1.34':
     dependencies:
       '@types/hoist-non-react-statics': 3.3.7(@types/react@19.1.13)
@@ -24510,6 +24623,15 @@ snapshots:
   '@types/svg-arc-to-cubic-bezier@3.2.3': {}
 
   '@types/tapable@1.0.12': {}
+
+  '@types/three@0.169.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.65
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
 
   '@types/tmp@0.0.33': {}
 
@@ -24554,6 +24676,8 @@ snapshots:
       '@types/webpack-sources': 3.2.3
       anymatch: 3.1.3
       source-map: 0.6.1
+
+  '@types/webxr@0.5.24': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -25841,6 +25965,8 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  accessor-fn@1.5.3: {}
 
   acorn-globals@6.0.0:
     dependencies:
@@ -27133,7 +27259,7 @@ snapshots:
   capital-case@1.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
       upper-case-first: 2.0.2
 
   capture-exit@2.0.0:
@@ -27224,7 +27350,7 @@ snapshots:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   char-regex@1.0.2: {}
 
@@ -27657,7 +27783,7 @@ snapshots:
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
       upper-case: 2.0.2
 
   constants-browserify@1.0.0: {}
@@ -28105,6 +28231,8 @@ snapshots:
 
   d3-axis@3.0.0: {}
 
+  d3-binarytree@1.0.2: {}
+
   d3-brush@3.0.0:
     dependencies:
       d3-dispatch: 3.0.1
@@ -28157,6 +28285,14 @@ snapshots:
     dependencies:
       d3-dsv: 3.0.1
 
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-force@3.0.0:
     dependencies:
       d3-dispatch: 3.0.1
@@ -28182,6 +28318,8 @@ snapshots:
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
 
   d3-path@1.0.9: {}
 
@@ -28335,6 +28473,10 @@ snapshots:
   dashdash@1.14.1:
     dependencies:
       assert-plus: 1.0.0
+
+  data-bind-mapper@1.0.3:
+    dependencies:
+      accessor-fn: 1.5.3
 
   data-urls@2.0.0:
     dependencies:
@@ -29831,6 +29973,12 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.28.3
+
   flush-write-stream@1.1.1:
     dependencies:
       inherits: 2.0.4
@@ -30510,7 +30658,7 @@ snapshots:
       gatsby-core-utils: 3.25.0
       gatsby-plugin-utils: 3.19.0(gatsby@4.25.9(@types/webpack@4.41.40)(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@4.9.5)(webpack-hot-middleware@2.26.1))(graphql@16.11.0)
       lodash: 4.18.1
-      probe-image-size: 7.3.0
+      probe-image-size: 7.2.3
       semver: 7.8.0
       sharp: 0.30.7
     transitivePeerDependencies:
@@ -30528,9 +30676,9 @@ snapshots:
       gatsby: 4.25.9(@types/webpack@4.41.40)(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 3.25.0
       gatsby-plugin-utils: 3.19.0(gatsby@4.25.9(@types/webpack@4.41.40)(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1))(graphql@16.11.0)
-      lodash: 4.17.23
+      lodash: 4.18.1
       probe-image-size: 7.2.3
-      semver: 7.7.4
+      semver: 7.8.0
       sharp: 0.30.7
     transitivePeerDependencies:
       - graphql
@@ -31802,7 +31950,7 @@ snapshots:
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   helpertypes@0.0.19: {}
 
@@ -32401,7 +32549,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   is-map@2.0.3: {}
 
@@ -32510,7 +32658,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   is-utf8@0.2.1:
     optional: true
@@ -32642,6 +32790,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   javascript-stringify@2.1.0: {}
+
+  jerrypick@1.1.2: {}
 
   jest-changed-files@27.5.1:
     dependencies:
@@ -33245,6 +33395,10 @@ snapshots:
 
   junk@3.1.0: {}
 
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.17.21
+
   katex@0.16.25:
     dependencies:
       commander: 8.3.0
@@ -33579,8 +33733,6 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  lodash@4.17.23: {}
-
   lodash@4.18.1: {}
 
   log-symbols@4.1.0:
@@ -33636,7 +33788,7 @@ snapshots:
 
   lower-case-first@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   lower-case@1.1.4: {}
 
@@ -34305,6 +34457,8 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+
+  meshoptimizer@0.18.1: {}
 
   methods@1.1.2: {}
 
@@ -35152,6 +35306,22 @@ snapshots:
 
   next-tick@1.1.0: {}
 
+  ngraph.events@1.4.0: {}
+
+  ngraph.forcelayout@3.3.1:
+    dependencies:
+      ngraph.events: 1.4.0
+      ngraph.merge: 1.0.0
+      ngraph.random: 1.2.0
+
+  ngraph.graph@20.1.2:
+    dependencies:
+      ngraph.events: 1.4.0
+
+  ngraph.merge@1.0.0: {}
+
+  ngraph.random@1.2.0: {}
+
   nice-try@1.0.5: {}
 
   nlcst-to-string@2.0.4: {}
@@ -35807,7 +35977,7 @@ snapshots:
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   path-data-parser@0.1.0: {}
 
@@ -36456,14 +36626,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  probe-image-size@7.3.0:
-    dependencies:
-      lodash.merge: 4.6.2
-      needle: 2.9.1
-      stream-parser: 0.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
@@ -37061,6 +37223,13 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
+  react-force-graph-3d@1.29.1(react@18.3.1):
+    dependencies:
+      3d-force-graph: 1.80.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-kapsule: 2.5.7(react@18.3.1)
+
   react-github-btn@1.4.0(react@18.3.1):
     dependencies:
       github-buttons: 2.29.1
@@ -37130,6 +37299,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-kapsule@2.5.7(react@18.3.1):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 18.3.1
 
   react-lifecycles-compat@3.0.4: {}
 
@@ -38163,7 +38337,7 @@ snapshots:
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
       upper-case-first: 2.0.2
 
   serialize-javascript@4.0.0:
@@ -38468,7 +38642,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   snapdragon-node@2.1.1:
     dependencies:
@@ -38614,7 +38788,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
 
@@ -39160,7 +39334,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   swiper@11.2.10: {}
 
@@ -39389,6 +39563,33 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  three-forcegraph@1.43.4(three@0.184.0):
+    dependencies:
+      accessor-fn: 1.5.3
+      d3-array: 3.2.4
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      data-bind-mapper: 1.0.3
+      kapsule: 1.16.3
+      ngraph.forcelayout: 3.3.1
+      ngraph.graph: 20.1.2
+      three: 0.184.0
+      tinycolor2: 1.6.0
+
+  three-render-objects@1.42.0(three@0.184.0):
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      float-tooltip: 1.7.5
+      kapsule: 1.16.3
+      polished: 4.3.1
+      three: 0.184.0
+
+  three@0.169.0: {}
+
+  three@0.184.0: {}
+
   throat@6.0.2: {}
 
   throttleit@1.0.1: {}
@@ -39419,6 +39620,8 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinycolor2@1.6.0: {}
+
   tinyexec@1.0.1: {}
 
   tinyglobby@0.2.15:
@@ -39439,7 +39642,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   tmp@0.0.33:
     dependencies:
@@ -40052,13 +40255,13 @@ snapshots:
 
   upper-case-first@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   upper-case@1.1.3: {}
 
   upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   uri-js-replace@1.0.1: {}
 

--- a/src/components/ProductGalaxy/FleetPanel.tsx
+++ b/src/components/ProductGalaxy/FleetPanel.tsx
@@ -1,0 +1,207 @@
+import React from 'react'
+import Link from 'components/Link'
+import type { ProductHandle } from 'hooks/productData/relationships'
+import type { Suggestion } from './graph'
+
+interface ProductLite {
+    handle: string
+    name: string
+    color?: string
+    slug?: string
+    description?: string
+    Icon?: React.ComponentType<{ className?: string }>
+}
+
+interface FleetPanelProps {
+    products: ProductLite[]
+    fleet: ReadonlySet<ProductHandle>
+    suggestions: Suggestion[]
+    onToggle: (handle: ProductHandle) => void
+    onHover: (handle: ProductHandle | null) => void
+    onClear: () => void
+}
+
+/**
+ * Single right-rail panel. State is determined by fleet size:
+ *  - empty: explain the concept + show suggested starting points.
+ *  - non-empty: list fleet members on top, then a merged "Where to go next" view
+ *    that surfaces each recommendation along with every pairsWith description that
+ *    connects it to one of the fleet's products.
+ */
+export default function FleetPanel({
+    products,
+    fleet,
+    suggestions,
+    onToggle,
+    onHover,
+    onClear,
+}: FleetPanelProps): JSX.Element {
+    const productByHandle = new Map(products.map((p) => [p.handle, p]))
+    const fleetProducts = Array.from(fleet)
+        .map((handle) => productByHandle.get(handle))
+        .filter((p): p is ProductLite => Boolean(p))
+
+    const fleetEmpty = fleet.size === 0
+
+    return (
+        <div className="font-mono text-xs p-3 space-y-4 text-primary">
+            <section>
+                <div className="flex items-center justify-between">
+                    <div className="uppercase tracking-widest text-secondary text-[10px]">
+                        › MY FLEET (<span className="text-orange">{String(fleet.size).padStart(2, '0')}</span>)
+                    </div>
+                    {!fleetEmpty && (
+                        <button
+                            type="button"
+                            onClick={onClear}
+                            className="text-[10px] uppercase tracking-widest underline text-secondary hover:text-orange"
+                        >
+                            Reset
+                        </button>
+                    )}
+                </div>
+                {fleetEmpty ? (
+                    <p className="text-secondary normal-case tracking-normal font-sans text-[12px] mt-2">
+                        Click a product (here, on the graph, or in the tray) to add it to your fleet. We&rsquo;ll chart
+                        where to expand next.
+                    </p>
+                ) : (
+                    <ul className="mt-2 space-y-1">
+                        {fleetProducts.map((p) => (
+                            <li key={p.handle}>
+                                <button
+                                    type="button"
+                                    onClick={() => onToggle(p.handle)}
+                                    onMouseEnter={() => onHover(p.handle)}
+                                    onMouseLeave={() => onHover(null)}
+                                    className="group w-full inline-flex items-center justify-between gap-2 min-h-[28px] px-2 border border-orange bg-orange/10 text-primary hover:bg-orange/20 transition-colors"
+                                    aria-label={`Remove ${p.name} from fleet`}
+                                >
+                                    <span className="flex items-center gap-1.5 min-w-0">
+                                        {p.Icon && (
+                                            <p.Icon className={`size-3 shrink-0 text-${p.color ?? 'secondary'}`} />
+                                        )}
+                                        <span className="text-[12px] font-sans normal-case tracking-normal font-semibold truncate">
+                                            {p.name}
+                                        </span>
+                                    </span>
+                                    <span className="text-[10px] uppercase tracking-widest text-secondary group-hover:text-orange shrink-0">
+                                        ✕
+                                    </span>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+
+            <section>
+                <div className="uppercase tracking-widest text-secondary text-[10px]">
+                    {fleetEmpty ? '› SUGGESTED STARTING POINTS' : '› WHERE TO GO NEXT'}
+                </div>
+                {suggestions.length === 0 && (
+                    <p className="text-secondary normal-case tracking-normal font-sans text-[12px] mt-2">
+                        No additional matches charted.
+                    </p>
+                )}
+                <ul className="mt-2 space-y-2">
+                    {suggestions.map((s, i) => {
+                        const product = productByHandle.get(s.handle)
+                        if (!product) return null
+
+                        // Build the merged description: one bullet per fleet product that
+                        // contributes a pairsWith edge to this recommendation.
+                        const pairsBullets = s.contributors
+                            .filter((c) => c.type === 'pairsWith')
+                            .map((c) => {
+                                const partner = productByHandle.get(c.from)
+                                return {
+                                    name: partner?.name ?? c.from,
+                                    color: partner?.color,
+                                    description: c.description,
+                                }
+                            })
+
+                        return (
+                            <li
+                                key={s.handle}
+                                className="border border-primary bg-accent px-2 py-1.5 hover:border-orange transition-colors"
+                                onMouseEnter={() => onHover(s.handle)}
+                                onMouseLeave={() => onHover(null)}
+                            >
+                                <div className="flex items-center justify-between gap-2">
+                                    <div className="flex items-center gap-1.5 min-w-0">
+                                        {product.Icon && (
+                                            <product.Icon
+                                                className={`size-3 shrink-0 text-${product.color ?? 'secondary'}`}
+                                            />
+                                        )}
+                                        <span
+                                            className={`text-[12px] font-sans normal-case tracking-normal font-semibold text-${
+                                                product.color ?? 'primary'
+                                            } truncate`}
+                                        >
+                                            {product.name}
+                                        </span>
+                                    </div>
+                                    <span className="text-[10px] uppercase tracking-widest text-secondary shrink-0">
+                                        {String(i + 1).padStart(2, '0')} · {s.score}
+                                    </span>
+                                </div>
+
+                                {fleetEmpty && product.description && (
+                                    <p className="text-[11px] normal-case tracking-normal font-sans text-secondary mt-1">
+                                        {product.description}
+                                    </p>
+                                )}
+
+                                {!fleetEmpty && pairsBullets.length > 0 && (
+                                    <ul className="mt-1.5 space-y-1.5">
+                                        {pairsBullets.map((b, idx) => (
+                                            <li
+                                                key={`${s.handle}-${b.name}-${idx}`}
+                                                className="normal-case tracking-normal font-sans"
+                                            >
+                                                <span
+                                                    className={`text-[10px] uppercase tracking-widest text-${
+                                                        b.color ?? 'secondary'
+                                                    }`}
+                                                >
+                                                    + {b.name}
+                                                </span>
+                                                {b.description && (
+                                                    <p className="text-[11px] text-secondary mt-0.5 leading-snug">
+                                                        {b.description}
+                                                    </p>
+                                                )}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+
+                                <div className="mt-1.5 flex gap-2 text-[10px] uppercase tracking-widest font-mono">
+                                    <button
+                                        type="button"
+                                        onClick={() => onToggle(s.handle)}
+                                        className="inline-flex items-center min-h-[22px] px-2 border border-primary text-primary bg-transparent hover:border-orange hover:text-orange transition-colors"
+                                    >
+                                        + Add to fleet
+                                    </button>
+                                    {product.slug && (
+                                        <Link
+                                            to={`/${product.slug}`}
+                                            state={{ newWindow: true }}
+                                            className="inline-flex items-center min-h-[22px] px-2 border border-primary text-primary bg-transparent hover:border-orange hover:text-orange transition-colors"
+                                        >
+                                            Learn more →
+                                        </Link>
+                                    )}
+                                </div>
+                            </li>
+                        )
+                    })}
+                </ul>
+            </section>
+        </div>
+    )
+}

--- a/src/components/ProductGalaxy/GalaxyCanvas.lazy.tsx
+++ b/src/components/ProductGalaxy/GalaxyCanvas.lazy.tsx
@@ -1,0 +1,27 @@
+import React, { lazy, Suspense } from 'react'
+import type { GalaxyCanvasProps } from './GalaxyCanvas'
+
+const GalaxyCanvasInner =
+    typeof window !== 'undefined' ? lazy(() => import('./GalaxyCanvas')) : ((() => null) as React.FC<GalaxyCanvasProps>)
+
+export default function GalaxyCanvasLazy(props: GalaxyCanvasProps): JSX.Element {
+    if (typeof window === 'undefined') {
+        return (
+            <div className="flex items-center justify-center w-full h-full text-accent font-mono text-xs">
+                CALIBRATING TELEMETRY...
+            </div>
+        )
+    }
+
+    return (
+        <Suspense
+            fallback={
+                <div className="flex items-center justify-center w-full h-full text-accent font-mono text-xs uppercase tracking-widest animate-pulse">
+                    › Initialising sublight engines...
+                </div>
+            }
+        >
+            <GalaxyCanvasInner {...props} />
+        </Suspense>
+    )
+}

--- a/src/components/ProductGalaxy/GalaxyCanvas.tsx
+++ b/src/components/ProductGalaxy/GalaxyCanvas.tsx
@@ -1,0 +1,347 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ForceGraph3D from 'react-force-graph-3d'
+import type { ForceGraphMethods } from 'react-force-graph-3d'
+import type { ProductHandle } from 'hooks/productData/relationships'
+import type { ProductGraph } from './graph'
+import { buildNodeObject } from './nodeMesh'
+import { getHudAccent, getProductColor, resolveTwHex, resolveTwRgba } from './colors'
+
+export interface GalaxyCanvasProps {
+    graph: ProductGraph
+    products: Array<{ handle: string; name: string; color?: string }>
+    selected: ReadonlySet<ProductHandle>
+    hovered: ProductHandle | null
+    onNodeHover: (handle: ProductHandle | null) => void
+    /** Toggles fleet membership. Replaces the old lock/focus semantics. */
+    onNodeClick: (handle: ProductHandle) => void
+    width: number
+    height: number
+}
+
+interface GraphNodeShape {
+    id: ProductHandle
+    name: string
+    colorToken?: string
+}
+
+interface GraphLinkShape {
+    source: ProductHandle
+    target: ProductHandle
+    type: string
+}
+
+// BFS-depth-driven X position for each node when a fleet is active. Fleet
+// nodes (depth 0) cluster on the far left, their direct neighbors hug them,
+// 2-hop nodes drift right, and anything 3+ hops or unreachable gets exiled.
+// Spread is large so the tiers visually separate even with link springs and
+// charge repulsion fighting them.
+const DEPTH_TARGET_X: Record<number, number> = {
+    0: -150,
+    1: -50,
+    2: 60,
+    3: 180,
+}
+// Strength = how aggressively the grouping force pulls each node to its X
+// target. Tuned so tiers visibly separate without forcing a zoom-out that
+// would shrink the labels below legibility.
+const GROUPING_STRENGTH = 0.28
+// Repulsion strength between every pair of nodes. d3 default is -30; mild
+// bump keeps tiers separated without inflating the bounding box.
+const CHARGE_STRENGTH = -90
+// Anything deeper than 2 (or unreachable from the fleet) is treated as 3.
+const FAR_DEPTH = 3
+
+// Camera transition timing and resting positions. Distances are tight enough
+// that the labels stay readable; the fleet view leans in rather than pulling
+// way out.
+const CAMERA_TRANSITION_MS = 1500
+const CAMERA_DEFAULT = {
+    pos: { x: 0, y: 0, z: 280 },
+    lookAt: { x: 0, y: 0, z: 0 },
+} as const
+// Fleet-active view: shifted right and tilted up slightly so the fleet
+// cluster sits on the left third of the screen.
+const CAMERA_FLEET = {
+    pos: { x: 40, y: 50, z: 360 },
+    lookAt: { x: 20, y: 0, z: 0 },
+} as const
+
+// Edge color resolvers. Amber (`orange` token) for relevant links, warm gray
+// (`light-7`) for inactive / neutral state — resolved at call time against
+// the live DOM so the canvas tracks `tailwind.config.js` automatically.
+const edgeActive = () => resolveTwRgba('text-orange', 0.9)
+const edgeDim = () => resolveTwRgba('text-light-7', 0.12)
+const edgeNeutral = () => resolveTwRgba('text-light-7', 0.45)
+
+// Particle color — full amber. Faded-out edges drop their particle count to
+// 0 (see `linkDirectionalParticles`), so we don't need a dim variant.
+const particleFull = () => resolveTwHex('text-orange')
+
+// Base particle speed (units / tick along the link). three-forcegraph default
+// is 0.01; the sign is flipped per-link to flow particles "outward" from the
+// fleet (see `linkDirectionalParticleSpeed`).
+const PARTICLE_SPEED = 0.008
+
+export default function GalaxyCanvas({
+    graph,
+    products,
+    selected,
+    hovered,
+    onNodeHover,
+    onNodeClick,
+    width,
+    height,
+}: GalaxyCanvasProps): JSX.Element {
+    const fgRef = useRef<ForceGraphMethods | undefined>(undefined)
+
+    const productByHandle = useMemo(() => {
+        const map = new Map<string, { name: string; color?: string }>()
+        for (const p of products) map.set(p.handle, { name: p.name, color: p.color })
+        return map
+    }, [products])
+
+    // graphData identity MUST be stable across hover/select changes — otherwise
+    // react-force-graph re-runs warmup + simulation every time the user moves the
+    // mouse. Selection and hover are surfaced through refs + d3 forces instead.
+    const data = useMemo(() => {
+        const nodes: GraphNodeShape[] = graph.nodes.map((n) => {
+            const meta = productByHandle.get(n.handle)
+            return {
+                id: n.handle,
+                name: meta?.name ?? n.handle,
+                colorToken: meta?.color,
+            }
+        })
+        const links: GraphLinkShape[] = graph.edges
+            .filter((e) => e.type === 'pairsWith')
+            .map((edge) => ({
+                source: edge.from,
+                target: edge.to,
+                type: edge.type,
+            }))
+        return { nodes, links }
+    }, [graph, productByHandle])
+
+    const selectedRef = useRef(selected)
+    const hoveredRef = useRef(hovered)
+    useEffect(() => {
+        selectedRef.current = selected
+    }, [selected])
+    useEffect(() => {
+        hoveredRef.current = hovered
+    }, [hovered])
+
+    // BFS depth of every node from the current fleet. Recomputed whenever the
+    // fleet or graph changes — cheap (16 nodes, ~30 edges) — and read by the
+    // grouping force on every tick to decide where to pull each node.
+    const depthsRef = useRef<Map<ProductHandle, number>>(new Map())
+    useEffect(() => {
+        const depths = new Map<ProductHandle, number>()
+        if (selected.size === 0) {
+            depthsRef.current = depths
+            return
+        }
+        const queue: ProductHandle[] = Array.from(selected)
+        for (const handle of queue) depths.set(handle, 0)
+        while (queue.length > 0) {
+            const current = queue.shift() as ProductHandle
+            const currentDepth = depths.get(current) ?? 0
+            for (const edge of graph.adjacency.get(current) ?? []) {
+                const other = edge.from === current ? edge.to : edge.from
+                if (depths.has(other)) continue
+                depths.set(other, currentDepth + 1)
+                queue.push(other)
+            }
+        }
+        depthsRef.current = depths
+    }, [selected, graph])
+
+    // three-forcegraph defers its first `_updateScene` call by a frame, so
+    // `state.layout` is briefly undefined right after mount. Calling
+    // `d3ReheatSimulation()` during that window flips `engineRunning` to true
+    // before `state.layout` exists and the next tick crashes inside
+    // `three-forcegraph.layoutTick`. We bail until the grouping force is
+    // attached, which signals that the library has finished wiring itself up.
+    const [graphReady, setGraphReady] = useState(false)
+
+    // Whenever fleet or hover changes: rebuild node meshes (cheap for 16 nodes)
+    // so the selection ring and label colors update without restarting the sim.
+    useEffect(() => {
+        const fg = fgRef.current
+        if (!fg || !graphReady) return
+        fg.refresh?.()
+    }, [selected, hovered, graphReady])
+
+    useEffect(() => {
+        const fg = fgRef.current
+        if (!fg || !graphReady) return
+        fg.d3ReheatSimulation?.()
+    }, [selected, graphReady])
+
+    // Slowly fly the camera so the fleet sits on the left third of the screen
+    // when the fleet is active, and back to a centered view when it's empty.
+    // Fires after init too, so URL-prefilled fleets land in the angled view.
+    useEffect(() => {
+        const fg = fgRef.current
+        if (!fg || !graphReady) return
+        const target = selected.size === 0 ? CAMERA_DEFAULT : CAMERA_FLEET
+        fg.cameraPosition?.(target.pos, target.lookAt, CAMERA_TRANSITION_MS)
+    }, [selected, graphReady])
+
+    // Install a custom d3 force that pulls each node to an X target based on
+    // its BFS distance from the fleet (see `depthsRef`):
+    //   - depth 0 (fleet)     → far left, tight cluster
+    //   - depth 1 (neighbor)  → hugs the fleet cluster
+    //   - depth 2             → drifts to the right
+    //   - depth ≥3 / unreachable → exiled far right
+    // With an empty fleet the force is a no-op so the layout uses pure d3
+    // defaults. Deferred to the next animation frame so three-forcegraph has
+    // fully initialised its layout before we attach extra forces.
+    useEffect(() => {
+        const fg = fgRef.current
+        if (!fg) return
+
+        type ForceableNode = { id: ProductHandle; x?: number; vx?: number }
+        let internalNodes: ForceableNode[] = []
+
+        const groupingForce = ((alpha: number) => {
+            const fleet = selectedRef.current
+            if (fleet.size === 0) return
+            const depths = depthsRef.current
+            for (const node of internalNodes) {
+                const raw = depths.get(node.id)
+                const depth = raw === undefined ? FAR_DEPTH : Math.min(raw, FAR_DEPTH)
+                const target = DEPTH_TARGET_X[depth]
+                const dx = target - (node.x ?? 0)
+                node.vx = (node.vx ?? 0) + dx * alpha * GROUPING_STRENGTH
+            }
+        }) as ((alpha: number) => void) & { initialize?: (nodes: ForceableNode[]) => void }
+
+        groupingForce.initialize = (nodes: ForceableNode[]) => {
+            internalNodes = nodes
+        }
+
+        const raf = requestAnimationFrame(() => {
+            // Re-read the ref — the canvas may have unmounted in the same frame.
+            const current = fgRef.current
+            if (!current) return
+            current.d3Force?.('grouping', groupingForce as any)
+
+            // Boost the built-in many-body charge so unconnected nodes and the
+            // higher-depth tiers actually drift apart instead of clumping.
+            const charge = current.d3Force?.('charge')
+            charge?.strength?.(CHARGE_STRENGTH)
+            setGraphReady(true)
+        })
+        return () => {
+            cancelAnimationFrame(raf)
+            setGraphReady(false)
+        }
+    }, [])
+
+    // One-shot debug log so we can confirm the canvas mounted and what data it
+    // received. If the user sees no logs, the lazy chunk never loaded; if it logs
+    // but never says "engine stopped", something is jamming the force simulation.
+    useEffect(() => {
+        // eslint-disable-next-line no-console
+        console.info('[ProductGalaxy] canvas mounted', {
+            nodes: data.nodes.length,
+            links: data.links.length,
+            size: { width, height },
+        })
+    }, [])
+
+    const nodeThreeObject = useCallback(
+        (node) =>
+            buildNodeObject({
+                handle: node.id,
+                name: node.name,
+                colorToken: node.colorToken,
+                selected: selectedRef.current.has(node.id),
+                hovered: hoveredRef.current === node.id,
+            }),
+        []
+    )
+
+    const linkColor = useCallback((link) => {
+        const fleet = selectedRef.current
+        if (fleet.size === 0) return edgeNeutral()
+        const sourceId = typeof link.source === 'object' ? link.source.id : link.source
+        const targetId = typeof link.target === 'object' ? link.target.id : link.target
+        const relevant = fleet.has(sourceId) || fleet.has(targetId)
+        return relevant ? edgeActive() : edgeDim()
+    }, [])
+
+    // Particles render on every edge when no fleet is active; once a fleet
+    // exists, only edges touching it get particles — faded-out edges go quiet.
+    const linkDirectionalParticles = useCallback((link) => {
+        const fleet = selectedRef.current
+        if (fleet.size === 0) return 2
+        const sourceId = typeof link.source === 'object' ? link.source.id : link.source
+        const targetId = typeof link.target === 'object' ? link.target.id : link.target
+        return fleet.has(sourceId) || fleet.has(targetId) ? 2 : 0
+    }, [])
+
+    const linkDirectionalParticleColor = useCallback(() => particleFull(), [])
+
+    // Direction of flow per link. With an empty fleet, particles run
+    // source → target — the order each pair was declared in `productEdges`.
+    // With a non-empty fleet, particles always flow *outwards* from the fleet:
+    // whichever endpoint has the lower BFS depth becomes the effective source.
+    // We don't mutate `data` for this (would reset the simulation); instead we
+    // flip the sign of `linkDirectionalParticleSpeed` so the same link runs
+    // backwards visually.
+    const linkDirectionalParticleSpeed = useCallback((link) => {
+        const fleet = selectedRef.current
+        if (fleet.size === 0) return PARTICLE_SPEED
+        const sourceId = typeof link.source === 'object' ? link.source.id : link.source
+        const targetId = typeof link.target === 'object' ? link.target.id : link.target
+        const depths = depthsRef.current
+        const sd = depths.get(sourceId) ?? Number.POSITIVE_INFINITY
+        const td = depths.get(targetId) ?? Number.POSITIVE_INFINITY
+        // Lower-depth endpoint is "closer to fleet" — particles should flow
+        // away from it. If source is already the lower-depth side, keep the
+        // default direction; otherwise flip.
+        return sd <= td ? PARTICLE_SPEED : -PARTICLE_SPEED
+    }, [])
+
+    return (
+        <ForceGraph3D
+            ref={fgRef}
+            graphData={data}
+            width={width}
+            height={height}
+            backgroundColor="rgba(0,0,0,0)"
+            showNavInfo={false}
+            nodeRelSize={4}
+            nodeOpacity={1}
+            nodeThreeObject={nodeThreeObject}
+            nodeLabel={(node) => {
+                const accent = getHudAccent()
+                return `<div style="font-family:'Source Code Pro',monospace;font-size:11px;color:${accent};background:#000;padding:4px 6px;border:1px solid ${accent}">› ${node.name.toUpperCase()}</div>`
+            }}
+            linkColor={linkColor}
+            linkWidth={1.4}
+            linkOpacity={1}
+            linkDirectionalParticles={linkDirectionalParticles}
+            linkDirectionalParticleWidth={1.2}
+            linkDirectionalParticleColor={linkDirectionalParticleColor}
+            linkDirectionalParticleSpeed={linkDirectionalParticleSpeed}
+            onNodeHover={(node: any) => onNodeHover(node ? node.id : null)}
+            onNodeClick={(node: any) => {
+                // eslint-disable-next-line no-console
+                console.debug('[ProductGalaxy] node click', node?.id)
+                onNodeClick(node.id)
+            }}
+            onEngineStop={() => {
+                // eslint-disable-next-line no-console
+                console.info('[ProductGalaxy] force simulation settled')
+            }}
+            enableNodeDrag={false}
+            cooldownTicks={120}
+            warmupTicks={30}
+        />
+    )
+}
+
+export { getProductColor }

--- a/src/components/ProductGalaxy/HUD.tsx
+++ b/src/components/ProductGalaxy/HUD.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+interface HUDProps {
+    nodeCount: number
+    edgeCount: number
+    selectedCount: number
+    focusedName?: string | null
+}
+
+// The HUD sits on top of the always-dark canvas, so explicit light-on-dark colors
+// are correct here regardless of the page theme. Warm `light-7` gray for chrome,
+// amber `orange` for the active labels — phosphor-monitor amber, not neon teal.
+export default function HUD({ nodeCount, edgeCount, selectedCount, focusedName }: HUDProps): JSX.Element {
+    return (
+        <div className="pointer-events-none absolute top-2 left-2 right-2 z-10 flex flex-wrap items-start justify-between gap-2 font-mono text-[10px] uppercase tracking-widest text-orange">
+            <div className="border border-light-7/40 bg-black/70 backdrop-blur-sm px-2 py-1 leading-snug">
+                <div className="flex gap-4 text-light-7">
+                    <span>
+                        NODES: <span className="text-orange">{nodeCount.toString().padStart(2, '0')}</span>
+                    </span>
+                    <span>
+                        LINKS: <span className="text-orange">{edgeCount.toString().padStart(2, '0')}</span>
+                    </span>
+                    <span>
+                        FLEET: <span className="text-orange">{selectedCount.toString().padStart(2, '0')}</span>
+                    </span>
+                </div>
+                <div className="text-orange/80 mt-0.5">
+                    {focusedName ? `› SCANNING: ${focusedName.toUpperCase()}` : '› AWAITING CONTACT'}
+                </div>
+            </div>
+            <div className="border border-light-7/40 bg-black/70 backdrop-blur-sm px-2 py-1 flex flex-col gap-0.5 leading-snug text-light-7">
+                <span>› DRAG TO ROTATE</span>
+                <span>› SCROLL TO ZOOM</span>
+                <span>› CLICK NODE TO ADD/REMOVE</span>
+            </div>
+        </div>
+    )
+}

--- a/src/components/ProductGalaxy/README.md
+++ b/src/components/ProductGalaxy/README.md
@@ -1,0 +1,63 @@
+# ProductGalaxy
+
+A 3D force-directed view of how PostHog products relate to one another, styled as a 1998-vintage sci-fi HUD. Mounted by `/products/galaxy`.
+
+## Files
+
+| File                       | Role                                                                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.tsx`                | Orchestrator. Owns layout, mounting, ResizeObserver for the canvas, and wires children together.                                       |
+| `useGalaxyState.ts`        | Hook that builds the graph, parses/syncs `?using=` query param, exposes fleet (`selected`) and `hovered` state, and `recommend()` suggestions. Clicking a node toggles fleet membership; there is no separate "locked target" concept. |
+| `graph.ts`                 | Pure functions: `buildGraph()` (dedupe + adjacency), `recommend()` (scoring), and their result types (`ProductGraph`, `GalaxyEdge`, `Suggestion`). Reads `productEdges` from `hooks/productData/relationships.ts`.                       |
+| `GalaxyCanvas.tsx`         | Client-only Three.js scene rendered by `react-force-graph-3d`. Imports `three` at module top level — do NOT import this file directly. |
+| `GalaxyCanvas.lazy.tsx`    | SSR-safe wrapper using `React.lazy` + `typeof window` guard. Always import this, never the raw `GalaxyCanvas`.                         |
+| `nodeMesh.ts`              | Builds the per-node `THREE.Group` (wireframe icosahedron, inner glow, label sprite, highlight ring). Client-only.                      |
+| `colors.ts`                | Maps PostHog color tokens to hex values mirroring `tailwind.config.js`. Shared by JSX (via Tailwind classes) and the WebGL meshes.     |
+| `Starfield.tsx`            | Pure-CSS twinkling starfield behind the canvas. Deterministic placement so SSR/CSR markup matches.                                     |
+| `HUD.tsx`                  | Top overlay with monospace stats (nodes / links / fleet / hover target).                                                               |
+| `FleetPanel.tsx`           | Right-rail panel. Lists fleet members plus a merged "Where to go next" view that surfaces every pairsWith description connecting each recommendation to the fleet. |
+| `SelectionTray.tsx`        | Left-rail chip list — "products I use." Same toggle semantics as clicking a node on the graph.                                         |
+| `SSRFallback.tsx`          | Crawlable text fallback (always in the DOM). Becomes `sr-only` after the canvas mounts so it stays for SEO and no-JS.                  |
+
+## Data flow
+
+```
+hooks/productData/relationships.ts ──► graph.ts ──► useGalaxyState ──► ProductGalaxy
+   (productEdges, handles, types)     (buildGraph,      (state)              ↓
+                                       recommend)                    useProducts (icons, colors, descriptions)
+                                                                             ↓
+                                                  GalaxyCanvas.lazy ──► GalaxyCanvas ──► nodeMesh / three.js
+```
+
+All relationship data is read from `src/hooks/productData/relationships.ts`. To change which products connect, edit `productEdges` in that file. Galaxy-specific graph construction and scoring live in `graph.ts` here.
+
+## Query parameter
+
+```
+/products/galaxy?using=product_analytics,session_replay
+```
+
+Accepts canonical handles OR kebab-case slugs from `relationships.ts → SLUG_ALIASES`. Unknown tokens are dropped silently.
+
+## Aesthetic tokens
+
+- Scanline overlay over the canvas (`mix-blend-screen`, ~5 % opacity green stripes).
+- Wireframe `IcosahedronGeometry` nodes coloured per product (see `colors.ts`).
+- `text-accent` + `font-mono` + `tracking-widest` + uppercase for all HUD copy.
+- Edges: `pairsWith` solid accent, `billedWith` / `sharesFreeTier` directional with arrowhead in amber. (`worksWith` is deprecated and not rendered — see `relationships.ts`.)
+- `prefers-reduced-motion`: simulation freezes after `cooldownTicks` regardless; particle animation on `pairsWith` is gentle enough to keep on.
+
+## Adding / removing nodes
+
+The graph mirrors `MAIN_PRODUCT_HANDLES` in `relationships.ts`. Adding a new node requires:
+
+1. Add the product to `initialProducts` in `src/hooks/useProducts.tsx` (or skip if it's already there).
+2. Add its handle to `MAIN_PRODUCT_HANDLES`.
+3. Add slug ↔ handle mapping to `SLUG_ALIASES` and `HANDLE_TO_SLUG`.
+4. Add edges to `productEdges`.
+
+## SSR considerations
+
+- `GalaxyCanvas.tsx` imports `three` and `react-force-graph-3d` synchronously. Never import it from a server-evaluated path. Always go through `GalaxyCanvas.lazy.tsx`.
+- `nodeMesh.ts` is client-only for the same reason. It's only imported inside `GalaxyCanvas.tsx`.
+- The page itself is registered in `gatsby-page-creator` automatically via its location at `src/pages/products/galaxy/index.tsx` — no `gatsby-node.ts` change required.

--- a/src/components/ProductGalaxy/SSRFallback.tsx
+++ b/src/components/ProductGalaxy/SSRFallback.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import Link from 'components/Link'
+import type { ProductHandle } from 'hooks/productData/relationships'
+import type { ProductGraph } from './graph'
+
+interface ProductLite {
+    handle: string
+    name: string
+    description?: string
+    slug?: string
+}
+
+interface SSRFallbackProps {
+    products: ProductLite[]
+    graph: ProductGraph
+    /** When true, collapse visually but keep in DOM for SEO. */
+    hiddenAfterMount: boolean
+}
+
+export default function SSRFallback({ products, graph, hiddenAfterMount }: SSRFallbackProps): JSX.Element {
+    return (
+        <section aria-hidden={hiddenAfterMount} className={hiddenAfterMount ? 'sr-only' : 'p-6 space-y-4 text-primary'}>
+            <h2 className="text-lg font-bold">PostHog product galaxy</h2>
+            <p className="opacity-70">
+                Interactive 3D view of how PostHog products work together. Enable JavaScript to use the explorer.
+            </p>
+            <ul className="grid gap-4 grid-cols-1 @md:grid-cols-2 @xl:grid-cols-3">
+                {products.map((product) => {
+                    const edges = graph.adjacency.get(product.handle as ProductHandle) ?? []
+                    const partnerNames = Array.from(
+                        new Set(edges.map((e) => (e.from === product.handle ? e.to : e.from)))
+                    )
+                        .map((handle) => products.find((p) => p.handle === handle)?.name ?? handle)
+                        .join(', ')
+                    return (
+                        <li key={product.handle} className="border border-primary p-3">
+                            <h3 className="font-semibold">
+                                {product.slug ? (
+                                    <Link to={`/${product.slug}`} state={{ newWindow: true }}>
+                                        {product.name}
+                                    </Link>
+                                ) : (
+                                    product.name
+                                )}
+                            </h3>
+                            {product.description && <p className="text-sm opacity-70 mt-1">{product.description}</p>}
+                            {edges.length > 0 && <p className="text-xs mt-2 opacity-70">Connects to: {partnerNames}</p>}
+                        </li>
+                    )
+                })}
+            </ul>
+        </section>
+    )
+}

--- a/src/components/ProductGalaxy/SelectionTray.tsx
+++ b/src/components/ProductGalaxy/SelectionTray.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import type { ProductHandle } from 'hooks/productData/relationships'
+
+interface ProductLite {
+    handle: string
+    name: string
+    color?: string
+    Icon?: React.ComponentType<{ className?: string }>
+}
+
+interface SelectionTrayProps {
+    products: ProductLite[]
+    selected: ReadonlySet<ProductHandle>
+    onToggle: (handle: ProductHandle) => void
+    onClear: () => void
+}
+
+export default function SelectionTray({ products, selected, onToggle, onClear }: SelectionTrayProps): JSX.Element {
+    return (
+        <div className="font-mono text-xs p-3 space-y-2 text-primary">
+            <div className="flex items-center justify-between">
+                <div className="uppercase tracking-widest text-secondary text-[10px]">› MY FLEET</div>
+                <button
+                    type="button"
+                    onClick={onClear}
+                    disabled={selected.size === 0}
+                    className="text-[10px] uppercase tracking-widest underline text-secondary hover:text-orange disabled:opacity-30 disabled:no-underline disabled:hover:text-secondary"
+                >
+                    Reset
+                </button>
+            </div>
+            <p className="text-secondary normal-case tracking-normal font-sans text-[12px]">
+                Tap which products you already use. The galaxy will recommend complementary signals.
+            </p>
+            <ul className="flex flex-wrap gap-1.5 pt-1">
+                {products.map((product) => {
+                    const isOn = selected.has(product.handle)
+                    return (
+                        <li key={product.handle}>
+                            <button
+                                type="button"
+                                onClick={() => onToggle(product.handle)}
+                                className={`group inline-flex items-center gap-1 min-h-[24px] px-2 border text-[10px] uppercase tracking-widest font-mono transition-colors ${
+                                    isOn
+                                        ? 'bg-orange/15 text-primary border-orange'
+                                        : 'bg-accent text-primary border-primary hover:border-orange hover:text-orange'
+                                }`}
+                                aria-pressed={isOn}
+                            >
+                                {product.Icon && (
+                                    <product.Icon className={`size-3 text-${product.color ?? 'secondary'}`} />
+                                )}
+                                <span>{product.name}</span>
+                            </button>
+                        </li>
+                    )
+                })}
+            </ul>
+        </div>
+    )
+}

--- a/src/components/ProductGalaxy/Starfield.tsx
+++ b/src/components/ProductGalaxy/Starfield.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react'
+
+interface Star {
+    x: number
+    y: number
+    size: number
+    twinkle: number
+}
+
+function pseudoRandom(seed: number): () => number {
+    let state = seed
+    return () => {
+        state = (state * 9301 + 49297) % 233280
+        return state / 233280
+    }
+}
+
+interface StarfieldProps {
+    /** How many stars to scatter. Stable for a given seed so SSR/CSR markup matches. */
+    count?: number
+    seed?: number
+}
+
+export default function Starfield({ count = 140, seed = 42 }: StarfieldProps): JSX.Element {
+    const stars = useMemo<Star[]>(() => {
+        const rand = pseudoRandom(seed)
+        return Array.from({ length: count }, () => ({
+            x: rand() * 100,
+            y: rand() * 100,
+            size: rand() < 0.85 ? 1 : 2,
+            twinkle: rand() * 4 + 2,
+        }))
+    }, [count, seed])
+
+    return (
+        <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
+            {stars.map((star, i) => (
+                <span
+                    key={i}
+                    className="absolute bg-white/80 rounded-full"
+                    style={{
+                        left: `${star.x}%`,
+                        top: `${star.y}%`,
+                        width: `${star.size}px`,
+                        height: `${star.size}px`,
+                        animation: `galaxyTwinkle ${star.twinkle}s ease-in-out ${(i % 7) * 0.3}s infinite alternate`,
+                    }}
+                />
+            ))}
+            <style>{`
+                @keyframes galaxyTwinkle {
+                    0% { opacity: 0.15; }
+                    100% { opacity: 0.85; }
+                }
+            `}</style>
+        </div>
+    )
+}

--- a/src/components/ProductGalaxy/colors.ts
+++ b/src/components/ProductGalaxy/colors.ts
@@ -1,0 +1,113 @@
+/**
+ * Color tokens for the Product Galaxy.
+ *
+ * Hex values are resolved at runtime by reading the live DOM: we render a
+ * hidden `<span class="text-{token}">`, ask `getComputedStyle()` what color
+ * the browser ended up applying, and parse the result. This keeps the canvas
+ * in sync with `tailwind.config.js` (and any theme override / safelist
+ * change) without us re-typing hex values that silently drift out of sync.
+ *
+ * SSR / pre-mount calls fall back to a compact hardcoded map. The canvas
+ * itself is client-only (see `GalaxyCanvas.lazy.tsx`), so the fallback only
+ * ever matters during module load before the first paint.
+ */
+
+/**
+ * SSR / first-paint fallback. Only used until the DOM exists and the resolver
+ * can ask the browser. Mirrors `tailwind.config.js` for the tokens we use.
+ */
+const SSR_FALLBACK: Record<string, string> = {
+    'text-orange': '#EB9D2A',
+    'text-light-7': '#B6B7AF',
+    'text-blue': '#2F80FA',
+    'text-sky-blue': '#2EA2D3',
+    'text-purple': '#B62AD9',
+    'text-teal': '#29DBBB',
+    'text-seagreen': '#30ABC6',
+    'text-red': '#F54E00',
+    'text-yellow': '#F7A501',
+    'text-salmon': '#F35454',
+    'text-green': '#6AA84F',
+    'text-green-2': '#36C46F',
+    'text-brown': '#3B2B26',
+    'text-lilac': '#8567FF',
+    'text-pink': '#E34C6F',
+}
+
+const NEUTRAL_CLASS = 'text-light-7'
+const ACCENT_CLASS = 'text-orange'
+
+// Two caches:
+//  - `hexCache`: className -> "#rrggbb". Only populated after a successful DOM
+//    probe, so a pre-DOM call (which returns the SSR fallback) never poisons
+//    the cache.
+//  - `rgbaCache`: keyed by hex+alpha (not className), so once the DOM-resolved
+//    hex differs from the SSR fallback, the rgba string for the real color is
+//    cached separately. `linkColor` fires per-edge per-frame, so caching here
+//    avoids ~thousands of string allocations per second.
+const hexCache = new Map<string, string>()
+const rgbaCache = new Map<string, string>()
+
+function rgbStringToHex(rgb: string): string | null {
+    // matches `rgb(R, G, B)`, `rgba(R, G, B, A)`, modern `rgb(R G B / A)`, etc.
+    const m = rgb.match(/(\d+(?:\.\d+)?)[\s,]+(\d+(?:\.\d+)?)[\s,]+(\d+(?:\.\d+)?)/)
+    if (!m) return null
+    const toHex = (n: string) => Math.round(parseFloat(n)).toString(16).padStart(2, '0')
+    return `#${toHex(m[1])}${toHex(m[2])}${toHex(m[3])}`
+}
+
+/**
+ * Resolve a Tailwind color class to its rendered hex. Cached per class.
+ * Returns the SSR fallback (or white) when the DOM isn't available.
+ */
+export function resolveTwHex(className: string): string {
+    const fallback = SSR_FALLBACK[className] ?? '#FFFFFF'
+    if (typeof window === 'undefined' || typeof document === 'undefined' || !document.body) {
+        return fallback
+    }
+    const cached = hexCache.get(className)
+    if (cached) return cached
+
+    try {
+        const el = document.createElement('span')
+        el.className = className
+        el.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none;width:0;height:0;'
+        document.body.appendChild(el)
+        const rgb = getComputedStyle(el).color
+        document.body.removeChild(el)
+        const hex = rgbStringToHex(rgb) ?? fallback
+        hexCache.set(className, hex)
+        return hex
+    } catch {
+        return fallback
+    }
+}
+
+/** Resolve a Tailwind color class and emit an `rgba(...)` string with a given alpha. Cached. */
+export function resolveTwRgba(className: string, alpha: number): string {
+    const hex = resolveTwHex(className)
+    const key = `${hex}|${alpha}`
+    const cached = rgbaCache.get(key)
+    if (cached) return cached
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    const rgba = `rgba(${r}, ${g}, ${b}, ${alpha})`
+    rgbaCache.set(key, rgba)
+    return rgba
+}
+
+/** Amber HUD accent — `text-orange` from the project palette. */
+export function getHudAccent(): string {
+    return resolveTwHex(ACCENT_CLASS)
+}
+
+/** Warm gray fallback for products that don't declare a brand color — `text-light-7`. */
+export function getNeutralHex(): string {
+    return resolveTwHex(NEUTRAL_CLASS)
+}
+
+export function getProductColor(token: string | undefined): string {
+    if (!token) return getNeutralHex()
+    return resolveTwHex(`text-${token}`)
+}

--- a/src/components/ProductGalaxy/graph.ts
+++ b/src/components/ProductGalaxy/graph.ts
@@ -1,0 +1,157 @@
+/**
+ * Graph construction and scoring for the Product Galaxy.
+ *
+ * Pure functions over the data in `src/hooks/productData/relationships.ts`.
+ * Everything here is specific to this app — the recommendation algorithm,
+ * the adjacency map, the BFS-driven layout substrate — so it lives next to
+ * its only consumer (`useGalaxyState.ts`) instead of polluting the shared
+ * data module.
+ */
+import {
+    EDGE_DIRECTED,
+    EDGE_WEIGHTS,
+    MAIN_PRODUCT_HANDLES,
+    normalizeHandle,
+    productEdges,
+} from 'hooks/productData/relationships'
+import type { EdgeType, ProductEdge, ProductHandle } from 'hooks/productData/relationships'
+
+export interface GalaxyNode {
+    handle: ProductHandle
+    /** Degree in the undirected sense (number of distinct connected products). */
+    degree: number
+}
+
+export interface GalaxyEdge extends ProductEdge {
+    /** Numeric weight derived from EDGE_WEIGHTS, used by force layout and scoring. */
+    weight: number
+}
+
+export interface ProductGraph {
+    nodes: GalaxyNode[]
+    /** Deduped edges. For an unordered pair (A, B) the highest-weight type is kept; directional types retain their direction. */
+    edges: GalaxyEdge[]
+    /** handle -> connected edges (both directions). */
+    adjacency: Map<ProductHandle, GalaxyEdge[]>
+}
+
+/**
+ * Build the graph for a given product universe. Filters out edges that reference
+ * products outside `validHandles`.
+ */
+export function buildGraph(validHandles: ReadonlyArray<ProductHandle> = MAIN_PRODUCT_HANDLES): ProductGraph {
+    const validSet = new Set(validHandles)
+    const seen = new Map<string, GalaxyEdge>()
+
+    for (const raw of productEdges) {
+        // `worksWith` is deprecated; it's kept on `productEdges` only so the legacy
+        // `ProductSidebar` "Works with..." panel can still derive content from it.
+        // It deliberately does not contribute to the Product Galaxy graph.
+        if (raw.type === 'worksWith') continue
+
+        const from = normalizeHandle(raw.from)
+        const to = normalizeHandle(raw.to)
+        if (!from || !to) {
+            if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+                // eslint-disable-next-line no-console
+                console.warn(`[relationships] dropping edge with unresolved ref:`, raw)
+            }
+            continue
+        }
+        if (!validSet.has(from) || !validSet.has(to)) continue
+        if (from === to) continue
+
+        const directed = EDGE_DIRECTED[raw.type]
+        const key = directed ? `${raw.type}:${from}->${to}` : `${raw.type}:${[from, to].sort().join('-')}`
+
+        const existing = seen.get(key)
+        const candidate: GalaxyEdge = {
+            ...raw,
+            from,
+            to,
+            weight: EDGE_WEIGHTS[raw.type],
+        }
+        if (!existing || EDGE_WEIGHTS[candidate.type] > existing.weight) {
+            seen.set(key, candidate)
+        }
+    }
+
+    const edges = Array.from(seen.values())
+
+    const adjacency = new Map<ProductHandle, GalaxyEdge[]>()
+    for (const handle of validHandles) adjacency.set(handle, [])
+    for (const edge of edges) {
+        adjacency.get(edge.from)?.push(edge)
+        adjacency.get(edge.to)?.push(edge)
+    }
+
+    const nodes: GalaxyNode[] = validHandles.map((handle) => {
+        const partners = new Set<ProductHandle>()
+        for (const edge of adjacency.get(handle) ?? []) {
+            partners.add(edge.from === handle ? edge.to : edge.from)
+        }
+        return { handle, degree: partners.size }
+    })
+
+    return { nodes, edges, adjacency }
+}
+
+/**
+ * Score complementary products for a given selection. Higher score = stronger fit.
+ * Empty selection returns the highest-degree products as "start here" defaults.
+ */
+export interface SuggestionContributor {
+    /** A fleet product that justifies this recommendation. */
+    from: ProductHandle
+    type: EdgeType
+    /** The pairsWith marketing copy explaining the connection, when available. */
+    description?: string
+}
+
+export interface Suggestion {
+    handle: ProductHandle
+    score: number
+    /** Which selected products contributed to this score, and why. */
+    contributors: SuggestionContributor[]
+}
+
+export function recommend(
+    selected: ReadonlySet<ProductHandle> | ReadonlyArray<ProductHandle>,
+    graph: ProductGraph,
+    k = 4
+): Suggestion[] {
+    const selectedSet = selected instanceof Set ? selected : new Set(selected)
+
+    if (selectedSet.size === 0) {
+        return [...graph.nodes]
+            .sort((a, b) => b.degree - a.degree)
+            .slice(0, k)
+            .map((n) => ({ handle: n.handle, score: n.degree, contributors: [] }))
+    }
+
+    const scored: Suggestion[] = []
+    for (const node of graph.nodes) {
+        if (selectedSet.has(node.handle)) continue
+        let score = 0
+        const contributors: SuggestionContributor[] = []
+        for (const edge of graph.adjacency.get(node.handle) ?? []) {
+            const other = edge.from === node.handle ? edge.to : edge.from
+            if (selectedSet.has(other)) {
+                score += edge.weight
+                contributors.push({ from: other, type: edge.type, description: edge.description })
+            }
+        }
+        if (score > 0) {
+            scored.push({ handle: node.handle, score, contributors })
+        }
+    }
+
+    scored.sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score
+        const aDegree = graph.nodes.find((n) => n.handle === a.handle)?.degree ?? 0
+        const bDegree = graph.nodes.find((n) => n.handle === b.handle)?.degree ?? 0
+        return bDegree - aDegree
+    })
+
+    return scored.slice(0, k)
+}

--- a/src/components/ProductGalaxy/index.tsx
+++ b/src/components/ProductGalaxy/index.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import useProducts from 'hooks/useProducts'
+import { useGalaxyState } from './useGalaxyState'
+import GalaxyCanvasLazy from './GalaxyCanvas.lazy'
+import HUD from './HUD'
+import FleetPanel from './FleetPanel'
+import SelectionTray from './SelectionTray'
+import Starfield from './Starfield'
+import SSRFallback from './SSRFallback'
+
+export default function ProductGalaxy(): JSX.Element {
+    const { products } = useProducts()
+    const { graph, selected, hovered, suggestions, toggleSelected, clearSelected, setHovered } = useGalaxyState()
+
+    const canvasContainerRef = useRef<HTMLDivElement | null>(null)
+    const [canvasSize, setCanvasSize] = useState({ width: 600, height: 480 })
+    const [mounted, setMounted] = useState(false)
+
+    useEffect(() => {
+        setMounted(true)
+    }, [])
+
+    useLayoutEffect(() => {
+        const el = canvasContainerRef.current
+        if (!el || typeof ResizeObserver === 'undefined') return
+        const update = () => {
+            setCanvasSize({ width: el.clientWidth, height: el.clientHeight })
+        }
+        update()
+        const observer = new ResizeObserver(update)
+        observer.observe(el)
+        return () => observer.disconnect()
+    }, [])
+
+    const productLite = useMemo(
+        () =>
+            products.map((p: any) => ({
+                handle: p.handle,
+                name: p.name,
+                color: p.color,
+                slug: p.slug,
+                description: p.description,
+                Icon: p.Icon,
+            })),
+        [products]
+    )
+
+    const hoveredProduct = hovered ? productLite.find((p) => p.handle === hovered) : null
+
+    return (
+        <div
+            data-scheme="primary"
+            className="@container relative w-full h-full bg-primary text-primary overflow-hidden"
+        >
+            <div className="absolute inset-0 grid gap-0 grid-cols-1 @md:grid-cols-[200px_1fr] @xl:grid-cols-[220px_1fr_300px] grid-rows-[auto_1fr_auto] @md:grid-rows-[1fr_auto] @xl:grid-rows-1">
+                {/* Left tray: product picker */}
+                <aside className="row-start-3 @md:row-start-1 col-span-1 border-r border-primary bg-primary overflow-y-auto max-h-[40%] @md:max-h-full">
+                    <SelectionTray
+                        products={productLite}
+                        selected={selected}
+                        onToggle={toggleSelected}
+                        onClear={clearSelected}
+                    />
+                </aside>
+
+                {/* Center: the 3D canvas. Stays dark regardless of theme — it's outer space. */}
+                <main
+                    ref={canvasContainerRef}
+                    className="relative row-start-2 @md:row-start-1 col-span-1 bg-black overflow-hidden"
+                    style={{
+                        backgroundImage:
+                            'radial-gradient(ellipse at center, rgba(15, 30, 60, 0.9) 0%, rgba(0, 0, 0, 1) 70%)',
+                    }}
+                >
+                    <Starfield />
+
+                    <HUD
+                        nodeCount={graph.nodes.length}
+                        edgeCount={graph.edges.filter((e) => e.type === 'pairsWith').length}
+                        selectedCount={selected.size}
+                        focusedName={hoveredProduct?.name ?? null}
+                    />
+
+                    {mounted && (
+                        <GalaxyCanvasLazy
+                            graph={graph}
+                            products={productLite}
+                            selected={selected}
+                            hovered={hovered}
+                            onNodeHover={setHovered}
+                            onNodeClick={toggleSelected}
+                            width={canvasSize.width}
+                            height={canvasSize.height}
+                        />
+                    )}
+
+                    <div
+                        aria-hidden
+                        className="pointer-events-none absolute inset-0 mix-blend-screen opacity-60"
+                        style={{
+                            backgroundImage:
+                                'repeating-linear-gradient(0deg, transparent 0, transparent 2px, rgba(235, 157, 42, 0.04) 2px, rgba(235, 157, 42, 0.04) 3px)',
+                        }}
+                    />
+                </main>
+
+                {/* Right rail: unified fleet + recommendations */}
+                <aside className="row-start-1 @xl:row-start-1 col-span-1 border-l border-primary bg-primary overflow-y-auto max-h-[40%] @xl:max-h-full @xl:col-start-3">
+                    <FleetPanel
+                        products={productLite}
+                        fleet={selected}
+                        suggestions={suggestions}
+                        onToggle={toggleSelected}
+                        onHover={setHovered}
+                        onClear={clearSelected}
+                    />
+                </aside>
+            </div>
+
+            <SSRFallback products={productLite} graph={graph} hiddenAfterMount={mounted} />
+        </div>
+    )
+}

--- a/src/components/ProductGalaxy/nodeMesh.ts
+++ b/src/components/ProductGalaxy/nodeMesh.ts
@@ -1,0 +1,93 @@
+/**
+ * Per-node Three.js mesh builder. Imported only inside GalaxyCanvas (client-only),
+ * so that `three` never evaluates during SSR.
+ */
+import {
+    Color,
+    Group,
+    IcosahedronGeometry,
+    LineBasicMaterial,
+    LineSegments,
+    Mesh,
+    MeshBasicMaterial,
+    Sprite,
+    SpriteMaterial,
+    Texture,
+    WireframeGeometry,
+} from 'three'
+import { getHudAccent, getProductColor } from './colors'
+
+const BASE_RADIUS = 6
+const SELECTED_RING_SCALE = 1.5
+const HOVER_RING_SCALE = 1.25
+
+export interface GalaxyNodeMeta {
+    handle: string
+    name: string
+    colorToken?: string
+    selected?: boolean
+    hovered?: boolean
+}
+
+function makeLabelSprite(name: string, hex: string): Sprite {
+    // Bumped canvas resolution + font + sprite scale together to keep text crisp
+    // at the larger display size.
+    const canvas = document.createElement('canvas')
+    canvas.width = 512
+    canvas.height = 128
+    const ctx = canvas.getContext('2d')
+    if (ctx) {
+        ctx.font = '700 44px "Source Code Pro", monospace'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.6)'
+        ctx.fillRect(0, 0, canvas.width, canvas.height)
+        ctx.strokeStyle = hex
+        ctx.lineWidth = 3
+        ctx.strokeRect(3, 3, canvas.width - 6, canvas.height - 6)
+        ctx.fillStyle = hex
+        ctx.fillText(name.toUpperCase(), canvas.width / 2, canvas.height / 2)
+    }
+    const texture = new Texture(canvas)
+    texture.needsUpdate = true
+    const material = new SpriteMaterial({ map: texture, transparent: true })
+    const sprite = new Sprite(material)
+    sprite.scale.set(34, 8.5, 1)
+    sprite.position.y = -BASE_RADIUS * 2
+    return sprite
+}
+
+export function buildNodeObject(meta: GalaxyNodeMeta): Group {
+    const group = new Group()
+    const hex = getProductColor(meta.colorToken)
+    const color = new Color(hex)
+
+    // Solid faint inner sphere so a node is still visible head-on through the wireframe.
+    const innerGeom = new IcosahedronGeometry(BASE_RADIUS * 0.6, 0)
+    const innerMat = new MeshBasicMaterial({ color, transparent: true, opacity: 0.2 })
+    group.add(new Mesh(innerGeom, innerMat))
+
+    // Main wireframe shell.
+    const shellGeom = new IcosahedronGeometry(BASE_RADIUS, 1)
+    const wire = new WireframeGeometry(shellGeom)
+    const wireMat = new LineBasicMaterial({ color, transparent: true, opacity: 0.95 })
+    group.add(new LineSegments(wire, wireMat))
+
+    // Highlight rings for selected / hovered state.
+    if (meta.selected) {
+        const ringGeom = new IcosahedronGeometry(BASE_RADIUS * SELECTED_RING_SCALE, 0)
+        const ringWire = new WireframeGeometry(ringGeom)
+        const ringMat = new LineBasicMaterial({ color: new Color(getHudAccent()), transparent: true, opacity: 0.9 })
+        group.add(new LineSegments(ringWire, ringMat))
+    } else if (meta.hovered) {
+        const ringGeom = new IcosahedronGeometry(BASE_RADIUS * HOVER_RING_SCALE, 0)
+        const ringWire = new WireframeGeometry(ringGeom)
+        const ringMat = new LineBasicMaterial({ color, transparent: true, opacity: 0.5 })
+        group.add(new LineSegments(ringWire, ringMat))
+    }
+
+    // Floating label below the node.
+    group.add(makeLabelSprite(meta.name, hex))
+
+    return group
+}

--- a/src/components/ProductGalaxy/useGalaxyState.ts
+++ b/src/components/ProductGalaxy/useGalaxyState.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useLocation } from '@reach/router'
+import { MAIN_PRODUCT_HANDLES, normalizeHandle } from 'hooks/productData/relationships'
+import type { ProductHandle } from 'hooks/productData/relationships'
+import { buildGraph, recommend } from './graph'
+import type { Suggestion } from './graph'
+
+const QUERY_PARAM = 'using'
+
+function parseUsingParam(search: string): Set<ProductHandle> {
+    if (!search) return new Set()
+    const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+    const raw = params.get(QUERY_PARAM)
+    if (!raw) return new Set()
+    const handles = new Set<ProductHandle>()
+    for (const token of raw.split(',')) {
+        const handle = normalizeHandle(token.trim())
+        if (handle) handles.add(handle)
+    }
+    return handles
+}
+
+function serializeUsingParam(selected: ReadonlySet<ProductHandle>): string {
+    if (selected.size === 0) return ''
+    return Array.from(selected).sort().join(',')
+}
+
+export interface GalaxyState {
+    graph: ReturnType<typeof buildGraph>
+    /** The user's fleet — products they say they use. Drives the recommendation engine and visual cues. */
+    selected: Set<ProductHandle>
+    /** Transient: the node currently under the mouse, for highlight only. */
+    hovered: ProductHandle | null
+    suggestions: Suggestion[]
+    /** Add to / remove from the fleet. The graph click handler and the chip tray both call this. */
+    toggleSelected: (handle: ProductHandle) => void
+    /** Empty the fleet. Bound to the "Reset" link in the selection tray. */
+    clearSelected: () => void
+    setHovered: (handle: ProductHandle | null) => void
+}
+
+export function useGalaxyState(): GalaxyState {
+    const location = useLocation()
+    const graph = useMemo(() => buildGraph(MAIN_PRODUCT_HANDLES), [])
+
+    const [selected, setSelected] = useState<Set<ProductHandle>>(() => parseUsingParam(location.search || ''))
+    const [hovered, setHovered] = useState<ProductHandle | null>(null)
+
+    // Sync URL when selection changes. Use replaceState so we don't pollute history.
+    useEffect(() => {
+        if (typeof window === 'undefined') return
+        const serialized = serializeUsingParam(selected)
+        const params = new URLSearchParams(window.location.search)
+        if (serialized) {
+            params.set(QUERY_PARAM, serialized)
+        } else {
+            params.delete(QUERY_PARAM)
+        }
+        const search = params.toString()
+        const newUrl = `${window.location.pathname}${search ? '?' + search : ''}${window.location.hash}`
+        window.history.replaceState(null, '', newUrl)
+    }, [selected])
+
+    const toggleSelected = useCallback((handle: ProductHandle) => {
+        setSelected((prev) => {
+            const next = new Set(prev)
+            if (next.has(handle)) next.delete(handle)
+            else next.add(handle)
+            return next
+        })
+    }, [])
+
+    const clearSelected = useCallback(() => setSelected(new Set()), [])
+
+    const suggestions = useMemo(() => recommend(selected, graph, 4), [selected, graph])
+
+    return {
+        graph,
+        selected,
+        hovered,
+        suggestions,
+        toggleSelected,
+        clearSelected,
+        setHovered,
+    }
+}

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -453,6 +453,22 @@ const appSettings: AppSettings = {
             center: true,
         },
     },
+    '/products/galaxy': {
+        size: {
+            min: {
+                width: 720,
+                height: 540,
+            },
+            max: {
+                width: 1400,
+                height: 1100,
+            },
+            fixed: false,
+        },
+        position: {
+            center: true,
+        },
+    },
     'home-test': {
         experiment: {
             variant: 'test',

--- a/src/hooks/productData/cdp.tsx
+++ b/src/hooks/productData/cdp.tsx
@@ -162,18 +162,6 @@ export const cdp = {
         },
         rows: ['cdp'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description:
-                'Get your source data into PostHog, then analyze it alongside your product data to unlock new insights and discover new user behaviors.',
-        },
-        {
-            slug: 'data-warehouse',
-            description:
-                'Build a data warehouse in PostHog and then pull in data from all your platforms to one place where it can be easily interrogated.',
-        },
-    ],
     presenterNotes: {
         overview:
             "Data stuck in silos is useless. Our CDP gets it moving - from anywhere into PostHog, then out to wherever you need it. No complex pipelines, no data engineering. Just connect, transform if needed, and send. It's plumbing that actually works.",

--- a/src/hooks/productData/data_warehouse.tsx
+++ b/src/hooks/productData/data_warehouse.tsx
@@ -458,24 +458,6 @@ export const dataWarehouse = {
             url: '/tutorials/stripe-reports#usage-by-top-customers',
         },
     ],
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Analyze data from any source independently, or alongside product data.',
-        },
-        {
-            slug: 'feature-flags',
-            description: 'Use synced data to toggle feature flags, trigger A/B experiments, and more.',
-        },
-        {
-            slug: 'experiments',
-            description: 'You can use data warehouse data as primary or secondary metrics in experiments.',
-        },
-        {
-            slug: 'docs/sql',
-            description: 'Create entirely custom queries, join sources, and get the answers you need.',
-        },
-    ],
     presenterNotes: {
         overview:
             '<strong>Presenter notes:</strong> Your product data is lonely inside your data warehouse unless it has all the relevant context you need to make decisions across your entire organization. PostHog\'s Data Warehouse brings them all together so you can answer questions like "What do high-value customers actually do in our product?" No ETL pipelines, no data engineering team required.',

--- a/src/hooks/productData/endpoints.tsx
+++ b/src/hooks/productData/endpoints.tsx
@@ -286,19 +286,6 @@ export const endpoints = {
         rows: ['endpoints', 'platform.deployment.open_core'],
         excluded_sections: ['platform'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description:
-                'Create insights in PostHog and expose their results through endpoints. Use trends, funnels, or retention analyses to power dashboards, feeds, or summaries in your application, without rebuilding the query elsewhere.',
-        },
-        {
-            slug: 'data-stack/managed-warehouse',
-            description:
-                'Combine product analytics data with other datasets using SQL in PostHog’s data warehouse. Expose the results through endpoints when you need more control over how data is shaped or joined.',
-        },
-    ],
-    worksWith: ['product_analytics', 'dashboards', 'session_replay', 'feature_flags'],
     presenterNotes: {
         overview:
             "<strong>Presenter notes:</strong> Endpoints let you take any insight or SQL query you've already built in PostHog and expose it as a stable API endpoint. Instead of cobbling together your own analytics API or hammering the Query API with ad-hoc requests, you define a query once and get back a URL your application can call repeatedly. The use cases are broad: embedded analytics dashboards for your customers, live metrics on your landing page, data feeds powering recommendations or leaderboards, or internal tools that need product data without the overhead of a custom pipeline. It's a simple three-step workflow – define your data, create the endpoint, retrieve the results – and it's designed to be production-ready from day one, with higher rate limits, optional materialization, caching, versioning, and an OpenAPI spec for every endpoint. During beta, it's completely free to use.",

--- a/src/hooks/productData/error_tracking.tsx
+++ b/src/hooks/productData/error_tracking.tsx
@@ -321,20 +321,6 @@ export const errorTracking = {
         ],
     },
     integrations: ['ab_experiments', 'product_analytics', 'session_replays'],
-    pairsWith: [
-        {
-            slug: 'session-replay',
-            description: 'Watch exactly how an error occurred for a specific user',
-        },
-        {
-            slug: 'product-analytics',
-            description: 'Analyze trends over time and get alerts when things go wrong',
-        },
-        {
-            slug: 'feature-flags',
-            description: 'Roll back features that cause errors, or test fixes with slow rollouts',
-        },
-    ],
     ai: {
         image: 'https://res.cloudinary.com/dmukukwp6/image/upload/ERROR_TRACKING_2f807c123b.png',
         imageAlt: 'PostHog AI and error tracking',

--- a/src/hooks/productData/experiments.tsx
+++ b/src/hooks/productData/experiments.tsx
@@ -411,22 +411,6 @@ export const experiments = {
         rows: ['experiments'],
         require_complete_data: true,
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Run analysis based on the value of a test, or build a cohort of users from a test variant',
-        },
-        {
-            slug: 'session-replay',
-            description:
-                "Watch recordings of users in a variant to discover nuances in why they did or didn't complete the goal",
-        },
-        {
-            slug: 'feature-flags',
-            description:
-                'Make changes to the feature flag the experiment uses - including JSON payload for each variant',
-        },
-    ],
     presenterNotes: {
         overview:
             '<strong>Presenter notes:</strong> Test product changes and measure their true impact. Run experiments on funnels like a signup flow, on single events such as revenue, or on advanced metrics like ratios. Track unlimited metrics to see how experiments affect other parts of your app and user journeys. Our Bayesian and frequentist engines provide clear, statistically rigorous results so you can make confident, data-backed decisions.',

--- a/src/hooks/productData/feature_flags.tsx
+++ b/src/hooks/productData/feature_flags.tsx
@@ -499,22 +499,6 @@ export const featureFlags = {
         rows: ['feature_flags'],
         excluded_sections: ['platform.libraries', 'platform.developer', 'platform.integrations', 'platform.security'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description:
-                "Run any insight filtered by a flag's value, or group by flag to see usage across a flag's variants",
-        },
-        {
-            slug: 'product-analytics',
-            description: "User paths: See how a flag's value influenced an intended outcome",
-        },
-        {
-            slug: 'session-replay',
-            description:
-                'Filter recordings down to only when a feature flag was called, or to a specific value of a flag',
-        },
-    ],
     presenterNotes: {
         overview:
             "<strong>Presenter notes:</strong> Feature flags control who sees what. We fixed the two biggest problems: latency (down from 500ms to under 50ms with local evaluation) and that annoying flicker on page load (bootstrapping makes flags instant). Ship faster, roll back instantly, see the impact in analytics. That's it.",

--- a/src/hooks/productData/llm_analytics.tsx
+++ b/src/hooks/productData/llm_analytics.tsx
@@ -640,25 +640,6 @@ export const llmAnalytics = {
         rows: ['llm_analytics'],
         excluded_sections: ['platform'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Correlate AI usage with user behavior and business metrics',
-        },
-        {
-            slug: 'dashboards',
-            description: 'Build custom dashboards combining LLM and product metrics',
-        },
-        {
-            slug: 'session-replay',
-            description: 'Watch how users interact with AI features in real sessions',
-        },
-        {
-            slug: 'feature-flags',
-            description: 'Roll out AI features gradually and test different models',
-        },
-    ],
-    worksWith: ['product_analytics', 'dashboards', 'session_replay', 'feature_flags'],
     presenterNotes: {
         overview:
             '<strong>Presenter notes:</strong> Track conversations, model performance, spans, costs, latency, and traces in LLM applications – all as regular PostHog events - roughly 10x cheaper than other LLM observability tools.',

--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -843,18 +843,6 @@ export const posthog_ai = {
             },
         ],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description:
-                'Get your source data into PostHog, then analyze it alongside your product data to unlock new insights and discover new user behaviors.',
-        },
-        {
-            slug: 'data-warehouse',
-            description:
-                'Build a data warehouse in PostHog and then pull in data from all your platforms to one place where it can be easily interrogated.',
-        },
-    ],
     presenterNotes: {
         // overview:
         //     "<strong>Presenter notes:</strong> PostHog AI is an AI agent that lives inside PostHog and actually understands your product data. It's not a chatbot slapped onto a dashboard. You can ask it to build insights, write HogQL queries, summarize session recordings, create surveys, set up feature flags—basically handle the grunt work that normally takes 20 minutes of clicking around. It routes complex tasks to specialized AI agents and uses context from your actual data. The big difference: it's trained on PostHog's data model and your specific setup, so it actually knows what it's doing.",

--- a/src/hooks/productData/product_analytics.tsx
+++ b/src/hooks/productData/product_analytics.tsx
@@ -72,7 +72,6 @@ export const productAnalytics = {
         max: MAX_PRODUCT_ANALYTICS,
     },
     volume: 1000000,
-    worksWith: ['session_replay', 'feature_flags', 'surveys'],
     customers: {
         ycombinator: {
             headline: 'gathers 30% more data than with Google Analytics',
@@ -579,22 +578,6 @@ export const productAnalytics = {
             },
         ],
     },
-    pairsWith: [
-        {
-            slug: 'session-replay',
-            description:
-                'Jump into a playlist of session recordings directly from any point in a graph, or segment of a funnel',
-        },
-        {
-            slug: 'feature-flags',
-            description: "See which feature flags are enabled for a user's session",
-        },
-        {
-            slug: 'experiments',
-            description:
-                'Generate a playlist of recordings limited to an A/B test or specific group within a multivariate experiment.',
-        },
-    ],
     presenterNotes: {
         overview:
             "<strong>Presenter notes:</strong> Product analytics tells you what's happening in your product. PostHog is different than others because every product we build is natively integrated. This means you can jump from a graph to a session recording to visually see why something happened. Plus we use autocapture, which tracks every click and pageview automatically. No more realizing you forgot to track something important – you can define events retroactively (we call these 'actions').",

--- a/src/hooks/productData/relationships.ts
+++ b/src/hooks/productData/relationships.ts
@@ -1,0 +1,518 @@
+/**
+ * Single source of truth for how PostHog products relate to one another.
+ *
+ * Add or edit edges here to control what shows up in:
+ *   - The Product Galaxy view (/products/galaxy)
+ *   - The "Works with..." panel in the product sidebar
+ *   - The "Pairs with..." slide on product landing pages
+ *
+ * Edges are stored using product `handle` (snake_case). Slugs and aliases
+ * are normalized on read via SLUG_ALIASES below.
+ */
+
+export type ProductHandle = string
+
+/**
+ * Edge variants between two products.
+ *
+ * - `pairsWith`: canonical marketing pairing with a description. Drives the graph
+ *   and the "Pairs with..." slide.
+ * - `billedWith`: directional. Target is the parent product for pricing.
+ * - `sharesFreeTier`: directional. Target is the product whose free tier is shared.
+ * - `worksWith`: @deprecated loose integration tag retained only so the existing
+ *   `ProductSidebar` "Works with..." accordion keeps rendering. Excluded from the
+ *   Product Galaxy graph and recommendations. Migrate sidebars to read from
+ *   `pairsWith` and drop this variant.
+ */
+export type EdgeType = 'pairsWith' | 'worksWith' | 'billedWith' | 'sharesFreeTier'
+
+export interface ProductEdge {
+    from: ProductHandle
+    to: ProductHandle
+    type: EdgeType
+    /** Marketing copy for `pairsWith` edges. Optional for other edge types. */
+    description?: string
+}
+
+export const EDGE_WEIGHTS: Record<EdgeType, number> = {
+    pairsWith: 3,
+    billedWith: 2,
+    sharesFreeTier: 2,
+    worksWith: 1,
+}
+
+export const EDGE_DIRECTED: Record<EdgeType, boolean> = {
+    pairsWith: false,
+    worksWith: false,
+    billedWith: true,
+    sharesFreeTier: true,
+}
+
+/**
+ * Map of non-canonical references (kebab-case slugs, partial paths) to the
+ * canonical product handle. Used when reading legacy data and when rendering
+ * `pairsWith` entries whose slug field doesn't match a product's slug field.
+ */
+export const SLUG_ALIASES: Record<string, ProductHandle> = {
+    'product-analytics': 'product_analytics',
+    'session-replay': 'session_replay',
+    'feature-flags': 'feature_flags',
+    surveys: 'surveys',
+    'data-warehouse': 'data_warehouse',
+    'data-stack/managed-warehouse': 'data_warehouse',
+    'realtime-destinations': 'realtime_destinations',
+    'error-tracking': 'error_tracking',
+    cdp: 'cdp',
+    'web-analytics': 'web_analytics',
+    experiments: 'experiments',
+    ai: 'posthog_ai',
+    'posthog-ai': 'posthog_ai',
+    'llm-analytics': 'llm_analytics',
+    'revenue-analytics': 'revenue_analytics',
+    logs: 'logs',
+    workflows: 'workflows_emails',
+    workflows_emails: 'workflows_emails',
+    endpoints: 'endpoints',
+}
+
+/** Reverse: handle → primary slug used for routing on the live site. */
+export const HANDLE_TO_SLUG: Record<ProductHandle, string> = {
+    product_analytics: 'product-analytics',
+    session_replay: 'session-replay',
+    feature_flags: 'feature-flags',
+    surveys: 'surveys',
+    data_warehouse: 'data-stack/managed-warehouse',
+    realtime_destinations: 'realtime-destinations',
+    error_tracking: 'error-tracking',
+    cdp: 'cdp',
+    web_analytics: 'web-analytics',
+    experiments: 'experiments',
+    posthog_ai: 'ai',
+    llm_analytics: 'llm-analytics',
+    revenue_analytics: 'revenue-analytics',
+    logs: 'logs',
+    workflows_emails: 'workflows',
+    endpoints: 'endpoints',
+}
+
+/**
+ * The 16 main billed products that appear as nodes in the Product Galaxy.
+ * Mirrors `initialProducts` in `useProducts.tsx`.
+ */
+export const MAIN_PRODUCT_HANDLES: ReadonlyArray<ProductHandle> = [
+    'product_analytics',
+    'session_replay',
+    'feature_flags',
+    'surveys',
+    'data_warehouse',
+    'realtime_destinations',
+    'error_tracking',
+    'cdp',
+    'web_analytics',
+    'experiments',
+    'posthog_ai',
+    'llm_analytics',
+    'revenue_analytics',
+    'logs',
+    'workflows_emails',
+    'endpoints',
+]
+
+/**
+ * Authoritative edge list. Lifted one-time from the per-product data files.
+ * `worksWith` edges describe loose feature-level integration.
+ * `pairsWith` edges are curated companion products with marketing copy.
+ * `billedWith` and `sharesFreeTier` edges are directional (from -> to is the parent).
+ */
+export const productEdges: ProductEdge[] = [
+    // -- product_analytics --
+    { from: 'product_analytics', to: 'session_replay', type: 'worksWith' },
+    { from: 'product_analytics', to: 'feature_flags', type: 'worksWith' },
+    { from: 'product_analytics', to: 'surveys', type: 'worksWith' },
+    {
+        from: 'product_analytics',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description:
+            'Jump into a playlist of session recordings directly from any point in a graph, or segment of a funnel',
+    },
+    {
+        from: 'product_analytics',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: "See which feature flags are enabled for a user's session",
+    },
+    {
+        from: 'product_analytics',
+        to: 'experiments',
+        type: 'pairsWith',
+        description:
+            'Generate a playlist of recordings limited to an A/B test or specific group within a multivariate experiment.',
+    },
+
+    // -- session_replay --
+    {
+        from: 'session_replay',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Jump into a playlist of session recordings directly from any time series in a graph',
+    },
+    {
+        from: 'session_replay',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: "See which feature flags are enabled for a user's session",
+    },
+    {
+        from: 'session_replay',
+        to: 'experiments',
+        type: 'pairsWith',
+        description:
+            'Generate a playlist of recordings limited to an A/B test or specific group within a multivariate experiment.',
+    },
+
+    // -- feature_flags --
+    {
+        from: 'feature_flags',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description:
+            "Run any insight filtered by a flag's value, or group by flag to see usage across a flag's variants",
+    },
+    {
+        from: 'feature_flags',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description: 'Filter recordings down to only when a feature flag was called, or to a specific value of a flag',
+    },
+
+    // -- surveys --
+    {
+        from: 'surveys',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Use insights to breakdown average scores, analyze results over time, or find trends.',
+    },
+    {
+        from: 'surveys',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: 'Connect a survey to a feature flag to gather feedback on your latest ideas and tests.',
+    },
+    {
+        from: 'surveys',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description:
+            "Watch recordings of users completing a survey to understand full context about a user's behavior.",
+    },
+
+    // -- data_warehouse --
+    {
+        from: 'data_warehouse',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Analyze data from any source independently, or alongside product data.',
+    },
+    {
+        from: 'data_warehouse',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: 'Use synced data to toggle feature flags, trigger A/B experiments, and more.',
+    },
+    {
+        from: 'data_warehouse',
+        to: 'experiments',
+        type: 'pairsWith',
+        description: 'You can use data warehouse data as primary or secondary metrics in experiments.',
+    },
+
+    // -- error_tracking --
+    {
+        from: 'error_tracking',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description: 'Watch exactly how an error occurred for a specific user',
+    },
+    {
+        from: 'error_tracking',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Analyze trends over time and get alerts when things go wrong',
+    },
+    {
+        from: 'error_tracking',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: 'Roll back features that cause errors, or test fixes with slow rollouts',
+    },
+
+    // -- cdp --
+    {
+        from: 'cdp',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description:
+            'Get your source data into PostHog, then analyze it alongside your product data to unlock new insights and discover new user behaviors.',
+    },
+    {
+        from: 'cdp',
+        to: 'data_warehouse',
+        type: 'pairsWith',
+        description:
+            'Build a data warehouse in PostHog and then pull in data from all your platforms to one place where it can be easily interrogated.',
+    },
+
+    // -- web_analytics --
+    { from: 'web_analytics', to: 'product_analytics', type: 'billedWith' },
+    {
+        from: 'web_analytics',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Go deeper than a dashboard by building your own insights and SQL queries from scratch.',
+    },
+    {
+        from: 'web_analytics',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description:
+            "Get more context by watching what users actually do on your site. Spot the nuances that quantifiable data doesn't tell you.",
+    },
+    {
+        from: 'web_analytics',
+        to: 'surveys',
+        type: 'pairsWith',
+        description:
+            'Get even more context by sending surveys to users. Arrange interviews. Ask questions. Serve pop-ups.',
+    },
+
+    // -- experiments --
+    { from: 'experiments', to: 'feature_flags', type: 'billedWith' },
+    { from: 'experiments', to: 'feature_flags', type: 'sharesFreeTier' },
+    {
+        from: 'experiments',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Run analysis based on the value of a test, or build a cohort of users from a test variant',
+    },
+    {
+        from: 'experiments',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description:
+            "Watch recordings of users in a variant to discover nuances in why they did or didn't complete the goal",
+    },
+    {
+        from: 'experiments',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: 'Make changes to the feature flag the experiment uses - including JSON payload for each variant',
+    },
+
+    // -- posthog_ai --
+    {
+        from: 'posthog_ai',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description:
+            'Get your source data into PostHog, then analyze it alongside your product data to unlock new insights and discover new user behaviors.',
+    },
+    {
+        from: 'posthog_ai',
+        to: 'data_warehouse',
+        type: 'pairsWith',
+        description:
+            'Build a data warehouse in PostHog and then pull in data from all your platforms to one place where it can be easily interrogated.',
+    },
+
+    // -- llm_analytics --
+    { from: 'llm_analytics', to: 'product_analytics', type: 'worksWith' },
+    { from: 'llm_analytics', to: 'session_replay', type: 'worksWith' },
+    { from: 'llm_analytics', to: 'feature_flags', type: 'worksWith' },
+    {
+        from: 'llm_analytics',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Correlate AI usage with user behavior and business metrics',
+    },
+    {
+        from: 'llm_analytics',
+        to: 'session_replay',
+        type: 'pairsWith',
+        description: 'Watch how users interact with AI features in real sessions',
+    },
+    {
+        from: 'llm_analytics',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description: 'Roll out AI features gradually and test different models',
+    },
+
+    // -- revenue_analytics --
+    { from: 'revenue_analytics', to: 'data_warehouse', type: 'billedWith' },
+    {
+        from: 'revenue_analytics',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Analyze revenue alongside user behavior and product usage',
+    },
+    {
+        from: 'revenue_analytics',
+        to: 'web_analytics',
+        type: 'pairsWith',
+        description: 'See revenue attribution by traffic source and campaign',
+    },
+    {
+        from: 'revenue_analytics',
+        to: 'data_warehouse',
+        type: 'pairsWith',
+        description: 'Connect payment platforms for automatic revenue tracking',
+    },
+
+    // -- workflows_emails --
+    { from: 'workflows_emails', to: 'experiments', type: 'worksWith' },
+    { from: 'workflows_emails', to: 'product_analytics', type: 'worksWith' },
+    { from: 'workflows_emails', to: 'feature_flags', type: 'worksWith' },
+    { from: 'workflows_emails', to: 'error_tracking', type: 'worksWith' },
+    {
+        from: 'workflows_emails',
+        to: 'experiments',
+        type: 'pairsWith',
+        description:
+            'Automatically follow up with users from test variants: send feedback surveys, activate successful groups, or roll out winning experiences.',
+    },
+    {
+        from: 'workflows_emails',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description:
+            'Trigger automations from real user behavior. Every click, session, or conversion can start a workflow.',
+    },
+    {
+        from: 'workflows_emails',
+        to: 'feature_flags',
+        type: 'pairsWith',
+        description:
+            'React when a feature is turned on, off, or rolled out to a specific segment. Target messages or follow-ups based on flag variations.',
+    },
+    {
+        from: 'workflows_emails',
+        to: 'error_tracking',
+        type: 'pairsWith',
+        description:
+            'Trigger alerts or messages when errors spike, or notify engineering teams directly in Slack when exceptions occur.',
+    },
+
+    // -- realtime_destinations --
+    {
+        from: 'realtime_destinations',
+        to: 'cdp',
+        type: 'pairsWith',
+        description: 'Stream events into the CDP and fan them back out to any downstream destination in real time.',
+    },
+    {
+        from: 'realtime_destinations',
+        to: 'workflows_emails',
+        type: 'pairsWith',
+        description: 'Trigger destination payloads as part of a multi-step workflow — alerts, syncs, follow-ups.',
+    },
+    {
+        from: 'realtime_destinations',
+        to: 'data_warehouse',
+        type: 'pairsWith',
+        description: 'Send live event data into your warehouse without batch ETL.',
+    },
+
+    // -- logs --
+    {
+        from: 'logs',
+        to: 'error_tracking',
+        type: 'pairsWith',
+        description: 'Jump from a captured exception into the surrounding application logs without leaving PostHog.',
+    },
+    {
+        from: 'logs',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description: 'Correlate backend log volume and severity with user behavior and feature usage.',
+    },
+    {
+        from: 'logs',
+        to: 'llm_analytics',
+        type: 'pairsWith',
+        description: 'Inspect the raw log stream behind an LLM trace to debug latency, errors, and tool calls.',
+    },
+
+    // -- endpoints --
+    { from: 'endpoints', to: 'product_analytics', type: 'worksWith' },
+    { from: 'endpoints', to: 'session_replay', type: 'worksWith' },
+    { from: 'endpoints', to: 'feature_flags', type: 'worksWith' },
+    {
+        from: 'endpoints',
+        to: 'product_analytics',
+        type: 'pairsWith',
+        description:
+            'Create insights in PostHog and expose their results through endpoints. Use trends, funnels, or retention analyses to power dashboards, feeds, or summaries in your application, without rebuilding the query elsewhere.',
+    },
+    {
+        from: 'endpoints',
+        to: 'data_warehouse',
+        type: 'pairsWith',
+        description:
+            "Combine product analytics data with other datasets using SQL in PostHog's data warehouse. Expose the results through endpoints when you need more control over how data is shaped or joined.",
+    },
+]
+
+/** Resolve a slug, alias, or already-canonical handle to a canonical handle, or `null` if unknown. */
+export function normalizeHandle(rawRef: string): ProductHandle | null {
+    if (!rawRef) return null
+    if (MAIN_PRODUCT_HANDLES.includes(rawRef)) return rawRef
+    if (rawRef in SLUG_ALIASES) return SLUG_ALIASES[rawRef]
+    return null
+}
+
+/**
+ * Re-derives the legacy `worksWith: ProductHandle[]` shape for a given product.
+ *
+ * @deprecated `worksWith` overlaps too much with `pairsWith` to justify its own
+ * concept. It is kept only so `ProductSidebar` keeps rendering its "Works with..."
+ * accordion without code changes. Migrate that consumer to read from
+ * `getPairsWith` (or skip the section entirely) and then delete this function
+ * along with the `'worksWith'` variant of {@link EdgeType}.
+ */
+export function getWorksWith(handle: ProductHandle): ProductHandle[] {
+    const partners = new Set<ProductHandle>()
+    for (const edge of productEdges) {
+        if (edge.type !== 'worksWith') continue
+        const from = normalizeHandle(edge.from)
+        const to = normalizeHandle(edge.to)
+        if (!from || !to) continue
+        if (from === handle && to !== handle) partners.add(to)
+        if (to === handle && from !== handle) partners.add(from)
+    }
+    return Array.from(partners)
+}
+
+/**
+ * Re-derives the legacy `pairsWith: { slug, description }[]` shape for a given product.
+ * Slug is computed from HANDLE_TO_SLUG. Falls back to the handle if no slug is known.
+ */
+export interface PairsWithEntry {
+    slug: string
+    description: string
+}
+
+export function getPairsWith(handle: ProductHandle): PairsWithEntry[] {
+    const entries: PairsWithEntry[] = []
+    for (const edge of productEdges) {
+        if (edge.type !== 'pairsWith') continue
+        const from = normalizeHandle(edge.from)
+        const to = normalizeHandle(edge.to)
+        if (from !== handle || !to) continue
+        entries.push({
+            slug: HANDLE_TO_SLUG[to] ?? to,
+            description: edge.description ?? '',
+        })
+    }
+    return entries
+}

--- a/src/hooks/productData/revenue_analytics.tsx
+++ b/src/hooks/productData/revenue_analytics.tsx
@@ -322,20 +322,6 @@ export const revenueAnalytics = {
         ],
         rows: ['revenue_analytics'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Analyze revenue alongside user behavior and product usage',
-        },
-        {
-            slug: 'web-analytics',
-            description: 'See revenue attribution by traffic source and campaign',
-        },
-        {
-            slug: 'data-warehouse',
-            description: 'Connect payment platforms for automatic revenue tracking',
-        },
-    ],
     presenterNotes: {
         overview:
             "<strong>Presenter notes:</strong> You already have everything in PostHog: who your customers are, how they use the app, what they like, what they don't. What if you also had how much money they're making and you could use that to power your product decisions? KA-CHOW, REVENUE ANALYTICS IS HERE, EXPLOSION MEME, YEAAAAH",

--- a/src/hooks/productData/session_replay.tsx
+++ b/src/hooks/productData/session_replay.tsx
@@ -567,21 +567,6 @@ window.posthog.onFeatureFlags(function () {
         rows: ['session_replay', 'heatmaps'],
         excluded_sections: ['platform.integrations', 'platform.libraries', 'platform.developer', 'platform.security'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Jump into a playlist of session recordings directly from any time series in a graph',
-        },
-        {
-            slug: 'feature-flags',
-            description: "See which feature flags are enabled for a user's session",
-        },
-        {
-            slug: 'experiments',
-            description:
-                'Generate a playlist of recordings limited to an A/B test or specific group within a multivariate experiment.',
-        },
-    ],
     ai: {
         image: 'https://res.cloudinary.com/dmukukwp6/image/upload/SESSION_REPLAY_a3ca565731.png',
         imageAlt: 'PostHog AI and session replay',

--- a/src/hooks/productData/surveys.tsx
+++ b/src/hooks/productData/surveys.tsx
@@ -437,21 +437,6 @@ export const surveys = {
             'Generate a post-purchase feedback survey',
         ],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Use insights to breakdown average scores, analyze results over time, or find trends.',
-        },
-        {
-            slug: 'feature-flags',
-            description: 'Connect a survey to a feature flag to gather feedback on your latest ideas and tests.',
-        },
-        {
-            slug: 'session-replay',
-            description:
-                "Watch recordings of users completing a survey to understand full context about a user's behavior.",
-        },
-    ],
     presenterNotes: {
         overview:
             "<strong>Presenter notes:</strong> Surveys let you ask users anything right inside your product. No-code for simple stuff, API if you want a custom UI. But what's different about PostHog Surveys is that it works with other PostHog products. See <em>who</em> answered what, watch their session recordings, run analytics on responses. Most survey tools are siloed - ours is part of the whole system that let's you drill in for additional context.",

--- a/src/hooks/productData/web_analytics.tsx
+++ b/src/hooks/productData/web_analytics.tsx
@@ -431,22 +431,6 @@ export const webAnalytics = {
         rows: ['web_analytics'],
         excluded_sections: ['platform.libraries', 'platform.developer', 'platform.integrations'],
     },
-    pairsWith: [
-        {
-            slug: 'product-analytics',
-            description: 'Go deeper than a dashboard by building your own insights and SQL queries from scratch.',
-        },
-        {
-            slug: 'session-replay',
-            description:
-                "Get more context by watching what users actually do on your site. Spot the nuances that quantifiable data doesn't tell you.",
-        },
-        {
-            slug: 'surveys',
-            description:
-                'Get even more context by sending surveys to users. Arrange interviews. Ask questions. Serve pop-ups.',
-        },
-    ],
     presenterNotes: {
         overview:
             "<strong>Presenter notes:</strong> Google took something great (GA3) and made it worse. So we built what GA3 should have evolved into - simple, privacy-focused, no sampling. Works out of the box. Plus it's part of the whole PostHog platform, so you can jump from a traffic spike to watching recordings of those exact sessions. And no cookies required if you don't want them.",

--- a/src/hooks/productData/workflows.tsx
+++ b/src/hooks/productData/workflows.tsx
@@ -342,29 +342,6 @@ export const workflows = {
             'Generate a SMS sequence to encourage users to complete a survey',
         ],
     },
-    pairsWith: [
-        {
-            slug: 'experiments',
-            description:
-                'Automatically follow up with users from test variants: send feedback surveys, activate successful groups, or roll out winning experiences.',
-        },
-        {
-            slug: 'product-analytics',
-            description:
-                'Trigger automations from real user behavior. Every click, session, or conversion can start a workflow.',
-        },
-        {
-            slug: 'feature-flags',
-            description:
-                'React when a feature is turned on, off, or rolled out to a specific segment. Target messages or follow-ups based on flag variations.',
-        },
-        {
-            slug: 'error-tracking',
-            description:
-                'Trigger alerts or messages when errors spike, or notify engineering teams directly in Slack when exceptions occur.',
-        },
-    ],
-    worksWith: ['experiments', 'product-analytics', 'feature-flags', 'error-tracking'],
     presenterNotes: {
         overview: '',
     },

--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -21,6 +21,7 @@ import { revenueAnalytics } from './productData/revenue_analytics'
 import { logs } from './productData/logs'
 import { realtimeDestinations } from './productData/realtime_destinations'
 import { endpoints } from './productData/endpoints'
+import { getPairsWith, getWorksWith } from './productData/relationships'
 
 const initialProducts = [
     productAnalytics,
@@ -67,6 +68,9 @@ export default function useProducts() {
                 freeLimit,
                 startsAt: startsAt && startsAt.length <= 3 ? Number(startsAt).toFixed(2) : startsAt,
                 unit,
+                // Cross-product relationships are sourced from productData/relationships.ts.
+                worksWith: getWorksWith(product.handle),
+                pairsWith: getPairsWith(product.handle),
             }
         })
     )

--- a/src/pages/products/galaxy/index.tsx
+++ b/src/pages/products/galaxy/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import Explorer from 'components/Explorer'
+import SEO from 'components/seo'
+import ProductGalaxy from 'components/ProductGalaxy'
+
+export default function ProductGalaxyPage(): JSX.Element {
+    return (
+        <>
+            <SEO
+                title="Product Galaxy"
+                description="Explore how PostHog products connect — visualize cross-product workflows and find complementary tools."
+                image="/images/og/default.png"
+            />
+
+            <Explorer
+                template="generic"
+                slug="product-galaxy"
+                title="Product Galaxy"
+                fullScreen
+                padding={false}
+                showAddressBar={false}
+                viewportClasses="[&>div>div]:h-full"
+            >
+                <ProductGalaxy />
+            </Explorer>
+        </>
+    )
+}


### PR DESCRIPTION
## Changes

Adds a new windowed app at **`/products/galaxy`** — a force-directed 3D graph of how PostHog's 16 main products relate to one another, styled like a 1998-vintage sci-fi terminal. It turns the implicit `pairsWith` relationships scattered across the product data files into something visitors can actually see and play with.

**How it works**

- Each main product is a wireframe node, colored by its brand token. Edges are the existing `pairsWith` declarations.
- Visitors click nodes to add products to their **fleet** ("what I already use"). The right rail then scores the remaining products by edge weight and surfaces recommended companions with the original `pairsWith` marketing copy as bullets.
- A custom d3-force pulls fleet nodes one way and pushes everything else outward **by BFS distance**, so a selection visually stratifies the universe into direct neighbors, two-hop products, and the far-away things. The camera slowly flies to fit the new layout (fleet ends up on the left third of the screen).
- Particles flow **outward** along edges from the fleet — direction is flipped per-link based on BFS depth, so the recommended next steps are obvious from across the room.
- Marketing can deep-link via `/products/galaxy?using=product_analytics,session_replay` to prefill the fleet and land directly in the angled view.

**Data layer changes**

- New `src/hooks/productData/relationships.ts` is now the single source of truth for `pairsWith` / `billedWith` / `sharesFreeTier` / `worksWith` (the last is `@deprecated`).
- The 16 per-product files no longer carry their own `pairsWith` / `worksWith` arrays. `useProducts` derives those legacy shapes from `relationships.ts` so **`ProductSidebar` and the "Pairs with..." slide keep working unchanged** — no other consumers needed to be touched.
- Galaxy-specific assembly (`buildGraph`, `recommend`, result types) lives in `src/components/ProductGalaxy/graph.ts` next to its only consumer, not in the shared data module.

**Frontend bits worth flagging for review**

- `src/components/ProductGalaxy/colors.ts` resolves Tailwind tokens against the live DOM (probe span + `getComputedStyle`, cached) and feeds the resulting hex values to three.js materials. The canvas tracks `tailwind.config.js` / `data-scheme` automatically — no hardcoded hex map drifting out of sync.
- HUD and panels use the project's warm gray palette with `orange` as a rare highlight. No neon teal anywhere.
- `SSRFallback.tsx` lists every product and its pairings as crawlable text so the page has indexable content before the canvas hydrates.
- The dev-mode UI freeze gotcha is documented in `GalaxyCanvas.tsx` next to the `graphReady` gate (three-forcegraph defers its first `_updateScene` by a frame; calling `d3ReheatSimulation` during that window crashes the next animation tick — the gate avoids it).

**Files touched outside the new directories**

- `src/context/App.tsx` — registers `/products/galaxy` in `appSettings` (size limits, center position).
- `src/hooks/useProducts.tsx` — three lines to inject `worksWith` / `pairsWith` from `relationships.ts`.
- `src/hooks/productData/*.tsx` — removed the now-duplicated `pairsWith` / `worksWith` arrays from each of the 16 product files (`billedWith` / `sharesFreeTier` stay — pricing, not relationship, concerns).
- `package.json` / `pnpm-lock.yaml` — adds `react-force-graph-3d` and `three`. The chunk is lazy-loaded and only hits this route.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)