### PR TITLE
docs(tracing): add initial Tracing product page and nav entry

### DIFF
--- a/contents/docs/tracing/start-here.mdx
+++ b/contents/docs/tracing/start-here.mdx
@@ -1,0 +1,84 @@
+---
+title: Getting started with Tracing
+hideRightSidebar: true
+contentMaxWidthClass: max-w-5xl
+---
+
+import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
+
+> **Note:** Tracing is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+
+<QuestLog firstSpeechBubble="Let's set up tracing!" lastSpeechBubble="Time to explore your traces!">
+
+<QuestLogItem
+    title="Install an OpenTelemetry trace exporter"
+    subtitle="Required"
+    icon="IconCode"
+>
+
+PostHog Tracing works with any OpenTelemetry client. No PostHog-specific packages are required. Use the OTel SDKs you already have, point your trace exporter at PostHog's HTTP endpoint, and add your project token.
+
+Set these on your OpenTelemetry SDK:
+
+```bash
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="<ph_client_api_host>/i/v1/traces"
+OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer <ph_project_token>"
+OTEL_SERVICE_NAME="my-app"
+```
+
+`<ph_client_api_host>` and `<ph_project_token>` are filled in with your project's values when you're logged in. Use your **project token** (the same one you use for capturing events), not a [personal API key](/docs/api#authentication).
+
+This is a different endpoint from PostHog's AI/LLM tracing (`/i/v0/ai/otel`), which only accepts generative-AI spans. For general application traces, use `/i/v1/traces`.
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Send context-rich spans"
+    subtitle="Required"
+    icon="IconStack"
+>
+
+PostHog ingests spans using OpenTelemetry's standard model: a trace is a tree of spans, each with a `trace_id`, `span_id`, and `parent_span_id`, plus timing, a service name, and attributes.
+
+Wrap the operations you care about – incoming requests, outgoing calls, database queries – in spans, and enrich them with attributes for business context.
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer("my-app")
+
+with tracer.start_as_current_span("checkout") as span:
+    span.set_attribute("user.id", "123")
+    span.set_attribute("cart.value", 4200)
+    # ... your code ...
+```
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Explore your traces"
+    subtitle="Required"
+    icon="IconListTree"
+>
+
+Once spans are flowing into PostHog, you can:
+
+- **Search and filter spans** by service, status, duration, and attributes
+- **Follow a trace end to end** as a waterfall to see where time goes
+- **Spot slow and failing operations** across your services
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Correlate traces with the rest of PostHog"
+    subtitle="Recommended"
+    icon="IconLogomark"
+>
+
+Tracing is part of PostHog's observability suite and shares the same OpenTelemetry pipeline as [Logs](/docs/logs). Because logs carry `trace_id` and `span_id`, you can pivot from a slow span to the exact log lines emitted during it.
+
+From there, your traces live alongside [Session Replay](/docs/session-replay), [Error Tracking](/docs/error-tracking), and [Product Analytics](/docs/product-analytics) – so you can go from a slow request to the user's session without switching tools.
+
+</QuestLogItem>
+
+</QuestLog>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6844,6 +6844,34 @@ export const docsMenu = {
             ],
         },
         {
+            name: 'Tracing',
+            icon: 'IconListTree',
+            color: 'purple',
+            url: '/docs/tracing',
+            description: 'Capture and explore distributed traces with OpenTelemetry.',
+            children: [
+                {
+                    name: 'Tracing',
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/tracing',
+                    icon: 'IconHome',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'Getting started',
+                },
+                {
+                    name: 'Start here',
+                    url: '/docs/tracing/start-here',
+                    icon: 'IconListCheck',
+                    color: 'orange',
+                    featured: true,
+                },
+            ],
+        },
+        {
             name: 'Endpoints',
             icon: 'IconCode2',
             color: 'blue',

--- a/src/pages/docs/tracing/index.tsx
+++ b/src/pages/docs/tracing/index.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { SEO } from 'components/seo'
+import ResourceItem from 'components/Docs/ResourceItem'
+import Intro from 'components/Docs/Intro'
+import ReaderView from 'components/ReaderView'
+import Link from 'components/Link'
+
+export const Content = () => {
+    return (
+        <>
+            <section className="mb-8">
+                <h2 className="mb-4">Overview</h2>
+                <div>
+                    <p>
+                        PostHog Tracing is a distributed tracing solution that works with the OpenTelemetry Protocol
+                        (OTLP). You don't need any vendor-specific SDKs. Use standard OpenTelemetry libraries to send
+                        spans to PostHog using your project token.
+                    </p>
+                    <p>Tracing is currently in alpha. Setup details may change before general availability.</p>
+                </div>
+            </section>
+
+            <section className="mb-8">
+                <h2 className="mb-4 mt-0">Why use PostHog Tracing?</h2>
+                <div>
+                    <ul>
+                        <li>
+                            <b>OpenTelemetry-compatible</b> – Use standard OpenTelemetry SDKs, no PostHog packages
+                            required. Works with any compatible client.
+                        </li>
+                        <li>
+                            <b>Part of the observability suite</b> – Traces share the same pipeline as{' '}
+                            <Link to="/docs/logs">Logs</Link>, and correlate with session replays, errors, and analytics
+                            by <code>trace_id</code>.
+                        </li>
+                        <li>
+                            <b>No vendor lock-in</b> – Works with your existing OpenTelemetry setup.
+                        </li>
+                    </ul>
+                </div>
+            </section>
+
+            <section className="mb-8">
+                <h2 className="mb-4 mt-0">How it works</h2>
+                <div>
+                    <p>Tracing acts as a generic OTLP receiver built by PostHog. Here's how it works:</p>
+                    <ol>
+                        <li>Use standard OpenTelemetry tracing APIs in your application</li>
+                        <li>Include your project token in the Authorization header or as a query parameter</li>
+                        <li>Configure your OpenTelemetry client to send spans to PostHog's HTTP endpoint</li>
+                        <li>Search and explore your traces in the PostHog interface</li>
+                    </ol>
+                </div>
+            </section>
+
+            <section className="mb-8">
+                <h2 className="mb-4">Next steps</h2>
+                <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid grid-cols-1 @md:grid-cols-2">
+                    <ResourceItem
+                        type="Getting started"
+                        title="Start here"
+                        description="A high-level overview of setting up tracing with OpenTelemetry"
+                        url="/docs/tracing/start-here"
+                    />
+                    <ResourceItem
+                        type="Related"
+                        title="Logs"
+                        description="Search and analyze your application logs – traces' sibling in the observability suite"
+                        url="/docs/logs"
+                    />
+                </ul>
+            </section>
+        </>
+    )
+}
+
+const Tracing: React.FC = () => {
+    return (
+        <ReaderView>
+            <SEO title="Tracing - Docs - PostHog" />
+
+            <div className="mx-auto max-w-4xl">
+                <section className="mb-6">
+                    <Intro
+                        subheader="Getting started"
+                        title="Tracing"
+                        description="Capture and explore distributed traces with PostHog and OpenTelemetry."
+                        buttonText="Get started!"
+                        buttonLink="/docs/tracing/start-here"
+                    />
+                </section>
+
+                <Content />
+            </div>
+        </ReaderView>
+    )
+}
+
+export default Tracing


### PR DESCRIPTION
## Changes

Adds documentation for PostHog Tracing (currently in alpha), a distributed tracing solution built on OpenTelemetry.

- Adds a new `/docs/tracing` overview page explaining what PostHog Tracing is, why to use it, and how it works
- Adds a `/docs/tracing/start-here` getting started guide using the `QuestLog` component, covering OTLP exporter setup, sending spans, exploring traces in PostHog, and correlating traces with Logs, Session Replay, Error Tracking, and Product Analytics
- Adds a **Tracing** section to the docs navigation menu

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`