### PR TITLE
fix: make PostHog Code coffee icon legible in dark mode on /slack-app

### DIFF
--- a/src/pages/slack-app/index.tsx
+++ b/src/pages/slack-app/index.tsx
@@ -304,8 +304,8 @@ type IntroCardProps = {
 const introCards: IntroCardProps[] = [
     {
         icon: IconCoffee,
-        iconColor: 'text-brown',
-        bulletClass: 'bg-brown',
+        iconColor: 'text-brown dark:text-brown-dark',
+        bulletClass: 'bg-brown dark:bg-brown-dark',
         href: '/code',
         title: 'PostHog Code',
         badge: 'Sandboxed',
@@ -657,7 +657,7 @@ const fighterOptions: { icon: IconComponent; iconColor: string; label: React.Rea
     },
     {
         icon: IconCoffee,
-        iconColor: 'text-brown',
+        iconColor: 'text-brown dark:text-brown-dark',
         label: (
             <Link to="/code" state={{ newWindow: true }} className="font-bold text-primary">
                 PostHog Code

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -144,6 +144,7 @@ module.exports = {
                 'blue-2': '#589DF8',
                 'blue-2-dark': '#1E2F46',
                 brown: '#3B2B26',
+                'brown-dark': '#C4A484',
                 'burnt-orange': '#DF6133',
                 'burnt-orange-dark': '#8E2600',
                 orange: '#EB9D2A',


### PR DESCRIPTION
## Problem

On `/slack-app`, the "PostHog Code" entries render the `IconCoffee` icon (and a matching dotted-list bullet) using the `brown` Tailwind token (`#3B2B26`). That's a near-black reddish-brown with no dark-mode variant, so in dark mode it sits against the `#1d1f27` background and is effectively invisible. Light mode is unaffected.

before

<img width="346" height="130" alt="image" src="https://github.com/user-attachments/assets/4a112e65-79d6-4701-b99d-a75a3742cee6" />


after

<img width="347" height="124" alt="image" src="https://github.com/user-attachments/assets/173f1bb1-834d-482d-83a4-75d2b6fde868" />


## Fix

- Add a paired `brown-dark` token (`#C4A484`, a light latte-brown) in `tailwind.config.js`, following the existing `-dark` pairing convention used by most other colors.
- Apply `dark:text-brown-dark` / `dark:bg-brown-dark` to both `IconCoffee` occurrences on the page (the intro card and the comparison list).

The icon SVG inherits `currentColor`, so the dark-mode class flows through automatically — no markup change needed.

## Testing

- Verified the diff is scoped to the two intended files.
- Visual check: in dark mode the coffee icon (and intro-card bullet) are now legible; light mode is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*