### PR TITLE
docs: add Roblox SDK

### DIFF
--- a/contents/docs/error-tracking/installation/roblox.mdx
+++ b/contents/docs/error-tracking/installation/roblox.mdx
@@ -1,0 +1,112 @@
+---
+title: Roblox error tracking installation
+platformLogo: roblox
+showStepsToc: true
+---
+
+import { Steps, Step } from 'components/Docs/Steps'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<Steps>
+
+<Step title="Install the Roblox SDK" badge="required">
+
+PostHog is available for Roblox through [Wally](https://wally.run) or as a model file you import in Studio.
+
+Via Wally, add the dependency to your `wally.toml`, run `wally install`, and map the package into `ReplicatedStorage`:
+
+```toml
+[dependencies]
+PostHog = "posthog/posthog-roblox@0.1.0"
+```
+
+You can also download the latest `posthog-roblox.rbxm` from the [releases page](https://github.com/PostHog/posthog-roblox/releases) and insert it into `ReplicatedStorage` in Studio. Either way you should end up with `ReplicatedStorage > PostHog`.
+
+Make sure HTTP requests are enabled for your experience: **Game Settings > Security > Allow HTTP Requests**.
+
+</Step>
+
+<Step title="Configure PostHog" badge="required">
+
+Initialize PostHog once from a server `Script` (for example in `ServerScriptService`), keeping error capture enabled:
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local PostHog = require(ReplicatedStorage:WaitForChild("PostHog"))
+
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>",
+    captureErrors = true,
+    errorDebounceSeconds = 1,
+})
+```
+
+You can find your project token and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.
+
+</Step>
+
+<Step title="Capture exceptions" badge="required">
+
+The Roblox SDK captures exceptions automatically by default. On the server it listens to `ScriptContext.Error`; requiring the module from a `LocalScript` captures unhandled client errors and relays them to the server.
+
+Captured events include the error message, the stack trace when available, and SDK metadata.
+
+For handled errors, call `CaptureException` manually with a subject, message, and optional trace and properties:
+
+```lua
+local ok, err = pcall(function()
+    saveGame(player)
+end)
+
+if not ok then
+    PostHog:CaptureException(player, err, debug.traceback(), {
+        flow = "save_game",
+    })
+end
+```
+
+<CalloutBox icon="IconInfo" title="Identified users" type="fyi">
+
+Server events are already attributed to the player you pass as the subject (by their `UserId`), so exceptions are linked to known users in PostHog automatically.
+
+</CalloutBox>
+
+</Step>
+
+<Step title="Configure error tracking options" badge="optional">
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `captureErrors` | boolean | `true` | Enables automatic exception capture. |
+| `errorDebounceSeconds` | number | `1` | Minimum seconds between automatic server error captures. |
+
+To disable automatic exception capture:
+
+```lua
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    captureErrors = false,
+})
+```
+
+</Step>
+
+<Step checkpoint title="Verify error tracking" badge="recommended">
+
+Trigger a test exception and confirm it appears in the [Error tracking](https://app.posthog.com/error_tracking) tab.
+
+```lua
+PostHog:CaptureException(nil, "Test exception from Roblox", debug.traceback())
+PostHog:Flush()
+```
+
+To test automatic capture, raise an unhandled error from a server `Script`:
+
+```lua
+error("Automatic test exception from Roblox")
+```
+
+</Step>
+
+</Steps>

--- a/contents/docs/error-tracking/references.mdx
+++ b/contents/docs/error-tracking/references.mdx
@@ -13,6 +13,7 @@ If you're looking for detailed reference documentation for the PostHog SDKs and 
 - [Python SDK](/docs/references/posthog-python?filter=error-tracking)
 - [.NET SDK](/docs/libraries/dotnet#error-tracking)
 - [Unity SDK](/docs/libraries/unity#error-tracking)
+- [Roblox SDK](/docs/libraries/roblox#error-tracking)
 
 ## API references
 

--- a/contents/docs/getting-started/_snippets/install.mdx
+++ b/contents/docs/getting-started/_snippets/install.mdx
@@ -11,7 +11,7 @@ import { WebsiteJSHtmlSnippet } from '../../product-analytics/installation/_snip
     <Tab.List>  
         <Tab>AI wizard</Tab>
         <Tab>JS snippet</Tab>
-        <Tab count="14">Libraries</Tab>
+        <Tab count="16">Libraries</Tab>
         <Tab count="22">Framework guides</Tab>
         <Tab>API</Tab>
     </Tab.List>

--- a/contents/docs/integrate/_snippets/install-roblox.mdx
+++ b/contents/docs/integrate/_snippets/install-roblox.mdx
@@ -1,0 +1,88 @@
+PostHog is available for Roblox through [Wally](https://wally.run) (the Roblox package manager), or as a model file you import in Studio. The SDK is server-authoritative: the server owns all batching and HTTP, and each player is a PostHog user keyed by their Roblox `UserId`.
+
+### Requirements
+
+- HTTP requests enabled for your experience: **Game Settings > Security > Allow HTTP Requests**. Only the Roblox server can make outbound HTTP requests, and only when this is on.
+- A PostHog project API key (starts with `phc_`).
+
+### Via Wally (recommended)
+
+Add the dependency to your `wally.toml`:
+
+```toml
+[dependencies]
+PostHog = "posthog/posthog-roblox@0.1.0"
+```
+
+Run `wally install`, then map the installed package into `ReplicatedStorage` in your [Rojo](https://rojo.space) project file so it replicates to clients:
+
+```json
+"ReplicatedStorage": {
+  "$className": "ReplicatedStorage",
+  "PostHog": { "$path": "Packages/PostHog" }
+}
+```
+
+### Via model file
+
+Download the latest `posthog-roblox.rbxm` from the [releases page](https://github.com/PostHog/posthog-roblox/releases). In Studio, right-click `ReplicatedStorage`, choose **Insert from File**, and select the file. Make sure the inserted instance is named `PostHog`.
+
+Either way, you should end up with `ReplicatedStorage > PostHog`, which both server and client code require.
+
+### Initialize on the server
+
+Initialize PostHog once from a server `Script` (for example in `ServerScriptService`):
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local PostHog = require(ReplicatedStorage:WaitForChild("PostHog"))
+
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>", -- usually https://us.i.posthog.com or https://eu.i.posthog.com
+})
+```
+
+> **Note:** `Init` must run on the server. Calling it from a `LocalScript` is ignored. Requiring the same module from a `LocalScript` gives you a thin client relay instead (see [Capturing events](#capturing-events)).
+
+### Configuration options
+
+Pass any of these to `PostHog:Init`. Only `apiKey` is required; everything else has a sensible default.
+
+```lua
+PostHog:Init({
+    -- Required
+    apiKey = "<ph_project_token>",
+
+    -- Connection
+    host = "https://us.i.posthog.com",
+
+    -- Event queue
+    flushAt = 20,                  -- Flush once this many events are queued (default: 20)
+    flushIntervalSeconds = 30,     -- Flush at least this often (default: 30)
+    maxQueueSize = 1000,           -- Drop the oldest events past this size (default: 1000)
+    maxBatchSize = 50,             -- Maximum events per HTTP request (default: 50)
+
+    -- Feature flags
+    preloadFeatureFlags = true,    -- Fetch a player's flags when they join (default: true)
+    sendFeatureFlagEvents = true,  -- Emit $feature_flag_called when a flag is read (default: true)
+    sendDefaultPersonPropertiesForFlags = true,
+
+    -- Autocapture and error tracking
+    captureLifecycleEvents = true, -- player_joined/left/idle, server_started/shutdown (default: true)
+    captureErrors = true,          -- Capture unhandled errors as $exception events (default: true)
+    errorDebounceSeconds = 1,      -- Minimum gap between auto-captured server errors (default: 1)
+
+    -- Identity
+    personProfiles = "identified_only", -- "identified_only" | "always" | "never"
+    serverDistinctId = "server",        -- distinct_id used for server-scoped (nil subject) events
+
+    -- Client relay
+    enableClientRelay = true,        -- Create the RemoteEvent that lets clients relay events (default: true)
+    clientRateLimitPerSecond = 20,   -- Per-player rate limit for relayed messages (default: 20)
+    maxClientPropertyCount = 100,    -- Maximum properties accepted from one client message (default: 100)
+
+    -- Diagnostics
+    logLevel = "warn",               -- "debug" | "info" | "warn" | "error" | "none"
+})
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-roblox.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-roblox.mdx
@@ -1,0 +1,78 @@
+Feature flags in the Roblox SDK are evaluated **per player**, so each flag call takes the player (or another subject) as its first argument. When `preloadFeatureFlags` is enabled (the default), a player's flags are fetched automatically when they join, so they're ready to read for the rest of the session.
+
+### Boolean feature flags
+
+```lua
+if PostHog:IsFeatureEnabled(player, "flag-key") then
+    -- Do something differently for this player
+end
+```
+
+`IsFeatureEnabled` accepts an optional default that's returned when the flag hasn't loaded yet:
+
+```lua
+if PostHog:IsFeatureEnabled(player, "flag-key", false) then
+    -- ...
+end
+```
+
+### Multivariate feature flags
+
+`GetFeatureFlag` returns a table with the flag's `value`, `isEnabled`, `variant`, and `payload`:
+
+```lua
+local flag = PostHog:GetFeatureFlag(player, "flag-key")
+if flag.isEnabled then
+    if flag.variant == "variant-key" then -- Replace with your variant key
+        -- Do something for this variant
+    end
+end
+```
+
+### Feature flag payloads
+
+Read the JSON payload attached to a flag with `GetFeatureFlagPayload`:
+
+```lua
+local payload = PostHog:GetFeatureFlagPayload(player, "checkout-config")
+if payload then
+    print(payload.theme, payload.maxItems)
+end
+```
+
+The payload is also available on the flag object returned by `GetFeatureFlag`:
+
+```lua
+local flag = PostHog:GetFeatureFlag(player, "checkout-config")
+local theme = flag.payload and flag.payload.theme
+```
+
+### Ensuring flags are loaded before use
+
+When a player joins, the SDK fetches their flags in the background (unless you set `preloadFeatureFlags = false`). For most of a session the flags are available immediately, but the very first read right after a player joins can race the network request.
+
+To force a fresh fetch and wait for it, call `ReloadFeatureFlags`. It **yields** until the request completes and returns whether it succeeded:
+
+```lua
+local ok = PostHog:ReloadFeatureFlags(player)
+if ok then
+    local enabled = PostHog:IsFeatureEnabled(player, "flag-key")
+end
+```
+
+### Overriding properties for flag evaluation
+
+Set the person or group properties used to evaluate a player's flags. By default this reloads their flags; pass `false` as the final argument to skip the reload:
+
+```lua
+-- Person properties for targeting
+PostHog:SetPersonPropertiesForFlags(player, {
+    plan = "premium",
+    beta_user = true,
+})
+
+-- Group properties for targeting
+PostHog:SetGroupPropertiesForFlags(player, "company", {
+    size = "enterprise",
+})
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-roblox.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-roblox.mdx
@@ -34,7 +34,7 @@ end
 Read the JSON payload attached to a flag with `GetFeatureFlagPayload`:
 
 ```lua
-local payload = PostHog:GetFeatureFlagPayload(player, "checkout-config")
+local payload = PostHog:GetFeatureFlagPayload(player, "shop-config")
 if payload then
     print(payload.theme, payload.maxItems)
 end
@@ -43,7 +43,7 @@ end
 The payload is also available on the flag object returned by `GetFeatureFlag`:
 
 ```lua
-local flag = PostHog:GetFeatureFlag(player, "checkout-config")
+local flag = PostHog:GetFeatureFlag(player, "shop-config")
 local theme = flag.payload and flag.payload.theme
 ```
 
@@ -67,12 +67,12 @@ Set the person or group properties used to evaluate a player's flags. By default
 ```lua
 -- Person properties for targeting
 PostHog:SetPersonPropertiesForFlags(player, {
-    plan = "premium",
-    beta_user = true,
+    level = 12,
+    is_vip = true,
 })
 
 -- Group properties for targeting
-PostHog:SetGroupPropertiesForFlags(player, "company", {
-    size = "enterprise",
+PostHog:SetGroupPropertiesForFlags(player, "guild", {
+    member_count = 42,
 })
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-roblox.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-roblox.mdx
@@ -1,5 +1,4 @@
 import SettingProperties from "./setting-properties-text.mdx"
-import NamingTip from "./naming-tip.mdx"
 import Intro from "./intro.mdx"
 
 <Intro />
@@ -10,11 +9,11 @@ On the server, every capture call takes a **subject** as its first argument so y
 local Players = game:GetService("Players")
 
 Players.PlayerAdded:Connect(function(player)
-    PostHog:Capture(player, "user_signed_up")
+    PostHog:Capture(player, "game_joined")
 end)
 ```
 
-<NamingTip />
+> **Tip:** We recommend naming events in an `[object] [verb]` format, where `[object]` is the entity the behavior relates to, and `[verb]` is the behavior itself. For example, `level completed`, `item purchased`, or `quest started`.
 
 The subject can be a `Player`, a numeric `UserId`, a string distinct ID, or `nil` for a server-scoped event that isn't attributed to any player:
 

--- a/contents/docs/integrate/send-events/_snippets/send-events-roblox.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-roblox.mdx
@@ -1,0 +1,64 @@
+import SettingProperties from "./setting-properties-text.mdx"
+import NamingTip from "./naming-tip.mdx"
+import Intro from "./intro.mdx"
+
+<Intro />
+
+On the server, every capture call takes a **subject** as its first argument so you can attribute the event to a specific player. Pass a `Player` and it resolves to their `UserId`:
+
+```lua
+local Players = game:GetService("Players")
+
+Players.PlayerAdded:Connect(function(player)
+    PostHog:Capture(player, "user_signed_up")
+end)
+```
+
+<NamingTip />
+
+The subject can be a `Player`, a numeric `UserId`, a string distinct ID, or `nil` for a server-scoped event that isn't attributed to any player:
+
+```lua
+PostHog:Capture(player, "level_completed")  -- a Player
+PostHog:Capture(123456, "level_completed")  -- a UserId
+PostHog:Capture(nil, "shop_restocked")      -- server-scoped, no person profile
+```
+
+<SettingProperties />
+
+```lua
+PostHog:Capture(player, "level_completed", {
+    level = 5,
+    duration_seconds = 92,
+    used_powerup = true,
+})
+```
+
+### Capturing from the client
+
+The same `PostHog` module works in a `LocalScript`, where it acts as a thin relay: calls are sent to the server over a `RemoteEvent` and attributed to the firing player. There's no API key on the client, and no subject argument:
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local PostHog = require(ReplicatedStorage:WaitForChild("PostHog"))
+
+PostHog:Capture("button_clicked", { button = "play" })
+```
+
+The server validates, rate-limits, and attributes every relayed event, so a client can't spoof another player or send reserved (`$`-prefixed) event names.
+
+### Capturing screen views
+
+Track which screens or menus a player views:
+
+```lua
+PostHog:Screen(player, "Main Menu")
+
+-- With additional properties
+PostHog:Screen(player, "Level Select", {
+    unlocked_levels = 5,
+})
+
+-- From a LocalScript (relayed, no subject)
+PostHog:Screen("Shop")
+```

--- a/contents/docs/integrate/send-events/_snippets/send-events-unity.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-unity.mdx
@@ -1,22 +1,21 @@
 import SettingProperties from "./setting-properties-text.mdx"
-import NamingTip from "./naming-tip.mdx"
 import Intro from "./intro.mdx"
 
 <Intro />
 
 ```csharp
-PostHog.Capture("user_signed_up");
+PostHog.Capture("level_completed");
 ```
 
-<NamingTip />
+> **Tip:** We recommend naming events in an `[object] [verb]` format, where `[object]` is the entity the behavior relates to, and `[verb]` is the behavior itself. For example, `level completed`, `item purchased`, or `quest started`.
 
 <SettingProperties />
 
 ```csharp
-PostHog.Capture("user_signed_up", new Dictionary<string, object>
+PostHog.Capture("level_completed", new Dictionary<string, object>
 {
-    { "login_type", "email" },
-    { "is_free_trial", true }
+    { "level_id", 5 },
+    { "score", 1250 }
 });
 ```
 

--- a/contents/docs/libraries/roblox/index.mdx
+++ b/contents/docs/libraries/roblox/index.mdx
@@ -8,7 +8,7 @@ platformLogo: roblox
 features:
   eventCapture: true
   userIdentification: true
-  autoCapture: false
+  autoCapture: true
   sessionRecording: false
   featureFlags: true
   groupAnalytics: true
@@ -44,21 +44,25 @@ Every player already has a real identity, their Roblox `UserId`, so player event
 ```lua
 PostHog:Identify(player, {
     display_name = player.DisplayName,
-    plan = "premium",
+    level = 12,
 })
 ```
 
 The first argument is a [subject](#capturing-events), so you can also identify by `UserId` or distinct ID. Pass a third argument to set properties only if they aren't already set (`$set_once`):
 
 ```lua
-PostHog:Identify(player, { plan = "premium" }, { first_seen = os.time() })
+PostHog:Identify(player, { favorite_mode = "survival" }, { first_seen = os.time() })
 ```
 
 ## Anonymous vs identified events
 
-import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
+PostHog captures two types of events: [**anonymous** and **identified**](/docs/data/anonymous-vs-identified-events). Identified events are attributed to a person and build a [person profile](/docs/data/persons); anonymous events are not.
 
-<IdentifiedVsAnonymousIntro />
+On Roblox this is simpler than on most platforms. Every player already has a stable identity, their Roblox `UserId`, so events you capture for a player are **identified** and create a person profile automatically. There's no logged-out or guest state to reconcile, and no `reset` to call.
+
+The events that stay **anonymous** are **server-scoped** events you capture with a `nil` subject. These describe the server or experience as a whole (for example `server_started` or `shop_restocked`) rather than any one player, so they don't create a person profile.
+
+> **Tip:** Anonymous events are cheaper to process than identified ones, so capture server-wide telemetry that isn't about a specific player with a `nil` subject rather than attributing it to an arbitrary player.
 
 ### Controlling person profiles
 
@@ -158,8 +162,8 @@ For handled errors you want to report, call `CaptureException` with a subject, a
 local ok, err = pcall(riskyOperation)
 if not ok then
     PostHog:CaptureException(player, err, debug.traceback(), {
-        context = "checkout_flow",
-        item_count = 5,
+        context = "load_world",
+        world = "desert",
     })
 end
 ```

--- a/contents/docs/libraries/roblox/index.mdx
+++ b/contents/docs/libraries/roblox/index.mdx
@@ -1,0 +1,297 @@
+---
+title: Roblox
+sidebarTitle: Roblox
+sidebar: Docs
+showTitle: true
+github: 'https://github.com/PostHog/posthog-roblox'
+platformLogo: roblox
+features:
+  eventCapture: true
+  userIdentification: true
+  autoCapture: false
+  sessionRecording: false
+  featureFlags: true
+  groupAnalytics: true
+  surveys: false
+  llmAnalytics: false
+  errorTracking: true
+---
+
+> **Note:** This SDK is currently in **beta**. Please report any issues on [GitHub](https://github.com/PostHog/posthog-roblox/issues).
+
+This is the official PostHog SDK for Roblox. It's **server-authoritative**: because only the Roblox server can make outbound HTTP requests, the server owns all batching, identity, feature flags, error tracking, and HTTP. A thin client module relays capture calls and client errors to the server over a `RemoteEvent`.
+
+Each player is a PostHog user, keyed by their stable Roblox `UserId`. The SDK keeps an in-memory event queue that's flushed on an interval and again on `game:BindToClose()`, which suits Roblox's ephemeral servers.
+
+## Installation
+
+import RobloxInstall from '../../integrate/_snippets/install-roblox.mdx'
+
+<RobloxInstall />
+
+## Capturing events
+
+import RobloxSendEvents from '../../integrate/send-events/_snippets/send-events-roblox.mdx'
+
+<RobloxSendEvents />
+
+## Identifying users
+
+> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
+
+Every player already has a real identity, their Roblox `UserId`, so player events are attributed and create [person profiles](/docs/data/persons) automatically. There's no anonymous-to-identified transition to manage and no `reset` to call. Use `Identify` to attach [person properties](/docs/product-analytics/person-properties) to a player:
+
+```lua
+PostHog:Identify(player, {
+    display_name = player.DisplayName,
+    plan = "premium",
+})
+```
+
+The first argument is a [subject](#capturing-events), so you can also identify by `UserId` or distinct ID. Pass a third argument to set properties only if they aren't already set (`$set_once`):
+
+```lua
+PostHog:Identify(player, { plan = "premium" }, { first_seen = os.time() })
+```
+
+## Anonymous vs identified events
+
+import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
+
+<IdentifiedVsAnonymousIntro />
+
+### Controlling person profiles
+
+By default, player events create person profiles and server-scoped events (those captured with a `nil` subject) do not. Change this with `personProfiles`:
+
+```lua
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    personProfiles = "identified_only", -- default
+})
+```
+
+Available options:
+
+- `"identified_only"` (default) – player events create profiles; server-scoped events don't.
+- `"always"` – every event creates or updates a person profile.
+- `"never"` – no event creates a person profile.
+
+## Super properties
+
+Super properties are attached to every event the server sends. They're **server-global**: set once on the server, they apply to events from every player, which makes them a good fit for server-wide context like the place version or region.
+
+Set them with `Register`, which takes a key and value:
+
+```lua
+PostHog:Register("place_version", game.PlaceVersion)
+PostHog:Register("region", "us-east")
+```
+
+> **Note:** Super properties live in memory for the lifetime of the server. Unlike on persistent clients, they aren't stored across sessions, so register the ones you need during `Init` or server startup.
+
+### Removing super properties
+
+```lua
+PostHog:Unregister("region")
+```
+
+## Group analytics
+
+Group analytics lets you associate a player's events with a group (for example a guild, party, or server). Read the [Group analytics](/docs/product-analytics/group-analytics) guide for more information.
+
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
+
+- Associate a player's events with a group:
+
+```lua
+PostHog:Group(player, "guild", "guild_id_in_your_db")
+```
+
+- Associate events with a group and update the group's properties:
+
+```lua
+PostHog:Group(player, "guild", "guild_id_in_your_db", {
+    name = "The Knights",
+    member_count = 42,
+})
+```
+
+The `name` is a special property used in the PostHog UI for the group's name. If you don't specify it, the group key is used instead.
+
+## Feature flags
+
+import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
+
+<FeatureFlagsLibsIntro />
+
+import RobloxFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/feature-flags-code-roblox.mdx'
+
+<RobloxFeatureFlagsCode />
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+```lua
+local flag = PostHog:GetFeatureFlag(player, "experiment-feature-flag-key")
+if flag.variant == "control" then
+    -- Do something for the control group
+elseif flag.variant == "test" then
+    -- Do something for the test group
+end
+```
+
+It's also possible to [run experiments without feature flags](/docs/experiments/running-experiments-without-feature-flags).
+
+## Error tracking
+
+The Roblox SDK captures unhandled errors automatically and sends them to PostHog as `$exception` events. This is enabled by default. On the server it listens to `ScriptContext.Error`; requiring the module on the client captures unhandled client errors and relays them to the server.
+
+For the full setup guide, see the [Roblox error tracking installation docs](/docs/error-tracking/installation/roblox).
+
+### Manual exception capture
+
+For handled errors you want to report, call `CaptureException` with a subject, a message, and an optional stack trace and properties:
+
+```lua
+local ok, err = pcall(riskyOperation)
+if not ok then
+    PostHog:CaptureException(player, err, debug.traceback(), {
+        context = "checkout_flow",
+        item_count = 5,
+    })
+end
+```
+
+From a `LocalScript`, the relay version takes no subject:
+
+```lua
+PostHog:CaptureException("Something went wrong", debug.traceback())
+```
+
+### Configuration
+
+```lua
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    captureErrors = true,        -- Enable automatic capture (default: true)
+    errorDebounceSeconds = 1,    -- Minimum gap between auto-captured server errors (default: 1)
+})
+```
+
+To disable automatic capture, set `captureErrors = false`.
+
+## Autocapture
+
+With `captureLifecycleEvents` enabled (the default), the SDK records a set of session and server events automatically, with no manual instrumentation. These give you concurrency, retention, and engagement metrics from the moment you initialize, so there's meaningful data to chart before you write a single custom event.
+
+| Event | When it fires | Key properties |
+| --- | --- | --- |
+| `server_started` | The SDK initializes on a server | `player_count`, `max_players`, `is_private_server`, `is_reserved_server` |
+| `server_shutdown` | The server shuts down (`game:BindToClose`) | `player_count`, `uptime_seconds` |
+| `player_joined` | A player joins | `is_teleport`, `player_count`, `account_age_days`, `membership_type`, `country_code` |
+| `player_left` | A player leaves | `session_duration_seconds`, `player_count`, `platform`, `country_code` |
+| `player_idle` | Roblox reports a player has gone idle | `idle_seconds` |
+
+Every event, autocaptured or manual, also carries standard context such as `$session_id`, `$os`, `$device_type`, place and server identifiers, and the SDK version.
+
+To turn autocapture off:
+
+```lua
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    captureLifecycleEvents = false,
+})
+```
+
+> **Note:** `platform` is reported by the client relay, so on `player_joined` (which fires the instant a player connects) it's usually not known yet; it's populated by the time `player_left` fires. `country_code` is resolved before `player_joined` is sent.
+
+## Sessions and teleports
+
+A session corresponds to a player's connection to a server, and every event carries its `$session_id`. Because experiences often teleport players between places, you can continue a player's session across a teleport so the whole journey is stitched together.
+
+Merge the SDK's teleport data into your `TeleportData` before teleporting:
+
+```lua
+local TeleportService = game:GetService("TeleportService")
+
+local options = Instance.new("TeleportOptions")
+options:SetTeleportData(PostHog:GetSessionTeleportData(player))
+
+TeleportService:TeleportAsync(placeId, { player }, options)
+```
+
+The destination server restores the session automatically when the player arrives, so their events keep the same `$session_id`.
+
+## The client relay
+
+Requiring `PostHog` from a `LocalScript` gives you a thin relay rather than the full SDK. It can't make HTTP requests, so it forwards capture calls and client errors to the server over a `RemoteEvent`, where they're attributed to the firing player.
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local PostHog = require(ReplicatedStorage:WaitForChild("PostHog"))
+
+-- Optional. Errors are captured automatically; pass { captureErrors = false } to turn that off.
+PostHog:Init()
+
+PostHog:Capture("button_clicked", { button = "play" })
+```
+
+The client is treated as untrusted. The server validates every relayed message, caps the number of properties, rate-limits per player, blocks reserved (`$`-prefixed) event names, and always attributes events to the sender, so a client can never spoof another player or the server. Set `enableClientRelay = false` during `Init` if you only capture on the server and want no client surface at all.
+
+## Opt out of data capture
+
+For privacy compliance, you can stop and resume capturing for a given subject at any time:
+
+```lua
+PostHog:OptOut(player)
+
+-- Later
+PostHog:OptIn(player)
+```
+
+## Debug mode
+
+If you're not seeing the events or feature flags you expect, raise the log level to see what the SDK is doing in the output:
+
+```lua
+PostHog:Init({
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>",
+    logLevel = "debug",
+})
+```
+
+Available log levels: `"none"`, `"error"`, `"warn"`, `"info"`, `"debug"`.
+
+## Manual flush
+
+Events are sent in batches (every `flushIntervalSeconds`, or once `flushAt` events are queued). Force a send immediately, for example while testing:
+
+```lua
+PostHog:Flush()
+```
+
+This is asynchronous and doesn't yield. On the client, `Flush` is a no-op since flushing happens on the server.
+
+## Shutdown
+
+The SDK flushes automatically on `game:BindToClose()`, so you rarely need to shut it down explicitly. If you want to stop autocapture, error tracking, and the relay, and flush early:
+
+```lua
+PostHog:Shutdown()
+```
+
+## Troubleshooting
+
+### Events not appearing in PostHog
+
+1. **HTTP is enabled.** Turn on **Game Settings > Security > Allow HTTP Requests**. Without it the server can't send anything.
+2. **`Init` ran on the server.** It must be called from a `Script`, not a `LocalScript`. With `logLevel = "debug"` you should see `PostHog initialized` in the output.
+3. **The key and host are correct.** The key starts with `phc_`, and the host matches your region (`https://us.i.posthog.com` or `https://eu.i.posthog.com`).
+4. **You waited for a flush.** Events batch every `flushIntervalSeconds` or once `flushAt` are queued. Call `PostHog:Flush()` to send immediately.
+
+### Client events not arriving
+
+Client events are relayed to the server, so the server SDK must be initialized with `enableClientRelay = true` (the default). If the client logs that the relay `RemoteEvent` wasn't found, the server SDK isn't running.

