### PR TITLE
feat: host IRL events speaker survey behind community login

### DIFF
--- a/src/pages/events-feedback-form.tsx
+++ b/src/pages/events-feedback-form.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { SEO } from 'components/seo'
+import Wizard from 'components/Wizard'
+import { Authentication } from 'components/Squeak'
+import { useUser } from 'hooks/useUser'
+import EmbeddedSurvey from 'components/Docs/EmbeddedSurvey'
+import ScrollArea from 'components/RadixUI/ScrollArea'
+
+const SURVEY_ID = process.env.GATSBY_EVENTS_FEEDBACK_SURVEY_ID ?? ''
+
+export default function EventsFeedbackForm() {
+    const { user, isLoading } = useUser()
+    const isPostHogTeam = !!user?.email?.endsWith('@posthog.com')
+
+    return (
+        <>
+            <SEO
+                title="IRL events feedback"
+                description="Sign in to submit IRL events feedback"
+                image="/images/og/default.png"
+            />
+            <Wizard>
+                {!isLoading && user && isPostHogTeam ? (
+                    <ScrollArea>
+                        <div className="p-6 max-w-2xl mx-auto">
+                            <EmbeddedSurvey surveyId={SURVEY_ID} />
+                        </div>
+                    </ScrollArea>
+                ) : (
+                    <div className="flex-1 flex flex-col items-center justify-center p-8">
+                        <div className="max-w-xs w-full space-y-6 text-center">
+                            <div className="space-y-1">
+                                <h1 className="text-xl font-bold text-primary m-0">IRL events feedback</h1>
+                                <p className="text-secondary text-sm m-0">
+                                    Requires a <strong>@posthog.com</strong> community account.
+                                </p>
+                            </div>
+                            {!isLoading && (
+                                <>
+                                    {user && !isPostHogTeam && (
+                                        <p className="bg-red/10 border border-red/20 rounded p-3 text-sm text-red text-left m-0">
+                                            Access is restricted to @posthog.com accounts. You're signed in as{' '}
+                                            <strong>{user.email}</strong>.
+                                        </p>
+                                    )}
+                                    {!user && (
+                                        <Authentication initialView="sign-in" showBanner={false} showProfile={false} />
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </Wizard>
+        </>
+    )
+}


### PR DESCRIPTION
## Changes

Adding a page `/events-feedback-form` which hosts an (in app) posthog survey behind the community login. It's the easiest way to prevent randos from posting to a hosted survey (beta), which doesn't have an auth mechanism at the moment.

There is an env var for the `survey_id`: `GATSBY_EVENTS_FEEDBACK_SURVEY_ID` (which tbh is pretty safe to include with this PR, but I'll share it on slack instead)

<img width="1077" height="908" alt="image" src="https://github.com/user-attachments/assets/5af2a274-2e11-43f3-9daf-850a998814fa" />
<img width="574" height="274" alt="image" src="https://github.com/user-attachments/assets/135a74aa-ef89-40db-a95b-01c748ebd405" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
