### PR TITLE
docs: rename APM "Tracing" to "Distributed tracing"

### DIFF
--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -104,7 +104,7 @@ The core of PostHog and Sentry are different. Sentry focuses on error and perfor
 
 ### Error and performance monitoring
 
-Error and performance monitoring is the main focus of Sentry. PostHog has a full error tracking product as well as [network performance recording](/docs/session-replay/network-recording) and [tracing](/docs/tracing) (in alpha), though Sentry's tracing and monitoring features are more mature.
+Error and performance monitoring is the main focus of Sentry. PostHog has a full error tracking product as well as [network performance recording](/docs/session-replay/network-recording) and [distributed tracing](/docs/distributed-tracing) (in alpha), though Sentry's tracing and monitoring features are more mature.
 
 <p>
 <ProductComparisonTable

--- a/contents/docs/distributed-tracing/basics.mdx
+++ b/contents/docs/distributed-tracing/basics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Why you need tracing
+title: Why you need distributed tracing
 ---
 
 Tracing follows a single request as it travels through your application – across the functions, services, databases, and APIs it touches along the way. Where [Logs](/docs/logs) record what happened at each point, a trace shows you the whole path: what called what, in what order, and how long each step took.
@@ -28,7 +28,7 @@ Each PostHog product answers a different question about your application:
 | **[Product Analytics](/docs/product-analytics)** | What users did | "User clicked checkout" |
 | **[Logs](/docs/logs)** | What happened at each point | "Inventory service returned 200 with 0 items" |
 | **[Error Tracking](/docs/error-tracking)** | What broke | "TypeError: cannot read property 'price' of undefined" |
-| **Tracing** | How the request flowed and where time went | "Checkout took 3.2s, and 2.8s of it was spent waiting on the inventory service" |
+| **Distributed tracing** | How the request flowed and where time went | "Checkout took 3.2s, and 2.8s of it was spent waiting on the inventory service" |
 
 Errors tell you something broke. Logs tell you what happened at one point. Tracing tells you **how the pieces connected, and where the time and failures actually came from** – across every service a request touched.
 
@@ -74,7 +74,7 @@ Useful tracing is about instrumenting the right boundaries, not every line of co
 
 ## How PostHog makes tracing useful
 
-**No vendor lock-in** - PostHog ingests traces over [OpenTelemetry (OTLP)](/docs/tracing/start-here). Use standard OTel libraries in any language, with no proprietary SDK. If you already export traces, point them at PostHog and you're done.
+**No vendor lock-in** - PostHog ingests traces over [OpenTelemetry (OTLP)](/docs/distributed-tracing/start-here). Use standard OTel libraries in any language, with no proprietary SDK. If you already export traces, point them at PostHog and you're done.
 
 **Built on the same pipeline as Logs** - Tracing uses the same OpenTelemetry-based ingestion as [Logs](/docs/logs), so a single OTel setup covers both.
 
@@ -84,6 +84,6 @@ Useful tracing is about instrumenting the right boundaries, not every line of co
 
 ## Next steps
 
-- **[Get started](/docs/tracing/start-here)** - Install an OpenTelemetry exporter and send your first spans
+- **[Get started](/docs/distributed-tracing/start-here)** - Install an OpenTelemetry exporter and send your first spans
 - **[Logs](/docs/logs)** - Capture what happened at each point, using the same OpenTelemetry setup
 - **[Error Tracking](/docs/error-tracking)** - Turn failures into issues you can assign and resolve

--- a/contents/docs/distributed-tracing/start-here.mdx
+++ b/contents/docs/distributed-tracing/start-here.mdx
@@ -1,12 +1,12 @@
 ---
-title: Getting started with Tracing
+title: Getting started with distributed tracing
 hideRightSidebar: true
 contentMaxWidthClass: max-w-5xl
 ---
 
 import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 
-> **Note:** Tracing is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Distributed tracing is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
 
 <QuestLog firstSpeechBubble="Let's set up tracing!" lastSpeechBubble="Time to explore your traces!">
 
@@ -16,7 +16,7 @@ import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
     icon="IconCode"
 >
 
-PostHog Tracing works with any OpenTelemetry client. No PostHog-specific packages are required. Use the OTel SDKs you already have, point your trace exporter at PostHog's HTTP endpoint, and add your project token.
+PostHog Distributed Tracing works with any OpenTelemetry client. No PostHog-specific packages are required. Use the OTel SDKs you already have, point your trace exporter at PostHog's HTTP endpoint, and add your project token.
 
 Set these on your OpenTelemetry SDK:
 
