### PR TITLE
docs(data-warehouse): add Trello source documentation

### DIFF
--- a/contents/docs/cdp/sources/trello.md
+++ b/contents/docs/cdp/sources/trello.md
@@ -1,0 +1,47 @@
+---
+title: Linking Trello as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Trello
+---
+
+<CalloutBox icon="IconInfo" title="Alpha release" type="fyi">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+Enter your Trello API key and token to sync your boards, cards, lists and more into the PostHog data warehouse.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Trello.
+3. Get your API key from [trello.com/power-ups/admin](https://trello.com/power-ups/admin) and generate a token with **read** access for your account.
+4. Back in PostHog, paste the values into the `API key` and `API token` fields and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Trello data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `boards` | Boards for the authenticated member | Full refresh |
+| `organizations` | Trello workspaces (organizations) | Full refresh |
+| `lists` | Lists across your boards | Full refresh |
+| `cards` | Cards across your boards (open cards only by default) | Full refresh |
+| `checklists` | Checklists across your boards | Full refresh |
+| `labels` | Labels across your boards | Full refresh |
+| `members` | Board members (deduplicated across boards) | Full refresh |
+| `actions` | Board activity actions | Incremental |
+
+**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+
+## Configuration
+
+<SourceParameters />


### PR DESCRIPTION
## Changes

Adds documentation for the **Trello** data warehouse source, covering how to link it, the credentials it needs, and the tables it syncs (with sync methods). Content is derived from the merged source implementation in `PostHog/posthog`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`