### PR TITLE
Update privacy mode documentation with data retention info

### DIFF
--- a/contents/docs/ai-observability/privacy-mode.mdx
+++ b/contents/docs/ai-observability/privacy-mode.mdx
@@ -4,6 +4,12 @@ title: Privacy mode
 
 To avoid storing potentially sensitive prompt and completion data, you can enable privacy mode. This excludes the `$ai_input` and `$ai_output_choices` properties from being captured.
 
+<CalloutBox icon="IconInfo" type="fyi" title="Data retention">
+
+PostHog removes these and other large `$ai_` properties after 30 days. See [data retention](/docs/ai-observability/basics#data-retention) for details.
+
+</CalloutBox>
+
 ## SDK config
 
 This can be done by setting the `privacy_mode` config option in the SDK like this:

--- a/contents/docs/ai-observability/privacy-mode.mdx
+++ b/contents/docs/ai-observability/privacy-mode.mdx
@@ -6,7 +6,7 @@ To avoid storing potentially sensitive prompt and completion data, you can enabl
 
 <CalloutBox icon="IconInfo" type="fyi" title="Data retention">
 
-PostHog removes these and other large `$ai_` properties after 30 days. See [data retention](/docs/ai-observability/basics#data-retention) for details.
+PostHog removes these and other large `$ai_` properties after 30 days. See [data retention](/docs/ai-observability/data-retention) for details.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Added a callout with a link to info about data retention.



## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x]  If I moved a page, I added a redirect in `vercel.json`
