### PR TITLE
Added replay debug info to docs

### DIFF
--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -8,7 +8,7 @@ This page covers troubleshooting for Session Replay. For setup, see the [install
 
 <AskAIInput placeholder="Type your question and hit enter..." />
 
-## Update posthog-js
+## Update `posthog-js`
 
 Having trouble with recordings? The most common solution is to update `posthog-js` to the latest version.
 
@@ -24,7 +24,7 @@ You can also check using the [SDK doctor](/docs/sdk-doctor) tool.
 
 ## Check the replay status on your events
 
-Recent versions of `posthog-js` attach diagnostic properties to every event that describe what session replay was doing at the moment the event was captured. Reading these is usually the fastest way to figure out _why_ a session wasn't recorded before you start changing settings.
+Recent versions of `posthog-js` attach diagnostic properties to every event that describe what Session Replay was doing at the moment the event was captured. Reading these is usually the fastest way to figure out _why_ a session wasn't recorded before you start changing settings.
 
 You can query them from the [SQL editor](/docs/sql) for a specific session ID:
 
@@ -45,7 +45,7 @@ ORDER BY timestamp DESC
 LIMIT 1
 ```
 
-Always look at the **latest** event in the session — early events may not yet reflect the final state (for example, `$has_recording` only flips to `true` once PostHog has confirmed at least one recording chunk was ingested).
+Always look at the **latest** event in the session – early events may not yet reflect the final state (for example, `$has_recording` only flips to `true` once PostHog has confirmed at least one recording chunk was ingested).
 
 ### The three core signals
 
@@ -63,8 +63,8 @@ These three properties together describe replay status. Read them as a set, not 
 | --- | --- |
 | `active` | The SDK is recording and producing snapshots. |
 | `buffering` | The SDK initialized but is waiting for a trigger, minimum duration threshold, or remote config before producing snapshots. |
-| `disabled` | Recording is turned off — either in [your project replay settings](https://us.posthog.com/settings/project-replay) or via SDK config at runtime. |
-| `sampled` | This session was included by the configured replay sample rate — recording started. |
+| `disabled` | Recording is turned off – either in [your project replay settings](https://us.posthog.com/settings/project-replay) or via SDK config at runtime. |
+| `sampled` | This session was included by the configured replay sample rate – recording started. |
 | `paused` | Recording is temporarily paused for this session (consent gate, programmatic `pause()`, or a max-duration cap). |
 
 #### `$session_recording_start_reason` values
@@ -84,8 +84,8 @@ These three properties together describe replay status. Read them as a set, not 
 | `null` / `false` | `active` or `sampled` | `recording_initialized` / `sampling_override` / `linked_flag_match` | Recording is running but PostHog hasn't confirmed ingestion yet, check a later event. |
 | `null` / `false` | `buffering` | any | The SDK is waiting on a [trigger](/docs/session-replay/how-to-control-which-sessions-you-record) or duration threshold, check the trigger status properties. |
 | `null` / `false` | `disabled` | any | Replay is off, either in [project settings](https://us.posthog.com/settings/project-replay) or via SDK config like `disable_session_recording: true`. |
-| `null` / `false` | any | `sampled_out` | Your sample rate excluded this session — increase the sample rate or use a trigger to guarantee capture for important flows. |
-| `null` / `false` | `paused` | any | Recording was paused mid-session — usually a consent flow or a programmatic `posthog.sessionRecording.pause()` call. |
+| `null` / `false` | any | `sampled_out` | Your sample rate excluded this session – increase the sample rate or use a trigger to guarantee capture for important flows. |
+| `null` / `false` | `paused` | any | Recording was paused mid-session – usually a consent flow or a programmatic `posthog.sessionRecording.pause()` call. |
 
 ### Lifecycle
 
@@ -109,8 +109,8 @@ buffering ──► active ──► (recording captured, $has_recording flips t
 | --- | --- |
 | `$sdk_debug_recording_script_not_loaded` | `true` if the `recorder.js` script failed to load. Usually caused by an ad blocker or CSP |
 | `$sdk_debug_replay_url_trigger_status` <br /> `$sdk_debug_replay_event_trigger_status` <br /> `$sdk_debug_replay_linked_flag_trigger_status` | Trigger states: `trigger_disabled` (none configured), `trigger_pending` (configured, waiting to match), or `trigger_matched` (fired). |
-| `$sdk_debug_replay_internal_buffer_length` <br /> `$sdk_debug_replay_flushed_size` | If `buffer_length` keeps growing across the session's events while `flushed_size` stays at `0`, the `POST /s/` upload is being blocked — usually an ad blocker or a misconfigured reverse proxy. |
-| `$replay_sample_rate` <br /> `$replay_minimum_duration` | The sample rate (0.0–1.0) and minimum duration (ms) in effect at capture time. |
+| `$sdk_debug_replay_internal_buffer_length` <br /> `$sdk_debug_replay_flushed_size` | If `buffer_length` keeps growing across the session's events while `flushed_size` stays at `0`, the `POST /s/` upload is being blocked – usually an ad blocker or a misconfigured reverse proxy. |
+| `$replay_sample_rate` <br /> `$replay_minimum_duration` | The sample rate (0.0 to 1.0) and minimum duration (ms) in effect at capture time. |
 
 If you're on an older SDK version, some of these properties won't be present, `null` means "unknown", not "false". Upgrading `posthog-js` will give you a much fuller picture.
 
@@ -122,7 +122,7 @@ There are a few common reasons that you may not see recordings appear in your pr
 
 Authorized domains for recordings is deprecated, you should use URL triggers instead. [Read more in our replay controls doc](/docs/session-replay/how-to-control-which-sessions-you-record#with-url-trigger-conditions).
 
-In your [project replay settings](https://us.posthog.com/settings/environment-replay#replay-authorized-domains), for older projects, there is a section for 'Authorized domains for replay'. This is the list of domains where posthog will capture recordings. You should make sure it's not too restrictive.
+In your [project replay settings](https://us.posthog.com/settings/environment-replay#replay-authorized-domains), for older projects, there is a section for 'Authorized domains for replay'. This is the list of domains where PostHog will capture recordings. You should make sure it's not too restrictive.
 
 For example, you may have `https://www.example.com` in the list. This will stop PostHog from capturing recordings on `https://example.com`.
 
@@ -130,7 +130,7 @@ If no domains are set here, PostHog will capture recordings on all domains.
 
 **2. `posthog-js` configurations**
 
-If you had previously disabled session recordings, you may have set the `disable_session_recording` option to `true` in posthog-js.
+If you had previously disabled session recordings, you may have set the `disable_session_recording` option to `true` in `posthog-js`.
 
 To re-enable session recordings you want to either remove the `disable_session_recording` option or set it to `false`.
 
@@ -138,7 +138,7 @@ You can read more about [`posthog-js` configurations here](/docs/libraries/js/co
 
 **3. Content security policy**
 
-When recordings are enabled, postHog-js will fetch a `recorder.js` script from the PostHog server. (This is not included in the default posthog-js to minimize the default bundle size)
+When recordings are enabled, `posthog-js` will fetch a `recorder.js` script from the PostHog server. (This is not included in the default `posthog-js` to minimize the default bundle size)
 
 Depending on your content security policy, this script may be blocked. If you have a `default-src`, `script-src`, `script-src-elem`, or `connect-src` directive in your CSP, you may need to ensure that PostHog domains are permitted (see [CSP documentation](/docs/advanced/content-security-policy)).
 
@@ -156,16 +156,16 @@ If you're having issues with recordings not looking correct, there are a few thi
 
 ### Ensure your website permits PostHog CORS
 
-Most assets rendered on your website or app are captured **inline** – meaning we keep a copy of the icon, css etc. to use when replaying. For some assets however, this is either too difficult or too costly to do, so instead we load them directly from the original webserver (just like your website does). This can lead to CORS issues where the webserver does not permit **us.posthog.com** (or **eu.posthog.com**) to load the required asset. Unfortunately we cannot easily detect when this happens, but the browsers's developer tools `(Option + ⌘ + J, or Shift + CTRL + J)` will log when these errors occur saying something like:
+Most assets rendered on your website or app are captured **inline** – meaning we keep a copy of the icon, CSS, etc. to use when replaying. For some assets however, this is either too difficult or too costly to do, so instead we load them directly from the original web server (just like your website does). This can lead to CORS issues where the web server does not permit **us.posthog.com** (or **eu.posthog.com**) to load the required asset. Unfortunately we cannot detect when this happens, but the browser's developer tools `(Option + ⌘ + J, or Shift + CTRL + J)` will log when these errors occur saying something like:
 
 ```
 Access to font at 'https://yourwebsite.com/fonts/MyriadPro-Bold.woff2' from origin 'https://us.posthog.com has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
 @ GET https://yourwebsite.com/fonts/MyriadPro-Bold.woff2 net: :ERR_FAILED 200
 ```
 
-If you see errors like this, please add `us.posthog.com` (or `eu.posthog.com`) to the list of permitted domains in your webservers CORS configuration.
+If you see errors like this, please add `us.posthog.com` (or `eu.posthog.com`) to the list of permitted domains in your web server's CORS configuration.
 
-### Adjust the crossorigin attribute on stylesheets
+### Adjust the `crossorigin` attribute on stylesheets
 If the `crossorigin` attribute is not set on `link` elements a Chrome specific protection will prevent programmatic access to stylesheet rules (e.g. `stylesheet.cssRules` throws an exception). This means that styles on your site render as expected but they cannot be captured by PostHog in order to recreate the session during playback.
 
 Setting `crossorigin="anonymous"` is the safest value you can set for the parameter as [no user credentials are added to the request](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#anonymous).
@@ -183,23 +183,23 @@ If the DOM contains images or other media assets referenced by a URL that is sig
 
 ## Unable to filter by user or page properties
 
-Some of the filtering options in session replays depend on [product analytics](/docs/product-analytics) events. 
+Some of the filtering options in session replays depend on [Product Analytics](/docs/product-analytics) events. 
 
 To enable all filtering options, we recommend capturing at least one event per session. Most commonly identifying users via `identify()`. This makes sure you can use all of the power of filtering by person and event properties.
 
-Since these events contribute to the product analytics usage and [billing limits](/docs/billing/limits-alerts), if you exceed your product analytics monthly limit, the recordings captured after that (until new billing period starts or limit is increased) won't be possible to filter by these properties.
+Since these events contribute to the Product Analytics usage and [billing limits](/docs/billing/limits-alerts), if you exceed your Product Analytics monthly limit, the recordings captured after that (until new billing period starts or limit is increased) won't be possible to filter by these properties.
 
 ## Internal users filtering or cohorts-based filters don't work
 
-If you use cohorts to filter sessions, or add a cohort condition into the "Filter out internal and test users" setting - it can work incorrectly (or not work at all) while cohorts are calculating.
+If you use cohorts to filter sessions, or add a cohort condition into the **Filter out internal and test users** setting – it can work incorrectly (or not work at all) while cohorts are calculating.
 
-To check, you can go to "People > Cohorts" and see if any of them are in "calculating" status. 99% of the time they will be available in a couple of minutes, and if not (got stuck) - you can ask PostHog support to recalculate them for you manually.
+To check, you can go to "People > Cohorts" and see if any of them are in "calculating" status. 99% of the time they will be available in a couple of minutes, and if not (got stuck) – you can ask PostHog support to recalculate them for you manually.
 
 ## Filtering can't find my custom events
 
 The most common reason for this is that you're trying to filter by events that weren't sent by the web SDK. For example, from another tool like Segment or one of our backend SDKs.
 
-Session replay relies on the `$session_id` property added to events by the web SDK to link events to sessions.
+Session Replay relies on the `$session_id` property added to events by the web SDK to link events to sessions.
 
 To workaround this, you can use the `posthog.onSessionId` method in the web SDK to register a callback that will be called each time the session ID changes. You can send this to your backend and add the `$session_id` property to your backend events. 
 
@@ -221,41 +221,41 @@ To fix this, either call a method that creates a person profile (like `identify(
 
 ## Browser freezes or crashes when recordings are enabled
 
-Some Cookie banners or "CMP"s modify the webpage in reaction to any changes to cookies, which can cause an infinite loop. If you are using a tool like this and experience the webpage becoming unresponsive or slow then try [configuring posthog](/docs/libraries/js/persistence) to use `persistence: "localStorage+cookie"`. This will use localStorage for the majority of storage needs, bypassing the infinite loop issue sometimes caused by cookie management tools.
+Some Cookie banners or "CMP"s modify the webpage in reaction to any changes to cookies, which can cause an infinite loop. If you are using a tool like this and experience the webpage becoming unresponsive or slow then try [configuring PostHog](/docs/libraries/js/persistence) to use `persistence: "localStorage+cookie"`. This will use `localStorage` for the majority of storage needs, bypassing the infinite loop issue sometimes caused by cookie management tools.
 
 ## Enable recordings when URL matches not working as expected
 
-The **Enable recordings when URL matches** setting is only supported in the web SDK version `1.171.0` and above. If your recordings aren’t being recorded as expected, even when the URL matches your regex, it’s likely due to an [outdated SDK version](/docs/sdk-doctor).
+The **Enable recordings when URL matches** setting is only supported in the web SDK version `1.171.0` and above. If your recordings aren't being recorded as expected, even when the URL matches your regex, it's likely due to an [outdated SDK version](/docs/sdk-doctor).
 
-Make sure you’re using version `1.171.0` or newer to ensure this feature works correctly.
+Make sure you're using version `1.171.0` or newer to ensure this feature works correctly.
 
 ## Network payload capture is not capturing headers
 
-Browser do not automatically allow JS to read headers from cross-origin requests. So, when making a request from app.mywebsite.example to api.mywebsite.example headers are not available to be copied and reported.
+Browser do not automatically allow JS to read headers from cross-origin requests. So, when making a request from `app.mywebsite.example` to `api.mywebsite.example` headers are not available to be copied and reported.
 
-You need to add `Access-Control-Expose-Headers: *` as a header on responses from api.mywebsite.example to allow all headers to be read cross origin. You can specify which headers you want to be available `Access-Control-Expose-Headers: Content-Encoding, X-Correlation-Id` if you don't want all headers to be accessible.
+You need to add `Access-Control-Expose-Headers: *` as a header on responses from `api.mywebsite.example` to allow all headers to be read cross origin. You can specify which headers you want to be available `Access-Control-Expose-Headers: Content-Encoding, X-Correlation-Id` if you don't want all headers to be accessible.
 
 ## Recorder Limitations
 
-Due to the complexity of browser rendering and replay, some web resources are unable to be recordered or playedback. These include:
+Due to the complexity of browser rendering and replay, some web resources are unable to be recorded or played back. These include:
 
-- **Object elements** - Most object elements cannot be played back. Non-HTML native plugins such as Flash or Silverlight cannot be recorded
-- **Heavy animations** - Some heavier animations such as SVG or Lottie animations may be _throttled_ or ignored entirely due to the performance overhead in recording and replaying
-- **Iframes** - iframes from the origins under your control **can** be recorded and played back. See [iframe recording](/docs/session-replay/iframes) for more info.
+- **Object elements** – Most object elements cannot be played back. Non-HTML native plugins such as Flash or Silverlight cannot be recorded
+- **Heavy animations** – Some heavier animations such as SVG or Lottie animations may be _throttled_ or ignored entirely due to the performance overhead in recording and replaying
+- **Iframes** – iframes from the origins under your control **can** be recorded and played back. See [iframe recording](/docs/session-replay/iframes) for more info.
 
 ## Angular performance
 
-It is sometimes necessary to run session replay outside of the Angular zone. See the [PostHog Angular docs for more detail](/docs/libraries/angular#session-replay)
+It is sometimes necessary to run Session Replay outside of the Angular zone. See the [PostHog Angular docs for more detail](/docs/libraries/angular#session-replay)
 
 ## Report your specific issue
 
 To report a specific problem, you can open a [GitHub issue](https://github.com/PostHog/posthog/issues/new/choose). To help us figure it out as quickly as possible, please include the following information:
 
 -   The URL of the page that you're trying to record
--   The version of posthog that you're using
--   The version of posthog-js that you're using
+-   The version of PostHog that you're using
+-   The version of `posthog-js` that you're using
 -   Details about the specific issue with your recording (e.g. how it looks and how it should look)
--   If you're on posthog-cloud, a link to the specific recording
+-   If you're on PostHog Cloud, a link to the specific recording
 -   Any unique details about your website (e.g. the frameworks that you're using etc.)
 
 ## Solved community questions

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -107,7 +107,7 @@ buffering ──► active ──► (recording captured, $has_recording flips t
 
 | Property | What it tells you |
 | --- | --- |
-| `$sdk_debug_recording_script_not_loaded` | `true` if the `recorder.js` script failed to load. Usually caused by an ad blocker or CSP — see [ad/tracking blockers](#4-adtracking-blockers) below. |
+| `$sdk_debug_recording_script_not_loaded` | `true` if the `recorder.js` script failed to load. Usually caused by an ad blocker or CSP |
 | `$sdk_debug_replay_url_trigger_status` <br /> `$sdk_debug_replay_event_trigger_status` <br /> `$sdk_debug_replay_linked_flag_trigger_status` | Trigger states: `trigger_disabled` (none configured), `trigger_pending` (configured, waiting to match), or `trigger_matched` (fired). |
 | `$sdk_debug_replay_internal_buffer_length` <br /> `$sdk_debug_replay_flushed_size` | If `buffer_length` keeps growing across the session's events while `flushed_size` stays at `0`, the `POST /s/` upload is being blocked — usually an ad blocker or a misconfigured reverse proxy. |
 | `$replay_sample_rate` <br /> `$replay_minimum_duration` | The sample rate (0.0–1.0) and minimum duration (ms) in effect at capture time. |

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -22,6 +22,98 @@ window.posthog.LIB_VERSION
 
 You can also check using the [SDK doctor](/docs/sdk-doctor) tool.
 
+## Check the replay status on your events
+
+Recent versions of `posthog-js` attach diagnostic properties to every event that describe what session replay was doing at the moment the event was captured. Reading these is usually the fastest way to figure out _why_ a session wasn't recorded before you start changing settings.
+
+You can query them from the [SQL editor](/docs/sql) for a specific session ID:
+
+```sql
+SELECT
+    properties.$has_recording AS has_recording,
+    properties.$recording_status AS recording_status,
+    properties.$session_recording_start_reason AS start_reason,
+    properties.$sdk_debug_recording_script_not_loaded AS script_blocked,
+    properties.$sdk_debug_replay_url_trigger_status AS url_trigger,
+    properties.$sdk_debug_replay_event_trigger_status AS event_trigger,
+    properties.$sdk_debug_replay_linked_flag_trigger_status AS flag_trigger,
+    properties.$replay_sample_rate AS sample_rate,
+    properties.$lib_version AS sdk_version
+FROM events
+WHERE $session_id = '<your-session-id>'
+ORDER BY timestamp DESC
+LIMIT 1
+```
+
+Always look at the **latest** event in the session — early events may not yet reflect the final state (for example, `$has_recording` only flips to `true` once PostHog has confirmed at least one recording chunk was ingested).
+
+### The three core signals
+
+These three properties together describe replay status. Read them as a set, not in isolation.
+
+| Property | What it tells you |
+| --- | --- |
+| `$has_recording` | `true` once PostHog has confirmed a recording exists for the session. The strongest positive signal. |
+| `$recording_status` | The SDK's current state: `active`, `buffering`, `disabled`, `sampled`, or `paused`. |
+| `$session_recording_start_reason` | Why recording started (or didn't). Useful for distinguishing "we chose not to record" from "we tried but couldn't". |
+
+#### `$recording_status` values
+
+| Value | Meaning |
+| --- | --- |
+| `active` | The SDK is recording and producing snapshots. |
+| `buffering` | The SDK initialized but is waiting for a trigger, minimum duration threshold, or remote config before producing snapshots. |
+| `disabled` | Recording is turned off — either in [your project replay settings](https://us.posthog.com/settings/project-replay) or via SDK config at runtime. |
+| `sampled` | This session was included by the configured replay sample rate — recording started. |
+| `paused` | Recording is temporarily paused for this session (consent gate, programmatic `pause()`, or a max-duration cap). |
+
+#### `$session_recording_start_reason` values
+
+| Value | Meaning |
+| --- | --- |
+| `recording_initialized` | Recording started as soon as the SDK initialized. |
+| `sampling_override` | Recording started because the session was included by the sampling rules. |
+| `sampled_out` | Recording was prevented because the session was excluded by sampling. |
+| `linked_flag_match` | Recording started because a linked feature flag matched. |
+
+### Reading the combination
+
+| `$has_recording` | `$recording_status` | `$session_recording_start_reason` | What it means |
+| --- | --- | --- | --- |
+| `true` | any | any | A recording exists. If you can't find it, the issue is UI filtering, retention, or it's still processing. |
+| `null` / `false` | `active` or `sampled` | `recording_initialized` / `sampling_override` / `linked_flag_match` | Recording is running but PostHog hasn't confirmed ingestion yet, check a later event. |
+| `null` / `false` | `buffering` | any | The SDK is waiting on a [trigger](/docs/session-replay/how-to-control-which-sessions-you-record) or duration threshold, check the trigger status properties. |
+| `null` / `false` | `disabled` | any | Replay is off, either in [project settings](https://us.posthog.com/settings/project-replay) or via SDK config like `disable_session_recording: true`. |
+| `null` / `false` | any | `sampled_out` | Your sample rate excluded this session — increase the sample rate or use a trigger to guarantee capture for important flows. |
+| `null` / `false` | `paused` | any | Recording was paused mid-session — usually a consent flow or a programmatic `posthog.sessionRecording.pause()` call. |
+
+### Lifecycle
+
+A normal session's `$recording_status` typically progresses like this:
+
+```text
+disabled ──── (config or setting turns replay off)
+
+buffering ──► active ──► (recording captured, $has_recording flips to true on later events)
+    │            │
+    │            └──► paused ──► active   (consent flow, programmatic control)
+    │
+    └──► (session ends before a trigger matches, buffer discarded, no recording stored)
+```
+
+`sampled` is an alternative entry point meaning "this session was rolled into the sample" and it behaves like `active` from a capture standpoint.
+
+### Other useful diagnostic properties
+
+| Property | What it tells you |
+| --- | --- |
+| `$sdk_debug_recording_script_not_loaded` | `true` if the `recorder.js` script failed to load. Usually caused by an ad blocker or CSP — see [ad/tracking blockers](#4-adtracking-blockers) below. |
+| `$sdk_debug_replay_url_trigger_status` <br /> `$sdk_debug_replay_event_trigger_status` <br /> `$sdk_debug_replay_linked_flag_trigger_status` | Trigger states: `trigger_disabled` (none configured), `trigger_pending` (configured, waiting to match), or `trigger_matched` (fired). |
+| `$sdk_debug_replay_internal_buffer_length` <br /> `$sdk_debug_replay_flushed_size` | If `buffer_length` keeps growing across the session's events while `flushed_size` stays at `0`, the `POST /s/` upload is being blocked — usually an ad blocker or a misconfigured reverse proxy. |
+| `$replay_sample_rate` <br /> `$replay_minimum_duration` | The sample rate (0.0–1.0) and minimum duration (ms) in effect at capture time. |
+
+If you're on an older SDK version, some of these properties won't be present, `null` means "unknown", not "false". Upgrading `posthog-js` will give you a much fuller picture.
+
 ## Recordings are not being captured
 
 There are a few common reasons that you may not see recordings appear in your project.


### PR DESCRIPTION
## Changes

Added replay debug info to the docs

<img width="2547" height="1298" alt="image" src="https://github.com/user-attachments/assets/6926d55e-d2ee-4e66-ab49-26ef21310b4e" />

<img width="2560" height="1292" alt="image" src="https://github.com/user-attachments/assets/d04720cc-70ad-4374-92d4-177c03129680" />
<img width="2557" height="1291" alt="image" src="https://github.com/user-attachments/assets/b800e710-317c-48d7-9ef3-254cc41405c4" />


## Checklist

- [X ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ X] Words are spelled using American English
- [ X] Use relative URLs for internal links
- [ X] I've checked the pages added or changed in the Vercel preview build 
- [X ] If I moved a page, I added a redirect in `vercel.json`
