### PR TITLE
feat: Document models in S3 batch export

### DIFF
--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -8,15 +8,60 @@ availability:
     enterprise: full
 ---
 
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+
 With batch exports, data can be exported to an S3 bucket.
 
 ## Models
 
-S3 supports all the models mentioned in the [batch export models reference](/docs/cdp/batch-exports#models).
-
-You can view the schema for each model inside the batch export configuration in the UI.
+This section describes the models that can be exported to S3.
 
 > **Note:** New fields may be added to these models over time. Therefore, it is recommended that any downstream processes are able to handle additional fields being added to the exported files.
+
+### Events model
+
+This is the default model for S3 batch exports. When exported in the Parquet file format, the schema is:
+
+| Field             | Type        | Description                                                                                                  |
+|-------------------|-------------|--------------------------------------------------------------------------------------------------------------|
+| uuid              | `STRING`    | The unique ID of the event within PostHog                                                                    |
+| event             | `STRING`    | The name of the event that was sent                                                                          |
+| distinct_id       | `STRING`    | The `distinct_id` of the user who sent the event                                                             |
+| person_id         | `STRING`    | The ID of the person the event is attributed to, resolved at ingestion time                                  |
+| properties        | `STRING`    | A JSON object with all the properties sent along with the event, stored as a JSON-encoded string in Parquet  |
+| person_properties | `STRING`    | A JSON object with the person's properties at ingestion time, stored as a JSON-encoded string in Parquet     |
+| elements_chain    | `STRING`    | The chain of DOM elements for `$autocapture` events. Empty for other events                                  |
+| timestamp         | `TIMESTAMP` | When the event occurred, as reported by the client. Microsecond precision, UTC                               |
+| created_at        | `TIMESTAMP` | When PostHog ingested the event. Microsecond precision, UTC                                                  |
+| _inserted_at      | `TIMESTAMP` | Internal field used by batch exports to track export progress. Included in files but safe to ignore          |
+
+> **Note:** The types above describe the **Parquet** file format. Other file formats represent the same data differently. For example, in **JSONLines** exports the timestamp fields (`timestamp`, `created_at`, and `_inserted_at`) are ISO 8601 strings, and `properties` and `person_properties` are nested JSON objects rather than JSON-encoded strings.
+
+### Persons model
+
+The schema of the persons model when exported in the Parquet file format is:
+
+| Field                      | Type        | Description                                                                                 |
+|----------------------------|-------------|---------------------------------------------------------------------------------------------|
+| team_id                    | `BIGINT`    | The ID of the project (team) the person belongs to                                          |
+| distinct_id                | `STRING`    | A `distinct_id` associated with the person                                                  |
+| person_id                  | `STRING`    | The ID of the person for this (`team_id`, `distinct_id`) pair                                |
+| properties                 | `STRING`    | A JSON object with the latest person properties, stored as a JSON-encoded string in Parquet |
+| person_distinct_id_version | `BIGINT`    | Internal version of the person-to-`distinct_id` mapping, used by batch exports during merges |
+| person_version             | `BIGINT`    | Internal version of the person's properties, used by batch exports during merges            |
+| created_at                 | `TIMESTAMP` | When the person was created. Microsecond precision, UTC                                      |
+| _inserted_at               | `TIMESTAMP` | Internal field used by batch exports to track export progress. Included in files but safe to ignore |
+| is_deleted                 | `BOOLEAN`   | Whether the person has been deleted                                                         |
+
+Each export contains one row per `(team_id, distinct_id)` pair, mapped to their corresponding `person_id` and latest `properties`.
+
+<PersonsModelNote />
+
+> **Note:** As with the events model, these types describe the **Parquet** file format. In **JSONLines** exports, `created_at` and `_inserted_at` are ISO 8601 strings and `properties` is a nested JSON object rather than a JSON-encoded string.
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
 
 
 ## Creating the batch export


### PR DESCRIPTION
## Changes

We don't document S3 models for some reason. The links just go back and forth. Haven't added sessions yet.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
