### PR TITLE
Update referral process details in hiring guide

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -213,7 +213,7 @@ If you know someone who would be a great addition to the team, please submit the
 -   You can provide context about their motivations, work style, or how they'd fit with our team
 -   You can help with closing them if they're interested (explaining PostHog culture, answering questions, etc.)
 
-Especially when referring cross-team, feel free to reach out to #team-talent and gather context before doing the work of referring (will save us all some work, and the candidate a rejection email!)
+When referring cross-team, it is optional to first reach out to #team-talent and gather context before doing the work of referring (will save us all some work, and the candidate a rejection email!). If you feel confident that the referral is a match for that team, please go ahead and submit the referral directly. You can read below what the process to refer is like. 
 Referring someone means we'll review them carefully. It doesn't guarantee they'll get an interview. We hold referred candidates to the same high bar as everyone else, and we'll let you know if they don't progress and why.
 
 #### Examples of insufficient referrals:


### PR DESCRIPTION
Clarified the process for cross-team referrals and emphasized the option (not obligation) to consult #team-talent before submitting a referral.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
