### PR TITLE
Rename --env-file to --dotenv-file in source maps CLI docs

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/cli.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/cli.mdx
@@ -22,10 +22,10 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
   <CLIAuthenticate />
 
-  If you already keep your project's configuration in a dotenv-style file, you can load these variables from it with the `--env-file` option instead of exporting them:
+  If you already keep your project's configuration in a dotenv-style file, you can load these variables from it with the `--dotenv-file` option instead of exporting them:
 
   ```bash
-  posthog-cli --env-file .env sourcemap upload --directory ./path/to/assets
+  posthog-cli --dotenv-file .env sourcemap upload --directory ./path/to/assets
   ```
 
 </Step>


### PR DESCRIPTION
Renames `--env-file` to `--dotenv-file` in the error tracking source maps CLI docs to match the CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)