### PR TITLE
Add social media support goal to editorial team objectives

### DIFF
--- a/contents/teams/editorial/objectives.mdx
+++ b/contents/teams/editorial/objectives.mdx
@@ -56,6 +56,23 @@
 
 - Freelance content meets our technical and editorial bar without heavy rewriting, and output increases without a proportional increase in Nat's time
 
+## Social media support for product launches
+
+**Owner:** <TeamMember name="Liam Graham" photo />
+
+**Motivation:** Our PMMs are doing great work already, and having social media-specific support will be a boon for all of our products. Also, now that I'm here, we can take some more risks with our content and try new things.
+
+**What we'll ship:**
+
+- Support major product launches with structured social campaigns
+- Create a framework for launch support going forward
+- Marketing team brown bag demo on social best practices
+
+**We'll know we're successful when:**
+
+- Stonks = up, looking at engagement and impressions on social
+- Folks from all teams know how they can contribute and post well
+
 ## Business as usual
 
 - A high quality newsletter every two weeks - <TeamMember name="Ian Vanagas" photo />


### PR DESCRIPTION
## Changes

Adds a new goal entry, "Social media support for product launches", to the bottom of the Goals section on the [editorial team page](https://posthog.com/teams/editorial). Owner: Liam Graham.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)