### PR TITLE
docs: document .NET PDB limitation

### DIFF
--- a/contents/docs/error-tracking/installation/dotnet.mdx
+++ b/contents/docs/error-tracking/installation/dotnet.mdx
@@ -67,6 +67,12 @@ You can find your project token and instance address in the [project settings](h
 
 The .NET SDK supports manual exception capture with `CaptureException`. It builds the `$exception` event for you, including exception type, message, stack frames, inner exceptions, aggregate exceptions, source context when available, and .NET runtime metadata.
 
+<CalloutBox icon="IconInfo" title="PDB uploads are not yet supported" type="fyi">
+
+File names, line numbers, and source context depend on debug information already available from the captured .NET stack trace. PostHog doesn't support uploading .NET PDB files yet, so production builds without runtime-accessible debug information may show less detailed stack frames ([issue](https://github.com/PostHog/posthog-dotnet/issues/166)).
+
+</CalloutBox>
+
 The examples below assume `posthog` is an `IPostHogClient` from dependency injection, or your singleton `PostHogClient`.
 
 ```csharp

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -39,6 +39,8 @@ import DotNetSendEvents from '../../integrate/send-events/_snippets/send-events-
 
 You can manually capture exceptions using `CaptureException`. This sends a `$exception` event with stack frames, inner exceptions, aggregate exceptions, source context when available, and .NET runtime metadata.
 
+File names, line numbers, and source context depend on debug information already available from the captured .NET stack trace. PostHog doesn't support uploading .NET PDB files yet, so production builds without runtime-accessible debug information may show less detailed stack frames.
+
 ```csharp
 try
 {


### PR DESCRIPTION
## Summary

- Document the current .NET Error Tracking limitation for file names, line numbers, and source context.
- Clarify that PostHog does not support .NET PDB uploads yet, so production builds without runtime-accessible debug information may show less detailed stack frames.
- Add the note to both the .NET Error Tracking installation guide and the .NET library reference.

## Context

Docs follow-up from PostHog/posthog-dotnet#166.

## Validation

- Docs formatter completed
- Markdownlint completed with 0 errors on touched files
- Vale completed with 0 errors on touched files; existing warnings remain
- Git diff check completed
