### PR TITLE
docs: add SME guidance on attending product team offsites

### DIFF
--- a/contents/handbook/support/support-smes.md
+++ b/contents/handbook/support/support-smes.md
@@ -99,3 +99,14 @@ You and your SME counterpart in the other timezone should work together to:
 
 As we grow, we'll need less manual coordination. For now, always consider coverage and communicate proactively.
 
+### Attending product team offsites
+
+Sometimes the engineering teams you partner with will run an offsite, and it's natural to want to join — you work closely with them, after all. A few things to keep in mind before booking flights:
+
+- **Give <TeamMember name="Abigail Richardson" photo /> a heads up early.** As soon as it's on your radar, mention it. That way we can talk through coverage together. Occasionally we'll need to say no if support is stretched too thin — much better to know that before anything is booked.
+- **Have a reason, or make it easy.** Joining makes most sense when either there's something specific you'd get out of being there in person, or the offsite is local enough that getting there is straightforward and cheap.
+- **It's not your offsite.** You're still expected to keep up with your normal tickets and support work while you're there. Don't get pulled fully into their agenda at the expense of customers.
+- **SLAs don't move.** We won't be posting customer notices for these trips, and response times should stay just as high as any other week.
+
+None of this is meant to discourage you — getting time with your product team can be genuinely valuable. Just loop us in early and keep customers as the priority.
+

--- a/contents/handbook/support/support-smes.md
+++ b/contents/handbook/support/support-smes.md
@@ -101,12 +101,15 @@ As we grow, we'll need less manual coordination. For now, always consider covera
 
 ### Attending product team offsites
 
-Sometimes the engineering teams you partner with will run an offsite, and it's natural to want to join — you work closely with them, after all. A few things to keep in mind before booking flights:
+You work closely with the engineering teams behind your products, so when one of them runs an offsite, it's natural to want to be there. Time in person with your product team can be genuinely valuable. A few things to make it work:
 
-- **Give <TeamMember name="Abigail Richardson" photo /> a heads up early.** As soon as it's on your radar, mention it. That way we can talk through coverage together. Occasionally we'll need to say no if support is stretched too thin — much better to know that before anything is booked.
-- **Have a reason, or make it easy.** Joining makes most sense when either there's something specific you'd get out of being there in person, or the offsite is local enough that getting there is straightforward and cheap.
-- **It's not your offsite.** You're still expected to keep up with your normal tickets and support work while you're there. Don't get pulled fully into their agenda at the expense of customers.
-- **SLAs don't move.** We won't be posting customer notices for these trips, and response times should stay just as high as any other week.
+- **Give <TeamMember name="Abigail Richardson" photo /> a shout early.** The moment it's on your radar, flag it, so we can sort coverage together. Every now and then we might have to say no if support's stretched thin - and that's better to hear before you've booked flights.
 
-None of this is meant to discourage you — getting time with your product team can be genuinely valuable. Just loop us in early and keep customers as the priority.
+- **Have a reason, or make it easy.** You likely partner with a few different teams, and you can't be at every one of their offsites — nor should you try to be. Joining makes most sense when there's something specific you'll get out of being there in person, or the offsite is local enough that turning up is cheap and easy.
+
+- **You're still on support.** It's their offsite, not yours — so keep up with your normal tickets while you're there. Soak up the context and dip into their agenda, just don't vanish from the queue.
+
+- **Don't leave customers hanging.** We won't post customer notices for these trips, so from a user's side nothing should feel different. People shouldn't be waiting around just because you're away — stay as responsive as you'd be any other week.
+
+None of this is meant to put you off. Loop us in early, keep customers the priority, and these trips are a great thing to do.
 


### PR DESCRIPTION
## Summary

- Adds a new "Attending product team offsites" subsection to the support SME handbook (`contents/handbook/support/support-smes.md`)
- Sets the expectation that SMEs flag potential offsite attendance to Abigail in advance, gives a simple test for when joining makes sense (specific reason, or local/easy/cheap), and reinforces that tickets and SLAs continue as normal — no customer notices will go out

## Context
Support team members who are SMEs are being asked by product teams if they are going to their offsites.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*