### PR TITLE
Blog: re-add 5 customer-facing analytics examples

### DIFF
--- a/contents/blog/customer-facing-analytics-examples.md
+++ b/contents/blog/customer-facing-analytics-examples.md
@@ -1,0 +1,103 @@
+---
+title: The 5 best customer-facing analytics examples (and what to steal from each)
+date: 2026-05-27
+rootPage: /blog
+sidebar: Blog
+showTitle: true
+hideAnchor: true
+author:
+    - lizzie-epton
+featuredImage: >-
+    https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/steal_86ee6fe7e4.png
+category: General
+tags:
+    - Endpoints
+    - Data
+    - Customer Analytics
+seo:
+    metaTitle: "The 5 best customer-facing analytics examples (and what to steal from each)"
+    metaDescription: '5 customer-facing analytics examples worth stealing, plus how to ship your own in PostHog without a data team or custom APIs.'
+---
+
+Customer-facing analytics are the stats you show your users, not your internal team. A users' usage dashboard, a "23 people are viewing this right now" counter on a product page, a public leaderboard, or how big your support queue is.
+
+Under the hood, a lot of these are powered by the same kind of infrastructure: a fast, authenticated API layer that takes product data and ships it straight into the place users will see it. At PostHog, we call this [Endpoints](/endpoints).
+
+Endpoints are a way to expose your PostHog data as fast, versioned, authenticated APIs you can [drop straight into your product](/docs/endpoints) without maintaining a custom API backend. 
+
+But, rather than telling you what customer-facing analytics is, we’re going to show you five companies who do it really well, and for each one, we've pulled out what's worth copying.
+
+## 1. Vercel Analytics: Embedded customer usage dashboard
+
+**Vercel** is the textbook case of a dashboard that customers log in to check. Every project deployed on Vercel ships with a Web Analytics panel that surfaces live visitor counts, top pages, referrers, UTM campaigns, and geographic breakdowns. All one click from the deploy button, with no separate tool to install.
+
+![Vercel's embedded analytics dashboard](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/vercel_dashboard_5e867b436f.png)
+
+### What to steal  
+
+Treat customer-facing analytics with the same latency expectations as the rest of the product. Vercel made the design choice for their Web Analytics so that data shows up "[seconds after enabling Analytics, not 30 minutes](https://vercel.com/changelog/new-usage-dashboard-for-pro-customers)". 
+
+Customer-facing analytics live or die on whether users trust the numbers are fresh — the moment they stop trusting, the dashboard quietly becomes wallpaper.
+
+Good news if you're a PostHog user: We just launched a real-time dashboard for [Web Analytics](/web-analytics). 
+
+## 2. Booking.com: Live metrics on the landing page
+
+Booking.com has made a science of turning live activity into social proof: "23 people are looking at this hotel right now." "Booked 4 times in the last 6 hours." "Only 2 rooms left at this price." These numbers are pulled from live booking and browsing data and dropped directly onto the property listing.
+
+![Booking.com using Endpoints to create scarcity](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/booking_com_931a76829b.png)
+
+### What to steal
+
+Put the analytics where the decision happens, not in a dashboard. Booking's live counters aren't a side feature, they're load-bearing conversion copy, and industry analysts have credited similar "shopping activation" widgets with [lifting direct bookings by close to 50%](https://blog.guestcentric.com/how-hotels-can-leverage-social-proof-to-increase-direct-bookings/). Audit your purchase flow for places a live number would move inventory, demand, recent activity, and put it inline. Real-time data that would matter to a buyer right now is wasted signal the moment you bury it two clicks deep in a reports tab.
+
+## 3. Product Hunt: Making leaderboards front and centre
+
+**Product Hunt's** entire homepage is a customer-facing leaderboard. Every 24 hours it ranks a few hundred new launches by upvotes, comments, and reviews, and rolls the top five into permanent "Yesterday / Last Week / Last Month" slots. The ranking logic is transparent enough that makers plan launches around it; [roughly 700–800 upvotes](https://flexprice.io/blog/how-we-ranked-product-of-the-day-on-product-hunt) is the bar for a weekday #1.
+
+![ProductHunt's homepage leaderboard](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/producthunt_6ca9a9dc9e.png)
+
+### What to steal
+
+Make your analytics two-sided. If you're sitting on ranking data , you have a potential product. Leaderboards get dismissed as a gimmick, but Product Hunt turned a database of upvotes into the homepage and let it do two jobs at once: recommendation feed for readers, scoreboard for makers. The more people check it, the more valuable ranking on it becomes.
+
+## 4. HogHero: Augmenting support data with user information
+
+One of the ways we use Endpoints is HogHero, our internal Zendesk app. 
+
+When a customer opens a support ticket, HogHero shows our support rep the recent conversations that customer had with PostHog AI before they reached a human. The rep gets the context instantly and they start the conversation already halfway to the answer.
+
+![PostHog HogHero dashboard](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/posthog_hoghero_877cc43b1c.png)
+
+### What to steal
+
+Customer-facing analytics doesn't have to mean end-customer-facing. The fastest way to make an internal tool feel magical is to put the right data inside the app people are already in, not build yet another place they have to log into. Our reps don't have to switch tabs to PostHog and rebuild the customer's context, the conversation history is just there, scoped to that customer, the moment the ticket opens.
+
+## 5. GitHub's contribution graph: Building a community through user analytics
+
+The green-square contribution graph on every GitHub profile is one of the most-copied analytics patterns on the internet. It's a one-year heatmap of commits, PRs, issues, and reviews, rendered on your public profile. It's functionally a behavior-change mechanic: "[don't break the streak](https://zachholman.com/posts/streaks/)" is a meme precisely because the graph makes the streak visible to you and everyone who looks at your profile.
+
+![One PostHogger's GitHub wrapped](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/git_wrapped_Gilbert09_81a0301f06.png)
+
+### What to steal
+
+Once you expose customer-facing analytics, users will ask for more – and some will just build it themselves. The contribution graph started life as a visualization and ended up as identity, habit-loop, and an entire third-party ecosystem of [GitHub Wrapped](https://git-wrapped.com/) tools. These are built by people who want to share their streaks which creates a viral community moment that's great for GitHub’s brand. 
+
+## The principles to make your customer-facing analytics a success
+
+Across all five, the same few principles keep showing up:
+* The data is live, or close enough, that users trust it.
+* It's embedded where the decision happens: in the listing, dashboard, or profile. It's not parked in a separate reports section.
+* It's scoped to the viewer. Customers see their own numbers, teams see their team's numbers, buyers see the listing's numbers.
+* It's owned like a product feature, not a data-team deliverable. Someone owns the latency, the UX, and the roadmap.
+
+## Endpoints makes customer-facing analytics simple
+
+Inspired to build customer-facing analytics yourself? We’re biased but we think you should check out [Endpoints](/endpoints). Here's how it works:
+
+1. **Start from something you already have in PostHog.** Open any saved insight, trend, or SQL query you've already built. If you've got a number you trust inside PostHog, you're 90% of the way there.
+2. **Turn it into an Endpoint.** Go to the three dots at the top of your insight screen and select 'Create Endpoint'. Endpoints wraps your query in a fast, versioned, authenticated API — no backend setup, no pipeline, no new tool to learn.
+3. **Drop it wherever you need the number to show up.** Your product, a customer-facing dashboard, your landing page, or an internal Slack bot — anywhere that accepts a URL or an API call.
+4. **Let it update itself.** The number stays live. If you tweak the underlying insight in PostHog, the Endpoint updates too. No rebuilds, no stale screenshots, no Monday-morning "can someone refresh this for me" messages.
+
+Take the data you already trust in PostHog, ship it to the place your users actually look, and let the tool do the heavy lifting for you. [Give it a try](/docs/endpoints/start-here), or you can check out [our docs](/docs/endpoints) to learn more.


### PR DESCRIPTION
## Summary
- Re-adds `contents/blog/customer-facing-analytics-examples.md` ("The 5 best customer-facing analytics examples (and what to steal from each)").
- Originally added in #16553 and reverted in #17060 — this PR restores the post unchanged so it can be published.

## Test plan
- [ ] Confirm preview renders the post at `/blog/customer-facing-analytics-examples`
- [ ] Confirm featured image and inline Cloudinary images load
- [ ] Confirm author (Lizzie Epton) and tags render correctly

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*