### PR TITLE
docs: Flutter property overrides for flag evaluation

### DIFF
--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -83,6 +83,20 @@ PostHog.identify(
 val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
 ```
 
+```dart
+// Properties are automatically available for flag evaluation
+await Posthog().identify(
+    userId: 'user-123',
+    userProperties: {
+        'email': 'user@company.com',
+        'plan': 'enterprise',
+    },
+)
+
+// This flag check can use 'plan' immediately
+final showFeature = await Posthog().isFeatureEnabled('enterprise-feature')
+```
+
 </MultiLanguage>
 
 #### From group calls
@@ -133,6 +147,20 @@ PostHog.group(
 
 // Group properties are available for flag evaluation
 val showFeature = PostHog.isFeatureEnabled("enterprise-companies-feature")
+```
+
+```dart
+await Posthog().group(
+    groupType: 'company',
+    groupKey: 'company-123',
+    groupProperties: {
+        'name': 'Acme Inc',
+        'plan': 'enterprise',
+    },
+)
+
+// Group properties are available for flag evaluation
+final showFeature = await Posthog().isFeatureEnabled('enterprise-companies-feature')
 ```
 
 </MultiLanguage>
@@ -203,7 +231,7 @@ This adds the following properties to flag requests:
 
 ### Default properties in mobile SDKs
 
-Mobile SDKs (React Native, iOS, and Android) include common device and app properties in every feature flag evaluation request. The `setDefaultPersonProperties` configuration option controls this behavior and defaults to `true`.
+Mobile SDKs (React Native, iOS, Android, and Flutter) include common device and app properties in every feature flag evaluation request. The `setDefaultPersonProperties` configuration option controls this behavior and defaults to `true`.
 
 | Property | Description |
 |----------|-------------|
@@ -268,6 +296,17 @@ PostHog.setPersonPropertiesForFlags(
 val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
 ```
 
+```dart
+// Set properties for flag evaluation
+await Posthog().setPersonPropertiesForFlags({
+    'plan': 'enterprise',
+    'company_size': 'large',
+})
+
+// Properties persist across flag evaluations
+final showFeature = await Posthog().isFeatureEnabled('enterprise-feature')
+```
+
 </MultiLanguage>
 
 > **Note:** Properties set with `setPersonPropertiesForFlags()` are additive. Each call merges new properties with existing ones rather than replacing them.
@@ -314,6 +353,15 @@ PostHog.setPersonPropertiesForFlags(mapOf("company_size" to "large"), reloadFeat
 PostHog.reloadFeatureFlags()
 ```
 
+```dart
+// Set properties without reloading
+await Posthog().setPersonPropertiesForFlags({'plan': 'enterprise'}, reloadFeatureFlags: false)
+await Posthog().setPersonPropertiesForFlags({'company_size': 'large'}, reloadFeatureFlags: false)
+
+// Manually reload when ready
+await Posthog().reloadFeatureFlags()
+```
+
 </MultiLanguage>
 
 ### Resetting property overrides
@@ -336,6 +384,10 @@ PostHogSDK.shared.resetPersonPropertiesForFlags()
 
 ```kotlin file=Android
 PostHog.resetPersonPropertiesForFlags()
+```
+
+```dart
+await Posthog().resetPersonPropertiesForFlags()
 ```
 
 </MultiLanguage>
@@ -406,6 +458,20 @@ PostHog.resetGroupPropertiesForFlags("company")
 
 // Reset all group properties
 PostHog.resetGroupPropertiesForFlags()
+```
+
+```dart
+// Set group properties for flag evaluation
+await Posthog().setGroupPropertiesForFlags('company', {
+    'plan': 'enterprise',
+    'employee_count': 500,
+})
+
+// Reset group properties for a specific type
+await Posthog().resetGroupPropertiesForFlags(groupType: 'company')
+
+// Reset all group properties
+await Posthog().resetGroupPropertiesForFlags()
 ```
 
 </MultiLanguage>

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -44,7 +44,7 @@ posthog.identify('user-123', {
 })
 
 // This flag check can use 'is_beta_user' immediately
-const showFeature = posthog.isFeatureEnabled('enterprise-feature')
+const showFeature = posthog.isFeatureEnabled('beta-feature')
 ```
 
 ```react-native
@@ -55,7 +55,7 @@ posthog.identify('user-123', {
 })
 
 // This flag check can use 'is_beta_user' immediately
-const showFeature = posthog.isFeatureEnabled('enterprise-feature')
+const showFeature = posthog.isFeatureEnabled('beta-feature')
 ```
 
 ```swift file=iOS
@@ -66,7 +66,7 @@ PostHogSDK.shared.identify("user-123", userProperties: [
 ])
 
 // This flag check can use 'is_beta_user' immediately
-let showFeature = PostHogSDK.shared.isFeatureEnabled("enterprise-feature")
+let showFeature = PostHogSDK.shared.isFeatureEnabled("beta-feature")
 ```
 
 ```kotlin file=Android
@@ -80,7 +80,7 @@ PostHog.identify(
 )
 
 // This flag check can use 'is_beta_user' immediately
-val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
+val showFeature = PostHog.isFeatureEnabled("beta-feature")
 ```
 
 ```dart
@@ -94,7 +94,7 @@ await Posthog().identify(
 )
 
 // This flag check can use 'is_beta_user' immediately
-final showFeature = await Posthog().isFeatureEnabled('enterprise-feature')
+final showFeature = await Posthog().isFeatureEnabled('beta-feature')
 ```
 
 </MultiLanguage>
@@ -254,33 +254,33 @@ Use `setPersonPropertiesForFlags()` to explicitly set properties for flag evalua
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
     is_beta_user: true,
-    signup_source: 'organic'
+    country: 'US'
 })
 
 // Properties persist across flag evaluations
