### PR TITLE
docs: warn access controls don't yet apply to underlying data

### DIFF
--- a/contents/docs/settings/access-control.mdx
+++ b/contents/docs/settings/access-control.mdx
@@ -107,7 +107,17 @@ Currently, resource access controls are available for:
 - Web analytics
 - (more resource types coming soon – looking for others? Let us know!)
 
-Note: We do not yet support limiting access to querying data, viewing replays, or accessing person / group profiles. Support for these features is planned for the near future.
+<CalloutBox icon="IconWarning" title="Access controls don't yet apply to underlying data" type="caution">
+
+Resource access controls limit access to resources in the PostHog UI and API, but they do **not** yet limit access to the underlying data. We don't currently support restricting:
+
+- **Querying data** – any project member can query events, data warehouse tables, and other data via SQL/HogQL, including through the [PostHog AI assistant](/docs/posthog-ai) and the API. For example, a user with "No access" to data warehouse sources can't open the SQL editor, but can still ask PostHog AI to query those tables on their behalf.
+- **Viewing session replays**
+- **Accessing person and group profiles**
+
+Data-level access control support is planned and actively being worked on.
+
+</CalloutBox>
 
 Resource access controls have four possible access levels:
 


### PR DESCRIPTION
## Changes

- Replace the plain note about unsupported data-level restrictions with a yellow caution callout so the gap is harder to miss
- State explicitly that resource access controls don't yet gate the underlying data — it remains queryable via SQL/HogQL, the API, and the PostHog AI assistant

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`