### PR TITLE
docs(data-warehouse): add Productboard source documentation

### DIFF
--- a/contents/docs/cdp/sources/productboard.md
+++ b/contents/docs/cdp/sources/productboard.md
@@ -1,0 +1,53 @@
+---
+title: Linking Productboard as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Productboard
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+The Productboard connector syncs your Productboard data – features, notes, objectives, releases, and more – into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Productboard.
+3. Next, you need a public API access token from Productboard. In your Productboard [workspace settings](https://app.productboard.com/), go to **Integrations → Public API** and create an access token. A Pro plan or higher is required. Grant read access for the resources you want to sync — for example `entities:read`, `notes:read`, `members:read`, and `teams:read`.
+4. Back in PostHog, enter the token in the `Access token` field and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Productboard data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `features` | Features in your Productboard workspace | Full refresh |
+| `subfeatures` | Subfeatures | Full refresh |
+| `components` | Components | Full refresh |
+| `products` | Products | Full refresh |
+| `initiatives` | Initiatives | Full refresh |
+| `objectives` | Objectives | Full refresh |
+| `key_results` | Key results | Full refresh |
+| `releases` | Releases | Full refresh |
+| `release_groups` | Release groups | Full refresh |
+| `companies` | Companies | Full refresh |
+| `users` | Users | Full refresh |
+| `notes` | Customer feedback notes | Incremental |
+| `members` | Workspace members | Full refresh |
+| `teams` | Teams | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **Productboard** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`