### PR TITLE
docs(handbook): add "Collaborating with PMs" to product marketing

### DIFF
--- a/contents/handbook/marketing/collaborating-with-pms.md
+++ b/contents/handbook/marketing/collaborating-with-pms.md
@@ -1,0 +1,16 @@
+---
+title: Collaborating with PMs
+sidebar: Handbook
+showTitle: true
+---
+
+PostHog's culture leans heavily on independence, but launching and growing a product is one area where product marketers (PMMs) and product managers (PMs) genuinely need to work together. Here are the most important things a PMM can do to build that relationship:
+
+- **Make first contact.** Don't wait for your PM to come to you. Reach out early to learn the team's revenue goals, activation and retention gaps, what marketing has been tried before, where users come from, and any quick opportunities. Ask for customer interviews and competitive research too.
+- **Live in your team's channel.** Monitor the team Slack daily for feature updates, sales notes, and customer feedback. PMMs often spot marketable features that PMs and engineers overlook.
+- **Show up in person and in meetings.** Use rare in-person gatherings for growth reviews and planning, and join sprint meetings to stay informed and show genuine interest in the team's work.
+- **Loop your PM into marketing.** Share quarterly plans, campaigns, and creative directions. Core assets like the product page, launch email, and launch blog should always get PM review.
+- **Run monthly growth reviews.** Meet 1:1 to assess product performance, acquisition, and drop-off points. These reviews often reveal gaps (like low retention) that inspire new tactics.
+- **Use AI to stay informed.** Lean on tools like the PostHog Slack app and scheduled tasks (e.g. a weekly product digest) to surface product status automatically instead of manually scrolling.
+
+For the full story, including concrete examples from working across PostHog's product teams, read [Collaborating with PMs as a product marketer](/blog/pm-pmm-collaboration).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1087,6 +1087,10 @@ export const handbookSidebar = [
                         url: '/handbook/marketing/product-announcements',
                     },
                     {
+                        name: 'Collaborating with PMs',
+                        url: '/handbook/marketing/collaborating-with-pms',
+                    },
+                    {
                         name: 'Incident comms',
                         url: '/handbook/marketing/incident-comms',
                     },


### PR DESCRIPTION
## Changes

Adds a new **Collaborating with PMs** page to the Product marketing section of the handbook, summarizing the key points from the [PM/PMM collaboration blog post](https://posthog.com/blog/pm-pmm-collaboration) and linking out to read more. Also wires it into the handbook nav under Product marketing.

**Why:** Make the practical guidance on how product marketers should work with product managers easy to find in the handbook, not just buried in a blog post.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BA574QMPG/p1781278213104869)*
