### PR TITLE
Fixes broken docs slug

### DIFF
--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -373,8 +373,8 @@ export const DocsIndex = () => {
                         <h6 className="text-lg">Feedback</h6>
 
                         <p>
-                            Our docs are perpetually a work in progress. The
-                            <SmallTeam slug="content" /> is responsible for what you see here.
+                            Our docs are perpetually a work in progress. The 
+                            <SmallTeam slug="docs-wizard" /> is responsible for what you see here.
                         </p>
                         <p>
                             At the end of each page, you can provide feedback about what was (or wasn't) helpful. We


### PR DESCRIPTION
## Changes

Updates a small team slug that was broken. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
