### PR TITLE
docs(ios): correct config defaults in iOS SDK configuration page

### DIFF
--- a/contents/docs/libraries/ios/configuration.mdx
+++ b/contents/docs/libraries/ios/configuration.mdx
@@ -226,9 +226,9 @@ The [`PostHogConfig` object](https://github.com/PostHog/posthog.com/pull/13379/f
 
 | Attribute | Description |
 |-----------|-------------|
-| `flushAt`<br/><br/>**Type:** Integer<br/>**Default:** `20` | The number of queued events that the posthog client should flush at. Setting this to `1` will not queue any events and will use more battery. |
+| `flushAt`<br/><br/>**Type:** Integer<br/>**Default:** `20` (`5` on tvOS) | The number of queued events that the posthog client should flush at. Setting this to `1` will not queue any events and will use more battery. |
 | `flushIntervalSeconds`<br/><br/>**Type:** Integer<br/>**Default:** `30` | The amount of time to wait before each tick of the flush timer. Smaller values will make events delivered in a more real-time manner and also use more battery. A value smaller than 10 seconds will seriously degrade overall performance. |
-| `maxQueueSize`<br/><br/>**Type:** Integer<br/>**Default:** `1000` | The maximum number of items to queue before starting to drop old ones. This should be a value greater than zero, the behavior is undefined otherwise. |
+| `maxQueueSize`<br/><br/>**Type:** Integer<br/>**Default:** `1000` (`100` on tvOS) | The maximum number of items to queue before starting to drop old ones. This should be a value greater than zero, the behavior is undefined otherwise. |
 | `maxBatchSize`<br/><br/>**Type:** Integer<br/>**Default:** `50` | Number of maximum events in a batch call. |
 | `maxRetries`<br/><br/>**Type:** Integer<br/>**Default:** `3` | Maximum number of consecutive flush attempts before the entire queue is dropped to avoid infinite retries against a permanently-broken backend (e.g. wrong API key, exhausted quota, deterministic 5xx). Increments on every retriable failure including HTTP 413 cap halving; resets on a successful 2xx response. |
 | `captureApplicationLifecycleEvents`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Whether the posthog client should automatically make a capture call for application lifecycle events, such as "Application Installed", "Application Updated" and "Application Opened". |
@@ -239,11 +239,12 @@ The [`PostHogConfig` object](https://github.com/PostHog/posthog.com/pull/13379/f
 | `sendFeatureFlagEvent`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Send a `$feature_flag_called` event when a feature flag is used automatically. |
 | `preloadFeatureFlags`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Preload feature flags automatically. |
 | `evaluationContexts`<br/><br/>**Type:** Array of Strings<br/>**Default:** `undefined` | Evaluation context tags that constrain which feature flags are evaluated. When set, only flags with matching evaluation context tags (or no evaluation context tags) will be returned. See [evaluation contexts documentation](/docs/feature-flags/evaluation-contexts) for more details. Available in version 3.34.0+. The legacy parameter `evaluationEnvironments` (version 3.33.0+) is also supported for backward compatibility. |
-| `debug`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Logs the SDK messages into Logcat. |
+| `debug`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Logs the SDK messages to the Xcode console. |
 | `optOut`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Prevents capturing any data if enabled. |
 | `getAnonymousId`<br/><br/>**Type:** Function<br/>**Default:** `undefined` | Hook that allows for modification of the default mechanism for generating anonymous id (which as of now is just random UUID v7). |
 | `dataMode`<br/><br/>**Type:** Enum<br/>**Default:** `.any` | Allows to send your data only if the data mode matches your configuration such as wifi only, cellular only or any. |
 | `personProfiles`<br/><br/>**Type:** Enum<br/>**Default:** `.identifiedOnly` | Determines the behavior for processing user profiles. |
+| `setDefaultPersonProperties`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Automatically set common device and app properties (such as `$app_version`, `$os_name`, and `$device_type`) as person properties for feature flag evaluation. See [property overrides](/docs/feature-flags/property-overrides) for more details. |
 | `sessionReplay`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Enable Recording of Session Replays. |
 | `sessionReplayConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Session Replay configuration. https://posthog.com/docs/session-replay/installation for more details |
 | `appGroupIdentifier`<br/><br/>**Type:** String<br/>**Default:** `nil` | The identifier of the App Group that should be used to store shared analytics data. PostHog will try to get the physical location of the App Group's shared container, otherwise fallback to the default location. |


### PR DESCRIPTION
## Summary

Audited the iOS SDK configuration docs against the real defaults in [posthog-ios](https://github.com/PostHog/posthog-ios) and fixed the drift found in the "All configuration options" table on `/docs/libraries/ios/configuration`.

All numeric/boolean/enum defaults across the iOS docs were verified against the SDK source — almost everything matched. This PR corrects the few inaccuracies and a missing option.

## Changes (`contents/docs/libraries/ios/configuration.mdx`)

- **`debug`**: description said "Logs the SDK messages into Logcat" — Logcat is Android. Changed to "Logs the SDK messages to the Xcode console."
- **`flushAt`**: default is `5` on tvOS (not `20`) — added `(`5` on tvOS)`. Source: `PostHogConfig.Defaults`.
- **`maxQueueSize`**: default is `100` on tvOS (not `1000`) — added `(`100` on tvOS)`. Source: `PostHogConfig.Defaults`.
- **`setDefaultPersonProperties`**: added a row for this real config option (default `true`) that was missing from the table (it was only documented in the feature-flags property-overrides page).

## Notes / out of scope

- The `captureApplicationLifecycleEvents` "Disabled by default" error in `product-analytics/autocapture.mdx` is intentionally **not** included here — it's already fixed by #17462.
- Minor items left as-is: the `dataMode` description implies `.cellular` restricts to cellular, but the SDK treats `.cellular` as legacy (same as `.any`); the install snippet pins `3.58.0` while the SDK is at `3.59.1` (SemVer-compatible, auto-bumped).