### PR TITLE
docs(handbook): add demo preparation to onsite common mistakes

### DIFF
--- a/contents/handbook/growth/sales/customer-onsites.md
+++ b/contents/handbook/growth/sales/customer-onsites.md
@@ -100,6 +100,7 @@ Notice: You're doing it anyway, specific location, low pressure, no stated agend
 - Don't treat this as a sales pitch - if you're showing up just to close a deal, you're not expanding your relationship and understanding of the customer.
 - Don't over-schedule - leaving buffer time for organic conversations is often more valuable than cramming in another session
 - Don't show up unprepared on their data - spend time before the visit building something useful in their PostHog instance that you can show them
+- Don't wing your product demos - rehearse the flow ahead of time, have a clear narrative, and test that everything works (logins, data loading, feature access) before you're in front of an audience. A demo that stalls or breaks live undermines your credibility and the customer's confidence in the product
 
 ## Follow-up
 

--- a/contents/handbook/growth/sales/customer-onsites.md
+++ b/contents/handbook/growth/sales/customer-onsites.md
@@ -100,7 +100,7 @@ Notice: You're doing it anyway, specific location, low pressure, no stated agend
 - Don't treat this as a sales pitch - if you're showing up just to close a deal, you're not expanding your relationship and understanding of the customer.
 - Don't over-schedule - leaving buffer time for organic conversations is often more valuable than cramming in another session
 - Don't show up unprepared on their data - spend time before the visit building something useful in their PostHog instance that you can show them
-- Don't wing your product demos - rehearse the flow ahead of time, have a clear narrative, and test that everything works (logins, data loading, feature access) before you're in front of an audience. A demo that stalls or breaks live undermines your credibility and the customer's confidence in the product
+- Don't wing your product demos – rehearse the flow ahead of time, have a clear narrative, and test that everything works (logins, data loading, feature access) before you're in front of an audience. A demo that stalls or breaks live undermines your credibility and the customer's confidence in the product
 
 ## Follow-up
 


### PR DESCRIPTION
## Changes

Adds a new point to the "Common mistakes to avoid" section of the [In-person sessions with customers](https://posthog.com/handbook/growth/sales/customer-onsites) handbook page, covering being unprepared for product demos. The new bullet advises rehearsing the demo flow, having a clear narrative, and testing that logins, data loading, and feature access all work before presenting to an audience.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*