### PR TITLE
Fix project-level IP data capture setting location

### DIFF
--- a/contents/docs/product-analytics/privacy.mdx
+++ b/contents/docs/product-analytics/privacy.mdx
@@ -29,7 +29,7 @@ Configure this setting in **Settings** > **Organization** > **General** under th
 
 Individual projects can override the organization default by configuring their own IP data capture setting. This is useful when you have specific privacy requirements for a particular project or environment.
 
-Configure at the project level in **Settings** > **Project** > **General** under the **IP data capture configuration** setting.  
+Configure at the project level in **Settings** > **Project** > **Privacy** under the **IP data capture configuration** setting.  
 
 ## Disable sensitive information with autocapture
 


### PR DESCRIPTION
The docs say the project-level IP data capture setting lives under **Settings > Project > General**, but it's actually under **Settings > Project > Privacy** (the "IP data capture configuration" section with the "Discard client IP data" toggle).

This updates the project-level configuration instructions to point to the correct location.