### PR TITLE
docs: clarify that React Native and Flutter replay always use screenshot mode

### DIFF
--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -12,7 +12,7 @@ We have taken our time to make sure we provide a useful and detailed recording e
 
 ### Wireframe mode (default)
 
-> **Note:** Wireframe mode is only available in the native [Android](/docs/session-replay/installation/android) and [iOS](/docs/session-replay/installation/ios) SDKs. [React Native](/docs/session-replay/installation/react-native) and [Flutter](/docs/session-replay/installation/flutter) always record in [screenshot mode](#screenshot-mode).
+> **Note:** Wireframe mode is available in native [Android](/docs/session-replay/installation/android) and [iOS](/docs/session-replay/installation/ios) SDKs. [React Native](/docs/session-replay/installation/react-native) and [Flutter](/docs/session-replay/installation/flutter) always record in [screenshot mode](#screenshot-mode).
 
 Mobile recording is primarily done using native APIs to grab the view hierarchy state when the screen is drawn. This is done carefully so as not to affect performance in any way a user may notice.
 
@@ -26,7 +26,7 @@ Below is an example of a screen captured in wireframe mode in Android:
 
 If `screenshot` (Android) or `screenshotMode` (iOS) option is enabled, the SDK will take a screenshot of the screen instead of a wireframe representation. The screenshot may contain sensitive information, so proceed with caution and ensure you're masking all relevant views.
 
-The React Native and Flutter SDKs always record in screenshot mode. This isn't configurable.
+The React Native and Flutter SDKs always record in screenshot mode. Currently, this is not configurable.
 
 Below is an example of a screen captured in screenshot mode in Android:
 

--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -12,6 +12,8 @@ We have taken our time to make sure we provide a useful and detailed recording e
 
 ### Wireframe mode (default)
 
+> **Note:** Wireframe mode is only available in the native [Android](/docs/session-replay/installation/android) and [iOS](/docs/session-replay/installation/ios) SDKs. [React Native](/docs/session-replay/installation/react-native) and [Flutter](/docs/session-replay/installation/flutter) always record in [screenshot mode](#screenshot-mode), because wireframe capture doesn't recognize the views these frameworks render with.
+
 Mobile recording is primarily done using native APIs to grab the view hierarchy state when the screen is drawn. This is done carefully so as not to affect performance in any way a user may notice.
 
 The view hierarchy is transformed to a JSON data structure and later rendered as an HTML [wireframe](https://www.figma.com/resource-library/what-is-wireframing/). Since it is a wireframe, the UI won't have the original look and feel but it should be close enough to understand the user's behavior.
@@ -23,6 +25,8 @@ Below is an example of a screen captured in wireframe mode in Android:
 ### Screenshot mode
 
 If `screenshot` (Android) or `screenshotMode` (iOS) option is enabled, the SDK will take a screenshot of the screen instead of a wireframe representation. The screenshot may contain sensitive information, so proceed with caution and ensure you're masking all relevant views.
+
+The React Native and Flutter SDKs always record in screenshot mode. This isn't configurable, as wireframe mode wouldn't capture the content of the views these frameworks render with.
 
 Below is an example of a screen captured in screenshot mode in Android:
 

--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -12,7 +12,7 @@ We have taken our time to make sure we provide a useful and detailed recording e
 
 ### Wireframe mode (default)
 
-> **Note:** Wireframe mode is only available in the native [Android](/docs/session-replay/installation/android) and [iOS](/docs/session-replay/installation/ios) SDKs. [React Native](/docs/session-replay/installation/react-native) and [Flutter](/docs/session-replay/installation/flutter) always record in [screenshot mode](#screenshot-mode), because wireframe capture doesn't recognize the views these frameworks render with.
+> **Note:** Wireframe mode is only available in the native [Android](/docs/session-replay/installation/android) and [iOS](/docs/session-replay/installation/ios) SDKs. [React Native](/docs/session-replay/installation/react-native) and [Flutter](/docs/session-replay/installation/flutter) always record in [screenshot mode](#screenshot-mode).
 
 Mobile recording is primarily done using native APIs to grab the view hierarchy state when the screen is drawn. This is done carefully so as not to affect performance in any way a user may notice.
 
@@ -26,7 +26,7 @@ Below is an example of a screen captured in wireframe mode in Android:
 
 If `screenshot` (Android) or `screenshotMode` (iOS) option is enabled, the SDK will take a screenshot of the screen instead of a wireframe representation. The screenshot may contain sensitive information, so proceed with caution and ensure you're masking all relevant views.
 
-The React Native and Flutter SDKs always record in screenshot mode. This isn't configurable, as wireframe mode wouldn't capture the content of the views these frameworks render with.
+The React Native and Flutter SDKs always record in screenshot mode. This isn't configurable.
 
 Below is an example of a screen captured in screenshot mode in Android:
 


### PR DESCRIPTION
## Changes

The [mobile session replay docs](https://posthog.com/docs/session-replay/mobile) describe wireframe mode as the default and screenshot mode as opt-in, but that only applies to the native Android and iOS SDKs. The React Native and Flutter SDKs force screenshot mode unconditionally in their native bridges, which isn't mentioned anywhere on the page. This mismatch was reported in PostHog/posthog-js#3796.

This adds a note under "Wireframe mode (default)" and a sentence under "Screenshot mode" making explicit that React Native and Flutter always record in screenshot mode and that this isn't configurable.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`