@@ -75,7 +75,7 @@ Once spans are flowing into PostHog, you can:
     icon="IconLogomark"
 >
 
-Tracing uses the same OpenTelemetry-based ingestion as [Logs](/docs/logs), so a single OTel setup covers both. Your traces also live in the same PostHog project as [Session Replay](/docs/session-replay), [Error Tracking](/docs/error-tracking), and [Product Analytics](/docs/product-analytics) – one platform instead of another observability vendor to run.
+Distributed tracing uses the same OpenTelemetry-based ingestion as [Logs](/docs/logs), so a single OTel setup covers both. Your traces also live in the same PostHog project as [Session Replay](/docs/session-replay), [Error Tracking](/docs/error-tracking), and [Product Analytics](/docs/product-analytics) – one platform instead of another observability vendor to run.
 
 </QuestLogItem>
 

--- a/contents/handbook/growth/use-case-selling/observability.md
+++ b/contents/handbook/growth/use-case-selling/observability.md
@@ -26,7 +26,7 @@ Separating this from Release Engineering is important because the buyer is often
 - **[Product Analytics](/docs/product-analytics)** — Error correlation with user behavior and business impact. Answer "how many users hit this error?" and "did this error cause drop-off in our conversion funnel?" Connect technical incidents to business outcomes.
 - **[PostHog AI](/docs/posthog-ai/allow-access)** — Natural language incident triage. "What errors spiked in the last hour and which users were affected?" without writing a query. Faster mean time to understanding during incidents. ([Example prompts](/docs/posthog-ai/example-prompts))
 - **Logging** *beta* — Centralized log collection and search. Logs are table stakes for any observability stack. Having logs alongside errors, replays, and analytics means the full debugging context lives in one place.
