### PR TITLE
docs: rename teams to AI Gateway and AI Observability

### DIFF
--- a/contents/handbook/cs-and-onboarding/engaging-unengaged-customers.md
+++ b/contents/handbook/cs-and-onboarding/engaging-unengaged-customers.md
@@ -66,7 +66,7 @@ Watch customer activity for signs they're exploring a product they haven't adopt
 
 **Suggested wording:**
 
-> Hey @[contact], saw you checking out LLM analytics and wanted to share a few things. It occurred to me that our LLM observability suite might be really helpful for your team.
+> Hey @[contact], saw you checking out AI observability and wanted to share a few things. It occurred to me that our LLM observability suite might be really helpful for your team.
 >
 > Not only do you get evals/traces/generations to track model performance, token usage, etc, you can then also connect those things back to PostHog session/user data. Which means you can actually easily run A/B and multivariate tests on things like prompts, models, and so on, while ALSO seeing how the LLM performance/quality have an impact on conversion and funnel.
 >

--- a/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
+++ b/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
@@ -77,9 +77,9 @@ Review the logs at `/tmp/posthog-wizard.log`. This log can be quite verbose, so 
 
 Potential points of upstream failure:
 
-- Without OAuth from PostHog, the wizard cannot access the LLM gateway. This will prevent all wizard runs. But if OAuth is not possible, we've probably got bigger problems than just the wizard itself.
+- Without OAuth from PostHog, the wizard cannot access the AI gateway. This will prevent all wizard runs. But if OAuth is not possible, we've probably got bigger problems than just the wizard itself.
 - If GitHub's release artifacts are not available, the wizard will be guessing blindly at how to integrate PostHog, producing incorrect and incomplete integrations.
-- If wizard's agent harness cannot connect to the LLM gateway, the wizard run will fail.
+- If wizard's agent harness cannot connect to the AI gateway, the wizard run will fail.
 - If Anthropic's API is down, the wizard run will fail.
 
 The wizard has the above upstream dependencies. It is also a bundle of client code, subject to various bugs and distribution mishaps. If upstream services are healthy but the wizard is still failing, it's likely a bug in the wizard itself.
@@ -92,6 +92,6 @@ Remember to do a quick sanity check after release with `npm @posthog/wizard@late
 
 ### Declare an incident
 
-If an upstream dependent PostHog service like OAuth or the LLM gateway is down, an incident may already in progress. Check the #incidents channel for any related alerts. If not, [declare an incident](/handbook/engineering/operations/incidents), describing the highest-level issue that's causing the wizard to fail.
+If an upstream dependent PostHog service like OAuth or the AI gateway is down, an incident may already in progress. Check the #incidents channel for any related alerts. If not, [declare an incident](/handbook/engineering/operations/incidents), describing the highest-level issue that's causing the wizard to fail.
 
 If the wizard client code itself is failing, that's an incident as well.

--- a/contents/handbook/marketing/ownership.md
+++ b/contents/handbook/marketing/ownership.md
@@ -23,8 +23,8 @@ We generally only have product marketers on teams that _already_ have a product 
 | *PostHog Code* | Annika | Cleo | James H |
 | *Replay* | Cory S | Sara* | Paul D'A |
 | *Surveys* | Cory S | | Surveys |
-| *LLM Analytics* | Marco (new) | To be hired | James H |
-| *LLM Gateway* | Marco (new) | | Ben W |
+| *AI Observability* | Marco (new) | To be hired | James H |
+| *AI Gateway* | Marco (new) | | Ben W |
 | *Product Analytics* | Mike W | To be hired | Paul D'A |
 | *Web Analytics* | Mike W | To be hired | Paul D'A |
 | *Conversations* | | Too early | James H |

--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -16,7 +16,7 @@ Products we know will work well if we ship them:
   - Think error tracking or feature flags. The [persona doesn't change](/handbook/who-we-build-for#our-current-persona) as the company gets bigger.
   - Especially true if it works for a 2 person startup, because that means we get in first
 - Products that are in extremely fast growing markets
-  - Think LLM Analytics, MCP 
+  - Think AI Observability, MCP 
 - Products that are very easy to integrate for our existing customers. 
   - For example, users can enable the product in PostHog without needing to make a code change, or products that built on top of data that people are already collecting in PostHog
 - Products that _you_ are excited to build. 

--- a/contents/teams/ai-gateway/index.mdx
+++ b/contents/teams/ai-gateway/index.mdx
@@ -6,7 +6,7 @@ hideAnchor: false
 template: team
 ---
 
-The AI gateway is PostHog's internal routing layer for calling LLM providers. It gives PostHog's AI features a single endpoint to call, with shared handling for things like provider routing, caching, fallbacks, and cost attribution. The team owns the gateway service, its provider integrations, the [AI Observability Playground](/docs/ai-observability/playground), and the seams where the gateway connects into the rest of PostHog — particularly <SmallTeam slug="ai-observability" />.
+The AI gateway is PostHog's internal routing layer for calling LLM providers. It gives PostHog's AI features a single endpoint to call, with shared handling for things like provider routing, caching, fallbacks, and cost attribution. The team owns the gateway service, its provider integrations, the [AI Observability Playground](/docs/ai-observability/playground), and the seams where the gateway connects into the rest of PostHog – particularly <SmallTeam slug="ai-observability" />.
 
 ## Working with other teams
 

--- a/contents/teams/ai-gateway/index.mdx
+++ b/contents/teams/ai-gateway/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: LLM Gateway
+title: AI Gateway
 sidebar: Handbook
 showTitle: true
 hideAnchor: false
 template: team
 ---
 
-The LLM gateway is PostHog's internal routing layer for calling LLM providers. It gives PostHog's AI features a single endpoint to call, with shared handling for things like provider routing, caching, fallbacks, and cost attribution. The team owns the gateway service, its provider integrations, the [AI Observability Playground](/docs/ai-observability/playground), and the seams where the gateway connects into the rest of PostHog — particularly <SmallTeam slug="ai-observability" />.
+The AI gateway is PostHog's internal routing layer for calling LLM providers. It gives PostHog's AI features a single endpoint to call, with shared handling for things like provider routing, caching, fallbacks, and cost attribution. The team owns the gateway service, its provider integrations, the [AI Observability Playground](/docs/ai-observability/playground), and the seams where the gateway connects into the rest of PostHog — particularly <SmallTeam slug="ai-observability" />.
 
 ## Working with other teams
 

--- a/src/pages/startups/[...slug].tsx
+++ b/src/pages/startups/[...slug].tsx
@@ -147,7 +147,7 @@ export default function Startups(): JSX.Element {
                                         <p className="m-0">
                                             PostHog for Startups helps early-stage teams and founders build better
                                             products, faster. Get over $50,000 in credits to use across any PostHog
-                                            features, including LLM analytics.
+                                            features, including AI observability.
                                         </p>
                                     ),
                                 },


### PR DESCRIPTION
## Changes

Renames stale references to match current team names:

- `LLM Gateway` → `AI Gateway`: team page (`contents/teams/ai-gateway/index.mdx`), wizard runbook, marketing ownership row
- `LLM Analytics` → `AI Observability`: `which-products.md`, marketing ownership row, CS sample message, startups page

Scoped to display text. Left for marketing to decide, since "LLM analytics" may be a deliberate SEO keyword and some refs are functional: the `/marketing/positioning/llm-analytics` page, the `.vale` product-name allowlist, the generated `InternalLinkData.csv`, the `/docs/api/llm-analytics` nav URL (real API slug), `ProductChangelog.tsx` team-label keys, `ko/_translations.ts`, and published blog posts.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A, no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*