### PR TITLE
docs: clarify MCP billing and AI data processing requirement in docs

### DIFF
--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -17,7 +17,9 @@ The PostHog MCP server is a hosted [Model Context Protocol](https://modelcontext
 
 ### How much does it cost?
 
-It's free. Connecting to the MCP server and calling its tools doesn't incur any charges on your PostHog bill. Standard PostHog [usage and billing](/docs/billing) still apply to the underlying data your queries consume.
+Connecting to the MCP server and calling its tools is free. Standard PostHog [usage and billing](/docs/billing) still apply to the underlying data your queries consume.
+
+Note that some tools use LLMs internally (for example, generating a HogQL query from a natural language question), and usage of these tools may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
 
 ### Which AI clients and editors are supported?
 

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -19,7 +19,7 @@ The PostHog MCP server is a hosted [Model Context Protocol](https://modelcontext
 
 Connecting to the MCP server and calling its tools is free. Standard PostHog [usage and billing](/docs/billing) still apply to the underlying data your queries consume.
 
-Note that some tools use LLMs internally (for example, generating a HogQL query from a natural language question), and usage of these tools may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
+Note that some tools use LLMs internally, and usage of these tools may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
 
 ### Which AI clients and editors are supported?
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -10,7 +10,9 @@ import PromptExample from "./_snippets/prompt-example.tsx"
 
 The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server is a free, hosted endpoint that lets your AI agent use PostHog – with just plain text questions your agents can ship a feature flag from a prompt, dig into a stack trace without leaving your editor, run a HogQL query through Claude, triage a support ticket, set up a CDP destination, and much more.
 
-It works with any MCP-compatible client, including [PostHog Code](/code), Claude Code, Claude Desktop, Cursor, Codex, VS Code, Windsurf, and Zed. 
+It works with any MCP-compatible client, including [PostHog Code](/code), Claude Code, Claude Desktop, Cursor, Codex, VS Code, Windsurf, and Zed.
+
+> Connecting to the MCP server and calling its tools is free, but some tools use LLMs internally and may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings.
 
 ## Get started in 30 seconds
 


### PR DESCRIPTION
## Changes

The MCP docs advertised the server as flatly free. While connecting and calling tools is free, some tools use LLMs internally (e.g. natural-language-to-HogQL) and may be billed as **PostHog AI** spend. Those AI-powered tools are also only available when **AI data processing** is enabled in org settings.

- **`faq.mdx`** – reworded the "How much does it cost?" answer to note LLM-backed tools may incur PostHog AI spend and require AI data processing to be enabled.
- **`index.mdx`** – added a callout under the overview with the same note.

Both link to [`/docs/posthog-ai/allow-access`](https://posthog.com/docs/posthog-ai/allow-access), which already documents that LLM-using MCP tools are filtered out when AI data processing is disabled.

**Why:** Teams are increasingly pushing token spend through PostHog AI (e.g. insight/subscription summaries), so the "completely free" framing in the MCP docs is no longer accurate and could surprise users on their bill.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781083675532179?thread_ts=1781083675.532179&cid=C09SK2PAGKF)*
