### PR TITLE
feat: add Logs retention pricing to pricing page

### DIFF
--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -12,15 +12,7 @@ import { Discount } from 'components/NotProductIcons'
 import Link from 'components/Link'
 import { IconInfo } from '@posthog/icons'
 import { formatUSD } from '../PricingSlider/pricingSliderLogic'
-import pluralizeWord from 'pluralize'
-
-// Don't pluralize all-uppercase units like GB, MB, TB
-const pluralizeUnit = (unit: string, count: number): string => {
-    if (unit === unit.toUpperCase()) {
-        return unit
-    }
-    return pluralizeWord(unit, count)
-}
+import { pluralizeUnit } from '../utils'
 
 const Heading = ({ title, subtitle, className = '' }: { title?: string; subtitle?: string; className?: string }) => {
     return (
@@ -84,6 +76,9 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
         return null
     }
 
+    const freeAllocation = plans[0]?.free_allocation
+    const hasFreeAllocation = freeAllocation !== null && freeAllocation !== undefined
+
     const [tiers, set_tiers] = useState(plans[plans.length - 1]?.tiers)
 
     useEffect(() => {
@@ -128,7 +123,7 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                                 index === 0 && up_to
                                     ? `First ${formatCompactNumber(up_to)} ${pluralizeUnit(unit, up_to)}`
                                     : index === 0 && !up_to
-                                    ? `Unlimited ${pluralizeUnit(unit, 2)}`
+                                    ? `${hasFreeAllocation ? 'Unlimited' : 'All'} ${pluralizeUnit(unit, 2)}`
                                     : !up_to
                                     ? `${formatCompactNumber(plans[plans.length - 1].tiers[index - 1]?.up_to)}+`
                                     : `${
@@ -148,7 +143,7 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                             <Title
                                 className={`${compact ? 'text-sm' : ''}`}
                                 title={
-                                    plans[0].free_allocation === up_to ? (
+                                    hasFreeAllocation && freeAllocation === up_to ? (
                                         <strong>Free</strong>
                                     ) : type === 'product_analytics' && index === tiers.length - 1 ? (
                                         // last row

--- a/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
@@ -5,7 +5,7 @@ import { calculatePrice, formatUSD } from '../../PricingSlider/pricingSliderLogi
 import { PricingTiers } from '../../Plans'
 import { NumericFormat } from 'react-number-format'
 import AutosizeInput from 'react-input-autosize'
-import pluralizeWord from 'pluralize'
+import { pluralizeUnit } from '../../utils'
 
 const TriggerEventsModal = ({ onClose, isVisible }) => {
     return (
@@ -54,6 +54,11 @@ const SliderRow = ({
     freeAllocationText,
 }) => {
     const [currentVolume, setCurrentVolume] = useState(volume)
+    const scaleMin = sliderConfig.scaleMin ?? Math.max(sliderConfig.min, 1)
+    const minimumVisibleValue = sliderConfig.min > 0 ? sliderConfig.min : scaleMin
+    // Logarithmic sliders cannot represent 0 directly, so 0-volume rows use the left edge of the scale.
+    const sliderValue = Math.max(currentVolume, minimumVisibleValue)
+    const hasFreeAllocationNote = Boolean(freeAllocation || freeAllocationText)
 
     useEffect(() => {
         if (billingTiers) {
@@ -63,7 +68,7 @@ const SliderRow = ({
     }, [currentVolume, billingTiers])
 
     const handleVolumeChange = (newVolume) => {
-        const roundedVolume = Math.round(newVolume)
+        const roundedVolume = Math.max(Math.round(newVolume || 0), 0)
         setCurrentVolume(roundedVolume)
 
         if (billingTiers) {
@@ -72,8 +77,15 @@ const SliderRow = ({
         }
     }
 
+    const handleSliderChange = (value) => {
+        const roundedVolume = Math.round(sliderCurve(value))
+        const newVolume =
+            sliderConfig.min === 0 && roundedVolume <= scaleMin ? 0 : Math.max(roundedVolume, sliderConfig.min)
+        handleVolumeChange(newVolume)
+    }
+
     return (
-        <div className="grid grid-cols-8 mb-4">
+        <div className={`grid grid-cols-8 ${hasFreeAllocationNote ? 'mb-4' : 'mb-10'}`}>
             <div className="col-span-6">
                 <p className="mb-2">
                     <NumericFormat
@@ -83,7 +95,7 @@ const SliderRow = ({
                         onValueChange={({ floatValue }) => handleVolumeChange(floatValue)}
                         customInput={AutosizeInput}
                     />{' '}
-                    <span className="opacity-70 text-sm">{label}s/month</span>
+                    <span className="opacity-70 text-sm">{pluralizeUnit(label, currentVolume || 2)}/month</span>
                 </p>
             </div>
             <div className="col-span-2 text-right pr-3">
@@ -94,12 +106,13 @@ const SliderRow = ({
                     stepsInRange={100}
                     marks={sliderConfig.marks}
                     min={sliderConfig.min}
+                    scaleMin={scaleMin}
                     max={sliderConfig.max}
-                    onChange={(value) => handleVolumeChange(Math.round(sliderCurve(value)))}
-                    value={inverseCurve(currentVolume)}
+                    onChange={handleSliderChange}
+                    value={inverseCurve(sliderValue)}
                 />
             </div>
-            {(freeAllocation || freeAllocationText) && (
+            {hasFreeAllocationNote && (
                 <div className="col-span-full pr-1.5 mt-10 md:mt-8 pb-4 flex gap-1 items-center">
                     <IconLightBulb className="size-5 inline-block text-[#4f9032] dark:text-green relative -top-px" />
                     <span className="text-sm text-[#4f9032] dark:text-green font-semibold">
@@ -108,7 +121,7 @@ const SliderRow = ({
                         ) : (
                             <>
                                 First {Math.round(freeAllocation).toLocaleString()}{' '}
-                                {pluralizeWord(unit, Math.round(freeAllocation))} free –&nbsp;
+                                {pluralizeUnit(unit, Math.round(freeAllocation))} free –&nbsp;
                                 <em>every month!</em>
                             </>
                         )}
@@ -290,7 +303,8 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                                     {activeProduct.productVariantName || activeProduct.name}
                                 </h4>
                                 <p className="opacity-70 m-0 text-sm mb-2">
-                                    <strong>{mainVolume.toLocaleString()}</strong> {activeProduct.billingData.unit}s
+                                    <strong>{mainVolume.toLocaleString()}</strong>{' '}
+                                    {pluralizeUnit(activeProduct.billingData.unit, mainVolume)}
                                 </p>
                                 <div className="overflow-auto -mx-4 px-4 md:mx-0 md:px-0">
                                     <div className="p-1 min-w-[500px] md:min-w-auto border border-input rounded-md mt-2">
@@ -311,8 +325,8 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                                         <div key={addon.key}>
                                             <h4 className="text-lg m-0">{addon.label}</h4>
                                             <p className="opacity-70 m-0 text-sm mb-2">
-                                                <strong>{addonData[index].volume.toLocaleString()}</strong> {addon.unit}
-                                                s
+                                                <strong>{addonData[index].volume.toLocaleString()}</strong>{' '}
+                                                {pluralizeUnit(addon.unit, addonData[index].volume)}
                                             </p>
                                             <div className="overflow-auto -mx-4 px-4 md:mx-0 md:px-0">
                                                 <div className="p-1 min-w-[500px] md:min-w-auto border border-input rounded-md mt-2">

--- a/src/components/Pricing/PricingSlider/Slider.tsx
+++ b/src/components/Pricing/PricingSlider/Slider.tsx
@@ -12,6 +12,7 @@ interface SliderProps {
     stepsInRange: number
     onChange: (value: number) => void
     value: number
+    scaleMin?: number
 }
 
 const MySlider = Slider.createSliderWithTooltip(Slider)
@@ -40,9 +41,10 @@ const abbreviateNumber = (number: number): string => {
     return `${scaled.toFixed(0) + suffix}`
 }
 
-const makeMarks = (marks: number[]): Record<number, string> => {
+const makeMarks = (marks: number[], scaleMin: number): Record<number, string> => {
     return marks.reduce((acc, cur) => {
-        acc[inverseCurve(cur)] = abbreviateNumber(cur)
+        const value = cur <= 0 ? scaleMin : cur
+        acc[inverseCurve(value)] = cur <= 0 ? '0' : abbreviateNumber(cur)
         return acc
     }, {} as Record<number, string>)
 }
@@ -61,14 +63,19 @@ const makeNonLinearMarks = (marks: number[], max): Record<number, string> => {
     }, {} as Record<number, string>)
 }
 
-export const LogSlider = ({ min, max, marks, stepsInRange, onChange, value }: SliderProps): JSX.Element => {
+export const LogSlider = ({ min, max, marks, stepsInRange, onChange, value, scaleMin }: SliderProps): JSX.Element => {
+    const effectiveMin = scaleMin ?? Math.max(min, 1)
+
     return (
         <MySlider
-            min={inverseCurve(min)}
+            min={inverseCurve(effectiveMin)}
             max={inverseCurve(max)}
-            marks={makeMarks(marks)}
-            step={(inverseCurve(max) - inverseCurve(min)) / stepsInRange}
-            tipFormatter={(value) => prettyInt(sliderCurve(value))}
+            marks={makeMarks(marks, effectiveMin)}
+            step={(inverseCurve(max) - inverseCurve(effectiveMin)) / stepsInRange}
+            tipFormatter={(value) => {
+                const roundedValue = Math.round(sliderCurve(value))
+                return min === 0 && roundedValue <= effectiveMin ? '0' : prettyInt(roundedValue)
+            }}
             onChange={onChange}
             className="slider center"
             value={value}

--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -111,7 +111,7 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
             />
             <FreeTierItem
                 name="Logs"
-                allocation="50 GB ingested"
+                allocation="10 GB ingested"
                 icon={<Icons.IconTerminal className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
                 size={size}
             />

--- a/src/components/Pricing/Test/PricingAccordion.tsx
+++ b/src/components/Pricing/Test/PricingAccordion.tsx
@@ -86,6 +86,7 @@ const AccordionItem = ({
                   type: addon.type,
               }))
             : []
+    const hasAddonRates = addonData.length > 0
 
     const Container = useMemo(() => (billedWith ? 'div' : 'button'), [billedWith])
 
@@ -131,7 +132,7 @@ const AccordionItem = ({
                             <em className="font-normal text-secondary text-sm">
                                 Billed with <span className="lowercase">{billedWith}</span>
                             </em>
-                        ) : includeAddonRates ? (
+                        ) : hasAddonRates ? (
                             <em className="font-normal text-secondary text-sm">Multiple resources</em>
                         ) : (
                             startsAt && (
@@ -165,7 +166,7 @@ const AccordionItem = ({
                     className={isOpen ? '' : 'overflow-hidden'}
                 >
                     <div className="px-3 pb-4">
-                        {includeAddonRates && addonData.length > 0 ? (
+                        {hasAddonRates ? (
                             <div className="space-y-6">
                                 {/* Main product pricing */}
                                 <div>

--- a/src/components/Pricing/utils.ts
+++ b/src/components/Pricing/utils.ts
@@ -1,0 +1,14 @@
+import pluralizeWord from 'pluralize'
+
+export const pluralizeUnit = (unit: string, count: number): string => {
+    if (!unit) {
+        return ''
+    }
+
+    // Don't pluralize all-uppercase units like GB, MB, TB.
+    if (unit === unit.toUpperCase()) {
+        return unit
+    }
+
+    return pluralizeWord(unit, count)
+}

--- a/src/constants/addons.ts
+++ b/src/constants/addons.ts
@@ -1,1 +1,7 @@
-export const EXCLUDED_ADDON_TYPES = ['mobile_replay', 'data_pipelines', 'data_warehouse_historical']
+export const EXCLUDED_ADDON_TYPES = [
+    'mobile_replay',
+    'data_pipelines',
+    'data_warehouse_historical',
+    'logs_retention_30d',
+    'logs_retention_90d',
+]

--- a/src/hooks/productData/logs.tsx
+++ b/src/hooks/productData/logs.tsx
@@ -4,6 +4,7 @@ export const logs = {
     name: 'Logs',
     Icon: IconActivity,
     description: 'Search and analyze your logs in PostHog',
+    productVariantName: 'Logs ingestion (14-day retention)',
     handle: 'logs',
     type: 'logs',
     slug: 'logs',
@@ -11,13 +12,43 @@ export const logs = {
     colorSecondary: 'green-2',
     category: 'product_engineering',
     wizardSupport: 'Coming soon',
+    includeAddonRates: true,
     slider: {
         // Values in GB (display_friendly=true converts MB to GB)
-        marks: [50, 100, 500, 1000, 5000],
-        min: 50,
+        marks: [0, 10, 50, 100, 500, 1000, 5000],
+        min: 10,
+        scaleMin: 1,
         max: 5000,
     },
-    volume: 50,
+    volume: 10,
+    addonSliders: [
+        {
+            key: 'logs_retention_30d',
+            label: '30-day retention',
+            sliderConfig: {
+                marks: [0, 10, 50, 100, 500, 1000, 5000],
+                min: 0,
+                scaleMin: 1,
+                max: 5000,
+            },
+            volume: 0,
+            unit: 'GB',
+            freeAllocation: 0,
+        },
+        {
+            key: 'logs_retention_90d',
+            label: '90-day retention',
+            sliderConfig: {
+                marks: [0, 10, 50, 100, 500, 1000, 5000],
+                min: 0,
+                scaleMin: 1,
+                max: 5000,
+            },
+            volume: 0,
+            unit: 'GB',
+            freeAllocation: 0,
+        },
+    ],
     seo: {
         title: 'Logs that already know your users',
         description:


### PR DESCRIPTION
## Changes

- Add Logs retention add-on rates to the pricing accordion while excluding them from generic add-ons.
- Update the Logs calculator for the new 10 GB free tier, 30-day retention, and 90-day retention.
- Align Logs slider scales so retention can start at 0 while ingestion starts at 10 GB.
- Share pricing unit pluralization between the pricing table and calculator.

<img width="580" height="310" alt="SCR-20260612-lzjb" src="https://github.com/user-attachments/assets/d13dc055-9cc9-4be2-b70e-6e6afa97a75a" />

<img width="607" height="359" alt="SCR-20260612-lzfn" src="https://github.com/user-attachments/assets/e2113763-b2b4-482f-b6d8-40e5e66d8778" />

<img width="876" height="812" alt="SCR-20260612-mbnn" src="https://github.com/user-attachments/assets/074600be-f221-43f1-8c09-41577237209b" />

## Checklist

- [x] I have read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I have checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable)
