### PR TITLE
feat: Support authenticating via PostHog OAuth

### DIFF
--- a/src/components/Squeak/components/Classic/ForgotPassword.tsx
+++ b/src/components/Squeak/components/Classic/ForgotPassword.tsx
@@ -4,6 +4,7 @@ import { CallToAction } from 'components/CallToAction'
 import { useApp } from '../../../../context/App'
 import { useWindow } from '../../../../context/Window'
 import Wizard from 'components/Wizard'
+import { SQUEAK_HOST } from 'lib/strapi'
 
 import SecurityHog from '../../../../images/security-hog.png'
 import { IconSpinner } from '@posthog/icons'
@@ -66,7 +67,7 @@ const ForgotPasswordForm: React.FC = () => {
                     email: values.email,
                 }
 
-                const response = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/auth/forgot-password`, {
+                const response = await fetch(`${SQUEAK_HOST}/api/auth/forgot-password`, {
                     method: 'POST',
                     body: JSON.stringify(body),
                     headers: {

--- a/src/components/Squeak/components/Classic/PostHogButton.tsx
+++ b/src/components/Squeak/components/Classic/PostHogButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { CallToAction } from 'components/CallToAction'
+import Logo from 'components/Logo'
+import { SQUEAK_HOST } from 'lib/strapi'
+
+interface PostHogButtonProps {
+    label?: string
+    className?: string
+}
+
+// Kicks off the PostHog OAuth flow with a full-page redirect to Strapi, which
+// builds the PKCE state and forwards the browser to oauth.posthog.com.
+const PostHogButton: React.FC<PostHogButtonProps> = ({ label = 'Sign in with PostHog', className = '' }) => {
+    const handleClick = () => {
+        window.location.href = `${SQUEAK_HOST}/api/connect/posthog`
+    }
+
+    return (
+        <CallToAction type="secondary" size="sm" width="full" className={className} onClick={handleClick}>
+            <span className="flex items-center justify-center gap-2">
+                <Logo noText className="h-4 w-auto" />
+                {label}
+            </span>
+        </CallToAction>
+    )
+}
+
+export default PostHogButton

--- a/src/components/Squeak/components/Classic/Register.tsx
+++ b/src/components/Squeak/components/Classic/Register.tsx
@@ -8,6 +8,7 @@ import Wizard from 'components/Wizard'
 
 import SecurityHog from '../../../../images/security-hog.png'
 import { IconSpinner } from '@posthog/icons'
+import PostHogButton from './PostHogButton'
 
 const Input = ({
     label,
@@ -72,7 +73,7 @@ const RegisterForm: React.FC = () => {
             } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)) {
                 errors.email = 'Invalid email address'
             } else if (values.email.toLowerCase().endsWith('@posthog.com')) {
-                errors.email = 'Your employee account is created automatically. Reset your password to log in.'
+                errors.email = 'Your employee account is created automatically. Sign in with PostHog instead.'
             }
             if (!values.password) {
                 errors.password = 'Required'
@@ -133,6 +134,12 @@ const RegisterForm: React.FC = () => {
                     </div>
                     <div data-scheme="primary" className="flex-1">
                         <h3 className="text-base font-semibold leading-tight mb-4">Create your PostHog.com account</h3>
+                        <PostHogButton label="Sign up with PostHog" className="mb-2" />
+                        <div className="flex items-center gap-2 text-xs text-muted my-2">
+                            <span className="flex-1 border-t border-border" />
+                            or
+                            <span className="flex-1 border-t border-border" />
+                        </div>
                         <form onSubmit={handleSubmit} className="space-y-2 mb-4">
                             <Input
                                 label="First name"

--- a/src/components/Squeak/components/Classic/ResetPassword.tsx
+++ b/src/components/Squeak/components/Classic/ResetPassword.tsx
@@ -6,6 +6,7 @@ import { useWindow } from '../../../../context/Window'
 import { useUser } from '../../../../hooks/useUser'
 import Wizard from 'components/Wizard'
 import { navigate } from 'gatsby'
+import { SQUEAK_HOST } from 'lib/strapi'
 
 import SecurityHog from '../../../../images/security-hog.png'
 import { IconSpinner } from '@posthog/icons'
@@ -82,7 +83,7 @@ const ResetPasswordForm: React.FC = () => {
                     passwordConfirmation: values.password,
                 }
 
-                const response = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/auth/reset-password`, {
+                const response = await fetch(`${SQUEAK_HOST}/api/auth/reset-password`, {
                     method: 'POST',
                     body: JSON.stringify(body),
                     headers: {

--- a/src/components/Squeak/components/Classic/SignIn.tsx
+++ b/src/components/Squeak/components/Classic/SignIn.tsx
@@ -87,8 +87,6 @@ const SignInForm: React.FC<SignInFormProps> = ({ onSuccess }) => {
                 }
                 rightNavigation={
                     <div className="flex items-center space-x-2">
-                        {errorMessage && <p className="text-red text-sm m-0 font-bold">{errorMessage}</p>}
-
                         <CallToAction
                             disabled={isSubmitting}
                             type="primary"
@@ -144,6 +142,8 @@ const SignInForm: React.FC<SignInFormProps> = ({ onSuccess }) => {
                             />
                             <button type="submit" className="hidden" />
                         </form>
+                        {errorMessage && <p className="text-red text-sm -mt-2 mb-2 font-bold">{errorMessage}</p>}
+
                         <div className="text-sm">
                             No account yet?{' '}
                             <button className="text-red dark:text-yellow font-semibold" onClick={openRegister}>

--- a/src/components/Squeak/components/Classic/SignIn.tsx
+++ b/src/components/Squeak/components/Classic/SignIn.tsx
@@ -11,6 +11,7 @@ import SecurityHog from '../../../../images/security-hog.png'
 import { IconSpinner } from '@posthog/icons'
 import { useToast } from '../../../../context/Toast'
 import Link from 'components/Link'
+import PostHogButton from './PostHogButton'
 
 const errorMessages: Record<string, string> = {
     'Invalid identifier or password': 'Invalid email or password',
@@ -105,11 +106,15 @@ const SignInForm: React.FC<SignInFormProps> = ({ onSuccess }) => {
                         <img src={SecurityHog} className="w-20" />
                     </div>
                     <div data-scheme="primary" className="flex-1">
-                        <h3 className="text-base font-semibold leading-tight mb-2">
-                            Enter your email and password to log on to PostHog.com
-                        </h3>
-                        <p className="text-xs text-red dark:text-orange">
-                            Your PostHog.com login is separate from the app's authentication.{' '}
+                        <h3 className="text-base font-semibold leading-tight mb-2">The hedgehogs missed you</h3>
+                        <PostHogButton label="Sign in with PostHog" className="mt-3 mb-2" />
+                        <div className="flex items-center gap-2 text-xs text-muted my-2">
+                            <span className="flex-1 border-t border-border" />
+                            or
+                            <span className="flex-1 border-t border-border" />
+                        </div>
+                        <p className="text-xs text-red dark:text-orange mb-2">
+                            The email and password below are separate from your PostHog app account.{' '}
                             <Link
                                 to="https://app.posthog.com"
                                 external

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import React, { createContext, useEffect, useState } from 'react'
 import qs from 'qs'
-import { ProfileData } from 'lib/strapi'
+import { ProfileData, SQUEAK_HOST } from 'lib/strapi'
 import usePostHog from './usePostHog'
 import Link from 'components/Link'
 import { useToast } from '../context/Toast'
@@ -147,6 +147,54 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         return jwt || localStorage.getItem('jwt')
     }
 
+    // Shared post-authentication steps once a JWT has been obtained (via password
+    // login or an OAuth provider): hydrate the user, persist the token, and run
+    // the distinct-id link + achievements check.
+    const finalizeLogin = async (token: string): Promise<User> => {
+        const user = await fetchUser(token)
+
+        if (!user) {
+            throw new Error('Failed to fetch user data')
+        }
+
+        localStorage.setItem('jwt', token)
+        setJwt(token)
+
+        try {
+            const distinctId = posthog?.get_distinct_id?.()
+
+            if (distinctId && distinctId !== COOKIELESS_SENTINEL_VALUE) {
+                await fetch(`${SQUEAK_HOST}/api/users/${user.id}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${token}`,
+                    },
+                    body: JSON.stringify({
+                        distinctId,
+                    }),
+                })
+            }
+
+            fetch(`${SQUEAK_HOST}/api/achievements/check`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    data: {
+                        date: new Date(),
+                    },
+                }),
+            })
+        } catch (error) {
+            console.error(error)
+        }
+
+        return user
+    }
+
     const login = async ({
         email,
         password,
@@ -159,7 +207,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         try {
             posthog?.capture('squeak login start')
 
-            const userRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/auth/local`, {
+            const userRes = await fetch(`${SQUEAK_HOST}/api/auth/local`, {
                 headers: {
                     'Content-Type': 'application/json',
                 },
@@ -176,50 +224,11 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                 throw new Error(userData?.error?.message)
             }
 
-            const user = await fetchUser(userData.jwt)
-
-            if (!user) {
-                throw new Error('Failed to fetch user data')
-            }
+            const user = await finalizeLogin(userData.jwt)
 
             posthog?.capture('squeak login success', {
                 email,
             })
-
-            localStorage.setItem('jwt', userData.jwt)
-            setJwt(userData.jwt)
-
-            try {
-                const distinctId = posthog?.get_distinct_id?.()
-
-                if (distinctId && distinctId !== COOKIELESS_SENTINEL_VALUE) {
-                    await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/users/${user.id}`, {
-                        method: 'PUT',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            Authorization: `Bearer ${userData.jwt}`,
-                        },
-                        body: JSON.stringify({
-                            distinctId,
-                        }),
-                    })
-                }
-
-                fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/achievements/check`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        Authorization: `Bearer ${userData.jwt}`,
-                    },
-                    body: JSON.stringify({
-                        data: {
-                            date: new Date(),
-                        },
-                    }),
-                })
-            } catch (error) {
-                console.error(error)
-            }
 
             return user
         } catch (error) {
@@ -280,7 +289,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         try {
             posthog?.capture('squeak signup start')
 
-            const res = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/auth/local/register`, {
+            const res = await fetch(`${SQUEAK_HOST}/api/auth/local/register`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -415,7 +424,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             token = await getJwt()
         }
 
-        const meRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/users/me?${meQuery}`, {
+        const meRes = await fetch(`${SQUEAK_HOST}/api/users/me?${meQuery}`, {
             headers: {
                 Authorization: `Bearer ${token}`,
             },
@@ -432,7 +441,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
         setUser(meData)
 
-        const notifications = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profile/notifications`, {
+        const notifications = await fetch(`${SQUEAK_HOST}/api/profile/notifications`, {
             headers: {
                 Authorization: `Bearer ${token}`,
             },
@@ -488,7 +497,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             },
         })
 
-        const profileRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles?${query}`)
+        const profileRes = await fetch(`${SQUEAK_HOST}/api/profiles?${query}`)
 
         if (!profileRes.ok) {
             throw new Error(`Failed to fetch profile`)
@@ -523,7 +532,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
         const jwt = await getJwt()
 
-        const subscriptionRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${profileID}`, {
+        const subscriptionRes = await fetch(`${SQUEAK_HOST}/api/profiles/${profileID}`, {
             method: 'PUT',
             body: JSON.stringify(body),
             headers: {
@@ -551,7 +560,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                       },
             },
         }
-        const likeRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${profileID}`, {
+        const likeRes = await fetch(`${SQUEAK_HOST}/api/profiles/${profileID}`, {
             method: 'PUT',
             body: JSON.stringify(body),
             headers: {
@@ -596,7 +605,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                       },
             },
         }
-        const likeRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${profileID}`, {
+        const likeRes = await fetch(`${SQUEAK_HOST}/api/profiles/${profileID}`, {
             method: 'PUT',
             body: JSON.stringify(body),
             headers: {
@@ -621,7 +630,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
     const updateNotifications = async (notifications: any) => {
         setNotifications(notifications)
-        await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${user?.profile.id}`, {
+        await fetch(`${SQUEAK_HOST}/api/profiles/${user?.profile.id}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -639,7 +648,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         const profileID = user?.profile?.id
         if (!profileID) return
         const jwt = await getJwt()
-        await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/replies/${id}/${vote}`, {
+        await fetch(`${SQUEAK_HOST}/api/replies/${id}/${vote}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -652,7 +661,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         const profileID = user?.profile?.id
         if (!profileID) return
         const jwt = await getJwt()
-        await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${profileID}`, {
+        await fetch(`${SQUEAK_HOST}/api/profiles/${profileID}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -690,7 +699,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         const profileID = user?.profile?.id
         if (!profileID) return
         const jwt = await getJwt()
-        await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${profileID}`, {
+        await fetch(`${SQUEAK_HOST}/api/profiles/${profileID}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -716,7 +725,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         const profileID = user?.profile?.id
         if (!profileID) return
         const jwt = await getJwt()
-        await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/report-spam`, {
+        await fetch(`${SQUEAK_HOST}/api/report-spam`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -17,7 +17,7 @@ export type User = {
     blocked: boolean
     confirmed: boolean
     createdAt: string
-    provider: 'local' | 'github' | 'google'
+    provider: 'local' | 'github' | 'google' | 'posthog'
     username: string
     profile: {
         id: number
@@ -53,6 +53,7 @@ type UserContextValue = {
     fetchUser: (token?: string | null) => Promise<User | null>
     getJwt: () => Promise<string | null>
     login: (args: { email: string; password: string }) => Promise<User | null | { error: string }>
+    loginWithProvider: (args: { provider: 'posthog'; accessToken: string }) => Promise<User | null | { error: string }>
     logout: () => Promise<void>
     signUp: (args: {
         email: string
@@ -98,6 +99,7 @@ export const UserContext = createContext<UserContextValue>({
     fetchUser: async () => null,
     getJwt: async () => null,
     login: async () => null,
+    loginWithProvider: async () => null,
     logout: async () => {
         // noop
     },
@@ -235,6 +237,55 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             posthog?.capture('squeak error', {
                 source: 'useUser.login',
                 email,
+                error: JSON.stringify(error),
+            })
+
+            console.error(error)
+
+            if (error instanceof Error) {
+                return { error: error.message }
+            }
+
+            return null
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    const loginWithProvider = async ({
+        provider,
+        accessToken,
+    }: {
+        provider: 'posthog'
+        accessToken: string
+    }): Promise<User | null | { error: string }> => {
+        setIsLoading(true)
+
+        try {
+            posthog?.capture('squeak oauth login start', { provider })
+
+            const res = await fetch(
+                `${SQUEAK_HOST}/api/auth/${provider}/callback?access_token=${encodeURIComponent(accessToken)}`
+            )
+
+            const data = await res.json()
+
+            if (!res.ok) {
+                throw new Error(data?.error?.message)
+            }
+
+            const user = await finalizeLogin(data.jwt)
+
+            posthog?.capture('squeak oauth login success', {
+                provider,
+                email: user.email,
+            })
+
+            return user
+        } catch (error) {
+            posthog?.capture('squeak error', {
+                source: 'useUser.loginWithProvider',
+                provider,
                 error: JSON.stringify(error),
             })
 
@@ -747,6 +798,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         isLoading,
         getJwt,
         login,
+        loginWithProvider,
         logout,
         signUp,
         fetchUser,

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -1,3 +1,10 @@
+// Host for client-side Squeak/Strapi calls (auth + the authenticated session).
+// Override via GATSBY_SQUEAK_AUTH_HOST — e.g. a local Strapi instance — for testing;
+// defaults to the normal API host so prod and other devs are unaffected. Note:
+// build-time sourcing (gatsby-source-squeak) uses GATSBY_SQUEAK_API_HOST directly and
+// is intentionally NOT affected by this, so it stays on the full-data cloud backend.
+export const SQUEAK_HOST = process.env.GATSBY_SQUEAK_AUTH_HOST || process.env.GATSBY_SQUEAK_API_HOST
+
 // Strapi helper types
 export type StrapiResult<T> = StrapiData<T> &
     StrapiMeta & {

--- a/src/pages/connect/posthog/redirect.tsx
+++ b/src/pages/connect/posthog/redirect.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { navigate } from 'gatsby'
+import SEO from 'components/seo'
+import { CallToAction } from 'components/CallToAction'
+import { IconSpinner } from '@posthog/icons'
+import { useUser } from 'hooks/useUser'
+import { useToast } from '../../../context/Toast'
+
+// Landing page for the PostHog OAuth flow. Strapi finishes the PKCE exchange
+// with oauth.posthog.com server-side, then redirects the browser here with
+// `?access_token=<PostHog provider token>`. We hand that token to Strapi's
+// `/api/auth/posthog/callback`, which verifies it and returns a Strapi JWT in
+// the response body.
+export default function PostHogRedirect(): JSX.Element {
+    const { loginWithProvider } = useUser()
+    const { addToast } = useToast()
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
+    const hasRun = useRef(false)
+
+    useEffect(() => {
+        if (hasRun.current) return
+        hasRun.current = true
+
+        const params = new URLSearchParams(window.location.search)
+        const accessToken = params.get('access_token')
+
+        // Drop the provider access_token from the address bar/history right away
+        // so it isn't retained in browser history or leaked via the Referer header.
+        if (window.location.search) {
+            window.history.replaceState({}, '', window.location.pathname)
+        }
+
+        if (!accessToken) {
+            setErrorMessage('Missing access token. Please try signing in again.')
+            return
+        }
+
+        const completeSignIn = async () => {
+            const user = await loginWithProvider({ provider: 'posthog', accessToken })
+
+            if (!user || 'error' in user) {
+                setErrorMessage(
+                    (user && 'error' in user && user.error) || 'There was an error signing in with PostHog.'
+                )
+                return
+            }
+
+            addToast({
+                title: 'Successfully signed in to PostHog.com',
+                description: 'Welcome back!',
+            })
+            navigate('/community', { replace: true })
+        }
+
+        completeSignIn()
+    }, [])
+
+    return (
+        <>
+            <SEO title="Signing in" noindex />
+            <div data-scheme="primary" className="flex flex-col items-center justify-center min-h-screen gap-4 p-8">
+                {errorMessage ? (
+                    <>
+                        <p className="text-red font-semibold m-0">{errorMessage}</p>
+                        <CallToAction type="primary" size="sm" to="/community">
+                            Back to community
+                        </CallToAction>
+                    </>
+                ) : (
+                    <>
+                        <IconSpinner className="size-8 animate-spin" />
+                        <p className="m-0">Signing you in&hellip;</p>
+                    </>
+                )}
+            </div>
+        </>
+    )
+}


### PR DESCRIPTION
This PR adds support for authenticating to posthog.com using PostHog OAuth. It also requires PostHog employees to use PostHog OAuth (no more password!). Must ship after https://github.com/PostHog/squeak-strapi/pull/190

Set `GATSBY_SQUEAK_AUTH_HOST=http://localhost:1337` in `.env.developement.local` to route auth to your local strapi instance.

<img width="490" height="421" alt="Screenshot 2026-06-02 at 22 34 19" src="https://github.com/user-attachments/assets/3431d825-4a20-49c8-9aec-f21be3cb5f55" />
