### PR TITLE
fix autoresearch blog

### DIFF
--- a/contents/blog/karpathy-autoresearch-query-engine-bug.md
+++ b/contents/blog/karpathy-autoresearch-query-engine-bug.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-01
-title: Andrej Karpathy's AI Autoresearch found a 3-year-old bug in PostHog's query engine (and improved performance across the board by 11%)
+title: Karpathy's Autoresearch found a 3-year-old bug in our query engine (and improved performance by 11%)
 rootPage: /blog
 sidebar: Blog
 showTitle: true

--- a/vercel.json
+++ b/vercel.json
@@ -58,8 +58,7 @@
     "redirects": [
         {
             "source": "/blog/autoresearch-query-bug",
-            "destination": "/blog/karpathy-autoresearch-query-engine-bug",
-            "statusCode": 301
+            "destination": "/blog/karpathy-autoresearch-query-engine-bug"
         },
         {
             "source": "/handbook/marketing/how-we-position-and-sell",


### PR DESCRIPTION
## Changes

1. Shorten title 
2. Fix redirect

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
