### PR TITLE
ci: build Gatsby cold in previews to stop cache-coherence failures

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -1,8 +1,10 @@
-name: Warm Gatsby cache
+name: Refresh Cloudinary cache
 
 on:
-    push:
-        branches: [master]
+    schedule:
+        # Daily — refresh the Cloudinary metadata cache that preview builds restore.
+        # (Preview builds run Gatsby cold, so this no longer seeds a Gatsby build cache.)
+        - cron: '0 6 * * *'
     workflow_dispatch:
 
 concurrency:
@@ -14,7 +16,7 @@ env:
 
 jobs:
     warm-cache:
-        name: Build & cache
+        name: Refresh Cloudinary cache
         runs-on: depot-ubuntu-latest-8
         timeout-minutes: 45
         permissions:
@@ -33,28 +35,11 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
-            # Rolling key: each warmup saves a fresh cache (unique run_id) so the shared cache
-            # tracks master content instead of freezing on first creation.
-            - name: Cache Gatsby
-              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-              with:
-                  path: |
-                      .cache
-                      public
-                  key: gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-${{ github.run_id }}
-                  restore-keys: |
-                      gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-
-                      gatsby-v2-${{ runner.os }}-
-
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            # Regenerate gatsby-plugin-mdx scopes fresh from the current checkout so a restored
-            # (rolling) cache from an earlier master state can't leave stale scopes that break the
-            # build. Keeps the saved cache coherent for preview builds to restore.
-            - name: Reset gatsby-plugin-mdx scopes
-              run: rm -rf .cache/caches/gatsby-plugin-mdx
-
+            # Build cold (no Gatsby cache) purely to run onPreInit's Cloudinary crawl, which
+            # writes .cloudinary-resources.json for preview builds to restore.
             - name: Build site
               run: pnpm build
               env:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -61,28 +61,11 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
-            # Restore only — the master cache-warmup job is the sole writer of the shared cache,
-            # so preview builds never persist their (possibly divergent) state back.
-            - name: Restore Gatsby cache
-              if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
-              uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-              with:
-                  path: |
-                      .cache
-                      public
-                  key: gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-${{ github.run_id }}
-                  restore-keys: |
-                      gatsby-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'gatsby-config.js') }}-
-                      gatsby-v2-${{ runner.os }}-
-
-            - name: Clean Gatsby cache
-              if: ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') }}
-              run: |
-                  echo "::warning::Gatsby cache skipped — 'no-cache' label detected. Running a clean build."
-                  rm -rf .cache public
-
+            # Gatsby builds cold (no .cache restore). Restoring a warm .cache across builds with
+            # differing MDX content caused gatsby-plugin-mdx incoherence ("Can't resolve …mdx",
+            # "X is not defined"); cold builds are reliable. We still restore the small Cloudinary
+            # metadata file (produced by the cache-warmup job) to skip the ~140s onPreInit crawl.
             - name: Restore Cloudinary metadata cache
-              if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
               uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: .cloudinary-resources.json
@@ -92,14 +75,6 @@ jobs:
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
-
-            # Always regenerate gatsby-plugin-mdx scopes from the current checkout. The restored
-            # cache's scopes can reference a different MDX module graph, causing webpack
-            # "Can't resolve …mdx" failures when a PR's content differs from the cached snapshot.
-            # (actions/cache's "!" exclude can't drop a subdir of an already-matched parent, so we
-            # delete it here instead.) Harmless no-op under the no-cache label (.cache is gone).
-            - name: Reset gatsby-plugin-mdx scopes
-              run: rm -rf .cache/caches/gatsby-plugin-mdx
 
             - name: Build site
               run: pnpm build


### PR DESCRIPTION
## Why

Reusing a warm Gatsby `.cache` across preview builds with differing MDX content is **not reliable** for this site. It produced a whack-a-mole of failures:

1. `Can't resolve '…/install-roblox.mdx'` from cached `gatsby-plugin-mdx` scopes (#17222 tried to fix by deleting the scopes before build).
2. After that, `ReferenceError: CalloutBox is not defined` during HTML generation — deleting the MDX scopes left the *restored webpack cache* referencing stale compiled MDX modules.

Empirically: **cold builds pass; any build that restores the warm cache fails.** (e.g. `fix-slack-app-cta-link` passed on a cache **miss**; `CarolDonnelly…` and `feat/post-newsletter-skill-updates` failed on a cache **hit**.) Rather than keep patching warm-cache reuse on live CI, this builds Gatsby cold — which is reliable — while keeping the wins that don't depend on the Gatsby cache.

## Changes

- **deploy-preview**: remove the Gatsby `.cache` restore (and the now-moot `no-cache` clean + mdx-scope-reset steps). Gatsby builds cold every run. Still restores the small `.cloudinary-resources.json` to skip the ~140s `onPreInit` Cloudinary crawl.
- **cache-warmup → "Refresh Cloudinary cache"**: drop the Gatsby cache entirely; its only remaining job is producing the Cloudinary metadata file. Trigger changed from every-master-push to a **daily schedule + manual dispatch** (a full build per push solely for a ~2 MB file was wasteful).

Kept from the earlier work: the **Depot runner**, the **Cloudinary metadata cache**, and the **CodeQL overlay** change.

## Trade-off

This gives up the warm-`.cache` speedup, so preview "Build site" returns to roughly its original duration (~12–14 min, minus ~140s now that Cloudinary is cached). The priority here is **reliable green builds**; the warm-cache speedup isn't safely achievable for this MDX-heavy site with the approaches tried.

## Note

Effectively supersedes #17222. Once merged, preview builds no longer restore any Gatsby cache, so the poisoned cache stops breaking PRs. Interim unblock for any red PR before merge: add the `no-cache` label and re-run.