### PR TITLE
Add marketing calendar link to Marketing and Content handbook pages

### DIFF
--- a/contents/handbook/content/index.md
+++ b/contents/handbook/content/index.md
@@ -27,6 +27,8 @@ Content is the main pillar of our marketing strategy. Our strategy is to go _dee
 
 Our latest goals can be found on the <SmallTeam slug="content" /> page. You can share ad-hoc ideas in our [#content-ideas Slack channel](https://posthog.slack.com/archives/C015CRUQR7Y).
 
+We use a shared [marketing calendar](https://calendar.google.com/calendar/u/0?cid=Y19hZTgzMWZjNGIxNDc4NjRiYzdlYWVjMjBiNDM0NzhjMmNjODdkYjZmZGUwOTZkMjUyMDFhZGUxZDA1Y2EzZWFhQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) to coordinate newsletters, launches, and other comms. Check it before scheduling anything that goes out to users, and add your own sends to it.
+
 ## Who is our audience?
 
 It should be the same as [who we are building for](/handbook/who-we-are-building-for). Specifically:

--- a/contents/handbook/content/index.md
+++ b/contents/handbook/content/index.md
@@ -27,7 +27,7 @@ Content is the main pillar of our marketing strategy. Our strategy is to go _dee
 
 Our latest goals can be found on the <SmallTeam slug="content" /> page. You can share ad-hoc ideas in our [#content-ideas Slack channel](https://posthog.slack.com/archives/C015CRUQR7Y).
 
-We use a shared [marketing calendar](https://calendar.google.com/calendar/u/0?cid=Y19hZTgzMWZjNGIxNDc4NjRiYzdlYWVjMjBiNDM0NzhjMmNjODdkYjZmZGUwOTZkMjUyMDFhZGUxZDA1Y2EzZWFhQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) to coordinate newsletters, launches, and other comms. Check it before scheduling anything that goes out to users, and add your own sends to it.
+We use a shared [marketing calendar](https://calendar.google.com/calendar/u/0?cid=Y183ZWQwZGZlZDAwYzlhMThkYmYwNGQ5M2U2MzNhOTc0ZjJmMmU1MTcyZjAwNjczYWJhM2ZkYjI5NTdiYWZmNTIxQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) to coordinate newsletters, launches, and other comms. Check it before scheduling anything that goes out to users, and add your own sends to it.
 
 ## Who is our audience?
 

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -26,6 +26,10 @@ To keep up with what's shipped and what's about to ship across the company, join
 
 Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the relevant channel. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.
 
+## Marketing calendar
+
+We keep a shared [marketing calendar](https://calendar.google.com/calendar/u/0?cid=Y19hZTgzMWZjNGIxNDc4NjRiYzdlYWVjMjBiNDM0NzhjMmNjODdkYjZmZGUwOTZkMjUyMDFhZGUxZDA1Y2EzZWFhQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) for scheduled emails, newsletters, launches, and other comms. Check it before scheduling anything that goes out to users so sends don't clash, and add your own to it.
+
 ## Marketing values
 
 1. Be opinionated


### PR DESCRIPTION
## Changes

Adds a link to the shared marketing calendar in two top-level handbook spots:

- **Marketing overview** – new `## Marketing calendar` section after "Slack channels to know".
- **Content overview** – a line near the top, after the goals/Slack intro.

Both point to the calendar and remind people to check it before scheduling user-facing sends and to add their own.

**Why:** Charles wanted the marketing calendar discoverable from the handbook (it's currently only referenced on issue templates) so the team can coordinate emails, newsletters, and launches without sends clashing.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1780995761274859?thread_ts=1780995761.274859&cid=C08CG24E3SR)*