### PR TITLE
Fix layout padding for list item under components/roadmap

### DIFF
--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -347,7 +347,7 @@ export function InProgress(
                     )}
                 </ul>
             </SideModal>
-            <li className={`pb-4 border border-primary rounded-md ${props?.className ?? ''}`}>
+            <li className={`pb-4 pl-0 border border-primary rounded-md ${props?.className ?? ''}`}>
                 <div className="flex sm:flex-row sm:space-x-4 flex-col-reverse space-y-reverse sm:space-y-0 space-y-4 p-4 bg-accent rounded-t-md">
                     <div className="sm:flex-grow">
                         <h4 className="text-lg flex space-x-1 items-center !m-0">{title}</h4>


### PR DESCRIPTION
## Changes

Minor CSS fix to prevent padding-inline-start being added via Tailwind Typography plugin.

Before the change:

<img width="1125" height="654" alt="image" src="https://github.com/user-attachments/assets/832bb17d-584f-46d7-9e26-36db341bc0c8" />

After (tested locally):

<img width="1013" height="648" alt="image" src="https://github.com/user-attachments/assets/5c3d21d9-d52c-4d5b-ad46-767fe1ec0fe0" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
