### PR TITLE
fix(ai-observability): decouple platform card label from page title

### DIFF
--- a/contents/docs/ai-observability/installation/anthropic.mdx
+++ b/contents/docs/ai-observability/installation/anthropic.mdx
@@ -1,5 +1,5 @@
 ---
-title: Anthropic AI Observability installation
+title: Anthropic
 platformIconName: IconAnthropic
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/anthropic.mdx
+++ b/contents/docs/ai-observability/installation/anthropic.mdx
@@ -1,5 +1,6 @@
 ---
-title: Anthropic
+title: Anthropic AI Observability installation
+platformLabel: Anthropic
 platformIconName: IconAnthropic
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/autogen.mdx
+++ b/contents/docs/ai-observability/installation/autogen.mdx
@@ -1,5 +1,5 @@
 ---
-title: AutoGen AI Observability installation
+title: AutoGen
 platformLogo: autogen
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/autogen.mdx
+++ b/contents/docs/ai-observability/installation/autogen.mdx
@@ -1,5 +1,6 @@
 ---
-title: AutoGen
+title: AutoGen AI Observability installation
+platformLabel: AutoGen
 platformLogo: autogen
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/aws-bedrock.mdx
+++ b/contents/docs/ai-observability/installation/aws-bedrock.mdx
@@ -1,5 +1,5 @@
 ---
-title: AWS Bedrock AI Observability installation
+title: AWS Bedrock
 platformLogo: awsBedrock
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/aws-bedrock.mdx
+++ b/contents/docs/ai-observability/installation/aws-bedrock.mdx
@@ -1,5 +1,6 @@
 ---
-title: AWS Bedrock
+title: AWS Bedrock AI Observability installation
+platformLabel: AWS Bedrock
 platformLogo: awsBedrock
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/azure-openai.mdx
+++ b/contents/docs/ai-observability/installation/azure-openai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azure OpenAI observability installation
+title: Azure OpenAI
 platformLogo: azureOpenAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/azure-openai.mdx
+++ b/contents/docs/ai-observability/installation/azure-openai.mdx
@@ -1,5 +1,6 @@
 ---
-title: Azure OpenAI
+title: Azure OpenAI observability installation
+platformLabel: Azure OpenAI
 platformLogo: azureOpenAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/cerebras.mdx
+++ b/contents/docs/ai-observability/installation/cerebras.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cerebras AI Observability installation
+title: Cerebras
 platformLogo: cerebras
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/cerebras.mdx
+++ b/contents/docs/ai-observability/installation/cerebras.mdx
@@ -1,5 +1,6 @@
 ---
-title: Cerebras
+title: Cerebras AI Observability installation
+platformLabel: Cerebras
 platformLogo: cerebras
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/claude-agent-sdk.mdx
+++ b/contents/docs/ai-observability/installation/claude-agent-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Claude Agent SDK AI Observability installation
+title: Claude Agent SDK
 platformIconName: IconAnthropic
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/claude-agent-sdk.mdx
+++ b/contents/docs/ai-observability/installation/claude-agent-sdk.mdx
@@ -1,5 +1,6 @@
 ---
-title: Claude Agent SDK
+title: Claude Agent SDK AI Observability installation
+platformLabel: Claude Agent SDK
 platformIconName: IconAnthropic
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/claude-code.mdx
+++ b/contents/docs/ai-observability/installation/claude-code.mdx
@@ -1,5 +1,5 @@
 ---
-title: Claude Code AI Observability installation
+title: Claude Code
 platformIconName: IconClaudeCode
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/claude-code.mdx
+++ b/contents/docs/ai-observability/installation/claude-code.mdx
@@ -1,5 +1,6 @@
 ---
-title: Claude Code
+title: Claude Code AI Observability installation
+platformLabel: Claude Code
 platformIconName: IconClaudeCode
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/cloudflare-ai-gateway.mdx
+++ b/contents/docs/ai-observability/installation/cloudflare-ai-gateway.mdx
@@ -1,5 +1,6 @@
 ---
