### PR TITLE
Speed up posthog.com preview builds

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -50,3 +50,15 @@ jobs:
               run: pnpm build
               env:
                   GATSBY_MINIMAL: 'true'
+                  # Provide Cloudinary creds so onPreInit crawls the resource list and writes
+                  # .cloudinary-resources.json for preview builds to restore (cloud name comes
+                  # from the committed .env.production).
+                  CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+                  CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
+
+            - name: Save Cloudinary metadata cache
+              if: success()
+              uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+              with:
+                  path: .cloudinary-resources.json
+                  key: cloudinary-${{ github.run_id }}

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -10,12 +10,12 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    NODE_OPTIONS: '--max_old_space_size=8192'
+    NODE_OPTIONS: '--max_old_space_size=12288'
 
 jobs:
     warm-cache:
         name: Build & cache
-        runs-on: ubuntu-latest
+        runs-on: depot-ubuntu-latest-8
         timeout-minutes: 45
         permissions:
             contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,11 @@ jobs:
         #   - https://gh.io/using-larger-runners (GitHub.com only)
         # Consider using larger runners or machines with greater resources for possible analysis time improvements.
         runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+        # Disable CodeQL overlay analysis. Its per-commit overlay-base database caches (~272 MB
+        # each) were pushing the repo's Actions cache over GitHub's 10 GB limit and risked evicting
+        # the Gatsby build cache. Overlay only speeds up CodeQL PR analysis, not our build job.
+        env:
+            CODEQL_OVERLAY_DATABASE_MODE: none
         permissions:
             # required for all workflows
             security-events: write

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -9,12 +9,12 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    NODE_OPTIONS: '--max_old_space_size=8192'
+    NODE_OPTIONS: '--max_old_space_size=12288'
 
 jobs:
     build-and-deploy:
         name: Build & deploy preview
-        runs-on: ubuntu-latest
+        runs-on: depot-ubuntu-latest-8
         timeout-minutes: 45
         if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,6 +78,15 @@ jobs:
                   echo "::warning::Gatsby cache skipped — 'no-cache' label detected. Running a clean build."
                   rm -rf .cache public
 
+            - name: Restore Cloudinary metadata cache
+              if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
+              uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+              with:
+                  path: .cloudinary-resources.json
+                  key: cloudinary-${{ github.run_id }}
+                  restore-keys: |
+                      cloudinary-
+
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ CLAUDE.local.md
 
 # Generated data files
 src/data/mcp-tools.json
+.cloudinary-resources.json
 
 # Python cache
 __pycache__

--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -5,6 +5,8 @@ import GitUrlParse from 'git-url-parse'
 import slugify from 'slugify'
 import { JSDOM } from 'jsdom'
 import { GatsbyNode } from 'gatsby'
+import fs from 'fs'
+import path from 'path'
 import { PAGEVIEW_CACHE_KEY } from './onPreBootstrap'
 
 require('dotenv').config({
@@ -51,6 +53,10 @@ exports.onPreInit = async function (_, options) {
 }
 
 const cloudinaryCache = {}
+// Persisted copy of the Cloudinary resource list. Produced by the master cache-warmup job and
+// restored in the preview build (see .github/workflows/{cache-warmup,deploy-preview}.yml), this
+// lets preview builds skip the multi-minute Cloudinary crawl in onPreInit below.
+const CLOUDINARY_CACHE_FILE = path.resolve(__dirname, '../.cloudinary-resources.json')
 
 let templateListPromise: Promise<any[]> | null = null
 async function getTemplateList() {
@@ -81,6 +87,22 @@ export const onPreInit: GatsbyNode['onPreInit'] = async function ({ actions }) {
         console.warn('Cloudinary credentials not found')
         return
     }
+
+    // Reuse a previously fetched resource list when available. The crawl below paginates the
+    // entire Cloudinary library (~2 min over the network), so skipping it greatly speeds up
+    // preview builds. A missing entry only omits image dimensions in onCreateNode (logged as a
+    // warning), so a stale cache degrades gracefully.
+    if (fs.existsSync(CLOUDINARY_CACHE_FILE)) {
+        try {
+            const cached = JSON.parse(fs.readFileSync(CLOUDINARY_CACHE_FILE, 'utf-8'))
+            Object.assign(cloudinaryCache, cached)
+            console.log(`Loaded ${Object.keys(cached).length} Cloudinary resources from cache`)
+            return
+        } catch {
+            // Corrupted/unreadable cache file — fall through to a fresh crawl
+        }
+    }
+
     console.log('Fetching cloudinary data')
 
     const fetchCloudinaryImages = async (nextCursor = null) => {
@@ -101,6 +123,9 @@ export const onPreInit: GatsbyNode['onPreInit'] = async function ({ actions }) {
     }
 
     await fetchCloudinaryImages()
+
+    // Persist for reuse by later builds (saved to the Actions cache by the master warmup job).
+    fs.writeFileSync(CLOUDINARY_CACHE_FILE, JSON.stringify(cloudinaryCache))
 }
 
 function getPublicID(image: string) {


### PR DESCRIPTION
Preview builds currently take ~12-14 minutes, which is annoyingly slow for a required check. Let's try to speed it up.