### PR TITLE
docs(mcp): document MCP server rate limits

### DIFF
--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -23,7 +23,7 @@ Note that some tools use LLMs internally, and usage of these tools may be billed
 
 ### Are there rate limits?
 
-MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request – there's no separate MCP limit layered on top. For example, analytics tools (insights, persons, session recordings) are limited to `240/minute` and `1200/hour`, SQL queries to `2400/hour`, and most other read/write tools to `480/minute` and `4800/hour`. These limits apply per team, across all users and keys in your organization.
+MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request – there's no separate MCP limit layered on top. These limits apply per team, across all users and keys in your organization.
 
 If a tool call does get rate limited, the server automatically retries it a few times – honoring the `Retry-After` header, or backing off exponentially – before surfacing an error, since AI agents can't wait and retry on their own.
 

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -23,7 +23,7 @@ Note that some tools use LLMs internally, and usage of these tools may be billed
 
 ### Are there rate limits?
 
-MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request – there's no separate MCP limit layered on top. These limits apply per team, across all users and keys in your organization.
+MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) – there's no separate MCP limit layered on top. These limits apply per team, across all users and keys in your organization.
 
 Some [AI-powered tools](#how-much-does-it-cost) (for example, sentiment analysis and trace summarization) have their own additional, lower limits because they run LLMs internally.
 

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -21,6 +21,18 @@ Connecting to the MCP server and calling its tools is free. Standard PostHog [us
 
 Note that some tools use LLMs internally, and usage of these tools may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
 
+### Are there rate limits?
+
+Yes, in two places:
+
+1. **The MCP server throttles its own outbound requests** to your PostHog instance to a maximum of 10 requests per second. When an agent fires tool calls faster than this, the server transparently queues them rather than failing. If a request is still rate limited by the PostHog API, the server automatically retries it up to three times, honoring the `Retry-After` header (or backing off exponentially) before surfacing an error.
+
+2. **Tool calls execute against the PostHog API**, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request. For example, analytics tools (insights, persons, session recordings) are limited to `240/minute` and `1200/hour`, SQL queries to `2400/hour`, and most other read/write tools to `480/minute` and `4800/hour`. These limits apply per team, across all users and keys in your organization.
+
+Some [AI-powered tools](#how-much-does-it-cost) (for example, sentiment analysis and trace summarization) have their own additional, lower limits because they run LLMs internally.
+
+If you regularly hit these limits, consider pulling data through [batch exports](/docs/cdp/batch-exports) or [endpoints](/docs/endpoints) instead.
+
 ### Which AI clients and editors are supported?
 
 Anything that speaks MCP works. We've tested and documented setup for Claude Code, Claude Desktop, Cursor, Codex, VS Code, Windsurf, and Zed. The [PostHog Wizard](https://github.com/PostHog/wizard) can install the server into most of these in one command.

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -25,8 +25,6 @@ Note that some tools use LLMs internally, and usage of these tools may be billed
 
 MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request – there's no separate MCP limit layered on top. These limits apply per team, across all users and keys in your organization.
 
-If a tool call does get rate limited, the server automatically retries it a few times – honoring the `Retry-After` header, or backing off exponentially – before surfacing an error, since AI agents can't wait and retry on their own.
-
 Some [AI-powered tools](#how-much-does-it-cost) (for example, sentiment analysis and trace summarization) have their own additional, lower limits because they run LLMs internally.
 
 If you regularly hit these limits, consider pulling data through [batch exports](/docs/cdp/batch-exports) or [endpoints](/docs/endpoints) instead.

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -23,11 +23,9 @@ Note that some tools use LLMs internally, and usage of these tools may be billed
 
 ### Are there rate limits?
 
-Yes, in two places:
+MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request – there's no separate MCP limit layered on top. For example, analytics tools (insights, persons, session recordings) are limited to `240/minute` and `1200/hour`, SQL queries to `2400/hour`, and most other read/write tools to `480/minute` and `4800/hour`. These limits apply per team, across all users and keys in your organization.
 
-1. **The MCP server throttles its own outbound requests** to your PostHog instance to a maximum of 10 requests per second. When an agent fires tool calls faster than this, the server transparently queues them rather than failing. If a request is still rate limited by the PostHog API, the server automatically retries it up to three times, honoring the `Retry-After` header (or backing off exponentially) before surfacing an error.
-
-2. **Tool calls execute against the PostHog API**, so they're subject to the same [API rate limits](/docs/api#rate-limiting) as any other personal API key request. For example, analytics tools (insights, persons, session recordings) are limited to `240/minute` and `1200/hour`, SQL queries to `2400/hour`, and most other read/write tools to `480/minute` and `4800/hour`. These limits apply per team, across all users and keys in your organization.
+If a tool call does get rate limited, the server automatically retries it a few times – honoring the `Retry-After` header, or backing off exponentially – before surfacing an error, since AI agents can't wait and retry on their own.
 
 Some [AI-powered tools](#how-much-does-it-cost) (for example, sentiment analysis and trace summarization) have their own additional, lower limits because they run LLMs internally.
 


### PR DESCRIPTION
## Changes

The PostHog MCP server's rate limits weren't documented anywhere on posthog.com. This adds an **"Are there rate limits?"** entry to the [MCP FAQ](/docs/model-context-protocol/faq) explaining that MCP tool calls run against the PostHog API and so are subject to the same per-team [API rate limits](/docs/api#rate-limiting) – there's no separate MCP throttle on top. It also notes that some AI-powered tools have their own lower limits.

**Why:** A community member pointed out the MCP rate limits weren't covered in public docs. The MCP server recently dropped its standalone outbound throttle so the API is now the single source of truth for rate limits, and the docs should reflect that.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07TQR0V16U/p1781106661516179?thread_ts=1781106661.516179&cid=C07TQR0V16U)*
