### PR TITLE
docs: add .NET evaluation contexts

### DIFF
--- a/contents/docs/feature-flags/evaluation-contexts.mdx
+++ b/contents/docs/feature-flags/evaluation-contexts.mdx
@@ -164,6 +164,15 @@ PostHog posthog = new PostHog.Builder("YOUR_API_KEY")
     .build();
 ```
 
+```csharp
+var posthog = new PostHogClient(new PostHogOptions
+{
+    ProjectToken = "YOUR_API_KEY",
+    HostUrl = new Uri("https://app.posthog.com"),
+    EvaluationContexts = ["main-app", "api", "backend"],
+});
+```
+
 </MultiLanguage>
 
 ## How evaluation works
@@ -319,5 +328,6 @@ Evaluation contexts are supported in the following SDKs:
 | [Node.js](/docs/libraries/node/) | 5.10.0+ | 5.9.6+ |
 | [Android](/docs/libraries/android) | 3.25.0+ | 3.24.0+ |
 | [iOS](/docs/libraries/ios) | 3.34.0+ | 3.33.0+ |
+| [.NET](/docs/libraries/dotnet) | PostHog 2.8.0+ / PostHog.AspNetCore 2.7.0+ | Not supported |
 
 > **Note:** Both parameter names work in newer SDK versions. If you're on an older version that only supports `evaluation_environments`, that will continue to work. We recommend using `evaluation_contexts` for new implementations.

--- a/contents/docs/feature-flags/evaluation-contexts.mdx
+++ b/contents/docs/feature-flags/evaluation-contexts.mdx
@@ -328,6 +328,6 @@ Evaluation contexts are supported in the following SDKs:
 | [Node.js](/docs/libraries/node/) | 5.10.0+ | 5.9.6+ |
 | [Android](/docs/libraries/android) | 3.25.0+ | 3.24.0+ |
 | [iOS](/docs/libraries/ios) | 3.34.0+ | 3.33.0+ |
-| [.NET](/docs/libraries/dotnet) | PostHog 2.8.0+ / PostHog.AspNetCore 2.7.0+ | Not supported |
+| [.NET](/docs/libraries/dotnet#evaluation-contexts) | `PostHog` 2.8.0+, `PostHog.AspNetCore` 2.7.0+ | Not supported |
 
 > **Note:** Both parameter names work in newer SDK versions. If you're on an older version that only supports `evaluation_environments`, that will continue to work. We recommend using `evaluation_contexts` for new implementations.

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -148,6 +148,35 @@ import DotNetFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets
 
 <DotNetFeatureFlagsCode />
 
+### Evaluation contexts
+
+Configure evaluation contexts to evaluate only flags intended for this application, platform, or product area. For ASP.NET Core apps using `PostHog.AspNetCore`, add them to the `PostHog` configuration section:
+
+```json
+{
+    "PostHog": {
+        "ProjectToken": "<ph_project_token>",
+        "HostUrl": "<ph_client_api_host>",
+        "EvaluationContexts": ["main-app", "api", "backend"]
+    }
+}
+```
+
+For code-based configuration, set `EvaluationContexts` on `PostHogOptions`:
+
+```csharp
+var posthog = new PostHogClient(new PostHogOptions
+{
+    ProjectToken = "<ph_project_token>",
+    HostUrl = new Uri("<ph_client_api_host>"),
+    EvaluationContexts = ["main-app", "api", "backend"],
+});
+```
+
+Remote `/flags` requests from `EvaluateFlagsAsync()` include `evaluation_contexts` when configured. Flags without evaluation contexts continue to evaluate for all SDKs; flags with contexts evaluate only when at least one configured context matches.
+
+For more details, see the [evaluation contexts guide](/docs/feature-flags/evaluation-contexts).
+
 ### Local evaluation
 
 import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-intro.mdx"

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -150,7 +150,7 @@ import DotNetFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets
 
 ### Evaluation contexts
 
-Configure evaluation contexts to evaluate only flags intended for this application, platform, or product area. For ASP.NET Core apps using `PostHog.AspNetCore`, add them to the `PostHog` configuration section:
+Configure evaluation contexts so this SDK only evaluates flags intended for the matching application, platform, or product area. For ASP.NET Core apps using `PostHog.AspNetCore`, add them to the `PostHog` configuration section:
 
 ```json
 {
@@ -173,7 +173,7 @@ var posthog = new PostHogClient(new PostHogOptions
 });
 ```
 
-Remote `/flags` requests from `EvaluateFlagsAsync()` include `evaluation_contexts` when configured. Flags without evaluation contexts continue to evaluate for all SDKs; flags with contexts evaluate only when at least one configured context matches.
+Remote `/flags` requests from `EvaluateFlagsAsync()` include `evaluation_contexts` when configured.
 
 For more details, see the [evaluation contexts guide](/docs/feature-flags/evaluation-contexts).
 


### PR DESCRIPTION
## Changes

- Add .NET configuration examples to the feature flag evaluation contexts guide.
- Add .NET SDK support/version details for `evaluation_contexts`.
- Document `PostHogOptions.EvaluationContexts` on the .NET SDK docs page, including ASP.NET Core `appsettings.json` configuration.

No screenshots: docs-only copy/code sample update.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

## Verification

- `git diff --check`
- `pnpm format:docs` was attempted, but this worktree does not have `node_modules` installed (`Cannot find module 'glob'`).
