### PR TITLE
chore: Add engineering inclusive language guidance

### DIFF
--- a/contents/handbook/docs-and-wizard/docs-style-guide.mdx
+++ b/contents/handbook/docs-and-wizard/docs-style-guide.mdx
@@ -226,13 +226,13 @@ Use precise verbs that clearly describe the action being performed.
 
 ### Inclusive language
 
-Prefer neutral, inclusive terms.
+Prefer neutral, inclusive terms. For engineering-focused guidance covering code, APIs, config names, migrations, and PR review, see [Inclusive language in engineering](/handbook/engineering/conventions/inclusive-language).
 
 | Instead of | Use |
 |------------|-----|
-| blacklist/whitelist | denylist/allowlist |
-| sanity check | validation, verification |
-| master/slave | primary/secondary |
+| `blacklist` / `whitelist` | `denylist` / `allowlist`, or more specific terms |
+| `sanity check` | `validation`, `verification`, `health check`, `smoke test` |
+| `master` / `slave` | `primary` / `replica`, `primary` / `secondary` |
 
 ### Avoid phrases that trivialize
 

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -28,6 +28,8 @@ Use this guidance for:
 
 ## Preferred language
 
+This table is not exhaustive. Use common sense and choose language that is clear, specific, and respectful for the context.
+
 | Instead of | Prefer | Notes |
 |------------|--------|-------|
 | `whitelist` | `allowlist`, `permitted`, `included`, `trusted`, or a specific name like `allowed_domains` | Prefer the specific noun over a generic list when possible. |
@@ -41,6 +43,9 @@ Use this guidance for:
 | `dummy` | `placeholder`, `sample`, `test`, `fake`, `stub`, `mock` | Use the term that matches the role in the code or test. |
 | Gendered defaults like `he`, `she`, `his`, or `her` | `they`, `their`, role names, or direct address | In docs, prefer addressing the reader directly with "you". |
 | `guys` | `team`, `folks`, `everyone`, `people` | Use a word that includes the whole group. |
