### PR TITLE
typo and link fix

### DIFF
--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -85,7 +85,7 @@ The questions are based on the ones used by [Culture Amp](https://www.cultureamp
 
 Only the People & Ops and Exec teams have access to the full list of responses, which are not anonymous. 
 
-We follow a template to report a summary of the results in an Issue. [You can view the latest survey results here](https://github.com/PostHog/company-internal/issues/1390) - just copy the formatting ever.  
+We follow a template to report a summary of the results in an Issue. <PrivateLink url="https://github.com/PostHog/company-internal/issues/2965">You can view the latest survey results here</PrivateLink> - just copy the formatting every time.  
 
 ### Current list of questions
 

--- a/contents/newsletter/the-companies-that-shaped-posthog.md
+++ b/contents/newsletter/the-companies-that-shaped-posthog.md
@@ -104,7 +104,7 @@ On top of this, we try to maintain a strong financial position and [never need t
 
 Y Combinator helps create many successful startups. Core to doing this is a couple pieces of advice:
 
-- **Build people something want.** This requires talking to users and having them shape the roadmap, even when your intuition says otherwise.
+- **Build something people want.** This requires talking to users and having them shape the roadmap, even when your intuition says otherwise.
 
 - **Launch now.** Shipping fast enables you to [test in production](/product-engineers/testing-in-production) and get the most real feedback possible.
 


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/posthog.com/issues/17171 and https://github.com/PostHog/posthog.com/issues/15813

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
