### PR TITLE
ci: fix stale gatsby-plugin-mdx cache breaking preview builds

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -33,18 +33,27 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
+            # Rolling key: each warmup saves a fresh cache (unique run_id) so the shared cache
+            # tracks master content instead of freezing on first creation.
             - name: Cache Gatsby
               uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: |
                       .cache
                       public
-                  key: gatsby-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}
+                  key: gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-${{ github.run_id }}
                   restore-keys: |
-                      gatsby-${{ runner.os }}-
+                      gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-
+                      gatsby-v2-${{ runner.os }}-
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
+
+            # Regenerate gatsby-plugin-mdx scopes fresh from the current checkout so a restored
+            # (rolling) cache from an earlier master state can't leave stale scopes that break the
+            # build. Keeps the saved cache coherent for preview builds to restore.
+            - name: Reset gatsby-plugin-mdx scopes
+              run: rm -rf .cache/caches/gatsby-plugin-mdx
 
             - name: Build site
               run: pnpm build

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -61,16 +61,19 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
-            - name: Cache Gatsby
+            # Restore only — the master cache-warmup job is the sole writer of the shared cache,
+            # so preview builds never persist their (possibly divergent) state back.
+            - name: Restore Gatsby cache
               if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
-              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+              uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: |
                       .cache
                       public
-                  key: gatsby-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}
+                  key: gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-${{ github.run_id }}
                   restore-keys: |
-                      gatsby-${{ runner.os }}-
+                      gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-
+                      gatsby-v2-${{ runner.os }}-
 
             - name: Clean Gatsby cache
               if: ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') }}
@@ -89,6 +92,14 @@ jobs:
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
+
+            # Always regenerate gatsby-plugin-mdx scopes from the current checkout. The restored
+            # cache's scopes can reference a different MDX module graph, causing webpack
+            # "Can't resolve …mdx" failures when a PR's content differs from the cached snapshot.
+            # (actions/cache's "!" exclude can't drop a subdir of an already-matched parent, so we
+            # delete it here instead.) Harmless no-op under the no-cache label (.cache is gone).
+            - name: Reset gatsby-plugin-mdx scopes
+              run: rm -rf .cache/caches/gatsby-plugin-mdx
 
             - name: Build site
               run: pnpm build


### PR DESCRIPTION
## Problem

Preview builds (`Build & deploy preview` → `Build site`) were failing with webpack errors like:

```
Can't resolve '../../../../contents/docs/integrate/_snippets/install-roblox.mdx'
  in '.cache/caches/gatsby-plugin-mdx/mdx-scopes-dir'
```

…even though those snippet files **exist** in the PR's checkout (e.g. [run 26847577920](https://github.com/PostHog/posthog.com/actions/runs/26847577920), PR #17212; also hit `chore/update-docs`). The restored warm `.cache` contained `gatsby-plugin-mdx` scopes inconsistent with the PR's MDX module graph, and because the cache key was **immutable** (never re-saved), the bad snapshot kept breaking every docs/MDX PR.

This is a pre-existing fragility of restoring Gatsby's warm `.cache` across builds with differing content — a separate PR hit the same class earlier with `Can't resolve './productData/llm_analytics'`. It just became consistent recently.

## Fix

- **Regenerate MDX scopes fresh:** `rm -rf .cache/caches/gatsby-plugin-mdx` after restore / before build in both the preview and warmup jobs, so scopes always match the current checkout. (`actions/cache`'s `!` exclude pattern can't drop a subdir of an already-matched parent — [actions/cache#364](https://github.com/actions/cache/issues/364) — so an explicit `rm` is used.)
- **Rolling, versioned key:** append `run_id` + prefix `restore-keys`, and bump the prefix to `gatsby-v2-`. This abandons the current bad cache and keeps each master warmup's cache tracking master content instead of freezing on first creation.
- **Preview builds are restore-only:** the master `cache-warmup` job is now the sole writer of the shared cache, so PRs never persist divergent state back.

## After merge (one-time)

Because `gatsby-v2-` abandons the old cache, the next master `cache-warmup` runs **cold once (~14 min)** to reseed, then preview builds are warm again *and* MDX-coherent.

## Unblocking red PRs in the meantime

Add the **`no-cache`** label and re-run for a clean build.