### PR TITLE
docs: centralize SDK examples in official docs

### DIFF
--- a/contents/docs/ai-observability/installation/azure-openai.mdx
+++ b/contents/docs/ai-observability/installation/azure-openai.mdx
@@ -24,6 +24,11 @@ tableOfContents: [
         value: 'Verify traces and generations',
         depth: 1,
     },
+    {
+        url: 'net-support',
+        value: '.NET support',
+        depth: 1,
+    },
 ]
 ---
 
@@ -41,3 +46,80 @@ import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
 <OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
     <AzureOpenAIInstallation modifySteps={addNextStepsStep} />
 </OnboardingContentWrapper>
+
+## .NET support
+
+`PostHog.AI` adds AI observability for .NET applications using Azure OpenAI. It is currently pre-release, so expect breaking changes before a stable release.
+
+Install the packages:
+
+```bash
+dotnet add package PostHog.AI
+dotnet add package Azure.AI.OpenAI
+```
+
+When using dependency injection, register PostHog first, then register an Azure OpenAI client with the PostHog handler:
+
+```csharp
+using System.ClientModel.Primitives;
+using Azure;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.DependencyInjection;
+using PostHog.AI;
+using PostHog.Config;
+
+var services = new ServiceCollection();
+
+services.AddPostHog(options =>
+{
+    options.PostConfigure(posthogOptions =>
+    {
+        posthogOptions.ProjectToken = "<ph_project_token>";
+        posthogOptions.HostUrl = new Uri("<ph_client_api_host>");
+    });
+});
+
+services.AddPostHogAI();
+services
+    .AddHttpClient("PostHogAzureOpenAIClient")
+    .AddPostHogOpenAIHandler();
+
+services.AddSingleton<AzureOpenAIClient>(sp =>
+{
+    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+    var httpClient = httpClientFactory.CreateClient("PostHogAzureOpenAIClient");
+
+    var options = new AzureOpenAIClientOptions
+    {
+        Transport = new HttpClientPipelineTransport(httpClient),
+    };
+
+    return new AzureOpenAIClient(
+        new Uri("<azure_openai_endpoint>"),
+        new AzureKeyCredential("<azure_openai_api_key>"),
+        options);
+});
+
+var serviceProvider = services.BuildServiceProvider();
+var azureOpenAIClient = serviceProvider.GetRequiredService<AzureOpenAIClient>();
+```
+
+Use `PostHogAIContext` to attach trace, session, span, and user context to AI calls made inside a scope:
+
+```csharp
+using PostHog.AI;
+
+using (PostHogAIContext.BeginScope(
+    distinctId: "user-123",
+    traceId: "trace-abc",
+    sessionId: "session-xyz",
+    spanId: "span-1",
+    spanName: "summarize_text",
+    parentId: null))
+{
+    var chatClient = azureOpenAIClient.GetChatClient("<deployment_name>");
+    await chatClient.CompleteChatAsync("Summarize this text");
+}
+```
+
+The integration captures `$ai_generation` and `$ai_embedding` events with model, latency, token, error, trace, session, and span properties. For more .NET SDK details, see the [.NET library docs](/docs/libraries/dotnet#ai-observability).

--- a/contents/docs/ai-observability/installation/openai.mdx
+++ b/contents/docs/ai-observability/installation/openai.mdx
@@ -29,6 +29,11 @@ tableOfContents: [
         value: 'Capture embeddings',
         depth: 1,
     },
+    {
+        url: 'net-support',
+        value: '.NET support',
+        depth: 1,
+    },
 ]
 ---
 
@@ -43,8 +48,61 @@ import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapp
 import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
 import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
 
-import LLMsSDKsCallout from './_snippets/llms-sdks-callout.mdx'
-
 <OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
     <OpenAIInstallation modifySteps={addNextStepsStep} />
 </OnboardingContentWrapper>
