### PR TITLE
docs(handbook): dedupe PR review checklist into how-we-review

### DIFF
--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -247,6 +247,8 @@ The workflow also runs a smoke test (health check) automatically on PRs that tou
 
 ## Reviewing code
 
+<!-- Keep this section to process only: who reviews what (human vs agent, Stamphog). The "what to look for" checklist and review mechanics live in how-we-review.md — link to it, don't duplicate it here. -->
+
 PRs can be written by humans or by agents (like PostHog Code). Either way, every PR needs a review before merging, and a human always merges.
 
 Who should review depends on who wrote the code (see [Creating PRs](#creating-prs)):
@@ -256,18 +258,7 @@ Who should review depends on who wrote the code (see [Creating PRs](#creating-pr
 
 We encourage the use of AI review agents (Codex, Copilot, Greptile, etc.) on PRs. Their comments and suggestions don't count as an approval, but they catch things humans miss and speed up the review process.
 
-When reviewing a PR, we look at the following things:
-
--   Does the PR actually solve the issue?
--   Does the solution make sense?
--   Will the code perform with millions of events/users/actions?
--   Are there tests and do they test the right things?
--   Are there any security flaws?
--   Is the code in line with our [coding conventions](/docs/contribute/coding-conventions)?
-
-Things we do not care about during review:
-
--   Syntax. If we're arguing about syntax, that means we should install a code formatter.
+For what to look for when reviewing, see: [How we review](/handbook/engineering/how-we-review).
 
 ## Merging
 

--- a/contents/handbook/engineering/how-we-review.md
+++ b/contents/handbook/engineering/how-we-review.md
@@ -4,6 +4,8 @@ sidebar: Handbook
 showTitle: true
 ---
 
+<!-- Canonical "how to review a PR" reference: review checklists, turnaround, partial reviews, and comment conventions live here. Shipping/release process and the human-vs-agent review policy live in development-process.md — link to this page from there, don't duplicate the checklist. -->
+
 Almost all PRs made to PostHog repositories will need a review from another engineer. We do this because, almost every time we review a PR, we find a bug, a performance issue, unnecessary code or UX that could have been confusing. Here's how we do it:
 
 ## Before requesting a review


### PR DESCRIPTION
The **Reviewing code** section in `development-process.md` carried its own "what to look for" checklist plus the no-syntax note, duplicating the fuller checklist already in `how-we-review.md`. Two copies meant they could drift, and it left the "full checklist" that the partial-reviews convention (#17072) references pointing at two different places.

This collapses the duplicate into a pointer, matching what the **Testing code** section already does. The Reviewing code section stays focused on process: who reviews what across humans and agents (Stamphog, AI review agents, human-in-the-loop for agent-authored PRs).

Also adds short HTML comments on both files so future edits keep the checklist in one place and don't re-duplicate it. `how-we-review.md` is now clearly the canonical review reference; `development-process.md` owns the shipping/release process and links over.

No content was rewritten beyond the dedupe, the existing checklist and partial-reviews wording in `how-we-review.md` are untouched.