--- a/contents/docs/libraries/unity/index.mdx
+++ b/contents/docs/libraries/unity/index.mdx
@@ -8,7 +8,7 @@ platformLogo: unity
 features:
   eventCapture: true
   userIdentification: true
-  autoCapture: false
+  autoCapture: true
   sessionRecording: true
   featureFlags: true
   groupAnalytics: true
@@ -63,9 +63,26 @@ await PostHog.ResetAsync();
 
 ## Anonymous vs identified events
 
-import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
+PostHog captures two types of events: [**anonymous** and **identified**](/docs/data/anonymous-vs-identified-events).
 
-<IdentifiedVsAnonymousIntro />
+**Identified events** let you attribute events to a specific player and attach [person properties](/docs/product-analytics/person-properties). They're best suited for players who have signed in.
+
+Scenarios where you want identified events are:
+
+- Tracking signed-in players across sessions and devices
+- Segmenting your analysis by individual player
+- Following a player's full journey from install through retention
+
+**Anonymous events** have no individually identifiable data. They're best suited for players you haven't identified yet.
+
+Scenarios where you want anonymous events are:
+
+- Players in a guest or pre-login flow
+- Sessions where players never create an account
+
+Under the hood, the key difference is that identified events create a [person profile](/docs/data/persons) and anonymous events do not.
+
+> **Important:** Anonymous events can be up to 4x cheaper to process than identified ones, so we recommend only capturing identified events when needed.
 
 ### Controlling person profiles
 

