### PR TITLE
docs: add #changelog and #coming-soon Slack channel guidance to handbook

### DIFF
--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -156,6 +156,15 @@ Also keep in mind that, as an open source platform, PostHog has contributors who
 
 > [Slackbot](https://slack.com/features/slackbot) is a handy AI agent that can search across the PostHog workspace in Slack to help answer your questions. If you're looking for information or trying to find a past conversation, Slackbot is a great place to start.
 
+**Keeping up with what we ship**
+
+We recommend everyone at PostHog joins these two channels to stay current on what's shipped and what's coming:
+
+- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) — what's just shipped. Owned by the [Docs & Wizard team](/teams/docs-wizard). Updates constantly as PRs merge.
+- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) — what's shipping soon. Owned by the [Marketing team](/teams/marketing). Posts a daily digest.
+
+Both channels are powered by agentic workflows that scan merged PRs and feature flag changes and summarize them into the relevant channel. PR authors can opt in or out manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for more detail.
+
 **Slack etiquette**
 
 Slack is used differently in different organizations. Here are some guidelines for how we use Slack at PostHog:

--- a/contents/handbook/docs-and-wizard/how-to-publish-changelog.mdx
+++ b/contents/handbook/docs-and-wizard/how-to-publish-changelog.mdx
@@ -9,6 +9,22 @@ We have one of the coolest [changelogs](/changelog) on the internet. It's also o
 
 As a company that ships weirdly fast, it's important to share what we're working on with as many people as possible, as often as possible. The changelog is a great way to do that.
 
+## Internal Slack channels
+
+We run two internal Slack channels that surface what we ship and what's about to ship. We recommend that everyone at PostHog joins both.
+
+| Channel | Use it for | Cadence | Owner |
+|---------|------------|---------|-------|
+| [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) | What's just shipped | Updates constantly as PRs merge | <SmallTeam slug="docs-wizard" /> |
+| [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) | What's shipping soon | Daily digest | <SmallTeam slug="marketing" /> |
+
+Both channels are powered by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo, classify them, and summarize them into the relevant channel. The `#changelog` channel posts each impactful change as it lands; the `#coming-soon` channel rolls up upcoming work into a single daily digest.
+
+You can also opt a PR into either workflow manually:
+
+- **PR template checkboxes** — the `posthog/posthog` PR template has *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes under **Automatic notifications**. Tick them when you want to override the automated classification.
+- **`@posthog` Slack app** — you can also include or exclude PRs from these workflows via the `@posthog` Slack app, which is handy after the fact (e.g. once a change is in production).
+
 <ProductVideo 
   videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/changelog_handbook_1_8038f2d9d4.mp4"
   autoPlay={false} 

--- a/contents/handbook/engineering/customer-comms.md
+++ b/contents/handbook/engineering/customer-comms.md
@@ -14,3 +14,12 @@ All you need to bring:
 Prior art to mirror: the feature-flags quota-limit rollout in [`product-internal#720`](https://github.com/PostHog/product-internal/pull/720).
 
 For the underlying email infrastructure (Customer.io tags, categories, unsubscribe behavior), see the [email comms handbook page](/handbook/brand/email-comms). For incidents specifically, see [engineering incidents](/handbook/engineering/operations/incidents) — Marketing handles those comms too.
+
+## Staying ahead of what's about to ship
+
+If you write or coordinate customer comms, join these two internal Slack channels — they're the lowest-friction way to know what's just shipped and what's about to land:
+
+- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Docs & Wizard team](/teams/docs-wizard) and updated constantly as PRs merge.
+- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. Owned by the [Marketing team](/teams/marketing) and posted as a daily digest.
+
+Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in `posthog/posthog` and summarize them into the channel. You can opt a PR in or out via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.

--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -78,3 +78,12 @@ Our small team page is maintained on the [Sales & CS team page](/teams/sales-cs)
 - Low ego, and a willingness to turn around even the most disgruntled and unreasonable customer
 - Hands-on people not motivated by managing a team
 - We would want to buy PostHog from them - this is more important than cool logos
+
+## Staying current with what we ship
+
+Being a [power user of PostHog](#sales-team-vision) means knowing what just shipped and what's about to land. Two internal Slack channels make this easy — we recommend everyone on the Sales & CS team joins both:
+
+- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Docs & Wizard team](/teams/docs-wizard) and updated constantly as PRs merge.
+- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. Owned by the [Marketing team](/teams/marketing) and posted as a daily digest.
+
+Both channels are populated by agentic workflows that scan merged PRs and feature flag changes and summarize them into the channel. Authors can also opt in or out using the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog).

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -17,6 +17,15 @@ Marketing at PostHog is a collaborative effort across several teams. There are s
 
 If you're not sure who to talk to, check [Who can help me?](/handbook/marketing/ownership).
 
+## Slack channels to know
+
+To keep up with what's shipped and what's about to ship across the company, join:
+
+- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Docs & Wizard team](/teams/docs-wizard) and updated constantly as PRs merge.
+- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. **Owned by the Marketing team** and posted as a daily digest.
+
+Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the relevant channel. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.
+
 ## Marketing values
 
 1. Be opinionated

--- a/contents/handbook/support/support-team.md
+++ b/contents/handbook/support/support-team.md
@@ -20,3 +20,12 @@ We're not a ticket-routing operation. We genuinely care about making our users' 
 <WhatWeDo />
 
 <OurLongTermVision />
+
+## Slack channels to stay current
+
+To answer customer questions well we need to know what's just shipped and what's about to land. Two internal channels keep this in front of you — every member of the Support team should join both:
+
+- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Docs & Wizard team](/teams/docs-wizard) and updated constantly as PRs merge.
+- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. Owned by the [Marketing team](/teams/marketing) and posted as a daily digest.
+
+Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the channel. Engineers can opt a PR in or out via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.


### PR DESCRIPTION
## Changes

Adds guidance to the handbook explaining the two internal Slack channels that surface what we ship:

- **`#changelog`** — what's just shipped. Owned by the Docs & Wizard team. Updates constantly as PRs merge.
- **`#coming-soon`** — what's shipping soon. Owned by the Marketing team. Posts a daily digest.

Both channels are powered by agentic workflows that scan merged PRs and feature flag changes in `posthog/posthog`, classify them, and summarize them into the relevant channel. PR authors can opt in or out manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app.

[`how-to-publish-changelog`](contents/handbook/docs-and-wizard/how-to-publish-changelog.mdx) is the canonical reference; the other pages add a short, audience-appropriate summary and link back.

Pages updated:

- `contents/handbook/company/communication.md` — under the Slack section
- `contents/handbook/docs-and-wizard/how-to-publish-changelog.mdx` — canonical reference, expanded with the `#coming-soon` channel and manual opt-in mechanisms
- `contents/handbook/engineering/customer-comms.md`
- `contents/handbook/growth/sales/overview.md`
- `contents/handbook/marketing/index.md`
- `contents/handbook/support/support-team.md`

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in \`vercel.json\`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*