-title: Cloudflare AI Gateway
+title: Cloudflare AI Gateway observability installation
+platformLabel: Cloudflare AI Gateway
 platformLogo: cloudflare
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/cloudflare-ai-gateway.mdx
+++ b/contents/docs/ai-observability/installation/cloudflare-ai-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloudflare AI Gateway observability installation
+title: Cloudflare AI Gateway
 platformLogo: cloudflare
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/cohere.mdx
+++ b/contents/docs/ai-observability/installation/cohere.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cohere AI Observability installation
+title: Cohere
 platformLogo: cohere
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/cohere.mdx
+++ b/contents/docs/ai-observability/installation/cohere.mdx
@@ -1,5 +1,6 @@
 ---
-title: Cohere
+title: Cohere AI Observability installation
+platformLabel: Cohere
 platformLogo: cohere
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/convex.mdx
+++ b/contents/docs/ai-observability/installation/convex.mdx
@@ -1,5 +1,6 @@
 ---
-title: Convex
+title: Convex AI Observability installation
+platformLabel: Convex
 platformLogo: convex
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/convex.mdx
+++ b/contents/docs/ai-observability/installation/convex.mdx
@@ -1,5 +1,5 @@
 ---
-title: Convex AI Observability installation
+title: Convex
 platformLogo: convex
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/crewai.mdx
+++ b/contents/docs/ai-observability/installation/crewai.mdx
@@ -1,5 +1,6 @@
 ---
-title: CrewAI
+title: CrewAI observability installation
+platformLabel: CrewAI
 platformLogo: crewai
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/crewai.mdx
+++ b/contents/docs/ai-observability/installation/crewai.mdx
@@ -1,5 +1,5 @@
 ---
-title: CrewAI observability installation
+title: CrewAI
 platformLogo: crewai
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/dedalus.mdx
+++ b/contents/docs/ai-observability/installation/dedalus.mdx
@@ -1,5 +1,5 @@
 ---
-title: Dedalus Labs AI Observability installation
+title: Dedalus Labs
 platformLogo: dedalus
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/dedalus.mdx
+++ b/contents/docs/ai-observability/installation/dedalus.mdx
@@ -1,5 +1,6 @@
 ---
-title: Dedalus Labs
+title: Dedalus Labs AI Observability installation
+platformLabel: Dedalus Labs
 platformLogo: dedalus
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/deepseek.mdx
+++ b/contents/docs/ai-observability/installation/deepseek.mdx
@@ -1,5 +1,5 @@
 ---
-title: DeepSeek AI Observability installation
+title: DeepSeek
 platformLogo: deepseek
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/deepseek.mdx
+++ b/contents/docs/ai-observability/installation/deepseek.mdx
@@ -1,5 +1,6 @@
 ---
-title: DeepSeek
+title: DeepSeek AI Observability installation
+platformLabel: DeepSeek
 platformLogo: deepseek
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/dspy.mdx
+++ b/contents/docs/ai-observability/installation/dspy.mdx
@@ -1,5 +1,6 @@
 ---
-title: DSPy
+title: DSPy AI Observability installation
+platformLabel: DSPy
 platformLogo: dspy
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/dspy.mdx
+++ b/contents/docs/ai-observability/installation/dspy.mdx
@@ -1,5 +1,5 @@
 ---
-title: DSPy AI Observability installation
+title: DSPy
 platformLogo: dspy
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/fireworks-ai.mdx
+++ b/contents/docs/ai-observability/installation/fireworks-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Fireworks AI Observability installation
+title: Fireworks AI
 platformLogo: fireworksAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/fireworks-ai.mdx
+++ b/contents/docs/ai-observability/installation/fireworks-ai.mdx
@@ -1,5 +1,6 @@
 ---
-title: Fireworks AI
+title: Fireworks AI Observability installation
+platformLabel: Fireworks AI
 platformLogo: fireworksAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/google.mdx
+++ b/contents/docs/ai-observability/installation/google.mdx
@@ -1,5 +1,5 @@
 ---
-title: Google AI Observability installation
+title: Google
 platformIconName: IconGemini
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/google.mdx
+++ b/contents/docs/ai-observability/installation/google.mdx
@@ -1,5 +1,6 @@
 ---
