### PR TITLE
handbook: clarify billing email covers vendor contracts

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -106,7 +106,7 @@ Joining an offsite? _Only use the offsite budget_, not your User Limit - it help
     - [Attaching receipts for multiple expenses](https://www.brex.com/support/receipts-for-expenses#attaching-receipts-to-multiple-expenses)
 - What do I do if I have a new tool/enterprise software subscription for the team to use?
   - Add [Janani](https://posthog.com/community/profiles/34497) as the Billing Admin to manage payments.
-- If I'm asked for a billing email for bill payments, what do I use?
+- If I'm asked for a billing email – for bill payments or when signing a vendor contract – what do I use?
   - Use finance@posthog.com
 - What if I'm driving for work-related purposes?
   - You can claim a mileage reimbursement through Brex. **Do not** separately expense fuel.


### PR DESCRIPTION
## Changes

Broadens the billing-email FAQ entry in the handbook's [Spending money](https://posthog.com/handbook/people/spending-money) page so it's clear that `finance@posthog.com` is also the billing email to give when **signing a vendor contract**, not just for bill payments.

This came up in Slack: someone signing a contract with a vendor needed a billing email, and Janani confirmed `finance@posthog.com` is the right one. The fact was already in the FAQ but framed only around "bill payments", so it wasn't obvious it applied to vendor contracts too.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A — no page moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
