### PR TITLE
Preserve /people view toggle on back navigation

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -1,7 +1,8 @@
 import CloudinaryImage from 'components/CloudinaryImage'
 import { AVATAR_FALLBACK_URL } from 'constants/index'
-import { graphql, useStaticQuery } from 'gatsby'
+import { graphql, useStaticQuery, navigate } from 'gatsby'
 import React, { useState, useMemo, useCallback, useEffect } from 'react'
+import { useLocation } from '@reach/router'
 import Link from 'components/Link'
 import { SEO } from '../seo'
 import ReactMarkdown from 'react-markdown'
@@ -286,7 +287,13 @@ interface PeopleProps {
 }
 
 export default function People({ searchTerm, filteredMembers }: PeopleProps = {}) {
+    const location = useLocation()
     const [activeTab, setActiveTab] = useState<'list' | 'map'>('list')
+
+    useEffect(() => {
+        const view = new URLSearchParams(location.search).get('view')
+        setActiveTab(view === 'map' ? 'map' : 'list')
+    }, [location.search])
 
     const {
         team: { teamMembers },
@@ -399,7 +406,18 @@ export default function People({ searchTerm, filteredMembers }: PeopleProps = {}
                             value: 'map',
                         },
                     ]}
-                    onValueChange={(value) => setActiveTab(value as 'list' | 'map')}
+                    onValueChange={(value) => {
+                        const tab = value as 'list' | 'map'
+                        setActiveTab(tab)
+                        const params = new URLSearchParams(location.search)
+                        if (tab === 'map') {
+                            params.set('view', 'map')
+                        } else {
+                            params.delete('view')
+                        }
+                        const qs = params.toString()
+                        navigate(qs ? `${location.pathname}?${qs}` : location.pathname, { replace: true })
+                    }}
                     value={activeTab}
                 />
             </div>


### PR DESCRIPTION
## Changes

Fixes a small UX issue on the [`/people`](https://posthog.com/people) page. I'm applying for the Technical CSM role and this will really speed up my research about the team ;)


**Before:** From the People page, switching to the Map view, clicking a team member's profile, and then hitting the browser back button drops you back on the List view — losing the user's place.

**After:** The active view is persisted in the URL as `?view=map`, so browser back-navigation restores the view the user came from.

_Considered persisting the user's pan/zoom position on the map (so back-navigation returns them to the exact spot they were looking at, not just the default view). Decided against bundling it into this PR as the implementation adds more complexity (would need moveend listeners writing to sessionStorage or extra URL params for lng/lat/zoom), and just returning to the map view (instead of resetting to list) is already a meaningful improvement by itself._

### Implementation

- Read the `view` query param on mount (and on any `location.search` change, so browser back/forward stays in sync) and reflect it in the existing `activeTab` state.
- On toggle change, update the URL with `navigate(..., { replace: true })` so toggling doesn't pollute history — only navigating away from `/people` creates a back-stop.
- `?view=list` is omitted from the URL (it's the default), keeping URLs clean.
- Other query params are preserved via `URLSearchParams.set/delete` rather than string replacement.

Uses the same `useLocation` from `@reach/router` + gatsby `navigate` pattern already used in `src/components/Editor/index.tsx`, `TemplatesLibrary/index.tsx`, and `IntegrationsLibrary/index.tsx`.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides. (n/a — code change)
- [ ] Words are spelled using American English (n/a — code change)
- [ ] Use relative URLs for internal links (n/a — code change)
- [x] I've checked the pages added or changed in the Vercel preview build (will check once preview is ready, tested on local and all looked good)
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

## Verification

Verified locally with `pnpm start`:

1. `/people` → List view, URL is clean
2. Click **Map** → URL becomes `/people?view=map`, view switches to map
3. Click a team member → opens `/community/profiles/<id>`
4. Browser back → returns to `/people?view=map` with **map view active** ✓
5. Direct load of `/people?view=map` opens in map view; direct load of `/people` opens in list view
6. Toggling List ↔ Map repeatedly does **not** add browser history entries (uses `replace: true`)