### PR TITLE
Handbook: add section on users as brand ambassadors

### DIFF
--- a/contents/handbook/brand/ambassador.md
+++ b/contents/handbook/brand/ambassador.md
@@ -50,25 +50,16 @@ It's okay to be helpful or respond to posts from frustrated users, but be mindfu
 
 **The simplest test:** would you be comfortable with a screenshot of that tweet being shared in the `#general` Slack channel? If yes, go for it!
 
-## It's not just employees, either
+## Our users are brand ambassadors too
 
-Our users are brand ambassadors too. A brand isn't just a logo or a tagline – it's every facet of the business, including how other people think about it. We can influence that, but never totally control it.
+Our brand is ultimately owned by the people who use us, talk about us, and advocate for us. We can shape it, but never fully control it.
 
-We've had an open approach [from the beginning](/founders/remote-culture). Letting people look behind the business facade has endeared us to them. By building a transparent, weird, and irreverent brand, we've won over a legion of hedgehog fans, some of whom pay us. **They're fans, not customers** – and our advocates shape our brand as much as we do.
-
-### A two-way dialog means listening, not always agreeing
-
-Having a community requires give and take. We give our users a voice, and we respect what that voice says. Sometimes they'll tell us they don't agree with our choices. While our users should influence our brand, they shouldn't dictate how we act.
-
-A recent example is our decision to train an ML model. We expected some backlash, some support, and some shrugs – and we got all three. We listened, but we still went ahead.
-
-### Brand affinity isn't bought
-
-It's earned through trust, transparency, and engagement.
+By building a transparent, weird, and irreverent brand, we've won over a legion of hedgehog fans, some of whom pay us. **They're fans, not customers** – and they shape our brand as much as we do.
 
 - **The better informed a user – the better user they'll be.** That's why we share mistakes and lessons freely through [content](/handbook/content).
