### PR TITLE
Document AI Observability data retention policy

### DIFF
--- a/contents/docs/ai-observability/basics.mdx
+++ b/contents/docs/ai-observability/basics.mdx
@@ -74,3 +74,24 @@ Here's a breakdown of this hierarchy:
 | [Span](/docs/ai-observability/spans) | Tracks an operation within a trace | A retrieval step or function call |
 | [Generation](/docs/ai-observability/generations) | An LLM call, tracked as `$ai_generation` events | Sending a prompt to Claude |
 | [Embedding](/docs/ai-observability/embeddings) | Converts text into vectors | Vectorizing documents for RAG |
+
+## Data retention
+
+AI Observability events are subject to a 30-day retention policy on their largest properties. Because LLM conversations can be very large, PostHog removes the heaviest properties from `$ai_` events after 30 days to keep storage efficient.
+
+The events themselves are **not** deleted; they're retained like any other product analytics event. Only the following properties are removed after 30 days:
+
+- `$ai_input`
+- `$ai_output`
+- `$ai_output_choices`
+- `$ai_input_state`
+- `$ai_output_state`
+- `$ai_tools`
+
+What this means in practice:
+
+- Metadata like model, provider, token counts, cost, latency, and trace IDs is **kept**, so cost, usage, and performance analysis on historical data is unaffected.
+- Insights, queries, and filters that don't reference the properties above continue to work on data of any age.
+- A trace older than 30 days still appears, but the input/output content for its generations will be missing.
+
+If you need to retain raw prompts and completions beyond 30 days, export them to your own storage (for example via a [batch export](/docs/cdp/batch-exports)) before they age out.

--- a/contents/docs/ai-observability/basics.mdx
+++ b/contents/docs/ai-observability/basics.mdx
@@ -74,24 +74,3 @@ Here's a breakdown of this hierarchy:
 | [Span](/docs/ai-observability/spans) | Tracks an operation within a trace | A retrieval step or function call |
 | [Generation](/docs/ai-observability/generations) | An LLM call, tracked as `$ai_generation` events | Sending a prompt to Claude |
 | [Embedding](/docs/ai-observability/embeddings) | Converts text into vectors | Vectorizing documents for RAG |
-
-## Data retention
-
-AI Observability events are subject to a 30-day retention policy on their largest properties. Because LLM conversations can be very large, PostHog removes the heaviest properties from `$ai_` events after 30 days to keep storage efficient.
-
-The events themselves are **not** deleted; they're retained like any other product analytics event. Only the following properties are removed after 30 days:
-
-- `$ai_input`
-- `$ai_output`
-- `$ai_output_choices`
-- `$ai_input_state`
-- `$ai_output_state`
-- `$ai_tools`
-
-What this means in practice:
-
-- Metadata like model, provider, token counts, cost, latency, and trace IDs is **kept**, so cost, usage, and performance analysis on historical data is unaffected.
-- Insights, queries, and filters that don't reference the properties above continue to work on data of any age.
-- A trace older than 30 days still appears, but the input/output content for its generations will be missing.
-
-If you need to retain raw prompts and completions beyond 30 days, export them to your own storage (for example via a [batch export](/docs/cdp/batch-exports)) before they age out.

--- a/contents/docs/ai-observability/data-retention.mdx
+++ b/contents/docs/ai-observability/data-retention.mdx
@@ -25,7 +25,7 @@ PostHog deletes the `ai_events` copy after 30 days. The trimmed copy in the `eve
 ## What this means for you
 
 - To read the large properties, query the `ai_events` table – even for traces less than 30 days old. The `events` table never contains them.
-- After 30 days, the large properties are gone. A trace older than 30 days still appears, but its generations show no input or output content.
+- After 30 days, the events are removed from the `ai_events` table, so a trace older than 30 days still appears, but its generations show no input or output content.
 - Metadata such as model, provider, token counts, cost, latency, and trace IDs stays available, so analysis of historical cost, usage, and performance is unaffected.
 - Insights, queries, and filters that don't reference the large properties keep working on data of any age.
 

--- a/contents/docs/ai-observability/data-retention.mdx
+++ b/contents/docs/ai-observability/data-retention.mdx
@@ -1,0 +1,32 @@
+---
+title: Data retention
+---
+
+PostHog retains the largest properties on `$ai_` events for 30 days. LLM conversations can be large, so storing these properties long-term is expensive. To keep costs down, PostHog deletes them after 30 days and keeps the rest of the event.
+
+## How retention works
+
+When PostHog ingests an `$ai_` event, the pipeline splits it into two copies:
+
+- A full copy, with every property, goes to the `ai_events` table.
+- A trimmed copy, without the large properties, goes to the `events` table.
+
+The large properties are:
+
+- `$ai_input`
+- `$ai_output`
+- `$ai_output_choices`
+- `$ai_input_state`
+- `$ai_output_state`
+- `$ai_tools`
+
+PostHog deletes the `ai_events` copy after 30 days. The trimmed copy in the `events` table persists like any other Product Analytics event, but it never includes the large properties.
+
+## What this means for you
+
+- To read the large properties, query the `ai_events` table – even for traces less than 30 days old. The `events` table never contains them.
+- After 30 days, the large properties are gone. A trace older than 30 days still appears, but its generations show no input or output content.
+- Metadata such as model, provider, token counts, cost, latency, and trace IDs stays available, so analysis of historical cost, usage, and performance is unaffected.
+- Insights, queries, and filters that don't reference the large properties keep working on data of any age.
+
+To keep raw prompts and completions beyond 30 days, set up a [batch export](/docs/cdp/batch-exports) to your own storage.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5926,6 +5926,12 @@ export const docsMenu = {
                     color: 'seagreen',
                 },
                 {
+                    name: 'Data retention',
+                    url: '/docs/ai-observability/data-retention',
+                    icon: 'IconDatabase',
+                    color: 'blue',
+                },
+                {
                     name: 'Troubleshooting',
                     url: '/docs/ai-observability/troubleshooting',
                     icon: 'IconQuestion',


### PR DESCRIPTION
## Summary

Documents the 30-day data retention policy for AI Observability `$ai_` events as a standalone **Data retention** page under Resources (moved out of the Basics page per review feedback).

At ingestion, each `$ai_` event is split into two copies:
- A full copy with all properties → `ai_events` table (deleted after 30 days).
- A trimmed copy without the large properties → `events` table (kept like any other Product Analytics event).

To read the large properties (`$ai_input`, `$ai_output`, `$ai_output_choices`, `$ai_input_state`, `$ai_output_state`, `$ai_tools`), query the `ai_events` table — even for traces under 30 days old.

## Changes
- Remove the Data retention section from `basics.mdx`
- Add `contents/docs/ai-observability/data-retention.mdx`
- Add the page under AI Observability > Resources in the nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)