### PR TITLE
Fix formatting in feedback section of docs

### DIFF
--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -373,7 +373,7 @@ export const DocsIndex = () => {
                         <h6 className="text-lg">Feedback</h6>
 
                         <p>
-                            Our docs are perpetually a work in progress. The
+                            Our docs are perpetually a work in progress. The 
                             <SmallTeam slug="content" /> is responsible for what you see here.
                         </p>
                         <p>

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -374,7 +374,7 @@ export const DocsIndex = () => {
 
                         <p>
                             Our docs are perpetually a work in progress. The 
-                            <SmallTeam slug="content" /> is responsible for what you see here.
+                            <SmallTeam slug="docs-wizard" /> is responsible for what you see here.
                         </p>
                         <p>
                             At the end of each page, you can provide feedback about what was (or wasn't) helpful. We


### PR DESCRIPTION
## Changes

*Please describe.*
Added a space between "The" and "content" because there was previously no space between the two.

*Add screenshots or screen recordings for visual / UI-focused changes.*

# OLD
<img width="328" height="91" alt="image" src="https://github.com/user-attachments/assets/70cdc687-7305-417e-8a87-e48e0fb4c02b" />


# NEW
<img width="330" height="99" alt="image" src="https://github.com/user-attachments/assets/818d59b9-b5f2-4985-9627-c6673f39283c" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
