### PR TITLE
Hide enterprise addon price in pricing calculator

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -3,7 +3,7 @@ import Tooltip from 'components/Tooltip'
 import { IconCopy, IconInfo, IconLightBulb } from '@posthog/icons'
 import Toggle from 'components/Toggle'
 import { calculatePrice, formatUSD } from '../PricingSlider/pricingSliderLogic'
-import { useStaticQuery } from 'gatsby'
+import { Link, useStaticQuery } from 'gatsby'
 import { allProductsData } from '../Pricing'
 import useProducts from 'hooks/useProducts'
 import { LogSlider, inverseCurve, sliderCurve } from '../PricingSlider/Slider'
@@ -451,32 +451,49 @@ export default function Tabbed() {
                                                 </span>
                                             </Tooltip>
                                         </div>
-                                        <Toggle
-                                            checked={checked}
-                                            onChange={(checked) =>
-                                                setPlatformAddons(
-                                                    platformAddons.map((addon) => {
-                                                        if (addon.type === type) {
-                                                            return { ...addon, checked }
-                                                        }
-                                                        return addon
-                                                    })
-                                                )
-                                            }
-                                        />
+                                        {type !== 'enterprise' && (
+                                            <Toggle
+                                                checked={checked}
+                                                onChange={(checked) =>
+                                                    setPlatformAddons(
+                                                        platformAddons.map((addon) => {
+                                                            if (addon.type === type) {
+                                                                return { ...addon, checked }
+                                                            }
+                                                            return addon
+                                                        })
+                                                    )
+                                                }
+                                            />
+                                        )}
                                     </div>
                                     <div className="col-span-3 sm:col-span-2 flex justify-between">
-                                        <div>
-                                            <strong className="text-[15px] md:text-base">
-                                                ${platformAddon.price.toLocaleString()}
-                                            </strong>
-                                            <span className="text-sm opacity-70">/mo</span>
-                                        </div>
-                                        <div className="text-right">
-                                            <p className={`font-semibold m-0 pr-3 ${checked ? '' : 'opacity-50'}`}>
-                                                ${checked ? platformAddon?.price : 0}
-                                            </p>
-                                        </div>
+                                        {type === 'enterprise' ? (
+                                            <Link
+                                                to="/talk-to-a-human?edition=enterprise"
+                                                className="text-red dark:text-yellow font-semibold text-sm"
+                                            >
+                                                Contact us
+                                            </Link>
+                                        ) : (
+                                            <>
+                                                <div>
+                                                    <strong className="text-[15px] md:text-base">
+                                                        ${platformAddon.price.toLocaleString()}
+                                                    </strong>
+                                                    <span className="text-sm opacity-70">/mo</span>
+                                                </div>
+                                                <div className="text-right">
+                                                    <p
+                                                        className={`font-semibold m-0 pr-3 ${
+                                                            checked ? '' : 'opacity-50'
+                                                        }`}
+                                                    >
+                                                        ${checked ? platformAddon?.price : 0}
+                                                    </p>
+                                                </div>
+                                            </>
+                                        )}
                                     </div>
                                 </div>
                             )

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -472,6 +472,7 @@ export default function Tabbed() {
                                             <Link
                                                 to="/talk-to-a-human?edition=enterprise"
                                                 className="text-red dark:text-yellow font-semibold text-sm"
+                                                state={{ newWindow: true }}
                                             >
                                                 Contact us
                                             </Link>

--- a/src/pages/platform-packages/index.tsx
+++ b/src/pages/platform-packages/index.tsx
@@ -113,7 +113,13 @@ export default function PlatformPackages() {
                                         {plan?.flat_rate && (
                                             <div className="flex items-baseline mt-auto">
                                                 {addon.type === 'enterprise' ? (
-                                                    <strong className="text-lg">Contact us</strong>
+                                                    <Link
+                                                        to="/talk-to-a-human?edition=enterprise"
+                                                        className="text-lg font-bold text-red dark:text-yellow"
+                                                        state={{ newWindow: true }}
+                                                    >
+                                                        Contact us
+                                                    </Link>
                                                 ) : (
                                                     <>
                                                         <strong className="text-lg">


### PR DESCRIPTION
## Changes

The pricing calculator's "Platform packages" section was showing the enterprise addon with a $2,000/mo price and a toggle that added it to the running total. We don't want to surface that price for now.

For the enterprise addon specifically:
- Removed the toggle
- Removed the $/mo price and per-row subtotal
- Added a "Contact us" link pointing to `/talk-to-a-human?edition=enterprise` (the same destination already used for the enterprise CTA elsewhere on the pricing page)

Other platform addons in the same list (non-legacy) continue to show their toggle, price, and subtotal — only the row with `type === 'enterprise'` is affected. This matches the existing pattern on `/platform-packages`, which also renders "Contact us" instead of a price for the enterprise package.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*