### PR TITLE
docs: standardize POSTHOG_PROJECT_TOKEN env var across SDK docs

### DIFF
--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -222,14 +222,14 @@ In your application code, update your PostHog initialization to use your proxy p
 <MultiLanguage>
 
 ```js file=US
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: '/yourpath',
   ui_host: 'https://us.posthog.com'
 })
 ```
 
 ```js file=EU
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: '/yourpath',
   ui_host: 'https://eu.posthog.com'
 })
@@ -348,7 +348,7 @@ requestHeaders.delete('cookie')
 Alternatively, configure PostHog to use `localStorage` instead of cookies:
 
 ```js
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: '/yourpath',
   persistence: 'localStorage'
 })

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -106,14 +106,14 @@ In your application code, update your PostHog initialization to use your proxy p
 <MultiLanguage>
 
 ```js file=US
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: '/yourpath',
   ui_host: 'https://us.posthog.com'
 })
 ```
 
 ```js file=EU
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: '/yourpath',
   ui_host: 'https://eu.posthog.com'
 })

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -168,7 +168,7 @@ import { browser } from '$app/environment'
 export function initPostHog() {
   if (!browser) return
 
-  posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+  posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
     api_host: '/yourpath',
     ui_host: 'https://us.posthog.com',
     persistence: 'localStorage'
@@ -184,7 +184,7 @@ import { browser } from '$app/environment'
 export function initPostHog() {
   if (!browser) return
 
-  posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+  posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
     api_host: '/yourpath',
     ui_host: 'https://eu.posthog.com',
     persistence: 'localStorage'

--- a/contents/docs/integrate/_snippets/install-nuxt.mdx
+++ b/contents/docs/integrate/_snippets/install-nuxt.mdx
@@ -12,7 +12,7 @@ import InstallWebPackageManagers from "./install-web-package-managers.mdx"
 export default defineNuxtConfig({
   runtimeConfig: {
     public: {
-      posthogToken: process.env.NUXT_PUBLIC_POSTHOG_TOKEN || '<ph_project_token>',
+      posthogToken: process.env.NUXT_PUBLIC_POSTHOG_PROJECT_TOKEN || '<ph_project_token>',
       posthogHost: process.env.NUXT_PUBLIC_POSTHOG_HOST || '<ph_client_api_host>',
       posthogDefaults: '<ph_posthog_js_defaults>',
     },

--- a/contents/docs/integrate/_snippets/install-react.mdx
+++ b/contents/docs/integrate/_snippets/install-react.mdx
@@ -9,7 +9,7 @@ import InstallReactPackageManagers from "./install-react-package-managers.mdx"
 2. Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, prefixing variable names with `VITE_` ensures they are accessible in the frontend.
 
 ```shell file=.env.local
-VITE_POSTHOG_TOKEN=<ph_project_token>
+VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 VITE_POSTHOG_HOST=<ph_client_api_host>
 ```
 
@@ -24,7 +24,7 @@ import App from './App.jsx'
 import posthog from 'posthog-js'; // +
 import { PostHogProvider } from '@posthog/react' // +
 
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '<ph_posthog_js_defaults>', // +
 }); // +

--- a/contents/docs/integrate/_snippets/nextjs/app-router-server-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/app-router-server-setup.mdx
@@ -7,7 +7,7 @@ This enables us to send events and fetch data from PostHog on the server – wit
 import { PostHog } from 'posthog-node'
 
 export default function PostHogClient() {
-  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
     host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     flushAt: 1,
     flushInterval: 0

--- a/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
@@ -7,7 +7,7 @@ import InstallWebPackageManagers from "../install-web-package-managers.mdx"
 Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token in your [project settings](https://app.posthog.com/project/settings).
 
 ```shell file=.env.local
-NEXT_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
 ```
 
@@ -22,7 +22,7 @@ Next.js provides the [`instrumentation-client.ts|js`](https://nextjs.org/docs/ap
 ```js file=instrumentation-client.js
 import posthog from 'posthog-js'
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: '<ph_posthog_js_defaults>'
 });
