### PR TITLE
Update blog, docs, and product page URLs for AI Observability rename

### DIFF
--- a/contents/blog/llm-analytics-clustering-how-it-works.mdx
+++ b/contents/blog/llm-analytics-clustering-how-it-works.mdx
@@ -320,7 +320,7 @@ Each job runs automatically during the next scheduled cycle, and the run selecto
 If you're already using [AI Observability](/llm-analytics) in PostHog, clustering runs automatically – no configuration needed. Want more control? Set up [clustering jobs](/docs/ai-observability/clusters#managing-clustering-jobs) to define exactly what gets clustered. If you're not using AI Observability yet, you can [get started in minutes](/docs/ai-observability/start-here) with SDKs for [OpenAI](/docs/ai-observability/installation/openai), [Anthropic](/docs/ai-observability/installation/anthropic), [LangChain](/docs/ai-observability/installation/langchain), [Vercel AI](/docs/ai-observability/installation/vercel-ai), and [many more](/docs/ai-observability/installation).
 
 <p>
-	<CallToAction to="https://app.posthog.com/llm-analytics/clusters">
+	<CallToAction to="https://app.posthog.com/ai-observability/clusters">
 		Try clusters in PostHog
 	</CallToAction>
 </p>

--- a/contents/blog/stop-ai-slop.md
+++ b/contents/blog/stop-ai-slop.md
@@ -160,7 +160,7 @@ When you connect eval results to real user behavior, you can see which AI behavi
 If you're already using [AI Observability](/llm-analytics) in PostHog, you can start creating evaluations right away. Your first 100 evaluation runs are on us. After that, you'll need to use your LLM API key. Evals count as regular LLM events (100K events included on our free tier).
 
 <p>
-	<CallToAction to="http://app.posthog.com/llm-analytics/evaluations">
+	<CallToAction to="https://app.posthog.com/ai-evals/evaluations">
 		Try evaluations in PostHog
 	</CallToAction>
 </p>

--- a/contents/customers/lovable.md
+++ b/contents/customers/lovable.md
@@ -33,7 +33,7 @@ At first, paying for overlapping tools may seem like an expensive mistake. At Lo
 
 “We tend to have several vendors running at the same time,” Viktor explains. “It lets us get much more insight. We use two other LLM observability and analytics tools right now, alongside PostHog. We just have one thing that emits the events, but we can check the outputs in different ways. It’s actually a pretty efficient way for us to find what works best before we double down on a single vendor — and means we have access to the best tools available while we test.”
 
-Among those tools is [a prompt playground feature](https://app.posthog.com/llm-analytics/playground) that enables teams to test prompts and see how different models respond and compare. It’s a feature that Lovable first saw in Langfuse, but as the team gravitated towards PostHog’s AI Observability beta they raised a feature request for it. Less than a month later, PostHog’s own LLM playground shipped and was specced to Lovable’s needs.
+Among those tools is [a prompt playground feature](https://app.posthog.com/ai-observability/playground) that enables teams to test prompts and see how different models respond and compare. It’s a feature that Lovable first saw in Langfuse, but as the team gravitated towards PostHog’s AI Observability beta they raised a feature request for it. Less than a month later, PostHog’s own LLM playground shipped and was specced to Lovable’s needs.
 
 “PostHog is definitely the best tool for AI Observability,” Viktor says. “It’s not just about where the tool is today, but also the fact that you’re improving faster. That’s huge for us because it means PostHog covers so many use-cases and we have so many tools in one place.”
 

--- a/contents/docs/ai-evals/evaluations.mdx
+++ b/contents/docs/ai-evals/evaluations.mdx
@@ -337,9 +337,9 @@ PostHog automatically disables evaluations and sets them to error status when:
 
 | Error reason             | Cause                                                     | How to resolve                                                                                                                                   |
 | ------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Trial limit reached**  | The 100 free trial evaluation runs have been exhausted.   | Add your own API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-llm-analytics#llm-analytics-byok).       |
+| **Trial limit reached**  | The 100 free trial evaluation runs have been exhausted.   | Add your own API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok).       |
 | **Model not allowed**    | The selected model isn't available on the trial plan.     | Switch to a trial-allowed model, or add your own provider API key.                                                                               |
-| **Provider key deleted** | The provider API key used by this evaluation was removed. | Add a new provider API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-llm-analytics#llm-analytics-byok). |
+| **Provider key deleted** | The provider API key used by this evaluation was removed. | Add a new provider API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok). |
 
 ### Identifying errored evaluations
 
