### PR TITLE
handbook: add partial reviews convention

### DIFF
--- a/contents/handbook/engineering/how-we-review.md
+++ b/contents/handbook/engineering/how-we-review.md
@@ -76,6 +76,12 @@ Not every team has someone available to review your PR right away. Posting in #d
   - There are no tests, no description, or no visual evidence of the change working
   - You're not confident the change is safe — say so. "I can't meaningfully review this, you need someone with more context" is always valid feedback
 
+## Partial reviews
+
+If you were asked to review only one aspect of a PR (e.g. copy, design, infra, security), submit your review as **Comment**, not **Approve**. An Approve from any reviewer clears the review requirement and marks the PR mergeable, so it should mean "I reviewed this against the full checklist above." Reserve Approve for when you actually did.
+
+If multiple reviewers are splitting aspects of a PR, the author is responsible for making sure at least one Approve came from someone who reviewed the code. CODEOWNERS can enforce this on a per-path basis where it matters.
+
 ## Review comment conventions
 
 Use prefixes on your review comments so the author knows what actually needs to change before merging:


### PR DESCRIPTION
## Changes

Adds a short "Partial reviews" section to `contents/handbook/engineering/how-we-review.md`. When a reviewer was asked to cover only one aspect of a PR (copy, design, infra, security), the convention is to submit the review as Comment rather than Approve. An Approve clears the review requirement and marks the PR mergeable, so it should mean the reviewer worked through the full checklist.

Came up after a charts PR where one person reviewed a single aspect, approved it, and the PR became immediately mergeable before anyone reviewed the actual code. CODEOWNERS handles this on high-impact paths; this convention is the cultural backstop everywhere else.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`