+
+## .NET support
+
+`PostHog.AI` adds AI observability for .NET applications using OpenAI. It is currently pre-release, so expect breaking changes before a stable release.
+
+Install the package:
+
+```bash
+dotnet add package PostHog.AI
+```
+
+When using dependency injection, register PostHog first, then register an OpenAI client with the PostHog handler:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using OpenAI;
+using PostHog.AI;
+using PostHog.Config;
+
+var services = new ServiceCollection();
+
+services.AddPostHog(options =>
+{
+    options.PostConfigure(posthogOptions =>
+    {
+        posthogOptions.ProjectToken = "<ph_project_token>";
+        posthogOptions.HostUrl = new Uri("<ph_client_api_host>");
+    });
+});
+
+services.AddPostHogOpenAIClient("<openai_api_key>");
+
+var serviceProvider = services.BuildServiceProvider();
+var openAIClient = serviceProvider.GetRequiredService<OpenAIClient>();
+```
+
+Use `PostHogAIContext` to attach trace, session, span, and user context to AI calls made inside a scope:
+
+```csharp
+using PostHog.AI;
+
+using (PostHogAIContext.BeginScope(
+    distinctId: "user-123",
+    traceId: "trace-abc",
+    sessionId: "session-xyz",
+    spanId: "span-1",
+    spanName: "summarize_text",
+    parentId: null))
+{
+    var chatClient = openAIClient.GetChatClient("gpt-4o-mini");
+    await chatClient.CompleteChatAsync("Summarize this text");
+}
+```
+
+The integration captures `$ai_generation` and `$ai_embedding` events with model, latency, token, error, trace, session, and span properties. For more .NET SDK details, see the [.NET library docs](/docs/libraries/dotnet#ai-observability).

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -207,54 +207,7 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 `PostHog.AI` adds [AI observability](/docs/ai-observability) for .NET applications using OpenAI or Azure OpenAI. It is currently pre-release, so expect breaking changes before a stable release.
 
-Install the package:
-
-```bash
-dotnet add package PostHog.AI
-```
-
-When using dependency injection, register PostHog first, then register an OpenAI client with the PostHog handler:
-
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using OpenAI;
-using PostHog;
-using PostHog.AI;
-
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.Services.AddPostHog(options =>
-{
-    options.ProjectToken = "<ph_project_token>";
-    options.HostUrl = new Uri("<ph_client_api_host>");
-});
-
-builder.Services.AddPostHogOpenAIClient("<openai_api_key>");
-
-var host = builder.Build();
-var openAIClient = host.Services.GetRequiredService<OpenAIClient>();
-```
-
-Use `PostHogAIContext` to attach trace, session, span, and user context to AI calls made inside a scope:
-
-```csharp
-using PostHog.AI;
-
-using (PostHogAIContext.BeginScope(
-    distinctId: "user-123",
-    traceId: "trace-abc",
-    sessionId: "session-xyz",
-    spanId: "span-1",
-    spanName: "summarize_text",
-    parentId: null))
-{
-    var chatClient = openAIClient.GetChatClient("gpt-4o-mini");
-    await chatClient.CompleteChatAsync("Summarize this text");
-}
-```
-
-The integration captures `$ai_generation` and `$ai_embedding` events with model, latency, token, error, trace, session, and span properties.
+For installation instructions, see the [OpenAI guide for .NET](/docs/ai-observability/installation/openai#net-support) or the [Azure OpenAI guide for .NET](/docs/ai-observability/installation/azure-openai#net-support).
 
 ## GeoIP properties
 

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -12,7 +12,7 @@ features:
   groupAnalytics: true
   errorTracking: true
   surveys: false
-  aiObservability: false
+  aiObservability: true
 ---
 
 This is an optional library you can install if you're working with .NET Core. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.
@@ -203,6 +203,58 @@ if (variant == "variant-name")
 
 It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags). 
 
