### PR TITLE
Add linkable anchors to past security advisories

### DIFF
--- a/contents/handbook/company/security-advisories.md
+++ b/contents/handbook/company/security-advisories.md
@@ -48,8 +48,8 @@ Currently, there are no active security advisories or CVEs. All is well.
 
 ## Past advisories
 
-<details>
-  <summary>June 2, 2026 / PSA-2026-00001</summary>
+<details id="PSA-2026-00001">
+  <summary>June 2, 2026 / PSA-2026-00001 <AdvisoryAnchor id="PSA-2026-00001" /></summary>
 
   <p><strong>Date:</strong> June 2, 2026<br />
   <strong>Advisory:</strong> PSA-2026-00001<br />
@@ -101,8 +101,8 @@ Currently, there are no active security advisories or CVEs. All is well.
 
 </details>
 
-<details>
-  <summary>August 15, 2025 / PSA-2025-00001</summary>
+<details id="PSA-2025-00001">
+  <summary>August 15, 2025 / PSA-2025-00001 <AdvisoryAnchor id="PSA-2025-00001" /></summary>
 
   <p><strong>Date:</strong> August 15, 2025<br />
   <strong>Advisory:</strong> PSA-2025-00001<br />
@@ -144,7 +144,12 @@ Currently, there are no active security advisories or CVEs. All is well.
 
 ### Advisory template
 
+Use the advisory code as the `<details>` `id` (and the matching `<AdvisoryAnchor>` `id`) so it can be linked directly. Linking to the anchor (e.g. `/handbook/company/security-advisories#PSA-2025-XXXXX`) auto-expands the advisory.
+
 ```
+<details id="PSA-2025-XXXXX">
+  <summary>August 15, 2025 / PSA-2025-XXXXX <AdvisoryAnchor id="PSA-2025-XXXXX" /></summary>
+
   <p><strong>Date:</strong> August 15, 2025<br />
   <strong>Advisory:</strong> PSA-2025-XXXXX<br />
   <strong>Severity:</strong> Low / Medium / Critical<br />
@@ -173,6 +178,8 @@ Currently, there are no active security advisories or CVEs. All is well.
     <li><strong>Fixed:</strong> January 10, 2024, 00:00 UTC</li>
     <li><strong>Disclosed:</strong> January 10, 2024, 00:00 UTC</li>
   </ul>
+
+</details>
 ```
 
 

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -39,6 +39,39 @@ export const CopyAnchor = ({ id = '', hovered }: { id: string; hovered: boolean 
     )
 }
 
+export const AdvisoryAnchor = ({ id = '' }: { id: string }): JSX.Element => {
+    const [copied, setCopied] = useState(false)
+    const { href } = useLocation()
+    // Copy the shareable link without toggling the parent <details>. Stopping propagation and
+    // the default action keeps the surrounding <summary> from opening/closing on click.
+    const handleClick = (e: React.MouseEvent) => {
+        e.stopPropagation()
+        e.preventDefault()
+        const url = `${href.replace(/#.*/, '')}#${id}`
+        window.history.replaceState(null, '', `#${id}`)
+        navigator.clipboard?.writeText(url)
+        setCopied(true)
+        setTimeout(() => {
+            setCopied(false)
+        }, 1000)
+    }
+
+    return (
+        <span className="inline-flex items-center align-middle">
+            <button
+                type="button"
+                onClick={handleClick}
+                aria-label="Copy link to this advisory"
+                title="Copy link to this advisory"
+                className="inline-flex opacity-40 hover:opacity-100 transition-opacity ml-2"
+            >
+                <IconLink className="size-4" />
+            </button>
+            {copied && <span className="ml-1.5 text-sm font-normal">Copied!</span>}
+        </span>
+    )
+}
+
 export const Heading = ({
     as = 'h1',
     children,

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -25,6 +25,7 @@ import { FeatureAvailability } from './components/FeatureAvailability'
 import FeatureOwnershipTable from './components/FeatureOwnershipTable'
 import { FormulaScreenshot } from './components/FormulaScreenshot'
 import { GDPRForm } from './components/GDPRForm'
+import { AdvisoryAnchor } from './components/Heading'
 import { HiddenSection } from './components/HiddenSection'
 import { HubSpotForm } from './components/HubSpotForm'
 import ImageSlider from './components/ImageSlider'
@@ -96,6 +97,7 @@ export const shortcodes = {
     FeatureAvailability,
     FormulaScreenshot,
     GDPRForm,
+    AdvisoryAnchor,
     HiddenSection,
     HubSpotForm,
     KeyboardShortcut,


### PR DESCRIPTION
## Changes

Each past advisory on the [security advisories page](/handbook/company/security-advisories) is now directly linkable, and opening such a link auto-expands that advisory.

- Added an `id` to each `<details>` matching its PSA code (e.g. `PSA-2026-00001`).
- Added a small **`AdvisoryAnchor`** component (a copy-link icon) inside each `<summary>`, next to the title — mirrors the existing heading copy-link affordance (`CopyAnchor`) and reuses `IconLink`. Clicking it copies the shareable URL and `stopPropagation()`/`preventDefault()` keep it from toggling the advisory open/closed.
- Registered `AdvisoryAnchor` as an MDX shortcode so it works in the `.md` file.
- Updated the **Advisory template** at the bottom of the page so future advisories follow the same pattern.

## How auto-expand works

No new JS/CSS needed — `ReaderView` already handles this on hash navigation: it finds the element by id, opens its `closest('details')`, and scrolls to it (`src/components/ReaderView/index.tsx`). Adding the matching `id`s is all that was required.

Example: `/handbook/company/security-advisories#PSA-2026-00001`

## Testing

- Pre-commit lint (prettier/eslint/markdownlint) passes.
- ⚠️ Not yet verified in a running browser (component rendering inside the raw-HTML `<summary>` and the no-toggle-on-click behavior). Worth a quick visual check on the preview deploy.