### PR TITLE
docs: remove Unity beta warnings

### DIFF
--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -4,7 +4,7 @@ The `PostHog` package supports any .NET platform that targets .NET Standard 2.1 
 
 > **Note:** We actively test with ASP.NET Core. Other platforms should work but haven't been specifically tested. If you encounter issues, please [report them on GitHub](https://github.com/PostHog/posthog-dotnet/issues).
 
-> **Not supported:** Classic UWP (requires .NET Standard 2.0 only). Microsoft has [deprecated UWP](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/migrate-to-windows-app-sdk-ovw) in favor of the Windows App SDK. For Unity projects, see our dedicated [Unity SDK](/docs/libraries/unity) (currently in beta).
+> **Not supported:** Classic UWP (requires .NET Standard 2.0 only). Microsoft has [deprecated UWP](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/migrate-to-windows-app-sdk-ovw) in favor of the Windows App SDK. For Unity projects, see our dedicated [Unity SDK](/docs/libraries/unity).
 
 ```bash
 dotnet add package PostHog.AspNetCore

--- a/contents/docs/libraries/unity/index.mdx
+++ b/contents/docs/libraries/unity/index.mdx
@@ -17,8 +17,6 @@ features:
   errorTracking: true
 ---
 
-> **Note:** This SDK is currently in **beta**. Please report any issues on [GitHub](https://github.com/PostHog/posthog-unity/issues).
-
 This is the official PostHog SDK for Unity. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your Unity game or application.
 
 PostHog Unity SDK supports Windows, Mac, Linux, iOS, Android, and WebGL platforms.
@@ -230,9 +228,7 @@ PostHog.Setup(new PostHogConfig
 
 ## Session Replay
 
-> **Note:** Session Replay for Unity is currently **experimental**. Performance impact varies based on your game's complexity and target devices.
-
-Session Replay enables you to record and watch user sessions in your Unity game. It captures screenshots, touch/mouse input, network requests, and console logs. Session Replay is **disabled by default** and must be explicitly enabled.
+Session Replay enables you to record and watch user sessions in your Unity game. It captures screenshots, touch/mouse input, network requests, and console logs. Session Replay is **disabled by default** and must be explicitly enabled. Performance impact varies based on your game's complexity and target devices.
 
 The SDK uses `AsyncGPUReadback` to capture screenshots without blocking the main thread, ensuring minimal performance impact during gameplay.
 


### PR DESCRIPTION
## Problem

The Unity SDK docs still described the SDK and Session Replay as beta/experimental even though they are now stable.

## Changes

- Removed the beta warning from the Unity SDK docs.
- Removed the experimental warning from Unity Session Replay while keeping the note about potential performance impact.
- Updated the .NET install snippet to stop referring to the Unity SDK as beta.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
