### PR TITLE
docs(react-native): native crash autocapture and symbol upload

### DIFF
--- a/contents/docs/error-tracking/installation/_snippets/et-installation-wrapper.tsx
+++ b/contents/docs/error-tracking/installation/_snippets/et-installation-wrapper.tsx
@@ -160,6 +160,15 @@ export const ErrorTrackingFlutterInstallationWrapper = () => (
 
 export const ErrorTrackingReactNativeInstallationWrapper = () => (
     <OnboardingContentWrapper snippets={{}}>
-        <ReactNativeInstallation modifySteps={(steps) => addNextStepsStep(steps, 'react-native')} />
+        <ReactNativeInstallation
+            modifySteps={(steps) =>
+                addNextStepsStep(steps, 'react-native', {
+                    mappingsUrl: '/docs/error-tracking/upload-source-maps/react-native',
+                    mappingsLabel: 'Upload source maps & native symbols',
+                    mappingsDescription:
+                        "Great, you're capturing exceptions! The next step is to upload source maps (for JavaScript stack traces) and native symbols (for native iOS/Android crash symbolication) so PostHog can generate accurate stack traces.",
+                })
+            }
+        />
     </OnboardingContentWrapper>
 )

--- a/contents/docs/error-tracking/upload-source-maps/react-native.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/react-native.mdx
@@ -6,6 +6,7 @@ showStepsToc: true
 import CLIDownload from "../_snippets/cli/download.mdx"
 import CLIAuthenticate from "../_snippets/cli/authenticate.mdx"
 import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
+import Tab from 'components/Tab'
 
 <CalloutBox icon="IconInfo" title="CLI version requirement" type="action">
 
@@ -165,11 +166,7 @@ If you are not using the Expo plugin (step 1), you will need to also disable Use
 
 </Step>
 
-<StepVerifySymbolSetsUpload />
-
-</Steps>
-
-## Native crash symbolication
+<Step title="Native crash symbolication" badge="optional">
 
 The steps above upload **JavaScript** source maps, which symbolicate exceptions thrown in your JS/TS code (including Hermes bytecode). They do **not** cover native iOS and Android crashes.
 
@@ -198,7 +195,13 @@ Symbolicated native crashes need all three of these working together:
 
 Both platforms upload through `posthog-cli`, which must be installed and authenticated – the same setup covered in the **Download CLI** and **Authenticate** steps above. In CI/CD builds (such as EAS Build), set the `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` environment variables (and `POSTHOG_CLI_HOST` for EU). See [authenticating the CLI](/docs/error-tracking/upload-source-maps/cli) for the full list.
 
-### Expo apps
+<Tab.Group tabs={['Expo', 'Bare React Native']}>
+<Tab.List>
+<Tab>Expo</Tab>
+<Tab>Bare React Native</Tab>
+</Tab.List>
+<Tab.Panels>
+<Tab.Panel>
 
 The `posthog-react-native/expo` config plugin can wire up native symbol upload for you during [prebuild](https://docs.expo.dev/workflow/continuous-native-generation/). It's **opt-in** – set `uploadNativeSymbols` to `true` in your [app.json](https://docs.expo.dev/versions/latest/config/app/#plugins):
 
@@ -226,7 +229,8 @@ To additionally upload native source files for source-code context (iOS only), p
 }
 ```
 
-### Bare React Native apps
+</Tab.Panel>
+<Tab.Panel>
 
 If you aren't using the Expo config plugin, wire up the uploads manually.
 
@@ -289,6 +293,16 @@ apply plugin: "com.posthog.android"
 ```
 
 The plugin uploads ProGuard/R8 mapping files and injects a matching map-id during your release build, so native Android crash stack traces are deobfuscated.
+
+</Tab.Panel>
+</Tab.Panels>
+</Tab.Group>
+
+</Step>
+
+<StepVerifySymbolSetsUpload />
+
+</Steps>
 
 ## Troubleshooting
 

--- a/contents/docs/error-tracking/upload-source-maps/react-native.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/react-native.mdx
@@ -169,6 +169,127 @@ If you are not using the Expo plugin (step 1), you will need to also disable Use
 
 </Steps>
 
+## Native crash symbolication
+
+The steps above upload **JavaScript** source maps, which symbolicate exceptions thrown in your JS/TS code (including Hermes bytecode). They do **not** cover native iOS and Android crashes.
+
+If you enable [native crash autocapture](/docs/libraries/react-native#native-crash-autocapture) (`errorTracking.autocapture.nativeCrashes`), you also need to upload **native** debug symbols at build time so those crash reports are readable. This reuses the native PostHog SDKs' own tooling:
+
+- **iOS** – upload dSYMs via posthog-ios's `upload-symbols.sh`, which runs `posthog-cli dsym upload`. You can optionally include native source files for source-code context around crashes.
+- **Android** – upload ProGuard/R8 mapping files via the official [`com.posthog.android` Gradle plugin](/docs/error-tracking/upload-mappings/android), which also injects a matching map-id into the app.
+
+<CalloutBox icon="IconInfo" title="Source-code context is iOS only" type="fyi">
+
+Including native source files for source-code context (`includeSource` / `POSTHOG_INCLUDE_SOURCE`) is supported on **iOS only**. The Android ProGuard/R8 mapping upload has no source-inclusion equivalent, so the option is ignored on Android.
+
+</CalloutBox>
+
+<CalloutBox icon="IconInfo" title="Three pieces are required end-to-end" type="info">
+
+Symbolicated native crashes need all three of these working together:
+
+1. **Build-time** – upload native symbols (this section).
+2. **Runtime** – enable [`errorTracking.autocapture.nativeCrashes`](/docs/libraries/react-native#native-crash-autocapture) and install `@posthog/react-native-plugin`.
+3. **Server-side** – enable the **Enable exception autocapture** setting in your project's [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture).
+
+</CalloutBox>
+
+### Prerequisites
+
+Both platforms upload through `posthog-cli`, which must be installed and authenticated – the same setup covered in the **Download CLI** and **Authenticate** steps above. In CI/CD builds (such as EAS Build), set the `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` environment variables (and `POSTHOG_CLI_HOST` for EU). See [authenticating the CLI](/docs/error-tracking/upload-source-maps/cli) for the full list.
+
+### Expo apps
+
+The `posthog-react-native/expo` config plugin can wire up native symbol upload for you during [prebuild](https://docs.expo.dev/workflow/continuous-native-generation/). It's **opt-in** – set `uploadNativeSymbols` to `true` in your [app.json](https://docs.expo.dev/versions/latest/config/app/#plugins):
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["posthog-react-native/expo", { "uploadNativeSymbols": true }]
+    ]
+  }
+}
+```
+
+When enabled, `expo prebuild` adds an iOS dSYM-upload build phase and applies the `com.posthog.android` Gradle plugin on Android.
+
+To additionally upload native source files for source-code context (iOS only), pass an options object instead of `true`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["posthog-react-native/expo", { "uploadNativeSymbols": { "includeSource": true } }]
+    ]
+  }
+}
+```
+
+### Bare React Native apps
+
+If you aren't using the Expo config plugin, wire up the uploads manually.
+
+#### iOS
+
+In Xcode, add a **Run Script** build phase to your main app target and place it **last** (so it runs after the dSYM bundle is produced). The `upload-symbols.sh` script ships inside the `PostHog` pod, which is pulled in transitively by `@posthog/react-native-plugin`.
+
+<MultiLanguage>
+
+```bash file=CocoaPods
+"${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+```
+
+```bash file=Swift Package Manager
+"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/posthog-ios/build-tools/upload-symbols.sh"
+```
+
+</MultiLanguage>
+
+Then, for your Release configuration, set these build settings:
+
+- **Debug Information Format** (`DEBUG_INFORMATION_FORMAT`) to **DWARF with dSYM File**, so dSYMs are generated.
+- **User Script Sandboxing** (`ENABLE_USER_SCRIPT_SANDBOXING`) to **No**, so the script can locate dSYMs, read `.git/` for release metadata, and run `posthog-cli`.
+
+To also upload native source files for source-code context (iOS only), prefix the script with `POSTHOG_INCLUDE_SOURCE=1`:
+
+<MultiLanguage>
+
+```bash file=CocoaPods
+POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+```
+
+```bash file=Swift Package Manager
+POSTHOG_INCLUDE_SOURCE=1 "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/posthog-ios/build-tools/upload-symbols.sh"
+```
+
+</MultiLanguage>
+
+This is the same flow as the [iOS dSYM upload guide](/docs/error-tracking/upload-source-maps/ios), which has a full Xcode walkthrough.
+
+#### Android
+
+In `android/build.gradle`, add the [PostHog Android Gradle plugin](/docs/error-tracking/upload-mappings/android) to your `buildscript` dependencies (and make sure `mavenCentral()` is in the `buildscript` repositories):
+
+```gradle file=android/build.gradle
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.posthog:posthog-android-gradle-plugin:1.2.0")
+    }
+}
+```
+
+Then apply the plugin in `android/app/build.gradle`:
+
+```gradle file=android/app/build.gradle
+apply plugin: "com.posthog.android"
+```
+
+The plugin uploads ProGuard/R8 mapping files and injects a matching map-id during your release build, so native Android crash stack traces are deobfuscated.
+
 ## Troubleshooting
 
 **Build fails with `Sandbox: bash deny(1) file-read-data`**

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -355,6 +355,44 @@ The `name` is a special property which is used in the PostHog UI for the name of
 
 To set up error tracking in your project, follow the [React Native installation guide](/docs/error-tracking/installation/react-native).
 
+### Native crash autocapture
+
+By default, autocapture only covers the JavaScript layer (`uncaughtExceptions`, `unhandledRejections`, and `console`). Native iOS and Android crashes – for example, a crash inside a native module or the platform runtime – happen below JavaScript, so the JS handlers never see them.
+
+To also capture native crashes, install the optional `@posthog/react-native-plugin` package and enable `nativeCrashes` in your `errorTracking.autocapture` config:
+
+```bash
+# Expo apps
+npx expo install @posthog/react-native-plugin
+
+# Bare React Native apps
+npm i @posthog/react-native-plugin
+```
+
+```react-native
+const posthog = new PostHog('<ph_project_token>', {
+  errorTracking: {
+    autocapture: {
+      uncaughtExceptions: true,
+      unhandledRejections: true,
+      nativeCrashes: true, // captures native iOS/Android crashes
+    },
+  },
+})
+```
+
+`nativeCrashes` is disabled by default and requires the `@posthog/react-native-plugin` package – if it isn't installed, the SDK logs a warning and native capture is a no-op (your JS-level autocapture is unaffected).
+
+Native autocapture is also gated server-side: it only fires when your project's **Enable exception autocapture** setting is on in [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture), the same remote setting that gates JS exception autocapture.
+
+Native crash stack traces are unreadable until you also upload native debug symbols at build time. See [native crash symbolication](/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication) for the iOS and Android setup.
+
+<CalloutBox icon="IconInfo" title="Minimum version" type="fyi">
+
+Remote configuration of the **Enable exception autocapture** setting requires `posthog-react-native` 4.35.0 or later.
+
+</CalloutBox>
+
 ### Error boundaries
 
 You can use the `PostHogErrorBoundary` component to capture React rendering errors thrown by components:

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -357,41 +357,9 @@ To set up error tracking in your project, follow the [React Native installation 
 
 ### Native crash autocapture
 
-By default, autocapture only covers the JavaScript layer (`uncaughtExceptions`, `unhandledRejections`, and `console`). Native iOS and Android crashes – for example, a crash inside a native module or the platform runtime – happen below JavaScript, so the JS handlers never see them.
+The JavaScript-level autocapture only covers exceptions thrown in your JS/TS code. To also capture native iOS and Android crashes – for example, a crash inside a native module or the platform runtime – install the optional `@posthog/react-native-plugin` package and enable `errorTracking.autocapture.nativeCrashes`. Native capture is gated by your project's **Enable exception autocapture** setting, and crash reports need native debug symbols uploaded at build time to produce readable stack traces.
 
-To also capture native crashes, install the optional `@posthog/react-native-plugin` package and enable `nativeCrashes` in your `errorTracking.autocapture` config:
-
-```bash
-# Expo apps
-npx expo install @posthog/react-native-plugin
-
-# Bare React Native apps
-npm i @posthog/react-native-plugin
-```
-
-```react-native
-const posthog = new PostHog('<ph_project_token>', {
-  errorTracking: {
-    autocapture: {
-      uncaughtExceptions: true,
-      unhandledRejections: true,
-      nativeCrashes: true, // captures native iOS/Android crashes
-    },
-  },
-})
-```
-
-`nativeCrashes` is disabled by default and requires the `@posthog/react-native-plugin` package – if it isn't installed, the SDK logs a warning and native capture is a no-op (your JS-level autocapture is unaffected).
-
-Native autocapture is also gated server-side: it only fires when your project's **Enable exception autocapture** setting is on in [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture), the same remote setting that gates JS exception autocapture.
-
-Native crash stack traces are unreadable until you also upload native debug symbols at build time. See [native crash symbolication](/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication) for the iOS and Android setup.
-
-<CalloutBox icon="IconInfo" title="Minimum version" type="fyi">
-
-Remote configuration of the **Enable exception autocapture** setting requires `posthog-react-native` 4.35.0 or later.
-
-</CalloutBox>
+Follow the [React Native installation guide](/docs/error-tracking/installation/react-native) for the full setup, and [native crash symbolication](/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication) to upload symbols.
 
 ### Error boundaries
 

--- a/contents/docs/session-replay/_snippets/react-native-manual-replay-control.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-manual-replay-control.mdx
@@ -1,4 +1,4 @@
-> Requires `posthog-react-native` >= [4.36.0](https://github.com/PostHog/posthog-js/releases) and `posthog-react-native-session-replay` >= [1.3.0](https://github.com/PostHog/posthog-react-native-session-replay/releases).
+> Requires `posthog-react-native` >= [4.36.0](https://github.com/PostHog/posthog-js/releases) and `posthog-react-native-session-replay` >= [1.3.0](https://github.com/PostHog/posthog-react-native-session-replay/releases). From `posthog-react-native` 4.47.0+, `posthog-react-native-session-replay` is renamed to `@posthog/react-native-plugin` (>= 2.0.1).
 
 Setting `sessionReplay` to `false` in your PostHog configuration will prevent PostHog from automatically starting session recordings on SDK setup.
 


### PR DESCRIPTION
## Changes

React Native native iOS/Android crash autocapture docs:

- Adds a "Native crash symbolication" step (Expo + bare React Native, tabbed) to the React Native source map upload page.
- Surfaces native symbols in the onboarding "next steps" and trims the runtime `nativeCrashes` config in the library reference.
- Notes the `posthog-react-native-session-replay` → `@posthog/react-native-plugin` rename.

Pairs with PostHog/posthog#63226.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
