### PR TITLE
Sponsor Django Software Foundation

### DIFF
--- a/contents/handbook/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/marketing/open-source-sponsorship.mdx
@@ -57,7 +57,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | Project                        | Author           | Why does PostHog sponsor                                                              | Sponsored via                           | Amount/month           |
 | -------------------------------| ---------------- | ------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------- |
 | [tailwindcss]                  | [tailwindlabs]   | A utility-first CSS framework we use to style our website and app                     | Directly                                | $2500                  |
-| [Django]                       | [Django Software Foundation] | The web framework our entire backend is built on                          | Directly                                | $2500                  |
+| [Django]                       | [Django Software Foundation] | The web framework our entire backend is built on                          | [GitHub Sponsors][github-sponsors]      | $2500                  |
 | [rrweb]                        | [yz-yu]          | Powers our session recording functionality                                            | [Open Collective][open-collective]      | $1000                  |
 | [Tiptap]                       | [ueberdosis]     | The headless editor framework that powers our Notebooks feature                       | [GitHub Sponsors][github-sponsors]      | $149                   |
 | [Next.js Boilerplate]          | [ixartz]         | Boilerplate and Starter for Next JS 14+, Tailwind CSS 3.3 and TypeScript              | [GitHub Sponsors][github-sponsors]      | $100                   |

--- a/contents/handbook/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/marketing/open-source-sponsorship.mdx
@@ -57,6 +57,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | Project                        | Author           | Why does PostHog sponsor                                                              | Sponsored via                           | Amount/month           |
 | -------------------------------| ---------------- | ------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------- |
 | [tailwindcss]                  | [tailwindlabs]   | A utility-first CSS framework we use to style our website and app                     | Directly                                | $2500                  |
+| [Django]                       | [Django Software Foundation] | The web framework our entire backend is built on                          | Directly                                | $2500                  |
 | [rrweb]                        | [yz-yu]          | Powers our session recording functionality                                            | [Open Collective][open-collective]      | $1000                  |
 | [Tiptap]                       | [ueberdosis]     | The headless editor framework that powers our Notebooks feature                       | [GitHub Sponsors][github-sponsors]      | $149                   |
 | [Next.js Boilerplate]          | [ixartz]         | Boilerplate and Starter for Next JS 14+, Tailwind CSS 3.3 and TypeScript              | [GitHub Sponsors][github-sponsors]      | $100                   |
@@ -76,6 +77,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 <!-- projects -->
 [rrweb]: https://github.com/rrweb-io/rrweb
 [tailwindcss]: https://github.com/tailwindlabs/tailwindcss
+[Django]: https://github.com/django/django
 [Tiptap]: https://github.com/ueberdosis/tiptap
 [Next.js Boilerplate]: https://github.com/ixartz/Next-js-Boilerplate
 [Refined GitHub]: https://github.com/refined-github/refined-github
@@ -90,6 +92,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 
 <!-- authors -->
 [tailwindlabs]: https://github.com/tailwindlabs
+[Django Software Foundation]: https://www.djangoproject.com/foundation/
 [yz-yu]: https://github.com/yz-yu
 [ueberdosis]: https://github.com/ueberdosis
 [ixartz]: https://github.com/ixartz


### PR DESCRIPTION
Adds the Django Software Foundation to our open-source sponsorship list, proposed at the **Platinum** corporate-membership tier ($30,000/year, ~$2,500/month).

**Why**
- Django is the web framework our entire backend is built on — squarely the "we fundamentally rely on some open-source projects" reason on this page. It would sit at parity with our current largest sponsorship (tailwindcss).
- The DSF [raised its 2026 fundraising goal to $500k](https://www.djangoproject.com/weblog/2026/jun/10/dsf-2026-fundraising-goals/) to fund its three Django Fellows, community events, and a first Executive Director hire.
- [Platinum corporate membership](https://www.djangoproject.com/foundation/corporate-membership/) puts the PostHog logo + link on the [DSF donate page](https://www.djangoproject.com/foundation/donate/) and grants a Django Supporter badge (the brand-benefit reason).

Set up via [GitHub Sponsors](https://github.com/sponsors/django) — their `$2,500/month` tier explicitly grants Platinum Corporate Members logo placement, so it routes through our existing GitHub Sponsors account rather than a separate invoice.

The tier/amount is of course just a proposal 😅 