-title: Google
+title: Google AI Observability installation
+platformLabel: Google
 platformIconName: IconGemini
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/groq.mdx
+++ b/contents/docs/ai-observability/installation/groq.mdx
@@ -1,5 +1,6 @@
 ---
-title: Groq
+title: Groq AI Observability installation
+platformLabel: Groq
 platformLogo: groq
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/groq.mdx
+++ b/contents/docs/ai-observability/installation/groq.mdx
@@ -1,5 +1,5 @@
 ---
-title: Groq AI Observability installation
+title: Groq
 platformLogo: groq
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/helicone.mdx
+++ b/contents/docs/ai-observability/installation/helicone.mdx
@@ -1,5 +1,5 @@
 ---
-title: Helicone AI Observability installation
+title: Helicone
 platformLogo: helicone
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/helicone.mdx
+++ b/contents/docs/ai-observability/installation/helicone.mdx
@@ -1,5 +1,6 @@
 ---
-title: Helicone
+title: Helicone AI Observability installation
+platformLabel: Helicone
 platformLogo: helicone
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/hugging-face.mdx
+++ b/contents/docs/ai-observability/installation/hugging-face.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hugging Face AI Observability installation
+title: Hugging Face
 platformLogo: huggingFace
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/hugging-face.mdx
+++ b/contents/docs/ai-observability/installation/hugging-face.mdx
@@ -1,5 +1,6 @@
 ---
-title: Hugging Face
+title: Hugging Face AI Observability installation
+platformLabel: Hugging Face
 platformLogo: huggingFace
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/instructor.mdx
+++ b/contents/docs/ai-observability/installation/instructor.mdx
@@ -1,5 +1,6 @@
 ---
-title: Instructor
+title: Instructor AI Observability installation
+platformLabel: Instructor
 platformLogo: instructor
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/instructor.mdx
+++ b/contents/docs/ai-observability/installation/instructor.mdx
@@ -1,5 +1,5 @@
 ---
-title: Instructor AI Observability installation
+title: Instructor
 platformLogo: instructor
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/langchain.mdx
+++ b/contents/docs/ai-observability/installation/langchain.mdx
@@ -1,5 +1,6 @@
 ---
-title: LangChain
+title: LangChain AI Observability installation
+platformLabel: LangChain
 platformIconName: IconLangChain
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/langchain.mdx
+++ b/contents/docs/ai-observability/installation/langchain.mdx
@@ -1,5 +1,5 @@
 ---
-title: LangChain AI Observability installation
+title: LangChain
 platformIconName: IconLangChain
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/langgraph.mdx
+++ b/contents/docs/ai-observability/installation/langgraph.mdx
@@ -1,5 +1,6 @@
 ---
-title: LangGraph
+title: LangGraph AI Observability installation
+platformLabel: LangGraph
 platformLogo: langgraph
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/langgraph.mdx
+++ b/contents/docs/ai-observability/installation/langgraph.mdx
@@ -1,5 +1,5 @@
 ---
-title: LangGraph AI Observability installation
+title: LangGraph
 platformLogo: langgraph
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/litellm.mdx
+++ b/contents/docs/ai-observability/installation/litellm.mdx
@@ -1,5 +1,5 @@
 ---
-title: LiteLLM AI Observability installation
+title: LiteLLM
 platformLogo: litellm
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/litellm.mdx
+++ b/contents/docs/ai-observability/installation/litellm.mdx
@@ -1,5 +1,6 @@
 ---
-title: LiteLLM
+title: LiteLLM AI Observability installation
+platformLabel: LiteLLM
 platformLogo: litellm
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/llamaindex.mdx
+++ b/contents/docs/ai-observability/installation/llamaindex.mdx
@@ -1,5 +1,6 @@
 ---
-title: LlamaIndex
+title: LlamaIndex AI Observability installation
+platformLabel: LlamaIndex
 platformLogo: llamaindex
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/llamaindex.mdx
+++ b/contents/docs/ai-observability/installation/llamaindex.mdx
@@ -1,5 +1,5 @@
 ---
-title: LlamaIndex AI Observability installation
+title: LlamaIndex
 platformLogo: llamaindex
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -1,5 +1,6 @@
 ---
