### PR TITLE
Add Brex reimbursement note to equipment spending guideline

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -171,6 +171,8 @@ As a guide, here's what we'd consider reasonable spend:
 - Chair - up to $500
 - Keyboard - up to $250
 
+If you want something more expensive, you can pay personally and submit a reimbursement request on Brex for up to the amount above.
+
 ### Software
 We are _strongly opposed_ to introducing new software that is designed for collaboration by default. There needs to be a very significant upside to introducing a new piece of software to outweigh its cost.
 


### PR DESCRIPTION
## Summary
- Clarifies in the equipment spending guideline that team members can pay personally for items above the listed reasonable spend amounts and submit a reimbursement request on Brex up to that limit.

## Test plan
- [ ] Verify the rendered handbook page at `/handbook/people/spending-money` shows the new sentence under the equipment spend guide.