### PR TITLE
feat: add Replay Vision docs page gated behind a feature flag

### DIFF
--- a/contents/docs/replay-vision.mdx
+++ b/contents/docs/replay-vision.mdx
@@ -38,10 +38,10 @@ The scanner type is chosen when you create a scanner and determines the shape of
 
 | Type | What it produces | Use it for |
 | --- | --- | --- |
-| **Monitor** | A true/false verdict, with reasoning | Flagging whether a specific condition occurred, e.g. "did the user get stuck with no clear next step?" |
+| **Monitor** | A true/false verdict, with reasoning | Flagging whether a specific condition occurred, e.g. "did someone get stuck with no clear next step?" |
 | **Classifier** | One or more tags from a vocabulary you define | Bucketing sessions, e.g. user intent (`browsing`, `purchasing`, `support`) or outcome (`task_completed`, `task_abandoned`, `blocked_by_error`) |
-| **Scorer** | A numeric score on a scale you define | Rating sessions on a dimension, e.g. a 0–10 frustration score |
-| **Summarizer** | A title and prose summary | Generating a short narrative of what the user did in each session |
+| **Scorer** | A numeric score on a scale you define | Rating sessions on a dimension, e.g. a 0 to 10 frustration score |
+| **Summarizer** | A title and prose summary | Generating a short narrative of what happened in each session |
 
 Every scanner also returns a **confidence** value and, in its reasoning, may include citations that link directly to the relevant moment in the recording's timeline.
 
