### PR TITLE
docs(go): Add server request context docs

### DIFF
--- a/contents/docs/error-tracking/installation/go.mdx
+++ b/contents/docs/error-tracking/installation/go.mdx
@@ -98,6 +98,8 @@ exception := posthog.Exception{
 client.Enqueue(exception)
 ```
 
+For `net/http` apps, use [Go SDK request context](/docs/libraries/go#request-context) to attach request metadata, session IDs, and request-scoped user context to exception events. Wrap handlers with `posthog.NewRequestContextMiddleware`, then enqueue exceptions with `posthog.EnqueueWithContext(r.Context(), client, exception)`.
+
 ### Option B: Automatic capture with slog
 
 The SDK provides a `SlogCaptureHandler` that wraps Go's standard `log/slog` logger and automatically captures log records as exceptions.

--- a/contents/docs/error-tracking/installation/go.mdx
+++ b/contents/docs/error-tracking/installation/go.mdx
@@ -98,7 +98,7 @@ exception := posthog.Exception{
 client.Enqueue(exception)
 ```
 
-For `net/http` apps, use [Go SDK request context](/docs/libraries/go#request-context) to attach request metadata, session IDs, and request-scoped user context to exception events. Wrap handlers with `posthog.NewRequestContextMiddleware`, then enqueue exceptions with `posthog.EnqueueWithContext(r.Context(), client, exception)`.
+To see how `net/http` services can automatically associate backend exceptions with frontend users, view the [Go request context documentation](/docs/libraries/go#request-context).
 
 ### Option B: Automatic capture with slog
 

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -83,6 +83,56 @@ client.Enqueue(posthog.Alias{
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
+## Request context
+
+Use request context to apply a distinct ID, session ID, and common request properties to capture and exception events inside a `net/http` request. This is useful when connecting frontend activity to backend events, session replay, error tracking, and feature flag evaluation.
+
+If you're using PostHog on your frontend, enable tracing headers for your backend domain:
+
+```js
+posthog.init('<ph_project_token>', {
+    __add_tracing_headers: ['your-backend-domain.com']
+})
+```
+
+Then wrap your handler with `NewRequestContextMiddleware` and use the context-aware helpers:
+
+```go
+handler := posthog.NewRequestContextMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    flags, err := posthog.EvaluateFlagsWithContext(r.Context(), client, posthog.EvaluateFlagsPayload{})
+    if err != nil {
+        // If neither the request context nor payload has a distinct ID,
+        // err is posthog.ErrNoDistinctID.
+    }
+
+    _ = posthog.EnqueueWithContext(r.Context(), client, posthog.Capture{
+        Event: "checkout started",
+        Flags: flags,
+    })
+}))
+```
+
+The middleware adds `$current_url`, `$request_method`, `$request_path`, `$user_agent`, and `$ip` properties. By default, it also reads `X-PostHog-Distinct-Id` and `X-PostHog-Session-Id` as request-scoped defaults. Explicit `DistinctId` values and `$session_id` properties passed to captures take precedence over request context.
+
+If request context is attached but no distinct ID is available, capture and exception events are sent as [personless events](/docs/data/anonymous-vs-identified-events) with an auto-generated UUID and `$process_person_profile: false`. Calls to `Enqueue` without request context still require `DistinctId`. `EvaluateFlagsWithContext` uses the request-scoped distinct ID when `EvaluateFlagsPayload.DistinctId` is empty, but it never generates personless IDs and returns `ErrNoDistinctID` when no distinct ID is available.
+
+Tracing headers are client-controlled analytics context, not authentication or authorization. For security-sensitive server-side decisions, pass an authenticated `DistinctId` explicitly or attach one to the request context:
+
+```go
+ctx := posthog.WithRequestContext(r.Context(), posthog.RequestContext{
+    DistinctId: user.ID,
+})
+```
+
+To ignore tracing headers while keeping request metadata, disable tracing header capture:
+
+```go
+handler := posthog.NewRequestContextMiddleware(
+    next,
+    posthog.WithCaptureTracingHeaders(false),
+)
+```
+
 ## Feature flags
 
 import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"


### PR DESCRIPTION
## Changes

- Document `posthog-go` server request context middleware and context-aware helpers for `net/http` apps.
- Explain tracing headers, request metadata, personless fallback behavior, `EvaluateFlagsWithContext`, and disabling tracing header capture.
- Link the Go error tracking installation guide to the new request context docs.

Validation: `git diff --check`

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
