### PR TITLE
docs: provisioning API uses access token, add session recording scope

### DIFF
--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -246,7 +246,7 @@ curl -X POST https://us.posthog.com/api/agentic/oauth/token \
 ```json
 {
   "token_type": "bearer",
-  "access_token": "phx_abc123...",
+  "access_token": "pha_abc123...",
   "refresh_token": "phr_def456...",
   "expires_in": 3600,
   "account": {
@@ -283,7 +283,7 @@ Use the access token to provision a PostHog project and get credentials.
 ```bash
 curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer phx_abc123..." \
+  -H "Authorization: Bearer pha_abc123..." \
   -H "API-Version: 0.1d" \
   -d '{
     "service_id": "analytics",
@@ -334,7 +334,7 @@ For recurring deep links from your application into PostHog – the most common 
 ```bash
 curl -X POST https://us.posthog.com/api/agentic/provisioning/deep_links \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer phx_abc123..." \
+  -H "Authorization: Bearer pha_abc123..." \
   -H "API-Version: 0.1d" \
   -d '{
     "purpose": "dashboard"
@@ -372,7 +372,7 @@ Rotate the project token and create a new personal API key for an existing provi
 ```bash
 curl -X POST https://us.posthog.com/api/agentic/provisioning/resources/12345/rotate_credentials \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer phx_abc123..." \
+  -H "Authorization: Bearer pha_abc123..." \
   -H "API-Version: 0.1d" \
   -d '{
     "label_prefix": "Acme Co"
