### PR TITLE
docs: document --env-file CLI flag for source map auth

### DIFF
--- a/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
+++ b/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
@@ -16,12 +16,6 @@ If you are using the CLI in a CI/CD environment such as GitHub Actions, you can 
 
 </div>
 
-If you already keep your project's configuration in a dotenv-style file, you can load these variables from it with the `--env-file` option instead of exporting them:
-
-```bash
-posthog-cli --env-file .env sourcemap upload --directory ./path/to/assets
-```
-
 You can also use the `--host` option instead of the `POSTHOG_CLI_HOST` environment variable to target a different PostHog instance or region. For EU users:
 
 ```bash

--- a/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
+++ b/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
@@ -22,8 +22,6 @@ If you already keep your project's configuration in a dotenv-style file, you can
 posthog-cli --env-file .env sourcemap upload --directory ./path/to/assets
 ```
 
-The process environment always takes precedence, and the file is only read when the required variables aren't already set. The full order of precedence is CLI arguments, then the process environment, then `--env-file`, then the credentials saved by `posthog-cli login`. Credentials are read from a single source, so `POSTHOG_CLI_HOST` is only used when it comes from the same source that supplied the API key and project ID.
-
 You can also use the `--host` option instead of the `POSTHOG_CLI_HOST` environment variable to target a different PostHog instance or region. For EU users:
 
 ```bash

--- a/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
+++ b/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
@@ -16,6 +16,14 @@ If you are using the CLI in a CI/CD environment such as GitHub Actions, you can 
 
 </div>
 
+If you already keep your project's configuration in a dotenv-style file, you can load these variables from it with the `--env-file` option instead of exporting them:
+
+```bash
+posthog-cli --env-file .env sourcemap upload --directory ./path/to/assets
+```
+
+The process environment always takes precedence, and the file is only read when the required variables aren't already set. The full order of precedence is CLI arguments, then the process environment, then `--env-file`, then the credentials saved by `posthog-cli login`. Credentials are read from a single source, so `POSTHOG_CLI_HOST` is only used when it comes from the same source that supplied the API key and project ID.
+
 You can also use the `--host` option instead of the `POSTHOG_CLI_HOST` environment variable to target a different PostHog instance or region. For EU users:
 
 ```bash

--- a/contents/docs/error-tracking/upload-source-maps/cli.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/cli.mdx
@@ -22,6 +22,12 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
   <CLIAuthenticate />
 
+  If you already keep your project's configuration in a dotenv-style file, you can load these variables from it with the `--env-file` option instead of exporting them:
+
+  ```bash
+  posthog-cli --env-file .env sourcemap upload --directory ./path/to/assets
+  ```
+
 </Step>
 
 <Step title="Inject" badge="required">


### PR DESCRIPTION
## Changes
<img width="790" height="208" alt="image" src="https://github.com/user-attachments/assets/bf50afae-fbd9-4442-b212-9770cf7c8b7d" />


Documents the new `--env-file` CLI option introduced in [PostHog/posthog#60465](https://github.com/PostHog/posthog/pull/60465), which loads `POSTHOG_CLI_*` credentials from a dotenv-style file.

The note was added to the shared CLI authenticate snippet (`contents/docs/error-tracking/_snippets/cli/authenticate.mdx`), so it appears consistently across all CLI-based source map upload pages (cli, web, react, node, nuxt, react-native, angular, ios, android, and the upload-source-maps index).

Documented behavior, matching the shipped code in that PR:
- Load credentials from a dotenv file via `--env-file <PATH>`
- Process environment always takes precedence; the file is only read when required variables aren't already set
- Full precedence: CLI args → process env → `--env-file` → credentials saved by `posthog-cli login`
- Credentials are read from a single source, so `POSTHOG_CLI_HOST` only applies when it comes from the same source as the API key and project ID

> **Note:** The source PR's description mentions auto-loading `./.env`/`.env.local`, but that was an earlier draft — the merged code (`commands.rs`/`auth.rs` + the README diff) ships an explicit `--env-file` flag, which is what's documented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)