### PR TITLE
Add Claude Opus 4.8 to /code supported LLMs

### DIFF
--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -1154,6 +1154,9 @@ const TableStakes = () => {
                                     <code>Claude Sonnet 4.6</code>
                                 </li>
                                 <li className="text-sm font-bold text-primary">
+                                    <code>Claude Opus 4.8</code>
+                                </li>
+                                <li className="text-sm font-bold text-primary">
                                     <code>Claude Opus 4.7</code>
                                 </li>
                                 <li className="text-sm font-bold text-primary">


### PR DESCRIPTION
## Changes

Adds **Claude Opus 4.8** to the "Supported LLMs" section on the `/code` page. The Anthropic column previously topped out at Opus 4.7.

The new entry is placed above Opus 4.7 to match the newest-first ordering already used in the OpenAI column (GPT-5.5 before GPT-5.4).

Anthropic column now reads:
- Claude Sonnet 4.6
- **Claude Opus 4.8** ← new
- Claude Opus 4.7
- Claude Haiku 4.5

## Notes

This is the only place model versions are listed. The `AIModelBadge` (line 96) and the docs reference Opus generically without a version, so no other changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)