### PR TITLE
Add redirect from /aio to /ai-observability

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -102,6 +102,7 @@
         { "source": "/teams/brand-vibes", "destination": "/teams/website" },
         { "source": "/teams/llm-gateway", "destination": "/teams/ai-gateway" },
         { "source": "/teams/llm-analytics", "destination": "/teams/ai-observability" },
+        { "source": "/aio", "destination": "/ai-observability" },
         { "source": "/teams/flags-platform", "destination": "/teams/feature-flags" },
         { "source": "/tutorials/nps-survey", "destination": "/templates/nps-survey" },
         { "source": "/questions/topics/:path*", "destination": "/questions/topic/:path*" },


### PR DESCRIPTION
## Changes

Adds a redirect so that `/aio` points to `/ai-observability`, giving a short, memorable shorthand URL for the AI observability product page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
