### PR TITLE
perf: lazy-load amcharts5 in CountriesWeHireIn

### DIFF
--- a/src/components/AMCharts/CountriesWeHireIn/index.tsx
+++ b/src/components/AMCharts/CountriesWeHireIn/index.tsx
@@ -1,8 +1,4 @@
-import React, { useLayoutEffect, useRef } from 'react'
-import * as am5 from '@amcharts/amcharts5'
-import * as am5map from '@amcharts/amcharts5/map'
-import am5geodata_worldLow from '@amcharts/amcharts5-geodata/worldLow'
-import am5themes_Animated from '@amcharts/amcharts5/themes/Animated'
+import React, { useLayoutEffect, useEffect, useRef, useState } from 'react'
 type ExclusionReason = 'sanctions' | 'high-cost' | 'contractors' | 'timezone'
 
 interface CountryRestriction {
@@ -126,9 +122,34 @@ export default function CountriesWeHireIn({
     children?: JSX.Element
 }): JSX.Element {
     const chartRef = useRef<HTMLDivElement>(null)
+    // amCharts5 is ~1 MiB; load it on demand so it stays out of the always-loaded bundle.
+    const [amcharts, setAmcharts] = useState<any>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        Promise.all([
+            import('@amcharts/amcharts5'),
+            import('@amcharts/amcharts5/map'),
+            import('@amcharts/amcharts5-geodata/worldLow'),
+            import('@amcharts/amcharts5/themes/Animated'),
+        ]).then(([am5, am5map, worldLow, animated]) => {
+            if (!cancelled) {
+                setAmcharts({
+                    am5,
+                    am5map,
+                    am5geodata_worldLow: (worldLow as any).default,
+                    am5themes_Animated: (animated as any).default,
+                })
+            }
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [])
 
     useLayoutEffect(() => {
-        if (!chartRef.current) return
+        if (!chartRef.current || !amcharts) return
+        const { am5, am5map, am5geodata_worldLow, am5themes_Animated } = amcharts
 
         am5.addLicense('AM5M-1930-8548-3690-4255')
 
@@ -229,7 +250,7 @@ export default function CountriesWeHireIn({
 
         // Set fill color and pattern based on exclusion reason
         polygonSeries.mapPolygons.template.adapters.add('fill', (_fill, target) => {
-            const dataItem = target.dataItem as am5.DataItem<any>
+            const dataItem = target.dataItem as any
             const id = (dataItem?.dataContext as any)?.id
 
             const restriction = restrictionMap.get(id)
@@ -241,7 +262,7 @@ export default function CountriesWeHireIn({
 
         // Set tooltip based on exclusion reason
         polygonSeries.mapPolygons.template.adapters.add('tooltipHTML', (_html, target) => {
-            const dataItem = target.dataItem as am5.DataItem<any>
+            const dataItem = target.dataItem as any
             const id = (dataItem?.dataContext as any)?.id
             const name = (dataItem?.dataContext as any)?.name
 
@@ -266,7 +287,7 @@ export default function CountriesWeHireIn({
         return () => {
             root.dispose()
         }
-    }, [excludedCountries])
+    }, [excludedCountries, amcharts])
 
     return (
         <div>


### PR DESCRIPTION
this approach worked nicely in the app
robot recorded what it believes is the affected page on the preview link

<img width="820" height="513" alt="17605-amcharts-hiring" src="https://github.com/user-attachments/assets/590d350d-7ad9-4c08-9c8c-d0c8cea46800" />

## Changes

Second bundle-split in the ratchet. `CountriesWeHireIn` (a hiring map) statically imported `@amcharts/amcharts5` + its map module, world geodata, and animated theme — **~1 MiB** — and it's the *only* amcharts consumer on the site. Because it lives in the auto-generated MDX shortcode registry (`mdxGlobalComponents`) that MDXProvider loads on every page, all of amcharts shipped eagerly everywhere.

This loads the four amcharts modules via dynamic `import()` into state and gates the chart-building `useLayoutEffect` on them (the same pattern as the mapbox fix in the parent PR). The map renders on demand; amcharts leaves the eager graph.

`CountriesWeHireIn` is used on the careers / "how we hire" content — please sanity-check that the world map still renders there on the preview.

### Expected impact

amcharts5 (~1 MiB, the bulk of the mdx-registry-unique weight) drops out of the `app` eager closure. Stacked on the mapbox PR, so the preview eager-graph comment shows the cumulative reduction.

## Checklist

- [x] Words are spelled using American English
- [ ] Verify the CountriesWeHireIn map still renders on the preview

## 🤖 Agent context

Stacked on #17604 (mapbox) which is stacked on #17603 (the checker). Ratchet so far: mapbox (-1.62 MiB) -> amcharts (this). Remaining eager candidates after this: Stickers (696 KiB), lottie-web (611 KiB, via gatsby-browser -> lottie-react), @mdxeditor/CodeMirror (OSTable), jspdf (OSChrome HeaderBar).
