### PR TITLE
adding a redirect, as 404d

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -745,6 +745,7 @@
             "destination": "/docs/libraries/google-tag-manager"
         },
         { "source": "/docs/experiments/manual", "destination": "/docs/experiments/start-here" },
+        { "source": "/docs/experiments/new-experimentation-engine", "destination": "/docs/experiments/start-here" },
         { "source": "/docs/experiments/under-the-hood", "destination": "/docs/experiments/experiment-significance" },
         { "source": "/docs/experiments/significance", "destination": "/docs/experiments/experiment-significance" },
         { "source": "/docs/experiments/statistics", "destination": "/docs/experiments/statistics-bayesian" },


### PR DESCRIPTION
## Changes

Claude linked me to this page https://posthog.com/docs/experiments/new-experimentation-engine which 404'd. 

<img width="1423" height="809" alt="Screenshot 2026-05-27 at 12 32 18 PM" src="https://github.com/user-attachments/assets/3531faec-77d5-49bc-99db-8c6f05df28fd" />

This now redirects to the experiments start page

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

