### PR TITLE
docs(data-warehouse): add MailerLite source documentation

### DIFF
--- a/contents/docs/cdp/sources/mailerlite.md
+++ b/contents/docs/cdp/sources/mailerlite.md
@@ -1,0 +1,53 @@
+---
+title: Linking MailerLite as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: MailerLite
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+The MailerLite connector pulls your MailerLite email marketing data into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to MailerLite.
+3. You need a MailerLite API key, which you can create in your [MailerLite integrations settings](https://dashboard.mailerlite.com/integrations/api).
+4. Back in PostHog, enter the key in the `API key` field and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using MailerLite data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `subscribers` | Subscribers in your account | Full refresh |
+| `campaigns` | Email campaigns | Full refresh |
+| `groups` | Subscriber groups | Full refresh |
+| `segments` | Subscriber segments | Full refresh |
+| `fields` | Custom subscriber field definitions | Full refresh |
+| `automations` | Automation workflows | Full refresh |
+| `forms_popup` | Pop-up forms | Full refresh |
+| `forms_embedded` | Embedded forms | Full refresh |
+| `forms_promotion` | Promotion forms | Full refresh |
+| `webhooks` | Configured webhooks | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Sync limitations
+
+The MailerLite API exposes no server-side timestamp filter on any list endpoint, so every table is full-refresh only.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **MailerLite** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

The MailerLite source is currently in alpha.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`