### PR TITLE
Add realtime-cohort-calculations to feature ownership map

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -353,6 +353,11 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         owner: ['billing', 'platform-features'],
         label: false,
     },
+    'realtime-cohort-calculations': {
+        feature: 'Realtime cohort calculations',
+        owner: ['feature-flags'],
+        label: false,
+    },
     replay: {
         feature: 'Replay',
         owner: ['replay'],


### PR DESCRIPTION
## Summary
- Adds a new entry in `src/hooks/useFeatureOwnership.tsx` for `realtime-cohort-calculations`, owned by the `feature-flags` team.
- Inserted alphabetically between `quota-limiting` and `replay`.
- `label: false` because no matching `feature/*` GitHub label exists yet — happy to wire one up if/when it's created.

## Test plan
- [ ] Confirm the entry sits between `quota-limiting` and `replay` in the diff.
- [ ] No type errors / formatting changes outside the inserted block.