### PR TITLE
docs: update Leon's SME area to Enterprise & Platform

### DIFF
--- a/contents/handbook/growth/sales/product-enablement.md
+++ b/contents/handbook/growth/sales/product-enablement.md
@@ -77,7 +77,7 @@ All content should include a "last updated" date so team members know they're wo
 | Feature flags | Sachin     | - |
 | Experiments | Sachin     | - |
 | Error tracking | Sean M | - |
-| Surveys | Leon        | - |
+| Enterprise & Platform | Leon        | - |
 | Data pipelines (batch and realtime) | Ryan       | - |
 | Data warehouse | Ryan       | - |
 | AI Observability | Leo        | - |


### PR DESCRIPTION
## Summary

- Updates the SME row on the [Product enablement handbook page](https://posthog.com/handbook/growth/sales/product-enablement#product-areas-and-smes) so Leon is listed against **Enterprise & Platform** instead of Surveys.

## Test plan

- [ ] Confirm the row at \`contents/handbook/growth/sales/product-enablement.md\` reads \`| Enterprise & Platform | Leon        | - |\`.
- [ ] After deploy, confirm the rendered row on the live handbook page reflects the change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*