### PR TITLE
docs(rust): add Rust error tracking installation guide

### DIFF
--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -1,0 +1,137 @@
+---
+title: Rust error tracking installation
+platformLogo: rust
+showStepsToc: true
+---
+
+import { Steps, Step } from 'components/Docs/Steps'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<Steps>
+
+<Step title="Install the Rust SDK" badge="required">
+
+Install the [PostHog Rust SDK](/docs/libraries/rust):
+
+```bash
+cargo add posthog-rs
+```
+
+Error tracking ships enabled by default through the `error-tracking` feature. If you build with `default-features = false`, add it back explicitly:
+
+```toml
+[dependencies]
+posthog-rs = { version = "*", default-features = false, features = ["error-tracking"] }
+```
+
+<CalloutBox icon="IconInfo" title="Source context not yet supported" type="fyi">
+
+The Rust SDK resolves stack traces in-process, so captured frames include file names, line numbers, and function names without any symbol uploads. Source context (displaying the surrounding lines of code in the error tracking UI) is not yet supported.
+
+</CalloutBox>
+
+</Step>
+
+<Step title="Initialize the client" badge="required">
+
+```rust
+let client = posthog_rs::client("<ph_project_token>").await;
+```
+
+The default client is async (Tokio). Building with `default-features = false` gives you a blocking client instead — the same methods without `.await`.
+
+</Step>
+
+<Step title="Capture exceptions" badge="required">
+
+`capture_exception` works with any `std::error::Error` and captures it personlessly — the exception type, message, and full `source()` chain are sent, with a stack trace recorded at the call site:
+
+```rust
+let error = std::io::Error::new(std::io::ErrorKind::Other, "connection refused");
+
+client.capture_exception(&error).await.unwrap();
+```
+
+To associate the exception with a person or attach context, use `capture_exception_with`:
+
+```rust
+use posthog_rs::CaptureExceptionOptions;
+
+client.capture_exception_with(
+    &error,
+    CaptureExceptionOptions::new()
+        .distinct_id("user_distinct_id")
+        .property("route", "/checkout").unwrap()
+        .group("company", "company_id")
+        .fingerprint("my-custom-fingerprint")
+        .level("warning"),
+).await.unwrap();
+```
+
+All options are optional: `distinct_id` links a person, `property` and `group` add context, `fingerprint` overrides [issue grouping](/docs/error-tracking/grouping-issues), and `level` sets the severity (defaults to `error`).
+
+If you use `anyhow`, pass the underlying error with `err.as_ref()`:
+
+```rust
+let result: anyhow::Result<()> = do_work();
+if let Err(err) = result {
+    client.capture_exception(err.as_ref()).await.unwrap();
+}
+```
+
+</Step>
+
+<Step title="Capture panics" badge="optional">
+
+Install the panic hook once near application startup to capture Rust panics automatically:
+
+```rust
+posthog_rs::install_panic_hook("<ph_project_token>").unwrap();
+```
+
+Panics are captured personlessly with the panic message, the panic site (file, line, and column), and a stack trace. The previously installed hook still runs afterwards, so default panic output and other integrations are unaffected.
+
+Panic capture is best-effort: hooks run before unwinding, so panics caught later by `catch_unwind` are still captured, while aborting processes may exit before delivery completes.
+
+</Step>
+
+<Step title="Configure stack traces" badge="optional">
+
+Stack trace capture and in-app frame classification are configured per client through `ErrorTrackingOptionsBuilder`:
+
+```rust
+use posthog_rs::{ClientOptionsBuilder, ErrorTrackingOptionsBuilder};
+
+let options = ClientOptionsBuilder::default()
+    .api_key("<ph_project_token>".to_string())
+    .error_tracking(
+        ErrorTrackingOptionsBuilder::default()
+            // Skip the stack walk entirely, e.g. for high-volume handled errors
+            .capture_stacktrace(false)
+            // Mark frames from a crate as library code rather than in-app
+            .in_app_exclude_paths(vec!["other_crate::".to_string()])
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let client = posthog_rs::client(options).await;
+```
+
+In-app patterns match both file paths and function symbols, so crate prefixes like `"my_crate::"` and path fragments like `"/service/"` both work. By default, frames from the cargo registry, the standard library, and vendored or target paths are classified as library code.
+
+</Step>
+
+<Step title="Verify error tracking" badge="recommended">
+
+Trigger a test exception to confirm events are being sent to PostHog. You should see it appear in the [error tracking issues view](https://app.posthog.com/error_tracking).
+
+```rust
+let error = std::io::Error::new(std::io::ErrorKind::Other, "This is a test exception from Rust");
+client.capture_exception(&error).await.unwrap();
+```
+
+</Step>
+
+</Steps>

--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -35,7 +35,10 @@ The Rust SDK resolves stack traces in-process, so captured frames include file n
 <Step title="Initialize the client" badge="required">
 
 ```rust
-let client = posthog_rs::client("<ph_project_token>").await;
+let client = posthog_rs::client((
+    "<ph_project_token>",
+    "<ph_client_api_host>",
+)).await;
 ```
 
 The default client is async (Tokio). Building with `default-features = false` gives you a blocking client instead — the same methods without `.await`.
@@ -86,7 +89,10 @@ if let Err(err) = result {
 Install the panic hook once near application startup to capture Rust panics automatically:
 
 ```rust
-posthog_rs::install_panic_hook("<ph_project_token>").unwrap();
+posthog_rs::install_panic_hook((
+    "<ph_project_token>",
+    "<ph_client_api_host>",
+)).unwrap();
 ```
 
 Panics are captured personlessly with the panic message, the panic site (file, line, and column), and a stack trace. The previously installed hook still runs afterwards, so default panic output and other integrations are unaffected.
@@ -104,6 +110,7 @@ use posthog_rs::{ClientOptionsBuilder, ErrorTrackingOptionsBuilder};
 
 let options = ClientOptionsBuilder::default()
     .api_key("<ph_project_token>".to_string())
+    .host("<ph_client_api_host>")
     .error_tracking(
         ErrorTrackingOptionsBuilder::default()
             // Skip the stack walk entirely, e.g. for high-volume handled errors

--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -84,23 +84,6 @@ if let Err(err) = result {
 
 </Step>
 
-<Step title="Capture panics" badge="optional">
-
-Install the panic hook once near application startup to capture Rust panics automatically:
-
-```rust
-posthog_rs::install_panic_hook((
-    "<ph_project_token>",
-    "<ph_client_api_host>",
-)).unwrap();
-```
-
-Panics are captured personlessly with the panic message, the panic site (file, line, and column), and a stack trace. The previously installed hook still runs afterwards, so default panic output and other integrations are unaffected.
-
-Panic capture is best-effort: hooks run before unwinding, so panics caught later by `catch_unwind` are still captured, while aborting processes may exit before delivery completes.
-
-</Step>
-
 <Step title="Configure stack traces" badge="optional">
 
 Stack trace capture and in-app frame classification are configured per client through `ErrorTrackingOptionsBuilder`:

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -88,7 +88,10 @@ client.capture_exception_with(
 To capture panics automatically, install the panic hook once near application startup:
 
 ```rust
-posthog_rs::install_panic_hook("<ph_project_token>").unwrap();
+posthog_rs::install_panic_hook((
+    "<ph_project_token>",
+    "<ph_client_api_host>",
+)).unwrap();
 ```
 
 For the full setup guide, see the [Rust error tracking installation docs](/docs/error-tracking/installation/rust).

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -9,6 +9,7 @@ features:
   groupAnalytics: true
   surveys: false
   aiObservability: false
+  errorTracking: true
 ---
 
 ## Installation
@@ -62,6 +63,35 @@ let client = posthog_rs::client(options).await;
 When local evaluation is enabled, flag definitions are fetched on initialization and periodically refreshed in the background. Flag evaluation then happens locally without network requests, providing 100-1000x faster performance.
 
 > **Note:** Local evaluation requires providing any person properties, groups, or group properties needed to evaluate the flag's release conditions, since PostHog can't fetch these automatically without a server request.
+
+## Error tracking
+
+You can capture exceptions and panics with the Rust SDK. `capture_exception` accepts any `std::error::Error` and records a stack trace at the call site; `capture_exception_with` additionally links a person and attaches context:
+
+```rust
+use posthog_rs::CaptureExceptionOptions;
+
+let error = std::io::Error::new(std::io::ErrorKind::Other, "connection refused");
+
+// Captured personlessly
+client.capture_exception(&error).await.unwrap();
+
+// Associated with a person, with optional context
+client.capture_exception_with(
+    &error,
+    CaptureExceptionOptions::new()
+        .distinct_id("user_distinct_id")
+        .property("route", "/checkout").unwrap(),
+).await.unwrap();
+```
+
+To capture panics automatically, install the panic hook once near application startup:
+
+```rust
+posthog_rs::install_panic_hook("<ph_project_token>").unwrap();
+```
+
+For the full setup guide, see the [Rust error tracking installation docs](/docs/error-tracking/installation/rust).
 
 ## Observability
 

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -66,7 +66,7 @@ When local evaluation is enabled, flag definitions are fetched on initialization
 
 ## Error tracking
 
-You can capture exceptions and panics with the Rust SDK. `capture_exception` accepts any `std::error::Error` and records a stack trace at the call site; `capture_exception_with` additionally links a person and attaches context:
+You can capture exceptions with the Rust SDK. `capture_exception` accepts any `std::error::Error` and records a stack trace at the call site; `capture_exception_with` additionally links a person and attaches context:
 
 ```rust
 use posthog_rs::CaptureExceptionOptions;
@@ -83,15 +83,6 @@ client.capture_exception_with(
         .distinct_id("user_distinct_id")
         .property("route", "/checkout").unwrap(),
 ).await.unwrap();
-```
-
-To capture panics automatically, install the panic hook once near application startup:
-
-```rust
-posthog_rs::install_panic_hook((
-    "<ph_project_token>",
-    "<ph_client_api_host>",
-)).unwrap();
 ```
 
 For the full setup guide, see the [Rust error tracking installation docs](/docs/error-tracking/installation/rust).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4889,6 +4889,10 @@ export const docsMenu = {
                             url: '/docs/error-tracking/installation/php',
                         },
                         {
+                            name: 'Rust',
+                            url: '/docs/error-tracking/installation/rust',
+                        },
+                        {
                             name: 'iOS',
                             url: '/docs/error-tracking/installation/ios',
                         },


### PR DESCRIPTION
## Problem

The Rust SDK shipped manual error tracking in v0.12.0 (PostHog/posthog-rs#129), but there are no error tracking docs for Rust. Per review on PostHog/posthog-rs#130, usage docs belong here as the canonical reference, not in the SDK README.

## Changes

- New `/docs/error-tracking/installation/rust` page following the Go/Elixir page structure: install (default `error-tracking` feature), client init, manual capture (`capture_exception` / `capture_exception_with` with options), stack trace configuration (`ErrorTrackingOptionsBuilder`), and a verify step
- Rust entry in the error tracking installation nav
- `## Error tracking` section + `errorTracking: true` feature flag on the Rust library page

## Notes

- Covers manual exception capture only (released in v0.12.0). Panic autocapture is still in review (PostHog/posthog-rs#130); its docs will be added once it ships.
- Stack traces resolve in-process (no symbol uploads); the page carries a "source context not yet supported" callout like Go's.

## Tests

- `node --check` on `src/navs/index.js`, YAML frontmatter parsed on both MDX files, `<Steps>`/`<Step>` tags balanced
- Code snippets mirror compiling examples from the SDK's tests/doctests
