### PR TITLE
docs: remove experimental flag cache provider labels

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-intro.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-intro.mdx
@@ -8,7 +8,7 @@ This enables you to:
 - Coordinate fetching so only one worker polls at a time
 - Pre-cache definitions for ultra-low-latency flag evaluation
 
-> **Note:** External cache providers are currently available in Node.js and Python SDKs only. This feature is experimental and may change in minor versions.
+> **Note:** External cache providers are currently available in the Node.js, Python, and Ruby SDKs.
 
 ## When to use an external cache
 

--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-node.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-node.mdx
@@ -3,7 +3,7 @@
 Import the interface from the SDK:
 
 ```typescript
-import { FlagDefinitionCacheProvider, FlagDefinitionCacheData } from 'posthog-node/experimental'
+import { FlagDefinitionCacheProvider, FlagDefinitionCacheData } from 'posthog-node'
 ```
 
 ## The interface

--- a/contents/docs/libraries/ruby-on-rails.mdx
+++ b/contents/docs/libraries/ruby-on-rails.mdx
@@ -430,7 +430,7 @@ end
 | `feature_flag_request_timeout_seconds` | Integer | `3` | Timeout, in seconds, for feature flag requests. |
 | `before_send` | Proc | `nil` | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or `nil` to drop the event. |
 
-The `PostHog.init` block supports the options above. Less common core options like `batch_size`, `disable_singleton_warning`, `skip_ssl_verification`, and the experimental `flag_definition_cache_provider` can be passed as an options hash to `PostHog.init(...)`; see the [Ruby SDK docs](/docs/libraries/ruby#configuration) for details.
+The `PostHog.init` block supports the options above. Less common core options like `batch_size`, `disable_singleton_warning`, `skip_ssl_verification`, and `flag_definition_cache_provider` can be passed as an options hash to `PostHog.init(...)`; see the [Ruby SDK docs](/docs/libraries/ruby#configuration) for details.
 
 ### Rails-specific options
 

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -58,7 +58,7 @@ Available client options:
 | `before_send` | Proc | `nil` | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or `nil` to drop the event. |
 | `disable_singleton_warning` | Boolean | `false` | Suppress warnings about multiple clients with the same API key. Use only when you intentionally need multiple clients. |
 | `skip_ssl_verification` | Boolean | `false` | Disable SSL certificate verification. Intended only for local development or custom deployments. |
-| `flag_definition_cache_provider` | Object | `nil` | Experimental provider for distributed feature flag definition caching. See [distributed flag definition caching](#distributed-flag-definition-caching). |
+| `flag_definition_cache_provider` | Object | `nil` | Provider for distributed feature flag definition caching. See [distributed flag definition caching](#distributed-flag-definition-caching). |
 
 ### Filtering or modifying events before sending
 
@@ -231,7 +231,7 @@ end
 
 ### Distributed flag definition caching
 
-`flag_definition_cache_provider` is an experimental API for sharing locally evaluated feature flag definitions across multiple workers or processes. The provider object must implement:
+`flag_definition_cache_provider` shares locally evaluated feature flag definitions across multiple workers or processes. The provider object must implement:
 
 - `flag_definitions` – returns cached definitions as a hash with `:flags`, `:group_type_mapping`, and `:cohorts`, or `nil` if empty.
 - `should_fetch_flag_definitions?` – returns `true` if this process should fetch fresh definitions from PostHog.
@@ -245,8 +245,6 @@ posthog = PostHog::Client.new({
   flag_definition_cache_provider: my_cache_provider
 })
 ```
-
-Because this API is experimental, it may change in future minor versions.
 
 ### Remote config payloads
 


### PR DESCRIPTION
## Changes

- Removed experimental wording for flag definition cache providers from the local evaluation distributed environments docs.
- Updated the Node.js import example to use the supported `posthog-node` export instead of `posthog-node/experimental`.
- Removed experimental wording from the Ruby and Rails SDK docs.

Companion SDK PRs:
- Python: https://github.com/PostHog/posthog-python/pull/631
- Ruby: https://github.com/PostHog/posthog-ruby/pull/157

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

Validation: verified no remaining `experimental` references in the local evaluation / Ruby docs with `rg -n -i 'experimental' contents/docs/feature-flags/local-evaluation contents/docs/libraries/ruby contents/docs/libraries/ruby-on-rails.mdx`.
