### PR TITLE
fix(footer): use gray text for status and legal links in dark mode

### DIFF
--- a/src/components/WebsiteFooter/index.tsx
+++ b/src/components/WebsiteFooter/index.tsx
@@ -22,13 +22,17 @@ export default function WebsiteFooter(): React.ReactElement {
                         {/* Copyright and status */}
                         <div className="flex items-center gap-4 justify-between @xl:justify-start">
                             <p className="text-secondary m-0">&copy; {new Date().getFullYear()} PostHog, Inc.</p>
-                            <AppStatus textClassName="text-xs underline" />
+                            <AppStatus textClassName="text-xs underline text-secondary" />
                         </div>
 
                         {/* Legal links */}
                         <nav className="flex flex-wrap items-center gap-x-4 gap-y-2">
                             {legalLinks.map((link) => (
-                                <Link key={link.label} to={link.url} className="transition-colors underline">
+                                <Link
+                                    key={link.label}
+                                    to={link.url}
+                                    className="transition-colors underline text-secondary"
+                                >
                                     {link.label}
                                 </Link>
                             ))}


### PR DESCRIPTION
## Changes

In **dark mode**, the website footer's "All systems operational" status text and the legal links (Terms, Privacy, DPA, SOC 2, HIPAA) inherited the default near-black text color, making them very hard to read against the dark background. The copyright line next to them already used `text-secondary` (gray) and rendered fine.

This applies `text-secondary` to the `AppStatus` text and the legal links so they render gray and adapt correctly across light/dark, matching the copyright.

| | Status + links color |
|---|---|
| Before | near-black (unreadable in dark mode) |
| After | `text-secondary` gray (`rgb(176,180,196)` in dark) |

<!-- Before/after screenshots of the footer in dark mode: -->

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (N/A — no page moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

### 1. Footer in dark mode – Before
<img width="1278" height="55" alt="pr-17608-footer-dark-mode-before" src="https://github.com/user-attachments/assets/449f47ff-b397-4162-9a8f-6ce3a31fed5c" />

### 2. Footer in dark mode – After
<img width="1278" height="55" alt="pr-17608-footer-dark-mode-after" src="https://github.com/user-attachments/assets/a89317a7-b156-43e9-b3e1-71f7fc8e3ab2" />
