### PR TITLE
docs: use nitro:build:public-assets hook for Nuxt sourcemap upload

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/nuxt.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/nuxt.mdx
@@ -36,7 +36,7 @@ export default defineNuxtConfig({
     client: true // +
   },
   hooks: {
-    'close': async () => {
+    'nitro:build:public-assets': async () => {
       console.log('Running PostHog sourcemap injection and upload...')
       try {
         execSync("posthog-cli sourcemap inject --directory '.output'", { // +


### PR DESCRIPTION
I LOVE WORKING WITH NUXT ❤️ 

Switch the Nuxt source map upload guide to run injection/upload from the `nitro:build:public-assets` hook instead of `close`, so it fires after build assets are written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)