### PR TITLE
Add annotation guidance to marketing handbook

### DIFF
--- a/contents/handbook/marketing/email-comms.md
+++ b/contents/handbook/marketing/email-comms.md
@@ -34,6 +34,8 @@ We regularly send three types of email broadcasts.
 
 Occasionally we send other ad-hoc email broadcasts for specific activities such as outages, reminders, announcements, or deprecations. 
 
+Whenever we send a broadcast, add an annotation (no emoji) in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the send date, so we can see its impact on our metrics later.
+
 ### Changelog
 The changelog email is part of [the new release process](/handbook/marketing/product-announcements) and is used for [product announcements](/handbook/marketing/product-announcements).
 

--- a/contents/handbook/marketing/email-comms.md
+++ b/contents/handbook/marketing/email-comms.md
@@ -58,6 +58,8 @@ The exceptions and other solutions are:
 
 >We specifically do not want emails we think people will reply to going into hey@posthog.com because it is sporadically monitored at best, and hard to collaborate through.
 
+If you're sending a launch email (alpha, beta, GA), it's helpful to add an annotation in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the send date, so we can see its impact on our metrics later.
+
 When we ask users to share feedback through email, it should either link to beta-feedback@posthog.com, the [support modal](http://app.posthog.com/home#supportModal), or to ourselves personally. Never hey@posthog.com.
 
 Doing this lets us filter out the noise for everyone else while still giving good visibility on meaningful feedback internally. If a user sends you feedback, you should share that with the relevant product team or in https://posthog.slack.com/archives/C011L071P8U 
@@ -107,8 +109,6 @@ This flow currently comprises a single, personal email from either Joe or the te
 When responses come in, Joe generally triages replies and directs feedback to the relevant team, as well as rewarding users with merch as thanks for their feedback. 
 
 > **Launching a beta?** It helps to let the Brand team know in [the team Slack](https://posthog.slack.com/archives/C083V7C6GKE). The team can then add your beta to the beta onboarding flow, and plan ahead for marketing announcements as needed.
-
-It's also helpful to add an annotation in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the send date, so we can see its impact on our metrics later.
 
 
 #### Onboarding - new hires

--- a/contents/handbook/marketing/email-comms.md
+++ b/contents/handbook/marketing/email-comms.md
@@ -34,8 +34,6 @@ We regularly send three types of email broadcasts.
 
 Occasionally we send other ad-hoc email broadcasts for specific activities such as outages, reminders, announcements, or deprecations. 
 
-Whenever we send a broadcast, add an annotation (no emoji) in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the send date, so we can see its impact on our metrics later.
-
 ### Changelog
 The changelog email is part of [the new release process](/handbook/marketing/product-announcements) and is used for [product announcements](/handbook/marketing/product-announcements).
 
@@ -51,11 +49,11 @@ The email is usually comprised of three sections, which inform users of new guid
 We categorize these emails as `Actually useful marketing emails` in Customer.io, so users can unsubscribe if they wish. This email usually comes directly from Joe. 
 
 ### Launch emails
-Most product and feature launch emails come from the Product Marketer who sent them -- but sometimes campaigns trigger from others, such as billing@posthog.com.
+Most product and feature launch emails come from the Product Marketer who sent them – but sometimes campaigns trigger from others, such as billing@posthog.com.
 
 The exceptions and other solutions are:
-- Sending emails from hey@posthog.com -- this is what we usually do for BIG sends, because it would overwhelm the sender's inbox with 'out-of-office' auto-replies.
-- Sending emails from beta-feedback@posthog.com -- this is a Google group tied to the automation in [#posthog-feedback](https://posthog.slack.com/archives/C011L071P8U ) by a Slack bot. Any responses to this address get posted in that channel and anyone can reply to them using the info in there.
+- Sending emails from hey@posthog.com – this is what we usually do for BIG sends, because it would overwhelm the sender's inbox with 'out-of-office' auto-replies.
+- Sending emails from beta-feedback@posthog.com – this is a Google group tied to the automation in [#posthog-feedback](https://posthog.slack.com/archives/C011L071P8U ) by a Slack bot. Any responses to this address get posted in that channel and anyone can reply to them using the info in there.
 - Sending emails from a specific person, but setting the reply-to address as one of the above. This is not common, but it's there if you want to use it.
 
 >We specifically do not want emails we think people will reply to going into hey@posthog.com because it is sporadically monitored at best, and hard to collaborate through.
@@ -108,7 +106,10 @@ This flow currently comprises a single, personal email from either Joe or the te
 
 When responses come in, Joe generally triages replies and directs feedback to the relevant team, as well as rewarding users with merch as thanks for their feedback. 
 
-> **Launching a beta?** It helps to let the Brand team know in [the team Slack](https://posthog.slack.com/archives/C083V7C6GKE). The team can then add your beta to the beta onboarding flow, and plan ahead for marketing announcements as needed. 
+> **Launching a beta?** It helps to let the Brand team know in [the team Slack](https://posthog.slack.com/archives/C083V7C6GKE). The team can then add your beta to the beta onboarding flow, and plan ahead for marketing announcements as needed.
+
+It's also helpful to add an annotation in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the send date, so we can see its impact on our metrics later.
+
 
 #### Onboarding - new hires
 This is an internal email flow for new hires, which triggers whenever a new user signs up with a PostHog email address. We currently exclude most old-time hires from this flow, to avoid blocking their inboxes. 

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -26,7 +26,7 @@ To keep up with what's shipped and what's about to ship across the company, join
 
 Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the relevant channel. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.
 
-> **Tip:** The [`@posthog` Slack app](/docs/slack-app) can also answer questions about our own product data — `@PostHog` it in any channel to pull metrics, a PR something to the website.
+> **Tip:** The [`@posthog` Slack app](/docs/slack-app) can also answer questions about our own product data. `@PostHog` it in any channel to pull metrics or PR something to the website.
 
 ## Marketing values
 

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -26,7 +26,7 @@ To keep up with what's shipped and what's about to ship across the company, join
 
 Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the relevant channel. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.
 
-> **Tip:** The [`@posthog` Slack app](/docs/slack-app) can also answer questions about our own product data — `@PostHog` it in any channel to pull metrics, dig into an insight, or check how a launch or campaign is performing without leaving Slack.
+> **Tip:** The [`@posthog` Slack app](/docs/slack-app) can also answer questions about our own product data — `@PostHog` it in any channel to pull metrics, a PR something to the website.
 
 ## Marketing values
 

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -26,6 +26,8 @@ To keep up with what's shipped and what's about to ship across the company, join
 
 Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the relevant channel. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/docs-and-wizard/how-to-publish-changelog) for the full flow.
 
+> **Tip:** The [`@posthog` Slack app](/docs/slack-app) can also answer questions about our own product data — `@PostHog` it in any channel to pull metrics, dig into an insight, or check how a launch or campaign is performing without leaving Slack.
+
 ## Marketing values
 
 1. Be opinionated

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -38,6 +38,8 @@ Major announcements involve changes which have a noticeable impact on the experi
 
 We might do anything and everything for a major announcement.
 
+Whenever we make a major announcement — including beta launches and pricing changes — add an annotation (no emoji) in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the day it happens, so we can tie shifts in our metrics back to it later.
+
 Examples of major announcements include [the surveys beta](/changelog?id=1945) or [the analytics pricing change](/changelog?id=1907).
 
 ### New product announcements
@@ -53,6 +55,7 @@ For new product announcements we generally apply the following best practices:
 - Ensure launch activities (such as changelog) link clearly to the docs.
 - Ensure the product is added to email and in-app onboarding flows.
 - Ensure the product is added to the [pricing page](/pricing) (this is typically owned by the product team's PM and the <SmallTeam slug="billing" />)
+- Add a 🚀 annotation in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the launch date, so the launch's impact is visible on dashboards.
 - Submit an [art request](/handbook/brand/art-requests) for any creative assets needed for the email campaign, blog post, social media posts etc...
 
 Comms should also be aware of [the engineering best practices for product launches](/handbook/engineering/development-process#best-practices-for-full-releases), so we can be sure that features launch well.

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -38,8 +38,6 @@ Major announcements involve changes which have a noticeable impact on the experi
 
 We might do anything and everything for a major announcement.
 
-Whenever we make a major announcement — including beta launches and pricing changes — add an annotation (no emoji) in [our PostHog project](https://us.posthog.com/project/2/data-management/annotations) on the day it happens, so we can tie shifts in our metrics back to it later.
-
 Examples of major announcements include [the surveys beta](/changelog?id=1945) or [the analytics pricing change](/changelog?id=1907).
 
 ### New product announcements


### PR DESCRIPTION
## Changes

Adds brief guidance to the marketing handbook telling product marketers to log marketing moments as PostHog annotations in project 2:

- **Product launches** → add a 🚀 annotation on the launch date ([product announcements](https://posthog.com/handbook/marketing/product-announcements))
- **Major announcements** (beta launches, pricing changes) → add a plain, emoji-less annotation
- **Email broadcasts** → add a plain annotation on the send date ([email comms](https://posthog.com/handbook/marketing/email-comms))

**Why:** We encourage annotation use on the marketing blog, but it isn't a documented step anywhere. This makes it a clear, lightweight habit so we can tie metric shifts back to what we did — and easily track product marketing efforts for awareness, adoption, and engagement.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1781121443320739)*