### PR TITLE
llm-analytics -> ai-observability

### DIFF
--- a/contents/docs/ai-observability/_snippets/embedding-event.mdx
+++ b/contents/docs/ai-observability/_snippets/embedding-event.mdx
@@ -1,11 +1,11 @@
 <!--
 This snippet imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/_snippets/embedding-event.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/_snippets/embedding-event.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
 import { OnboardingContentWrapper } from "components/Docs/OnboardingContentWrapper"
-import { EmbeddingEvent } from "onboarding/llm-analytics/_snippets/embedding-event.tsx"
+import { EmbeddingEvent } from "onboarding/ai-observability/_snippets/embedding-event.tsx"
 
 <OnboardingContentWrapper>
     <EmbeddingEvent />

--- a/contents/docs/ai-observability/_snippets/generation-event.mdx
+++ b/contents/docs/ai-observability/_snippets/generation-event.mdx
@@ -1,11 +1,11 @@
 <!--
 This snippet imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/_snippets/generation-event.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/_snippets/generation-event.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
 import { OnboardingContentWrapper } from "components/Docs/OnboardingContentWrapper"
-import { GenerationEvent } from "onboarding/llm-analytics/_snippets/generation-event.tsx"
+import { GenerationEvent } from "onboarding/ai-observability/_snippets/generation-event.tsx"
 
 <OnboardingContentWrapper>
     <GenerationEvent />

--- a/contents/docs/ai-observability/_snippets/notable-generation-properties.mdx
+++ b/contents/docs/ai-observability/_snippets/notable-generation-properties.mdx
@@ -1,11 +1,11 @@
 <!--
 This snippet imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/_snippets/notable-generation-properties.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/_snippets/notable-generation-properties.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
 import { OnboardingContentWrapper } from "components/Docs/OnboardingContentWrapper"
-import { NotableGenerationProperties } from "onboarding/llm-analytics/_snippets/notable-generation-properties.tsx"
+import { NotableGenerationProperties } from "onboarding/ai-observability/_snippets/notable-generation-properties.tsx"
 
 <OnboardingContentWrapper>
     <NotableGenerationProperties />

--- a/contents/docs/ai-observability/_snippets/span-event.mdx
+++ b/contents/docs/ai-observability/_snippets/span-event.mdx
@@ -1,11 +1,11 @@
 <!--
 This snippet imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/_snippets/span-event.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/_snippets/span-event.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
 import { OnboardingContentWrapper } from "components/Docs/OnboardingContentWrapper"
-import { SpanEvent } from "onboarding/llm-analytics/_snippets/span-event.tsx"
+import { SpanEvent } from "onboarding/ai-observability/_snippets/span-event.tsx"
 
 <OnboardingContentWrapper>
     <SpanEvent />

--- a/contents/docs/ai-observability/_snippets/trace-event.mdx
+++ b/contents/docs/ai-observability/_snippets/trace-event.mdx
@@ -1,11 +1,11 @@
 <!--
 This snippet imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/_snippets/trace-event.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/_snippets/trace-event.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
 import { OnboardingContentWrapper } from "components/Docs/OnboardingContentWrapper"
-import { TraceEvent } from "onboarding/llm-analytics/_snippets/trace-event.tsx"
+import { TraceEvent } from "onboarding/ai-observability/_snippets/trace-event.tsx"
 
 <OnboardingContentWrapper>
     <TraceEvent />

