### PR TITLE
docs: update Android SDK docs

### DIFF
--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -118,7 +118,7 @@ Test environments, staging servers, and CI pipelines can silently accumulate fea
 The key settings are:
 - **JavaScript**: `advanced_disable_feature_flags: true` stops the SDK from hitting `/flags` on init
 - **Mobile SDKs**: `preloadFeatureFlags = false` prevents automatic flag fetching
-- **All SDKs**: Use flag overrides or bootstrapping to provide values locally without network requests
+- **SDKs with local overrides or bootstrapping**: Provide values locally without network requests
 
 <MultiLanguage>
 
@@ -149,12 +149,15 @@ posthog.init('<ph_project_token>', {
 ```
 
 ```android
+import com.posthog.android.PostHogAndroid
+import com.posthog.android.PostHogAndroidConfig
+
 // Detect test/CI environment
 val isTestEnv = BuildConfig.DEBUG || System.getProperty("CI") != null
 
-val config = PostHogConfig(apiKey = "<ph_project_token>").apply {
+val config = PostHogAndroidConfig(apiKey = "<ph_project_token>").apply {
     if (isTestEnv) {
-        // Disable flag requests entirely
+        // Disable automatic flag requests
         preloadFeatureFlags = false
         sendFeatureFlagEvent = false
 
@@ -164,12 +167,11 @@ val config = PostHogConfig(apiKey = "<ph_project_token>").apply {
     }
 }
 
-PostHog.setup(context, config)
+PostHogAndroid.setup(context, config)
 
-// If tests need flags to work, override them locally:
-if (isTestEnv) {
-    PostHog.with { it.overrideFeatureFlag("your-flag", true) }
-}
+// The Android SDK doesn't support local feature flag overrides.
+// If tests need deterministic values, wrap your own flag reads in test code
+// or use a separate PostHog project/environment with fixed flag rules.
 ```
 
 ```ios
@@ -236,7 +238,7 @@ if (isTestEnv) {
 
 </MultiLanguage>
 
-For staging environments where you want flags to work but don't need real-time evaluation, consider using [flag overrides and bootstrapping](/docs/feature-flags/testing#method-2-use-posthogfeatureflagsoverridefeatureflags) instead of fetching from the server.
+For staging environments where you want flags to work but don't need real-time evaluation, consider using [flag overrides and bootstrapping](/docs/feature-flags/testing#method-2-use-posthogfeatureflagsoverridefeatureflags) instead of fetching from the server in SDKs that support local overrides.
 
 ## Audit environments to catch unexpected `/flags` calls
 

--- a/contents/docs/feature-flags/evaluation-contexts.mdx
+++ b/contents/docs/feature-flags/evaluation-contexts.mdx
@@ -117,9 +117,12 @@ const posthogAsync = PostHog.initAsync('YOUR_API_KEY', {
 ```
 
 ```android
-val config = PostHogConfig(
-    apiKey = "YOUR_API_KEY",
-    host = "https://app.posthog.com"
+import com.posthog.android.PostHogAndroid
+import com.posthog.android.PostHogAndroidConfig
+
+val config = PostHogAndroidConfig(
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>"
 ).apply {
     evaluationContexts = listOf("main-app", "android", "mobile")
 }

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
@@ -24,6 +24,23 @@ if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-k
 }
 ```
 
+### Feature flag values and payloads together
+
+If you need both the flag value and payload, use `getFeatureFlagResult` so both values come from the same evaluation result.
+
+```kotlin
+import com.posthog.PostHog
+
+val result = PostHog.getFeatureFlagResult("flag-key")
+
+if (result?.value == "variant-key") {
+    val payload = result.payload
+    // Do something with the variant and payload
+}
+```
+
+You can also inspect all currently loaded feature flag results with `PostHog.getAllFeatureFlags()`.
+
 ### Ensuring flags are loaded before usage
 
 Every time a user opens the app, we send a request in the background to fetch the feature flags that apply to that user. We store those flags in the storage.
@@ -46,7 +63,7 @@ val config = PostHogAndroidConfig(apiKey = "<ph_project_token>").apply {
     }
 }
 
-// And/Or manually the SDK is initialized
+// And/or after the SDK is initialized
 PostHog.reloadFeatureFlags {
     if (PostHog.isFeatureEnabled("flag-key")) {
         // do something
@@ -62,4 +79,15 @@ Feature flag values are cached. If something has changed with your user and you'
 import com.posthog.PostHog
 
 PostHog.reloadFeatureFlags()
+```
+
+### Tracking feature usage
+
+To track when someone sees or interacts with a feature, use `captureFeatureView` and `captureFeatureInteraction`.
+
+```kotlin
+import com.posthog.PostHog
+
+PostHog.captureFeatureView("flag-key", flagVariant = "variant-key")
+PostHog.captureFeatureInteraction("flag-key", flagVariant = "variant-key")
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-android.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-android.mdx
@@ -36,7 +36,7 @@ PostHog autocapture automatically tracks the following events for you:
 -   **Application Installed** - when the app is installed.
 -   **Application Updated** - when the app is updated.
 -   **$screen** - when the user navigates. (if using `android.app.Activity`)
--   **$exception** - when the app throws exceptions.
+-   **$exception** - when uncaught exception autocapture is enabled. To use this, enable [Android error tracking](/docs/error-tracking/installation/android) and exception autocapture in the SDK config.
 
 ### Capturing screen views
 

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -299,7 +299,7 @@ The PostHog Android SDK will continue to capture events when the device is offli
 
 ## Debug mode 
 
-If you're not seeing the expected events being captured, the feature flags being evaluated, or session replay/error tracking behavior, you can enable debug mode to see what's happening. 
+If you're not seeing the expected events being captured, the feature flags being evaluated, surveys being shown, or session replay/error tracking behavior, you can enable debug mode to see what's happening. 
 
 You can enable debug mode by setting the `debug` option to `true` in the `PostHogAndroidConfig` object. This will enable verbose logs about the inner workings of the SDK.
 
@@ -356,7 +356,6 @@ val config = PostHogAndroidConfig(
 | `captureApplicationLifecycleEvents` | `true` | Captures `Application Installed`, `Application Updated`, `Application Opened`, and `Application Backgrounded`. |
 | `captureScreenViews` | `true` | Captures `$screen` for foreground `android.app.Activity` screens. |
 | `captureDeepLinks` | `true` | Captures `Deep Link Opened` with URL/query/referrer properties. |
-| `sessionReplayConfig` | `PostHogSessionReplayConfig()` | Configures Android session replay. See [session replay installation](/docs/session-replay/installation/android). |
 
 ### Core options
 
@@ -386,7 +385,6 @@ val config = PostHogAndroidConfig(
 | `featureFlagCalledCacheSize` | `1000` | Number of feature flag calls cached for deduplicating `$feature_flag_called` events. |
 | `preloadFeatureFlags` | `true` | Fetches feature flags automatically during setup. |
 | `evaluationContexts` | `null` | Context tags that constrain which feature flags are evaluated. Available in version 3.25.0+. |
-| `evaluationEnvironments` | `null` | Deprecated alias for `evaluationContexts`. |
 | `onFeatureFlags` | `null` | Callback invoked when feature flags are loaded. |
 
 ### Product configuration objects
@@ -399,8 +397,6 @@ val config = PostHogAndroidConfig(
 | `errorTrackingConfig` | `PostHogErrorTrackingConfig()` | Configures error tracking. `autoCapture` defaults to `false`; set it to `true` to autocapture uncaught exceptions when project settings also enable error tracking. |
 | `surveys` | `false` | Internal/experimental native Android survey support. Native Android survey UI is not fully supported or documented yet. |
 | `surveysConfig` | `PostHogSurveysConfig()` | Internal/experimental survey display delegate configuration, primarily for hybrid SDKs. |
-
-`remoteConfig` is a deprecated no-op in current Android SDK versions because remote config is always enabled.
 
 ### Event filtering with `beforeSend`
 
@@ -418,13 +414,11 @@ config.addBeforeSend { event ->
 }
 ```
 
-`propertiesSanitizer` still exists for backwards compatibility, but it is deprecated. Use `addBeforeSend` and `removeBeforeSend` for new code.
-
 # FAQ
 
 ## What Android API level is required?
 
-The Android SDK supports Android API 21 and newer. Session replay requires Android API 26 and newer.
+The Android SDK supports Android API 23 and newer.
 
 ## Do I need to declare permissions in the AndroidManifest.xml?
 

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -8,7 +8,7 @@ platformLogo: android
 features:
   eventCapture: true
   userIdentification: true
-  autoCapture: false
+  autoCapture: true
   sessionRecording: true
   featureFlags: true
   groupAnalytics: true
@@ -299,7 +299,7 @@ The PostHog Android SDK will continue to capture events when the device is offli
 
 ## Debug mode 
 
-If you're not seeing the expected events being captured, the feature flags being evaluated, or the surveys being shown, you can enable debug mode to see what's happening. 
+If you're not seeing the expected events being captured, the feature flags being evaluated, or session replay/error tracking behavior, you can enable debug mode to see what's happening. 
 
 You can enable debug mode by setting the `debug` option to `true` in the `PostHogAndroidConfig` object. This will enable verbose logs about the inner workings of the SDK.
 
@@ -312,85 +312,120 @@ val config = PostHogAndroidConfig(apiKey = POSTHOG_API_KEY, host = POSTHOG_HOST)
 
 ## All configuration options
 
-When creating the PostHog client, there are many options you can set:
+When creating the PostHog client, pass a `PostHogAndroidConfig`. It inherits the core `PostHogConfig` options and adds Android-specific options.
 
 ```kotlin
-val config = PostHogAndroidConfig(apiKey = POSTHOG_API_KEY, host = POSTHOG_HOST).apply {
-    // Capture certain application events automatically. (on/true by default)
+import com.posthog.PersonProfiles
+import com.posthog.android.PostHogAndroidConfig
+
+val config = PostHogAndroidConfig(
+    apiKey = POSTHOG_API_KEY,
+    host = POSTHOG_HOST
+).apply {
     captureApplicationLifecycleEvents = true
-
-    // Capture screen views automatically. (on/true by default)
-    captureScreenViews = true // (on/true by default)
-
-    // Capture deep links as part of the screen call. (on/true by default)
+    captureScreenViews = true
     captureDeepLinks = true
 
-    // Maximum number of events to keep in queue before flushing (20 by default)
     flushAt = 20
-
-    // Number of maximum events in memory and disk, when the maximum is exceed, the oldest event is deleted and the new one takes place. (1000 by default)
     maxQueueSize = 1000
-
-    // Number of maximum events in a batch call. (50 by default)
     maxBatchSize = 50
-
-    // Maximum delay before flushing the queue (30 seconds)
+    maxRetries = 3
     flushIntervalSeconds = 30
 
-    // Logs the SDK messages into Logcat. (off/false by default)
     debug = false
-
-    // Prevents capturing any data if enabled. (off/false by default)
     optOut = false
 
-    // Send a '$feature_flag_called' event when a feature flag is used automatically. (on/true by default)
     sendFeatureFlagEvent = true
-
-    // Preload feature flags automatically. (on/true by default)
+    featureFlagCalledCacheSize = 1000
     preloadFeatureFlags = true
-
-    // Evaluation context tags that constrain which feature flags are evaluated. (not set by default)
-    // When set, only flags with matching evaluation context tags (or no evaluation context tags) will be returned.
-    // Available in version 3.25.0+. The legacy parameter `evaluationEnvironments` (version 3.24.0+) is also supported.
     evaluationContexts = listOf("production", "android", "mobile")
 
-    // Callback that is called when feature flags are loaded (not set by default)
-    onFeatureFlags = { ... }
-
-    // Callback that allows to sanitize the event properties (not set by default)
-    propertiesSanitizer = { properties -> ... }
-
-    // Hook for encrypt and decrypt events
-    // Devices are sandbox already
-    // Defaults to no encryption
-    encryption = object : PostHogEncryption { ... }
-
-    // Hook that allows for modification of the default mechanism for
-    // generating anonymous id (which as of now is just random UUID v7)
-    getAnonymousId = { ... }
-
-    // Determines the behavior for processing user profiles.
-    // Defaults to PersonProfiles.IDENTIFIED_ONLY
+    setDefaultPersonProperties = true
     personProfiles = PersonProfiles.IDENTIFIED_ONLY
-
-    // Enable Recording of Session Replay. (off/false by default)
-    sessionReplay = false
-
-    // Session Replay configuration
-    // https://posthog.com/docs/session-replay/installation for more details
-    sessionReplayConfig = PostHogSessionReplayConfig(...)
-
-    // Whether the SDK should reuse the anonymous Id between user changes. 
-    // When enabled, a single Id will be used for all anonymous users on this device (off/false by default)
     reuseAnonymousId = false
 
-    // Error tracking configuration
-    errorTrackingConfig = PostHogErrorTrackingConfig(...)
+    sessionReplay = false
+    errorTrackingConfig.autoCapture = false
 }
 ```
 
+### Android-specific options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `captureApplicationLifecycleEvents` | `true` | Captures `Application Installed`, `Application Updated`, `Application Opened`, and `Application Backgrounded`. |
+| `captureScreenViews` | `true` | Captures `$screen` for foreground `android.app.Activity` screens. |
+| `captureDeepLinks` | `true` | Captures `Deep Link Opened` with URL/query/referrer properties. |
+| `sessionReplayConfig` | `PostHogSessionReplayConfig()` | Configures Android session replay. See [session replay installation](/docs/session-replay/installation/android). |
+
+### Core options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `debug` | `false` | Enables verbose SDK logs in Logcat. You can also call `PostHog.debug(true)`. |
+| `optOut` | `false` | Prevents data capture when enabled. You can also call `PostHog.optOut()` and `PostHog.optIn()`. |
+| `flushAt` | `20` | Number of queued events that triggers a flush. |
+| `maxQueueSize` | `1000` | Maximum number of events kept across memory and disk before FIFO eviction. |
+| `maxBatchSize` | `50` | Maximum number of events sent in one batch request. |
+| `maxRetries` | `3` | Maximum retry attempts for failed requests. |
+| `flushIntervalSeconds` | `30` | Maximum delay before queued data is flushed. |
+| `encryption` | `null` | Optional `PostHogEncryption` implementation for encrypting persisted queued events. |
+| `proxy` | `null` | Optional `java.net.Proxy` for PostHog API requests. |
+| `getAnonymousId` | generated UUID | Optional hook to customize anonymous ID generation. |
+| `reuseAnonymousId` | `false` | Reuses one anonymous ID across user changes on the same device. |
+| `personProfiles` | `PersonProfiles.IDENTIFIED_ONLY` | Controls when person profiles are processed: `IDENTIFIED_ONLY`, `ALWAYS`, or `NEVER`. |
+| `setDefaultPersonProperties` | `true` | Includes default person properties for person profile updates. |
+| `releaseIdentifier` | app/version fallback | Release identifier used by error tracking and uploaded ProGuard/R8 mappings. The Android Gradle plugin can inject this automatically. |
+| `tracingHeaders` | `null` | Exact hostnames that should receive PostHog tracing headers when using `PostHogOkHttpInterceptor`. |
+
+### Feature flag options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `sendFeatureFlagEvent` | `true` | Sends `$feature_flag_called` when a feature flag is evaluated. |
+| `featureFlagCalledCacheSize` | `1000` | Number of feature flag calls cached for deduplicating `$feature_flag_called` events. |
+| `preloadFeatureFlags` | `true` | Fetches feature flags automatically during setup. |
+| `evaluationContexts` | `null` | Context tags that constrain which feature flags are evaluated. Available in version 3.25.0+. |
+| `evaluationEnvironments` | `null` | Deprecated alias for `evaluationContexts`. |
+| `onFeatureFlags` | `null` | Callback invoked when feature flags are loaded. |
+
+### Product configuration objects
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `sessionReplay` | `false` | Enables session replay when project settings also allow recording. |
+| `sessionReplayConfig` | `PostHogSessionReplayConfig()` | Configures masking, screenshots, Logcat capture, sampling, and custom drawable conversion. |
+| `logs` | `PostHogLogsConfig()` | Configures [Android logs](/docs/logs/installation/android). |
+| `errorTrackingConfig` | `PostHogErrorTrackingConfig()` | Configures error tracking. `autoCapture` defaults to `false`; set it to `true` to autocapture uncaught exceptions when project settings also enable error tracking. |
+| `surveys` | `false` | Internal/experimental native Android survey support. Native Android survey UI is not fully supported or documented yet. |
+| `surveysConfig` | `PostHogSurveysConfig()` | Internal/experimental survey display delegate configuration, primarily for hybrid SDKs. |
+
+`remoteConfig` is a deprecated no-op in current Android SDK versions because remote config is always enabled.
+
+### Event filtering with `beforeSend`
+
+Use `addBeforeSend` to redact, modify, or drop events before they are queued. Return `null` to drop an event.
+
+```kotlin
+config.addBeforeSend { event ->
+    event.properties?.remove("password")
+
+    if (event.event == "internal_debug_event") {
+        null
+    } else {
+        event
+    }
+}
+```
+
+`propertiesSanitizer` still exists for backwards compatibility, but it is deprecated. Use `addBeforeSend` and `removeBeforeSend` for new code.
+
 # FAQ
+
+## What Android API level is required?
+
+The Android SDK supports Android API 21 and newer. Session replay requires Android API 26 and newer.
 
 ## Do I need to declare permissions in the AndroidManifest.xml?
 
-We don't declare nor use any 'Service', so no permissions are needed.
+Usually, no. The SDK declares `android.permission.INTERNET` and `android.permission.ACCESS_NETWORK_STATE`, and Android's manifest merger adds them to your app. The SDK does not declare or require an Android `Service`.

--- a/contents/docs/logs/installation/android.mdx
+++ b/contents/docs/logs/installation/android.mdx
@@ -6,7 +6,6 @@ showStepsToc: true
 ---
 
 import { Steps, Step } from 'components/Docs/Steps'
-import AndroidInstall from '../../integrate/_snippets/install-android.mdx'
 import LogsNextSteps from './_snippets/logs-next-steps.mdx'
 
 The PostHog Android SDK has built-in support for capturing structured Logs from Android apps. The SDK handles the OTLP encoding, batching, on-disk persistence across app restarts, and lifecycle integration. You just call `PostHog.logger.{trace,debug,info,warn,error,fatal}(...)`.
@@ -19,9 +18,7 @@ The PostHog Android SDK has built-in support for capturing structured Logs from 
 
 <Step title="Install posthog-android" badge="required">
 
-If you haven't installed `posthog-android` yet, follow the steps below. For full details, see the [Android SDK guide](/docs/libraries/android).
-
-<AndroidInstall />
+If you haven't installed `posthog-android` yet, follow the [Android SDK installation guide](/docs/libraries/android#installation).
 
 </Step>
 
@@ -30,24 +27,13 @@ If you haven't installed `posthog-android` yet, follow the steps below. For full
 Configure Logs through `config.logs` before calling `PostHogAndroid.setup(...)`. All fields are optional; defaults are tuned for mobile (cellular bandwidth, battery, app lifecycle).
 
 ```kotlin
-import com.posthog.android.PostHogAndroid
-import com.posthog.android.PostHogAndroidConfig
-
-class SampleApp : Application() {
-    override fun onCreate() {
-        super.onCreate()
-
-        val config = PostHogAndroidConfig(
-            apiKey = "<ph_project_token>",
-            host = "<ph_client_api_host>",
-        ).apply {
-            logs.serviceName = "my-app"        // OTLP service.name – shown in the Logs UI
-            logs.environment = "production"    // OTLP deployment.environment
-            logs.serviceVersion = "1.2.3"      // OTLP service.version
-        }
-
-        PostHogAndroid.setup(this, config)
-    }
+val config = PostHogAndroidConfig(
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>",
+).apply {
+    logs.serviceName = "my-app"        // OTLP service.name – shown in the Logs UI
+    logs.environment = "production"    // OTLP deployment.environment
+    logs.serviceVersion = "1.2.3"      // OTLP service.version
 }
 ```
 

--- a/contents/docs/logs/installation/android.mdx
+++ b/contents/docs/logs/installation/android.mdx
@@ -74,6 +74,19 @@ PostHog.logger.log("rendered cart", severity = PostHogLogSeverity.DEBUG)
 
 Available severity levels: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`.
 
+If you need W3C trace correlation, call `PostHog.captureLog(...)` directly and pass `traceId`, `spanId`, and `traceFlags`.
+
+```kotlin
+PostHog.captureLog(
+    "payment failed",
+    severity = PostHogLogSeverity.ERROR,
+    attributes = mapOf("code" to "PAY_3001"),
+    traceId = "4bf92f3577b34da6a3ce929d0e0e4736",
+    spanId = "00f067aa0ba902b7",
+    traceFlags = 0x01,
+)
+```
+
 Records are buffered, batched, persisted to disk, and flushed automatically – every 30 seconds, when the buffer hits the threshold, when the app moves to the background, or on `PostHog.flush()`. `flush()` drains events, Session Replay, and Logs together.
 
 Each record is automatically tagged with the current distinct ID, session ID, current screen, app foreground/background state, and active Feature Flags at the moment of capture.

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -434,44 +434,7 @@ PostHogSDK.shared.setup(config)
 
 ### Android navigation and lifecycle autocapture
 
-PostHog automatically captures navigation, lifecycle, and deep-link events as users navigate your app and when the app is launched, updated, backgrounded, or opened from a deep link.
-
-PostHog captures the following events:
-
-| Event name                 | Description                                                  |
-| -------------------------- | ------------------------------------------------------------ |
-| `$screen`                  | Screen view changes for `android.app.Activity` screens       |
-| `Deep Link Opened`         | App opens from a deep link                                   |
-| `Application Installed`    | First app launch                                             |
-| `Application Updated`      | App version updates                                          |
-| `Application Opened`       | App opens from a closed state or comes to the foreground     |
-| `Application Backgrounded` | App moves to the background                                  |
-
-#### Configuring Android navigation and lifecycle autocapture
-
-Screen navigation, deep-link, and application lifecycle autocapture are enabled by default. You can disable them with `PostHogAndroidConfig`.
-
-| Option                              | Description                                                              |
-| ----------------------------------- | ------------------------------------------------------------------------ |
-| `captureScreenViews`                | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable `$screen` autocapture. |
-| `captureDeepLinks`                  | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable `Deep Link Opened` autocapture. |
-| `captureApplicationLifecycleEvents` | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable application lifecycle event autocapture. |
-
-```kotlin
-import com.posthog.android.PostHogAndroid
-import com.posthog.android.PostHogAndroidConfig
-
-val config = PostHogAndroidConfig(
-    apiKey = "<ph_project_token>",
-    host = "<ph_client_api_host>"
-).apply {
-    captureScreenViews = false
-    captureDeepLinks = false
-    captureApplicationLifecycleEvents = false
-}
-
-PostHogAndroid.setup(context, config)
-```
+Android lifecycle, screen, and deep-link autocapture are documented in the [Android SDK capturing events guide](/docs/libraries/android#capturing-events). Configuration options are documented in the [Android SDK configuration reference](/docs/libraries/android#all-configuration-options).
 
 Android does not currently support interaction autocapture for arbitrary taps or gestures.
 

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -41,7 +41,7 @@ Autocapture is available in the following SDKs, each with a different set of cap
 
 - [JavaScript Web](/docs/libraries/js) - enabled by default
 - [React](/docs/libraries/react) - enabled by default
-- [Android](/docs/libraries/android) - enabled by default
+- [Android](/docs/libraries/android) - navigation, lifecycle, and deep-link autocapture enabled by default; interaction autocapture is not supported
 - [iOS](/docs/libraries/ios) - enabled by default (element interactions - `$autocapture` events disabled by default)
 - [React Native](/docs/libraries/react-native) - disabled by default
 - [Flutter](/docs/libraries/flutter) - disabled by default
@@ -344,10 +344,11 @@ To exclude specific UI elements from autocapture or session replay, add `ph-no-c
 
 ## Navigation and lifecycle event autocapture
 
-<Tab.Group tabs={['Web', 'iOS', 'React Native']}>
+<Tab.Group tabs={['Web', 'iOS', 'Android', 'React Native']}>
 <Tab.List>
 <Tab>Web</Tab>
 <Tab>iOS</Tab>
+<Tab>Android</Tab>
 <Tab>React Native</Tab>
 </Tab.List>
 <Tab.Panels>
@@ -427,6 +428,52 @@ config.captureApplicationLifecycleEvents = false // Enabled by default; set to f
 
 PostHogSDK.shared.setup(config)
 ```
+
+</Tab.Panel>
+<Tab.Panel>
+
+### Android navigation and lifecycle autocapture
+
+PostHog automatically captures navigation, lifecycle, and deep-link events as users navigate your app and when the app is launched, updated, backgrounded, or opened from a deep link.
+
+PostHog captures the following events:
+
+| Event name                 | Description                                                  |
+| -------------------------- | ------------------------------------------------------------ |
+| `$screen`                  | Screen view changes for `android.app.Activity` screens       |
+| `Deep Link Opened`         | App opens from a deep link                                   |
+| `Application Installed`    | First app launch                                             |
+| `Application Updated`      | App version updates                                          |
+| `Application Opened`       | App opens from a closed state or comes to the foreground     |
+| `Application Backgrounded` | App moves to the background                                  |
+
+#### Configuring Android navigation and lifecycle autocapture
+
+Screen navigation, deep-link, and application lifecycle autocapture are enabled by default. You can disable them with `PostHogAndroidConfig`.
+
+| Option                              | Description                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| `captureScreenViews`                | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable `$screen` autocapture. |
+| `captureDeepLinks`                  | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable `Deep Link Opened` autocapture. |
+| `captureApplicationLifecycleEvents` | **Type:** `boolean`. Defaults to `true`. Set to `false` to disable application lifecycle event autocapture. |
+
+```kotlin
+import com.posthog.android.PostHogAndroid
+import com.posthog.android.PostHogAndroidConfig
+
+val config = PostHogAndroidConfig(
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>"
+).apply {
+    captureScreenViews = false
+    captureDeepLinks = false
+    captureApplicationLifecycleEvents = false
+}
+
+PostHogAndroid.setup(context, config)
+```
+
+Android does not currently support interaction autocapture for arbitrary taps or gestures.
 
 </Tab.Panel>
 <Tab.Panel>

--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -1,12 +1,9 @@
 ## Step one: Add PostHog to your app
 
-import AndroidInstall from "../../integrate/_snippets/install-android.mdx"
-
 export const EnableSessionReplayDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-dark-mode.png"
 export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-light-mode.png"
 
-
-<AndroidInstall />
+If you haven't installed `posthog-android` yet, follow the [Android SDK installation guide](/docs/libraries/android#installation).
 
 > Session replay requires PostHog Android SDK version >= [3.4.0](https://github.com/PostHog/posthog-android/releases), and it's recommended to always use [the latest version](/docs/sdk-doctor).
 

--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -1,9 +1,12 @@
 ## Step one: Add PostHog to your app
 
+import AndroidInstall from "../../integrate/_snippets/install-android.mdx"
+
 export const EnableSessionReplayDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-dark-mode.png"
 export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-light-mode.png"
 
-If you haven't installed `posthog-android` yet, follow the [Android SDK installation guide](/docs/libraries/android#installation).
+
+<AndroidInstall />
 
 > Session replay requires PostHog Android SDK version >= [3.4.0](https://github.com/PostHog/posthog-android/releases), and it's recommended to always use [the latest version](/docs/sdk-doctor).
 

--- a/contents/docs/session-replay/_snippets/android-logging.mdx
+++ b/contents/docs/session-replay/_snippets/android-logging.mdx
@@ -1,13 +1,1 @@
-You can enable this feature from your client-side by setting `captureLogcat = true` in our [Android SDK config](/docs/session-replay/installation/android#step-two-configure-replay-settings).
-
-```android_kotlin
-val config = PostHogAndroidConfig(apiKey = "<ph_project_token>").apply {
-    // Enable session recording. Requires enabling in your project settings as well.
-    // Default is false.
-    sessionReplay = true
-    // Capture logs automatically. Default is true.
-    // Remote configuration via project settings requires SDK version 3.32.0 or higher.
-    sessionReplayConfig.captureLogcat = true
-    ...
-}
-```
+You can enable this feature from your client-side by setting `captureLogcat = true` in your [Android Session Replay configuration](/docs/session-replay/installation/android#step-three-configure-replay-settings). Remote configuration via project settings requires Android SDK version 3.32.0 or higher.

--- a/contents/docs/session-replay/_snippets/android-network.mdx
+++ b/contents/docs/session-replay/_snippets/android-network.mdx
@@ -13,3 +13,24 @@ private val client = OkHttpClient.Builder()
 ```
 
 > **Note:** Only metric-like data like speed, size, and response code are captured. No data is captured from the request or response body.
+
+## Add tracing headers
+
+The same interceptor can also add PostHog tracing headers to specific hosts. Configure exact hostnames with `tracingHeaders`, then add `PostHogOkHttpInterceptor` to the `OkHttpClient` used for those requests.
+
+```android_kotlin
+import com.posthog.PostHogOkHttpInterceptor
+import com.posthog.android.PostHogAndroidConfig
+import okhttp3.OkHttpClient
+
+val config = PostHogAndroidConfig(apiKey = "<ph_project_token>").apply {
+    // Exact hostnames only: no protocol, port, path, or wildcard.
+    tracingHeaders = listOf("api.example.com")
+}
+
+private val client = OkHttpClient.Builder()
+    .addInterceptor(PostHogOkHttpInterceptor(captureNetworkTelemetry = true))
+    .build()
+```
+
+When the request hostname matches, the interceptor adds `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` when those values are available.

--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -30,7 +30,7 @@ Below is an example of a screen captured in screenshot mode in Android:
 
 ## Next steps
 
-* [Android session replay](/docs/session-replay/android)
-* [iOS session replay](/docs/session-replay/ios)
-* [React Native session replay](/docs/session-replay/react-native)
-* [Flutter session replay](/docs/session-replay/flutter)
+* [Android session replay](/docs/session-replay/installation/android)
+* [iOS session replay](/docs/session-replay/installation/ios)
+* [React Native session replay](/docs/session-replay/installation/react-native)
+* [Flutter session replay](/docs/session-replay/installation/flutter)


### PR DESCRIPTION
## Changes

Updates Android SDK docs to match the current public SDK API and configuration:

- Fixes Android feature flag snippets to use `PostHogAndroidConfig` / `PostHogAndroid.setup` and removes unsupported local override guidance.
- Clarifies Android autocapture behavior, including exception autocapture requirements.
- Expands the Android SDK configuration reference with current public options and defaults.
- Adds Android feature flag result, feature usage, Logs trace correlation, and OkHttp tracing header docs.
- Updates mobile session replay links to point at current installation pages.
- Reduces duplicated Android setup snippets in Logs and Session Replay logging docs by linking to canonical Android setup/configuration pages.

No screenshots or screen recordings; docs-only changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