+| `cripple`, `crippled` | `break`, `disable`, `hamper`, `severely limit` | Common in incident write-ups when describing breakages. |
+| `normal`, when describing users or behavior | `typical`, `default`, `common`, `expected` | Calling one group or behavior `normal` can imply others are abnormal. |
+| `suffers from`, `afflicted with` | `has`, `is` | Avoid pathologizing language, particularly in accessibility. For example, write `a user who is colorblind` instead of `a user who suffers from colorblindness`. |
 | Casual uses of `crazy`, `insane`, or `lame` | `unexpected`, `surprising`, `broken`, `high-volume`, `difficult`, `unhelpful` | Describe the behavior or impact instead. |
 
 ## Examples

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -1,0 +1,117 @@
+---
+title: Inclusive language in engineering
+sidebar: Handbook
+showTitle: true
+---
+
+PostHog is built by and for people from many backgrounds. Clear, specific language helps everyone understand our code, product, docs, and operations. Some common technical terms carry unnecessary historical, cultural, or exclusionary baggage. Use neutral, precise alternatives when naming new things.
+
+This is guidance for engineering work. For docs-specific style, see the [docs style guide](/handbook/docs-and-wizard/docs-style-guide).
+
+## What this applies to
+
+Use this guidance for:
+
+- Product UI copy, settings, labels, tooltips, and errors
+- Code identifiers, comments, tests, fixtures, and examples
+- Public APIs, SDK options, CLI commands, environment variables, event names, and property names
+- Database tables, columns, migrations, queues, jobs, dashboards, and alerts
+- Handbook pages, docs, runbooks, incidents, post-mortems, issues, and PR descriptions
+
+## Default approach
+
+1. **Be specific first.** `blocked_email_domains` is clearer than a generic `email_denylist`. `trusted_proxy_ips` is clearer than `proxy_allowlist`.
+2. **Use neutral fallback terms.** If a generic list term is the clearest option, use `allowlist`, `denylist`, or `blocklist`.
+3. **Do not break users for a rename.** Public APIs, SDK options, environment variables, event names, properties, and stored data need aliases, migrations, deprecations, or a compatibility plan.
+4. **Improve old language when it is safe.** UI text, docs, comments, tests, local variables, and private helper names are usually safe to update when you touch nearby code.
+5. **Do not mirror external language unless needed.** If a vendor API, protocol, or file format uses a term, quote it when needed for accuracy, but use our preferred language in PostHog-owned names.
+
+## Preferred language
+
+| Instead of | Prefer | Notes |
+|------------|--------|-------|
+| `whitelist` | `allowlist`, `permitted`, `included`, `trusted`, or a specific name like `allowed_domains` | Prefer the specific noun over a generic list when possible. |
+| `blacklist` | `denylist`, `blocklist`, `blocked`, `excluded`, or a specific name like `blocked_ips` | Use `blocklist` when the behavior is blocking access or traffic. |
+| `whitelisted` | `allowed`, `permitted`, `trusted`, `included` | Use the verb that describes what the system does. |
+| `blacklisted` | `blocked`, `denied`, `excluded`, `filtered` | Use `filtered` when the item is removed from results rather than blocked from access. |
+| `master` / `slave` | `primary` / `replica`, `primary` / `secondary`, `leader` / `follower`, `source` / `replica` | For databases, prefer `primary` and `replica`. For consensus systems, `leader` and `follower` may be clearer. |
+| `master` branch | `main` | Use `main` for new repositories. Do not rename existing default branches without an owner and migration plan. |
+| `sanity check` | `validation`, `verification`, `health check`, `smoke test`, `quick check` | Pick the term that describes the actual check. |
+| `grandfathered` | `legacy`, `existing`, `retained access`, or explicit wording like "available on old plans" | Be clear about why something still applies. |
+| `dummy` | `placeholder`, `sample`, `test`, `fake`, `stub`, `mock` | Use the term that matches the role in the code or test. |
+| Gendered defaults like `he`, `she`, `his`, or `her` | `they`, `their`, role names, or direct address | In docs, prefer addressing the reader directly with "you". |
+| `guys` | `team`, `folks`, `everyone`, `people` | Use a word that includes the whole group. |
+| Casual uses of `crazy`, `insane`, or `lame` | `unexpected`, `surprising`, `broken`, `high-volume`, `difficult`, `unhelpful` | Describe the behavior or impact instead. |
+
+## Examples
+
+Prefer names that explain the rule or behavior:
+
+| Less clear | Better |
+|------------|--------|
+| `ip_whitelist` | `allowed_ip_addresses` |
+| `proxy_whitelist` | `trusted_proxy_ips` |
+| `property_blacklist` | `excluded_properties` |
+| `is_user_blacklisted` | `is_user_blocked` |
+| `master_database` | `primary_database` |
+| `slave_database` | `replica_database` |
+| `dummy_user` | `test_user` |
+| `sanity_check_query()` | `validate_query()` |
+
+User-facing copy should follow the same pattern:
+
+| Instead of | Use |
+|------------|-----|
+| `This domain is whitelisted.` | `This domain is allowed.` |
+| `This IP is blacklisted.` | `This IP is blocked.` |
+| `Run a sanity check before deploying.` | `Run a smoke test before deploying.` |
+| `This customer is grandfathered into the old plan.` | `This customer has retained access to the old plan.` |
+
+## Changing existing code
+
+Changing old names is valuable, but stability matters more than a tidy diff.
+
+Low-risk changes are usually fine when they are near the code you are already touching:
+
+- UI copy
+- Docs and handbook text
+- Comments
+- Tests and fixtures
+- Local variables
+- Private helper functions
+
+Higher-risk changes need a plan:
+
+- Public SDK options
+- API request or response fields
+- Environment variables
+- Event names and properties
+- Database table or column names
+- Queue names, topic names, and persisted job payloads
+- Dashboard, alert, or metric names that other teams depend on
+
+For higher-risk changes, prefer an additive migration:
+
+1. Add the new name.
+2. Keep the old name as a deprecated alias.
+3. Make precedence explicit if both names are present.
+4. Update docs and examples.
+5. Add telemetry or logging if you need to know when the old name is no longer used.
+6. Remove the old name only after the owning team has approved the migration.
+
+Avoid large rename-only PRs across unrelated areas. They create review noise and merge conflicts. If a broad rename is needed, split it by owned area and keep each PR mechanical.
+
+## Reviewing PRs
+
+Treat inclusive language like any other naming feedback:
+
+- Request changes for new user-facing copy, public APIs, SDK options, config names, and docs.
+- Suggest changes for private code when the fix is low risk.
+- Do not block urgent fixes because of old internal names unless the PR introduces new user-facing language.
+- If a rename could break users, ask for a compatibility plan instead of asking for a direct replacement.
+
+## Tooling
+
+Vale checks handbook and docs content for some inclusive language issues. The shared rule lives in `.vale/styles/PostHogBase/Inclusivity.yml`.
+
+If you add a new pattern to this page and want it enforced automatically, update the Vale rule in the same PR. Keep automated checks focused on clear cases with low false positives.

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -18,17 +18,20 @@ Use this guidance for:
 - Database tables, columns, migrations, queues, jobs, dashboards, and alerts
 - Handbook pages, docs, runbooks, incidents, post-mortems, issues, and PR descriptions
 
