### PR TITLE
docs: update React Native SDK docs

### DIFF
--- a/contents/docs/libraries/react-native/_snippets/autocapture-config-rn.mdx
+++ b/contents/docs/libraries/react-native/_snippets/autocapture-config-rn.mdx
@@ -1,7 +1,7 @@
 ```react-native
 <PostHogProvider apiKey="<ph_project_token>" autocapture={{
-    captureTouches: true,
-    captureScreens: true,
+    captureTouches: true, // Disabled by default
+    captureScreens: true, // Enabled by default
     ignoreLabels: [], // Any labels here will be ignored from the stack in touch events
     customLabelProp: "ph-label",
     maxElementsCaptured: 20,

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -93,9 +93,11 @@ PostHog autocapture can automatically track the following events for you:
 >
 > For React Navigation v7, we recommend disabling automatic screen capture for screens and manually calling `posthog.screen()` inside each screen component. See the [Capturing screen views](/docs/libraries/react-native#capturing-screen-views) section below.
 
-With autocapture, all touch events for children of `PosthogProvider` are tracked, capturing a snapshot of the view hierarchy at that point. This enables you to create [insights](/docs/product-analytics/insights) in PostHog without having to add custom events.
+Application lifecycle events are enabled by default. Screen capture is enabled by default in `PostHogProvider` unless you set `captureScreens: false`. Touch capture is disabled by default and requires `captureTouches: true`.
 
-PostHog will try to generate a sensible name for the touched element based on the React component `displayName` or `name`. If you prefer, you can set your own name using the `ph-label` prop:
+When touch capture is enabled, touch events for children of `PostHogProvider` are tracked, capturing a snapshot of the view hierarchy at that point. This enables you to create [insights](/docs/product-analytics/insights) in PostHog without adding custom events.
+
+PostHog will try to generate a sensible name for touched elements based on the React component `displayName` or `name`. If you prefer, you can set your own name using the `ph-label` prop:
 
 ```react-native
 <View ph-label="my-special-label"></View>