@@ -31,7 +31,7 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
 ```ts file=instrumentation-client.ts
 import posthog from 'posthog-js'
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN!, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: '<ph_posthog_js_defaults>'
 });

--- a/contents/docs/integrate/_snippets/nextjs/pages-router-server-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/pages-router-server-setup.mdx
@@ -37,7 +37,7 @@ export async function getServerSideProps(ctx) {
 
   if (session) {
     const client = new PostHog(
-      process.env.NEXT_PUBLIC_POSTHOG_TOKEN,
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
       {
         host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
       }

--- a/contents/docs/integrate/_snippets/vuejs/composition-install.mdx
+++ b/contents/docs/integrate/_snippets/vuejs/composition-install.mdx
@@ -13,7 +13,7 @@ import posthog from "posthog-js";
 
 const app = createApp(App);
 
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN || '<ph_project_token>', {
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN || '<ph_project_token>', {
   api_host: import.meta.env.VITE_POSTHOG_HOST || '<ph_client_api_host>',
   defaults: '2026-01-30',
 });

--- a/contents/docs/integrations/lovable.mdx
+++ b/contents/docs/integrations/lovable.mdx
@@ -31,7 +31,7 @@ Initialize at module top-level in the main App file (NOT inside useEffect):
 import posthog from 'posthog-js'
 import { PostHogProvider } from '@posthog/react'
 
-posthog.init(POSTHOG_TOKEN, {
+posthog.init(POSTHOG_PROJECT_TOKEN, {
   api_host: HOST,
   person_profiles: 'identified_only',
   capture_pageview: false,

--- a/contents/docs/integrations/replit.mdx
+++ b/contents/docs/integrations/replit.mdx
@@ -33,15 +33,15 @@ Once connected, give Replit Agent this prompt to add PostHog with error tracking
 Add PostHog to this project for error tracking and analytics with source map uploads.
 
 Use the PostHog MCP to:
-- Get the project token (from `projects-get`) → set as `VITE_POSTHOG_TOKEN`
+- Get the project token (from `projects-get`) → set as `VITE_POSTHOG_PROJECT_TOKEN`
 - Get the host URL → set as `VITE_POSTHOG_HOST`
-- Set `VITE_POSTHOG_TOKEN` and `VITE_POSTHOG_HOST` as shared environment variables so they work in both development and production
+- Set `VITE_POSTHOG_PROJECT_TOKEN` and `VITE_POSTHOG_HOST` as shared environment variables so they work in both development and production
 
 Install packages: posthog-js and @posthog/cli
 
 Create a PostHog client at client/src/lib/posthog.ts that:
 - Initializes with defaults: `'<ph_posthog_js_defaults>', capture_exceptions: true, autocapture: true, capture_pageview: true`
-- Uses env vars `VITE_POSTHOG_TOKEN` and `VITE_POSTHOG_HOST`
+- Uses env vars `VITE_POSTHOG_PROJECT_TOKEN` and `VITE_POSTHOG_HOST`
 - Exports a wrapper around `posthog.captureException(error)` - do NOT manually capture $exception events
 
 Initialize PostHog in `App.tsx` with `useEffect`.
@@ -116,7 +116,7 @@ Check that `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` are set as **secre
 
 ### Events not appearing
 
-Verify `VITE_POSTHOG_TOKEN` and `VITE_POSTHOG_HOST` are set correctly and that PostHog is initialized before your app renders.
+Verify `VITE_POSTHOG_PROJECT_TOKEN` and `VITE_POSTHOG_HOST` are set correctly and that PostHog is initialized before your app renders.
 
 ### MCP not connecting
 

--- a/contents/docs/libraries/cloudflare-workers.mdx
+++ b/contents/docs/libraries/cloudflare-workers.mdx
@@ -25,7 +25,7 @@ Afterwards, set up your project token and host in your `wrangler.jsonc` (or `wra
     "enabled": true
   },
   "vars": { 
-    "POSTHOG_TOKEN": "<ph_project_token>",
+    "POSTHOG_PROJECT_TOKEN": "<ph_project_token>",
     "POSTHOG_HOST": "<ph_client_api_host>",
   },
 }
