### PR TITLE
fix: load PostHog assets from asset host

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,6 +3,7 @@
 GATSBY_POSTHOG_API_KEY=sTMFPsFhdP1Ssg
 GATSBY_POSTHOG_API_HOST=https://d1iyf54ud053a4.cloudfront.net
 GATSBY_POSTHOG_UI_HOST=https://us.posthog.com
+GATSBY_POSTHOG_ASSET_HOST=https://us-assets.i.posthog.com
 
 GATSBY_SQUEAK_API_HOST=https://better-animal-d658c56969.strapiapp.com
 

--- a/gatsby/onPreBootstrap.ts
+++ b/gatsby/onPreBootstrap.ts
@@ -54,11 +54,20 @@ export const onPreBootstrap: GatsbyNode['onPreBootstrap'] = async ({ cache }) =>
     // Enrich video data with thumbnails and titles from APIs
     await enrichVideos()
     if (process.env.GATSBY_POSTHOG_API_KEY && process.env.GATSBY_POSTHOG_API_HOST) {
-        const posthogScript = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        const assetHost = process.env.GATSBY_POSTHOG_ASSET_HOST
+        // The "1" pins the array.js major version; strict_script_versioning makes the
+        // SDK load its lazy chunks from matching versioned paths on the asset host.
+        const arrayRoute = assetHost
+            ? `${assetHost}/static/1/array.js`
+            : `${process.env.GATSBY_POSTHOG_API_HOST}/static/array.js`
+        const assetHostConfig = assetHost
+            ? `asset_host: "${assetHost}",\n    strict_script_versioning: true,\n    `
+            : ''
+        const posthogScript = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src="${arrayRoute}",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 posthog.init("${process.env.GATSBY_POSTHOG_API_KEY}", {
     api_host: "${process.env.GATSBY_POSTHOG_API_HOST}",
     ui_host: "${process.env.GATSBY_POSTHOG_UI_HOST}",
-    capture_pageview: false,
+    ${assetHostConfig}capture_pageview: false,
     capture_pageleave: true,
     persistence: 'localStorage+cookie',
     cookie_persisted_properties: ['prod_interest'],


### PR DESCRIPTION
## Changes

- Load the PostHog browser snippet from `GATSBY_POSTHOG_ASSET_HOST` when configured, using the versioned `/static/1/array.js` route.
- Keep the existing API-host `/static/array.js` fallback when no asset host is configured.
- Add `GATSBY_POSTHOG_ASSET_HOST=https://us-assets.i.posthog.com` to production env and pass `asset_host` plus `strict_script_versioning` so lazy SDK chunks resolve from matching asset-host versioned paths.

## Q/A

> What's `strict_script_versioning`?

When true, it forces all externally loaded scripts to use the same exact version of the loaded `array.js`. E.g., if `/static/1/array.js` resolves to v1.386.0, all other assets **must** also load external scripts released in the same version (such as `/static/1.386.0/autocapture.js`).

> What's `asset_host`?

This specifies the domain that `array.js` loads external resources from. This property is meant to allow legacy/custom reverse proxies to load assets without modifying the routing logic on the reverse proxy. Our managed reverse proxies running on Cloudflare don't need this.

> Is this documented anywhere?

Not yet. We're dogfooding the new routes that serve versioned `array.js` assets first. Documentation will follow shortly after we've ironed out any issues.

## Tested

- `pnpm exec prettier --check gatsby/onPreBootstrap.ts`
- `curl https://us-assets.i.posthog.com/static/1/array.js` → 200
- `curl https://us-assets.i.posthog.com/static/1.386.0/tracing-headers.js` → 200
- Vercel deployment looks correct

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
