### PR TITLE
feat(replay-vision): set custom OG image

### DIFF
--- a/src/pages/replay-vision.tsx
+++ b/src/pages/replay-vision.tsx
@@ -218,6 +218,8 @@ export default function ReplayVisionPage() {
             <SEO
                 title="Replay Vision - PostHog"
                 description="Point an AI scanner at your recordings, and let it watch every session for you: flagging bugs, scoring frustration, tagging behavior, and summarizing what happened."
+                image="https://res.cloudinary.com/dmukukwp6/image/upload/doctor_hogs_sub_ff499630e0.jpg"
+                imageType="absolute"
             />
             <Editor slug="/replay-vision" maxWidth="100%" hasPadding={false}>
                 <div className="@container not-prose font-rounded">


### PR DESCRIPTION
## Changes

Set a custom Open Graph / Twitter card image for the `/replay-vision` page. Previously the page had no `image` prop on its `<SEO>` component, so it fell back to the site default OG image.

**Why:** The Replay Vision page should show its own branded preview image when shared on social/Slack instead of the generic site default.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BA574QMPG/p1781277672918729)*
