### PR TITLE
Fix Slack app docs to reflect current behavior

### DIFF
--- a/contents/docs/slack-app/commands.mdx
+++ b/contents/docs/slack-app/commands.mdx
@@ -37,7 +37,6 @@ Before you lean on the Slack app, here's a list of things to know:
 
 - **Ephemeral sandbox.** Each task runs in a fresh sandbox that lives roughly six hours. Long iterations need re-prompting once it recycles.
 - **Personal GitHub auth is per user.** Every teammate who wants to ship a PR has to connect their own GitHub once. First-time setup has known rough edges.
-- **Single-author follow-ups.** Only the person who started a task can steer it. Colleagues' messages become context, not instructions.
 - **Text input only.** The agent can't read images yet – paste descriptions instead of screenshots.
 - **DMs coming soon.** The bot doesn't respond in direct messages yet. For now, add it to a private channel of one if you want a quiet space.
 - **500-repo cap on the picker.** If your team's GitHub install exposes more than 500 repos, the list is truncated. Add a routing rule for repos that fall off the end.

--- a/contents/docs/slack-app/index.mdx
+++ b/contents/docs/slack-app/index.mdx
@@ -52,7 +52,7 @@ Reply in the thread to send a follow-up to the running agent. Anything you say w
 
 Once the agent finishes, you can reply to it by sending a new message in the thread with `@PostHog` to continue the existing conversation.
 
-Only the person that started a task can drive it. If other people add to a thread (a comment, a file, a link), the agent treats it as context to consider, not a prompt to follow. If you want to take over, start a new thread and paste the existing messages in as context.
+Anyone in the thread can send follow-ups. Each message is forwarded to the running agent as a new turn in the same conversation, so teammates can steer the run together, drop in extra context, or answer a question the agent asked.
 
 ## Emoji cues
 

--- a/contents/docs/slack-app/index.mdx
+++ b/contents/docs/slack-app/index.mdx
@@ -54,6 +54,8 @@ Once the agent finishes, you can reply to it by sending a new message in the thr
 
 Anyone in the thread can send follow-ups. Each message is forwarded to the running agent as a new turn in the same conversation, so teammates can steer the run together, drop in extra context, or answer a question the agent asked.
 
+Heads up: the resulting PR is still authored under whoever started the task – their personal GitHub integration is the one wired up – so a teammate's follow-up edits land under the original requester's name. If you want the PR credited to you, start your own task.
+
 ## Emoji cues
 
 The bot reacts to your `@PostHog` message as it works through your request, so you can scan a busy channel and see what's still in flight without opening every thread:

