### PR TITLE
Point art requests to #team-graphics instead of #team-marketing

### DIFF
--- a/.github/ISSUE_TEMPLATE/art-request-template.md
+++ b/.github/ISSUE_TEMPLATE/art-request-template.md
@@ -16,7 +16,7 @@ projects:
 > **How art requests work**
 > By default, Lottie, Heidi & Daniel should be assigned to all art requests and the request will be added to [the art project board](https://github.com/orgs/PostHog/projects/65). They will decide who will work on this brief and reassign as needed. You can check the project board for updates if needed. 
 >
-> If your request is genuinely urgent, please share in [#team-marketing channel](https://posthog.slack.com/archives/C08CG24E3SR) and mention Lottie, Heidi, Daniel, and/or Cory.
+> If your request is genuinely urgent, please share in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie, Heidi, Daniel, and/or Cory.
 
 ## Outline
 _Avoid being overly prescriptive and instead provide context about what you're trying to convey - i.e. a feeling, reaction, or narrative._

--- a/contents/handbook/brand/art-requests.md
+++ b/contents/handbook/brand/art-requests.md
@@ -37,7 +37,7 @@ The Art & Brand Planning board uses GitHub Actions to keep work moving:
 
 To establish a clear connection between the task and the working file, designers will create a frame containing a link to the task. They should then add a link to that frame within the task for easy reference.
 
-Lottie and Daniel usually ask for two weeks minimum notice, but can often work faster on things if needed. If your request is genuinely urgent, please share your request issue in [#team-marketing channel](https://posthog.slack.com/archives/C08CG24E3SR) and mention Lottie, Daniel, and/or [Cory](https://posthog.com/community/profiles/30200).
+Lottie and Daniel usually ask for two weeks minimum notice, but can often work faster on things if needed. If your request is genuinely urgent, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie, Daniel, and/or [Cory](https://posthog.com/community/profiles/30200).
 
 ## Hedgehog library
 

--- a/contents/handbook/marketing/speaker-guide.md
+++ b/contents/handbook/marketing/speaker-guide.md
@@ -86,7 +86,7 @@ A few principles for building out slides:
 * If a slide doesn't support the one true thing you identified in step 3, cut it.  
 * Speaking of speaker notes, you will save yourself time and head space if you always have notes.
 
-For feedback on design or help with navigating the [PostHog brand assets](https://posthog.com/handbook/company/brand-assets) ([Hoggies](https://www.figma.com/design/I0VKEEjbkKUDSVzFus2Lpu/Hoggies?node-id=2226-55&t=1sj1GezTKuCfaybF-1) included), stop by [\#team-marketing](https://posthog.slack.com/archives/C08CG24E3SR)
+For feedback on design or help with navigating the [PostHog brand assets](https://posthog.com/handbook/company/brand-assets) ([Hoggies](https://www.figma.com/design/I0VKEEjbkKUDSVzFus2Lpu/Hoggies?node-id=2226-55&t=1sj1GezTKuCfaybF-1) included), stop by [\#team-graphics](https://posthog.slack.com/archives/C0AU440KS6P)
 
 ## **6. Practice out loud. Twice minimum.**
 


### PR DESCRIPTION
The art team now sits on the **Graphics team** and uses the **#team-graphics** Slack channel ([C0AU440KS6P](https://posthog.slack.com/archives/C0AU440KS6P)), not #team-marketing. This updates the urgent-request channel references so people route requests to the right place.

## Changes
- **Art request issue template** — urgent requests now point to #team-graphics
- **Handbook → Art requests** — same urgent-channel update (the page already described the Graphics team)
- **Handbook → Speaker guide** — design/brand-asset help now points to #team-graphics

## Why
Lottie (who handles art requests) is no longer on marketing, and a recent urgent thumbnail request went to the wrong channel as a result.

## Note
`contents/teams/marketing/index.mdx` still describes "the illustration group" as part of the marketing team. That's a structural statement about team composition rather than request routing, so I left it for the marketing/graphics teams to update as they see fit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1781147598960299?thread_ts=1781147598.960299&cid=C08CG24E3SR)*