### PR TITLE
fix(pricing): prevent event types dialog from cropping in small windows

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
@@ -82,7 +82,7 @@ const Modal = ({ onClose, isVisible }) => {
                 onClick={() => onClose()}
             ></div>
             <div
-                className={`max-w-full z-[1000001] fixed left-4 md:left-8 right-4 md:right-8 rounded-tl md:rounded-tl-lg rounded-tr md:rounded-tr-lg flex flex-col bg-white dark:bg-accent-dark transition-all duration-300 ease-out
+                className={`max-w-full z-[1000001] fixed left-4 md:left-8 right-4 md:right-8 bottom-4 md:bottom-8 rounded-tl md:rounded-tl-lg rounded-tr md:rounded-tr-lg flex flex-col bg-white dark:bg-accent-dark transition-all duration-300 ease-out
           ${isVisible ? '!opacity-100 top-4' : 'opacity-0 top-[100vh]'}`}
             >
                 <div className="w-full h-fit flex justify-between p-4 border-b border-primary">
@@ -93,7 +93,7 @@ const Modal = ({ onClose, isVisible }) => {
                     </button>
                 </div>
 
-                <div className="max-h-[calc(100vh_-_1rem_-_60px_-_122px)] md:max-h-[calc(100vh_-_1rem_-_60px)] overflow-y-auto px-4 py-4 md:pb-8">
+                <div className="flex-1 min-h-0 overflow-y-auto px-4 py-4 md:pb-8">
                     {/* <h3 className="mb-2 text-lg">Save money if you don't need user properties</h3>
                     <p className="font-semibold opacity-70 text-[15px]">(Custom user properties more expensive to process)</p>
                     <p className="mb-2">The more data we store about users, the higher the cost. So the less data you need, the more you can save.</p> */}


### PR DESCRIPTION
## Problem

In the pricing calculator, clicking **explain event types** opens the "Event types, explained" dialog. When the PostHog window is resized small, the dialog crops the end of its content instead of scrolling.

<img width="1920" height="993" alt="Screenshot 2026-06-12 at 12 53 36" src="https://github.com/user-attachments/assets/6592ea3d-87ce-4e48-9906-b4ea8aec6163" />

## Cause

The dialog's scroll area used a viewport-based `max-h: calc(100vh - …)`. Inside posthog.com's desktop-OS windowed UI, the modal is `position: fixed` against the transformed window container — so its height should track the window. But the `100vh` calc measured against the **full browser viewport**, not the smaller window. When the window was smaller than the viewport, the computed max-height exceeded the window, the inner area never needed to scroll, and the window simply clipped the overflow.

## Fix

- Anchor the panel at both top and bottom (`bottom-4 md:bottom-8`) so its height is bounded by the containing window rather than its content.
- Replace the viewport-based `max-h` with `flex-1 min-h-0` on the content area so it fills the remaining space and scrolls via the existing `overflow-y-auto`.

This makes the dialog scroll correctly at any window size.

## Screenshots (before)

The end of the dialog content is cropped when the window is too small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)