### PR TITLE
docs(logs): update free tier to 10 GB and add retention note in start…

### DIFF
--- a/contents/docs/logs/start-here.mdx
+++ b/contents/docs/logs/start-here.mdx
@@ -194,7 +194,7 @@ Logs with `$exception` events become issues you can assign, resolve, and alert o
 
 <QuestLogItem 
   title="Use for free"
-  subtitle="Free 50 GB/mo"
+  subtitle="Free 10 GB/mo"
   icon="IconPiggyBank"
 >
 
@@ -203,8 +203,9 @@ PostHog's Logs is built to be cost-effective by default, with a generous free ti
 ## TL;DR 💸
 
 - No credit card required to start
-- First 50 GB of ingested logs per month are free
-- Above 50 GB we have usage-based pricing at $0.25/GB with discounts 
+- First 10 GB of ingested logs per month are free
+- Above 10 GB we have usage-based pricing at $0.25/GB with discounts 
+- All logs are retained 14 days by default, and we also offer 30-day or 90-day retention options for an additional storage charge – see [pricing](/pricing) for more details
 - Set billing limits to avoid surprise charges
 - See our [pricing page](/docs/logs/pricing) for more up-to-date details
 


### PR DESCRIPTION
## Changes

Updates the **Use for free** TL;DR on [`/docs/logs/start-here`](https://posthog.com/docs/logs/start-here#quest-item-use-for-free):

- Free-tier copy changed from **50 GB** to **10 GB** — both the quest-item subtitle (`Free 50 GB/mo` → `Free 10 GB/mo`) and the two pricing bullets ("First 50 GB…" / "Above 50 GB…").
- Added a new bullet: logs are retained **14 days by default**, with optional **30-day or 90-day** retention for an additional storage charge, linking to the [pricing page](/pricing).

Single-file change: `contents/docs/logs/start-here.mdx`.

> **Note:** The `/logs` marketing page pricing slide and any other "50 GB free" figures sourced from the billing API are intentionally left untouched — those are being updated separately.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` _(n/a — no pages moved)_
