### PR TITLE
docs(data-warehouse): add Asana source documentation

### DIFF
--- a/contents/docs/cdp/sources/asana.md
+++ b/contents/docs/cdp/sources/asana.md
@@ -1,0 +1,51 @@
+---
+title: Linking Asana as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Asana
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+The Asana connector pulls your Asana data — workspaces, users, projects, tasks, and more — into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Asana.
+3. You need a personal access token from Asana. Create one from the [Asana developer console](https://app.asana.com/0/my-apps). Grant these read scopes so every table can sync: `workspaces:read`, `users:read`, `projects:read`, `tasks:read`, `tags:read`, `teams:read`, and `custom_fields:read`. Copy the token value.
+4. Back in PostHog, paste the token in the `Personal access token` field and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Asana data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `workspaces` | Workspaces your token can access | Full refresh |
+| `users` | Users across your visible workspaces | Full refresh |
+| `projects` | Projects in each workspace | Full refresh |
+| `tasks` | Tasks across all projects | Full refresh |
+| `tags` | Tags in each workspace | Full refresh |
+| `sections` | Sections within each project | Full refresh |
+| `teams` | Teams in each organization workspace | Full refresh |
+| `custom_fields` | Custom field definitions per workspace | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Sync limitations
+
+All Asana tables are full refresh only. Asana's list endpoints do not expose a usable server-side timestamp filter, so each sync reloads the full collection.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **Asana** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`