-const showFeature = posthog.isFeatureEnabled('enterprise-feature')
+const showFeature = posthog.isFeatureEnabled('beta-feature')
 ```
 
 ```react-native
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
     is_beta_user: true,
-    signup_source: 'organic'
+    country: 'US'
 })
 
 // Properties persist across flag evaluations
-const showFeature = posthog.isFeatureEnabled('enterprise-feature')
+const showFeature = posthog.isFeatureEnabled('beta-feature')
 ```
 
 ```swift file=iOS
 // Set properties for flag evaluation
 PostHogSDK.shared.setPersonPropertiesForFlags([
     "is_beta_user": true,
-    "signup_source": "organic"
+    "country": "US"
 ])
 
 // Properties persist across flag evaluations
-let showFeature = PostHogSDK.shared.isFeatureEnabled("enterprise-feature")
+let showFeature = PostHogSDK.shared.isFeatureEnabled("beta-feature")
 ```
 
 ```kotlin file=Android
@@ -288,23 +288,23 @@ let showFeature = PostHogSDK.shared.isFeatureEnabled("enterprise-feature")
 PostHog.setPersonPropertiesForFlags(
     mapOf(
         "is_beta_user" to true,
-        "signup_source" to "organic"
+        "country" to "US"
     )
 )
 
 // Properties persist across flag evaluations
-val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
+val showFeature = PostHog.isFeatureEnabled("beta-feature")
 ```
 
 ```dart
 // Set properties for flag evaluation
 await Posthog().setPersonPropertiesForFlags({
     'is_beta_user': true,
-    'signup_source': 'organic',
+    'country': 'US',
 })
 
 // Properties persist across flag evaluations
-final showFeature = await Posthog().isFeatureEnabled('enterprise-feature')
+final showFeature = await Posthog().isFeatureEnabled('beta-feature')
 ```
 
 </MultiLanguage>
@@ -320,7 +320,7 @@ By default, calling `setPersonPropertiesForFlags()` triggers an automatic reload
 ```js file=Web
 // Set properties without reloading
 posthog.setPersonPropertiesForFlags({ is_beta_user: true }, false)
-posthog.setPersonPropertiesForFlags({ signup_source: 'organic' }, false)
+posthog.setPersonPropertiesForFlags({ country: 'US' }, false)
 
 // Manually reload when ready
 posthog.reloadFeatureFlags()
@@ -329,7 +329,7 @@ posthog.reloadFeatureFlags()
 ```react-native
 // Set properties without reloading
 posthog.setPersonPropertiesForFlags({ is_beta_user: true }, false)
-posthog.setPersonPropertiesForFlags({ signup_source: 'organic' }, false)
+posthog.setPersonPropertiesForFlags({ country: 'US' }, false)
 
 // Manually reload when ready
 posthog.reloadFeatureFlags()
@@ -338,7 +338,7 @@ posthog.reloadFeatureFlags()
 ```swift file=iOS
 // Set properties without reloading
 PostHogSDK.shared.setPersonPropertiesForFlags(["is_beta_user": true], reloadFeatureFlags: false)
