### PR TITLE
Clarify Slack app page: rename intro boxes, FAQ order, table tweaks

### DIFF
--- a/src/pages/slack-app/index.tsx
+++ b/src/pages/slack-app/index.tsx
@@ -303,11 +303,11 @@ type IntroCardProps = {
 
 const introCards: IntroCardProps[] = [
     {
-        icon: IconCoffee,
+        icon: IconCode,
         iconColor: 'text-brown dark:text-brown-dark',
         bulletClass: 'bg-brown dark:bg-brown-dark',
         href: '/code',
-        title: 'PostHog Code',
+        title: 'Coding',
         badge: 'Sandboxed',
         description: (
             <>
@@ -326,7 +326,7 @@ const introCards: IntroCardProps[] = [
         iconColor: 'text-blue',
         bulletClass: 'bg-blue',
         href: '/ai',
-        title: 'PostHog AI',
+        title: 'Analytics',
         badge: 'Via MCP',
         description: (
             <>
@@ -475,8 +475,8 @@ const compareRows: CompareRow[] = [
     },
     {
         label: 'Models',
-        ai: "Auto-picked from OpenAI and Anthropic, we tune so you don't have to.",
-        slack: "Auto-picked from OpenAI and Anthropic (we tune so you don't have to).",
+        ai: "Auto-picked from OpenAI and Anthropic (we tune so you don't have to).",
+        slack: 'Auto-picked from OpenAI and Anthropic.',
         code: 'You pick: Claude Code or Codex, with reasoning effort dialed in per task.',
     },
 ]
@@ -488,6 +488,23 @@ const compareLinks: { label: string; url: string }[] = [
 ]
 
 const faqItems = [
+    {
+        trigger: 'Do I need PostHog Code to use the PostHog Slack app?',
+        content: (
+            <p>
+                No. The Slack app isn't gated on a{' '}
+                <Link
+                    to="/code"
+                    state={{ newWindow: true }}
+                    className="text-red dark:text-yellow font-semibold hover:underline"
+                >
+                    PostHog Code
+                </Link>{' '}
+                subscription. They share the same coding agent under the hood – the Slack app is just the front door if
+                you'd rather work from a thread than a desktop app.
+            </p>
+        ),
+    },
     {
         trigger: 'How does the PostHog Slack app decide when to answer or code?',
         content: (
@@ -604,23 +621,6 @@ const faqItems = [
             <p>
                 Not at all. It's a Slack message. People in sales and marketing have already merged PRs to our main
                 repo. Describe the problem or the idea, and the agent takes it from there.
-            </p>
-        ),
-    },
-    {
-        trigger: 'Do I need PostHog Code to use the PostHog Slack app?',
-        content: (
-            <p>
-                No. The Slack app isn't gated on a{' '}
-                <Link
-                    to="/code"
-                    state={{ newWindow: true }}
-                    className="text-red dark:text-yellow font-semibold hover:underline"
-                >
-                    PostHog Code
-                </Link>{' '}
-                subscription. They share the same coding agent under the hood – the Slack app is just the front door if
-                you'd rather work from a thread than a desktop app.
             </p>
         ),
     },
@@ -786,6 +786,7 @@ export default function SlackAppPage(): JSX.Element {
                     <h3>
                         Choose your <Highlight>fighter</Highlight>
                     </h3>
+                    <p>Same agent, three front doors.</p>
                     <div className="not-prose grid @lg/reader-content:grid-cols-2 gap-6 items-center my-6">
                         <div className="space-y-4">
                             {fighterOptions.map(({ icon: Icon, iconColor, label, copy }, index) => (


### PR DESCRIPTION
## Changes

Small clarity edits to the `/slack-app` page following feedback in the [marketing thread](https://posthog.slack.com/archives/C06LMMS3YP4/p1781090678166239?thread_ts=1781090678.166239&cid=C06LMMS3YP4):

- Renamed the two intro boxes under the header to **Coding in Slack** and **Analytics in Slack** (were "PostHog Code" / "PostHog AI"), and swapped the coffee-cup icon on the coding box for a code icon. This avoids implying you need a PostHog Code subscription to generate PRs.
- Added a one-liner under the **Choose your fighter** heading to set up the content that follows.
- In the comparison table's *Models* row, parenthesized "(we tune so you don't have to)" on the PostHog AI cell and removed the now-repetitive copy from the Slack app cell.
- Moved **"Do I need PostHog Code to use the PostHog Slack app?"** to be the first FAQ item.

**Why:** Several people (including non-engineers) read the page as implying PRs require a PostHog Code subscription. These tweaks make the dual coding/analytics nature clearer and surface the "no Code subscription needed" answer up front.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a – no page moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06LMMS3YP4/p1781090678166239?thread_ts=1781090678.166239&cid=C06LMMS3YP4)*