+## AI observability
+
+`PostHog.AI` adds [AI observability](/docs/ai-observability) for .NET applications using OpenAI or Azure OpenAI. It is currently pre-release, so expect breaking changes before a stable release.
+
+Install the package:
+
+```bash
+dotnet add package PostHog.AI
+```
+
+When using dependency injection, register PostHog first, then register an OpenAI client with the PostHog handler:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenAI;
+using PostHog;
+using PostHog.AI;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddPostHog(options =>
+{
+    options.ProjectToken = "<ph_project_token>";
+    options.HostUrl = new Uri("<ph_client_api_host>");
+});
+
+builder.Services.AddPostHogOpenAIClient("<openai_api_key>");
+
+var host = builder.Build();
+var openAIClient = host.Services.GetRequiredService<OpenAIClient>();
+```
+
+Use `PostHogAIContext` to attach trace, session, span, and user context to AI calls made inside a scope:
+
+```csharp
+using PostHog.AI;
+
+using (PostHogAIContext.BeginScope(
+    distinctId: "user-123",
+    traceId: "trace-abc",
+    sessionId: "session-xyz",
+    spanId: "span-1",
+    spanName: "summarize_text",
+    parentId: null))
+{
+    var chatClient = openAIClient.GetChatClient("gpt-4o-mini");
+    await chatClient.CompleteChatAsync("Summarize this text");
+}
+```
+
+The integration captures `$ai_generation` and `$ai_embedding` events with model, latency, token, error, trace, session, and span properties.
 
 ## GeoIP properties
 

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -259,6 +259,73 @@ See our guide on [identifying users](/docs/getting-started/identify-users) for m
 
 </Step>
 
+<Step title="Configure advanced options" badge="optional">
+
+### Feature flag bootstrap
+
+Set `bootstrapFlags` to evaluate feature flags on the server and pass the results to the client, which avoids flag flicker on first render:
+
+```tsx
+<PostHogProvider bootstrapFlags>{children}</PostHogProvider>
+```
+
+You can also limit the flags evaluated and provide properties used for evaluation:
+
+```tsx
+<PostHogProvider
+    bootstrapFlags={{
+        flags: ['new-ui', 'pricing-v2'],
+        groups: { company: 'posthog' },
+        personProperties: { plan: 'enterprise' },
+        groupProperties: {
+            company: { industry: 'tech' },
+        },
+    }}
+>
+    {children}
+</PostHogProvider>
+```
+
+Enabling `bootstrapFlags` calls `cookies()` internally, which opts the route into dynamic rendering.
+
+### Consent-aware setup
+
+If your app requires consent before setting cookies, disable anonymous cookie seeding in middleware:
+
+```ts file=middleware.ts
+export default postHogMiddleware({
+    proxy: true,
+    seedAnonymousCookie: false,
+})
+```
+
+Then initialize the client with capture disabled until the user opts in:
+
+```tsx
+<PostHogProvider clientOptions={{ opt_out_capturing_by_default: true }}>{children}</PostHogProvider>
+```
+
+### API proxy options
+
+Pass an object to `proxy` to customize the ingest path or host:
+
+```ts file=middleware.ts
+export default postHogMiddleware({
+    proxy: {
+        pathPrefix: '/analytics',
+        host: 'https://eu.i.posthog.com',
+    },
+})
+```
+
+When you change the proxy path, use the same path in `clientOptions.api_host`:
+
+```tsx
+<PostHogProvider clientOptions={{ api_host: '/analytics' }}>{children}</PostHogProvider>
+```
+
+</Step>
+
 <Step title="Further reading" badge="recommended">
 
 - [How to set up Next.js analytics, Feature Flags, and more](/tutorials/nextjs-analytics)

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -281,6 +281,37 @@ posthog.set_socket_options([
 
 Pass `None` to `set_socket_options()` to reset to default behavior.
 
+## Filtering or modifying events before sending
+
+Use `before_send` to modify or drop events before they are queued for delivery. Return the modified event dictionary to send it, or `None` to drop it.
+
+```python
+from typing import Any
+
+import posthog
+
+
+def scrub_pii(event: dict[str, Any]) -> dict[str, Any] | None:
+    properties = event.get("properties", {})
+
+    if "email" in properties:
+        email = properties["email"]
+        properties["email"] = f"***@{email.split('@', 1)[1]}" if "@" in email else "***"
+
+    if event.get("event") == "test_event":
+        return None
+
+    return event
+
+
+client = posthog.Client(
+    api_key="<ph_project_api_key>",
+    before_send=scrub_pii,
+)
+```
+
+If your callback raises an exception, the SDK logs the error and continues with the original unmodified event.
+
 ## Historical migrations
 
 You can use the Python or Node SDK to run [historical migrations](/docs/migrate) of data into PostHog. To do so, set the `historical_migration` option to `true` when initializing the client.

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -63,3 +63,23 @@ When local evaluation is enabled, flag definitions are fetched on initialization
 
 > **Note:** Local evaluation requires providing any person properties, groups, or group properties needed to evaluate the flag's release conditions, since PostHog can't fetch these automatically without a server request.
 
+## Observability
+
+The Rust SDK uses [`tracing`](https://docs.rs/tracing) for structured logging. Add a tracing subscriber to your application to see SDK logs:
+
+```rust
+use tracing_subscriber::{fmt, EnvFilter};
+
+tracing_subscriber::fmt()
+    .with_env_filter(EnvFilter::from_default_env())
+    .init();
+```
+
+Set `RUST_LOG` to control the log level:
+
+```bash
+RUST_LOG=posthog_rs=debug cargo run
+```
+
+Use `posthog_rs=warn` for warnings and errors only, or `posthog_rs=trace` for detailed local-evaluation and cache logs.
+


### PR DESCRIPTION
## Changes

- Add/move SDK usage examples into the official documentation so repository READMEs can link here as the single source of truth.
- Document .NET AI observability setup, `@posthog/next` advanced options, Python `before_send`, and Rust tracing configuration.

No screenshots: documentation-only changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
