### PR TITLE
docs(data-warehouse): add Gorgias source documentation

### DIFF
--- a/contents/docs/cdp/sources/gorgias.md
+++ b/contents/docs/cdp/sources/gorgias.md
@@ -1,0 +1,57 @@
+---
+title: Linking Gorgias as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Gorgias
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+Enter your Gorgias credentials to pull your helpdesk data – tickets, messages, customers, users, and more – into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Gorgias.
+3. Next, gather your Gorgias credentials:
+   - **Gorgias domain (subdomain)** – your account subdomain, e.g. `your-company` for `your-company.gorgias.com`.
+   - **Account email** – the email of the account that owns the API key.
+   - **API key** – create one in your Gorgias account under **Settings → REST API**.
+
+   This source authenticates with HTTP Basic Auth (email plus API key) and requires read access to the endpoints you want to sync.
+4. Back in PostHog, enter the credentials and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Gorgias data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `tickets` | Support tickets | Full refresh |
+| `messages` | Messages on tickets | Full refresh |
+| `customers` | Customers | Full refresh |
+| `users` | Helpdesk users (agents) | Full refresh |
+| `satisfaction_surveys` | Customer satisfaction surveys | Full refresh |
+| `tags` | Tags | Full refresh |
+| `views` | Views | Full refresh |
+| `teams` | Teams | Full refresh |
+| `macros` | Macros | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Sync limitations
+
+All Gorgias tables are full refresh only. Gorgias list endpoints have no server-side timestamp filter (only client-side ordering), so true incremental sync is not currently possible.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **Gorgias** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

The Gorgias source is currently in alpha.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`