### PR TITLE
Document billing vs. finance routing in sales CRM handbook

### DIFF
--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -161,10 +161,13 @@ For support or billing questions submitted via the sales channel, disqualify wit
 
 Billing and finance questions look similar but go to different teams. Route by what the customer is actually asking for:
 
-- **Invoices → billing team** Questions about what an invoice says or what information goes on it — line items, amounts, tax, dates, the entity we bill under, or adding a PO number to an invoice. The <SmallTeam slug="billing" /> owns the invoice itself.
+- **Invoices → billing team** Questions about what an invoice says or what information goes on it — line items, amounts, dates, the entity we bill under, or adding a PO number to an invoice. The <SmallTeam slug="billing" /> owns the invoice itself.
+
 - **Collections → finance team** Anything about getting paid or where an invoice needs to go — requests to upload an invoice to a customer's payment portal (e.g. Zip, Coupa, Ariba), supplier-onboarding or vendor-setup forms, requests for extra documentation or information from us, and chasing overdue payments.
 
 A quick test: if the question can be answered by reading or correcting the invoice, it's **billing**. If it asks us to send the invoice somewhere specific, complete a form, or provide extra information, it's **finance**.
+
+Tax is owned by finance, who handle tax determination and compliance via Anrok. Billing only gets involved when a specific tax amount has to appear as an explicit line item on an invoice. For anything about tax rates, treatment, or whether tax applies, ask finance.
 
 This comes up most with managed customers, where POs and payment notices sit at the intersection of sales, billing, and finance. These often arrive via the sales channel (the contact form or sales@) even though they belong to billing or finance — disqualify and re-route them using the split above rather than working them as leads.
 

--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -161,8 +161,8 @@ For support or billing questions submitted via the sales channel, disqualify wit
 
 Billing and finance questions look similar but go to different teams. Route by what the customer is actually asking for:
 
-- **Invoices → billing team.** Questions about what an invoice says or what information goes on it — line items, amounts, tax, dates, the entity we bill under, or adding a PO number to an invoice. The <SmallTeam slug="billing" /> owns the invoice itself.
-- **Collections → finance team (finance@posthog.com).** Anything about getting paid or where an invoice needs to go — requests to upload an invoice to a customer's payment portal (e.g. Zip, Coupa, Ariba), supplier-onboarding or vendor-setup forms, requests for extra documentation or information from us, and chasing overdue payments.
+- **Invoices → billing team** Questions about what an invoice says or what information goes on it — line items, amounts, tax, dates, the entity we bill under, or adding a PO number to an invoice. The <SmallTeam slug="billing" /> owns the invoice itself.
+- **Collections → finance team** Anything about getting paid or where an invoice needs to go — requests to upload an invoice to a customer's payment portal (e.g. Zip, Coupa, Ariba), supplier-onboarding or vendor-setup forms, requests for extra documentation or information from us, and chasing overdue payments.
 
 A quick test: if the question can be answered by reading or correcting the invoice, it's **billing**. If it asks us to send the invoice somewhere specific, complete a form, or provide extra information, it's **finance**.
 

--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -157,6 +157,17 @@ If you meet a potential customer elsewhere (e.g., events, introductions, referra
 
 For support or billing questions submitted via the sales channel, disqualify with **Support Request** or **Billing Support Request** as in [Completed contact form](#completed-contact-form) (Zendesk ticket automation). If you still see legacy lead records from older flows, the same reasons apply; ticket creation may use [this Zapier path](https://zapier.com/editor/274433115/published) for some automations.
 
+#### Billing vs. finance: who owns what
+
+Billing and finance questions look similar but go to different teams. Route by what the customer is actually asking for:
+
+- **Invoices → billing team.** Questions about what an invoice says or what information goes on it — line items, amounts, tax, dates, the entity we bill under, or adding a PO number to an invoice. The <SmallTeam slug="billing" /> owns the invoice itself.
+- **Collections → finance team (finance@posthog.com).** Anything about getting paid or where an invoice needs to go — requests to upload an invoice to a customer's payment portal (e.g. Zip, Coupa, Ariba), supplier-onboarding or vendor-setup forms, requests for extra documentation or information from us, and chasing overdue payments.
+
+A quick test: if the question can be answered by reading or correcting the invoice, it's **billing**. If it asks us to send the invoice somewhere specific, complete a form, or provide extra information, it's **finance**.
+
+This comes up most with managed customers, where POs and payment notices sit at the intersection of sales, billing, and finance. These often arrive via the sales channel (the contact form or sales@) even though they belong to billing or finance — disqualify and re-route them using the split above rather than working them as leads.
+
 ### Below Threshold – Auto (Customer.io)
 
 When you should route someone to self-serve onboarding instead of hands-on sales, mark the task **Below Threshold – Auto**. That triggers the automated onboarding flow in <PrivateLink url="https://fly.customer.io/workspaces/127208/journeys/campaigns/109/overview">customer.io</PrivateLink>, which guides them without manual outreach. Manual TAE judgment under the sales-assist threshold uses **Below Sales Assist Threshold – Pass** or **Below Sales Assist Threshold – Prospect** (see splits above), not this auto reason.


### PR DESCRIPTION
## Changes

Updates the **Support and billing routing** section of the sales CRM handbook page to document when a billing/finance question should go to the **billing team** vs. the **finance team**, per [Mine's guidance in Slack](https://posthog.slack.com/archives/C08UNFX75ST/p1780007927106869):

- **Invoices → billing team** — questions about what an invoice says or what info goes on it (line items, amounts, tax, dates, billing entity, adding a PO number).
- **Collections → finance team (finance@posthog.com)** — requests to upload invoices to a customer's payment portal (Zip, Coupa, Ariba), supplier-onboarding/vendor-setup forms, asks for extra documentation from us, and chasing overdue payments.

Includes a quick "read/correct the invoice = billing; send it somewhere or add info = finance" test, and a note that these requests often arrive via the sales channel (contact form / sales@) and should be re-routed rather than worked as leads — the situation that prompted this ([Zendesk #59283](https://posthoghelp.zendesk.com/agent/tickets/59283)).

This is the handbook half of the follow-up; the matching `sales@` disqualification reason that routes to finance is a separate SFDC config change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)
