### PR TITLE
fix: update PostHog AI pricing copy

### DIFF
--- a/contents/blog/best-product-analytics-tools-for-startups.mdx
+++ b/contents/blog/best-product-analytics-tools-for-startups.mdx
@@ -195,7 +195,7 @@ Want to skip the manual setup entirely? You can try out the [PostHog wizard](/do
 | LLM observability | 100K events | $0.00006/event |
 | Logs | 50GB ingested | $0.25/GB |
 | Workflows | 10K messages/channel | $0.003000/email |
-| PostHog AI | 2,000 credits | $0.01/credit |
+| PostHog AI | 500 credits | $1 per 100 credits |
 
 Every product is billed independently – you only pay for what you use beyond the free tier, and there are bulk discounts for higher usage. No per-seat fees, you get unlimited team members on every plan. 
 
@@ -715,4 +715,3 @@ Most tools offer EU hosting, data residency options, and consent management.
 Read our guide on the [best GDPR compliant analytics tools](/blog/best-gdpr-compliant-analytics-tools) for more details.
 
 </details>
-

--- a/contents/blog/posthog-vs-pendo.mdx
+++ b/contents/blog/posthog-vs-pendo.mdx
@@ -75,7 +75,7 @@ Adding a credit card unlocks additional features like advanced paths, correlatio
 - **LLM observability**: 100 thousand events/month
 - **Logs**: 50GB ingested/month
 - **Workflows**: 10,000 messages per channel/month
-- **PostHog AI**: 2,000 credits/month
+- **PostHog AI**: 500 credits/month (worth $5)
 
 When it comes their product platforms, here is how they compare:
 

--- a/contents/blog/posthog-vs-plausible.mdx
+++ b/contents/blog/posthog-vs-plausible.mdx
@@ -193,7 +193,7 @@ PostHog is [entirely usage-based](/pricing). Its free tier includes:
 | Data warehouse                |    1 million synced rows    |  From $0.000015/row      |
 | Logs                          |    50 GB ingested           |  From $0.25/GB           |
 | Workflows                     |    10,000 messages/channel  |  From $0.003/email       |
-| PostHog AI                    |    2,000 credits            |  From $0.01/credit      |
+| PostHog AI                    |    500 credits              |  From $1 per 100 credits |
 
 A lot of products also use volume-based pricing that gets cheaper as you scale – the more you use, the less you pay per unit. See the [calculator](/pricing) for exact rates at your volume.
 

--- a/contents/docs/posthog-ai/pricing.mdx
+++ b/contents/docs/posthog-ai/pricing.mdx
@@ -8,9 +8,9 @@ import Pricing from "components/Pricing/PricingCalculator/SingleProduct";
 
 AI features in PostHog consume **AI credits**. Each time you interact with an AI-powered feature – whether you're asking PostHog AI to write SQL, summarize data, or analyze sessions – credits are spent based on the resources required to complete your request.
 
-This means you pay for what you use. There’s no fixed subscription and every organization gets a monthly free tier worth $20 (2,000 AI credits) to explore PostHog AI's features.
+This means you pay for what you use. There’s no fixed subscription and every organization gets a monthly free tier worth $5 (500 AI credits) to explore PostHog AI's features.
 
-For reference, **1,000 AI credits = $10**.
+For reference, **100 AI credits = $1**.
 
 We apply a simple, consistent 20% markup over the underlying LLM provider’s cost. So 1 PostHog AI credit corresponds to $0.008333 of raw inference.
 

--- a/contents/faq.mdx
+++ b/contents/faq.mdx
@@ -49,7 +49,7 @@ PostHog offers a generous free tier with no credit card required:
 - **LLM observability**: 100 thousand events/month
 - **Logs**: 50GB ingested/month
 - **Workflows**: 10,000 messages per channel/month
-- **PostHog AI**: 2,000 credits/month
+- **PostHog AI**: 500 credits/month
 
 Beyond the free tier, pricing is usage-based and scales down as volume increases. There are no seat-based charges – unlimited team members can access the platform.
 

--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -99,7 +99,7 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
             />
             <FreeTierItem
                 name="PostHog AI"
-                allocation="2K credits (worth $20)"
+                allocation="500 credits (worth $5)"
                 icon={<Icons.IconSparkles className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
                 size={size}
             />

--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -28,11 +28,11 @@ export const posthog_ai = {
     category: 'automation',
     slug: 'ai',
     slider: {
-        marks: [2000, 10000, 50000, 100000],
-        min: 2000,
+        marks: [500, 3000, 10000, 50000, 100000],
+        min: 500,
         max: 100000,
     },
-    volume: 2000,
+    volume: 500,
     customPricingContent: (
         <div data-scheme="secondary" className="prose prose-sm text-lg mt-8 mb-12 leading-normal text-primary">
             <h3 className="text-xl font-bold text-primary mb-4">How credits work</h3>
@@ -55,8 +55,8 @@ export const posthog_ai = {
             </ul>
             <p>
                 PostHog automatically selects the most efficient model for each AI feature. We apply a simple,
-                consistent 20% markup over the underlying LLM provider’s cost: So 1 PostHog AI credit equals $0.8333 of
-                raw inference, and 1,000 credits cost $10.
+                consistent 20% markup over the underlying LLM provider’s cost: So 1 PostHog AI credit equals $0.008333
+                of raw inference, and 100 credits cost $1.
             </p>
         </div>
     ),
@@ -865,7 +865,7 @@ export const posthog_ai = {
         answers:
             "These are real questions our users ask. The useful thing about PostHog AI is it's not just searching your data—it's building the analysis for you. Want to know your churn rate? It'll create the cohort definition, run the calculation, and show you the visualization. Need to understand where users drop off? It builds the funnel and then lets you jump to session recordings of those exact users. The SQL query requests are probably the most common—people know what data they want but don't want to spend 30 minutes remembering the exact syntax and table names. It's basically your coworker who's really good at PostHog and has time to help.",
         pricing:
-            "We charge for AI based on the actual token usage from the underlying LLM providers, with a 20% markup. One PostHog AI credit equals $0.8333 of raw inference cost, so 1,000 credits is $10. Simple queries like 'what were my daily active users in October?' use very few credits—maybe 50-100 credits. More complex tasks like analyzing hundreds of session recordings or rewriting SQL queries multiple times will consume more, but you see the cost in real-time so there's no surprises.<br /><br />Everyone starts with 2,000 free credits per month. After that, you pay for what you use. The more credits you need, the cheaper they get (volume pricing). We automatically route to the most efficient model for each task—you're not stuck paying GPT-4 prices when a smaller model works fine.<br /><br />The thing is, even complex queries are usually cheaper than the time you'd spend building them manually. A 500-credit task that saves you 20 minutes is still a good deal. And unlike seat-based pricing, your whole team can use it without multiplying costs.",
+            "We charge for AI based on the actual token usage from the underlying LLM providers, with a 20% markup. One PostHog AI credit equals $0.008333 of raw inference cost, so 500 credits is $5. Simple queries like 'what were my daily active users in October?' use very few credits, maybe 50-100 credits. More complex tasks like analyzing hundreds of session recordings or rewriting SQL queries multiple times will consume more, but you see the cost in real-time so there are no surprises.<br /><br />Everyone starts with 500 free credits per month. After that, you pay for what you use. The more credits you need, the cheaper they get (volume pricing). We automatically route to the most efficient model for each task, so you're not stuck paying GPT-4 prices when a smaller model works fine.<br /><br />The thing is, even complex queries are usually cheaper than the time you'd spend building them manually. A 500-credit task that saves you 20 minutes is still a good deal. And unlike seat-based pricing, your whole team can use it without multiplying costs.",
         'comparison-summary':
             "Most analytics platforms either (a) don't have AI, (b) slapped ChatGPT onto their dashboard and called it 'AI-powered,' or (c) have AI that only does one thing like anomaly detection. PostHog AI is different because it's deeply integrated into every product and actually understands your data model. It can write valid HogQL, knows your event names, understands your feature flags—it's not just a general-purpose LLM trying to help.<br /><br />The closest comparison is probably Amplitude's AI, but that only works inside Amplitude. We're open source, so you can see exactly how it works and even self-host if you want. Our pricing is also transparent and usage-based instead of requiring an enterprise contract.",
         docs: "The docs for PostHog AI explain how it works under the hood—what models we use, how we handle context, what each AI agent specializes in. We're upfront about limitations too: it's not perfect, it can make mistakes, and you should verify important queries before acting on them. That said, it's getting better fast. We're constantly training it on more examples and improving the prompts.<br /><br />If you run into issues or have ideas for how AI could be more useful in specific workflows, tell us. The team actively monitors feedback because this is still early days and we're trying to build something that's actually useful, not just a checkbox feature.",


### PR DESCRIPTION
## Changes

Updates the public PostHog AI pricing surfaces to match the new 500-credit monthly free tier and $5 allowance.

- Updates the PostHog AI docs pricing page to say the free tier is worth $5
- Updates the main pricing page calculator defaults, slider marks, presenter copy, free-tier grid, and general FAQ so PostHog AI starts from 500 free credits.

Local testing note: to test this against the new Billing config locally, run Billing from PostHog/billing#1951 or the `feat/posthog-ai-5-dollar-plans` branch, then set `posthog.com/.env.development` to point `BILLING_SERVICE_URL` at the local Billing instance, usually `localhost://8100`. Do not commit that local env-file change.

Follow-ups still needed: this PR only updates the main pricing surfaces touched here. A broader launch-content sweep may still find stale PostHog AI pricing references in other pages, and related product changes such as Slack agent mentions - feel free to commit to this branch directly or create a separate PR for this.

<img width="1600" height="897" alt="SCR-20260612-pdle" src="https://github.com/user-attachments/assets/413baaf1-3e3b-4402-aa3d-03dc95609ae1" />
<img width="1148" height="428" alt="SCR-20260612-pafq" src="https://github.com/user-attachments/assets/f7ba40f0-47ae-4c23-8efc-7b8e87323abc" />
<img width="735" height="570" alt="SCR-20260612-pads" src="https://github.com/user-attachments/assets/b3bc64aa-f390-434e-a46d-7de4c4c43572" />
<img width="946" height="773" alt="SCR-20260612-ozwa" src="https://github.com/user-attachments/assets/3004f82a-3609-4fb1-96a7-ca880168c161" />
<img width="642" height="128" alt="SCR-20260612-oztm" src="https://github.com/user-attachments/assets/8a164abf-61d6-45d3-9886-3b539a5ddac1" />
<img width="613" height="320" alt="SCR-20260612-ozrn" src="https://github.com/user-attachments/assets/1b9569d2-9535-437f-8085-05e0d08150fe" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
