### PR TITLE
docs(ai-observability): render notable generation properties on OpenAI install page

### DIFF
--- a/contents/docs/ai-observability/installation/openai.mdx
+++ b/contents/docs/ai-observability/installation/openai.mdx
@@ -40,10 +40,11 @@ See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard
 
 import { OpenAIInstallation } from 'onboarding/ai-observability/openai.tsx'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
+import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
 
 import LLMsSDKsCallout from './_snippets/llms-sdks-callout.mdx'
 
-<OnboardingContentWrapper>
+<OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
     <OpenAIInstallation modifySteps={addNextStepsStep} />
 </OnboardingContentWrapper>


### PR DESCRIPTION
## Changes

The OpenAI AI observability install page (`/docs/ai-observability/installation/openai`) renders the lead-in line *"You can expect captured `$ai_generation` events to have the following properties:"* but no properties table followed it.

The cause: `openai.mdx` never imported the `NotableGenerationProperties` snippet, nor passed it to `<OnboardingContentWrapper>` via the `snippets` prop — so the placeholder the shared onboarding component expects was empty. Every other provider install page (e.g. `openai-agents.mdx`, plus 37 others) already wires this up.

This adds the missing import and `snippets` prop so the table (`$ai_model`, `$ai_latency`, `$ai_tools`, `$ai_input`, …) renders, matching the rest of the installation docs.

Before: lead-in line with no table below it.
After: properties table renders under the "Call OpenAI LLMs" step.