### PR TITLE
docs: fix iOS captureScreenViews default

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -409,11 +409,11 @@ PostHog captures the following events:
 
 #### Configuring screen navigation autocapture
 
-Screen navigation autocapture is not enabled by default. You can enable it by setting `captureScreenViews` to `true` in the config.
+Screen navigation autocapture is enabled by default because `captureScreenViews` defaults to `true`. You can disable it by setting `captureScreenViews` to `false` in the config.
 
 | Option                              | Description                                                                                     |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `captureScreenViews`                | **Type:** `boolean`. When set to `true`, autocapture will capture screen views.                 |
+| `captureScreenViews`                | **Type:** `boolean`. Defaults to `true`. When set to `true`, autocapture will capture screen views. |
 | `captureApplicationLifecycleEvents` | **Type:** `boolean`. When set to `true`, autocapture will capture application lifecycle events. |
 
 For example, your initialization code might look like this:


### PR DESCRIPTION
## Changes

- Correct the iOS autocapture docs to state that `captureScreenViews` defaults to `true`.
- Clarify that screen navigation autocapture can be disabled by setting `captureScreenViews` to `false`.

Closes https://github.com/PostHog/posthog.com/issues/16182

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