--- a/src/components/Docs/Integrate.tsx
+++ b/src/components/Docs/Integrate.tsx
@@ -103,8 +103,10 @@ const query = graphql`
                             "/docs/libraries/python"
                             "/docs/libraries/react"
                             "/docs/libraries/react-native"
+                            "/docs/libraries/roblox"
                             "/docs/libraries/ruby"
                             "/docs/libraries/rust"
+                            "/docs/libraries/unity"
                         ]
                     }
                 }

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -113,6 +113,8 @@ export const LOGOS = {
         'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/rudderstack.svg',
     pinterestAds: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pinterest_ads_563b842dc5.png',
     revenuecat: 'https://res.cloudinary.com/dmukukwp6/image/upload/logomark_red_background_9ea591e17a.svg',
+    // TODO(roblox): placeholder. Upload the Roblox logo to Cloudinary and replace this URL before publishing.
+    roblox: 'https://res.cloudinary.com/dmukukwp6/image/upload/roblox_PLACEHOLDER_replace_before_publishing.svg',
     rollup: 'https://res.cloudinary.com/dmukukwp6/image/upload/Rollup_js_c306a2fde3.svg',
     ruby: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/ruby.svg',
     rust: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/rust.svg',

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -113,8 +113,7 @@ export const LOGOS = {
         'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/rudderstack.svg',
     pinterestAds: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pinterest_ads_563b842dc5.png',
     revenuecat: 'https://res.cloudinary.com/dmukukwp6/image/upload/logomark_red_background_9ea591e17a.svg',
-    // TODO(roblox): placeholder. Upload the Roblox logo to Cloudinary and replace this URL before publishing.
-    roblox: 'https://res.cloudinary.com/dmukukwp6/image/upload/roblox_PLACEHOLDER_replace_before_publishing.svg',
+    roblox: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Roblox_Corporation_2025_logo_svg_301751b47c.png',
     rollup: 'https://res.cloudinary.com/dmukukwp6/image/upload/Rollup_js_c306a2fde3.svg',
     ruby: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/ruby.svg',
     rust: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/rust.svg',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2315,6 +2315,14 @@ export const docsMenu = {
                             ],
                         },
                         {
+                            name: 'Roblox',
+                            url: '/docs/libraries/roblox',
+                            badge: {
+                                title: 'Beta',
+                                className: '!bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50',
+                            },
+                        },
+                        {
                             name: 'Ruby',
                             url: '/docs/libraries/ruby',
                         },
@@ -4827,6 +4835,10 @@ export const docsMenu = {
                         {
                             name: 'Unity',
                             url: '/docs/error-tracking/installation/unity',
+                        },
+                        {
+                            name: 'Roblox',
+                            url: '/docs/error-tracking/installation/roblox',
                         },
                         {
                             name: 'Elixir',


### PR DESCRIPTION
## Changes

Adds documentation for the official **PostHog Roblox SDK** ([PostHog/posthog-roblox](https://github.com/PostHog/posthog-roblox)), mirroring the Unity SDK's docs presence so Roblox shows up in the SDKs section. The SDK is currently in beta.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A, no pages were moved)
