### PR TITLE
Fix feature flag billing callout to clarify per-request pricing

### DIFF
--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -38,11 +38,9 @@ Feature flags are **not** billed based on `$feature_flag_called` events, which a
 
 The number of `/flags` requests and the number of `$feature_flag_called` events are **not** directly related.
 
-<CalloutBox icon="IconWarning" title="Unused flags still incur charges" type="caution">
+<CalloutBox icon="IconInfo" title="Removing flags from code doesn't reduce your bill" type="info">
 
-  Active feature flags you're not using in your code are still evaluated (and charged) every time the `/flags` endpoint is called. This includes when surveys are loaded, as survey targeting evaluates all active flags to determine eligibility.
-
-  To stop charges for unused flags, you must **disable, delete, or archive** them in the PostHog UI – [simply removing them from your code](/docs/vscode-extension/stale-flag-cleanup) is not enough.
+  Billing is per `/flags` request, not per flag evaluated. Having fewer active flags doesn't reduce costs — what matters is the number of requests made. To reduce your bill, reduce the number of `/flags` requests (see options below), or [remove stale flags](/docs/vscode-extension/stale-flag-cleanup) to keep your project tidy.
 
 </CalloutBox>
 

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -38,11 +38,7 @@ Feature flags are **not** billed based on `$feature_flag_called` events, which a
 
 The number of `/flags` requests and the number of `$feature_flag_called` events are **not** directly related.
 
-<CalloutBox icon="IconInfo" title="Removing flags from code doesn't reduce your bill" type="info">
-
-  Billing is per `/flags` request, not per flag evaluated. Having fewer active flags doesn't reduce costs — what matters is the number of requests made. To reduce your bill, reduce the number of `/flags` requests (see options below), or [remove stale flags](/docs/vscode-extension/stale-flag-cleanup) to keep your project tidy.
-
-</CalloutBox>
+The number of active flags in your project does not affect the cost of each `/flags` request, so deactivating or removing flags has no direct billing impact. What reduces your bill is reducing the number of `/flags` requests themselves (see options below).
 
 ### Creating a billable usage dashboard
 


### PR DESCRIPTION
## Changes

Updates the callout box in the feature flags cost-cutting docs to accurately reflect how billing works. The previous callout incorrectly implied that active flags not used in code still incur charges on a per-flag basis. In reality, billing is per `/flags` request regardless of how many flags are evaluated in each call — having fewer active flags doesn't reduce costs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`