### PR TITLE
Add Integrations feature owned by Workflows team

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -217,6 +217,11 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         feature: 'Insights',
         owner: ['product-analytics'],
     },
+    integrations: {
+        feature: 'Integrations',
+        owner: ['workflows'],
+        label: 'feature/integrations',
+    },
     'internal-messaging': {
         feature: 'Internal messaging (email, notifications)',
         owner: ['platform-features'],


### PR DESCRIPTION
## Changes

Adds an `integrations` entry to `FEATURE_DATA` in `src/hooks/useFeatureOwnership.tsx`, assigning the Workflows team as the owner of the Integrations feature.

Per the Slack discussion, Workflows/CDP has built and maintained the integrations layer end-to-end, so this records that ownership on the website where teams and feature ownership are documented.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*