-title: Manual capture
+title: Manual capture AI Observability installation
+platformLabel: Manual capture
 platformIconName: IconCode
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -1,5 +1,5 @@
 ---
-title: Manual capture AI Observability installation
+title: Manual capture
 platformIconName: IconCode
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/mastra.mdx
+++ b/contents/docs/ai-observability/installation/mastra.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mastra AI Observability installation
+title: Mastra
 platformLogo: mastra
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/mastra.mdx
+++ b/contents/docs/ai-observability/installation/mastra.mdx
@@ -1,5 +1,6 @@
 ---
-title: Mastra
+title: Mastra AI Observability installation
+platformLabel: Mastra
 platformLogo: mastra
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/mirascope.mdx
+++ b/contents/docs/ai-observability/installation/mirascope.mdx
@@ -1,5 +1,6 @@
 ---
-title: Mirascope
+title: Mirascope AI Observability installation
+platformLabel: Mirascope
 platformLogo: mirascope
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/mirascope.mdx
+++ b/contents/docs/ai-observability/installation/mirascope.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mirascope AI Observability installation
+title: Mirascope
 platformLogo: mirascope
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/mistral.mdx
+++ b/contents/docs/ai-observability/installation/mistral.mdx
@@ -1,5 +1,6 @@
 ---
-title: Mistral
+title: Mistral AI Observability installation
+platformLabel: Mistral
 platformLogo: mistral
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/mistral.mdx
+++ b/contents/docs/ai-observability/installation/mistral.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mistral AI Observability installation
+title: Mistral
 platformLogo: mistral
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/ollama.mdx
+++ b/contents/docs/ai-observability/installation/ollama.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ollama AI Observability installation
+title: Ollama
 platformLogo: ollama
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/ollama.mdx
+++ b/contents/docs/ai-observability/installation/ollama.mdx
@@ -1,5 +1,6 @@
 ---
-title: Ollama
+title: Ollama AI Observability installation
+platformLabel: Ollama
 platformLogo: ollama
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openai-agents.mdx
+++ b/contents/docs/ai-observability/installation/openai-agents.mdx
@@ -1,5 +1,6 @@
 ---
-title: OpenAI Agents SDK
+title: OpenAI Agents SDK observability installation
+platformLabel: OpenAI Agents SDK
 platformIconName: IconOpenAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openai-agents.mdx
+++ b/contents/docs/ai-observability/installation/openai-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenAI Agents SDK observability installation
+title: OpenAI Agents SDK
 platformIconName: IconOpenAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openai.mdx
+++ b/contents/docs/ai-observability/installation/openai.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenAI observability installation
+title: OpenAI
 platformIconName: IconOpenAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openai.mdx
+++ b/contents/docs/ai-observability/installation/openai.mdx
@@ -1,5 +1,6 @@
 ---
-title: OpenAI
+title: OpenAI observability installation
+platformLabel: OpenAI
 platformIconName: IconOpenAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openclaw.mdx
+++ b/contents/docs/ai-observability/installation/openclaw.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenClaw AI Observability installation
+title: OpenClaw
 platformIconName: IconOpenClaw
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openclaw.mdx
+++ b/contents/docs/ai-observability/installation/openclaw.mdx
@@ -1,5 +1,6 @@
 ---
-title: OpenClaw
+title: OpenClaw AI Observability installation
+platformLabel: OpenClaw
 platformIconName: IconOpenClaw
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openrouter.mdx
+++ b/contents/docs/ai-observability/installation/openrouter.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenRouter AI Observability installation
+title: OpenRouter
 platformIconName: IconOpenRouter
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/openrouter.mdx
+++ b/contents/docs/ai-observability/installation/openrouter.mdx
@@ -1,5 +1,6 @@
 ---
-title: OpenRouter
+title: OpenRouter AI Observability installation
+platformLabel: OpenRouter
 platformIconName: IconOpenRouter
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/opentelemetry.mdx
+++ b/contents/docs/ai-observability/installation/opentelemetry.mdx
@@ -1,5 +1,6 @@
 ---
