### PR TITLE
Update speaker guide call-out and recent talks

### DIFF
--- a/contents/handbook/marketing/speaker-guide.md
+++ b/contents/handbook/marketing/speaker-guide.md
@@ -6,7 +6,7 @@ showTitle: true
 
 You volunteered or have been asked  to speak at a dev meetup, give a demo at a conference, or present PostHog to a virtual or in-person audience. Maybe you said yes before you thought too hard about it. That's fine — good talks happen this way. This guide is for preparing and delivering your talk.
 
->*Want slide examples from other speakers?* See [recent talks](#slides-from-recent-talks). *Have questions?* Ask in [#team-irl-events](https://posthog.slack.com/archives/C0AB78YBCNA) or ping whoever put you up to this. *Still need demo tips?* [Here are 24 more](https://newsletter.posthog.com/p/how-to-demo).
+>**Want slide examples from other speakers?** See [recent talks](#slides-from-recent-talks). **Have questions?** Ask in [#team-irl-events](https://posthog.slack.com/archives/C0AB78YBCNA) or ping whoever put you up to this. **Still need demo tips?** [Here are 24 more](https://newsletter.posthog.com/p/how-to-demo).
 
 ## **1. Know your room before you write a word**
 
@@ -123,6 +123,7 @@ If you receive a question that you believe is off-topic or unfitting for the set
 
 ## Slides from recent talks
 
+* June 2026 - <TeamMember name="James Hawkins"/> - [AI happened. Now what?](https://docs.google.com/presentation/d/1QHGxTd8RkABiIQenjqe12dEdrIlfIXFpmhp9wRFeQyM/edit?usp=sharing)  
 * May 2026 - <TeamMember name="Meikel Ratz"/> - [Stop Snacking. Start Cooking](https://www.figma.com/deck/84jm6dUfWcXhFEmhojvMUL/Myke---AI-killed-the-busywork?node-id=1-20157&viewport=-1045%2C-95%2C0.46&t=AWFACVyZDrZb1paw-1&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1)  
 * March 2026 - <TeamMember name="Sarah Sanders"/> - [Onboarding sucks](https://www.figma.com/slides/4rGB61lnyYnspct1J4sWYR/Future-of-DevEx-talk?node-id=1-20157&t=o4gv82hYwY37dqkj-0)  
 * March 2026 - <TeamMember name="Rafael Audibert"/> - [Just let engineers cook](https://www.figma.com/deck/N9Q3bAvqNKFBTQC6T95Tra/Rafa---PH-slide-deck-template?node-id=1-20157&t=2VKu4S3lHierX7No-1)  

--- a/contents/handbook/marketing/speaker-guide.md
+++ b/contents/handbook/marketing/speaker-guide.md
@@ -6,7 +6,7 @@ showTitle: true
 
 You volunteered or have been asked  to speak at a dev meetup, give a demo at a conference, or present PostHog to a virtual or in-person audience. Maybe you said yes before you thought too hard about it. That's fine — good talks happen this way. This guide is for preparing and delivering your talk.
 
->For examples from other speaker, reference slides from [previous talks](#examples-from-previous-talks). **Have any questions?** Ask in [#team-irl-events](https://posthog.slack.com/archives/C0AB78YBCNA) or ping whoever put you up to this.
+>*Want slide examples from other speakers?* See [recent talks](#slides-from-recent-talks). *Have questions?* Ask in [#team-irl-events](https://posthog.slack.com/archives/C0AB78YBCNA) or ping whoever put you up to this. *Still need demo tips?* [Here are 24 more](https://newsletter.posthog.com/p/how-to-demo).
 
 ## **1. Know your room before you write a word**
 
@@ -121,9 +121,11 @@ If you receive a question that you believe is off-topic or unfitting for the set
 
 ---
 
-## Examples from previous talks:
+## Slides from recent talks
 
-* Feb 2026 - <TeamMember name="Emanuele Capparelli"/> - [Lisbon SaaS Founders Presentation](https://pitch.com/v/lisbon-saas-founder-x-posthog-x-supabase-hgnmr3)  
+* May 2026 - <TeamMember name="Meikel Ratz"/> - [Stop Snacking. Start Cooking](https://www.figma.com/deck/84jm6dUfWcXhFEmhojvMUL/Myke---AI-killed-the-busywork?node-id=1-20157&viewport=-1045%2C-95%2C0.46&t=AWFACVyZDrZb1paw-1&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1)  
+* March 2026 - <TeamMember name="Sarah Sanders"/> - [Onboarding sucks](https://www.figma.com/slides/4rGB61lnyYnspct1J4sWYR/Future-of-DevEx-talk?node-id=1-20157&t=o4gv82hYwY37dqkj-0)  
+* March 2026 - <TeamMember name="Rafael Audibert"/> - [Just let engineers cook](https://www.figma.com/deck/N9Q3bAvqNKFBTQC6T95Tra/Rafa---PH-slide-deck-template?node-id=1-20157&t=2VKu4S3lHierX7No-1)  
 * Feb 2026 - <TeamMember name="Michael Matloka"/> - [10 learning from launching an agentic AI product at scale](https://www.figma.com/slides/zMNBsNihNxKyS6z7sSwiRK/10-learnings-from-launching-an-agentic-AI-product-at-scale?t=6hlWStUDlHsITOKo-6)  
 * Nov 2025 - <TeamMember name="James Hawkins"/> - [How to build a cult](https://drive.google.com/file/d/1BMgl2y817m5t43D6NCr9hstnGO1kKxJy/view)  
 * Oct 2025 - <TeamMember name="Joshua Snyder"/> - [Code that fixes itself](https://docs.google.com/presentation/d/1sYsmTPugdttQqshPa6yIKQcUu5Rje3-fPMbRGtyrfZg/edit?slide=id.p#slide=id.p)  


### PR DESCRIPTION
## Changes

Updates the [speaker guide](https://posthog.com/handbook/marketing/speaker-guide):

- Fixed a typo and added a link to the [how-to-demo newsletter post](https://newsletter.posthog.com/p/how-to-demo) in the intro call-out.
- Added three recent talks (Meikel Ratz, Sarah Sanders, Rafael Audibert) and removed Emanuele Capparelli's talk from the examples section.
- Retitled the section to "Slides from recent talks".

**Why:** Keep the speaker guide's examples current and point speakers to extra demo tips. Requested in https://posthog.slack.com/archives/C0AB78YBCNA/p1780999358705469.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
