### PR TITLE
docs(data-warehouse): add Iterable source documentation

### DIFF
--- a/contents/docs/cdp/sources/iterable.md
+++ b/contents/docs/cdp/sources/iterable.md
@@ -1,0 +1,44 @@
+---
+title: Linking Iterable as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Iterable
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+Enter your Iterable API key to pull your Iterable data into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Iterable.
+3. Create a **server-side** API key with read permissions in your [Iterable integrations settings](https://app.iterable.com/settings/apiKeys). Client-side (Mobile/Browser/JWT) keys are not supported. Note the data center that issued the key (US or EU).
+4. Back in PostHog, paste the key into the `API key` field, select the matching `Data center` (US at `api.iterable.com` or EU at `api.eu.iterable.com`), and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Iterable data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `campaigns` | Iterable campaigns | Full refresh |
+| `channels` | Messaging channels | Full refresh |
+| `lists` | Subscriber lists | Full refresh |
+| `message_types` | Message types | Full refresh |
+| `templates` | Message templates | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **Iterable** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`