### PR TITLE
Add Yeti (Naver) crawler to robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -7,4 +7,7 @@ Disallow: /*.md$
 User-agent: DuckDuckBot
 Disallow: /*.md$
 
-Sitemap: https://posthog.com/sitemap/sitemap-index.xml 
+User-agent: Yeti
+Disallow: /*.md$
+
+Sitemap: https://posthog.com/sitemap/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Adds Naver's web crawler (Yeti) to `robots.txt` with the same `*.md` disallow rule as other bots
- Ensures Yeti can discover and follow the sitemap at `/sitemap/sitemap-index.xml`

Part of Naver SEO setup for `/ko` pages.