@@ -361,7 +361,7 @@ Once the issue is resolved, open the evaluation and toggle it back on.
 
 Each evaluation run counts as one AI Observability event toward your quota.
 
-**LLM judge evaluations** use an LLM to score your generations. Your first 100 evaluation runs are on us so you can try the feature right away. After that, add your own API key from OpenAI, Azure OpenAI, Google Gemini, Anthropic, OpenRouter, Fireworks, or Together AI in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-llm-analytics#llm-analytics-byok) to keep running evaluations.
+**LLM judge evaluations** use an LLM to score your generations. Your first 100 evaluation runs are on us so you can try the feature right away. After that, add your own API key from OpenAI, Azure OpenAI, Google Gemini, Anthropic, OpenRouter, Fireworks, or Together AI in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok) to keep running evaluations.
 
 If a provider API key is deleted or an evaluation hits trial limits, PostHog automatically disables the affected evaluations and shows an error status. See [Evaluation status and errors](#evaluation-status-and-errors) for details on error states and how to resolve them.
 

--- a/contents/docs/ai-observability/dashboard.md
+++ b/contents/docs/ai-observability/dashboard.md
@@ -6,7 +6,7 @@ availability:
     enterprise: full
 ---
 
-The [AI Observability dashboard](https://app.posthog.com/llm-analytics) provides an overview of your LLM usage and performance. Out of the box, it includes insights on:
+The [AI Observability dashboard](https://app.posthog.com/ai-observability) provides an overview of your LLM usage and performance. Out of the box, it includes insights on:
 
 - Users
 - Traces
@@ -27,7 +27,7 @@ It can be filtered like any dashboard in PostHog, including by event, person, an
 
 The AI Observability dashboard is fully customizable. You can add your own insights, add text cards, and more. To customize the dashboard:
 
-1. Head to the [AI Observability dashboard](https://app.posthog.com/llm-analytics)
+1. Head to the [AI Observability dashboard](https://app.posthog.com/ai-observability)
 2. Click the **Edit dashboard** button in the top right
 3. Click the **Add text card** button to add labels, or the **Add insight** button to import insights
 
@@ -43,4 +43,4 @@ This dashboard is a great starting point for understanding your LLM usage and pe
 - How many of my users are interacting with my LLM features?
 - Are there generation latency spikes?
 
-To dive into specific generation events, click on the [generations](https://app.posthog.com/llm-analytics/generations), [traces](https://app.posthog.com/llm-analytics/traces), or [sentiment](https://app.posthog.com/llm-analytics/sentiment) tabs to explore your LLM data.
+To dive into specific generation events, click on the [generations](https://app.posthog.com/ai-observability/generations), [traces](https://app.posthog.com/ai-observability/traces), or [sentiment](https://app.posthog.com/ai-observability/sentiment) tabs to explore your LLM data.

--- a/contents/docs/ai-observability/generations.mdx
+++ b/contents/docs/ai-observability/generations.mdx
@@ -17,7 +17,7 @@ Generations are events that capture LLM calls and their responses. They represen
   View recent AI generation events in the <b>Activity</b> tab
 </Caption>
 
-The **AI Observability** > [**Generations** tab](https://app.posthog.com/llm-analytics/generations) displays a list of generations, along with a preview of key autocaptured properties. You can filter and search for generations by various properties.
+The **AI Observability** > [**Generations** tab](https://app.posthog.com/ai-observability/generations) displays a list of generations, along with a preview of key autocaptured properties. You can filter and search for generations by various properties.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/llm_generations_b12119af33.png"

--- a/contents/docs/ai-observability/installation/_snippets/verify-llm-events-step.mdx
+++ b/contents/docs/ai-observability/installation/_snippets/verify-llm-events-step.mdx
@@ -10,6 +10,6 @@ Let's make sure LLM events are being captured and sent to PostHog. Under **AI Ob
     padding={false}
 />
 
-<OSButton variant="secondary" asLink className="my-2" size="sm" to="https://app.posthog.com/llm-analytics/generations" external>
+<OSButton variant="secondary" asLink className="my-2" size="sm" to="https://app.posthog.com/ai-observability/generations" external>
   Check for LLM events in PostHog
 </OSButton>

--- a/contents/docs/ai-observability/installation/claude-code.mdx
+++ b/contents/docs/ai-observability/installation/claude-code.mdx
@@ -104,7 +104,7 @@ When the session ends, the plugin automatically parses the session log file and 
 
 After completing a session:
 
-1. Go to the [AI Observability](https://us.posthog.com/llm-analytics) tab in PostHog.
+1. Go to the [AI Observability](https://us.posthog.com/ai-observability) tab in PostHog.
 2. You should see traces and generations appearing within a few minutes.
 
 You can also check the status of the last send from within Claude Code:

--- a/contents/docs/ai-observability/installation/openclaw.mdx
+++ b/contents/docs/ai-observability/installation/openclaw.mdx
@@ -94,7 +94,7 @@ The PostHog plugin initializes automatically on startup. Once users send message
 
 After sending a few messages through your gateway:
 
-1. Go to the [AI Observability](https://us.posthog.com/llm-analytics) tab in PostHog.
+1. Go to the [AI Observability](https://us.posthog.com/ai-observability) tab in PostHog.
 2. You should see traces and generations appearing within a few minutes.
 
 ## Configuration options

--- a/contents/docs/ai-observability/installation/pi.mdx
+++ b/contents/docs/ai-observability/installation/pi.mdx
@@ -77,7 +77,7 @@ The extension initializes automatically and captures events for every LLM call, 
 
 After running a few prompts through pi:
 
-1. Go to the [AI Observability](https://us.posthog.com/llm-analytics) tab in PostHog.
+1. Go to the [AI Observability](https://us.posthog.com/ai-observability) tab in PostHog.
 2. You should see traces and generations appearing within a few minutes.
 
 ## Configuration options

--- a/contents/docs/ai-observability/link-session-replay.mdx
+++ b/contents/docs/ai-observability/link-session-replay.mdx
@@ -145,7 +145,7 @@ def chat():
 
 Once you've set up session linking, you can navigate from LLM generations to their corresponding session replays:
 
-1. In the [AI Observability dashboard](https://app.posthog.com/llm-analytics), find the generation or trace you're interested in
+1. In the [AI Observability dashboard](https://app.posthog.com/ai-observability), find the generation or trace you're interested in
 2. Click the session replay button to jump directly to the replay
 3. Watch the user's interaction with your AI features in context
 

--- a/contents/docs/ai-observability/playground.mdx
+++ b/contents/docs/ai-observability/playground.mdx
@@ -21,12 +21,12 @@ The playground lets you test and experiment with LLM prompts directly inside Pos
 
 ## Getting started
 
-1. Navigate to [**AI Observability** > **Playground**](https://app.posthog.com/llm-analytics/playground)
+1. Navigate to [**AI Observability** > **Playground**](https://app.posthog.com/ai-observability/playground)
 2. Choose a model from the model picker
 3. Write a system prompt and add messages
 4. Click **Run**
 
-The playground works out of the box with PostHog-provided trial models — no setup required. To use your own API keys for higher rate limits and access to more models, add them in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-llm-analytics#llm-analytics-byok).
+The playground works out of the box with PostHog-provided trial models — no setup required. To use your own API keys for higher rate limits and access to more models, add them in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok).
 
 Click the reset button to clear the playground back to its default state at any time.
 
@@ -106,4 +106,4 @@ You can also open the playground directly from the [traces](/docs/ai-observabili
 
 When using trial models, the playground enforces rate limits. If you hit a limit, a banner shows how long until your next request.
 
-[Add your own API keys](https://app.posthog.com/settings/environment-llm-analytics#llm-analytics-byok) to remove PostHog rate limits. BYOK models are subject only to the provider's own rate limits.
+[Add your own API keys](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok) to remove PostHog rate limits. BYOK models are subject only to the provider's own rate limits.

--- a/contents/docs/ai-observability/sentiment.mdx
+++ b/contents/docs/ai-observability/sentiment.mdx
@@ -6,7 +6,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Sentiment classification is in beta" type="fyi">
 
-Sentiment classification is currently in beta. We'd love to [hear your feedback](https://app.posthog.com/llm-analytics#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we develop this feature.
+Sentiment classification is currently in beta. We'd love to [hear your feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we develop this feature.
 
 </CalloutBox>
 

--- a/contents/docs/ai-observability/traces.mdx
+++ b/contents/docs/ai-observability/traces.mdx
@@ -4,7 +4,7 @@ title: Traces
 
 import TraceEventSnippet from "./_snippets/trace-event.mdx"
 
-Traces are a collection of [generations](/docs/ai-observability/generations) and [spans](/docs/ai-observability/spans) that capture a full interaction between a user and an LLM. The [traces tab](https://app.posthog.com/llm-analytics/traces) lists them along with the properties autocaptured by PostHog like the person, total cost, total latency, and more.
+Traces are a collection of [generations](/docs/ai-observability/generations) and [spans](/docs/ai-observability/spans) that capture a full interaction between a user and an LLM. The [traces tab](https://app.posthog.com/ai-observability/traces) lists them along with the properties autocaptured by PostHog like the person, total cost, total latency, and more.
 
 ## Sessions vs Traces
 
@@ -45,7 +45,7 @@ PostHog can classify the sentiment of user messages in a trace as negative, neut
 
 ## Search traces with PostHog AI
 
-[PostHog AI](/docs/posthog-ai) can search and analyze your LLM traces using natural language. When you're on an [AI Observability page](https://app.posthog.com/llm-analytics), PostHog AI automatically switches to its AI Observability mode, giving it access to tools for searching traces by date range, model, cost, error status, and other properties.
+[PostHog AI](/docs/posthog-ai) can search and analyze your LLM traces using natural language. When you're on an [AI Observability page](https://app.posthog.com/ai-observability), PostHog AI automatically switches to its AI Observability mode, giving it access to tools for searching traces by date range, model, cost, error status, and other properties.
 
 Example prompts you can try:
 

--- a/contents/docs/prompt-management/_snippets/prompt-experiments-body.mdx
+++ b/contents/docs/prompt-management/_snippets/prompt-experiments-body.mdx
@@ -15,7 +15,7 @@ Use this when you have a candidate change to a prompt (a wording tweak, a new in
 
 You need at least two versions of a prompt before you can create an experiment from it.
 
-1. In **LLM analytics** → **Prompts**, open the prompt you want to test (or [create a new one](/docs/llm-analytics/prompts#creating-prompts))
+1. In **Prompt management** → **Prompts**, open the prompt you want to test (or [create a new one](/docs/prompt-management/prompts#creating-prompts))
 2. If it only has one version, edit the body and save. Every save creates a new immutable version.
 3. Repeat for as many versions as you want to compare (up to 10)
 
@@ -159,7 +159,7 @@ Results populate within seconds of the first events landing. Each tile shows the
 
 - **Cost** — mean LLM cost per user (`$ai_total_cost_usd` on `$ai_generation`). Goal: decrease.
 - **Latency** — mean LLM latency per user (`$ai_latency`). Goal: decrease.
-- **Eval pass rate** — share of `$ai_evaluation` events that returned a pass, scoped to this prompt. Populates only if you have [LLM evaluations](/docs/llm-analytics/evaluations) configured.
+- **Eval pass rate** — share of `$ai_evaluation` events that returned a pass, scoped to this prompt. Populates only if you have [LLM evaluations](/docs/ai-evals/evaluations) configured.
 
 export const PromptExperimentResultsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2026_05_21_at_17_34_40_5e448cfbdf.png"
 export const PromptExperimentResultsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2026_05_21_at_17_34_54_68fa203949.png"

--- a/contents/docs/prompt-management/prompts.mdx
+++ b/contents/docs/prompt-management/prompts.mdx
@@ -14,7 +14,7 @@ Prompt management lets you create and update LLM prompts directly in PostHog. Wh
 - **Non-engineers can iterate** – Product and content teams can tweak prompts without touching code
 - **Track prompt usage** – Link prompts to generations to see which prompts drive which outputs
 - **Versioning** – Every change creates an immutable version you can view, compare, or restore
-- **[A/B testing](/docs/llm-analytics/prompt-experiments)** – Compare prompt versions on cost, latency, and eval pass rate using PostHog Experiments
+- **[A/B testing](/docs/prompt-management/prompt-experiments)** – Compare prompt versions on cost, latency, and eval pass rate using PostHog Experiments
 
 ## Creating prompts
 

--- a/contents/docs/prompt-management/skills-store.mdx
+++ b/contents/docs/prompt-management/skills-store.mdx
@@ -148,7 +148,7 @@ The body can reference bundled files by path. Agents pull them with `skill-file-
 You can deep-link directly to a specific bundled file within a skill by adding a `?file=` query parameter to the skill URL:
 
 ```text
-https://app.posthog.com/llm-analytics/skills/hog-release-notes?file=references/changelog.md
+https://app.posthog.com/prompt-management/skills/hog-release-notes?file=references/changelog.md
 ```
 
 When someone visits this URL, the file viewer automatically expands, loads the file content, and scrolls it into view. Combine it with `version` to link to a file in a specific skill version — e.g. `?file=scripts/run.py&version=3`. This is useful for sharing a specific reference document or script with a teammate.

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -177,7 +177,7 @@ Now, when we run `npm run dev` again and submit an input, we should see a respon
 
 ## 3. Viewing generations in PostHog
 
-Once you generate a few responses, go to PostHog's [AI Observability tab](https://app.posthog.com/llm-analytics) to get an overview of traces, users, costs, and more.
+Once you generate a few responses, go to PostHog's [AI Observability tab](https://app.posthog.com/ai-observability) to get an overview of traces, users, costs, and more.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_05_at_10_00_08_2x_a4773a9cd5.png"
@@ -186,7 +186,7 @@ Once you generate a few responses, go to PostHog's [AI Observability tab](https:
     classes="rounded"
 />
 
-You can also go into more detail by clicking on the [generations tab](https://app.posthog.com/llm-analytics/generations). This shows each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
+You can also go into more detail by clicking on the [generations tab](https://app.posthog.com/ai-observability/generations). This shows each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_05_at_10_04_35_2x_2dbca9be6b.png"

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -188,7 +188,7 @@ Now, when we run `npm run dev` again and submit an input, we should see a respon
 
 ## 3. Viewing generations in PostHog
 
-Once you generate a few responses, go to PostHog's [AI Observability tab](https://app.posthog.com/llm-analytics) to get an overview of traces, users, costs, and more.
+Once you generate a few responses, go to PostHog's [AI Observability tab](https://app.posthog.com/ai-observability) to get an overview of traces, users, costs, and more.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_14_at_18_28_10_2x_242d0e7bf5.png"
@@ -197,7 +197,7 @@ Once you generate a few responses, go to PostHog's [AI Observability tab](https:
   classes="rounded"
 />
 
-You can also go into more detail by clicking on the [generations tab](https://app.posthog.com/llm-analytics/generations). This shows each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
+You can also go into more detail by clicking on the [generations tab](https://app.posthog.com/ai-observability/generations). This shows each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_14_at_18_33_38_2x_a185b712f0.png"

--- a/contents/tutorials/openai-observability.md
+++ b/contents/tutorials/openai-observability.md
@@ -171,7 +171,7 @@ Now, when we run `npm run dev` again and submit an input, we should see a respon
 
 ## 3. Viewing generations in PostHog
 
-Once you generate a few responses, go to PostHog's [AI Observability tab](https://app.posthog.com/llm-analytics) to get an overview of traces, users, costs, and more.
+Once you generate a few responses, go to PostHog's [AI Observability tab](https://app.posthog.com/ai-observability) to get an overview of traces, users, costs, and more.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_23_at_10_58_04_2x_a87f97d692.png" 
@@ -180,7 +180,7 @@ Once you generate a few responses, go to PostHog's [AI Observability tab](https:
   classes="rounded"
 />
 
-You can also go into more detail by clicking on the [generations tab](https://us.posthog.com/llm-analytics/generations). This shows each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
+You can also go into more detail by clicking on the [generations tab](https://us.posthog.com/ai-observability/generations). This shows each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_23_at_11_05_47_2x_31ac89084d.png" 

--- a/contents/tutorials/openrouter-observability.md
+++ b/contents/tutorials/openrouter-observability.md
@@ -177,7 +177,7 @@ Now, when you run `npm run dev` again, you can choose your model, enter your mes
 
 ## 3. Viewing generations in PostHog
 
-After generating a few responses with different models, go to PostHog to access the [AI Observability dashboard](https://app.posthog.com/llm-analytics) to see:
+After generating a few responses with different models, go to PostHog to access the [AI Observability dashboard](https://app.posthog.com/ai-observability) to see:
 
 - Overview of all AI interactions
 - Cost breakdowns by model
@@ -192,7 +192,7 @@ After generating a few responses with different models, go to PostHog to access 
   classes="rounded"
 />
 
-Head to the [generations tab](https://app.posthog.com/llm-analytics/generations) to get details on each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
+Head to the [generations tab](https://app.posthog.com/ai-observability/generations) to get details on each generation as well as model, cost, token usage, latency, and more. You can even see the conversation input and output.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_20_at_14_47_59_2x_d4196d55f8.png"

--- a/src/hooks/featureDefinitions/llm_analytics.tsx
+++ b/src/hooks/featureDefinitions/llm_analytics.tsx
@@ -3,7 +3,7 @@ export const llmAnalyticsFeatures = {
         name: 'AI Observability',
         description: 'Monitor and debug your LLM-powered features',
         url: '/llm-analytics',
-        docsUrl: '/docs/llm-analytics',
+        docsUrl: '/docs/ai-observability',
     },
     features: {
         generation_tracking: {

--- a/src/pages/llm-analytics/index.tsx
+++ b/src/pages/llm-analytics/index.tsx
@@ -156,43 +156,43 @@ const NativeIntegrationsSlide = () => {
         {
             logo: OpenAILogo,
             name: 'OpenAI',
-            link: '/docs/llm-analytics/installation/openai',
+            link: '/docs/ai-observability/installation/openai',
         },
         {
             logo: AnthropicLogo,
             name: 'Anthropic',
-            link: '/docs/llm-analytics/installation/anthropic',
+            link: '/docs/ai-observability/installation/anthropic',
         },
         {
             logo: GeminiLogo,
             name: 'Google Gemini',
-            link: '/docs/llm-analytics/installation/google',
+            link: '/docs/ai-observability/installation/google',
         },
         {
             logo: LangChainLogo,
             name: 'LangChain',
-            link: '/docs/llm-analytics/installation/langchain',
+            link: '/docs/ai-observability/installation/langchain',
         },
         {
             logo: VercelLogo,
             name: 'Vercel AI SDK',
-            link: '/docs/llm-analytics/installation/vercel-ai',
+            link: '/docs/ai-observability/installation/vercel-ai',
         },
         {
             logo: OpenRouterLogo,
             name: 'OpenRouter',
-            link: '/docs/llm-analytics/installation/openrouter',
+            link: '/docs/ai-observability/installation/openrouter',
         },
         {
             logoLight: LiteLLMLogoLight,
             logoDark: LiteLLMLogoDark,
             name: 'LiteLLM',
-            link: '/docs/llm-analytics/installation/litellm',
+            link: '/docs/ai-observability/installation/litellm',
         },
         {
             isManualCapture: true,
             name: '</> Manual Capture',
-            link: '/docs/llm-analytics/installation/manual-capture',
+            link: '/docs/ai-observability/installation/manual-capture',
         },
     ]
 
@@ -276,7 +276,7 @@ const NativeIntegrationsSlide = () => {
                             ))}
                         </ul>
                         <Link
-                            to="/docs/llm-analytics/installation/manual-capture"
+                            to="/docs/ai-observability/installation/manual-capture"
                             className="text-lg font-semibold underline inline-flex items-center gap-1 group mt-auto mb-3"
                             state={{ newWindow: true }}
                         >


### PR DESCRIPTION
## Changes

LLM Analytics was [split into three products](https://github.com/PostHog/posthog/pull/59479) with new in-app URL slugs:

- AI Observability → `/ai-observability/...`
- Evaluations → `/ai-evals/...`
- Prompt Management → `/prompt-management/...`

This rounds up the remaining stale URL references on posthog.com so links go to the new locations directly instead of relying on redirects in the app.

Updated:

- **Blog posts** (2): `stop-ai-slop.md`, `llm-analytics-clustering-how-it-works.mdx` — CallToAction buttons
- **Tutorials** (4): `openai-observability.md`, `anthropic-analytics.md`, `cohere-analytics.md`, `openrouter-observability.md` — "Viewing in PostHog" steps
- **Docs** (11): AI Observability `dashboard`, `traces`, `generations`, `playground`, `sentiment`, `link-session-replay`, `installation/{pi,openclaw,claude-code}`, the `verify-llm-events-step` snippet; Evaluations `evaluations`; Prompt Management `prompts`, `skills-store`, and the `prompt-experiments-body` snippet
- **Settings URLs**: `environment-llm-analytics#llm-analytics-byok` → `environment-ai-observability#ai-observability-byok` (confirmed against [Radu's PR](https://github.com/PostHog/posthog/pull/59479))
- **Customers**: `lovable.md` playground link
- **Product page**: `src/pages/llm-analytics/index.tsx` — integration card links to the new docs paths
- **Feature definitions**: `llm_analytics.tsx` — `docsUrl` pointer

Intentionally left as-is:

- The marketing landing page route `/llm-analytics` on posthog.com — new product pages for the three products are being set up separately
- The `team-llm-analytics@posthog.com` email and `#panel=...:llm-analytics:...` feedback panel fragment — those are tied to the underlying team/feedback identifier, which doesn't appear to have been renamed in @Radu-Raicea's PR
- The `teams/llm-analytics/` handbook folder — out of scope for this URL pass
- The `.claude/skills/InternalLinkData.csv` reference data — gets regenerated separately

cc @Radu-Raicea for review.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*