### PR TITLE
Fix Slack settings deep link in slack-app CTA

### DIFF
--- a/contents/docs/workflows/_snippets/add-posthog-to-slack-workspace.mdx
+++ b/contents/docs/workflows/_snippets/add-posthog-to-slack-workspace.mdx
@@ -1,4 +1,4 @@
-Starting in PostHog, you can add the PostHog Slack app to your workspace in [your project settings](https://app.posthog.com/settings/project#integration-slack).
+Starting in PostHog, you can add the PostHog Slack app to your workspace in [your project settings](https://app.posthog.com/settings/project-integrations#integration-slack).
 
 <ProductScreenshot
     imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/allow_slack_bb68272218.png" 

--- a/src/pages/slack-app/index.tsx
+++ b/src/pages/slack-app/index.tsx
@@ -32,7 +32,7 @@ import {
     IconWrench,
 } from '@posthog/icons'
 
-const CONNECT_SLACK_URL = 'https://app.posthog.com/settings/project#integration-slack'
+const CONNECT_SLACK_URL = 'https://app.posthog.com/settings/project-integrations#integration-slack'
 
 type IconComponent = React.ComponentType<{ className?: string }>
 


### PR DESCRIPTION
## Changes

The **Connect Slack** CTA on [/slack-app](https://posthog.com/slack-app) pointed to `https://app.posthog.com/settings/project#integration-slack`.

That URL is broken: `/settings/project` is a *level-only* settings URL. The app's settings router redirects level-only URLs to the **first** project section (account/general) and **drops the hash** in the process, so `#integration-slack` never resolves — and the Slack integration setting isn't even rendered on that section to scroll to.

The Slack integration lives in the **integrations** section (`environment-integrations` → canonical `project-integrations`). The correct deep link is `/settings/project-integrations#integration-slack` — exactly what the app generates via `urls.settings('project-integrations', 'integration-slack')` and the in-app "copy link" button, and the pattern the [setup docs](https://posthog.com/docs/slack-app/setup) already use.

This PR:
- Fixes the `CONNECT_SLACK_URL` CTA on the `/slack-app` landing page (used in two places: the hero and the "Try it" section).
- Fixes the same broken link in the workflows `add-posthog-to-slack-workspace` snippet.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*