### PR TITLE
docs: fix iOS lifecycle autocapture default

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -422,6 +422,7 @@ For example, your initialization code might look like this:
 let config = PostHogConfig(projectToken: <ph_project_token>, host: <ph_client_api_host>)
 
 config.captureElementInteractions = true // Disabled by default
+config.captureScreenViews = false // Enabled by default; set to false to disable
 config.captureApplicationLifecycleEvents = false // Enabled by default; set to false to disable
 
 PostHogSDK.shared.setup(config)

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -407,14 +407,14 @@ PostHog captures the following events:
 | `Application Opened`       | App becomes active/foreground                     |
 | `Application Backgrounded` | App moves to background                           |
 
-#### Configuring screen navigation autocapture
+#### Configuring screen navigation and lifecycle autocapture
 
-Screen navigation autocapture is enabled by default because `captureScreenViews` defaults to `true`. You can disable it by setting `captureScreenViews` to `false` in the config.
+Screen navigation and application lifecycle autocapture are enabled by default because `captureScreenViews` and `captureApplicationLifecycleEvents` default to `true`. You can disable them by setting either option to `false` in the config.
 
-| Option                              | Description                                                                                     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Option                              | Description                                                                                         |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `captureScreenViews`                | **Type:** `boolean`. Defaults to `true`. When set to `true`, autocapture will capture screen views. |
-| `captureApplicationLifecycleEvents` | **Type:** `boolean`. When set to `true`, autocapture will capture application lifecycle events. |
+| `captureApplicationLifecycleEvents` | **Type:** `boolean`. Defaults to `true`. When set to `true`, autocapture will capture application lifecycle events. |
 
 For example, your initialization code might look like this:
 
@@ -422,7 +422,7 @@ For example, your initialization code might look like this:
 let config = PostHogConfig(projectToken: <ph_project_token>, host: <ph_client_api_host>)
 
 config.captureElementInteractions = true // Disabled by default
-config.captureApplicationLifecycleEvents = true // Disabled by default
+config.captureApplicationLifecycleEvents = false // Enabled by default; set to false to disable
 
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -413,8 +413,8 @@ Screen navigation and application lifecycle autocapture are enabled by default b
 
 | Option                              | Description                                                                                         |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `captureScreenViews`                | **Type:** `boolean`. Defaults to `true`. When set to `true`, autocapture will capture screen views. |
-| `captureApplicationLifecycleEvents` | **Type:** `boolean`. Defaults to `true`. When set to `true`, autocapture will capture application lifecycle events. |
+| `captureScreenViews`                | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable screen view autocapture. |
+| `captureApplicationLifecycleEvents` | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable application lifecycle event autocapture. |
 
 For example, your initialization code might look like this:
 


### PR DESCRIPTION
## Changes

Fixes an inconsistency in the iOS navigation and lifecycle autocapture docs by documenting that `captureApplicationLifecycleEvents` defaults to `true`, matching the iOS configuration reference.

Also updates the enabled-by-default option descriptions to explain how to disable screen view and application lifecycle autocapture, and updates the example to show disabling lifecycle autocapture with `captureApplicationLifecycleEvents = false`.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
