### PR TITLE
docs(data-warehouse): add Resend source documentation

### DIFF
--- a/contents/docs/cdp/sources/resend.md
+++ b/contents/docs/cdp/sources/resend.md
@@ -1,0 +1,44 @@
+---
+title: Linking Resend as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Resend
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+The Resend connector pulls your Resend data – audiences, broadcasts, contacts, domains, and emails – into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Resend.
+3. Next, you need an API key from Resend. In your [Resend API keys settings](https://resend.com/api-keys), create an API key. Grant the key **full access** (or a read-enabled access token) so that audiences, broadcasts, contacts, domains, and emails can be read. Copy the key value (it starts with `re_`).
+4. Back in PostHog, enter the key in the `API key` field and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Resend data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `audiences` | Contact audiences in your Resend account | Full refresh |
+| `broadcasts` | Broadcasts sent through Resend | Full refresh |
+| `domains` | Sending domains | Full refresh |
+| `emails` | Sent emails | Full refresh |
+| `contacts` | Contacts across each of your audiences | Full refresh |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **Resend** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`