--- a/contents/docs/ai-observability/installation/anthropic.mdx
+++ b/contents/docs/ai-observability/installation/anthropic.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/anthropic.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/anthropic.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { AnthropicInstallation } from 'onboarding/llm-analytics/anthropic.tsx'
+import { AnthropicInstallation } from 'onboarding/ai-observability/anthropic.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/autogen.mdx
+++ b/contents/docs/ai-observability/installation/autogen.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/autogen.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/autogen.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { AutoGenInstallation } from 'onboarding/llm-analytics/autogen.tsx'
+import { AutoGenInstallation } from 'onboarding/ai-observability/autogen.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/aws-bedrock.mdx
+++ b/contents/docs/ai-observability/installation/aws-bedrock.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/aws-bedrock.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/aws-bedrock.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { AWSBedrockInstallation } from 'onboarding/llm-analytics/aws-bedrock.tsx'
+import { AWSBedrockInstallation } from 'onboarding/ai-observability/aws-bedrock.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/azure-openai.mdx
+++ b/contents/docs/ai-observability/installation/azure-openai.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/azure-openai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/azure-openai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { AzureOpenAIInstallation } from 'onboarding/llm-analytics/azure-openai.tsx'
+import { AzureOpenAIInstallation } from 'onboarding/ai-observability/azure-openai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/cerebras.mdx
+++ b/contents/docs/ai-observability/installation/cerebras.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/cerebras.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/cerebras.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { CerebrasInstallation } from 'onboarding/llm-analytics/cerebras.tsx'
+import { CerebrasInstallation } from 'onboarding/ai-observability/cerebras.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/claude-agent-sdk.mdx
+++ b/contents/docs/ai-observability/installation/claude-agent-sdk.mdx
@@ -43,11 +43,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/claude-agent-sdk.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/claude-agent-sdk.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { ClaudeAgentSDKInstallation } from 'onboarding/llm-analytics/claude-agent-sdk.tsx'
+import { ClaudeAgentSDKInstallation } from 'onboarding/ai-observability/claude-agent-sdk.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/cloudflare-ai-gateway.mdx
+++ b/contents/docs/ai-observability/installation/cloudflare-ai-gateway.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/cloudflare-ai-gateway.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/cloudflare-ai-gateway.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { CloudflareAIGatewayInstallation } from 'onboarding/llm-analytics/cloudflare-ai-gateway.tsx'
+import { CloudflareAIGatewayInstallation } from 'onboarding/ai-observability/cloudflare-ai-gateway.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/cohere.mdx
+++ b/contents/docs/ai-observability/installation/cohere.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/cohere.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/cohere.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { CohereInstallation } from 'onboarding/llm-analytics/cohere.tsx'
+import { CohereInstallation } from 'onboarding/ai-observability/cohere.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/convex.mdx
+++ b/contents/docs/ai-observability/installation/convex.mdx
@@ -33,11 +33,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/convex.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/convex.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { ConvexInstallation } from 'onboarding/llm-analytics/convex.tsx'
+import { ConvexInstallation } from 'onboarding/ai-observability/convex.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/crewai.mdx
+++ b/contents/docs/ai-observability/installation/crewai.mdx
@@ -33,11 +33,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/crewai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/crewai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { CrewAIInstallation } from 'onboarding/llm-analytics/crewai.tsx'
+import { CrewAIInstallation } from 'onboarding/ai-observability/crewai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/dedalus.mdx
+++ b/contents/docs/ai-observability/installation/dedalus.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/dedalus.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/dedalus.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { DedalusInstallation } from 'onboarding/llm-analytics/dedalus.tsx'
+import { DedalusInstallation } from 'onboarding/ai-observability/dedalus.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/deepseek.mdx
+++ b/contents/docs/ai-observability/installation/deepseek.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/deepseek.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/deepseek.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { DeepSeekInstallation } from 'onboarding/llm-analytics/deepseek.tsx'
+import { DeepSeekInstallation } from 'onboarding/ai-observability/deepseek.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/dspy.mdx
+++ b/contents/docs/ai-observability/installation/dspy.mdx
@@ -33,11 +33,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/dspy.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/dspy.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { DSPyInstallation } from 'onboarding/llm-analytics/dspy.tsx'
+import { DSPyInstallation } from 'onboarding/ai-observability/dspy.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/fireworks-ai.mdx
+++ b/contents/docs/ai-observability/installation/fireworks-ai.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/fireworks-ai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/fireworks-ai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { FireworksAIInstallation } from 'onboarding/llm-analytics/fireworks-ai.tsx'
+import { FireworksAIInstallation } from 'onboarding/ai-observability/fireworks-ai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/google.mdx
+++ b/contents/docs/ai-observability/installation/google.mdx
@@ -33,11 +33,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/google.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/google.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { GoogleInstallation } from 'onboarding/llm-analytics/google.tsx'
+import { GoogleInstallation } from 'onboarding/ai-observability/google.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/groq.mdx
+++ b/contents/docs/ai-observability/installation/groq.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/groq.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/groq.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { GroqInstallation } from 'onboarding/llm-analytics/groq.tsx'
+import { GroqInstallation } from 'onboarding/ai-observability/groq.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/helicone.mdx
+++ b/contents/docs/ai-observability/installation/helicone.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/helicone.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/helicone.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { HeliconeInstallation } from 'onboarding/llm-analytics/helicone.tsx'
+import { HeliconeInstallation } from 'onboarding/ai-observability/helicone.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/hugging-face.mdx
+++ b/contents/docs/ai-observability/installation/hugging-face.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/hugging-face.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/hugging-face.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { HuggingFaceInstallation } from 'onboarding/llm-analytics/hugging-face.tsx'
+import { HuggingFaceInstallation } from 'onboarding/ai-observability/hugging-face.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/instructor.mdx
+++ b/contents/docs/ai-observability/installation/instructor.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/instructor.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/instructor.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { InstructorInstallation } from 'onboarding/llm-analytics/instructor.tsx'
+import { InstructorInstallation } from 'onboarding/ai-observability/instructor.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/langchain.mdx
+++ b/contents/docs/ai-observability/installation/langchain.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/langchain.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/langchain.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { LangChainInstallation } from 'onboarding/llm-analytics/langchain.tsx'
+import { LangChainInstallation } from 'onboarding/ai-observability/langchain.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/langgraph.mdx
+++ b/contents/docs/ai-observability/installation/langgraph.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/langgraph.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/langgraph.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { LangGraphInstallation } from 'onboarding/llm-analytics/langgraph.tsx'
+import { LangGraphInstallation } from 'onboarding/ai-observability/langgraph.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/litellm.mdx
+++ b/contents/docs/ai-observability/installation/litellm.mdx
@@ -38,11 +38,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/litellm.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/litellm.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { LiteLLMInstallation } from 'onboarding/llm-analytics/litellm.tsx'
+import { LiteLLMInstallation } from 'onboarding/ai-observability/litellm.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/llamaindex.mdx
+++ b/contents/docs/ai-observability/installation/llamaindex.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/llamaindex.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/llamaindex.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { LlamaIndexInstallation } from 'onboarding/llm-analytics/llamaindex.tsx'
+import { LlamaIndexInstallation } from 'onboarding/ai-observability/llamaindex.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -23,11 +23,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/manual.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/manual.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { ManualInstallation } from 'onboarding/llm-analytics/manual.tsx'
+import { ManualInstallation } from 'onboarding/ai-observability/manual.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
 import GenerationEvent from '../_snippets/generation-event.mdx'