@@ -49,7 +49,7 @@ Every scanner also returns a **confidence** value and, in its reasoning, may inc
 
 1. Go to **Replay Vision** in the PostHog app and select **New scanner** (or start from a template).
 2. Pick a [scanner type](#scanner-types). Templates are available for common cases – dead-end detection, session summary, user intent, frustration score, and session outcome.
-3. Write a prompt describing what the scanner should look for. Be concrete and avoid speculation – e.g. *"Return true if the user appears stuck on a page — scrolling without engaging, hovering over elements with no clear CTA, or abandoning shortly after arriving."*
+3. Write a prompt describing what the scanner should look for. Be concrete and avoid speculation – e.g. *"Return true if someone appears stuck on a page – scrolling without engaging, hovering over elements with no clear CTA, or abandoning shortly after arriving."*
 4. Configure the type-specific options:
    - **Classifier** – define your tag vocabulary, and optionally allow multiple tags per session or freeform tags.
    - **Scorer** – set the numeric scale (min, max, and an optional label).
@@ -106,7 +106,7 @@ Key properties on each event:
 | `session_id` | The recording that was observed |
 | `triggered_by` | Whether the observation was scheduled or run on-demand |
 | `model_used` | The Gemini model used |
-| `scanner_output_confidence` | The model's confidence (0.0–1.0) |
+| `scanner_output_confidence` | The model's confidence (0.0 to 1.0) |
 | `scanner_output_verdict` | (Monitor) the true/false verdict |
 | `scanner_output_tags` | (Classifier) the assigned tags |
 | `scanner_output_score` | (Scorer) the numeric score |
@@ -139,6 +139,6 @@ When you enable **Signals** on a scanner, notable findings (such as a monitor re
 
 ## Further reading
 
-- [Session replay](/docs/session-replay)
+- [Session Replay](/docs/session-replay)
 - [Summarize sessions with PostHog AI](/docs/session-replay/session-summaries-ai)
 - [Find replays with PostHog AI](/docs/session-replay/find-replays-ai)

--- a/contents/docs/replay-vision.mdx
+++ b/contents/docs/replay-vision.mdx
@@ -1,0 +1,144 @@
+---
+title: Replay Vision
+featureFlag: replay-vision-docs
+noindex: true
+---
+
+Replay Vision uses AI to automatically watch your [session recordings](/docs/session-replay) and turn what it sees into structured, queryable data. You configure **scanners** – named AI probes that describe what to look for – and PostHog applies them to your recordings, producing **observations** you can query, chart, and alert on.
+
+The key idea is that Replay Vision actually *watches the video* of each recording alongside its events. This lets it pick up on visual and behavioral cues – hesitation, confusion, where a user's attention goes – that aren't captured by clicks and pageviews alone. Instead of manually reviewing hundreds of replays to spot a pattern, you describe what matters once and let it run continuously.
+
+<CalloutBox type="fyi" title="Replay Vision is in beta">
+
+Replay Vision is currently in beta and rolling out gradually. Some details below – especially scanner types, quotas, and supported models – may change before general availability.
+
+</CalloutBox>
+
+{/* TODO: add ProductScreenshot of the Replay Vision scanner list once UI screenshots are available / more final */}
+
+## How it works
+
+Replay Vision is built around two concepts:
+
+- **Scanner** – a configured AI probe scoped to your project. A scanner has a natural-language prompt describing what to look for, a [scanner type](#scanner-types) that determines what kind of output it produces, a set of recording filters that select which sessions it applies to, and a sampling rate.
+- **Observation** – one application of a scanner to a single recording. Each observation runs the scanner against that session and produces a structured result that's persisted and emitted as a queryable [`$recording_observed` event](#querying-observations-as-events).
+
+When a scanner runs against a recording, PostHog:
+
+1. Renders the recording to a sped-up video (inactive periods are trimmed out).
+2. Sends that video, along with the session's raw events (clicks, pageviews, rage clicks, dead clicks, exceptions, and more), to a Google Gemini model.
+3. Asks the model to produce a structured response matching the scanner's type.
+4. Saves the result as an observation and captures it as a `$recording_observed` event in your project.
+
+Each observation snapshots the scanner's configuration at the time it ran, so editing a scanner later never retroactively changes past observations.
+
+## Scanner types
+
+The scanner type is chosen when you create a scanner and determines the shape of the output. It can't be changed afterwards – to switch types, create a new scanner.
+
+| Type | What it produces | Use it for |
+| --- | --- | --- |
+| **Monitor** | A true/false verdict, with reasoning | Flagging whether a specific condition occurred, e.g. "did the user get stuck with no clear next step?" |
+| **Classifier** | One or more tags from a vocabulary you define | Bucketing sessions, e.g. user intent (`browsing`, `purchasing`, `support`) or outcome (`task_completed`, `task_abandoned`, `blocked_by_error`) |
+| **Scorer** | A numeric score on a scale you define | Rating sessions on a dimension, e.g. a 0–10 frustration score |
+| **Summarizer** | A title and prose summary | Generating a short narrative of what the user did in each session |
+
+Every scanner also returns a **confidence** value and, in its reasoning, may include citations that link directly to the relevant moment in the recording's timeline.
+
+## Creating a scanner
+
+1. Go to **Replay Vision** in the PostHog app and select **New scanner** (or start from a template).
+2. Pick a [scanner type](#scanner-types). Templates are available for common cases – dead-end detection, session summary, user intent, frustration score, and session outcome.
+3. Write a prompt describing what the scanner should look for. Be concrete and avoid speculation – e.g. *"Return true if the user appears stuck on a page — scrolling without engaging, hovering over elements with no clear CTA, or abandoning shortly after arriving."*
+4. Configure the type-specific options:
+   - **Classifier** – define your tag vocabulary, and optionally allow multiple tags per session or freeform tags.
+   - **Scorer** – set the numeric scale (min, max, and an optional label).
+   - **Summarizer** – set the summary length.
+5. Set **recording filters** to choose which sessions the scanner applies to (by person properties, session properties, cohorts, or events) and a **sampling rate** to control how many matching sessions get scanned.
+6. Optionally enable [Signals](#signals) so notable findings can trigger alerts.
+7. Save. The scanner is enabled by default.
+
+<CalloutBox type="fyi" title="Estimate your usage first">
+
+When configuring a scanner's filters and sampling rate, PostHog estimates how many observations it will generate per month so you can size it against your [quota](#quota-and-limits) before enabling it.
+
+</CalloutBox>
+
+## Running scanners
+
+There are two ways scanners produce observations:
+
+### Automatically on matching sessions
+
+Once a scanner is enabled, PostHog periodically sweeps for new recordings that match the scanner's filters and runs the scanner against a sample of them. This happens in the background – you set up the scanner once and observations accumulate as new matching sessions come in.
+
+Each (scanner, session) pair is only ever observed once, so re-sweeping never produces duplicate observations for the same recording.
+
+### On-demand on a single recording
+
+You can also run a scanner against a specific recording immediately:
+
+- **From the replay player** – open a recording and use the **Scan this recording** action to pick a scanner and run it against the session you're watching.
+- **Via MCP** – use the `vision-scanners-scan-session` [MCP tool](/docs/model-context-protocol) to scan a session programmatically.
+
+<CalloutBox type="caution" title="Some sessions are skipped">
+
+A scanner won't run on a recording that has no replay data, is too short, too inactive, too long, or has no events. These are marked **ineligible** rather than failed, and don't count against your quota.
+
+</CalloutBox>
+
+## Reading results
+
+### In the app
+
+Each scanner has an **Observations** tab listing every observation it's produced, with the result, status, and what triggered it. Open an individual observation to see its full structured output, the reasoning behind it (with clickable citations into the recording timeline), the prompt that produced it, and an embedded player so you can watch the relevant session.
+
+### Querying observations as events
+
+Every successful observation is captured as a `$recording_observed` event in your project, so you can build [insights](/docs/product-analytics/insights), [dashboards](/docs/product-analytics/dashboards), and [alerts](/docs/alerts) on top of Replay Vision output using [SQL](/docs/product-analytics/sql).
+
+Key properties on each event:
+
+| Property | Description |
+| --- | --- |
+| `scanner_name` | Name of the scanner that produced the observation |
+| `scanner_type` | `monitor`, `classifier`, `scorer`, or `summarizer` |
+| `session_id` | The recording that was observed |
+| `triggered_by` | Whether the observation was scheduled or run on-demand |
+| `model_used` | The Gemini model used |
+| `scanner_output_confidence` | The model's confidence (0.0–1.0) |
+| `scanner_output_verdict` | (Monitor) the true/false verdict |
+| `scanner_output_tags` | (Classifier) the assigned tags |
+| `scanner_output_score` | (Scorer) the numeric score |
+| `scanner_output_reasoning` | The model's reasoning |
+
+For example, to count monitor sessions flagged true by a "Dead-end pages" scanner over the last week:
+
+```sql
+SELECT
+    toStartOfDay(timestamp) AS day,
+    count() AS flagged_sessions
+FROM events
+WHERE event = '$recording_observed'
+  AND properties.scanner_name = 'Dead-end pages'
+  AND properties.scanner_output_verdict = true
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY day
+ORDER BY day
+```
+
+## Signals
+
+When you enable **Signals** on a scanner, notable findings (such as a monitor returning true, or a scorer crossing a threshold) can surface as actionable [Signals](/docs/signals) – so a human gets notified about important sessions without anyone manually reviewing replays.
+
+## Quota and limits
+
+- Replay Vision observations are subject to a monthly quota per organization. In-progress observations count against the quota, and when it's reached, new observations are skipped until the next calendar month. A usage meter in the app shows your current month's consumption.
+- Replay Vision currently runs on Google Gemini models only.
+- Each recording is observed at most once per scanner.
+
+## Further reading
+
+- [Session replay](/docs/session-replay)
+- [Summarize sessions with PostHog AI](/docs/session-replay/session-summaries-ai)
+- [Find replays with PostHog AI](/docs/session-replay/find-replays-ai)

--- a/contents/docs/replay-vision.mdx
+++ b/contents/docs/replay-vision.mdx
@@ -14,8 +14,6 @@ Replay Vision is currently in beta and rolling out gradually. Some details below
 
 </CalloutBox>
 
-{/* TODO: add ProductScreenshot of the Replay Vision scanner list once UI screenshots are available / more final */}
-
 ## How it works
 
 Replay Vision is built around two concepts:

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -36,6 +36,7 @@ import { useLocation } from '@reach/router'
 import { getProseClasses, isMarkdownContentPath } from '../../constants'
 import { useWindow } from '../../context/Window'
 import { MenuItem, useApp } from '../../context/App'
+import { useActiveFeatureFlags, filterMenuByFlags } from '../../hooks/useActiveFeatureFlags'
 import { Questions } from 'components/Squeak'
 import { navigate } from 'gatsby'
 import { DocsPageSurvey } from 'components/DocsPageSurvey'
@@ -479,9 +480,13 @@ const resolveMenuIcons = (items: MenuItem[] | undefined, resolveIcons = false): 
 
 const Menu = (props: { parent: MenuItem }) => {
     const { setActiveInternalMenu, activeInternalMenu: windowActiveInternalMenu, parent: windowParent } = useWindow()
+    const activeFlags = useActiveFeatureFlags()
 
     const parent = props.parent || windowParent
-    const activeInternalMenu = windowActiveInternalMenu || parent.children?.[0]
+    // Hide any flag-gated products/pages the current user can't see.
+    const visibleChildren = filterMenuByFlags(parent.children, activeFlags)
+    const activeInternalMenu = windowActiveInternalMenu || visibleChildren?.[0]
+    const visibleActiveChildren = filterMenuByFlags(activeInternalMenu?.children, activeFlags)
 
     return (
         <>
@@ -489,7 +494,7 @@ const Menu = (props: { parent: MenuItem }) => {
                 groups={[
                     {
                         label: null,
-                        items: parent.children?.map((menuItem) => {
+                        items: visibleChildren?.map((menuItem) => {
                             return {
                                 value: menuItem.url || menuItem.name,
                                 label: menuItem.name,
@@ -504,7 +509,7 @@ const Menu = (props: { parent: MenuItem }) => {
                 className="w-full mb-2"
                 value={activeInternalMenu?.url || activeInternalMenu?.name}
                 onValueChange={(value) => {
-                    const selectedMenu = parent.children?.find(
+                    const selectedMenu = visibleChildren?.find(
                         (menuItem) => menuItem.url === value || menuItem.name === value
                     )
                     setActiveInternalMenu(selectedMenu)
@@ -514,7 +519,7 @@ const Menu = (props: { parent: MenuItem }) => {
                 }}
                 dataScheme="primary"
             />
-            <TreeMenu key={activeInternalMenu?.url} items={resolveMenuIcons(activeInternalMenu?.children)} />
+            <TreeMenu key={activeInternalMenu?.url} items={resolveMenuIcons(visibleActiveChildren)} />
         </>
     )
 }

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -34,6 +34,10 @@ export interface MenuItem {
     platformLogo?: string
     showChildrenIcons?: boolean
     sortChildrenAlpha?: boolean
+    // When set, this item (and its children) is only shown to users for whom the
+    // named PostHog feature flag is enabled. Gating is client-side only — see
+    // src/hooks/useActiveFeatureFlags.ts and note the static-site caveat.
+    featureFlag?: string
     children?: MenuItem[]
 }
 

--- a/src/hooks/useActiveFeatureFlags.ts
+++ b/src/hooks/useActiveFeatureFlags.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import usePostHog from './usePostHog'
+
+/**
+ * Returns the list of currently-enabled PostHog feature flag keys, updating
+ * reactively as flags resolve in the browser. Returns `null` until flags load
+ * (and during SSR), so callers should treat `null` as "flags not yet known".
+ *
+ * Note: posthog-js calls the `onFeatureFlags` listener whenever flags change,
+ * and returns an unsubscribe function we use for cleanup.
+ */
+export const useActiveFeatureFlags = (): string[] | null => {
+    const posthog = usePostHog()
+    const [flags, setFlags] = useState<string[] | null>(null)
+
+    useEffect(() => {
+        if (!posthog?.onFeatureFlags) {
+            return
+        }
+        return posthog.onFeatureFlags((enabledFlags: string[]) => {
+            setFlags(enabledFlags)
+        })
+    }, [posthog])
+
+    return flags
+}
+
+/**
+ * Recursively filters a menu tree, dropping any item whose `featureFlag` is not
+ * in `activeFlags`. Items without a `featureFlag` are always kept.
+ *
+ * Fails closed: while `activeFlags` is `null` (SSR / flags not yet loaded),
+ * flagged items are hidden. This avoids flashing gated entries to users who
+ * shouldn't see them, at the cost of a brief delay before they appear for users
+ * who should. Generic so it works with any nav-item shape.
+ */
+export const filterMenuByFlags = <T extends { featureFlag?: string; children?: T[] }>(
+    items: T[] | undefined,
+    activeFlags: string[] | null
+): T[] | undefined =>
+    items
+        ?.filter((item) => !item.featureFlag || !!activeFlags?.includes(item.featureFlag))
+        .map((item) => ({
+            ...item,
+            children: item.children ? filterMenuByFlags(item.children, activeFlags) : item.children,
+        }))

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4116,7 +4116,7 @@ export const docsMenu = {
                 {
                     name: 'Overview',
                     url: '/docs/replay-vision',
-                    icon: 'IconHome',
+                    icon: 'IconEye',
                     color: 'seagreen',
                 },
             ],

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4103,6 +4103,25 @@ export const docsMenu = {
             ],
         },
         {
+            name: 'Replay Vision',
+            url: '/docs/replay-vision',
+            color: 'yellow',
+            icon: 'IconEye',
+            description: 'Use AI to automatically watch your session recordings and turn what it sees into queryable data',
+            featureFlag: 'replay-vision-docs',
+            children: [
+                {
+                    name: 'Replay Vision',
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/replay-vision',
+                    icon: 'IconHome',
+                    color: 'seagreen',
+                },
+            ],
+        },
+        {
             name: 'Feature Flags',
             icon: 'IconToggle',
             color: 'seagreen',

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -12,11 +12,14 @@ import ScrollArea from 'components/RadixUI/ScrollArea'
 import { SearchUI } from 'components/SearchUI'
 import SmallTeam from 'components/SmallTeam'
 import { useApp } from '../../context/App'
+import { useActiveFeatureFlags, filterMenuByFlags } from '../../hooks/useActiveFeatureFlags'
 
 // Process docsMenu to extract structure
-const processDocsMenu = () => {
-    const productOSSection = docsMenu.children.find((item) => item.name === 'Product OS')
-    const productSections = docsMenu.children.filter((item) => item.name !== 'Product OS')
+const processDocsMenu = (activeFlags: string[] | null) => {
+    // Drop any flag-gated products the current user can't see before building the grid.
+    const visibleChildren = filterMenuByFlags(docsMenu.children, activeFlags) || []
+    const productOSSection = visibleChildren.find((item) => item.name === 'Product OS')
+    const productSections = visibleChildren.filter((item) => item.name !== 'Product OS')
 
     const featuredIntegrationItems = [
         'Install and configure',
@@ -106,7 +109,8 @@ const renderSectionContent = (children: any[]) => {
 }
 
 export const DocsIndex = () => {
-    const topLevelSections = processDocsMenu()
+    const activeFlags = useActiveFeatureFlags()
+    const topLevelSections = processDocsMenu(activeFlags)
     const [isMac, setIsMac] = React.useState<boolean | undefined>(undefined)
     useEffect(() => {
         setIsMac(typeof window !== 'undefined' && window.navigator.userAgent.toLowerCase().includes('macintosh'))
@@ -373,7 +377,7 @@ export const DocsIndex = () => {
                         <h6 className="text-lg">Feedback</h6>
 
                         <p>
-                            Our docs are perpetually a work in progress. The 
+                            Our docs are perpetually a work in progress. The
                             <SmallTeam slug="docs-wizard" /> is responsible for what you see here.
                         </p>
                         <p>

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -36,6 +36,9 @@ import SidebarSection from 'components/PostLayout/SidebarSection'
 import Contributor from 'components/Docs/Contributors'
 import { useProductInterestFromPathname } from 'hooks/useProductInterest'
 import slugify from 'slugify'
+import usePostHog from 'hooks/usePostHog'
+import { RenderInClient } from 'components/RenderInClient'
+import NotFoundPage from 'components/NotFoundPage'
 
 const DestinationsLibraryCallout = () => {
     return (
@@ -319,12 +322,15 @@ export default function Handbook({ data: { post, postHogSource }, pageContext: {
             hideRightSidebar,
             contentMaxWidthClass,
             showByline,
+            featureFlag,
+            noindex,
         },
         fields: { slug, appConfig, templateConfigs, commits },
         excerpt,
     } = post
 
     const sourceFields = postHogSource?.sourceFields ?? null
+    const posthog = usePostHog()
 
     // Track product interest for cross-subdomain cookie
     useProductInterestFromPathname(slug)
@@ -369,6 +375,39 @@ export default function Handbook({ data: { post, postHogSource }, pageContext: {
         ...shortcodes,
     }
 
+    const readerView = (
+        <ReaderView
+            body={{
+                type: 'mdx',
+                content: body,
+                ...(showByline
+                    ? {
+                          contributors,
+                          date,
+                          tags: tags?.map((tag) => ({
+                              label: tag,
+                              url:
+                                  tag === 'Post mortems'
+                                      ? '/handbook/company/post-mortems'
+                                      : `/blog/tags/${slugify(tag, { lower: true })}`,
+                          })),
+                      }
+                    : null),
+            }}
+            title={title}
+            tableOfContents={frontmatterTableOfContents || tableOfContents}
+            mdxComponents={components}
+            commits={commits}
+            filePath={post.parent?.relativePath}
+            homeURL={breadcrumbBase.url}
+            description={seo?.metaDescription || excerpt}
+            showSurvey
+            hideRightSidebar={hideRightSidebar}
+            contentMaxWidthClass={contentMaxWidthClass}
+            sourceInstanceName={post.parent?.sourceInstanceName}
+        />
+    )
+
     return (
         <>
             <SEO
@@ -377,37 +416,20 @@ export default function Handbook({ data: { post, postHogSource }, pageContext: {
                 article
                 image={`${process.env.GATSBY_CLOUDFRONT_OG_URL}/${slug.replace(/\//g, '')}.jpeg`}
                 imageType="absolute"
+                // Flag-gated pages are always noindexed: the content ships in the static
+                // HTML, so we at least keep it out of search engines while in beta.
+                noindex={!!noindex || !!featureFlag}
             />
-            <ReaderView
-                body={{
-                    type: 'mdx',
-                    content: body,
-                    ...(showByline
-                        ? {
-                              contributors,
-                              date,
-                              tags: tags?.map((tag) => ({
-                                  label: tag,
-                                  url:
-                                      tag === 'Post mortems'
-                                          ? '/handbook/company/post-mortems'
-                                          : `/blog/tags/${slugify(tag, { lower: true })}`,
-                              })),
-                          }
-                        : null),
-                }}
-                title={title}
-                tableOfContents={frontmatterTableOfContents || tableOfContents}
-                mdxComponents={components}
-                commits={commits}
-                filePath={post.parent?.relativePath}
-                homeURL={breadcrumbBase.url}
-                description={seo?.metaDescription || excerpt}
-                showSurvey
-                hideRightSidebar={hideRightSidebar}
-                contentMaxWidthClass={contentMaxWidthClass}
-                sourceInstanceName={post.parent?.sourceInstanceName}
-            />
+            {featureFlag ? (
+                <RenderInClient
+                    // Render nothing until flags resolve, then show the page only if the
+                    // viewer has the gating flag enabled (otherwise the standard 404).
+                    placeholder={null}
+                    render={() => (posthog?.isFeatureEnabled(featureFlag) ? readerView : <NotFoundPage />)}
+                />
+            ) : (
+                readerView
+            )}
         </>
     )
 }
@@ -502,6 +524,8 @@ export const query = graphql`
             }
             frontmatter {
                 showByline
+                featureFlag
+                noindex
                 tableOfContents {
                     depth
                     url


### PR DESCRIPTION
## Summary

Adds a new top-level **Replay Vision** docs product at `/docs/replay-vision` and reusable, opt-in feature-flag gating for docs pages.

## What's included

- **New docs page** `contents/docs/replay-vision.mdx` (Replay Vision overview) + a new top-level "Replay Vision" product section in `docsMenu` (`src/navs/index.js`).
- **Reusable docs flag-gating**: a `featureFlag` field on `MenuItem`, a reactive `useActiveFeatureFlags` hook, and a `filterMenuByFlags` helper (`src/hooks/useActiveFeatureFlags.ts`).
- The page, its docs-nav entries (sidebar product switcher + tree menu), and the docs-home product grid are **hidden for users without the `replay-vision-docs` flag**. The page also renders a 404 and is `noindex`ed for non-flagged users (`src/templates/Handbook.tsx`).
- The `replay-vision-docs` flag (PostHog project 2) is **staff-scoped** (email contains `posthog.com`) during beta.

## ⚠️ Caveat

Gating is **client-side only** — posthog.com is a static Gatsby site, so the content ships in the static HTML. This is soft hiding + `noindex`, **not** true access control. Hold for GA if genuine privacy is required.

## Test plan

- `yarn start`; **flag off**: no Replay Vision in the docs nav or docs-home grid, `/docs/replay-vision` 404s, `noindex` meta present in `<head>`.
- **flag on** (staff / email contains posthog.com): nav entry appears, page renders.

> Note: the commit is currently **unsigned** — it was created in an environment without the SSH commit-signing key loaded.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*