### PR TITLE
handbook: add guidance on third-party stock transfer solicitations

### DIFF
--- a/contents/handbook/people/share-options.mdx
+++ b/contents/handbook/people/share-options.mdx
@@ -52,6 +52,25 @@ That being said, you can use <PrivateLink url="https://docs.google.com/spreadshe
 Since these numbers are based on assumptions, we cannot promise you that value, but in any case it can give you a sense of what the stock may be worth.
 
 
+### What should I do if someone contacts me about buying my PostHog shares?
+
+Don't engage. This is coming up increasingly – LinkedIn ads, cold outreach from platforms, and direct messages from individuals all claiming to be able to buy your PostHog shares or options. **Unless PostHog has explicitly communicated a secondary sale opportunity internally, none of these companies or platforms have been approved by us, and any transaction you enter into with them will not be legally valid.**
+
+PostHog's company documents prohibit any transfer of our stock without prior board approval – and "transfer" covers a lot more than just an outright sale. It includes forward contracts, futures, and any arrangement where you're effectively passing an economic interest in your shares to someone else, regardless of how the deal is structured or what it's called. Any transfer without board approval simply isn't valid. There's no clever structure that gets around this.
+
+These platforms know about the consent requirement and usually claim they've found a workaround. Some offer to advance you cash now, with an informal agreement that you'll hand over the shares when you eventually can sell. Others claim to be buying a right to your future proceeds rather than the shares themselves. Neither approach works – they still fall under the same restrictions. The bigger problem is that these companies put all the risk on you. If the deal later falls apart – which it very well might, since it was never valid to begin with – you're the one left dealing with the consequences, not them. PostHog has not authorized any of these companies or platforms, and we have no relationship with any of them. If they've implied otherwise, that's not accurate.
+
+**This applies to former employees too**
+
+Leaving PostHog doesn't change this. The same restrictions apply after your employment ends, and any sale of your shares or options still requires board approval. If you're a former employee who's been approached, the answer is the same: it's not possible without our involvement.
+
+**When will I actually get to sell?**
+
+We try to run regular secondary sales, usually aligned with our financing rounds, to give the team real liquidity opportunities. When one is available, we'll let the whole team know at the same time. Any legitimate opportunity to sell will always come directly from PostHog – not from a cold message or a LinkedIn ad.
+
+If you've been approached by one of these companies and have questions, reach out to Hector in Slack.
+
+
 ### What if I leave PostHog before this exit event happens?
  
 Happily, we have set up terms that are industry-leading in their friendliness to team members! If you leave PostHog, you will have 10 years from the date your stock option was _granted_ to exercise any vested portion. Note that the exact deadline you have for exercise is whatever is written on your stock option agreement under "Expiration Date".

--- a/contents/handbook/people/share-options.mdx
+++ b/contents/handbook/people/share-options.mdx
@@ -58,7 +58,7 @@ Don't engage. This is coming up increasingly – LinkedIn ads, cold outreach fro
 
 PostHog's company documents prohibit any transfer of our stock without prior board approval – and "transfer" covers a lot more than just an outright sale. It includes forward contracts, futures, and any arrangement where you're effectively passing an economic interest in your shares to someone else, regardless of how the deal is structured or what it's called. Any transfer without board approval simply isn't valid. There's no clever structure that gets around this.
 
-These platforms know about the consent requirement and usually claim they've found a workaround. Some offer to advance you cash now, with an informal agreement that you'll hand over the shares when you eventually can sell. Others claim to be buying a right to your future proceeds rather than the shares themselves. Neither approach works – they still fall under the same restrictions. The bigger problem is that these companies put all the risk on you. If the deal later falls apart – which it very well might, since it was never valid to begin with – you're the one left dealing with the consequences, not them. PostHog has not authorized any of these companies or platforms, and we have no relationship with any of them. If they've implied otherwise, that's not accurate.
+These platforms know about the consent requirement and usually claim they've found a workaround. Some offer to advance you cash now, with an informal agreement that you'll hand over the shares when you eventually can sell. Others claim to be buying a right to your future proceeds rather than the shares themselves. Neither approach works – they still fall under the same restrictions. The bigger problem is that these companies put all the risk on you. Because the transaction was never valid to begin with, it will be void – PostHog won't update the cap table to reflect it, and we won't recognize the third party as having any interest in your shares. That creates a genuinely awkward situation: if PostHog is acquired or goes public, you're still the lawful owner of record, which means the proceeds flow to you, not to whoever you made the informal arrangement with. You'd then be on the hook to repay them – or find yourself in a legal dispute with a company that had no legitimate claim to your shares in the first place. PostHog has not authorized any of these companies or platforms, and we have no relationship with any of them. If they've implied otherwise, that's not accurate.
 
 **This applies to former employees too**
 
@@ -66,7 +66,7 @@ Leaving PostHog doesn't change this. The same restrictions apply after your empl
 
 **When will I actually get to sell?**
 
-We try to run regular secondary sales, usually aligned with our financing rounds, to give the team real liquidity opportunities. When one is available, we'll let the whole team know at the same time. Any legitimate opportunity to sell will always come directly from PostHog – not from a cold message or a LinkedIn ad.
+We try to run regular secondary sales to give the team real liquidity opportunities. When one is available, we'll let the whole team know at the same time. Any legitimate opportunity to sell will always come directly from PostHog – not from a cold message or a LinkedIn ad.
 
 If you've been approached by one of these companies and have questions, reach out to Hector in Slack.
 


### PR DESCRIPTION
## Summary

- Adds a new FAQ entry to the share options handbook page addressing the increasing number of third-party platforms and individuals reaching out to employees about buying their PostHog shares
- Explains that PostHog's governing documents require board approval for any stock transfer (including forward contracts, futures, and constructive sales), and that no third-party platform has been authorized
- Covers former employees, explains the risk these platforms shift onto option holders, and clarifies that legitimate secondary sale opportunities will always be communicated internally

## Context

Employees have been receiving unsolicited LinkedIn ads and direct messages from platforms claiming to buy their PostHog shares. This entry gives the team clear, plain-language guidance on why these offers aren't valid and what to do if approached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)