### PR TITLE
Update two docs for clarity

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -281,6 +281,7 @@ Flags without evaluation contexts continue to evaluate for all requests (default
 - SDKs must send the `evaluation_contexts` parameter with matching contexts for the flag to evaluate (the legacy `evaluation_environments` parameter is also supported)
 - Flags with no evaluation contexts will evaluate for all requests (default behavior)
 - At least one evaluation context must match for the flag to be included in the evaluation
+- Evaluation contexts and (and evaluation runtime) do not affect local evaluation behavior
 
 </CalloutBox>
 

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -281,7 +281,7 @@ Flags without evaluation contexts continue to evaluate for all requests (default
 - SDKs must send the `evaluation_contexts` parameter with matching contexts for the flag to evaluate (the legacy `evaluation_environments` parameter is also supported)
 - Flags with no evaluation contexts will evaluate for all requests (default behavior)
 - At least one evaluation context must match for the flag to be included in the evaluation
-- Evaluation contexts and (and evaluation runtime) do not affect local evaluation behavior
+- Evaluation contexts and and evaluation runtime do not affect local evaluation behavior
 
 </CalloutBox>
 

--- a/contents/docs/product-analytics/funnels.mdx
+++ b/contents/docs/product-analytics/funnels.mdx
@@ -209,7 +209,7 @@ In this case, you can choose from which step the properties should be selected f
 
 ##### 1. First touchpoint
 
-In this case, the first property value seen in any of the steps is chosen.
+In this case, the first property value seen in any occurrences of the funnel events.
 
 Consider this example sequence of events:
 

--- a/contents/docs/product-analytics/funnels.mdx
+++ b/contents/docs/product-analytics/funnels.mdx
@@ -209,7 +209,7 @@ In this case, you can choose from which step the properties should be selected f
 
 ##### 1. First touchpoint
 
-In this case, the first property value seen in any occurrences of the funnel events.
+In this case, the first property value seen in any occurrence of funnel events.
 
 Consider this example sequence of events:
 


### PR DESCRIPTION
Two docs are 1. Funnels and 2. Creating Feature Flags

1.
Clarified the description of the first touchpoint attribution mode based on this ticket: https://posthog.slack.com/archives/C04G7E5K5U3/p1778527993829529?thread_ts=1778505884.017919&cid=C04G7E5K5U3

Originally indicated this setting looks for the first instance of a property within the confines of the funnel. In truth the first occurrence of any funnel event, even outside the date range of the funnel, is included.

2.
Added a note on interaction between evaluation contexts and local evaluation based on this ticket: https://posthog.slack.com/archives/C05KCMDMU8G/p1780492381372119

Originally was missing any notes, causing PostHogAI to hallucinate an answer. More clarity should help here.