-- **Use brand to shorten the distance.** What we post online and how we show up in person should always tie back to the mission of making really great tools for developers. As we scale, brand is the thing that will keep us close to [who we're building for](/handbook/who-we-build-for).
-- **Brand attracts talent, too.** People with cool ideas want to work at companies where they can see those ideas actually come to life. 
+- **Use brand to shorten the distance.** Big companies feel far away. As we grow, everything we post and every room we show up in is a chance to stay close to [who we're building for](/handbook/who-we-build-for).
+- **A two-way dialog means listening, not always agreeing.** We give our users a voice, and we respect what that voice says. Sometimes they'll tell us they don't agree with our choices.
+- **Brand attracts talent.** People with cool ideas want to work at companies where they see cool ideas actually come to life.
 
 ## Giving someone the brand ambassador experience
 

--- a/contents/handbook/brand/ambassador.md
+++ b/contents/handbook/brand/ambassador.md
@@ -52,11 +52,9 @@ It's okay to be helpful or respond to posts from frustrated users, but be mindfu
 
 ## It's not just employees, either
 
-Our users are brand ambassadors too – whether they pay us or not.
+Our users are brand ambassadors too. A brand isn't just a logo or a tagline – it's every facet of the business, including how other people think about it. We can influence that, but never totally control it.
 
-A brand isn't just a logo or a tagline. It's every facet of the business, including how other people think about it. We can influence how people think about PostHog, but we can never totally control it. Modern brand building is a two-way street.
-
-We've had an open approach from the beginning. Letting people look behind the business facade has endeared us to them. By building a cool, irreverent brand around our mission, we've won over a legion of hedgehog fans, some of whom pay us. **They're fans, not customers** – and our advocates shape our brand as much as we do.
+We've had an open approach [from the beginning](/founders/remote-culture). Letting people look behind the business facade has endeared us to them. By building a transparent, weird, and irreverent brand, we've won over a legion of hedgehog fans, some of whom pay us. **They're fans, not customers** – and our advocates shape our brand as much as we do.
 
 ### A two-way dialog means listening, not always agreeing
 
@@ -64,15 +62,13 @@ Having a community requires give and take. We give our users a voice, and we res
 
 A recent example is our decision to train an ML model. We expected some backlash, some support, and some shrugs – and we got all three. We listened, but we still went ahead.
 
-### Brand affinity isn't bought – it's earned
+### Brand affinity isn't bought
 
 It's earned through trust, transparency, and engagement.
 
-- **The better informed a user, the better informed their purchase – and the better user they'll be.** That's why we share mistakes and lessons freely through [content and editorial](/handbook/content).
-- **Leading a crusade creates a context of higher purpose and meaning.** Anything we do that isn't aligned with our values is a tiny strike against the brand. What we do online and in person should always tie back to the crusade of making really great tools for developers.
-- **Brand attracts talent, too.** People with cool ideas want to work at companies where those ideas will come to life. Use brand to shorten the distance between our users and us.
-
-TL;DR: our brand is the collective gut reaction to everything we do – see [the rest of the handbook](/handbook/brand/overview) for what that looks like in practice.
+- **The better informed a user – the better user they'll be.** That's why we share mistakes and lessons freely through [content](/handbook/content).
+- **Use brand to shorten the distance.** What we post online and how we show up in person should always tie back to the mission of making really great tools for developers. As we scale, brand is the thing that will keep us close to [who we're building for](/handbook/who-we-build-for).
+- **Brand attracts talent, too.** People with cool ideas want to work at companies where they can see those ideas actually come to life. 
 
 ## Giving someone the brand ambassador experience
 

--- a/contents/handbook/brand/ambassador.md
+++ b/contents/handbook/brand/ambassador.md
@@ -58,7 +58,7 @@ A brand isn't just a logo or a tagline. It's every facet of the business, includ
 
 We've had an open approach from the beginning. Letting people look behind the business facade has endeared us to them. By building a cool, irreverent brand around our mission, we've won over a legion of hedgehog fans, some of whom pay us. **They're fans, not customers** – and our advocates shape our brand as much as we do.
 
-### A two-way dialogue means listening, not always agreeing
+### A two-way dialog means listening, not always agreeing
 
 Having a community requires give and take. We give our users a voice, and we respect what that voice says. Sometimes they'll tell us they don't agree with our choices. While our users should influence our brand, they shouldn't dictate how we act.
 
@@ -68,7 +68,7 @@ A recent example is our decision to train an ML model. We expected some backlash
 
 It's earned through trust, transparency, and engagement.
 
-- **The better informed a user, the better informed their purchase – and the better user they'll be.** That's why we share mistakes and learnings freely through [content and editorial](/handbook/content).
+- **The better informed a user, the better informed their purchase – and the better user they'll be.** That's why we share mistakes and lessons freely through [content and editorial](/handbook/content).
 - **Leading a crusade creates a context of higher purpose and meaning.** Anything we do that isn't aligned with our values is a tiny strike against the brand. What we do online and in person should always tie back to the crusade of making really great tools for developers.
 - **Brand attracts talent, too.** People with cool ideas want to work at companies where those ideas will come to life. Use brand to shorten the distance between our users and us.
 

--- a/contents/handbook/brand/ambassador.md
+++ b/contents/handbook/brand/ambassador.md
@@ -50,6 +50,30 @@ It's okay to be helpful or respond to posts from frustrated users, but be mindfu
 
 **The simplest test:** would you be comfortable with a screenshot of that tweet being shared in the `#general` Slack channel? If yes, go for it!
 
+## It's not just employees, either
+
+Our users are brand ambassadors too – whether they pay us or not.
+
+A brand isn't just a logo or a tagline. It's every facet of the business, including how other people think about it. We can influence how people think about PostHog, but we can never totally control it. Modern brand building is a two-way street.
+
+We've had an open approach from the beginning. Letting people look behind the business facade has endeared us to them. By building a cool, irreverent brand around our mission, we've won over a legion of hedgehog fans, some of whom pay us. **They're fans, not customers** – and our advocates shape our brand as much as we do.
+
+### A two-way dialogue means listening, not always agreeing
+
+Having a community requires give and take. We give our users a voice, and we respect what that voice says. Sometimes they'll tell us they don't agree with our choices. While our users should influence our brand, they shouldn't dictate how we act.
+
+A recent example is our decision to train an ML model. We expected some backlash, some support, and some shrugs – and we got all three. We listened, but we still went ahead.
+
+### Brand affinity isn't bought – it's earned
+
+It's earned through trust, transparency, and engagement.
+
+- **The better informed a user, the better informed their purchase – and the better user they'll be.** That's why we share mistakes and learnings freely through [content and editorial](/handbook/content).
+- **Leading a crusade creates a context of higher purpose and meaning.** Anything we do that isn't aligned with our values is a tiny strike against the brand. What we do online and in person should always tie back to the crusade of making really great tools for developers.
+- **Brand attracts talent, too.** People with cool ideas want to work at companies where those ideas will come to life. Use brand to shorten the distance between our users and us.
+
+TL;DR: our brand is the collective gut reaction to everything we do – see [the rest of the handbook](/handbook/brand/overview) for what that looks like in practice.
+
 ## Giving someone the brand ambassador experience
 
 The best way to create brand ambassadors isn't to ask people to be them, it's to give them an experience so good they can't help but talk about it.


### PR DESCRIPTION
## Changes

Adds a new section to `/handbook/brand/ambassador` explaining that brand ambassadors aren't just employees — our users (paying or not) shape the brand too.

The section sits between "For everyone on social media" and "Giving someone the brand ambassador experience", so the philosophy ("fans, not customers", a two-way dialogue, brand affinity is earned) sets up the practical advice on creating ambassadors that follows.

Content remixed from the supplied draft and styled to match the surrounding handbook tone — short paragraphs, sentence-case headings, American English, relative internal links, links into `/handbook/content` and `/handbook/brand/overview`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no moves)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*