### PR TITLE
chore: add missing access control resources to docs

### DIFF
--- a/contents/docs/settings/access-control.mdx
+++ b/contents/docs/settings/access-control.mdx
@@ -97,13 +97,17 @@ Currently, resource access controls are available for:
 - Customer Analytics
 - Dashboards
 - Endpoints
+- Error tracking
 - Experiments
 - Feature flags
 - Insights
+- LLM analytics
+- Logs
 - Managed data warehouse sources
 - Notebooks
 - Session recordings
 - Surveys
+- Traces
 - Web analytics
 - (more resource types coming soon – looking for others? Let us know!)
 


### PR DESCRIPTION
## Changes

Add some resources that were missing from the access control docs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
