### PR TITLE
Add graphics team responsibilities to brand ownership handbook

### DIFF
--- a/contents/handbook/brand/approvals.md
+++ b/contents/handbook/brand/approvals.md
@@ -34,3 +34,11 @@ When in doubt, ask in the `#design-review` Slack channel. Lottie and Cory are, f
 - **Events team** - In-person events, PostHog speaking engagements, meetups.
 - **Docs & Wizard team** - Docs, obviously. 
 - **Everyone** – Handbook updates. 
+
+### Graphics team
+
+To reduce collaboration overhead, the graphics team splits its work into three areas. This is a starting point we're trialing for a few weeks – if someone is overwhelmed or away, others can step in. A few assignments are temporary while we're in the middle of the rebrand (noted below).
+
+- **Illustration (Heidi)** – Newsletter and blog images, email artwork, hedgehog illustrations (used across the website, events, etc.), animating hogs, team crests, and merch design.
+- **Graphic design (Lottie)** – Website art (e.g. icons, backgrounds), paid ads, billboards and OOH, event graphics, and doing more weird. Also owns YouTube thumbnails and video assets temporarily, until the rebrand is done (then → Daniel).
+- **Production design (Daniel)** – Design ops (cleaning up and componentizing Figma), social media (repurposing existing assets only, no net new), merch file formatting, event flyers (soon to be self-serve on the web), and moving off Pitch and into Figma Slides.

--- a/contents/handbook/brand/approvals.md
+++ b/contents/handbook/brand/approvals.md
@@ -27,12 +27,12 @@ When in doubt, ask in the `#design-review` Slack channel. Lottie and Cory are, f
 ## Who owns what
 
 - **Website team** – Website, copy, major design decisions, motion work for web.
-- **Graphics team** - Graphics, artwork, merch, anything illustrated, motion work for video.
+- **Graphics team** – Graphics, artwork, merch, anything illustrated, motion work for video.
 - **Editorial team** – Blog, email copy, messaging guidelines, social presence.
-- **Marketing team** - Email copy, external partnerships, influencers.
-- **YouTube team** - Video production, editing.
-- **Events team** - In-person events, PostHog speaking engagements, meetups.
-- **Docs & Wizard team** - Docs, obviously. 
+- **Marketing team** – Email copy, external partnerships, influencers.
+- **YouTube team** – Video production, editing.
+- **Events team** – In-person events, PostHog speaking engagements, meetups.
+- **Docs & Wizard team** – Docs, obviously. 
 - **Everyone** – Handbook updates. 
 
 ### Graphics team responsibilities

--- a/contents/handbook/brand/approvals.md
+++ b/contents/handbook/brand/approvals.md
@@ -26,8 +26,8 @@ When in doubt, ask in the `#design-review` Slack channel. Lottie and Cory are, f
 
 ## Who owns what
 
-- **Cory** (Design Lead) – Website, copy, major design decisions, motion work for web.
-- **Lottie** (Graphics Lead) - Graphics, artwork, merch, anything illustrated, motion work for video.
+- **Website team** – Website, copy, major design decisions, motion work for web.
+- **Graphics team** - Graphics, artwork, merch, anything illustrated, motion work for video.
 - **Editorial team** – Blog, email copy, messaging guidelines, social presence.
 - **Marketing team** - Email copy, external partnerships, influencers.
 - **YouTube team** - Video production, editing.
@@ -35,9 +35,9 @@ When in doubt, ask in the `#design-review` Slack channel. Lottie and Cory are, f
 - **Docs & Wizard team** - Docs, obviously. 
 - **Everyone** – Handbook updates. 
 
-### Graphics team
+### Graphics team responsibilities
 
-To reduce collaboration overhead, the graphics team splits its work into three areas. This is a starting point we're trialing for a few weeks – if someone is overwhelmed or away, others can step in. A few assignments are temporary while we're in the middle of the rebrand (noted below).
+This is who owns what on #team-graphics:
 
 - **Illustration (Heidi)** – Newsletter and blog images, email artwork, hedgehog illustrations (used across the website, events, etc.), animating hogs, team crests, and merch design.
 - **Graphic design (Lottie)** – Website art (e.g. icons, backgrounds), paid ads, billboards and OOH, event graphics, and doing more weird. Also owns YouTube thumbnails and video assets temporarily, until the rebrand is done (then → Daniel).


### PR DESCRIPTION
## Changes

Added a **Graphics team** subsection under "Who owns what" on the brand ownership & approvals handbook page, documenting how the graphics team is dividing work across three areas (Illustration → Heidi, Graphic design → Lottie, Production design → Daniel). Temporary rebrand-era assignments (YouTube thumbnails / video assets) are noted as such.

**Why:** Lottie is allocating clear areas of ownership across the graphics team to reduce collaboration overhead, and the team wants this written down somewhere sensible in the handbook.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AU440KS6P/p1780588031288729?thread_ts=1780588031.288729&cid=C0AU440KS6P)*
