### PR TITLE
Add Support to feature ownership table

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -475,6 +475,10 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         feature: 'Subscriptions',
         owner: ['analytics-platform'],
     },
+    support: {
+        feature: 'Support',
+        owner: ['conversations'],
+    },
     surveys: {
         feature: 'Surveys',
         owner: ['surveys'],


### PR DESCRIPTION
Adds the **Support** product to the feature ownership table on `/handbook/engineering/feature-ownership`, owned by the [Conversations](/teams/conversations) team.

## Changes
- New `support` entry in `src/hooks/useFeatureOwnership.tsx`
- Owner renders via `<SmallTeam slug="conversations" />`, linking to the Conversations team
- Label defaults to `feature/support` (auto-generated GitHub issue link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)