### PR TITLE
Redirect /slack to /slack-app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,11 @@
     ],
     "redirects": [
         {
+            "source": "/slack",
+            "destination": "/slack-app",
+            "statusCode": 301
+        },
+        {
             "source": "/blog/autoresearch-query-bug",
             "destination": "/blog/karpathy-autoresearch-query-engine-bug"
         },


### PR DESCRIPTION
## Changes

**A manifesto for /slack**

We believe a URL should keep its promise.

Once, `/slack` was a doorway to a community — a room full of hedgehogs, questions, and the warm hum of people helping each other in real time. That room has been quiet for a long while. The page that lives there today says as much: "Our Slack community has moved." A tombstone is no destination.

We believe in second lives, not dead ends.

So we are not deleting `/slack` — we are repurposing it. The path that once meant *come chat with us* will now mean *come work with us*, pointing visitors to `/slack-app`, where Slack and PostHog actually do something together.

We believe redirects are a kindness.

Old links in blog posts, founder stories, and roadmap pages still whisper `posthog.com/slack`. Rather than leave those travelers stranded on a farewell notice, we send them somewhere alive. A permanent `301` does this honestly, and tells the search engines we mean it.

That's the whole change:

- `/slack` → `/slack-app` (`301`, permanent)

The old `SlackPage` component stays put — it's still used as an MDX global — but the edge redirect now wins before anyone ever reaches it.

cc @cleopleurodon for review 🦔

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