@@ -403,7 +403,7 @@ curl -X POST https://us.posthog.com/api/agentic/oauth/token \
 ```json
 {
   "token_type": "bearer",
-  "access_token": "phx_new_token...",
+  "access_token": "pha_new_token...",
   "refresh_token": "phr_new_refresh...",
   "expires_in": 3600
 }

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -327,8 +327,6 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
 
 For authenticated REST API calls, use the OAuth `access_token` from [Step 2](#step-2-exchange-the-code-for-tokens) as a `Bearer` token. It carries the [scopes](#available-scopes) you requested in the account request. Provisioning does not return a `personal_api_key` in this response.
 
-> **Breaking change:** Provisioning no longer returns a `personal_api_key`. If your integration read it from the `/resources` response, switch to the OAuth `access_token` above as your `Bearer` credential and list the scopes you need (for example `session_recording:read`, `query:read`) in the [`scopes`](#available-scopes) array of your account request. Refreshing a token can only keep or narrow its scopes, so new scopes apply only to connections provisioned _after_ you add them.
-
 ### Deep linking
 
 For recurring deep links from your application into PostHog – the most common case is an "Open in PostHog" button on a user's connected project – use the deep-link endpoint. Each call returns a short-lived, single-use URL that logs the user into their PostHog project on click. There's no consent screen and no email-mismatch friction: the URL mints a fresh PostHog session for the right user, overriding any other session the browser happens to have.

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -299,7 +299,7 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `service_id` | string | No | The plan to provision. `"analytics"` (default) provisions a standard project. `"free"` and `"pay_as_you_go"` set the billing plan explicitly. |
-| `label_prefix` | string | No | Label prefix for the personal API key shown in PostHog, up to 25 characters. The key is labeled `{label_prefix} - {team_name}`. If omitted, empty, or whitespace-only, the key is labeled with just the team name. |
+| `label_prefix` | string | No | Label prefix for the provisioned personal API key, up to 25 characters, used only when a personal API key is issued (off by default). When issued, the key is labeled `{label_prefix} - {team_name}`; if omitted, empty, or whitespace-only, just the team name. |
 | `configuration.project_name` | string | No | Project name (defaults to `"Default project"`) |
 
 **Response** (HTTP 200):
@@ -326,6 +326,8 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
 | `host` | The API host (`https://us.posthog.com` or `https://eu.posthog.com`) |
 
 For authenticated REST API calls, use the OAuth `access_token` from [Step 2](#step-2-exchange-the-code-for-tokens) as a `Bearer` token. It carries the [scopes](#available-scopes) you requested in the account request. Provisioning does not return a `personal_api_key` in this response.
+
+> **Breaking change:** Provisioning no longer returns a `personal_api_key`. If your integration read it from the `/resources` response, switch to the OAuth `access_token` above as your `Bearer` credential and list the scopes you need (for example `session_recording:read`, `query:read`) in the [`scopes`](#available-scopes) array of your account request. Refreshing a token can only keep or narrow its scopes, so new scopes apply only to connections provisioned _after_ you add them.
 
 ### Deep linking
 
@@ -367,7 +369,7 @@ This endpoint is gated on the `provisioning_can_issue_deep_links` flag on your p
 
 ### Rotate project credentials
 
-Rotate the project token and create a new personal API key for an existing provisioned project:
+Rotate the project token for an existing provisioned project:
 
 ```bash
 curl -X POST https://us.posthog.com/api/agentic/provisioning/resources/12345/rotate_credentials \
@@ -383,7 +385,7 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources/12345/rot
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `label_prefix` | string | No | Label prefix for the new personal API key shown in PostHog, up to 25 characters. The key is labeled `{label_prefix} - {team_name}`. If omitted, empty, or whitespace-only, the key is labeled with just the team name. |
+| `label_prefix` | string | No | Label prefix for the personal API key, up to 25 characters, used only when a personal API key is issued (off by default). When issued, the key is labeled `{label_prefix} - {team_name}`; if omitted, empty, or whitespace-only, just the team name. |
 
 The response has the same shape as the project provisioning response and includes the rotated `api_key` and `host`.
 
@@ -409,11 +411,11 @@ curl -X POST https://us.posthog.com/api/agentic/oauth/token \
 }
 ```
 
-Each refresh token is single-use. The response includes a new refresh token for subsequent refreshes.
+Each refresh token is single-use. The response includes a new refresh token for subsequent refreshes. Refreshing can only keep or narrow a token's scopes, never add them — to grant additional scopes, request them in a new account request, and they apply to connections provisioned afterward.
 
 ### Available scopes
 
-The `scopes` field in the account request controls what permissions the access token receives. If omitted, a default set of scopes is granted. The default set does not include every scope below, so request explicitly the scopes your integration needs. Available scopes:
+The `scopes` field in the account request controls what permissions the access token receives. If omitted, a default set of scopes is granted. The default set does not include every scope below, so explicitly request the scopes your integration needs. Available scopes:
 
 | Scope | Description |
 |---|---|

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -312,8 +312,7 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
   "complete": {
     "access_configuration": {
       "api_key": "phc_abc123...",
-      "host": "https://us.posthog.com",
-      "personal_api_key": "phx_def456..."
+      "host": "https://us.posthog.com"
     }
   }
 }
@@ -325,7 +324,8 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources \
 |---|---|
 | `api_key` | The project token (starts with `phc_`) – use this to initialize PostHog SDKs |
 | `host` | The API host (`https://us.posthog.com` or `https://eu.posthog.com`) |
-| `personal_api_key` | A personal API key scoped to this project – use this for the PostHog API |
+
+For authenticated REST API calls, use the OAuth `access_token` from [Step 2](#step-2-exchange-the-code-for-tokens) as a `Bearer` token. It carries the [scopes](#available-scopes) you requested in the account request. Provisioning does not return a `personal_api_key` in this response.
 
 ### Deep linking
 
@@ -385,7 +385,7 @@ curl -X POST https://us.posthog.com/api/agentic/provisioning/resources/12345/rot
 |---|---|---|---|
 | `label_prefix` | string | No | Label prefix for the new personal API key shown in PostHog, up to 25 characters. The key is labeled `{label_prefix} - {team_name}`. If omitted, empty, or whitespace-only, the key is labeled with just the team name. |
 
-The response has the same shape as the project provisioning response and includes the rotated `api_key`, `host`, and new `personal_api_key`.
+The response has the same shape as the project provisioning response and includes the rotated `api_key` and `host`.
 
 ### Refresh tokens
 
@@ -413,12 +413,13 @@ Each refresh token is single-use. The response includes a new refresh token for 
 
 ### Available scopes
 
-The `scopes` field in the account request controls what permissions the access token receives. If omitted, a default set of scopes is granted. Available scopes:
+The `scopes` field in the account request controls what permissions the access token receives. If omitted, a default set of scopes is granted. The default set does not include every scope below, so request explicitly the scopes your integration needs. Available scopes:
 
 | Scope | Description |
 |---|---|
 | `customer_journey:read` | Read customer journey data |
 | `query:read` | Execute read-only queries |
+| `session_recording:read` | Read session recordings |
 | `conversation:read` | Read PostHog AI conversations |
 | `conversation:write` | Create and update PostHog AI conversations |
 | `experiment:read` | Read experiments |
@@ -607,7 +608,6 @@ async function provisionPostHogAccount(email, name) {
     type: 'provisioned',
     apiKey: resource.complete.access_configuration.api_key,
     host: resource.complete.access_configuration.host,
-    personalApiKey: resource.complete.access_configuration.personal_api_key,
     projectId: resource.id,
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -411,7 +411,7 @@ curl -X POST https://us.posthog.com/api/agentic/oauth/token \
 }
 ```
 
-Each refresh token is single-use. The response includes a new refresh token for subsequent refreshes. Refreshing can only keep or narrow a token's scopes, never add them — to grant additional scopes, request them in a new account request, and they apply to connections provisioned afterward.
+Each refresh token is single-use. The response includes a new refresh token for subsequent refreshes. Refreshing can only keep or narrow a token's scopes, never add them. To grant additional scopes, request them in a new account request; they apply to connections provisioned afterward.
 
 ### Available scopes
 


### PR DESCRIPTION
## Problem

The provisioning docs told partners to authenticate with the `personal_api_key` from the `/resources` response. Provisioning no longer returns one by default; the OAuth `access_token` is the credential for the API. Partners following the docs hit 403s on endpoints like session recordings and queries because they relied on the removed key and didn't know to request scopes on the access token. `session_recording:read` was also missing from the available-scopes table entirely.

## Changes

- Remove `personal_api_key` from the resources response example, response-fields table, rotate-credentials note, and the SDK snippet
- Point partners to the OAuth `access_token` (as a Bearer token) as the API credential, scoped to what they request in the account request
- Add `session_recording:read` to the available-scopes table, and note the default set is a subset so scopes should be requested explicitly
- Note in the Refresh tokens section that refreshing can only keep or narrow scopes (new scopes apply only to connections provisioned afterward)
- Fix the rotate-credentials and `label_prefix` copy, which still described minting a personal API key — rotate uses the same default-off gate, so it returns only `api_key` + `host`

## Preview

- Page route: `/docs/integrate/provisioning` (open this path on the deploy preview once it builds)
- Source file: `contents/docs/integrate/provisioning.mdx`

## How did you test this code

Docs-only change. Verified the scope names and the access-token flow against the provisioning backend.

## Changelog

No

