### PR TITLE
Set default window size for /ko homepage

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -371,6 +371,40 @@ const appSettings: AppSettings = {
             },
         },
     },
+    '/ko': {
+        size: {
+            min: {
+                width: 700,
+                height: 500,
+            },
+            max: {
+                width: 960,
+                height: 1000,
+            },
+            fixed: false,
+        },
+        position: {
+            center: true,
+            getPositionDefaults: (size, windows, getDesktopCenterPosition) => {
+                if (typeof window === 'undefined') {
+                    return {
+                        x: 0,
+                        y: 0,
+                    }
+                }
+
+                const { x, y } = getDesktopCenterPosition(size)
+                const iconColumnRight = 145
+                const keyboardGardenImageLeft = window.innerWidth - 700
+                if (x + size.width > keyboardGardenImageLeft) {
+                    const availableWidth = keyboardGardenImageLeft - iconColumnRight
+                    const newX = iconColumnRight + Math.max(0, (availableWidth - size.width) / 2)
+                    return { x: newX, y }
+                }
+                return { x, y }
+            },
+        },
+    },
     '/products': {
         size: {
             min: {


### PR DESCRIPTION
## Summary

Follow-up to #17081. The Korean homepage was missing an entry in `appSettings` in `src/context/App.tsx`, so its window fell through to the `window.innerWidth * 0.9` fallback in `getInitialSize` and opened much wider than the English homepage.

This adds a `/ko` entry that mirrors `/`'s control-variant settings:
- size: min 700×500, max 960×1000
- centering logic with the same keyboard-garden right-edge offset

## Why not include the experiment field?

The English `/` entry has an `experiment` field tied to the `homepage-test` A/B test, which can route some users to a `home-test` entry with 1200×900 dimensions. The Korean page is its own design and not part of that experiment, so propagating it would point `getKey` at a variant page that doesn't apply to Korean visitors. Korean visitors get the control-variant size regardless of which variant they'd see on the English homepage.

## Test plan

- [ ] Open https://posthog.com/ko after deploy → window opens at the same default size as https://posthog.com (960×1000, capped at 90% of viewport, centered with the icon-column / keyboard-garden offsets).
- [ ] Switch back and forth between / and /ko in the same session and confirm both windows look the same width by default.