-## Default approach
+## How to choose language
 
-1. **Be specific first.** `blocked_email_domains` is clearer than a generic `email_denylist`. `trusted_proxy_ips` is clearer than `proxy_allowlist`.
-2. **Use neutral fallback terms.** If a generic list term is the clearest option, use `allowlist`, `denylist`, or `blocklist`.
-3. **Do not break users for a rename.** Public APIs, SDK options, environment variables, event names, properties, and stored data need aliases, migrations, deprecations, or a compatibility plan.
-4. **Improve old language when it is safe.** UI text, docs, comments, tests, local variables, and private helper names are usually safe to update when you touch nearby code.
-5. **Do not mirror external language unless needed.** If a vendor API, protocol, or file format uses a term, quote it when needed for accuracy, but use our preferred language in PostHog-owned names.
+When you add new names or copy:
+
+- **Be specific first.** `blocked_email_domains` is clearer than a generic `email_denylist`. `trusted_proxy_ips` is clearer than `proxy_allowlist`.
+- **Use neutral fallback terms.** If a generic list term is the clearest option, use `allowlist`, `denylist`, or `blocklist`.
+- **Use common sense.** This page is guidance, not a complete dictionary. Choose language that is clear, specific, and respectful for the context.
+- **Do not mirror external language unless needed.** If a vendor API, protocol, or file format uses a term, quote it when needed for accuracy, but use our preferred language in PostHog-owned names.
+
+For existing names, see [Changing existing code](#changing-existing-code).
 
 ## Preferred language
 
-This table is not exhaustive. Use common sense and choose language that is clear, specific, and respectful for the context.
+This table is not exhaustive.
 
 | Instead of | Prefer | Notes |
 |------------|--------|-------|
@@ -75,6 +78,11 @@ User-facing copy should follow the same pattern:
 ## Changing existing code
 
 Changing old names is valuable, but stability matters more than a tidy diff.
+
+Use these principles for existing names:
+
+- **Do not break users for a rename.** Public APIs, SDK options, environment variables, event names, properties, and stored data need aliases, migrations, deprecations, or a compatibility plan.
+- **Improve old language when it is safe.** UI text, docs, comments, tests, local variables, and private helper names are usually safe to update when you touch nearby code.
 
 Low-risk changes are usually fine when they are near the code you are already touching:
 

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -95,6 +95,8 @@ Higher-risk changes need a plan:
 - Queue names, topic names, and persisted job payloads
 - Dashboard, alert, or metric names that other teams depend on
 
+For broad, cross-cutting changes, align with [Developer Experience](/handbook/engineering/developer-experience) and the relevant feature owners before starting. They can help plan rollout, CI impact, compatibility, and repository-wide linting changes.
+
 For higher-risk changes, prefer an additive migration:
 
 1. Add the new name.

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -114,4 +114,6 @@ Treat inclusive language like any other naming feedback:
 
 Vale checks handbook and docs content for some inclusive language issues. The shared rule lives in `.vale/styles/PostHogBase/Inclusivity.yml`.
 
+Enable inclusive language linting in codebases whenever the ecosystem supports it. For example, Swift projects that use SwiftLint can enable its [`inclusive_language`](https://realm.github.io/SwiftLint/inclusive_language.html) rule.
+
 If you add a new pattern to this page and want it enforced automatically, update the Vale rule in the same PR. Keep automated checks focused on clear cases with low false positives.

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -51,30 +51,6 @@ This table is not exhaustive.
 | `suffers from`, `afflicted with` | `has`, `is` | Avoid pathologizing language, particularly in accessibility. For example, write `a user who is colorblind` instead of `a user who suffers from colorblindness`. |
 | Casual uses of `crazy`, `insane`, or `lame` | `unexpected`, `surprising`, `broken`, `high-volume`, `difficult`, `unhelpful` | Describe the behavior or impact instead. |
 
-## Examples
-
-Prefer names that explain the rule or behavior:
-
-| Less clear | Better |
-|------------|--------|
-| `ip_whitelist` | `allowed_ip_addresses` |
-| `proxy_whitelist` | `trusted_proxy_ips` |
-| `property_blacklist` | `excluded_properties` |
-| `is_user_blacklisted` | `is_user_blocked` |
-| `master_database` | `primary_database` |
-| `slave_database` | `replica_database` |
-| `dummy_user` | `test_user` |
-| `sanity_check_query()` | `validate_query()` |
-
-User-facing copy should follow the same pattern:
-
-| Instead of | Use |
-|------------|-----|
-| `This domain is whitelisted.` | `This domain is allowed.` |
-| `This IP is blacklisted.` | `This IP is blocked.` |
-| `Run a sanity check before deploying.` | `Run a smoke test before deploying.` |
-| `This customer is grandfathered into the old plan.` | `This customer has retained access to the old plan.` |
-
 ## Changing existing code
 
 Changing old names is valuable, but stability matters more than a tidy diff.

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -96,7 +96,7 @@ Avoid large rename-only PRs across unrelated areas. They create review noise and
 
 Treat inclusive language like any other naming feedback:
 
-- Request changes for new user-facing copy, public APIs, SDK options, config names, and docs.
+- Consider whether to request changes for new user-facing copy, public APIs, SDK options, config names, and docs where it is hard to change in a follow-up
 - Suggest changes for private code when the fix is low risk.
 - Do not block urgent fixes because of old internal names unless the PR introduces new user-facing language.
 - If a rename could break users, ask for a compatibility plan instead of asking for a direct replacement.

--- a/contents/handbook/engineering/conventions/inclusive-language.md
+++ b/contents/handbook/engineering/conventions/inclusive-language.md
@@ -6,6 +6,8 @@ showTitle: true
 
 PostHog is built by and for people from many backgrounds. Clear, specific language helps everyone understand our code, product, docs, and operations. Some common technical terms carry unnecessary historical, cultural, or exclusionary baggage. Use neutral, precise alternatives when naming new things.
 
+The goal of this guide is to help us choose clearer language and provide alternatives for words that may have non-inclusive meanings. It is not about blaming people for wording used in older code, docs, or good-faith conversations. As with all feedback at PostHog, [assume positive intent](/handbook/people/feedback#how-to-receive-feedback-well) and treat suggestions as constructive naming feedback.
+
 This is guidance for engineering work. For docs-specific style, see the [docs style guide](/handbook/docs-and-wizard/docs-style-guide).
 
 ## What this applies to

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -12,6 +12,7 @@ import { SUPPORTED_SDK_IDS } from '../src/components/SdkReferences/utils'
 import dayjs from 'dayjs'
 
 const DEFAULT_CHANGELOG_PLAYLIST_ID = 'PLnOY1RYHjDfxcuWI_L1xwuhoXAsxR59VL'
+const isMinimalBuild = process.env.GATSBY_MINIMAL === 'true'
 
 type ChangelogPlaylistVideo = {
     videoId: string
@@ -1203,7 +1204,8 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
         sourceCloudinaryImages(),
         sourceGithubNodes(),
         fetchWorkflowTemplates(),
-        fetchReferences(),
+        // Minimal PR previews don't create SDK reference pages, so skip this Strapi-backed fetch there.
+        ...(isMinimalBuild ? [] : [fetchReferences()]),
         fetchEvents(),
         fetchAchievements(),
         fetchAchievementGroups(),

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -761,6 +761,10 @@ export const handbookSidebar = [
                         url: '/handbook/engineering/conventions/backend-coding',
                     },
                     {
+                        name: 'Inclusive language',
+                        url: '/handbook/engineering/conventions/inclusive-language',
+                    },
+                    {
                         name: 'Scripts',
                         url: '/handbook/engineering/conventions/scripts',
                     },


### PR DESCRIPTION
## Problem

Engineering guidance for inclusive technical language was only covered briefly in the docs style guide. We needed a more engineering-focused handbook page that covers code, APIs, config names, migrations, and PR review.

Preview builds also fetched Strapi-backed SDK reference data even though minimal PR previews don't create SDK reference pages, which made previews vulnerable to unrelated transient Strapi failures.

## Changes

- Added a new Engineering → Coding conventions page for inclusive language in engineering.
- Clarified that the guide is meant to provide alternatives for potentially non-inclusive words, not blame people for wording used in good faith.
- Linked to PostHog's feedback guidance on assuming positive intent.
- Reworked the page flow to separate guidance for choosing new language from guidance for changing existing code.
- Documented preferred terms and guidance for changing existing code safely.
- Clarified that the preferred-language table is not exhaustive and engineers should use common sense.
- Added preferred-language entries for words like `cripple`, `normal`, and `suffers from`.
- Removed the separate examples section because it duplicated the preferred-language table.
- Added guidance to align with Developer Experience and feature owners for broad, cross-cutting changes.
- Added guidance to enable inclusive language linting when available, with SwiftLint as an example.
- Added the new page to the Engineering sidebar.
- Updated the docs style guide to link to the new engineering guidance.
- Skipped SDK reference fetching during minimal builds, since SDK reference pages are not created in that mode.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

preview https://c755219a.posthog-preview.pages.dev/handbook/engineering/conventions/inclusive-language
