### PR TITLE
Clarify HOGS should be written privately before pasting into doc

### DIFF
--- a/contents/handbook/company/goal-setting.md
+++ b/contents/handbook/company/goal-setting.md
@@ -19,7 +19,7 @@ In terms of accountability, <TeamMember name="Scott Lewis" photo /> will notify 
 
 ### Planning template
 
-Teams should fill in the previous quarter reflection async in the doc before the meeting starts. **HOGS should be written privately and independently – in your own notes, not the shared doc – then pasted in at the start of the session.** Doing them privately first stops people from being skewed by each other's thinking before they've formed their own view. The meeting itself should be 20% reviewing the past, and 80% talking about goals for next quarter. Don't fall into the trap of spending most of your time reviewing and then rushing the goals right at the end. 
+Teams should fill in the previous quarter reflection async in the doc before the meeting starts. **HOGS should be written privately and independently, in your own notes rather than the shared doc, then pasted in at the start of the session.** Doing them privately first stops people from being skewed by each other's thinking before they've formed their own view. The meeting itself should be 20% reviewing the past, and 80% talking about goals for next quarter. Don't fall into the trap of spending most of your time reviewing and then rushing the goals right at the end. 
 
 ```md
 ## Last quarter objectives reflection (5 mins - do as a team)
@@ -32,9 +32,9 @@ What else did we get done? List items from the changelog or PRs merged if they w
 
 You may also want to write some overall thoughts about how the quarter generally went.
 
-## HOGS (10 minutes - written privately beforehand, pasted in at the **start** of the session)
+## HOGS (10 minutes, written privately beforehand and pasted in at the **start** of the session)
 
-Everyone should write their HOGS **privately and independently** before the meeting – in your own notes, not this doc – then paste them in at the start of the session. Keeping them private until then means people don't anchor on each other's thinking. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
+Everyone should write their HOGS **privately and independently** before the meeting, in your own notes rather than this doc, then paste them in at the start of the session. Keeping them private until then means people don't anchor on each other's thinking. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
 
 Add entries under each question with your initials/name like: "- (your name): My comment"
 

--- a/contents/handbook/company/goal-setting.md
+++ b/contents/handbook/company/goal-setting.md
@@ -19,7 +19,7 @@ In terms of accountability, <TeamMember name="Scott Lewis" photo /> will notify 
 
 ### Planning template
 
-Teams should fill in the previous quarter reflection async in the doc before the meeting starts. **HOGS should be written privately and independently — in your own notes, not the shared doc — then pasted in at the start of the session.** Doing them privately first stops people from being skewed by each other's thinking before they've formed their own view. The meeting itself should be 20% reviewing the past, and 80% talking about goals for next quarter. Don't fall into the trap of spending most of your time reviewing and then rushing the goals right at the end. 
+Teams should fill in the previous quarter reflection async in the doc before the meeting starts. **HOGS should be written privately and independently – in your own notes, not the shared doc – then pasted in at the start of the session.** Doing them privately first stops people from being skewed by each other's thinking before they've formed their own view. The meeting itself should be 20% reviewing the past, and 80% talking about goals for next quarter. Don't fall into the trap of spending most of your time reviewing and then rushing the goals right at the end. 
 
 ```md
 ## Last quarter objectives reflection (5 mins - do as a team)
@@ -34,7 +34,7 @@ You may also want to write some overall thoughts about how the quarter generally
 
 ## HOGS (10 minutes - written privately beforehand, pasted in at the **start** of the session)
 
-Everyone should write their HOGS **privately and independently** before the meeting — in your own notes, not this doc — then paste them in at the start of the session. Keeping them private until then means people don't anchor on each other's thinking. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
+Everyone should write their HOGS **privately and independently** before the meeting – in your own notes, not this doc – then paste them in at the start of the session. Keeping them private until then means people don't anchor on each other's thinking. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
 
 Add entries under each question with your initials/name like: "- (your name): My comment"
 

--- a/contents/handbook/company/goal-setting.md
+++ b/contents/handbook/company/goal-setting.md
@@ -19,7 +19,7 @@ In terms of accountability, <TeamMember name="Scott Lewis" photo /> will notify 
 
 ### Planning template
 
-Teams should fill in the previous quarter and HOGS sections async in the doc before the meeting starts. The meeting itself should be 20% reviewing the past, and 80% talking about goals for next quarter. Don't fall into the trap of spending most of your time reviewing and then rushing the goals right at the end. 
+Teams should fill in the previous quarter reflection async in the doc before the meeting starts. **HOGS should be written privately and independently — in your own notes, not the shared doc — then pasted in at the start of the session.** Doing them privately first stops people from being skewed by each other's thinking before they've formed their own view. The meeting itself should be 20% reviewing the past, and 80% talking about goals for next quarter. Don't fall into the trap of spending most of your time reviewing and then rushing the goals right at the end. 
 
 ```md
 ## Last quarter objectives reflection (5 mins - do as a team)
@@ -32,9 +32,9 @@ What else did we get done? List items from the changelog or PRs merged if they w
 
 You may also want to write some overall thoughts about how the quarter generally went.
 
-## HOGS (10 minutes - all the content should be here **before** the meeting starts)
+## HOGS (10 minutes - written privately beforehand, pasted in at the **start** of the session)
 
-This should be done BEFORE the meeting by everyone, independently and in this doc before the meeting starts. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
+Everyone should write their HOGS **privately and independently** before the meeting — in your own notes, not this doc — then paste them in at the start of the session. Keeping them private until then means people don't anchor on each other's thinking. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
 
 Add entries under each question with your initials/name like: "- (your name): My comment"
 


### PR DESCRIPTION
## Changes

**TL;DR:** Clarifies the quarterly planning process so teams write their HOGS privately and independently before pasting them into the shared doc at the start of the session. Writing privately first prevents people from anchoring on each other's thinking before forming their own view.

This PR updates the goal-setting handbook page to:

- Clarify that only the **previous quarter reflection** should be filled in async in the shared doc before the meeting.
- Add explicit guidance that **HOGS should be written privately and independently** in your own notes (not the shared doc), then pasted in at the start of the session.
- Explain the rationale: keeping HOGS private until the session start stops people from being skewed by each other's thinking.
- Update the HOGS section heading and inline instructions in the planning template to reflect this private-first process.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*