### PR TITLE
Add Endpoints to positioning index

### DIFF
--- a/contents/handbook/marketing/positioning/index.md
+++ b/contents/handbook/marketing/positioning/index.md
@@ -35,6 +35,7 @@ Positioning is dynamic. See [how we name and position things](#how-we-name-and-p
 - [**Experiments**](/handbook/marketing/positioning/experiments) — A/B testing wired to the same data as everything else
 - [**Data warehouse**](/handbook/marketing/positioning/data-warehouse) — The context layer for your agents, not just a SQL bucket
 - [**Data pipelines**](/handbook/marketing/positioning/data-pipelines) — CDP, reverse-ETL, and transformations bundled — typically 5–10x cheaper than Segment
+- [**Endpoints**](/handbook/marketing/positioning/endpoints) — Turn any saved insight or SQL query into a stable, authenticated HTTP endpoint
 - [**LLM analytics**](/handbook/marketing/positioning/llm-analytics) — Knowing why your LLM-powered feature is bleeding money or shipping nonsense
 - [**PostHog AI**](/handbook/marketing/positioning/posthog-ai) — A query interface that already knows your schema (and your users)
 


### PR DESCRIPTION
## Summary

- Adds a missing entry for [Endpoints](/handbook/marketing/positioning/endpoints) to the "The products" list in the positioning index
- The `endpoints.md` page existed but wasn't linked from the index, so it wasn't showing up on the website
- Placed after Data pipelines, alongside the rest of the data stack products

## Test plan

- [ ] Verify `/handbook/marketing/positioning` shows the Endpoints entry in the product list
- [ ] Confirm the link resolves correctly to `/handbook/marketing/positioning/endpoints`