### PR TITLE
docs: link logs to a person + custom attribute key

### DIFF
--- a/contents/docs/data/persons.mdx
+++ b/contents/docs/data/persons.mdx
@@ -106,6 +106,8 @@ Clicking on a person in the [People tab](https://app.posthog.com/persons) opens 
 
 - **Recordings** shows all of the session replays a person has generated. Note this is subject to the retention policy of your plan, so people who haven't been active recently may have none.
 
+- **Logs** shows every [log](/docs/logs) emitted on behalf of this person — backend OTel logs, frontend SDK logs, anything carrying the `posthogDistinctId` attribute (or a [custom attribute key](/docs/logs/link-person#customizing-the-attribute-key) you've configured). Useful for debugging a specific user's issue across services.
+
 - **Cohorts** shows all the [cohorts](/docs/data/cohorts) a person belongs to.
 
 - **Related groups:** shows [groups](/docs/product-analytics/group-analytics) (e.g. organizations, projects, and instances) a person belongs to.

--- a/contents/docs/logs/basics.mdx
+++ b/contents/docs/logs/basics.mdx
@@ -84,3 +84,4 @@ Our [best practices guide](/docs/logs/best-practices) covers this in depth, incl
 - **[Best practices](/docs/logs/best-practices)** - What to log, how to structure it, and patterns that actually work
 - **[Debug with AI](/docs/logs/debugging-with-mcp)** - Use the PostHog MCP server to query logs with AI agents
 - **[Link logs to Session Replay](/docs/logs/link-session-replay)** - Connect backend logs to frontend user sessions
+- **[Link logs to a person](/docs/logs/link-person)** - Surface every log emitted on behalf of a user on their PostHog person profile

--- a/contents/docs/logs/best-practices.mdx
+++ b/contents/docs/logs/best-practices.mdx
@@ -62,7 +62,7 @@ Instead, emit one rich log per request per service:
 {
   "event": "payment.completed",
   "duration_ms": 342,
-  "posthog_distinct_id": "user_abc123",
+  "posthogDistinctId": "user_abc123",
   "order_id": "ord_789",
   "amount_cents": 4999,
   "currency": "USD",
@@ -94,7 +94,7 @@ Payment failed for user abc123 - Stripe error: card_declined (amount: $49.99)
 ```json
 {
   "event": "payment.failed",
-  "posthog_distinct_id": "user_abc123",
+  "posthogDistinctId": "user_abc123",
   "error_type": "card_declined",
   "provider": "stripe",
   "amount_cents": 4999
@@ -116,7 +116,7 @@ Two concepts that separate useful logs from noise. You want both high cardinalit
 <details>
 <summary>What is cardinality?</summary>
 
-Cardinality is the number of unique values a field has. `posthog_distinct_id` has high cardinality (millions of unique values). `log_level` has low cardinality (5 values). High-cardinality fields are what enable you to debug specific requests and users.
+Cardinality is the number of unique values a field has. `posthogDistinctId` has high cardinality (millions of unique values). `log_level` has low cardinality (5 values). High-cardinality fields are what enable you to debug specific requests and users.
 
 Some teams avoid high-cardinality fields because older logging tools can't handle them efficiently. Modern columnar databases (like ClickHouse, which PostHog uses under the hood) handle high cardinality just fine. Don't let outdated tooling concerns stop you from logging the fields that matter.
 
@@ -146,7 +146,7 @@ This lets you move from "500 errors spiked" to "500 errors spiked for enterprise
 In OpenTelemetry, this context splits into two layers.
 
 1. **Resource attributes** are set once when your service starts. They describe the service itself: `service.name`, `deployment.environment`, `service.version`, `cloud.region`. Every log from that process automatically includes them.
-2. **Log attributes** are set per event. They describe what happened in that specific request: `posthog_distinct_id`, `order_id`, `payment_method`, `duration_ms`.
+2. **Log attributes** are set per event. They describe what happened in that specific request: `posthogDistinctId`, `order_id`, `payment_method`, `duration_ms`.
 
 <CalloutBox icon="IconInfo" title="Correlate with Product Analytics" type="fyi">
 
@@ -179,7 +179,7 @@ The implementation details vary by language, but the pattern is always the same.
   def handle_checkout(request):
       attrs = {
           "event": "checkout",
-          "posthog_distinct_id": request.user.id,
+          "posthogDistinctId": request.user.id,
           "subscription_tier": request.user.tier,
       }
 
@@ -217,7 +217,7 @@ The implementation details vary by language, but the pattern is always the same.
   function handleCheckout(req, res) {
     const attrs = {
       event: "checkout",
-      posthog_distinct_id: req.user.id,
+      posthogDistinctId: req.user.id,
       subscription_tier: req.user.tier,
     };
 
@@ -250,7 +250,7 @@ The implementation details vary by language, but the pattern is always the same.
   func HandleCheckout(w http.ResponseWriter, r *http.Request) {
       log := slog.With(
           "event", "checkout",
-          "posthog_distinct_id", r.Context().Value("posthog_distinct_id"),
+          "posthogDistinctId", r.Context().Value("posthogDistinctId"),
       )
 
       cart, _ := getCart(r.Context())
@@ -362,7 +362,7 @@ Some things should never appear in your logs:
 
 - **Secrets:** API keys, passwords, tokens, credit card numbers. If you log these by accident, you now have a security incident *and* a logging problem.
 - **Request and response bodies:** Logging full payloads is one of the fastest ways to blow up storage costs and accidentally capture PII, auth tokens, or sensitive user data. Log the metadata (status code, content length, duration), not the body.
-- **Personal data you don't need:** Full email addresses, IP addresses, or other PII beyond what's required for debugging. If you need to correlate logs to a user but can't store raw identifiers, hash or tokenize them. Check your GDPR, HIPAA, or other compliance requirements, as even fields like `posthog_distinct_id` or `email` may need masking depending on your jurisdiction.
+- **Personal data you don't need:** Full email addresses, IP addresses, or other PII beyond what's required for debugging. If you need to correlate logs to a user but can't store raw identifiers, hash or tokenize them. Check your GDPR, HIPAA, or other compliance requirements, as even fields like `posthogDistinctId` or `email` may need masking depending on your jurisdiction.
 - **High-frequency health checks:** Load balancer pings and liveness probes generate massive volume with zero debugging value. Exclude them.
 - **Unnecessary duplication:** If a downstream service logs the same event, you don't always need to log it again upstream. That said, when you're debugging a production incident at 2am, having key context from downstream calls in your own service's logs can save you from correlating across multiple systems under pressure. The rule of thumb: don't log a play-by-play of every call you make, but do include the outcome and any data you'd need to debug without switching to another service's logs.
 
@@ -379,7 +379,7 @@ Use this to audit your existing logging or as a starting point for a new service
 
 ### Business and trace context
 
-- **The "Who":** `posthog_distinct_id`, `org_id`, `account_tier`, or equivalent
+- **The "Who":** `posthogDistinctId`, `org_id`, `account_tier`, or equivalent
 - **The "What":** `order_id`, `transaction_id`, `feature_flag_variants`, or equivalent
 - **The "Where":** `service.name`, `service.version`, `deployment.environment` set as OTel resource attributes
 - **Trace IDs:** OpenTelemetry `trace_id` is attached so you can jump from logs to traces

--- a/contents/docs/logs/installation/_snippets/logs-next-steps.mdx
+++ b/contents/docs/logs/installation/_snippets/logs-next-steps.mdx
@@ -6,6 +6,7 @@
 | **[Search logs](/docs/logs/search)** | Use the search interface to find specific log entries |
 | **Filter by level** | Filter by `INFO`, `WARN`, `ERROR`, etc. |
 | **[Link session replay](/docs/logs/link-session-replay)** | Connect logs to users and session replays by passing `posthogDistinctId` and `sessionId` |
+| **[Link logs to a person](/docs/logs/link-person)** | Surface every log emitted on behalf of a user on their PostHog person profile |
 | **[Logging best practices](/docs/logs/best-practices)** | Learn what to log, how to structure logs, and patterns that make logs useful in production |
 
 <CallToAction type="primary" to="/docs/logs/troubleshooting">

--- a/contents/docs/logs/link-person.mdx
+++ b/contents/docs/logs/link-person.mdx
@@ -1,0 +1,131 @@
+---
+title: Link logs to a person
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+PostHog can surface every log emitted on behalf of a specific user on that user's profile in the **Logs** tab. The link is attribute-based: each log carries a person identifier as an OpenTelemetry log attribute, and PostHog matches it to a person's `distinct_id`.
+
+## Why link logs to a person?
+
+When logs are linked to a person you can:
+
+- **Debug a specific user's issue**: jump from the person's profile straight to every backend log written while they were active, no service-name guessing.
+- **Trace failures across services**: frontend SDK logs, backend OTel logs, and any other source converge under one identity.
+- **Pivot from logs to other product data**: events, recordings, feature flags, and surveys are all on the same person.
+
+## Prerequisites
+
+- [Logs](/docs/logs) is enabled for your project.
+- A [logging client installed](/docs/logs/installation) on your backend (or you use the JavaScript / React Native SDKs which handle this automatically — see below).
+- Each log record carries the person identifier as an attribute. By default the attribute key is `posthogDistinctId` — the same key the [PostHog JavaScript SDK](/docs/libraries/js) and [React Native SDK](/docs/libraries/react-native) auto-attach.
+
+> **Logs captured client-side:** When you call `posthog.captureLog` / `posthog.logger.*` from the JavaScript web SDK or React Native SDK, the current `distinct_id` is attached as `posthogDistinctId` on every log automatically. No further setup needed.
+
+## Implementation
+
+### Backend (OpenTelemetry)
+
+When you emit logs directly via OpenTelemetry from a backend — Python, Go, Node.js without `posthog.logger`, or your own collector pipeline — add `posthogDistinctId` to each log record's attributes. Set it to the same `distinct_id` you use when calling `posthog.capture`.
+
+<MultiLanguage>
+
+```javascript file=JavaScript
+import { logs } from '@opentelemetry/api-logs'
+
+const logger = logs.getLogger('my-app')
+
+app.post('/api/checkout', async (req, res) => {
+  const userId = req.userId  // ... get your user ID
+
+  logger.emit({
+    severityText: 'info',
+    body: 'Checkout completed',
+    attributes: {
+      posthogDistinctId: userId,    // Links to PostHog person
+      orderId: 'A-123',
+    },
+  })
+
+  res.json({ success: true })
+})
+```
+
+```python file=Python
+import logging
+
+logger = logging.getLogger(__name__)
+
+@app.route('/api/checkout', methods=['POST'])
+def checkout():
+    user_id = current_user.distinct_id
+
+    logger.info(
+        "Checkout completed",
+        extra={
+            "posthogDistinctId": user_id,    # Links to PostHog person
+            "orderId": "A-123",
+        }
+    )
+
+    return jsonify({"success": True})
+```
+
+```go file=Go
+import (
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/log"
+)
+
+log.Info("Checkout completed",
+    attribute.String("posthogDistinctId", currentUser.DistinctID),  // Links to PostHog person
+    attribute.String("orderId", "A-123"),
+)
+```
+
+</MultiLanguage>
+
+> **Note:** PostHog matches the value against every `distinct_id` we know about for the person, so as long as the value matches **one** of their identifiers, the log will appear on the profile. Identified-after-anonymous flows still link correctly.
+
+### Verifying the link
+
+1. Send a log carrying `posthogDistinctId` set to a known user.
+2. Open that user's profile in the [People tab](https://app.posthog.com/persons).
+3. Open the **Logs** tab. The log appears within a few seconds.
+
+If the log does not appear, check:
+
+- **Attribute key spelling**: `posthogDistinctId` is camelCase with a lowercase `p`. PostHog matches it exactly. `distinct_id`, `posthog_distinct_id`, and `user_id` are not equivalent unless you've explicitly configured one of them — see [Customizing the attribute key](#customizing-the-attribute-key) below.
+- **Attribute value**: must equal one of the person's `distinct_id`s. Prefixed or partial matches are not picked up.
+- **The log's timestamp**: the **Logs** tab respects the date range picker. Extend the range if the log is older than the default window.
+
+## Customizing the attribute key
+
+If your pipeline emits the person identifier under a different key (for example `user.id`, `customerId`, or a legacy `distinct_id`), point PostHog at that key with the `logs_config` endpoint:
+
+```bash
+curl -X PATCH "https://app.posthog.com/api/projects/<PROJECT_ID>/logs_config/" \
+     -H "Authorization: Bearer <PERSONAL_API_KEY>" \
+     -H "Content-Type: application/json" \
+     -d '{"logs_distinct_id_attribute_key": "user.id"}'
+```
+
+Only one key per project. Pick the key your pipeline actually emits — there is no fallback chain, so a log that lacks the configured key is unlinked from any person.
+
+When the key has been customized, the person profile's **Logs** tab shows a small hint above the volume chart indicating which attribute is being used as the person pivot.
+
+## What this does not do
+
+- It does not retroactively re-link old logs after you change the configured key. Logs are matched at query time, so the new key applies as soon as it's saved, but logs ingested under the old key still need to match the configured key to appear on a person profile.
+- It does not link by IP, user-agent, or any other heuristic. Only attribute-value equality.
+- It does not affect ingestion. Logs without the configured attribute are stored normally; they're just not surfaced on any person profile.
+
+## See also
+
+- [Link logs to session replay](/docs/logs/link-session-replay): pair `posthogDistinctId` with `sessionId` to also link to recordings.
+- [Logging best practices](/docs/logs/best-practices)
+- [Person profiles](/docs/data/persons)

--- a/contents/docs/logs/link-session-replay.mdx
+++ b/contents/docs/logs/link-session-replay.mdx
@@ -155,6 +155,7 @@ If no session ID is found in the log entry, the tab displays a message prompting
 
 ## See also
 
+- [Link logs to a person](/docs/logs/link-person): same `posthogDistinctId` attribute, surfaced on the person profile's Logs tab.
 - [Session replay installation](/docs/session-replay/installation)
 - [Logs installation](/docs/logs/installation)
 - [Search logs](/docs/logs/search)

--- a/contents/docs/logs/troubleshooting.mdx
+++ b/contents/docs/logs/troubleshooting.mdx
@@ -58,6 +58,16 @@ This page covers troubleshooting for Logs. For setup, see the [installation guid
 - Check that log attributes are properly structured
 - Use the OpenTelemetry logging APIs instead of raw log libraries
 
+## Logs not appearing on a person's profile
+
+**Problem**: Logs are searchable in the **Logs** view, but the person profile's **Logs** tab is empty (or missing logs you expected to see).
+
+**Solutions**:
+- Confirm each log record carries the attribute `posthogDistinctId` (camelCase, lowercase `p`) — see [Link logs to a person](/docs/logs/link-person). `distinct_id`, `posthog_distinct_id`, and `user_id` are **not** equivalent unless you've explicitly configured one as the [custom attribute key](/docs/logs/link-person#customizing-the-attribute-key).
+- The value of the attribute must equal one of the person's `distinct_id`s exactly — partial or prefixed matches are not picked up.
+- If your team has customized the attribute key (via the `logs_config` endpoint), the person profile's Logs tab shows a hint above the chart indicating which key is being used. Make sure your pipeline emits logs under that exact key.
+- Date range: the person Logs tab respects the same date range picker as the main Logs view. Expand the range if the logs are older than the default window.
+
 ## Project token authentication issues
 
 **Problem**: Confused about which key to use or how to authenticate.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6829,6 +6829,12 @@ export const docsMenu = {
                     color: 'blue',
                 },
                 {
+                    name: 'Link logs to a person',
+                    url: '/docs/logs/link-person',
+                    icon: 'IconPerson',
+                    color: 'blue',
+                },
+                {
                     name: 'Set up alerts',
                     url: '/docs/logs/alerts',
                     icon: 'IconBell',


### PR DESCRIPTION
## Changes
<img width="877" height="294" alt="image" src="https://github.com/user-attachments/assets/da004cb0-6cd7-4027-aec3-f142023a7ac7" />

Adds a new **Link logs to a person** page covering the OTel attribute convention that surfaces logs on a PostHog person profile, and updates surrounding pages so users discover and verify the linkage correctly.

**New page** ([`/docs/logs/link-person`](https://posthog.com/docs/logs/link-person)):

- Mirrors the structure of the existing `link-session-replay` page
- Documents the default attribute key `posthogDistinctId` (the same one [posthog-js/](https://github.com/PostHog/posthog-js/blob/main/packages/core/src/logs/logs-utils.ts) auto-attaches) and the SDK auto-attach behavior on JS / React Native
- Multi-language examples (JavaScript / Python / Go) for backend emission via OpenTelemetry
- Customising the attribute key per team via the `logs_config` endpoint (e.g. `user.id`, `customerId`)
- Verifying the link + a "what this does not do" footer to head off the common misconceptions (retroactive re-linking, IP/UA heuristics, ingestion impact)

**Other pages touched**:

| File | What changed |
|---|---|
| `src/navs/index.js` | Sidebar entry under Logs → Guides, right after **Link Session Replay** |
| `contents/docs/data/persons.mdx` | Added **Logs** to the person profile tab inventory (previously listed Events / Recordings / Cohorts / Related groups / Feature flags / History but Logs was missing) |
| `contents/docs/logs/basics.mdx` | Cross-link in Next steps |
| `contents/docs/logs/link-session-replay.mdx` | Cross-link in **See also** |
| `contents/docs/logs/installation/_snippets/logs-next-steps.mdx` | New row in the post-install next-steps table |
| `contents/docs/logs/troubleshooting.mdx` | New "Logs not appearing on a person's profile" section covering attribute key spelling + the configurable-key case |
| `contents/docs/logs/best-practices.mdx` | **Real doc bug fix**: renamed 9× `posthog_distinct_id` (snake_case) → `posthogDistinctId` (camelCase). PostHog stores log attribute keys verbatim in ClickHouse (`Map(String, String)`) with no normalization. The SDK auto-attaches `posthogDistinctId`; the default config key (`TeamLogsConfig.logs_distinct_id_attribute_key`) is also `posthogDistinctId`. Logs emitted under `posthog_distinct_id` weren't linked to a person profile unless the team had explicitly patched the config. The best-practices examples were teaching users a key that silently didn't work. |

Net diff: **8 files, +161/-9 lines**.

**Deliberately skipped** (better as follow-up PRs):

- Per-language installation pages (`installation/{nodejs,python,go,java,nextjs,ios,android,other,datadog}.mdx`) — each example payload needs a language-specific review to add `posthogDistinctId` consistently. Better as a separate PR so language reviewers can sign off independently.
- `changelog.mdx` — pulls from the roadmap API via topic filter, not a static MDX edit.

**Note on `posthogDistinctId` naming**: it's camelCase, which is stylistically out of place next to surrounding snake_case keys (`order_id`, `duration_ms`, etc.) in the best-practices examples. But it's load-bearing for correctness: the SDK emits it as camelCase, and the entire pipeline (SDK → Rust ingest → ClickHouse → query) stores keys verbatim with no normalization. The frontend Logs viewer keeps a defensive `DISTINCT_ID_KEYS` array matching ~9 variants for the person/session resolver, but that's the only place it's tolerant. Aligning everything to an OTel-canonical `posthog.distinct_id` is a separate, larger change (SDK + default config + migration).

Companion product PR with the in-app changes (architectural pinned-filter fix + the small "this attribute is customised" hint on the person profile Logs tab): https://github.com/PostHog/posthog/pull/61008

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no moves)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*