### PR TITLE
Update autoresearch blog post title and slug

### DIFF
--- a/contents/blog/karpathy-autoresearch-query-engine-bug.md
+++ b/contents/blog/karpathy-autoresearch-query-engine-bug.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-01
-title: How autoresearch found a 3-year-old bug in our query engine
+title: Andrej Karpathy's AI Autoresearch found a 3-year-old bug in PostHog's query engine (and improved performance across the board by 11%)
 rootPage: /blog
 sidebar: Blog
 showTitle: true

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,11 @@
     ],
     "redirects": [
         {
+            "source": "/blog/autoresearch-query-bug",
+            "destination": "/blog/karpathy-autoresearch-query-engine-bug",
+            "statusCode": 301
+        },
+        {
             "source": "/handbook/marketing/how-we-position-and-sell",
             "destination": "/handbook/marketing/positioning",
             "statusCode": 301


### PR DESCRIPTION
## Changes

Updates the autoresearch blog post per the Slack discussion to lead with the more clickable hook (Andrej Karpathy / AI Autoresearch) and the catchy 11% performance gain.

- **Title:** "How autoresearch found a 3-year-old bug in our query engine" → "Andrej Karpathy's AI Autoresearch found a 3-year-old bug in PostHog's query engine (and improved performance across the board by 11%)"
- **Slug:** `/blog/autoresearch-query-bug` → `/blog/karpathy-autoresearch-query-engine-bug`
- Added a 301 redirect from the old slug to the new one in `vercel.json`

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
