### PR TITLE
perf: lazy-load jspdf for presentation PDF export

### DIFF
--- a/src/lib/exportToPdf.ts
+++ b/src/lib/exportToPdf.ts
@@ -1,6 +1,3 @@
-import { toJpeg } from 'html-to-image'
-import jsPDF from 'jspdf'
-
 interface ExportToPdfOptions {
     slideId?: string
     filename?: string
@@ -13,6 +10,10 @@ const formatProductName = (handle: string): string => {
 
 export const exportToPdf = async ({ slideId, filename }: ExportToPdfOptions = {}) => {
     try {
+        // jspdf (~330 KiB) and html-to-image are only needed for this export, so load them
+        // on demand to keep them out of the always-loaded bundle.
+        const [{ default: jsPDF }, { toJpeg }] = await Promise.all([import('jspdf'), import('html-to-image')])
+
         let finalFilename = filename
         if (!finalFilename && slideId) {
             const productName = formatProductName(slideId)


### PR DESCRIPTION
this approach worked nicely in the app
robot recorded what it believes is the affected page on the preview link

<img width="820" height="513" alt="17607-jspdf-export" src="https://github.com/user-attachments/assets/1f43cd7a-333f-4710-9a2e-4d66f2694284" />

## Changes

Fourth bundle-split in the ratchet, and the cleanest one. `src/lib/exportToPdf.ts` statically imported `jspdf` (~330 KiB) and `html-to-image`, so they shipped on every page via `OSChrome/HeaderBar` — even though they're only used when a user exports a presentation to PDF.

`exportToPdf` is already an async function, so this just moves both imports to a dynamic `import()` at the top of it. No component/Suspense changes.

Please sanity-check on the preview: open a presentation and use the PDF export in the header bar.

### Expected impact

jspdf (~330 KiB, plus html-to-image on this path) drops out of the `app` eager closure. Stacked on the lottie PR.

## Checklist

- [x] Words are spelled using American English
- [ ] Verify presentation PDF export still works on the preview

## 🤖 Agent context

Stack: #17603 (checker) <- #17604 (mapbox) <- #17605 (amcharts) <- #17606 (lottie) <- this (jspdf). html-to-image is still statically imported by RoadmapForm/MSPaint/photobooth, so it may remain eager via those — separate follow-up. Remaining eager candidates: @mdxeditor/CodeMirror (OSTable, 458 KiB), Stickers (696 KiB, MDX scope), @radix-ui/react-icons (481 KiB).
