### PR TITLE
feat: add hedgehog mode toggle to "things that spark joy" menu

### DIFF
--- a/src/components/HedgehogMode/index.tsx
+++ b/src/components/HedgehogMode/index.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useState } from 'react'
+import React, { lazy, Suspense, useEffect, useSyncExternalStore } from 'react'
 
 const HedgeHogModeRenderer =
     typeof window !== 'undefined'
@@ -6,34 +6,40 @@ const HedgeHogModeRenderer =
         : () => null
 
 const HEDGEHOG_MODE_STORAGE_KEY = 'hedgehog-mode-enabled'
-const HEDGEHOG_MODE_EVENT = 'hedgehog-mode-changed'
 
-const getHedgehogModeEnabled = () => {
+// localStorage is the source of truth; an external store lets every caller
+// (the menu toggle and the renderer) stay in sync and re-render live, without a
+// reload. The `storage` event keeps separate tabs in sync.
+const listeners = new Set<() => void>()
+
+const getHedgehogModeEnabled = (): boolean => {
     return typeof window !== 'undefined' && localStorage.getItem(HEDGEHOG_MODE_STORAGE_KEY) === 'true'
 }
 
-// Shared across every caller so a toggle in one place (e.g. the menu) updates the
-// renderer live, without a reload. State changes broadcast a window event; the
-// `storage` event keeps it in sync across tabs.
-export const useHedgehogMode = (): [boolean, (enabled: boolean) => void] => {
-    const [hedgehogModeEnabled, setHedgehogModeEnabled] = useState(getHedgehogModeEnabled())
-
-    useEffect(() => {
-        const sync = () => setHedgehogModeEnabled(getHedgehogModeEnabled())
-        window.addEventListener(HEDGEHOG_MODE_EVENT, sync)
-        window.addEventListener('storage', sync)
-        return () => {
-            window.removeEventListener(HEDGEHOG_MODE_EVENT, sync)
-            window.removeEventListener('storage', sync)
-        }
-    }, [])
-
-    const _setHedgehogModeEnabled = (enabled: boolean) => {
-        localStorage.setItem(HEDGEHOG_MODE_STORAGE_KEY, enabled.toString())
-        window.dispatchEvent(new Event(HEDGEHOG_MODE_EVENT))
+const setHedgehogModeEnabledStore = (enabled: boolean): void => {
+    if (typeof window === 'undefined') {
+        return
     }
+    localStorage.setItem(HEDGEHOG_MODE_STORAGE_KEY, enabled.toString())
+    listeners.forEach((listener) => listener())
+}
 
-    return [hedgehogModeEnabled, _setHedgehogModeEnabled]
+const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener)
+    window.addEventListener('storage', listener)
+    return () => {
+        listeners.delete(listener)
+        window.removeEventListener('storage', listener)
+    }
+}
+
+export const useHedgehogMode = (): [boolean, (enabled: boolean) => void] => {
+    const hedgehogModeEnabled = useSyncExternalStore(
+        subscribe,
+        getHedgehogModeEnabled,
+        () => false // server snapshot
+    )
+    return [hedgehogModeEnabled, setHedgehogModeEnabledStore]
 }
 
 export default function HedgeHogModeEmbed(): JSX.Element | null {

--- a/src/components/HedgehogMode/index.tsx
+++ b/src/components/HedgehogMode/index.tsx
@@ -5,16 +5,32 @@ const HedgeHogModeRenderer =
         ? lazy(() => import('@posthog/hedgehog-mode').then((module) => ({ default: module.HedgehogModeRenderer })))
         : () => null
 
+const HEDGEHOG_MODE_STORAGE_KEY = 'hedgehog-mode-enabled'
+const HEDGEHOG_MODE_EVENT = 'hedgehog-mode-changed'
+
 const getHedgehogModeEnabled = () => {
-    return typeof window !== 'undefined' && localStorage.getItem('hedgehog-mode-enabled') === 'true'
+    return typeof window !== 'undefined' && localStorage.getItem(HEDGEHOG_MODE_STORAGE_KEY) === 'true'
 }
 
+// Shared across every caller so a toggle in one place (e.g. the menu) updates the
+// renderer live, without a reload. State changes broadcast a window event; the
+// `storage` event keeps it in sync across tabs.
 export const useHedgehogMode = (): [boolean, (enabled: boolean) => void] => {
     const [hedgehogModeEnabled, setHedgehogModeEnabled] = useState(getHedgehogModeEnabled())
 
+    useEffect(() => {
+        const sync = () => setHedgehogModeEnabled(getHedgehogModeEnabled())
+        window.addEventListener(HEDGEHOG_MODE_EVENT, sync)
+        window.addEventListener('storage', sync)
+        return () => {
+            window.removeEventListener(HEDGEHOG_MODE_EVENT, sync)
+            window.removeEventListener('storage', sync)
+        }
+    }, [])
+
     const _setHedgehogModeEnabled = (enabled: boolean) => {
-        localStorage.setItem('hedgehog-mode-enabled', enabled.toString())
-        setHedgehogModeEnabled(enabled)
+        localStorage.setItem(HEDGEHOG_MODE_STORAGE_KEY, enabled.toString())
+        window.dispatchEvent(new Event(HEDGEHOG_MODE_EVENT))
     }
 
     return [hedgehogModeEnabled, _setHedgehogModeEnabled]
@@ -28,8 +44,8 @@ export default function HedgeHogModeEmbed(): JSX.Element | null {
         const hedgehogModeForceValue = window.location.search.includes('hedgehog_mode=true')
             ? true
             : window.location.search.includes('hedgehog_mode=false')
-            ? false
-            : undefined
+              ? false
+              : undefined
 
         if (hedgehogModeForceValue !== undefined && hedgehogModeForceValue !== hedgehogModeEnabled) {
             setHedgehogModeEnabled(hedgehogModeForceValue)

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -28,6 +28,8 @@ import {
 } from 'components/OSIcons'
 import { useApp } from '../../context/App'
 import { IconChevronDown } from '@posthog/icons'
+import { useHedgehogMode } from 'components/HedgehogMode'
+import Toggle from 'components/Toggle'
 import { navigate } from 'gatsby'
 import { useToast } from '../../context/Toast'
 import usePostHog from '../../hooks/usePostHog'
@@ -338,6 +340,7 @@ export function useMenuData(): MenuType[] {
     } = useApp()
     const { addToast } = useToast()
     const posthog = usePostHog()
+    const [hedgehogModeEnabled, setHedgehogModeEnabled] = useHedgehogMode()
 
     // Define main navigation items (excluding logo menu)
     const mainNavItems: MenuType[] = [
@@ -654,6 +657,19 @@ export function useMenuData(): MenuType[] {
                     label: 'Things that spark joy',
                     icon: <IconSparksJoy className="size-4" />,
                     items: [
+                        {
+                            type: 'item',
+                            onClick: () => setHedgehogModeEnabled(!hedgehogModeEnabled),
+                            node: (
+                                <span className="px-2.5 flex w-full justify-between items-center gap-2">
+                                    <span>Hedgehog mode</span>
+                                    <Toggle checked={hedgehogModeEnabled} onChange={() => undefined} />
+                                </span>
+                            ),
+                        },
+                        {
+                            type: 'separator',
+                        },
                         {
                             type: 'item',
                             label: 'Browse all',

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -29,7 +29,6 @@ import {
 import { useApp } from '../../context/App'
 import { IconChevronDown } from '@posthog/icons'
 import { useHedgehogMode } from 'components/HedgehogMode'
-import Toggle from 'components/Toggle'
 import { navigate } from 'gatsby'
 import { useToast } from '../../context/Toast'
 import usePostHog from '../../hooks/usePostHog'
@@ -663,7 +662,21 @@ export function useMenuData(): MenuType[] {
                             node: (
                                 <span className="px-2.5 flex w-full justify-between items-center gap-2">
                                     <span>Hedgehog mode</span>
-                                    <Toggle checked={hedgehogModeEnabled} onChange={() => undefined} />
+                                    {/* Presentational toggle — the whole row is the clickable menu item */}
+                                    <span className="relative inline-flex items-center justify-center h-2 w-8 flex-shrink-0">
+                                        <span
+                                            aria-hidden
+                                            className="pointer-events-none absolute w-full h-full rounded-md bg-[#c4c4c4] dark:bg-[#5A5A5A]"
+                                        />
+                                        <span
+                                            aria-hidden
+                                            className={`pointer-events-none absolute left-0 inline-block h-4 w-4 rounded-full transition-transform ease-in-out duration-200 ${
+                                                hedgehogModeEnabled
+                                                    ? 'translate-x-5 bg-teal'
+                                                    : 'translate-x-0 bg-[#555] dark:bg-[#999]'
+                                            }`}
+                                        />
+                                    </span>
                                 </span>
                             ),
                         },


### PR DESCRIPTION
## Changes

Adds a "Hedgehog mode" toggle to the top of the **Things that spark joy** menu in the taskbar, so hedgehog mode can be turned on/off from the UI. Previously the only in-app way to flip it was the `?hedgehog_mode=true/false` query param.

- **`src/components/HedgehogMode/index.tsx`** — reworked `useHedgehogMode` into an external store backed by `useSyncExternalStore`, with `localStorage` as the source of truth. Previously each caller seeded its own `useState` from localStorage only at mount, so a change in one place (the menu) couldn't update the renderer (`HedgeHogModeEmbed`) without a reload. Now every caller subscribes to the same store: setting the value writes localStorage and notifies all subscribers, so the on-screen hedgehog appears/disappears live. A `storage` listener keeps separate tabs in sync. This also restores the live re-render for the existing `?hedgehog_mode=true` path.
- **`src/components/TaskBarMenu/menuData.tsx`** — added a toggle row wired to `useHedgehogMode`. The whole row is the clickable menu item and the switch is rendered as a presentational indicator (no nested interactive control), which avoids a nested button inside the Radix menu item swallowing the click.

### Notes for reviewers

- There are two pre-existing state sources for the same `hedgehog-mode-enabled` localStorage key: a `LayoutContext` copy used by the legacy `MainNav` toggle, and the `useHedgehogMode` hook that actually drives the renderer. This PR wires the menu to the hook that drives rendering and leaves `LayoutContext`/`MainNav` untouched. Unifying them into a single source of truth is a reasonable follow-up.
- The Korean taskbar menu (`KoreanTaskBarMenu/menuData.tsx`) has the same structure and did not get the toggle, to keep scope focused. Easy to mirror if we want parity.
- This branch is stacked on the `@posthog/hedgehog-mode` version-bump branch (#17351), which it merges in to carry the `0.0.52` bump. Review against that base so the diff focuses on the toggle changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`