### PR TITLE
docs: reflect that the wizard does more than installation

### DIFF
--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -6,7 +6,7 @@ import WizardInstall from 'getting-started/_snippets/wizard.mdx'
 
 The PostHog wizard is an agentic CLI tool that uses AI to set up and manage PostHog in your codebase. By default, it installs and instruments PostHog for you, the way an expert would.
 
-It does more than installation though. The wizard can also audit an existing integration, migrate you from another vendor, upload source maps, set up revenue analytics, and diagnose configuration issues – so it's just as useful after you're up and running as it is on day one.
+It does more than installation though. The wizard can also audit an existing integration, migrate you from another vendor, upload source maps, set up Revenue Analytics, and diagnose configuration issues – so it's just as useful after you're up and running as it is on day one.
 
 Set up the PostHog platform in minutes, with a single command.
 
@@ -57,8 +57,8 @@ The wizard isn't just for getting started. It bundles a growing set of agent ski
 | `npx @posthog/wizard audit` | Audits an existing integration for correctness and best practices |
 | `npx @posthog/wizard events-audit` | Inventories every captured event, mapped to its file, area, and 30-day volume |
 | `npx @posthog/wizard migrate` | Migrates an existing analytics or feature flag vendor to PostHog |
-| `npx @posthog/wizard revenue` | Sets up [Stripe revenue analytics](/docs/revenue-analytics) |
-| `npx @posthog/wizard upload-source-maps` | Uploads [source maps](/docs/error-tracking/upload-source-maps) to PostHog error tracking |
+| `npx @posthog/wizard revenue` | Sets up [Stripe Revenue Analytics](/docs/revenue-analytics) |
+| `npx @posthog/wizard upload-source-maps` | Uploads [source maps](/docs/error-tracking/upload-source-maps) to PostHog Error Tracking |
 | `npx @posthog/wizard mcp add` | Installs the [PostHog MCP server](/docs/model-context-protocol) for your AI agent |
 
 Run `npx @posthog/wizard --help` to see every available command.

--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -4,7 +4,9 @@ title: AI wizard
 
 import WizardInstall from 'getting-started/_snippets/wizard.mdx'
 
-The PostHog wizard automatically installs and instruments PostHog into your application codebase using AI. It's an agentic CLI tool that handles the entire PostHog integration process on your behalf.
+The PostHog wizard is an agentic CLI tool that uses AI to set up and manage PostHog in your codebase. By default, it installs and instruments PostHog for you, the way an expert would.
+
+It does more than installation though. The wizard can also audit an existing integration, migrate you from another vendor, upload source maps, set up revenue analytics, and diagnose configuration issues – so it's just as useful after you're up and running as it is on day one.
 
 Set up the PostHog platform in minutes, with a single command.
 
@@ -43,6 +45,23 @@ Running the wizard automatically:
 <Caption>
 The AI wizard integrating both the JS Web SDK and Node SDK into a Next.js application
 </Caption>
+
+## More than installation
+
+The wizard isn't just for getting started. It bundles a growing set of agent skills you can run at any time – on a brand-new project or an existing PostHog integration – by passing a command. If you already have PostHog instrumented, these help you keep your setup healthy, complete, and cost-efficient.
+
+| Command | What it does |
+| --- | --- |
+| `npx @posthog/wizard` | Installs and instruments PostHog in your codebase (the default) |
+| `npx @posthog/wizard doctor` | Diagnoses your PostHog project for configuration issues and setup warnings |
+| `npx @posthog/wizard audit` | Audits an existing integration for correctness and best practices |
+| `npx @posthog/wizard events-audit` | Inventories every captured event, mapped to its file, area, and 30-day volume |
+| `npx @posthog/wizard migrate` | Migrates an existing analytics or feature flag vendor to PostHog |
+| `npx @posthog/wizard revenue` | Sets up [Stripe revenue analytics](/docs/revenue-analytics) |
+| `npx @posthog/wizard upload-source-maps` | Uploads [source maps](/docs/error-tracking/upload-source-maps) to PostHog error tracking |
+| `npx @posthog/wizard mcp add` | Installs the [PostHog MCP server](/docs/model-context-protocol) for your AI agent |
+
+Run `npx @posthog/wizard --help` to see every available command.
 
 ## AI wizard installation
 