-title: OpenTelemetry
+title: OpenTelemetry AI Observability installation
+platformLabel: OpenTelemetry
 platformLogo: opentelemetry
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/opentelemetry.mdx
+++ b/contents/docs/ai-observability/installation/opentelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry AI Observability installation
+title: OpenTelemetry
 platformLogo: opentelemetry
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/perplexity.mdx
+++ b/contents/docs/ai-observability/installation/perplexity.mdx
@@ -1,5 +1,5 @@
 ---
-title: Perplexity AI Observability installation
+title: Perplexity
 platformLogo: perplexity
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/perplexity.mdx
+++ b/contents/docs/ai-observability/installation/perplexity.mdx
@@ -1,5 +1,6 @@
 ---
-title: Perplexity
+title: Perplexity AI Observability installation
+platformLabel: Perplexity
 platformLogo: perplexity
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/pi.mdx
+++ b/contents/docs/ai-observability/installation/pi.mdx
@@ -1,5 +1,6 @@
 ---
-title: Pi Coding Agent
+title: Pi Coding Agent AI Observability installation
+platformLabel: Pi Coding Agent
 platformIconName: IconCode
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/pi.mdx
+++ b/contents/docs/ai-observability/installation/pi.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pi Coding Agent AI Observability installation
+title: Pi Coding Agent
 platformIconName: IconCode
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/portkey.mdx
+++ b/contents/docs/ai-observability/installation/portkey.mdx
@@ -1,5 +1,6 @@
 ---
-title: Portkey
+title: Portkey AI Observability installation
+platformLabel: Portkey
 platformLogo: portkey
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/portkey.mdx
+++ b/contents/docs/ai-observability/installation/portkey.mdx
@@ -1,5 +1,5 @@
 ---
-title: Portkey AI Observability installation
+title: Portkey
 platformLogo: portkey
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/pydantic-ai.mdx
+++ b/contents/docs/ai-observability/installation/pydantic-ai.mdx
@@ -1,5 +1,6 @@
 ---
-title: Pydantic AI
+title: Pydantic AI Observability installation
+platformLabel: Pydantic AI
 platformLogo: pydanticAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/pydantic-ai.mdx
+++ b/contents/docs/ai-observability/installation/pydantic-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pydantic AI Observability installation
+title: Pydantic AI
 platformLogo: pydanticAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/semantic-kernel.mdx
+++ b/contents/docs/ai-observability/installation/semantic-kernel.mdx
@@ -1,5 +1,6 @@
 ---
-title: Semantic Kernel
+title: Semantic Kernel AI Observability installation
+platformLabel: Semantic Kernel
 platformLogo: semanticKernel
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/semantic-kernel.mdx
+++ b/contents/docs/ai-observability/installation/semantic-kernel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Semantic Kernel AI Observability installation
+title: Semantic Kernel
 platformLogo: semanticKernel
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/smolagents.mdx
+++ b/contents/docs/ai-observability/installation/smolagents.mdx
@@ -1,5 +1,6 @@
 ---
-title: smolagents
+title: smolagents AI Observability installation
+platformLabel: smolagents
 platformLogo: smolagents
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/smolagents.mdx
+++ b/contents/docs/ai-observability/installation/smolagents.mdx
@@ -1,5 +1,5 @@
 ---
-title: smolagents AI Observability installation
+title: smolagents
 platformLogo: smolagents
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/together-ai.mdx
+++ b/contents/docs/ai-observability/installation/together-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Together AI Observability installation
+title: Together AI
 platformLogo: togetherAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/together-ai.mdx
+++ b/contents/docs/ai-observability/installation/together-ai.mdx
@@ -1,5 +1,6 @@
 ---
-title: Together AI
+title: Together AI Observability installation
+platformLabel: Together AI
 platformLogo: togetherAI
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/vercel-ai.mdx
+++ b/contents/docs/ai-observability/installation/vercel-ai.mdx
@@ -1,5 +1,6 @@
 ---
