### PR TITLE
Replay Vision product page

### DIFF
--- a/src/components/WaitlistForm/index.tsx
+++ b/src/components/WaitlistForm/index.tsx
@@ -7,9 +7,29 @@ import { useApp } from '../../context/App'
 import Link from 'components/Link'
 import { IconDiscord } from 'components/OSIcons/Icons'
 
-export function WaitlistForm({ autoFocus = false, confetti = true }: { autoFocus?: boolean; confetti?: boolean }) {
+interface WaitlistFormProps {
+    autoFocus?: boolean
+    confetti?: boolean
+    productHandle?: string
+    productName?: string
+    surveyId?: string
+    showTitle?: boolean
+    buttonLabel?: string
+    showDiscord?: boolean
+}
+
+export function WaitlistForm({
+    autoFocus = false,
+    confetti = true,
+    productHandle = 'posthog_code',
+    productName = 'PostHog Code',
+    surveyId,
+    showTitle = true,
+    buttonLabel = 'Get updates',
+    showDiscord = true,
+}: WaitlistFormProps) {
     const posthog = usePostHog()
-    const selectedProduct = useProduct({ handle: 'posthog_code' })
+    const selectedProduct = useProduct({ handle: productHandle })
     const { setConfetti } = useApp()
     const [email, setEmail] = useState('')
     const [submitted, setSubmitted] = useState(false)
@@ -18,6 +38,12 @@ export function WaitlistForm({ autoFocus = false, confetti = true }: { autoFocus
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault()
         if (!email) return
+        if (surveyId) {
+            posthog?.capture('survey sent', {
+                $survey_id: surveyId,
+                $survey_response: email,
+            })
+        }
         posthog?.capture('subscribe_to_product_updates', { email, selectedProduct })
         if (confetti) {
             setConfetti(true)
@@ -30,24 +56,28 @@ export function WaitlistForm({ autoFocus = false, confetti = true }: { autoFocus
             <p className="text-sm mt-0 mb-4 border border-green rounded-md p-3 bg-green/10">
                 <strong>You&apos;re on the list!</strong>
                 <br />
-                We&apos;ll let you know when <span className="inline-block">PostHog Code</span> is ready.
-                <br />
-                <br />
-                <Link
-                    className="group flex items-center gap-1 text-sm font-medium"
-                    to="https://discord.com/invite/E9xV2WnR98"
-                    externalNoIcon
-                >
-                    <IconDiscord className="size-6 text-secondary group-hover:text-primary" />
-                    <span className="group-hover:underline">Join our Discord</span>
-                </Link>
+                We&apos;ll let you know when <span className="inline-block">{productName}</span> is ready.
+                {showDiscord && (
+                    <>
+                        <br />
+                        <br />
+                        <Link
+                            className="group flex items-center gap-1 text-sm font-medium"
+                            to="https://discord.com/invite/E9xV2WnR98"
+                            externalNoIcon
+                        >
+                            <IconDiscord className="size-6 text-secondary group-hover:text-primary" />
+                            <span className="group-hover:underline">Join our Discord</span>
+                        </Link>
+                    </>
+                )}
             </p>
         )
     }
 
     return (
         <form onSubmit={handleSubmit} className="space-y-2">
-            <h3 className="text-lg font-bold mb-2 !mt-0">Join the waitlist</h3>
+            {showTitle && <h3 className="text-lg font-bold mb-2 !mt-0">Join the waitlist</h3>}
             <Input
                 ref={inputRef}
                 autoFocus={autoFocus}
@@ -62,7 +92,7 @@ export function WaitlistForm({ autoFocus = false, confetti = true }: { autoFocus
                 required
             />
             <OSButton variant="primary" size="md" width="full" onClick={handleSubmit}>
-                Get updates
+                {buttonLabel}
             </OSButton>
         </form>
     )

--- a/src/constants/productNavigation.ts
+++ b/src/constants/productNavigation.ts
@@ -75,7 +75,15 @@ export const productOrder: Record<string, string[]> = {
         'bi',
         'data_out',
     ],
-    product_engineering: ['session_replay', 'experiments', 'feature_flags', 'logs', 'error_tracking', 'early_access'],
+    product_engineering: [
+        'session_replay',
+        'replay_vision',
+        'experiments',
+        'feature_flags',
+        'logs',
+        'error_tracking',
+        'early_access',
+    ],
     analytics: [
         'web_analytics',
         'product_analytics',

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -491,6 +491,22 @@ const appSettings: AppSettings = {
             center: true,
         },
     },
+    '/replay-vision': {
+        size: {
+            min: {
+                width: 700,
+                height: 500,
+            },
+            max: {
+                width: 900,
+                height: 1000,
+            },
+            fixed: false,
+        },
+        position: {
+            center: true,
+        },
+    },
     'home-test': {
         experiment: {
             variant: 'test',

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -30,6 +30,7 @@ import {
     IconTrends,
     IconCursorClick,
     IconChat,
+    IconLlmPromptEvaluation,
 } from '@posthog/icons'
 import useProducts from './useProducts'
 
@@ -1744,6 +1745,17 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
                 },
             ],
             worksWith: ['feature_flags', 'surveys', 'product_analytics', 'session_replay'],
+        },
+        {
+            name: 'Replay Vision',
+            Icon: IconLlmPromptEvaluation,
+            description: 'AI-powered session replay analysis that watches recordings for you',
+            handle: 'replay_vision',
+            color: 'yellow',
+            colorSecondary: 'yellow',
+            category: 'product_engineering',
+            slug: 'replay-vision',
+            status: 'beta',
         },
         {
             name: 'API',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4107,25 +4107,6 @@ export const docsMenu = {
             ],
         },
         {
-            name: 'Replay Vision',
-            url: '/docs/replay-vision',
-            color: 'yellow',
-            icon: 'IconEye',
-            description: 'Use AI to automatically watch your session recordings and turn what it sees into queryable data',
-            featureFlag: 'replay-vision-docs',
-            children: [
-                {
-                    name: 'Replay Vision',
-                },
-                {
-                    name: 'Overview',
-                    url: '/docs/replay-vision',
-                    icon: 'IconEye',
-                    color: 'seagreen',
-                },
-            ],
-        },
-        {
             name: 'Feature Flags',
             icon: 'IconToggle',
             color: 'seagreen',

--- a/src/pages/replay-vision.tsx
+++ b/src/pages/replay-vision.tsx
@@ -1,0 +1,236 @@
+import React, { useState } from 'react'
+import SEO from 'components/seo'
+import Editor from 'components/Editor'
+import {
+    IconCode,
+    IconWarning,
+    IconDocument,
+    IconCursorClick,
+    IconSort,
+    IconTrending,
+    IconCheckCircle,
+    IconLlmPromptEvaluation,
+} from '@posthog/icons'
+import OSButton from 'components/OSButton'
+import { WaitlistForm } from 'components/WaitlistForm'
+import CloudinaryImage from 'components/CloudinaryImage'
+
+const SURVEY_ID = '019e82bb-e78f-0000-7141-addb508840d4'
+
+const scannerCards = [
+    {
+        icon: IconCode,
+        color: 'text-purple',
+        bgColor: 'bg-purple/10',
+        title: 'Create from scratch',
+        description: 'Build a fully custom scanner with your own prompt and configuration.',
+    },
+    {
+        icon: IconWarning,
+        color: 'text-red',
+        bgColor: 'bg-red/10',
+        title: 'Dead ends',
+        description: 'Detect sessions where the user gets stuck on a page with no clear path forward.',
+    },
+    {
+        icon: IconDocument,
+        color: 'text-seagreen',
+        bgColor: 'bg-green/10',
+        title: 'Session summary',
+        description: 'Generate a short narrative of what the user actually did in the session.',
+    },
+    {
+        icon: IconCursorClick,
+        color: 'text-blue',
+        bgColor: 'bg-blue/10',
+        title: 'User intent',
+        description: 'Classify the session by what the user appeared to be trying to do.',
+    },
+    {
+        icon: IconTrending,
+        color: 'text-yellow',
+        bgColor: 'bg-yellow/10',
+        title: 'Frustration score',
+        description: 'Score how much friction or frustration the user appeared to experience.',
+    },
+    {
+        icon: IconCheckCircle,
+        color: 'text-teal',
+        bgColor: 'bg-teal/10',
+        title: 'Session outcome',
+        description: 'Tag each session with what actually happened - task completed, abandoned, errored, etc.',
+    },
+]
+
+const useCaseCards = [
+    {
+        icon: IconWarning,
+        color: 'text-red',
+        title: 'Find the bugs that hurt',
+        description:
+            'Surface errors that were actually visible to users and blocked them from finishing a task. Eliminate the console noise nobody saw.',
+    },
+    {
+        icon: IconTrending,
+        color: 'text-yellow',
+        title: 'Triage by frustration, not guesswork',
+        description: "Let the scorer rank your sessions so you watch the 10 that matter, not 10,000 that don't.",
+    },
+    {
+        icon: IconCursorClick,
+        color: 'text-blue',
+        title: 'Spot patterns at scale',
+        description:
+            'Sessions get tagged automatically, so "where are people getting stuck on mobile checkout?" becomes a search, not hours of watching.',
+    },
+]
+
+function HeroSection() {
+    const [showForm, setShowForm] = useState(false)
+
+    return (
+        <section className="my-6 @4xl/editor:mb-16 tracking-[-0.0125em] max-w-3xl mx-auto px-4 @xl:px-8">
+            <div className="mb-8">
+                <div className="flex items-center gap-2 mb-3">
+                    <IconLlmPromptEvaluation className="size-6 text-yellow" />
+                    <span className="text-base font-semibold">Replay Vision</span>
+                </div>
+                <h1 className="text-xl @xl:text-3xl font-bold leading-tight mb-4 @xl:mb-6 !mt-0">
+                    The fast-forward button for session replay.
+                </h1>
+                <p className="text-base @xl:text-lg leading-relaxed mb-6">
+                    Point an AI scanner at your recordings, and let it watch every session for you: flagging bugs,
+                    scoring frustration, tagging behavior, and summarizing what happened. You get the findings, while{' '}
+                    <strong>Replay Vision</strong> does the homework.
+                </p>
+            </div>
+
+            <div className="@container max-w-sm">
+                {showForm ? (
+                    <WaitlistForm
+                        autoFocus
+                        showDiscord={false}
+                        productHandle="replay_vision"
+                        productName="Replay Vision"
+                        surveyId={SURVEY_ID}
+                    />
+                ) : (
+                    <div className="flex flex-wrap items-center gap-2">
+                        <OSButton variant="primary" size="lg" onClick={() => setShowForm(true)}>
+                            Join the waitlist
+                        </OSButton>
+                    </div>
+                )}
+            </div>
+        </section>
+    )
+}
+
+function HowItWorks() {
+    return (
+        <section className="relative mb-8 @xl:mb-16">
+            <h2 className="text-2xl font-bold mb-2">How it works</h2>
+            <p className="mb-6">
+                Replay Vision runs scanners: AI agents you configure and point at your sessions. Set a trigger, pick
+                what you want it to look for, and it runs across every matching recording automatically.
+            </p>
+
+            <div className="grid @md:grid-cols-2 @2xl:grid-cols-3 gap-4 mb-6">
+                {scannerCards.map(({ icon: Icon, color, bgColor, title, description }) => (
+                    <div key={title} className={`rounded-md border border-primary p-4 ${bgColor}`}>
+                        <div className="flex items-center gap-2 mb-2">
+                            <Icon className={`size-5 ${color}`} />
+                            <h3 className="text-base font-bold m-0">{title}</h3>
+                        </div>
+                        <p className="text-sm m-0 text-secondary">{description}</p>
+                    </div>
+                ))}
+            </div>
+
+            <p className="text-sm text-secondary">
+                Every observation comes with a confidence score and links straight to the exact moment in the recording,
+                so you can verify it in one click, not go hunting.
+            </p>
+        </section>
+    )
+}
+
+function UseCases() {
+    return (
+        <section className="relative mb-8 @xl:mb-16">
+            <h2 className="text-2xl font-bold mb-6">What you'd actually use it for</h2>
+
+            <ul className="divide-y divide-border">
+                {useCaseCards.map(({ icon: Icon, color, title, description }, i) => (
+                    <li
+                        key={title}
+                        className={`pl-8 relative ${
+                            i === 0 ? 'pb-4' : i === useCaseCards.length - 1 ? 'pt-4' : 'py-4'
+                        }`}
+                    >
+                        <Icon className={`size-6 absolute left-0 ${i === 0 ? 'top-0.5' : 'top-[1.125rem]'} ${color}`} />
+                        <h3 className="text-base font-bold mb-0">{title}</h3>
+                        <p className="text-sm mt-1 mb-0 text-secondary">{description}</p>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    )
+}
+
+function HonestBit() {
+    return (
+        <section className="relative mb-8 @xl:mb-16">
+            <h2 className="text-2xl font-bold mb-2">The honest bit</h2>
+            <p className="mb-6">
+                It's early. Replay Vision is getting near a closed beta. We're rolling access out in batches so we can
+                actually talk to the people using it and get the quality right before we go wide. Join the list and
+                you'll be near the front.
+            </p>
+            <div className="max-w-lg @container bg-yellow/10 border border-yellow rounded-md px-8 py-6 shadow-xl">
+                <WaitlistForm
+                    productHandle="replay_vision"
+                    productName="Replay Vision"
+                    surveyId={SURVEY_ID}
+                    showDiscord={false}
+                />
+            </div>
+        </section>
+    )
+}
+
+export default function ReplayVisionPage() {
+    return (
+        <>
+            <SEO
+                title="Replay Vision - PostHog"
+                description="Point an AI scanner at your recordings, and let it watch every session for you: flagging bugs, scoring frustration, tagging behavior, and summarizing what happened."
+            />
+            <Editor slug="/replay-vision" maxWidth="100%" hasPadding={false}>
+                <div className="@container not-prose font-rounded">
+                    <header className="relative mb-12">
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/texture_tan_9608fcca70.png"
+                            className="dark:hidden absolute inset-0"
+                            imgClassName="h-full w-full"
+                        />
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/texture_tan_dark_a92b0e022d.png"
+                            className="hidden dark:block absolute inset-0"
+                            imgClassName="h-full w-full"
+                        />
+                        <div className="relative flex flex-col items-center w-full py-4">
+                            <HeroSection />
+                        </div>
+                    </header>
+
+                    <div className="max-w-3xl mx-auto px-4 @xl:px-8">
+                        <HowItWorks />
+                        <UseCases />
+                        <HonestBit />
+                    </div>
+                </div>
+            </Editor>
+        </>
+    )
+}

--- a/src/pages/replay-vision.tsx
+++ b/src/pages/replay-vision.tsx
@@ -90,37 +90,50 @@ function HeroSection() {
 
     return (
         <section className="my-6 @4xl/editor:mb-16 tracking-[-0.0125em] max-w-3xl mx-auto px-4 @xl:px-8">
-            <div className="mb-8">
-                <div className="flex items-center gap-2 mb-3">
+            <div className="mb-8 ">
+                <div className="mb-6 flex justify-center @2xl:hidden">
+                    <CloudinaryImage
+                        className="max-w-[350px] w-full"
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/600898537_01bdccfb_7418_4248_8075_d00a62a810e3_06c543f11b.svg"
+                    />
+                </div>
+                <div className="flex items-start gap-2 mb-3">
                     <IconLlmPromptEvaluation className="size-6 text-yellow" />
                     <span className="text-base font-semibold">Replay Vision</span>
                 </div>
                 <h1 className="text-xl @xl:text-3xl font-bold leading-tight mb-4 @xl:mb-6 !mt-0">
                     The fast-forward button for session replay.
                 </h1>
-                <p className="text-base @xl:text-lg leading-relaxed mb-6">
-                    Point an AI scanner at your recordings, and let it watch every session for you: flagging bugs,
-                    scoring frustration, tagging behavior, and summarizing what happened. You get the findings, while{' '}
-                    <strong>Replay Vision</strong> does the homework.
-                </p>
-            </div>
-
-            <div className="@container max-w-sm">
-                {showForm ? (
-                    <WaitlistForm
-                        autoFocus
-                        showDiscord={false}
-                        productHandle="replay_vision"
-                        productName="Replay Vision"
-                        surveyId={SURVEY_ID}
-                    />
-                ) : (
-                    <div className="flex flex-wrap items-center gap-2">
-                        <OSButton variant="primary" size="lg" onClick={() => setShowForm(true)}>
-                            Join the waitlist
-                        </OSButton>
+                <div className="flex items-start gap-6">
+                    <div className="flex-1">
+                        <p className="text-base @xl:text-lg leading-relaxed mb-6">
+                            Point an AI scanner at your recordings, and let it watch every session for you: flagging
+                            bugs, scoring frustration, tagging behavior, and summarizing what happened. You get the
+                            findings, while <strong>Replay Vision</strong> does the homework.
+                        </p>
+                        <div className="@container max-w-sm">
+                            {showForm ? (
+                                <WaitlistForm
+                                    autoFocus
+                                    showDiscord={false}
+                                    productHandle="replay_vision"
+                                    productName="Replay Vision"
+                                    surveyId={SURVEY_ID}
+                                />
+                            ) : (
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <OSButton variant="primary" size="lg" onClick={() => setShowForm(true)}>
+                                        Join the waitlist
+                                    </OSButton>
+                                </div>
+                            )}
+                        </div>
                     </div>
-                )}
+                    <CloudinaryImage
+                        className="max-w-[324px] w-full hidden @2xl:block"
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/600898537_01bdccfb_7418_4248_8075_d00a62a810e3_06c543f11b.svg"
+                    />
+                </div>
             </div>
         </section>
     )


### PR DESCRIPTION
## Changes

- Adds Replay Vision product page (based on [this](https://docs.google.com/document/d/1gIWG9CAuOGhjH3ZTcTl7D3WvslBYKnW75S-5QMaTuiI/edit?tab=t.0) copy)
- Adds new Replay Vision page to product nav under Product Engineering
- Refactors `WaitlistForm` component to allow us to reuse it (currently only used on `/code` in prod)


https://github.com/user-attachments/assets/68ee0fd6-519d-4856-83bd-ba82312c7bac