-PostHogSDK.shared.setPersonPropertiesForFlags(["signup_source": "organic"], reloadFeatureFlags: false)
+PostHogSDK.shared.setPersonPropertiesForFlags(["country": "US"], reloadFeatureFlags: false)
 
 // Manually reload when ready
 PostHogSDK.shared.reloadFeatureFlags()
@@ -347,7 +347,7 @@ PostHogSDK.shared.reloadFeatureFlags()
 ```kotlin file=Android
 // Set properties without reloading
 PostHog.setPersonPropertiesForFlags(mapOf("is_beta_user" to true), reloadFeatureFlags = false)
-PostHog.setPersonPropertiesForFlags(mapOf("signup_source" to "organic"), reloadFeatureFlags = false)
+PostHog.setPersonPropertiesForFlags(mapOf("country" to "US"), reloadFeatureFlags = false)
 
 // Manually reload when ready
 PostHog.reloadFeatureFlags()
@@ -356,7 +356,7 @@ PostHog.reloadFeatureFlags()
 ```dart
 // Set properties without reloading
 await Posthog().setPersonPropertiesForFlags({'is_beta_user': true}, reloadFeatureFlags: false)
-await Posthog().setPersonPropertiesForFlags({'signup_source': 'organic'}, reloadFeatureFlags: false)
+await Posthog().setPersonPropertiesForFlags({'country': 'US'}, reloadFeatureFlags: false)
 
 // Manually reload when ready
 await Posthog().reloadFeatureFlags()