-title: Vercel AI SDK
+title: Vercel AI SDK observability installation
+platformLabel: Vercel AI SDK
 platformLogo: vercel
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/vercel-ai.mdx
+++ b/contents/docs/ai-observability/installation/vercel-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Vercel AI SDK observability installation
+title: Vercel AI SDK
 platformLogo: vercel
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/xai.mdx
+++ b/contents/docs/ai-observability/installation/xai.mdx
@@ -1,5 +1,6 @@
 ---
-title: xAI
+title: xAI Observability installation
+platformLabel: xAI
 platformLogo: xai
 showStepsToc: true
 tableOfContents: [

--- a/contents/docs/ai-observability/installation/xai.mdx
+++ b/contents/docs/ai-observability/installation/xai.mdx
@@ -1,5 +1,5 @@
 ---
-title: xAI Observability installation
+title: xAI
 platformLogo: xai
 showStepsToc: true
 tableOfContents: [

--- a/src/hooks/docs/usePlatformList.ts
+++ b/src/hooks/docs/usePlatformList.ts
@@ -28,6 +28,9 @@
  * MDX frontmatter format:
  * - platformLogo: Key from `src/constants/logos.ts` (e.g., "stripe", "react", "nodejs")
  * - platformIconName: Icon like "IconCode" (fallback if no logo)
+ * - platformLabel: Optional explicit card label. Overrides the suffix-stripped
+ *   title — use when the auto-derived label is wrong (e.g. provider name
+ *   contains the suffix, like "Fireworks AI" + "AI Observability installation").
  *
  * Usage:
  * const platforms = usePlatformList('docs/error-tracking/installation', 'error tracking installation')
@@ -113,6 +116,7 @@ export default function usePlatformList(
                     slug
                     frontmatter {
                         title
+                        platformLabel
                         platformLogo
                         platformIconName
                         platformSourceType
@@ -133,9 +137,12 @@ export default function usePlatformList(
             return true
         })
         .map((node: any) => {
-            let label = node.frontmatter.title
+            // Prefer an explicit `platformLabel` when set — the strip-suffix
+            // fallback breaks when provider names overlap the suffix (e.g.
+            // "Fireworks AI Observability installation" stripping to "Fireworks").
+            let label = node.frontmatter.platformLabel || node.frontmatter.title
 
-            if (titleSuffix) {
+            if (!node.frontmatter.platformLabel && titleSuffix) {
                 // Extract versioning content in title (ex: "(v3.6 and below)")
                 const parenMatch = label.match(/\(([^)]+)\)/)
                 const versionInfo = parenMatch ? ` ${parenMatch[0]}` : ''


### PR DESCRIPTION
## Changes

The platform cards on [`/docs/ai-observability/start-here`](https://posthog.com/docs/ai-observability/start-here) render with stray "observability" appended to several provider names — "OpenAI observability installation", "Vercel AI SDK observability installation", "xAI Observability installation", etc.

The grid is generated by `usePlatformList('docs/ai-observability/installation', 'AI Observability installation')`, which strips the trailing suffix from each MDX `title:` to derive the card label. Two failure modes:

1. **Titles drift from the canonical suffix.** After the LLM Analytics → AI Observability rename, some titles ended with `observability installation` (no leading "AI", lowercase), so the regex didn't match and the suffix leaked into the label.
2. **Provider names overlap the suffix.** Even with a canonical title, names like "Fireworks AI", "Together AI", "Pydantic AI" get over-stripped to "Fireworks" / "Together" / "Pydantic" because the regex consumes the trailing " AI" as part of the suffix.

### Approach

Keep the descriptive `title:` for SEO/AEO/GEO (search engines want "OpenAI observability installation", not just "OpenAI") and add a new optional `platformLabel:` frontmatter field that overrides the auto-derived card label.

- `src/hooks/docs/usePlatformList.ts`: prefers `platformLabel` over the suffix-stripped title; documents the new field.
- 43 MDX files under `contents/docs/ai-observability/installation/`: original titles restored, `platformLabel:` added with the clean provider name (`OpenAI`, `Fireworks AI`, `xAI`, `Vercel AI SDK`, `OpenAI Agents SDK`, etc.).

Other docs sections (error tracking, surveys, etc.) are untouched — they continue to use the suffix-strip path and gain nothing from setting `platformLabel`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` *(N/A — no pages moved)*

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
