### PR TITLE
docs(data-warehouse): add ClickUp source documentation

### DIFF
--- a/contents/docs/cdp/sources/clickup.md
+++ b/contents/docs/cdp/sources/clickup.md
@@ -1,0 +1,49 @@
+---
+title: Linking ClickUp as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ClickUp
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+The ClickUp connector pulls your ClickUp data — workspaces, spaces, folders, lists, tasks, and goals — into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to ClickUp.
+3. You need a personal API token and your workspace ID from ClickUp. Generate a personal token (it starts with `pk_`) under **Settings → Apps** in ClickUp. Your **Workspace ID** is the numeric ID in your ClickUp URL: `https://app.clickup.com/{workspace_id}/...`.
+4. Back in PostHog, enter the `API token` and `Workspace ID`, then click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using ClickUp data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `workspaces` | Workspaces your token can access | Full refresh |
+| `spaces` | Spaces within the workspace | Full refresh |
+| `folders` | Folders within each space | Full refresh |
+| `lists` | Lists (folderless lists and lists within folders) | Full refresh |
+| `tasks` | Tasks within the workspace | Incremental |
+| `goals` | Goals within the workspace | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Sync limitations
+
+Only the tasks table supports incremental sync, using `date_updated` as the cursor. The other tables are full refresh only.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **ClickUp** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`