@@ -532,7 +532,7 @@ Server-side SDKs handle property overrides differently. Instead of persistent se
 const flags = await client.evaluateFlags('user-distinct-id', {
     personProperties: {
         is_beta_user: true,
-        signup_source: 'organic',
+        country: 'US',
     },
     groups: {
         company: 'company-123',
@@ -553,7 +553,7 @@ flags = posthog.evaluate_flags(
     "user-distinct-id",
     person_properties={
         "is_beta_user": True,
-        "signup_source": "organic",
+        "country": "US",
     },
     groups={
         "company": "company-123",
@@ -574,7 +574,7 @@ $flags = PostHog::evaluateFlags(
     distinctId: 'user-distinct-id',
     personProperties: [
         'is_beta_user' => true,
-        'signup_source' => 'organic',
+        'country' => 'US',
     ],
     groups: [
         'company' => 'company-123',
@@ -595,7 +595,7 @@ flags = posthog.evaluate_flags(
     'user-distinct-id',
     person_properties: {
         is_beta_user: true,
-        signup_source: 'organic',
+        country: 'US',
     },
     groups: {
         company: 'company-123',
@@ -616,7 +616,7 @@ flags, err := client.EvaluateFlags(posthog.EvaluateFlagsPayload{
     DistinctId: "user-distinct-id",
     PersonProperties: posthog.NewProperties().
         Set("is_beta_user", true).
-        Set("signup_source", "organic"),
+        Set("country", "US"),
     Groups: posthog.NewGroups().
         Set("company", "company-123"),
     GroupProperties: map[string]posthog.Properties{
@@ -637,7 +637,7 @@ PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "user-distinct-id",
     PostHogEvaluateFlagsOptions.builder()
         .personProperty("is_beta_user", true)
-        .personProperty("signup_source", "organic")
+        .personProperty("country", "US")
         .group("company", "company-123")
         .groupProperty("company", "plan", "enterprise")
         .groupProperty("company", "employee_count", 500)

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -254,7 +254,7 @@ Use `setPersonPropertiesForFlags()` to explicitly set properties for flag evalua
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
     is_beta_user: true,
-    country: 'US'
+    email: 'user@company.com'
 })
 
 // Properties persist across flag evaluations
@@ -265,7 +265,7 @@ const showFeature = posthog.isFeatureEnabled('beta-feature')
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
     is_beta_user: true,
-    country: 'US'
+    email: 'user@company.com'
 })
 
 // Properties persist across flag evaluations
@@ -276,7 +276,7 @@ const showFeature = posthog.isFeatureEnabled('beta-feature')
 // Set properties for flag evaluation
 PostHogSDK.shared.setPersonPropertiesForFlags([
     "is_beta_user": true,
-    "country": "US"
+    "email": "user@company.com"
 ])
 
 // Properties persist across flag evaluations
@@ -288,7 +288,7 @@ let showFeature = PostHogSDK.shared.isFeatureEnabled("beta-feature")
 PostHog.setPersonPropertiesForFlags(
     mapOf(
         "is_beta_user" to true,
-        "country" to "US"
+        "email" to "user@company.com"
     )
 )
 
@@ -300,7 +300,7 @@ val showFeature = PostHog.isFeatureEnabled("beta-feature")
 // Set properties for flag evaluation
 await Posthog().setPersonPropertiesForFlags({
     'is_beta_user': true,
-    'country': 'US',
+    'email': 'user@company.com',
 })
 
 // Properties persist across flag evaluations
@@ -320,7 +320,7 @@ By default, calling `setPersonPropertiesForFlags()` triggers an automatic reload
 ```js file=Web
 // Set properties without reloading
 posthog.setPersonPropertiesForFlags({ is_beta_user: true }, false)
-posthog.setPersonPropertiesForFlags({ country: 'US' }, false)
+posthog.setPersonPropertiesForFlags({ email: 'user@company.com' }, false)
 
 // Manually reload when ready
 posthog.reloadFeatureFlags()
@@ -329,7 +329,7 @@ posthog.reloadFeatureFlags()
 ```react-native
 // Set properties without reloading
 posthog.setPersonPropertiesForFlags({ is_beta_user: true }, false)
-posthog.setPersonPropertiesForFlags({ country: 'US' }, false)
+posthog.setPersonPropertiesForFlags({ email: 'user@company.com' }, false)
 
 // Manually reload when ready
 posthog.reloadFeatureFlags()
@@ -338,7 +338,7 @@ posthog.reloadFeatureFlags()
 ```swift file=iOS
 // Set properties without reloading
 PostHogSDK.shared.setPersonPropertiesForFlags(["is_beta_user": true], reloadFeatureFlags: false)
-PostHogSDK.shared.setPersonPropertiesForFlags(["country": "US"], reloadFeatureFlags: false)
+PostHogSDK.shared.setPersonPropertiesForFlags(["email": "user@company.com"], reloadFeatureFlags: false)
 
 // Manually reload when ready
 PostHogSDK.shared.reloadFeatureFlags()
@@ -347,7 +347,7 @@ PostHogSDK.shared.reloadFeatureFlags()
 ```kotlin file=Android
 // Set properties without reloading
 PostHog.setPersonPropertiesForFlags(mapOf("is_beta_user" to true), reloadFeatureFlags = false)
-PostHog.setPersonPropertiesForFlags(mapOf("country" to "US"), reloadFeatureFlags = false)
+PostHog.setPersonPropertiesForFlags(mapOf("email" to "user@company.com"), reloadFeatureFlags = false)
 
 // Manually reload when ready
 PostHog.reloadFeatureFlags()
@@ -356,7 +356,7 @@ PostHog.reloadFeatureFlags()
 ```dart
 // Set properties without reloading
 await Posthog().setPersonPropertiesForFlags({'is_beta_user': true}, reloadFeatureFlags: false)
-await Posthog().setPersonPropertiesForFlags({'country': 'US'}, reloadFeatureFlags: false)
+await Posthog().setPersonPropertiesForFlags({'email': 'user@company.com'}, reloadFeatureFlags: false)
 
 // Manually reload when ready
 await Posthog().reloadFeatureFlags()
@@ -532,7 +532,7 @@ Server-side SDKs handle property overrides differently. Instead of persistent se
 const flags = await client.evaluateFlags('user-distinct-id', {
     personProperties: {
         is_beta_user: true,
-        country: 'US',
+        email: 'user@company.com',
     },
     groups: {
         company: 'company-123',
@@ -553,7 +553,7 @@ flags = posthog.evaluate_flags(
     "user-distinct-id",
     person_properties={
         "is_beta_user": True,
-        "country": "US",
+        "email": "user@company.com",
     },
     groups={
         "company": "company-123",
@@ -574,7 +574,7 @@ $flags = PostHog::evaluateFlags(
     distinctId: 'user-distinct-id',
     personProperties: [
         'is_beta_user' => true,
-        'country' => 'US',
+        'email' => 'user@company.com',
     ],
     groups: [
         'company' => 'company-123',
@@ -595,7 +595,7 @@ flags = posthog.evaluate_flags(
     'user-distinct-id',
     person_properties: {
         is_beta_user: true,
-        country: 'US',
+        email: 'user@company.com',
     },
     groups: {
         company: 'company-123',
@@ -616,7 +616,7 @@ flags, err := client.EvaluateFlags(posthog.EvaluateFlagsPayload{
     DistinctId: "user-distinct-id",
     PersonProperties: posthog.NewProperties().
         Set("is_beta_user", true).
-        Set("country", "US"),
+        Set("email", "user@company.com"),
     Groups: posthog.NewGroups().
         Set("company", "company-123"),
     GroupProperties: map[string]posthog.Properties{
@@ -637,7 +637,7 @@ PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "user-distinct-id",
     PostHogEvaluateFlagsOptions.builder()
         .personProperty("is_beta_user", true)
-        .personProperty("country", "US")
+        .personProperty("email", "user@company.com")
         .group("company", "company-123")
         .groupProperty("company", "plan", "enterprise")
         .groupProperty("company", "employee_count", 500)

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -254,7 +254,7 @@ Use `setPersonPropertiesForFlags()` to explicitly set properties for flag evalua
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
     plan: 'enterprise',
-    company_size: 'large'
+    signup_source: 'organic'
 })
 
 // Properties persist across flag evaluations
@@ -265,7 +265,7 @@ const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
     plan: 'enterprise',
-    company_size: 'large'
+    signup_source: 'organic'
 })
 
 // Properties persist across flag evaluations
@@ -276,7 +276,7 @@ const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 // Set properties for flag evaluation
 PostHogSDK.shared.setPersonPropertiesForFlags([
     "plan": "enterprise",
-    "company_size": "large"
+    "signup_source": "organic"
 ])
 
 // Properties persist across flag evaluations
@@ -288,7 +288,7 @@ let showFeature = PostHogSDK.shared.isFeatureEnabled("enterprise-feature")
 PostHog.setPersonPropertiesForFlags(
     mapOf(
         "plan" to "enterprise",
-        "company_size" to "large"
+        "signup_source" to "organic"
     )
 )
 
@@ -300,7 +300,7 @@ val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
 // Set properties for flag evaluation
 await Posthog().setPersonPropertiesForFlags({
     'plan': 'enterprise',
-    'company_size': 'large',
+    'signup_source': 'organic',
 })
 
 // Properties persist across flag evaluations
@@ -320,7 +320,7 @@ By default, calling `setPersonPropertiesForFlags()` triggers an automatic reload
 ```js file=Web
 // Set properties without reloading
 posthog.setPersonPropertiesForFlags({ plan: 'enterprise' }, false)
-posthog.setPersonPropertiesForFlags({ company_size: 'large' }, false)
+posthog.setPersonPropertiesForFlags({ signup_source: 'organic' }, false)
 
 // Manually reload when ready
 posthog.reloadFeatureFlags()
@@ -329,7 +329,7 @@ posthog.reloadFeatureFlags()
 ```react-native
 // Set properties without reloading
 posthog.setPersonPropertiesForFlags({ plan: 'enterprise' }, false)
-posthog.setPersonPropertiesForFlags({ company_size: 'large' }, false)
+posthog.setPersonPropertiesForFlags({ signup_source: 'organic' }, false)
 
 // Manually reload when ready
 posthog.reloadFeatureFlags()
@@ -338,7 +338,7 @@ posthog.reloadFeatureFlags()
 ```swift file=iOS
 // Set properties without reloading
 PostHogSDK.shared.setPersonPropertiesForFlags(["plan": "enterprise"], reloadFeatureFlags: false)
-PostHogSDK.shared.setPersonPropertiesForFlags(["company_size": "large"], reloadFeatureFlags: false)
+PostHogSDK.shared.setPersonPropertiesForFlags(["signup_source": "organic"], reloadFeatureFlags: false)
 
 // Manually reload when ready
 PostHogSDK.shared.reloadFeatureFlags()
@@ -347,7 +347,7 @@ PostHogSDK.shared.reloadFeatureFlags()
 ```kotlin file=Android
 // Set properties without reloading
 PostHog.setPersonPropertiesForFlags(mapOf("plan" to "enterprise"), reloadFeatureFlags = false)
-PostHog.setPersonPropertiesForFlags(mapOf("company_size" to "large"), reloadFeatureFlags = false)
+PostHog.setPersonPropertiesForFlags(mapOf("signup_source" to "organic"), reloadFeatureFlags = false)
 
 // Manually reload when ready
 PostHog.reloadFeatureFlags()
@@ -356,7 +356,7 @@ PostHog.reloadFeatureFlags()
 ```dart
 // Set properties without reloading
 await Posthog().setPersonPropertiesForFlags({'plan': 'enterprise'}, reloadFeatureFlags: false)
-await Posthog().setPersonPropertiesForFlags({'company_size': 'large'}, reloadFeatureFlags: false)
+await Posthog().setPersonPropertiesForFlags({'signup_source': 'organic'}, reloadFeatureFlags: false)
 
 // Manually reload when ready
 await Posthog().reloadFeatureFlags()
@@ -532,7 +532,7 @@ Server-side SDKs handle property overrides differently. Instead of persistent se
 const flags = await client.evaluateFlags('user-distinct-id', {
     personProperties: {
         plan: 'enterprise',
-        company_size: 'large',
+        signup_source: 'organic',
     },
     groups: {
         company: 'company-123',
@@ -553,7 +553,7 @@ flags = posthog.evaluate_flags(
     "user-distinct-id",
     person_properties={
         "plan": "enterprise",
-        "company_size": "large",
+        "signup_source": "organic",
     },
     groups={
         "company": "company-123",
@@ -574,7 +574,7 @@ $flags = PostHog::evaluateFlags(
     distinctId: 'user-distinct-id',
     personProperties: [
         'plan' => 'enterprise',
-        'company_size' => 'large',
+        'signup_source' => 'organic',
     ],
     groups: [
         'company' => 'company-123',
@@ -595,7 +595,7 @@ flags = posthog.evaluate_flags(
     'user-distinct-id',
     person_properties: {
         plan: 'enterprise',
-        company_size: 'large',
+        signup_source: 'organic',
     },
     groups: {
         company: 'company-123',
@@ -616,7 +616,7 @@ flags, err := client.EvaluateFlags(posthog.EvaluateFlagsPayload{
     DistinctId: "user-distinct-id",
     PersonProperties: posthog.NewProperties().
         Set("plan", "enterprise").
-        Set("company_size", "large"),
+        Set("signup_source", "organic"),
     Groups: posthog.NewGroups().
         Set("company", "company-123"),
     GroupProperties: map[string]posthog.Properties{
@@ -637,7 +637,7 @@ PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "user-distinct-id",
     PostHogEvaluateFlagsOptions.builder()
         .personProperty("plan", "enterprise")
-        .personProperty("company_size", "large")
+        .personProperty("signup_source", "organic")
         .group("company", "company-123")
         .groupProperty("company", "plan", "enterprise")
         .groupProperty("company", "employee_count", 500)

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -40,10 +40,10 @@ When you call `identify()` with person properties, those properties are automati
 // Properties are automatically available for flag evaluation
 posthog.identify('user-123', {
     email: 'user@company.com',
-    plan: 'enterprise'
+    is_beta_user: true
 })
 
-// This flag check can use 'plan' immediately
+// This flag check can use 'is_beta_user' immediately
 const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 ```
 
@@ -51,10 +51,10 @@ const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 // Properties are automatically available for flag evaluation
 posthog.identify('user-123', {
     email: 'user@company.com',
-    plan: 'enterprise'
+    is_beta_user: true
 })
 
-// This flag check can use 'plan' immediately
+// This flag check can use 'is_beta_user' immediately
 const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 ```
 
@@ -62,10 +62,10 @@ const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 // Properties are automatically available for flag evaluation
 PostHogSDK.shared.identify("user-123", userProperties: [
     "email": "user@company.com",
-    "plan": "enterprise"
+    "is_beta_user": true
 ])
 
-// This flag check can use 'plan' immediately
+// This flag check can use 'is_beta_user' immediately
 let showFeature = PostHogSDK.shared.isFeatureEnabled("enterprise-feature")
 ```
 
@@ -75,11 +75,11 @@ PostHog.identify(
     "user-123",
     userProperties = mapOf(
         "email" to "user@company.com",
-        "plan" to "enterprise"
+        "is_beta_user" to true
     )
 )
 
-// This flag check can use 'plan' immediately
+// This flag check can use 'is_beta_user' immediately
 val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
 ```
 
@@ -89,11 +89,11 @@ await Posthog().identify(
     userId: 'user-123',
     userProperties: {
         'email': 'user@company.com',
-        'plan': 'enterprise',
+        'is_beta_user': true,
     },
 )
 
-// This flag check can use 'plan' immediately
+// This flag check can use 'is_beta_user' immediately
 final showFeature = await Posthog().isFeatureEnabled('enterprise-feature')
 ```
 
@@ -253,7 +253,7 @@ Use `setPersonPropertiesForFlags()` to explicitly set properties for flag evalua
 ```js file=Web
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
-    plan: 'enterprise',
+    is_beta_user: true,
     signup_source: 'organic'
 })
 
@@ -264,7 +264,7 @@ const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 ```react-native
 // Set properties for flag evaluation
 posthog.setPersonPropertiesForFlags({
-    plan: 'enterprise',
+    is_beta_user: true,
     signup_source: 'organic'
 })
 
@@ -275,7 +275,7 @@ const showFeature = posthog.isFeatureEnabled('enterprise-feature')
 ```swift file=iOS
 // Set properties for flag evaluation
 PostHogSDK.shared.setPersonPropertiesForFlags([
-    "plan": "enterprise",
+    "is_beta_user": true,
     "signup_source": "organic"
 ])
 
@@ -287,7 +287,7 @@ let showFeature = PostHogSDK.shared.isFeatureEnabled("enterprise-feature")
 // Set properties for flag evaluation
 PostHog.setPersonPropertiesForFlags(
     mapOf(
-        "plan" to "enterprise",
+        "is_beta_user" to true,
         "signup_source" to "organic"
     )
 )
@@ -299,7 +299,7 @@ val showFeature = PostHog.isFeatureEnabled("enterprise-feature")
 ```dart
 // Set properties for flag evaluation
 await Posthog().setPersonPropertiesForFlags({
-    'plan': 'enterprise',
+    'is_beta_user': true,
     'signup_source': 'organic',
 })
 
@@ -319,7 +319,7 @@ By default, calling `setPersonPropertiesForFlags()` triggers an automatic reload
 
 ```js file=Web
 // Set properties without reloading
-posthog.setPersonPropertiesForFlags({ plan: 'enterprise' }, false)
+posthog.setPersonPropertiesForFlags({ is_beta_user: true }, false)
 posthog.setPersonPropertiesForFlags({ signup_source: 'organic' }, false)
 
 // Manually reload when ready
@@ -328,7 +328,7 @@ posthog.reloadFeatureFlags()
 
 ```react-native
 // Set properties without reloading
-posthog.setPersonPropertiesForFlags({ plan: 'enterprise' }, false)
+posthog.setPersonPropertiesForFlags({ is_beta_user: true }, false)
 posthog.setPersonPropertiesForFlags({ signup_source: 'organic' }, false)
 
 // Manually reload when ready
@@ -337,7 +337,7 @@ posthog.reloadFeatureFlags()
 
 ```swift file=iOS
 // Set properties without reloading
-PostHogSDK.shared.setPersonPropertiesForFlags(["plan": "enterprise"], reloadFeatureFlags: false)
+PostHogSDK.shared.setPersonPropertiesForFlags(["is_beta_user": true], reloadFeatureFlags: false)
 PostHogSDK.shared.setPersonPropertiesForFlags(["signup_source": "organic"], reloadFeatureFlags: false)
 
 // Manually reload when ready
@@ -346,7 +346,7 @@ PostHogSDK.shared.reloadFeatureFlags()
 
 ```kotlin file=Android
 // Set properties without reloading
-PostHog.setPersonPropertiesForFlags(mapOf("plan" to "enterprise"), reloadFeatureFlags = false)
+PostHog.setPersonPropertiesForFlags(mapOf("is_beta_user" to true), reloadFeatureFlags = false)
 PostHog.setPersonPropertiesForFlags(mapOf("signup_source" to "organic"), reloadFeatureFlags = false)
 
 // Manually reload when ready
@@ -355,7 +355,7 @@ PostHog.reloadFeatureFlags()
 
 ```dart
 // Set properties without reloading
-await Posthog().setPersonPropertiesForFlags({'plan': 'enterprise'}, reloadFeatureFlags: false)
+await Posthog().setPersonPropertiesForFlags({'is_beta_user': true}, reloadFeatureFlags: false)
 await Posthog().setPersonPropertiesForFlags({'signup_source': 'organic'}, reloadFeatureFlags: false)
 
 // Manually reload when ready
@@ -531,7 +531,7 @@ Server-side SDKs handle property overrides differently. Instead of persistent se
 ```node
 const flags = await client.evaluateFlags('user-distinct-id', {
     personProperties: {
-        plan: 'enterprise',
+        is_beta_user: true,
         signup_source: 'organic',
     },
     groups: {
@@ -552,7 +552,7 @@ const flagValue = flags.getFlag('feature-flag-key')
 flags = posthog.evaluate_flags(
     "user-distinct-id",
     person_properties={
-        "plan": "enterprise",
+        "is_beta_user": True,
         "signup_source": "organic",
     },
     groups={
@@ -573,7 +573,7 @@ flag_value = flags.get_flag("feature-flag-key")
 $flags = PostHog::evaluateFlags(
     distinctId: 'user-distinct-id',
     personProperties: [
-        'plan' => 'enterprise',
+        'is_beta_user' => true,
         'signup_source' => 'organic',
     ],
     groups: [
@@ -594,7 +594,7 @@ $flagValue = $flags->getFlag('feature-flag-key');
 flags = posthog.evaluate_flags(
     'user-distinct-id',
     person_properties: {
-        plan: 'enterprise',
+        is_beta_user: true,
         signup_source: 'organic',
     },
     groups: {
@@ -615,7 +615,7 @@ flag_value = flags.get_flag('feature-flag-key')
 flags, err := client.EvaluateFlags(posthog.EvaluateFlagsPayload{
     DistinctId: "user-distinct-id",
     PersonProperties: posthog.NewProperties().
-        Set("plan", "enterprise").
+        Set("is_beta_user", true).
         Set("signup_source", "organic"),
     Groups: posthog.NewGroups().
         Set("company", "company-123"),
@@ -636,7 +636,7 @@ flagValue := flags.GetFlag("feature-flag-key")
 PostHogFeatureFlagEvaluations flags = posthog.evaluateFlags(
     "user-distinct-id",
     PostHogEvaluateFlagsOptions.builder()
-        .personProperty("plan", "enterprise")
+        .personProperty("is_beta_user", true)
         .personProperty("signup_source", "organic")
         .group("company", "company-123")
         .groupProperty("company", "plan", "enterprise")

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -146,6 +146,23 @@ import FlutterFeatureFlagsCode from '../../integrate/feature-flags-code/_snippet
 
 <FlutterFeatureFlagsCode />
 
+### Setting properties for flag evaluation
+
+If a flag targets person or group properties, you can send those properties inline with the next flag evaluation request instead of waiting for a `$set` event to be ingested. This avoids the race where a flag returns a stale value right after you set a property.
+
+```dart
+// Person properties — included in the next flag evaluation request
+await Posthog().setPersonPropertiesForFlags({
+    'storefront_country': 'US',
+    'plan': 'enterprise',
+})
+
+// Group properties
+await Posthog().setGroupPropertiesForFlags('company', {'plan': 'enterprise'})
+```
+
+By default these reload feature flags, and the returned `Future` completes once the reload finishes, so the next `getFeatureFlag` reflects the new properties. Pass `reloadFeatureFlags: false` to set several properties before reloading. Use `resetPersonPropertiesForFlags()` and `resetGroupPropertiesForFlags()` to clear them. See [property overrides for flag evaluation](/docs/feature-flags/property-overrides) for details.
+
 ## Experiments (A/B tests)
 
 Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code:

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -154,7 +154,7 @@ If a flag targets person or group properties, you can send those properties inli
 // Person properties — included in the next flag evaluation request
 await Posthog().setPersonPropertiesForFlags({
     'storefront_country': 'US',
-    'plan': 'enterprise',
+    'is_beta_user': true,
 })
 
 // Group properties


### PR DESCRIPTION
Adds Flutter/Dart documentation for the new `setPersonPropertiesForFlags`, `setGroupPropertiesForFlags`, and `reset*` APIs shipping in `posthog_flutter` (PostHog/posthog-flutter#412).

## Changes
- **Property overrides page**: added Dart/Flutter tabs to all six `<MultiLanguage>` examples (identify, group, `setPersonPropertiesForFlags`, reload control, reset, group overrides).
- **Flutter library page**: new "Setting properties for flag evaluation" subsection linking to the property-overrides page.
- Added Flutter to the mobile default-properties list.

Brings Flutter to parity with the iOS / Android / React Native docs for property overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)