### PR TITLE
Add Claude Fable 5 to supported LLMs on /code page

### DIFF
--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -93,7 +93,7 @@ function AIModelBadge({ innerRef }: { innerRef: React.RefObject<HTMLSpanElement>
             className="inline-flex items-center gap-1.5 border border-primary rounded px-2 py-1 text-xs bg-accent align-middle ml-6 mt-0 mb-2"
         >
             <span className="font-semibold">Supports</span>
-            <span className="text-secondary">Haiku, Opus, Sonnet, GPT 5.4, GPT 5.5</span>
+            <span className="text-secondary">Fable, Haiku, Opus, Sonnet, GPT 5.4, GPT 5.5</span>
         </span>
     )
 }
@@ -1150,6 +1150,9 @@ const TableStakes = () => {
                                 Anthropic
                             </p>
                             <ul className="m-0 mt-1 list-none p-0 space-y-2">
+                                <li className="text-sm font-bold text-primary">
+                                    <code>Claude Fable 5</code>
+                                </li>
                                 <li className="text-sm font-bold text-primary">
                                     <code>Claude Sonnet 4.6</code>
                                 </li>


### PR DESCRIPTION
## Changes

The supported LLMs list on `/code` was missing Fable. Added **Claude Fable 5** to the Anthropic column of the "Supported LLMs" section, and added "Fable" to the inline model badge in the hero copy.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B70P3KWLW/p1781210242219559)*