--- a/src/pages/slack-app/index.tsx
+++ b/src/pages/slack-app/index.tsx
@@ -526,7 +526,7 @@ const faqItems = [
                 Set a default repo per channel. Or set regex routing rules so the bot picks the right repo from the
                 channel name or the task description. When the bot isn't sure, it opens a picker in-thread. See the{' '}
                 <Link
-                    to="/docs/posthog-code/slack"
+                    to="/docs/slack-app/commands"
                     state={{ newWindow: true }}
                     className="text-red dark:text-yellow font-semibold hover:underline"
                 >
@@ -540,9 +540,9 @@ const faqItems = [
         trigger: 'Can multiple people drive the same task?',
         content: (
             <p>
-                No. The agent will only follow instructions from the individual who originally kicked off the task. If
-                other people add to a thread (e.g., comment, add a file or link), the agent treats it as data to
-                consider, not instructions to obey (it might even tell you to step off).
+                Yes. Anyone in the thread can send follow-ups to the running agent. Every message in the thread is
+                forwarded as a new turn in the same conversation, so teammates can steer mid-run, drop in extra context,
+                or answer a question the agent asked.
             </p>
         ),
     },
@@ -551,10 +551,16 @@ const faqItems = [
         content: (
             <p>
                 Branches get a <code>posthog-code/</code> prefix, and each commit includes a{' '}
-                <code>Generated-By: PostHog Code</code> line plus a <code>Task-Id</code> so you can trace it back. The
-                author is the bot by default, or you can connect you personal github integration
-                [here](https://app.posthog.com/settings/user-personal-integrations) – so the PR shows up under your
-                name.
+                <code>Generated-By: PostHog Code</code> line plus a <code>Task-Id</code> so you can trace it back. PRs
+                are authored under your name via your{' '}
+                <Link
+                    to="https://app.posthog.com/settings/user-personal-integrations"
+                    external
+                    className="text-red dark:text-yellow font-semibold hover:underline"
+                >
+                    personal GitHub integration
+                </Link>
+                , which every teammate connects once before they can ship code.
             </p>
         ),
     },
@@ -598,7 +604,7 @@ const faqItems = [
         trigger: 'Do I need PostHog Code to use the PostHog Slack app?',
         content: (
             <p>
-                No. The Slack app has its own feature flag and isn't gated on a{' '}
+                No. The Slack app is generally available and isn't gated on a{' '}
                 <Link
                     to="/code"
                     state={{ newWindow: true }}
@@ -624,7 +630,6 @@ const faqItems = [
                         GitHub auth is per-user via a personal integration. Onboarding has a known gap; first-time setup
                         is rougher than it should be.
                     </li>
-                    <li>Only the user who started a task can follow up in-thread.</li>
                     <li>
                         No screenshot input yet – the bot reads text only. Paste descriptions instead of images for now.
                     </li>
@@ -734,8 +739,8 @@ export default function SlackAppPage(): JSX.Element {
                         <li>It plans the work, edits files, and runs checks inside a sandboxed environment.</li>
                         <li>It opens a draft PR with a detailed description, and links it back into the thread.</li>
                         <li>
-                            It iterates on follow-up messages from the original requester (and politely declines
-                            commands from your colleagues).
+                            It iterates on follow-up messages from anyone in the thread, so teammates can steer the run
+                            together.
                         </li>
                         <li>
                             It watches CI, reruns failed jobs that look environmental, and doesn't touch workflow files.

--- a/src/pages/slack-app/index.tsx
+++ b/src/pages/slack-app/index.tsx
@@ -604,7 +604,7 @@ const faqItems = [
         trigger: 'Do I need PostHog Code to use the PostHog Slack app?',
         content: (
             <p>
-                No. The Slack app is generally available and isn't gated on a{' '}
+                No. The Slack app isn't gated on a{' '}
                 <Link
                     to="/code"
                     state={{ newWindow: true }}

--- a/src/pages/slack-app/index.tsx
+++ b/src/pages/slack-app/index.tsx
@@ -539,11 +539,18 @@ const faqItems = [
     {
         trigger: 'Can multiple people drive the same task?',
         content: (
-            <p>
-                Yes. Anyone in the thread can send follow-ups to the running agent. Every message in the thread is
-                forwarded as a new turn in the same conversation, so teammates can steer mid-run, drop in extra context,
-                or answer a question the agent asked.
-            </p>
+            <>
+                <p>
+                    Yes. Anyone in the thread can send follow-ups to the running agent. Every message in the thread is
+                    forwarded as a new turn in the same conversation, so teammates can steer mid-run, drop in extra
+                    context, or answer a question the agent asked.
+                </p>
+                <p>
+                    Heads up: the resulting PR is still authored under whoever started the task – their personal GitHub
+                    integration is the one wired up – so a teammate's follow-up edits land under the original
+                    requester's name. If you want the PR credited to you, start your own task.
+                </p>
+            </>
         ),
     },
     {


### PR DESCRIPTION
A couple of post-beta tweaks to the Slack app product page and adjacent docs — copy reflected pre-beta behavior that has since changed:

- **Multi-driver follow-ups**: anyone in the thread can now follow up on a running task (no single-author restriction).
- **PR authorship**: PRs are authored under the user via their personal GitHub integration, not as the bot by default. Replaced literal markdown `[here](…)` syntax inside JSX with a real `<Link>` to `/settings/user-personal-integrations`.
- **Not gated**: the Slack app isn't behind a feature flag or a PostHog Code subscription (still in beta though).
- **Broken link**: `/docs/posthog-code/slack` → `/docs/slack-app/commands`.
- Removed stale single-author bullets from limitations on `/slack-app` and `/docs/slack-app/commands`, and rewrote the matching paragraph on `/docs/slack-app`.

Commit metadata details (`posthog-code/` branch prefix, `Generated-By: PostHog Code`, `Task-Id`) are accurate and stay.