### PR TITLE
docs(cs): Add topics preparation to pre-outreach research

### DIFF
--- a/contents/handbook/cs-and-onboarding/engaging-unengaged-customers.md
+++ b/contents/handbook/cs-and-onboarding/engaging-unengaged-customers.md
@@ -14,7 +14,9 @@ The common thread: **do your homework first, then lead with something specific a
 
 ## Pre-outreach research
 
-Before reaching out, spend 10 minutes understanding where the customer is at. This makes all the difference between a generic check-in and a genuinely helpful conversation.
+Before reaching out, spend at least 10 minutes understanding where the customer is at. This makes all the difference between a generic check-in and a genuinely helpful conversation.
+
+Ideally, you should never enter a call without a backlog of proactive **relevant** topics to burn through if the primary issue is resolved quickly (like a new upcoming products,events, questions about their product). The goal isn't a quick check-in; it's ensuring that every minute the customer spends on a call with us feels insightful and necessary.
 
 ### Review their engagement metrics
 


### PR DESCRIPTION
## Changes

### Why?
Right now, the handbook frames pre-outreach research as a quick "10-minute check" to understand where a customer is at. While that's fine for a baseline technical check, it can make our outreach feel pretty transactional.

If you  jump on a call to debug a specific telemetry drop or bug, and it gets resolved in the first 5 minutes, you shouldn't just awkwardly end the call early. Research should be a framework to ensure yo never run out of high-leverage topics that make the customer's calendar time feel completely justified.

Unless the customer explicitly wants to hop off, you should try and achieve value as much value as possible. Like upcoming product betas, asking for feedback on tools they recently adopted, or talking about relevant platform trends.
### Before
`Before reaching out, spend 10 minutes understanding where the customer is at. This makes all the difference between a generic check-in and a genuinely helpful conversation.`

### After
`Before reaching out, spend at least 10 minutes [...]`

`Ideally, you should never enter a call without a backlog of proactive **relevant** topics to burn through if the primary issue is resolved quickly (like a new upcoming products,events, questions about their product). The goal isn't a quick check-in; it's ensuring that every minute the customer spends on a call with us feels insightful and necessary.`

## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [X] Use relative URLs for internal links
- [X] I've checked the pages added or changed in the Vercel preview build 
- [X] If I moved a page, I added a redirect in `vercel.json`