-- **[Tracing](/docs/tracing)** *alpha* — Distributed tracing over OpenTelemetry (OTLP). Follow a request across services to see what called what and where the time went, in the same project as errors, logs, replays, and analytics.
+- **[Distributed tracing](/docs/distributed-tracing)** *alpha* — Distributed tracing over OpenTelemetry (OTLP). Follow a request across services to see what called what and where the time went, in the same project as errors, logs, replays, and analytics.
 - *Roadmap: APM* — Not shipped yet. When full APM arrives, the observability story becomes complete: errors + logs + traces + replay + analytics in one platform.
 
 ## Adoption path and expansion path

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6899,18 +6899,18 @@ export const docsMenu = {
             ],
         },
         {
-            name: 'Tracing',
+            name: 'Distributed tracing',
             icon: 'IconListTree',
             color: 'purple',
-            url: '/docs/tracing',
+            url: '/docs/distributed-tracing',
             description: 'Capture and explore distributed traces with OpenTelemetry.',
             children: [
                 {
-                    name: 'Tracing',
+                    name: 'Distributed tracing',
                 },
                 {
                     name: 'Overview',
-                    url: '/docs/tracing',
+                    url: '/docs/distributed-tracing',
                     icon: 'IconHome',
                     color: 'seagreen',
                 },
@@ -6919,14 +6919,14 @@ export const docsMenu = {
                 },
                 {
                     name: 'Start here',
-                    url: '/docs/tracing/start-here',
+                    url: '/docs/distributed-tracing/start-here',
                     icon: 'IconListCheck',
                     color: 'orange',
                     featured: true,
                 },
                 {
-                    name: 'Why you need tracing',
-                    url: '/docs/tracing/basics',
+                    name: 'Why you need distributed tracing',
+                    url: '/docs/distributed-tracing/basics',
                     icon: 'IconBook',
                     color: 'seagreen',
                 },

--- a/src/pages/docs/distributed-tracing/index.tsx
+++ b/src/pages/docs/distributed-tracing/index.tsx
@@ -12,16 +12,18 @@ export const Content = () => {
                 <h2 className="mb-4">Overview</h2>
                 <div>
                     <p>
-                        PostHog Tracing is a distributed tracing solution that works with the OpenTelemetry Protocol
-                        (OTLP). You don't need any vendor-specific SDKs. Use standard OpenTelemetry libraries to send
-                        spans to PostHog using your project token.
+                        PostHog Distributed Tracing works with the OpenTelemetry Protocol (OTLP). You don't need any
+                        vendor-specific SDKs. Use standard OpenTelemetry libraries to send spans to PostHog using your
+                        project token.
                     </p>
-                    <p>Tracing is currently in alpha. Setup details may change before general availability.</p>
+                    <p>
+                        Distributed tracing is currently in alpha. Setup details may change before general availability.
+                    </p>
                 </div>
             </section>
 
             <section className="mb-8">
-                <h2 className="mb-4 mt-0">Why use PostHog Tracing?</h2>
+                <h2 className="mb-4 mt-0">Why use PostHog Distributed Tracing?</h2>
                 <div>
                     <ul>
                         <li>
@@ -43,7 +45,7 @@ export const Content = () => {
             <section className="mb-8">
                 <h2 className="mb-4 mt-0">How it works</h2>
                 <div>
-                    <p>Tracing acts as a generic OTLP receiver built by PostHog. Here's how it works:</p>
+                    <p>Distributed tracing acts as a generic OTLP receiver built by PostHog. Here's how it works:</p>
                     <ol>
                         <li>Use standard OpenTelemetry tracing APIs in your application</li>
                         <li>Include your project token in the Authorization header or as a query parameter</li>
@@ -60,13 +62,13 @@ export const Content = () => {
                         type="Getting started"
                         title="Why you need tracing"
                         description="What a trace is, what it shows you that nothing else does, and when it saves you"
-                        url="/docs/tracing/basics"
+                        url="/docs/distributed-tracing/basics"
                     />
                     <ResourceItem
                         type="Getting started"
                         title="Start here"
                         description="A high-level overview of setting up tracing with OpenTelemetry"
-                        url="/docs/tracing/start-here"
+                        url="/docs/distributed-tracing/start-here"
                     />
                     <ResourceItem
                         type="Related"
@@ -80,19 +82,19 @@ export const Content = () => {
     )
 }
 
-const Tracing: React.FC = () => {
+const DistributedTracing: React.FC = () => {
     return (
         <ReaderView>
-            <SEO title="Tracing - Docs - PostHog" />
+            <SEO title="Distributed tracing - Docs - PostHog" />
 
             <div className="mx-auto max-w-4xl">
                 <section className="mb-6">
                     <Intro
                         subheader="Getting started"
-                        title="Tracing"
+                        title="Distributed tracing"
                         description="Capture and explore distributed traces with PostHog and OpenTelemetry."
                         buttonText="Get started!"
-                        buttonLink="/docs/tracing/start-here"
+                        buttonLink="/docs/distributed-tracing/start-here"
                     />
                 </section>
 
@@ -102,4 +104,4 @@ const Tracing: React.FC = () => {
     )
 }
 
-export default Tracing
+export default DistributedTracing

--- a/vercel.json
+++ b/vercel.json
@@ -118,6 +118,8 @@
         { "source": "/docs/user-guides/:path*", "destination": "/manual/:path*" },
         { "source": "/docs/integrate/(client|server)/:path*", "destination": "/docs/integrate/:path*" },
         { "source": "/docs/session-recording/:path*", "destination": "/docs/session-replay/:path*" },
+        { "source": "/docs/tracing", "destination": "/docs/distributed-tracing", "statusCode": 301 },
+        { "source": "/docs/tracing/:path*", "destination": "/docs/distributed-tracing/:path*", "statusCode": 301 },
         {
             "source": "/docs/posthog-code/inbox/triage",
             "destination": "/docs/posthog-code/inbox/implementation",


### PR DESCRIPTION
## Changes

Disambiguates the **APM tracing product** from **AI Observability "Traces"**. Searching "posthog tracing" currently surfaces both, and in-docs search for "tracing" lands users on the LLM page. This renames the APM product to **Distributed tracing** — the exact-match phrase Datadog, New Relic, Honeycomb, and Grafana all reserve for the APM product.

**Slug + redirects**
- Moved `src/pages/docs/tracing/` → `src/pages/docs/distributed-tracing/` and `contents/docs/tracing/` → `contents/docs/distributed-tracing/`
- Added two 301 redirects in `vercel.json` (`/docs/tracing` and `/docs/tracing/:path*`)

**Labels & SEO**
- `<SEO title>` and page H1 → "Distributed tracing"
- Nav product card + section labels in `src/navs/index.js`
- Frontmatter titles in `start-here.mdx` / `basics.mdx`
- Body prose ("PostHog Distributed Tracing", the comparison-table row)

**Descriptive anchor text (link-equity / SERP clarity)**
- `contents/blog/posthog-vs-sentry.mdx` and `contents/handbook/growth/use-case-selling/observability.md` now link with "distributed tracing" anchor text instead of bare "tracing"

The AI Observability "Traces" docs are intentionally left untouched here — see the companion PR for the glossary page.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)