--- a/contents/docs/ai-observability/installation/mastra.mdx
+++ b/contents/docs/ai-observability/installation/mastra.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/mastra.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/mastra.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { MastraInstallation } from 'onboarding/llm-analytics/mastra.tsx'
+import { MastraInstallation } from 'onboarding/ai-observability/mastra.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/mirascope.mdx
+++ b/contents/docs/ai-observability/installation/mirascope.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/mirascope.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/mirascope.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { MirascopeInstallation } from 'onboarding/llm-analytics/mirascope.tsx'
+import { MirascopeInstallation } from 'onboarding/ai-observability/mirascope.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/mistral.mdx
+++ b/contents/docs/ai-observability/installation/mistral.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/mistral.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/mistral.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { MistralInstallation } from 'onboarding/llm-analytics/mistral.tsx'
+import { MistralInstallation } from 'onboarding/ai-observability/mistral.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/ollama.mdx
+++ b/contents/docs/ai-observability/installation/ollama.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/ollama.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/ollama.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { OllamaInstallation } from 'onboarding/llm-analytics/ollama.tsx'
+import { OllamaInstallation } from 'onboarding/ai-observability/ollama.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/openai-agents.mdx
+++ b/contents/docs/ai-observability/installation/openai-agents.mdx
@@ -38,11 +38,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/openai-agents.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/openai-agents.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { OpenAIAgentsInstallation } from 'onboarding/llm-analytics/openai-agents.tsx'
+import { OpenAIAgentsInstallation } from 'onboarding/ai-observability/openai-agents.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/openai.mdx
+++ b/contents/docs/ai-observability/installation/openai.mdx
@@ -33,11 +33,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/openai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/openai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { OpenAIInstallation } from 'onboarding/llm-analytics/openai.tsx'
+import { OpenAIInstallation } from 'onboarding/ai-observability/openai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
 