@@ -195,33 +197,7 @@ If you are doing this as part of a user logging out you can instead simply [`pos
 
 ## Opt out of data capture
 
-You can completely opt-out users from data capture. To do this, there are two options:
-
-1. Opt users out by default by setting `opt_out_capturing_by_default` to `true` in your PostHog config:
-
-```javascript
-posthog.init('<ph_project_token>', {
-    opt_out_capturing_by_default: true,
-});
-```
-
-2. Opt users out on a per-person basis by calling `opt_out_capturing()`:
-
-```javascript
-posthog.opt_out_capturing()
-```
-
-Similarly, you can opt users in:
-
-```javascript
-posthog.opt_in_capturing()
-```
-
-To check if a user is opted out:
-
-```javascript
-posthog.has_opted_out_capturing()
-```
+You can completely opt users out from data capture by default or on a per-person basis. See [Opt in/out](#opt-inout) for the current React Native API.
 
 ## Flush
 
@@ -304,52 +280,15 @@ For details on how to implement bootstrapping, see our [bootstrapping guide](/do
 
 ## Experiments (A/B tests)
 
-Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code:
-
-```react-native
-// With the useFeatureFlag hook
-import { useFeatureFlag } from 'posthog-react-native'
-
-const MyComponent = () => {
-    const variant = useFeatureFlag('experiment-feature-flag-key')
-
-    if (variant === undefined) {
-        // the response is undefined if the flags are being loaded
-        return null
-    }
-
-    if (variant == 'variant-name') {
-        // do something
-    }
-}           
-```
+Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code. See [adding experiment code](/docs/experiments/adding-experiment-code) for React Native examples.
 
 It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).
 
 ## Group analytics
 
-Group analytics allows you to associate the events for that person's session with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics) guide for more information.
+Group analytics allows you to associate the events for that person's session with a group (e.g. teams, organizations, etc.). See [Group Analytics](/docs/product-analytics/group-analytics) for implementation details.
 
 > **Note:**  This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing).
-
--   Associate the events for this session with a group
-
-```js
-posthog.group('company', 'company_id_in_your_db')
-
-posthog.capture('upgraded_plan') // this event is associated with company ID `company_id_in_your_db`
-```
-
--   Associate the events for this session with a group AND update the properties of that group
-
-```js
-posthog.group('company', 'company_id_in_your_db', {
-    name: 'Awesome Inc.',
-    employees: 11,
-})
-```
-
-The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Error tracking
 

--- a/contents/docs/product-analytics/_snippets/multilanguage/check-opt-out.mdx
+++ b/contents/docs/product-analytics/_snippets/multilanguage/check-opt-out.mdx
@@ -13,7 +13,7 @@ PostHog.isOptOut()
 ```
 
 ```react-native
-posthog.has_opted_out_capturing()
+posthog.optedOut
 ```
 
 </MultiLanguage> 

--- a/contents/docs/product-analytics/_snippets/multilanguage/opt-in.mdx
+++ b/contents/docs/product-analytics/_snippets/multilanguage/opt-in.mdx
@@ -13,7 +13,7 @@ PostHog.optIn()
 ```
 
 ```react-native
-posthog.opt_in_capturing()
+posthog.optIn()
 ```
 
 </MultiLanguage> 

--- a/contents/docs/product-analytics/_snippets/multilanguage/opt-out-default.mdx
+++ b/contents/docs/product-analytics/_snippets/multilanguage/opt-out-default.mdx
@@ -22,9 +22,15 @@ PostHogAndroid.setup(this, config)
 ```
 
 ```react-native
-posthog.init('<ph_project_token>', {
-    opt_out_capturing_by_default: true,
-});
+<PostHogProvider
+    apiKey="<ph_project_token>"
+    options={{
+        host: '<ph_client_api_host>',
+        defaultOptIn: false,
+    }}
+>
+    ...
+</PostHogProvider>
 ```
 
 </MultiLanguage> 

--- a/contents/docs/product-analytics/_snippets/multilanguage/opt-out-per-person.mdx
+++ b/contents/docs/product-analytics/_snippets/multilanguage/opt-out-per-person.mdx
@@ -13,7 +13,7 @@ PostHog.optOut()
 ```
 
 ```react-native
-posthog.opt_out_capturing()
+posthog.optOut()
 ```
 
 </MultiLanguage> 

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -240,68 +240,9 @@ See the [iOS autocapture documentation](/docs/libraries/ios/configuration#autoca
 
 ### React Native interaction autocapture
 
-The PostHog [React Native SDK](/docs/libraries/react-native) can automatically capture touch events when the user interacts with the screen. To enable this, set the `captureTouches` config option to true in your autocapture config like this:
+The PostHog [React Native SDK](/docs/libraries/react-native) can automatically capture touch events when the user interacts with the screen.
 
-```jsx
-<PostHogProvider
-  apiKey="<ph_project_token>"
-  autocapture={{
-    captureTouches: true,
-  }}
->
-  ...
-</PostHogProvider>
-```
-
-Autocaptured events display as the autocaptured interaction type in the [activity tab](https://app.posthog.com/activity/explore), such as `touched ...`.
-
-#### Configuring interaction autocapture
-
-You can configure the following options:
-
-| Option                | Description                                                                                                                                                                                                      |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `captureTouches`      | **Type:** `boolean`. When set to `true`, autocapture will capture touch events.                                                                                                                                  |
-| `ignoreLabels`        | **Type:** `string[]`. List of labels to ignore from the stack in touch events.                                                                                                                                   |
-| `customLabelProp`     | **Type:** `string`. Default: `ph-label`. If you set a custom label prop such as `<View ph-label="product-card">`, the UI element will display as `product-card` instead of a generic `View`.                     |
-| `maxElementsCaptured` | **Type:** `number`. The maximum number of elements to capture in the component hierarchy.                                                                                                                        |
-| `noCaptureProp`       | **Type:** `string`. Default: `ph-no-capture`. The prop to use for no capture. For example, if set to `data-no-tracking` the component `<Button data-no-tracking>This won't be tracked</Button>` will be ignored. |
-| `propsToCapture`      | **Type:** `string[]`. List of props to capture from the component hierarchy. By default, identifiers and text content are captured.                                                                              |
-
-```jsx
-<PostHogProvider
-  apiKey="<ph_project_token>"
-  autocapture={{
-    captureTouches: true,
-    ignoreLabels: [], // Any labels here will be ignored from the stack in touch events
-    customLabelProp: "ph-label",
-    maxElementsCaptured: 20,
-    noCaptureProp: "ph-no-capture",
-    propsToCapture: ["testID"], // Limit which props are captured. By default, identifiers and text content are captured.
-  }}
->
-  ...
-</PostHogProvider>
-```
-
-#### Preventing sensitive data capture
-
-To exclude specific UI elements from autocapture or session replay, add `ph-no-capture` (or your custom `noCaptureProp`) as either an `accessibilityLabel` or `accessibilityIdentifier`. When PostHog detects this label or identifier anywhere in the view hierarchy, the element is either ignored or masked:
-
-```jsx
-<PostHogProvider apiKey="<ph_project_token>" autocapture={{
-    captureTouches: true,
-    noCaptureProp: "ph-no-capture", // Optionally, you can use a custom prop like "data-no-capture"
-    // ...
-}}>
-    ...
-</PostHogProvider>
-
-// This view will be excluded from autocapture
-<View ph-no-capture>
-    ...
-</View>
-```
+See the [React Native autocapture docs](/docs/libraries/react-native#autocapture) for supported events, configuration options, and privacy controls.
 
 </Tab.Panel>
 </Tab.Panels>
@@ -410,18 +351,9 @@ Android does not currently support interaction autocapture for arbitrary taps or
 
 ### React Native navigation and lifecycle autocapture
 
-PostHog can automatically captures navigation and lifecycle events as the user navigates in the app and when the app is launched, updated, or backgrounded.
+PostHog can automatically capture navigation and lifecycle events as the user navigates in the app and when the app is launched, updated, or backgrounded.
 
-#### Configuring screen navigation autocapture
-
-Screen navigation autocapture is **not enabled by default**. You can enable it by setting `captureScreens` to `true` in the config. When enable, PostHog autocaptures events like:
-
-| `$screen` | When the user navigates. If using `@react-navigation/native` (v6 or lower) or `react-native-navigation`. See [React Native docs](/docs/libraries/react-native#capturing-screen-views) for config options. |
-| `Application Installed` | When app is first installed |
-| `Application Updated` | When app is updated to new version |
-| `Application Opened` | When app is opened from cold start |
-| `Application Became Active` | When app becomes active from background |
-| `Application Backgrounded` | When app goes to background |
+See the [React Native autocapture docs](/docs/libraries/react-native#autocapture) for supported events and configuration details.
 
 </Tab.Panel>
 </Tab.Panels>

--- a/contents/docs/product-analytics/installation/react-native.mdx
+++ b/contents/docs/product-analytics/installation/react-native.mdx
@@ -22,36 +22,4 @@ If you're using [React Native Web](https://github.com/necolas/react-native-web) 
 
 ### Without the PostHogProvider
 
-If you prefer not to use the provider, initialize PostHog in its own file and import the instance:
-
-```react-native file=posthog.ts
-import PostHog from 'posthog-react-native'
-
-export const posthog = new PostHog('<ph_project_token>', {
-  host: '<ph_client_api_host>' // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
-})
-```
-
-Then access PostHog by importing your instance:
-
-```react-native
-import { posthog } from './posthog'
-
-export function MyApp() {
-    useEffect(() => {
-        posthog.capture('event_name')
-    }, [])
-
-    return <View>Your app code</View>
-}
-```
-
-You can also use this instance with the PostHogProvider:
-
-```react-native
-import { posthog } from './posthog'
-
-export function MyApp() {
-  return <PostHogProvider client={posthog}>{/* Your app code */}</PostHogProvider>
-}
-```
+If you prefer not to use the provider, see the [React Native SDK installation guide](/docs/libraries/react-native#without-the-posthogprovider) for the standalone client setup.


### PR DESCRIPTION
## Changes

Problem: React Native SDK docs had duplicated inline examples across product pages and the SDK guide, and a few privacy/autocapture snippets did not match the current `posthog-react-native` API.

Changes:
- Reduced duplicated React Native setup, autocapture, experiment, and group analytics snippets by linking to canonical docs sections.
- Updated React Native opt-in/out examples to use `defaultOptIn`, `optIn()`, `optOut()`, and `optedOut`.
- Clarified current React Native autocapture defaults for lifecycle, screen, and touch capture.

No screenshots — docs-only changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
