### PR TITLE
docs(cs):Update CS core principles to focus on value

### DIFF
--- a/contents/handbook/cs-and-onboarding/customer-success.md
+++ b/contents/handbook/cs-and-onboarding/customer-success.md
@@ -8,7 +8,7 @@ Customer Success Managers (CSMs) help customers get more value out of PostHog so
 
 ## Principles
 
-- **Show, don't tell.** Help customers prioritize their needs, deliver bad news early, and stay on top of their questions. Under promise, over deliver.
+- **Show, don't tell.** Help customers prioritize their needs, deliver bad news early, and stay on top of their questions. Scope honestly, constantly deliver value. 
 - **Help them save money, even when it costs us short term.** Long-term value matters more.
 - **Be their voice inside PostHog.** Advocacy only works if you're willing to go to bat for them. Push product and engineering to understand why a feature matters.
 


### PR DESCRIPTION
## Changes

### Why?
Right now, the handbook uses the line "Under promise, over deliver." While the rest of the docs do a great job acknowledging the importance of offering value, this specific phrase can transmit the sensation that it's better to just focus on "overdelivering" as a metric rather than building truly meaningful exchanges with the customer.

Updating this phrasing to focus on honest scoping and continuous value fits the actual company culture much better in my opinion.

### Before
`Show, don't tell. Help customers prioritize their needs, deliver bad news early, and stay on top of their questions. Under promise, over deliver.
`

#### After
`Show, don't tell. Help customers prioritize their needs, deliver bad news early, and stay on top of their questions. Scope honestly, constantly deliver value.
`

Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [X] Use relative URLs for internal links
- [X] I've checked the pages added or changed in the Vercel preview build
- [X] If I moved a page, I added a redirect in vercel.json