--- a/contents/docs/ai-observability/installation/openrouter.mdx
+++ b/contents/docs/ai-observability/installation/openrouter.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/openrouter.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/openrouter.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { OpenRouterInstallation } from 'onboarding/llm-analytics/openrouter.tsx'
+import { OpenRouterInstallation } from 'onboarding/ai-observability/openrouter.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/opentelemetry.mdx
+++ b/contents/docs/ai-observability/installation/opentelemetry.mdx
@@ -38,11 +38,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/opentelemetry.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/opentelemetry.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { OpenTelemetryInstallation } from 'onboarding/llm-analytics/opentelemetry.tsx'
+import { OpenTelemetryInstallation } from 'onboarding/ai-observability/opentelemetry.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/perplexity.mdx
+++ b/contents/docs/ai-observability/installation/perplexity.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/perplexity.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/perplexity.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { PerplexityInstallation } from 'onboarding/llm-analytics/perplexity.tsx'
+import { PerplexityInstallation } from 'onboarding/ai-observability/perplexity.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/portkey.mdx
+++ b/contents/docs/ai-observability/installation/portkey.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/portkey.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/portkey.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { PortkeyInstallation } from 'onboarding/llm-analytics/portkey.tsx'
+import { PortkeyInstallation } from 'onboarding/ai-observability/portkey.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/pydantic-ai.mdx
+++ b/contents/docs/ai-observability/installation/pydantic-ai.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/pydantic-ai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/pydantic-ai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { PydanticAIInstallation } from 'onboarding/llm-analytics/pydantic-ai.tsx'
+import { PydanticAIInstallation } from 'onboarding/ai-observability/pydantic-ai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/semantic-kernel.mdx
+++ b/contents/docs/ai-observability/installation/semantic-kernel.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/semantic-kernel.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/semantic-kernel.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { SemanticKernelInstallation } from 'onboarding/llm-analytics/semantic-kernel.tsx'
+import { SemanticKernelInstallation } from 'onboarding/ai-observability/semantic-kernel.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/smolagents.mdx
+++ b/contents/docs/ai-observability/installation/smolagents.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/smolagents.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/smolagents.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { SmolagentsInstallation } from 'onboarding/llm-analytics/smolagents.tsx'
+import { SmolagentsInstallation } from 'onboarding/ai-observability/smolagents.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/together-ai.mdx
+++ b/contents/docs/ai-observability/installation/together-ai.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/together-ai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/together-ai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { TogetherAIInstallation } from 'onboarding/llm-analytics/together-ai.tsx'
+import { TogetherAIInstallation } from 'onboarding/ai-observability/together-ai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/vercel-ai.mdx
+++ b/contents/docs/ai-observability/installation/vercel-ai.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/vercel-ai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/vercel-ai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { VercelAIInstallation } from 'onboarding/llm-analytics/vercel-ai.tsx'
+import { VercelAIInstallation } from 'onboarding/ai-observability/vercel-ai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'

--- a/contents/docs/ai-observability/installation/xai.mdx
+++ b/contents/docs/ai-observability/installation/xai.mdx
@@ -28,11 +28,11 @@ tableOfContents: [
 
 <!--
 This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/llm-analytics/xai.tsx
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/xai.tsx
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { XAIInstallation } from 'onboarding/llm-analytics/xai.tsx'
+import { XAIInstallation } from 'onboarding/ai-observability/xai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'


### PR DESCRIPTION
## Changes

- Fixes build failures caused by monorepo renaming `docs/onboarding/llm-analytics/` to `docs/onboarding/ai-observability/`
- Updates all 45 MDX import paths and source comments to match new folder name
