### PR TITLE
Update autoresearch blog post title and slug

### DIFF
--- a/contents/blog/andrej-karpathy-autoresearch-query-engine-bug.md
+++ b/contents/blog/andrej-karpathy-autoresearch-query-engine-bug.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-01
-title: How autoresearch found a 3-year-old bug in our query engine
+title: Andrej Karpathy's AI Autoresearch found a 3-year-old bug in PostHog's query engine (and improved performance across the board by 11%)
 rootPage: /blog
 sidebar: Blog
 showTitle: true

--- a/vercel.json
+++ b/vercel.json
@@ -87,6 +87,10 @@
             "destination": "/handbook/strategy/ideal-customer-persona"
         },
         { "source": "/blog/carbon-offset-wren", "destination": "/handbook/people/spending-money" },
+        {
+            "source": "/blog/autoresearch-query-bug",
+            "destination": "/blog/andrej-karpathy-autoresearch-query-engine-bug"
+        },
         { "source": "/hogwars", "destination": "/sparks-joy/hogwars" },
         { "source": "/youreastar", "destination": "https://www.youtube.com/watch?v=SD7B2teuLXk" },
         {


### PR DESCRIPTION
## Changes

Updates the autoresearch blog post to lead with the Andrej Karpathy hook and the 11% performance improvement, per the team discussion.

- **Title** changed from "How autoresearch found a 3-year-old bug in our query engine" to "Andrej Karpathy's AI Autoresearch found a 3-year-old bug in PostHog's query engine (and improved performance across the board by 11%)"
- **Slug** changed from `/blog/autoresearch-query-bug` to `/blog/andrej-karpathy-autoresearch-query-engine-bug` (file renamed)
- **Redirect** added in `vercel.json` from the old slug to the new one

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
