### PR TITLE
Fix: Preserve window size on navigation

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1594,7 +1594,8 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                                   fromHistory: newWindow.fromHistory,
                                   props: newWindow.props,
                                   location: newWindow.location,
-                                  size: newWindow.size,
+                                  // Keep the window's current size on navigation; only fixed-size apps adopt the target page's size
+                                  size: newWindow.fixedSize ? newWindow.size : w.size,
                               }
                             : w
                     )


### PR DESCRIPTION
## Changes

In OS mode, if you open two windows side by side (resized ~50/50) and then click a link inside one of them, that window resizes back to a default size instead of staying as you'd sized it. The cause was in `replaceFocusedWindow`: navigating within a window overwrote its size with the new page's default. 

The fix keeps the current size on navigation, except for fixed-size (modal-style) apps, which still open at their set dimensions.

### Screen recordings

Before:
https://github.com/user-attachments/assets/2daae0a6-ab76-4b9e-ad95-c34e7e17075b

After:
https://github.com/user-attachments/assets/694ed347-7664-4e8b-b0c5-6473bea66f3f



## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