@@ -39,7 +39,7 @@ import { PostHog } from 'posthog-node'
 
 export function createPostHogClient(env) {
 
-  const posthog = new PostHog(env.POSTHOG_TOKEN, {
+  const posthog = new PostHog(env.POSTHOG_PROJECT_TOKEN, {
     host: env.POSTHOG_HOST,
     flushAt: 1, // Send events immediately in edge environment
     flushInterval: 0, // Don't wait for interval

--- a/contents/docs/libraries/convex.mdx
+++ b/contents/docs/libraries/convex.mdx
@@ -99,7 +99,7 @@ Environment variables:
 | --- | --- | --- |
 | `POSTHOG_PROJECT_TOKEN` | Yes | Your project token (`phc_`). Sends events and evaluates flags remotely. |
 | `POSTHOG_HOST` | No | Defaults to `https://us.i.posthog.com`. Use `https://eu.i.posthog.com` for EU Cloud or your self-hosted URL. |
-| `POSTHOG_PERSONAL_API_KEY` | No | A [feature flags secure API key](/docs/feature-flags/local-evaluation#step-1-find-your-feature-flags-secure-api-key) (`phs_`, recommended) or personal API key (`phx_`). Setting it enables local flag evaluation and starts the refresh cron. |
+| `POSTHOG_PERSONAL_API_KEY` | No | A [feature flags secure API key](/docs/feature-flags/local-evaluation#step-1-find-your-feature-flags-secure-api-key) (`phs_`, recommended) or personal API key (`phx_`). Setting it enables local flag evaluation. |
 | `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` | No | Cron interval for refreshing flag definitions. Defaults to `60`. Raise it on free-tier dev deployments to cut function-call usage. |
 
 ### 2. Set your PostHog credentials
@@ -115,11 +115,7 @@ For local feature flag evaluation (covered in step 5), also set a [feature flags
 npx convex env set POSTHOG_PERSONAL_API_KEY phs_your_feature_flags_secure_api_key
 ```
 
-<CalloutBox icon="IconInfo" title="Setting the personal API key starts the cron" type="fyi">
-
-`POSTHOG_PERSONAL_API_KEY` is checked at deploy time, so after setting it in production you need to redeploy for the cron to register. To skip the cron entirely (e.g. on a free-tier dev deployment), leave the var unset.
-
-</CalloutBox>
+Local evaluation kicks in on the next cron tick — no redeploy needed.
 
 ### 3. Initialize the client
 
@@ -175,7 +171,7 @@ Use the same Convex user ID as the `distinctId` everywhere so PostHog can stitch
 - **Local** (`getFeatureFlag`, `isFeatureEnabled`, `getFeatureFlagPayload`, `getAllFlags`) runs against flag definitions cached on your Convex deployment. Works in queries, mutations, and actions. No per-call network request, and a query re-runs automatically when cached definitions refresh. Requires `POSTHOG_PERSONAL_API_KEY`. Use this when you can.
 - **Remote** (`evaluateFlag`, `evaluateFlagPayload`, `evaluateAllFlags`) hits PostHog's `/flags` endpoint on every call. Action-only. Handles every flag, including the ones local can't, and needs no personal API key.
 
-Local evaluation runs automatically once `POSTHOG_PERSONAL_API_KEY` is set. The component registers its own cron at deploy time and refreshes flag definitions every minute, so you don't write your own. Tune the cadence with `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`. If you call a local-eval method without the key configured, the client throws and points you at the remote `evaluate*` methods.
+Local evaluation runs automatically once `POSTHOG_PERSONAL_API_KEY` is set. The component runs its own cron that refreshes flag definitions every minute, so you don't write your own. Tune the cadence with `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`. If you call a local-eval method without the key configured, the client throws and points you at the remote `evaluate*` methods.
 
 Read a flag from a query:
 
@@ -287,8 +283,8 @@ import posthog from "posthog-js"
 import { PostHogProvider } from "@posthog/react"
 import App from "./App"
 
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN, {
-    api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST,
 })
 
 createRoot(document.getElementById("root")!).render(
@@ -332,8 +328,8 @@ Mount `<AuthSync />` once near the root of your app, inside the `<PostHogProvide
 Remember you'll also need to configure the environment variables on the frontend to point to your PostHog instance.
 
 ```sh
-npx convex env set VITE_PUBLIC_POSTHOG_PROJECT_TOKEN <ph_project_token>
-npx convex env set VITE_PUBLIC_POSTHOG_HOST <ph_client_api_host>
+npx convex env set VITE_POSTHOG_PROJECT_TOKEN <ph_project_token>
+npx convex env set VITE_POSTHOG_HOST <ph_client_api_host>
 ```
 
 </CalloutBox>

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -84,7 +84,7 @@ Next.js overrides the default `fetch` behavior on the server to introduce their 
 You can override that configuration when initializing PostHog, but make sure you understand the pros/cons of using Next.js's cache and that you might get cached results rather than the actual result our server would return. This is important for feature flags, for example.
 
 ```tsx
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   // ... your configuration
   fetch_options: {
     cache: 'force-cache', // Use Next.js cache

--- a/contents/docs/libraries/react-router/_snippets/step-env-variables.mdx
+++ b/contents/docs/libraries/react-router/_snippets/step-env-variables.mdx
@@ -1,7 +1,7 @@
 Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, prefixing variable names with `VITE_` ensures they are accessible in the frontend.
 
 ```shell file=.env.local
-VITE_POSTHOG_TOKEN=<ph_project_token>
+VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 VITE_POSTHOG_HOST=<ph_client_api_host>
 ```
 

--- a/contents/docs/libraries/react-router/react-router-v6.mdx
+++ b/contents/docs/libraries/react-router/react-router-v6.mdx
@@ -114,7 +114,7 @@ import posthog from 'posthog-js'; // +
 import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react' // +
 
 // Initialize PostHog
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '2026-01-30', // +
 }); // +
@@ -205,7 +205,7 @@ Now that you've set up PostHog for React Router V7 in declarative mode, you can 
 To help PostHog track your user sessions across the client and server, you'll need to add the `__add_tracing_headers: ['your-backend-domain1.com', 'your-backend-domain2.com', ...]` option to your PostHog initialization:
 
 ```tsx
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30',
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +

--- a/contents/docs/libraries/react-router/react-router-v7-data-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-data-mode.mdx
@@ -113,7 +113,7 @@ import Root, { RootErrorBoundary } from "./app/root";
 import posthog from 'posthog-js'; // +
 import { PostHogProvider } from '@posthog/react' // +
 
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30', // +
 }); // +
@@ -196,7 +196,7 @@ Now that you've set up PostHog for React Router V7 in data mode, you can continu
 To help PostHog track your user sessions across the client and server, you'll need to add the `__add_tracing_headers: ['your-backend-domain1.com', 'your-backend-domain2.com', ...]` option to your PostHog initialization:
 
 ```tsx
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30',
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +

--- a/contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx
@@ -114,7 +114,7 @@ import posthog from 'posthog-js'; // +
 import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react' // +
 
 // Initialize PostHog
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '2026-01-30', // +
 }); // +
@@ -205,7 +205,7 @@ Now that you've set up PostHog for React Router V7 in declarative mode, you can 
 To help PostHog track your user sessions across the client and server, you'll need to add the `__add_tracing_headers: ['your-backend-domain1.com', 'your-backend-domain2.com', ...]` option to your PostHog initialization:
 
 ```tsx
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, {
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '2026-01-30',
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +

--- a/contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx
@@ -135,7 +135,7 @@ import { HydratedRouter } from "react-router/dom";
 import posthog from 'posthog-js'; // +
 import { PostHogProvider } from '@posthog/react'  // +
 
-posthog.init(import.meta.env.VITE_POSTHOG_TOKEN, { // +
+posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
   defaults: '2026-01-30', // +
   __add_tracing_headers: [ window.location.host, 'localhost' ], // +
@@ -240,7 +240,7 @@ export interface PostHogContext extends RouterContextProvider {
 }
 
 export const posthogMiddleware: Route.MiddlewareFunction = async ({ request, context }, next) => {
-  const posthog = new PostHog(process.env.VITE_POSTHOG_TOKEN!, {
+  const posthog = new PostHog(process.env.VITE_POSTHOG_PROJECT_TOKEN!, {
     host: process.env.VITE_POSTHOG_HOST!,
     flushAt: 1,
     flushInterval: 0,

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -78,7 +78,7 @@ The provider takes an initialized and configured client instance like this:
 import posthog from 'posthog-js';
 import { PostHogProvider} from '@posthog/react'
 
-posthog.init(process.env.REACT_APP_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.REACT_APP_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST,
   defaults: '<ph_posthog_js_defaults>',
 });

--- a/contents/docs/libraries/vercel.mdx
+++ b/contents/docs/libraries/vercel.mdx
@@ -129,7 +129,7 @@ npm i flags @flags-sdk/posthog
 Next, set up the required environment variables. The adapter uses these values as defaults. You can get both of them in [your project settings](https://us.posthog.com/settings/project). 
 
 ``` file=.env.local
-NEXT_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_api_client_host>
 ```
 

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -49,7 +49,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <PostHogProvider
-      apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_TOKEN}
+      apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_PROJECT_TOKEN}
       options={options}
     >
       <App />

--- a/contents/tutorials/bootstrap-feature-flags-react.md
+++ b/contents/tutorials/bootstrap-feature-flags-react.md
@@ -35,7 +35,7 @@ Next, get your PostHog project token and instance address from the getting start
 
 ```bash
 # .env.local
-VITE_POSTHOG_TOKEN=<ph_project_token>
+VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 VITE_POSTHOG_HOST=<ph_client_api_host>
 ```
 
@@ -55,7 +55,7 @@ const options = {
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
+    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
       <App />
     </PostHogProvider>
   </StrictMode>,
@@ -153,7 +153,7 @@ const options = {
 hydrateRoot(
   document.getElementById('root'),
   <StrictMode>
-    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
+    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
       <App />
     </PostHogProvider>
   </StrictMode>
@@ -206,7 +206,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Initialize PostHog client
 const client = new PostHog(
-  process.env.VITE_POSTHOG_TOKEN,
+  process.env.VITE_POSTHOG_PROJECT_TOKEN,
   { 
     host: process.env.VITE_POSTHOG_HOST,
     personalApiKey: process.env.POSTHOG_PERSONAL_API_KEY // This one is server-only
@@ -262,7 +262,7 @@ In the route's `try` block, we'll get or create a distinct ID and use it to get 
 try {
   // Get or create distinct ID
   let distinctId = null;
-  const phCookie = req.cookies[`ph_${process.env.VITE_POSTHOG_TOKEN}_posthog`];
+  const phCookie = req.cookies[`ph_${process.env.VITE_POSTHOG_PROJECT_TOKEN}_posthog`];
   if (phCookie) {
     distinctId = JSON.parse(phCookie)['distinct_id'];
   }
@@ -332,7 +332,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Initialize PostHog client
 const client = new PostHog(
-  process.env.VITE_POSTHOG_TOKEN,
+  process.env.VITE_POSTHOG_PROJECT_TOKEN,
   { 
     host: process.env.VITE_POSTHOG_HOST,
     personalApiKey: process.env.POSTHOG_PERSONAL_API_KEY // This one is server-only
@@ -360,7 +360,7 @@ async function createServer() {
     try {
       // Get or create distinct ID
       let distinctId = null;
-      const phCookie = req.cookies[`ph_${process.env.VITE_POSTHOG_TOKEN}_posthog`];
+      const phCookie = req.cookies[`ph_${process.env.VITE_POSTHOG_PROJECT_TOKEN}_posthog`];
       if (phCookie) {
         distinctId = JSON.parse(phCookie)['distinct_id'];
       }

--- a/contents/tutorials/ios-analytics.md
+++ b/contents/tutorials/ios-analytics.md
@@ -138,9 +138,9 @@ import PostHog
 @main
 struct ios_analyticsApp: App {
     init() {
-        let POSTHOG_TOKEN = "<ph_project_token>"
+        let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
         let POSTHOG_HOST = "<ph_client_api_host>" // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
-        let configuration = PostHogConfig(apiKey: POSTHOG_TOKEN, host: POSTHOG_HOST)
+        let configuration = PostHogConfig(apiKey: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
         PostHogSDK.shared.setup(configuration)
     }
     

--- a/contents/tutorials/ios-feature-flags.md
+++ b/contents/tutorials/ios-feature-flags.md
@@ -100,9 +100,9 @@ import PostHog
 @main
 struct posthog_feature_flagsApp: App {
     init() {
-        let POSTHOG_TOKEN = "<ph_project_token>"
+        let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
         let POSTHOG_HOST = "<ph_client_api_host>" // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
-        let configuration = PostHogConfig(apiKey: POSTHOG_TOKEN, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
+        let configuration = PostHogConfig(apiKey: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
         PostHogSDK.shared.setup(configuration)
     }
     

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -84,7 +84,7 @@ First, [sign up for PostHog](https://app.posthog.com/signup) if you haven't alre
 Next, we need your project token and client API host. You can get both from your [project settings](https://app.posthog.com/settings/project). Add both of these to a `.env.local` file in our base directory.
 
 ``` file=.env.local
-NEXT_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
 ```
 
@@ -94,7 +94,7 @@ We can now initialize PostHog. Next.js 15.3 added support for `instrumentation-c
 // instrumentation-client.js
 import posthog from 'posthog-js'
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: '2026-01-30',
 });
@@ -216,7 +216,7 @@ Next, create a `posthog.js` file in the app folder that returns a PostHog Node c
 import { PostHog } from 'posthog-node'
 
 export default function PostHogClient() {
-  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
     host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     flushAt: 1,
     flushInterval: 0
@@ -240,7 +240,7 @@ import posthogClient from '../../posthog'
 
 export async function GET(request) {
 
-  const cookieName = 'ph_' + process.env.NEXT_PUBLIC_POSTHOG_TOKEN + '_posthog'
+  const cookieName = 'ph_' + process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN + '_posthog'
   const cookieValue = request.cookies.get(cookieName)?.value
   const distinctId = cookieValue ? JSON.parse(cookieValue).distinct_id : 'placeholder'
 
@@ -272,7 +272,7 @@ import posthogClient from '../../posthog'
 
 export async function GET(request) {
 
-  const cookieName = 'ph_' + process.env.NEXT_PUBLIC_POSTHOG_TOKEN + '_posthog'
+  const cookieName = 'ph_' + process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN + '_posthog'
   const cookieValue = request.cookies.get(cookieName)?.value
   const distinctId = cookieValue ? JSON.parse(cookieValue).distinct_id : 'placeholder'
 

--- a/contents/tutorials/nextjs-pages-analytics.md
+++ b/contents/tutorials/nextjs-pages-analytics.md
@@ -277,7 +277,7 @@ Once this is working, we have all the functionality we want in our Next.js app a
 At this point, you need a PostHog project (it's [free to sign up](https://app.posthog.com/signup)). Once created, get your project token and instance address from [your project settings](https://us.posthog.com/settings/project) and add it to your `.env.local` file.
 
 ```shell file=.env.local
-NEXT_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
 ```
 
@@ -293,7 +293,7 @@ Afterwards, create an `instrumentation-client.js` file in the base `pages-tutori
 // instrumentation-client.js
 import posthog from 'posthog-js'
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: '2026-01-30'
 });
@@ -572,7 +572,7 @@ export async function getServerSideProps(ctx) {
 
   if (session) {
     const client = new PostHog(
-      process.env.NEXT_PUBLIC_POSTHOG_TOKEN,
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
       { host: process.env.NEXT_PUBLIC_POSTHOG_HOST }
     )
     flags = await client.getAllFlags(session.user.email);

--- a/contents/tutorials/nextjs-supabase-signup-funnel.mdx
+++ b/contents/tutorials/nextjs-supabase-signup-funnel.mdx
@@ -253,11 +253,11 @@ A user can now sign up with our app but there are a number of potential drop-off
 Add two new environment variables to `.env.local` that will be used with the PostHog JavaScript SDK:
 
 ```
-NEXT_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
 NEXT_PUBLIC_POSTHOG_HOST=your_posthog_host
 ```
 
-The value for `NEXT_PUBLIC_POSTHOG_TOKEN` can be found via **Project** in the left-hand menu of your PostHog app, underneath the **Project token** heading.
+The value for `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` can be found via **Project** in the left-hand menu of your PostHog app, underneath the **Project token** heading.
 
 The value for `NEXT_PUBLIC_POSTHOG_HOST` is the public URL for ingesting events into your PostHog instance. If you're using US cloud, this is `https://us.i.posthog.com`.
 
@@ -279,7 +279,7 @@ import { PostHogProvider } from '@posthog/react'
 
 // Check that PostHog is client-side
 if (typeof window !== 'undefined') {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
         // Enable debug mode in development
         loaded: (posthog) => {


### PR DESCRIPTION
## Changes

- Renamed `*_POSTHOG_TOKEN` → `*_POSTHOG_PROJECT_TOKEN` across the Vite, Next.js, Nuxt, React, iOS, Cloudflare Workers, and Lovable snippets so the var name matches what it holds (`phc_…`).
- Fixed `VITE_PUBLIC_*` → `VITE_*` in `contents/docs/libraries/convex.mdx` — Vite has no `_PUBLIC_` infix.
- Synced the Convex local-eval copy with [posthog-js#3684](https://github.com/PostHog/posthog-js/pull/3684): the refresh cron registers unconditionally now, so I dropped the deploy-time gotcha callout and reworded the cron paragraph.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A, no moves)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*