### PR TITLE
Fix iOS, Rust, and React Router logos in dark mode

### DIFF
--- a/src/components/IntegrationsLibrary/index.tsx
+++ b/src/components/IntegrationsLibrary/index.tsx
@@ -3,7 +3,7 @@ import { useStaticQuery, graphql, navigate } from 'gatsby'
 import OSTable from 'components/OSTable'
 import Link from 'components/Link'
 import { Select } from 'components/RadixUI/Select'
-import { getLogo } from 'constants/logos'
+import { getLogo, getDarkClassForLogo } from 'constants/logos'
 import { SELF_HOSTED_SOURCES } from 'constants/sources'
 
 const getIconUrl = (iconUrl: string) => {
@@ -27,7 +27,7 @@ const Title = ({ pipeline }: { pipeline: any }) => {
             <img
                 src={getIconUrl(pipeline.icon_url)}
                 alt={pipeline.name}
-                className="w-6 h-6 object-contain flex-shrink-0"
+                className={`w-6 h-6 object-contain flex-shrink-0 ${getDarkClassForLogo(pipeline.icon_url)}`}
             />
             {url ? (
                 <Link to={url} state={{ newWindow: true }}>

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -3,6 +3,7 @@ import ZoomHover from 'components/ZoomHover'
 import React, { useEffect, useState } from 'react'
 import * as NewIcons from '@posthog/icons'
 import * as OSIcons from 'components/OSIcons'
+import { getDarkClassForLogo } from 'constants/logos'
 
 interface IItem {
     label: string | React.ReactNode
@@ -57,7 +58,12 @@ export const ListItem = ({
                     className="group flex w-full justify-between items-center space-x-2 rounded border border-b-4 border-transparent !text-inherit hover:!text-inherit"
                 >
                     <span className="flex items-center space-x-2">
-                        {image && <img className="icon size-8 rounded-sm" src={image} />}
+                        {image && (
+                            <img
+                                className={`icon size-8 rounded-sm ${getDarkClassForLogo(image)}`}
+                                src={image}
+                            />
+                        )}
                         {Icon && <Icon className={`size-8 ${iconColor ? `text-${iconColor}` : ``} shrink-0`} />}
 
                         <span className="grid">

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -30,7 +30,7 @@ import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import CloudinaryImage from 'components/CloudinaryImage'
 import * as PostHogIcons from '@posthog/icons'
 import * as OSIcons from '../OSIcons/Icons'
-import { getLogo } from '../../constants/logos'
+import { getLogo, getDarkClassForLogo } from '../../constants/logos'
 import SearchProvider from 'components/Editor/SearchProvider'
 import { useLocation } from '@reach/router'
 import { getProseClasses, isMarkdownContentPath } from '../../constants'
@@ -461,7 +461,7 @@ const resolveMenuIcons = (items: MenuItem[] | undefined, resolveIcons = false): 
         if (resolveIcons) {
             if (item.platformLogo) {
                 const url = getLogo(item.platformLogo)
-                if (url) icon = <img src={url} className="size-full" />
+                if (url) icon = <img src={url} className={`size-full ${getDarkClassForLogo(url)}`} />
             } else if (typeof icon === 'string') {
                 const IconComponent = (PostHogIcons as any)[icon] || (OSIcons as any)[icon]
                 if (IconComponent) icon = <IconComponent className="size-full" />

--- a/src/components/WizardPage/index.tsx
+++ b/src/components/WizardPage/index.tsx
@@ -11,7 +11,7 @@ import WistiaVideo from 'components/WistiaVideo'
 import TeamMember from 'components/TeamMember'
 import Link from 'components/Link'
 import ProductList from 'components/ProductList'
-import { getLogo } from '../../constants/logos'
+import { getLogo, getDarkClassForLogo } from '../../constants/logos'
 import WizardCommand from 'components/WizardCommand'
 
 function WizardHeader(): JSX.Element {
@@ -138,7 +138,13 @@ function SupportedFrameworks(): JSX.Element {
                                         className="flex items-center gap-2 text-sm !text-inherit hover:underline"
                                         state={{ newWindow: true }}
                                     >
-                                        {logoUrl && <img src={logoUrl} alt={fw.name} className="size-5 rounded-sm" />}
+                                        {logoUrl && (
+                                            <img
+                                                src={logoUrl}
+                                                alt={fw.name}
+                                                className={`size-5 rounded-sm ${getDarkClassForLogo(logoUrl)}`}
+                                            />
+                                        )}
                                         <span>{fw.name}</span>
                                     </Link>
                                 </li>

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -157,3 +157,17 @@ export type LogoKey = keyof typeof LOGOS
 export function getLogo(key: string): string | undefined {
     return LOGOS[key as LogoKey]
 }
+
+// Logos whose source SVGs have hardcoded dark fills/strokes and render poorly on dark backgrounds.
+// `dark:invert` flips pure-black artwork to white; `dark:hue-rotate-180` preserves the original
+// hue of color elements after inversion (used for logos that mix color with black).
+const LOGO_DARK_CLASS_BY_URL: Record<string, string> = {
+    [LOGOS.ios]: 'dark:invert',
+    [LOGOS.rust]: 'dark:invert',
+    [LOGOS.reactRouter]: 'dark:invert dark:hue-rotate-180',
+}
+
+export function getDarkClassForLogo(url?: string): string {
+    if (!url) return ''
+    return LOGO_DARK_CLASS_BY_URL[url] ?? ''
+}

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -4,7 +4,7 @@ import Editor from 'components/Editor'
 import { IconArrowUpRight, IconCheck, IconFlask, IconToggle, IconTrends, IconWarning } from '@posthog/icons'
 import OSButton from 'components/OSButton'
 import { Accordion } from 'components/RadixUI/Accordion'
-import { LOGOS, type LogoKey } from 'constants/logos'
+import { LOGOS, type LogoKey, getDarkClassForLogo } from 'constants/logos'
 import TabbedCarousel from 'components/TabbedCarousel'
 import type { TabbedCarouselTab } from 'components/TabbedCarousel'
 import { ChoppyReveal } from 'components/Code/ChoppyReveal'
@@ -1171,7 +1171,9 @@ const TableStakes = () => {
                                     <img
                                         src={LOGOS[row.logoKey]}
                                         alt=""
-                                        className="size-7 shrink-0 object-contain"
+                                        className={`size-7 shrink-0 object-contain ${getDarkClassForLogo(
+                                            LOGOS[row.logoKey]
+                                        )}`}
                                         aria-hidden
                                     />
                                     <p className="m-0 text-base font-bold text-primary">{row.name}</p>


### PR DESCRIPTION
## Summary

The iOS, Rust, and React Router logos render as near-invisible dark silhouettes on the dark-mode SDKs and Frameworks lists (and any other surface that uses them). The source SVGs have hardcoded black fills/strokes and are served via `<img>` tags, so `currentColor`-based tricks don't help.

- Adds a small `getDarkClassForLogo(url)` helper in `src/constants/logos.ts`, keyed by logo URL
  - iOS, Rust → `dark:invert` (flips pure-black SVGs to white)
  - React Router → `dark:invert dark:hue-rotate-180` (keeps the red `R` intact while flipping the dark dots to white)
- Applies the class wherever a logo `<img>` is rendered: `List`, `WizardPage`, `ReaderView`, `IntegrationsLibrary`, and `pages/code.tsx`. The helper is a no-op for any URL that isn't in the affected set, so it's a safe addition.

Before/after happens at render — no new SVG assets, no Cloudinary uploads.

## Test plan

- [ ] In dark mode, visit `/docs/feature-flags` and confirm the SDKs and frameworks block shows iOS (white apple), Rust (white gear), and React Router (red R with white dots) clearly
- [ ] Confirm light mode is unchanged
- [ ] Spot-check `/docs/frameworks`, `/r/session-replay`, and the wizard page

🤖 Generated with [Claude Code](https://claude.com/claude-code)