### PR TITLE
docs(oauth): Remove team-growth email from claiming section, link to CIMD

### DIFF
--- a/contents/docs/api/oauth.mdx
+++ b/contents/docs/api/oauth.mdx
@@ -78,9 +78,7 @@ The scopes available through OAuth are listed in the `scopes_supported` field of
 
 ## Claiming your OAuth integration
 
-The <SmallTeam slug="growth" /> is working on creating a better, more streamlined process for partners to register and claim OAuth integrations with PostHog. In the meantime, CIMD provides a reliable way to integrate with PostHog's OAuth system without a manual registration step.
-
-If you need to register an official OAuth integration or have questions about the integration process, email **team-growth@posthog.com**.
+The <SmallTeam slug="growth" /> is working on creating a better, more streamlined process for partners to register and claim OAuth integrations with PostHog. In the meantime, [CIMD](#client-id-metadata-document-cimd) provides a reliable way to integrate with PostHog's OAuth system without a manual registration step.
 
 ## Token types
 


### PR DESCRIPTION
## Changes

Removes the mention of emailing **team-growth@posthog.com** from the "Claiming your OAuth integration" section of the OAuth docs. The section still describes the claiming process, and now links the inline "CIMD" reference to the [Client ID Metadata Document (CIMD)](https://posthog.com/docs/api/oauth#client-id-metadata-document-cimd) section in the same doc.

Left the unrelated team-growth email in `provisioning.mdx` untouched, since that one is about requesting a higher rate limit for production — not about claiming an integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)