--- a/contents/handbook/engineering/ai/ai-platform.md
+++ b/contents/handbook/engineering/ai/ai-platform.md
@@ -73,7 +73,7 @@ These are the AI features users interact with directly:
 - **[Deep research](/handbook/engineering/ai/products#deep-research)**: Automated investigative research for complex, open-ended problems
 - **[Session summaries](/handbook/engineering/ai/products#session-summaries)**: Batch analysis of session recordings to find patterns
 - **[PostHog Code](/handbook/engineering/ai/products#posthog-code)**: Agent development environment that gives each task its own isolated workspace
-- **[Wizard](/handbook/engineering/ai/products#wizard)**: CLI tool for automated PostHog installation and setup
+- **[Wizard](/handbook/engineering/ai/products#wizard)**: CLI tool for automated PostHog installation, plus skills to audit, migrate, and manage an existing integration
 - **[MCP Server](/handbook/engineering/ai/products#mcp)**: Protocol integration for third-party AI tools like Claude Code
 
 ### 2. Core infrastructure
@@ -128,9 +128,9 @@ An agent development environment that solves the messy workflow problem of engin
 [Learn more →](/handbook/engineering/ai/products#posthog-code)
 
 ### Wizard [General availability]
-Get PostHog set up in minutes instead of hours. The Wizard detects your tech stack, generates integration code, verifies the installation, and gets you collecting data with minimal manual work.
+Get PostHog set up in minutes instead of hours. The Wizard detects your tech stack, generates integration code, verifies the installation, and gets you collecting data with minimal manual work. Beyond setup, it can audit an existing integration, migrate you from another vendor, and run other skills on demand.
 
-**Best for**: New PostHog users, setting up new projects, quick integration
+**Best for**: New PostHog users, setting up new projects, quick integration, and auditing or improving an existing integration
 **Status**: General availability | **Pricing**: Free
 
 [Learn more →](/handbook/engineering/ai/products#wizard)

--- a/contents/handbook/engineering/ai/products.md
+++ b/contents/handbook/engineering/ai/products.md
@@ -390,13 +390,13 @@ The Wizard handles installation and basic setup across PostHog's supported SDKs.
 - Configuring autocapture and basic options
 
 It's no longer just a one-time setup tool, though. The Wizard now bundles a growing set of agent skills (sourced from [context-mill](/handbook/docs-and-wizard/context-mill)) that work just as well on an existing PostHog integration as on a new project. Each is invoked as a command, for example:
-- `npx @posthog/wizard doctor` — diagnose a project for configuration issues and setup warnings
-- `npx @posthog/wizard audit` — audit an existing integration for correctness, best practices, and cost-optimization opportunities (with an `audit web-analytics` variant for web analytics misconfigurations)
-- `npx @posthog/wizard events-audit` — inventory every captured event, mapped to its file, area, and 30-day volume
-- `npx @posthog/wizard migrate` — migrate an existing analytics or feature flag vendor to PostHog
-- `npx @posthog/wizard revenue` — set up Stripe revenue analytics
-- `npx @posthog/wizard upload-source-maps` — upload source maps to PostHog error tracking
-- `npx @posthog/wizard mcp add` — install the PostHog MCP server
+- `npx @posthog/wizard doctor` – diagnose a project for configuration issues and setup warnings
+- `npx @posthog/wizard audit` – audit an existing integration for correctness, best practices, and cost-optimization opportunities (with an `audit web-analytics` variant for web analytics fixes)
+- `npx @posthog/wizard events-audit` – inventory every captured event, mapped to its file, area, and 30-day volume
+- `npx @posthog/wizard migrate` – migrate an existing analytics or feature flag vendor to PostHog
+- `npx @posthog/wizard revenue` – set up Stripe Revenue Analytics
+- `npx @posthog/wizard upload-source-maps` – upload source maps to PostHog Error Tracking
+- `npx @posthog/wizard mcp add` – install the PostHog MCP server
 
 ### Future direction
 

--- a/contents/handbook/engineering/ai/products.md
+++ b/contents/handbook/engineering/ai/products.md
@@ -383,21 +383,29 @@ The entire experience uses Clack.cc for a polished CLI interface with clear prom
 
 ### Current capabilities
 
-Right now, the Wizard handles installation and basic setup across PostHog's supported SDKs. It's particularly good at:
+The Wizard handles installation and basic setup across PostHog's supported SDKs. It's particularly good at:
 - Detecting complex framework setups (like Next.js with app router vs pages router)
 - Handling different package managers (npm, yarn, pnpm)
 - Placing initialization code in the right location based on framework conventions
 - Configuring autocapture and basic options
 
+It's no longer just a one-time setup tool, though. The Wizard now bundles a growing set of agent skills (sourced from [context-mill](/handbook/docs-and-wizard/context-mill)) that work just as well on an existing PostHog integration as on a new project. Each is invoked as a command, for example:
+- `npx @posthog/wizard doctor` — diagnose a project for configuration issues and setup warnings
+- `npx @posthog/wizard audit` — audit an existing integration for correctness, best practices, and cost-optimization opportunities (with an `audit web-analytics` variant for web analytics misconfigurations)
+- `npx @posthog/wizard events-audit` — inventory every captured event, mapped to its file, area, and 30-day volume
+- `npx @posthog/wizard migrate` — migrate an existing analytics or feature flag vendor to PostHog
+- `npx @posthog/wizard revenue` — set up Stripe revenue analytics
+- `npx @posthog/wizard upload-source-maps` — upload source maps to PostHog error tracking
+- `npx @posthog/wizard mcp add` — install the PostHog MCP server
+
 ### Future direction
 
-The Wizard's long-term vision is much broader than one-time setup. Imagine:
+The Wizard's long-term vision is broader still. Imagine:
 - **Continuous instrumentation**: The Wizard could watch your codebase and suggest event tracking for new features. "I noticed you added a new checkout flow — want me to add tracking events?"
 - **Instrumentation improvements**: "Your signup flow isn't tracking all the steps — I can add events to fill the gaps."
-- **Best practices**: "You're tracking events in 5 different ways. I can standardize this for you."
 - **Integration with PostHog Code**: The Wizard is already integrated into PostHog Code, handling PostHog instrumentation automatically when generating code (feature flags, experiments, custom events).
 
-This would turn the Wizard from a one-time setup tool into an ongoing assistant that keeps your PostHog instrumentation clean and comprehensive.
+This turns the Wizard from a one-time setup tool into an ongoing assistant that keeps your PostHog instrumentation clean and comprehensive.
 
 ### Current status & ownership
 

--- a/contents/wizard.mdx
+++ b/contents/wizard.mdx
@@ -11,6 +11,8 @@ PostHog Wizard is an agentic CLI tool that installs and configures PostHog for y
 
 The wizard starts by analyzing your codebase, then it automagically sets up the right tools, custom events, and dashboards for your product.
 
+It's not just for getting started, either. The wizard bundles a growing set of agent skills you can run at any time – even if you already have PostHog instrumented – to audit your integration, migrate from another vendor, set up revenue analytics, upload source maps, and more. See the [AI wizard docs](/docs/ai-engineering/ai-wizard#more-than-installation) for the full list of commands.
+
 <DemoVideo />
 
 It's free, open source, and doesn't enable any paid features. It works with a growing list of PostHog products.
@@ -55,7 +57,7 @@ Like almost everything we make, PostHog Wizard is open source. Want to fork it a
 
 PostHog Wizard is instructed to focus on finding valuable funnel events in your codebase – between 10-15 events and files, so it's unlikely to rack up a bill.
 
-That said, we plan on introducing a cost cutting skill, intended for existing PostHog customers who want to reduce the volume of existing events logged to PostHog to help reduce cost.
+If you're an existing PostHog customer who wants to reduce the volume of events you're logging, run `npx @posthog/wizard audit` (or `events-audit`) to surface correctness issues and cost-optimization opportunities in your existing integration.
 
 #### Why does PostHog Wizard only configure 10-15 events?
 

--- a/contents/wizard.mdx
+++ b/contents/wizard.mdx
@@ -11,7 +11,7 @@ PostHog Wizard is an agentic CLI tool that installs and configures PostHog for y
 
 The wizard starts by analyzing your codebase, then it automagically sets up the right tools, custom events, and dashboards for your product.
 
-It's not just for getting started, either. The wizard bundles a growing set of agent skills you can run at any time – even if you already have PostHog instrumented – to audit your integration, migrate from another vendor, set up revenue analytics, upload source maps, and more. See the [AI wizard docs](/docs/ai-engineering/ai-wizard#more-than-installation) for the full list of commands.
+It's not just for getting started, either. The wizard bundles a growing set of agent skills you can run at any time – even if you already have PostHog instrumented – to audit your integration, migrate from another vendor, set up Revenue Analytics, upload source maps, and more. See the [AI wizard docs](/docs/ai-engineering/ai-wizard#more-than-installation) for the full list of commands.
 
 <DemoVideo />
 


### PR DESCRIPTION
## Changes

The PostHog wizard now bundles a growing set of [agent skills](https://github.com/PostHog/context-mill/tree/main/transformation-config/skills) that work on existing PostHog integrations, not just fresh installs (auditing, migrating, source maps, revenue analytics, `doctor`, MCP setup). Our docs still framed the wizard as an install/setup-only tool for new users.

This updates the framing and documents the additional commands:

- **`contents/docs/ai-engineering/ai-wizard.mdx`** — broadened the intro and added a "More than installation" section with a table of the available commands.
- **`contents/wizard.mdx`** — updated the TL;DR and the cost-cutting FAQ (the audit skills now deliver this).
- **`contents/handbook/engineering/ai/products.md`** and **`ai-platform.md`** — refreshed the now-stale "Current capabilities" / "Best for" copy.

**Why:** A user asked whether the wizard works when PostHog is already instrumented. It does — via skills for existing users — but the docs didn't say so.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07TQR0V16U/p1781030476703129?thread_ts=1781030476.703129&cid=C07TQR0V16U)*