### PR TITLE
docs(feature-ownership): update Cloud agents and Signals team ownership

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -56,8 +56,8 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         owner: ['product-analytics'],
     },
     'background-agents': {
-        feature: 'Background agents',
-        owner: ['posthog-ai'],
+        feature: 'Cloud agents',
+        owner: ['posthog-code'],
         label: 'feature/background-agents',
     },
     'api-structure': {
@@ -242,7 +242,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'mcp-server': {
         feature: 'MCP server',
-        owner: ['posthog-ai'],
+        owner: ['signals'],
         label: 'feature/mcp',
     },
     notebooks: {
@@ -320,7 +320,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'posthog-ai': {
         feature: 'PostHog AI platform',
-        owner: ['posthog-ai'],
+        owner: ['signals'],
         label: 'feature/posthog-ai',
     },
     'posthog-code': {
@@ -440,7 +440,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'slack-app': {
         feature: 'Slack app',
-        owner: ['posthog-ai'],
+        owner: ['signals'],
         label: 'feature/slack-app',
     },
     settings: {


### PR DESCRIPTION
## Changes

Updates the [Feature ownership](https://posthog.com/handbook/engineering/feature-ownership) table (sourced from `src/hooks/useFeatureOwnership.tsx`):

- Renamed **Background agents** → **Cloud agents** and moved ownership to the **Code** team
- Moved **Slack app** ownership to the **Signals** team
- Moved **MCP server** ownership to the **Signals** team
- Moved **PostHog AI platform** ownership to the **Signals** team

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
