### PR TITLE
Handbook: clarify who controls our social accounts

### DIFF
--- a/contents/handbook/marketing/social-media.md
+++ b/contents/handbook/marketing/social-media.md
@@ -6,6 +6,10 @@ showTitle: true
 
 > **Got a launch, Beta, GA, or project you want promoted on social?** Tag <TeamMember name="Liam Graham" /> in Slack and use the checklist below to give him the information he needs.
 
+## Who controls our social accounts
+
+<TeamMember name="Liam Graham" /> owns and runs PostHog's main social media accounts. If you need something posted from an official account, want a reply sent from one, or have a question about our presence on a platform, he's your point of contact.
+
 When we promote a launch on social, <TeamMember name="Liam Graham" /> needs a handful of things to turn it into great posts. 
 
 


### PR DESCRIPTION
## Changes

Adds a short "Who controls our social accounts" section to the social media handbook page, stating that Liam Graham owns and runs PostHog's main social accounts and is the point of contact for posting/replying from official accounts.

**Why:** Someone searched the handbook to find who controls our socials and came up empty — this makes the answer easy to find for future people.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07TQR0V16U/p1781322374423509?thread_ts=1781322374.423509&cid=C07TQR0V16U)*
