### PR TITLE
Posthog code/slack app cross links

### DIFF
--- a/src/components/AI/AIEverywhereSlide.tsx
+++ b/src/components/AI/AIEverywhereSlide.tsx
@@ -14,7 +14,7 @@ export default function AIEverywhereSlide(): JSX.Element {
                 </p>
             </div>
 
-            <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-6 @2xl:gap-10 items-start">
+            <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-6 @2xl:gap-10">
                 <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
                     <Link
                         to="/docs/model-context-protocol"
@@ -38,28 +38,29 @@ export default function AIEverywhereSlide(): JSX.Element {
                                 delete it; "how often is this endpoint hit?" before you rewrite it.
                             </li>
                             <li>
-                                <strong>Size the impact</strong> – pull errors, affected users, and replays into the
-                                conversation while you're already there.
+                                <strong>Size the impact</strong> – check who's on a feature flag or how an experiment is
+                                trending before you decide to ramp, hold, or roll back.
                             </li>
                             <li>
                                 <strong>Verify the deploy</strong> – see whether latency, errors, or conversion actually
-                                moved before you write the PR description.
+                                moved before you ship the next thing.
                             </li>
                         </ul>
                     </div>
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog_in_claude_5dd8ef4761.png"
+                        className="mt-auto"
                         imgClassName="w-full block"
                     />
                 </div>
 
                 <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
                     <Link
-                        to="/slack-app"
+                        to="/docs/slack-app/"
                         state={{ newWindow: true }}
                         className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
                     >
-                        Slack app
+                        Slack app docs
                         <IconArrowUpRight className="size-4" />
                     </Link>
                     <div className="p-6 pr-16 pb-4">
@@ -77,9 +78,8 @@ export default function AIEverywhereSlide(): JSX.Element {
                         </p>
                         <ul className="space-y-2 text-xl @2xl:text-base">
                             <li>
-                                <strong>An SQL-fluent product analyst who loves your data</strong> – ask anything and
-                                PostHog AI writes the HogQL, runs it against your real events, and brings the answer
-                                back to the thread.
+                                <strong>Pull product data into a thread</strong> – conduct research and query data to
+                                answer product and customer questions.
                             </li>
                             <li>
                                 <strong>Subscribe to product insights and dashboards</strong> – receive a regular digest
@@ -93,6 +93,7 @@ export default function AIEverywhereSlide(): JSX.Element {
                     </div>
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/subscription_insights_50ce62125e.png"
+                        className="mt-auto"
                         imgClassName="w-full block"
                     />
                 </div>

--- a/src/components/AI/AIEverywhereSlide.tsx
+++ b/src/components/AI/AIEverywhereSlide.tsx
@@ -2,102 +2,107 @@ import React from 'react'
 import { IconArrowUpRight, IconPlug } from '@posthog/icons'
 import Link from 'components/Link'
 import CloudinaryImage from 'components/CloudinaryImage'
+import ScrollArea from 'components/RadixUI/ScrollArea'
 import { LOGOS } from 'constants/logos'
 
 export default function AIEverywhereSlide(): JSX.Element {
     return (
-        <div data-scheme="primary" className="h-full bg-primary text-primary p-4 @md:p-8 flex flex-col justify-center">
-            <div className="text-center mb-6 @2xl:mb-10">
-                <h2 className="text-5xl @2xl:text-4xl mb-2">PostHog AI, wherever you work</h2>
-                <p className="text-2xl @2xl:text-xl text-secondary">
-                    Bring your product data into the tools you already use.
-                </p>
-            </div>
-
-            <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-6 @2xl:gap-10">
-                <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
-                    <Link
-                        to="/docs/model-context-protocol"
-                        state={{ newWindow: true }}
-                        className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
-                    >
-                        MCP docs
-                        <IconArrowUpRight className="size-4" />
-                    </Link>
-                    <div className="p-6 pr-16 pb-4">
-                        <h3 className="text-3xl @2xl:text-2xl mb-3 flex items-center gap-3">
-                            <IconPlug className="size-8 @2xl:size-7 shrink-0" />
-                            In your coding agent
-                        </h3>
-                        <p className="text-xl @2xl:text-base leading-snug mb-4">
-                            Plug PostHog into Claude, Cursor, and anything else that speaks MCP.
+        <div data-scheme="primary" className="h-full bg-primary text-primary flex flex-col">
+            <ScrollArea className="h-full">
+                <div className="p-4 @md:p-8 flex flex-col justify-center min-h-full">
+                    <div className="text-center mb-6 @2xl:mb-10">
+                        <h2 className="text-5xl @2xl:text-4xl mb-2">PostHog AI, wherever you work</h2>
+                        <p className="text-2xl @2xl:text-xl text-secondary">
+                            Bring your product data into the tools you already use.
                         </p>
-                        <ul className="space-y-2 text-xl @2xl:text-base">
-                            <li>
-                                <strong>Check before you change</strong> – "is anyone still on this flag?" before you
-                                delete it; "how often is this endpoint hit?" before you rewrite it.
-                            </li>
-                            <li>
-                                <strong>Size the impact</strong> – check who's on a feature flag or how an experiment is
-                                trending before you decide to ramp, hold, or roll back.
-                            </li>
-                            <li>
-                                <strong>Verify the deploy</strong> – see whether latency, errors, or conversion actually
-                                moved before you ship the next thing.
-                            </li>
-                        </ul>
                     </div>
-                    <CloudinaryImage
-                        src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog_in_claude_5dd8ef4761.png"
-                        className="mt-auto"
-                        imgClassName="w-full block"
-                    />
-                </div>
 
-                <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
-                    <Link
-                        to="/docs/slack-app/"
-                        state={{ newWindow: true }}
-                        className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
-                    >
-                        Slack app docs
-                        <IconArrowUpRight className="size-4" />
-                    </Link>
-                    <div className="p-6 pr-16 pb-4">
-                        <h3 className="text-3xl @2xl:text-2xl mb-3 flex items-center gap-3">
-                            <img
-                                src={LOGOS.slack}
-                                alt=""
-                                aria-hidden
-                                className="size-10 @2xl:size-9 shrink-0 object-contain"
+                    <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-6 @2xl:gap-10">
+                        <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
+                            <Link
+                                to="/docs/model-context-protocol"
+                                state={{ newWindow: true }}
+                                className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
+                            >
+                                MCP docs
+                                <IconArrowUpRight className="size-4" />
+                            </Link>
+                            <div className="p-6 pr-16 pb-4">
+                                <h3 className="text-3xl @2xl:text-2xl mb-3 flex items-center gap-3">
+                                    <IconPlug className="size-8 @2xl:size-7 shrink-0" />
+                                    In your coding agent
+                                </h3>
+                                <p className="text-xl @2xl:text-base leading-snug mb-4">
+                                    Plug PostHog into Claude, Cursor, and anything else that speaks MCP.
+                                </p>
+                                <ul className="space-y-2 text-xl @2xl:text-base">
+                                    <li>
+                                        <strong>Check before you change</strong> – "is anyone still on this flag?"
+                                        before you delete it; "how often is this endpoint hit?" before you rewrite it.
+                                    </li>
+                                    <li>
+                                        <strong>Size the impact</strong> – check who's on a feature flag or how an
+                                        experiment is trending before you decide to ramp, hold, or roll back.
+                                    </li>
+                                    <li>
+                                        <strong>Verify the deploy</strong> – see whether latency, errors, or conversion
+                                        actually moved before you ship the next thing.
+                                    </li>
+                                </ul>
+                            </div>
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog_in_claude_5dd8ef4761.png"
+                                className="mt-auto"
+                                imgClassName="w-full block"
                             />
-                            In Slack
-                        </h3>
-                        <p className="text-xl @2xl:text-base leading-snug mb-4">
-                            Mention <code>@PostHog</code> with a data question, quick fix, or chore.
-                        </p>
-                        <ul className="space-y-2 text-xl @2xl:text-base">
-                            <li>
-                                <strong>Pull product data into a thread</strong> – conduct research and query data to
-                                answer product and customer questions.
-                            </li>
-                            <li>
-                                <strong>Subscribe to product insights and dashboards</strong> – receive a regular digest
-                                in your chosen Slack channels.
-                            </li>
-                            <li>
-                                <strong>Set up Slack notifications via PostHog Data Pipelines</strong> – get timely
-                                notifications of any event or action in PostHog.
-                            </li>
-                        </ul>
+                        </div>
+
+                        <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
+                            <Link
+                                to="/docs/slack-app/"
+                                state={{ newWindow: true }}
+                                className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
+                            >
+                                Slack app docs
+                                <IconArrowUpRight className="size-4" />
+                            </Link>
+                            <div className="p-6 pr-16 pb-4">
+                                <h3 className="text-3xl @2xl:text-2xl mb-3 flex items-center gap-3">
+                                    <img
+                                        src={LOGOS.slack}
+                                        alt=""
+                                        aria-hidden
+                                        className="size-10 @2xl:size-9 shrink-0 object-contain"
+                                    />
+                                    In Slack
+                                </h3>
+                                <p className="text-xl @2xl:text-base leading-snug mb-4">
+                                    Mention <code>@PostHog</code> with a data question, quick fix, or chore.
+                                </p>
+                                <ul className="space-y-2 text-xl @2xl:text-base">
+                                    <li>
+                                        <strong>Pull product data into a thread</strong> – conduct research and query
+                                        data to answer product and customer questions.
+                                    </li>
+                                    <li>
+                                        <strong>Subscribe to product insights and dashboards</strong> – receive a
+                                        regular digest in your chosen Slack channels.
+                                    </li>
+                                    <li>
+                                        <strong>Set up Slack notifications via PostHog Data Pipelines</strong> – get
+                                        timely notifications of any event or action in PostHog.
+                                    </li>
+                                </ul>
+                            </div>
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/subscription_insights_50ce62125e.png"
+                                className="mt-auto"
+                                imgClassName="w-full block"
+                            />
+                        </div>
                     </div>
-                    <CloudinaryImage
-                        src="https://res.cloudinary.com/dmukukwp6/image/upload/subscription_insights_50ce62125e.png"
-                        className="mt-auto"
-                        imgClassName="w-full block"
-                    />
                 </div>
-            </div>
+            </ScrollArea>
         </div>
     )
 }

--- a/src/components/AI/AIEverywhereSlide.tsx
+++ b/src/components/AI/AIEverywhereSlide.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { IconArrowUpRight, IconPlug } from '@posthog/icons'
+import Link from 'components/Link'
+import CloudinaryImage from 'components/CloudinaryImage'
+import { LOGOS } from 'constants/logos'
+
+export default function AIEverywhereSlide(): JSX.Element {
+    return (
+        <div data-scheme="primary" className="h-full bg-primary text-primary p-4 @md:p-8 flex flex-col justify-center">
+            <div className="text-center mb-6 @2xl:mb-10">
+                <h2 className="text-5xl @2xl:text-4xl mb-2">PostHog AI, wherever you work</h2>
+                <p className="text-2xl @2xl:text-xl text-secondary">
+                    Bring your product data into the tools you already use.
+                </p>
+            </div>
+
+            <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-6 @2xl:gap-10 items-start">
+                <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
+                    <Link
+                        to="/docs/model-context-protocol"
+                        state={{ newWindow: true }}
+                        className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
+                    >
+                        MCP docs
+                        <IconArrowUpRight className="size-4" />
+                    </Link>
+                    <div className="p-6 pr-16 pb-4">
+                        <h3 className="text-3xl @2xl:text-2xl mb-3 flex items-center gap-3">
+                            <IconPlug className="size-8 @2xl:size-7 shrink-0" />
+                            In your coding agent
+                        </h3>
+                        <p className="text-xl @2xl:text-base leading-snug mb-4">
+                            Plug PostHog into Claude, Cursor, and anything else that speaks MCP.
+                        </p>
+                        <ul className="space-y-2 text-xl @2xl:text-base">
+                            <li>
+                                <strong>Check before you change</strong> – "is anyone still on this flag?" before you
+                                delete it; "how often is this endpoint hit?" before you rewrite it.
+                            </li>
+                            <li>
+                                <strong>Size the impact</strong> – pull errors, affected users, and replays into the
+                                conversation while you're already there.
+                            </li>
+                            <li>
+                                <strong>Verify the deploy</strong> – see whether latency, errors, or conversion actually
+                                moved before you write the PR description.
+                            </li>
+                        </ul>
+                    </div>
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog_in_claude_5dd8ef4761.png"
+                        imgClassName="w-full block"
+                    />
+                </div>
+
+                <div className="relative border border-primary rounded-md bg-accent flex flex-col overflow-hidden">
+                    <Link
+                        to="/slack-app"
+                        state={{ newWindow: true }}
+                        className="absolute top-4 right-4 z-10 inline-flex items-center gap-1 text-sm font-semibold text-red hover:underline"
+                    >
+                        Slack app
+                        <IconArrowUpRight className="size-4" />
+                    </Link>
+                    <div className="p-6 pr-16 pb-4">
+                        <h3 className="text-3xl @2xl:text-2xl mb-3 flex items-center gap-3">
+                            <img
+                                src={LOGOS.slack}
+                                alt=""
+                                aria-hidden
+                                className="size-10 @2xl:size-9 shrink-0 object-contain"
+                            />
+                            In Slack
+                        </h3>
+                        <p className="text-xl @2xl:text-base leading-snug mb-4">
+                            Mention <code>@PostHog</code> with a data question, quick fix, or chore.
+                        </p>
+                        <ul className="space-y-2 text-xl @2xl:text-base">
+                            <li>
+                                <strong>An SQL-fluent product analyst who loves your data</strong> – ask anything and
+                                PostHog AI writes the HogQL, runs it against your real events, and brings the answer
+                                back to the thread.
+                            </li>
+                            <li>
+                                <strong>Subscribe to product insights and dashboards</strong> – receive a regular digest
+                                in your chosen Slack channels.
+                            </li>
+                            <li>
+                                <strong>Set up Slack notifications via PostHog Data Pipelines</strong> – get timely
+                                notifications of any event or action in PostHog.
+                            </li>
+                        </ul>
+                    </div>
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/subscription_insights_50ce62125e.png"
+                        imgClassName="w-full block"
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/pages/ai/index.tsx
+++ b/src/pages/ai/index.tsx
@@ -158,12 +158,12 @@ export default function PostHogAI(): JSX.Element {
         order: [
             'overview',
             'features',
+            'everywhere',
             'demos',
             'try-it',
             'capabilities',
             'videos',
             'you',
-            'everywhere',
             'roadmap',
             'pricing',
             'getting-started',

--- a/src/pages/ai/index.tsx
+++ b/src/pages/ai/index.tsx
@@ -9,6 +9,7 @@ import ScrollArea from 'components/RadixUI/ScrollArea'
 import CustomRoadmapSlide from 'components/AI/CustomRoadmapSlide'
 import CustomPersonasSlide from 'components/AI/CustomPersonasSlide'
 import CustomCapabilitiesSlide from 'components/AI/CustomCapabilitiesSlide'
+import AIEverywhereSlide from 'components/AI/AIEverywhereSlide'
 import { useWindow } from '../../context/Window'
 import TerminalView from 'components/AI/TerminalView'
 import usePostHog from 'hooks/usePostHog'
@@ -143,6 +144,11 @@ export default function PostHogAI(): JSX.Element {
                 name: 'Advanced modes',
                 component: CustomCapabilitiesSlide,
             },
+            {
+                slug: 'everywhere',
+                name: 'PostHog AI everywhere',
+                component: AIEverywhereSlide,
+            },
             // {
             //     slug: 'manifesto',
             //     name: 'AI manifesto',
@@ -157,6 +163,7 @@ export default function PostHogAI(): JSX.Element {
             'capabilities',
             'videos',
             'you',
+            'everywhere',
             'roadmap',
             'pricing',
             'getting-started',

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -1080,7 +1080,6 @@ const Instrumentation = () => {
 
 const integrationRows: { name: string; logoKey: LogoKey }[] = [
     { name: 'Linear', logoKey: 'linear' },
-    { name: 'Slack', logoKey: 'slack' },
     { name: 'GitHub', logoKey: 'github' },
     { name: 'Granola', logoKey: 'granola' },
     { name: 'Zendesk', logoKey: 'zendesk' },
@@ -1213,6 +1212,50 @@ const TableStakes = () => {
 
                         <div className="absolute inset-0 bg-gradient-to-b from-light/0 via-light/25 to-light dark:from-dark/0 dark:via-dark/25 dark:to-dark"></div>
                     </div>
+                </div>
+            </div>
+        </section>
+    )
+}
+
+const SlackAppCallout = () => {
+    return (
+        <section className="relative mb-12 @2xl:mb-20 px-4 @xl:px-8">
+            <div className="grid @2xl:grid-cols-2 gap-8 @2xl:gap-12 items-center">
+                <div>
+                    <SectionLabel>Also from PostHog</SectionLabel>
+                    <h2 className="text-3xl font-bold mb-3">Prefer Slack? Meet the PostHog Slack app</h2>
+                    <p className="mb-4">
+                        When you're not at your desk, the PostHog Slack app handles drive-by tasks — answer data
+                        questions, triage issues, and kick off PRs without leaving the thread. Same agent muscle as
+                        PostHog Code, with a lower-friction surface for your team.
+                    </p>
+                    <ul className="space-y-2 mb-6">
+                        <li className="relative pl-5">
+                            <IconCheck className="size-4 text-green absolute left-0 top-1" />
+                            Ask product or data questions in any channel
+                        </li>
+                        <li className="relative pl-5">
+                            <IconCheck className="size-4 text-green absolute left-0 top-1" />
+                            Mention <code>@PostHog</code> to triage an error or open a PR
+                        </li>
+                        <li className="relative pl-5">
+                            <IconCheck className="size-4 text-green absolute left-0 top-1" />
+                            Subscribe channels to scheduled insights and alerts
+                        </li>
+                    </ul>
+                    <OSButton asLink to="/slack-app" variant="primary" size="lg">
+                        Learn about the Slack app
+                    </OSButton>
+                </div>
+                <div>
+                    <ZoomImage>
+                        <img
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_app_chat_1_c6573ce6da.png"
+                            alt="PostHog Slack app screenshot"
+                            className="w-full rounded-md shadow-2xl border border-primary"
+                        />
+                    </ZoomImage>
                 </div>
             </div>
         </section>
@@ -1549,6 +1592,8 @@ export default function CodePage() {
                         <Instrumentation />
 
                         <TableStakes />
+
+                        <SlackAppCallout />
 
                         <TLDR ready={postHogWayDone} />
 

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -1232,8 +1232,8 @@ const SlackAppCallout = () => {
                         <p className="mb-4">
                             Answer data questions, fix bugs, and kick off PRs by mentioning <code>@PostHog</code>.
                         </p>
-                        <OSButton asLink to="/slack-app" variant="primary" size="md">
-                            Learn about the Slack app
+                        <OSButton asLink to="/slack-app" state={{ newWindow: true }} variant="primary" size="md">
+                            About the Slack app
                         </OSButton>
                     </div>
                     <ul className="space-y-2">

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -1080,6 +1080,7 @@ const Instrumentation = () => {
 
 const integrationRows: { name: string; logoKey: LogoKey }[] = [
     { name: 'Linear', logoKey: 'linear' },
+    { name: 'Slack', logoKey: 'slack' },
     { name: 'GitHub', logoKey: 'github' },
     { name: 'Granola', logoKey: 'granola' },
     { name: 'Zendesk', logoKey: 'zendesk' },
@@ -1221,42 +1222,48 @@ const TableStakes = () => {
 const SlackAppCallout = () => {
     return (
         <section className="relative mb-12 @2xl:mb-20 px-4 @xl:px-8">
-            <div className="grid @2xl:grid-cols-2 gap-8 @2xl:gap-12 items-center">
-                <div>
-                    <SectionLabel>Also from PostHog</SectionLabel>
-                    <h2 className="text-3xl font-bold mb-3">Prefer Slack? Meet the PostHog Slack app</h2>
-                    <p className="mb-4">
-                        When you're not at your desk, the PostHog Slack app handles drive-by tasks — answer data
-                        questions, triage issues, and kick off PRs without leaving the thread. Same agent muscle as
-                        PostHog Code, with a lower-friction surface for your team.
-                    </p>
-                    <ul className="space-y-2 mb-6">
+            <div className="border border-primary rounded-md bg-accent overflow-hidden">
+                <div className="p-6 @2xl:p-8 grid @2xl:grid-cols-2 gap-6 @2xl:gap-10">
+                    <div>
+                        <p className="text-sm font-semibold uppercase tracking-wide text-secondary mb-2">
+                            While you wait...
+                        </p>
+                        <h2 className="text-2xl font-bold mb-2">PostHog Code in Slack</h2>
+                        <p className="mb-4">
+                            Answer data questions, fix bugs, and kick off PRs by mentioning <code>@PostHog</code>.
+                        </p>
+                        <OSButton asLink to="/slack-app" variant="primary" size="md">
+                            Learn about the Slack app
+                        </OSButton>
+                    </div>
+                    <ul className="space-y-2">
                         <li className="relative pl-5">
                             <IconCheck className="size-4 text-green absolute left-0 top-1" />
-                            Ask product or data questions in any channel
+                            Ship a fix from a bug report
                         </li>
                         <li className="relative pl-5">
                             <IconCheck className="size-4 text-green absolute left-0 top-1" />
-                            Mention <code>@PostHog</code> to triage an error or open a PR
+                            Diagnose and fix failing CI
                         </li>
                         <li className="relative pl-5">
                             <IconCheck className="size-4 text-green absolute left-0 top-1" />
-                            Subscribe channels to scheduled insights and alerts
+                            Rip out a feature flag after rollout
+                        </li>
+                        <li className="relative pl-5">
+                            <IconCheck className="size-4 text-green absolute left-0 top-1" />
+                            Fix typos and update content
+                        </li>
+                        <li className="relative pl-5">
+                            <IconCheck className="size-4 text-green absolute left-0 top-1" />
+                            Work across repos
                         </li>
                     </ul>
-                    <OSButton asLink to="/slack-app" variant="primary" size="lg">
-                        Learn about the Slack app
-                    </OSButton>
                 </div>
-                <div>
-                    <ZoomImage>
-                        <img
-                            src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_app_chat_1_c6573ce6da.png"
-                            alt="PostHog Slack app screenshot"
-                            className="w-full rounded-md shadow-2xl border border-primary"
-                        />
-                    </ZoomImage>
-                </div>
+                <img
+                    src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_app_update_docs_f0c917f70a.png"
+                    alt="PostHog Slack app screenshot"
+                    className="w-full block"
+                />
             </div>
         </section>
     )
@@ -1593,9 +1600,9 @@ export default function CodePage() {
 
                         <TableStakes />
 
-                        <SlackAppCallout />
-
                         <TLDR ready={postHogWayDone} />
+
+                        <SlackAppCallout />
 
                         <FAQ />
                     </div>


### PR DESCRIPTION
## Changes

Links depending on product page --> https://github.com/PostHog/posthog.com/pull/17077 and docs --> https://github.com/PostHog/posthog.com/pull/17085

### PostHog AI
Added after features slide

<img width="2676" height="1430" alt="CleanShot 2026-05-29 at 12 44 37@2x" src="https://github.com/user-attachments/assets/b2b3ec69-695f-466a-88a2-a18f33dca35f" />

### PostHog Code
Added beneath the waitlist 

<img width="1570" height="1070" alt="CleanShot 2026-05-29 at 12 41 28@2x" src="https://github.com/user-attachments/assets/0f53b5b6-bc50-4ac6-8cd1-5502a2e8c259" />


## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
