### PR TITLE
fix(home): use white logo in hero for dark mode

### DIFF
--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -353,11 +353,12 @@ function HeroImage(): JSX.Element {
 }
 
 function TestHero(): JSX.Element {
+    const { siteSettings } = useApp()
     return (
         <>
             <div className="text-center @xl:text-left mb-12">
                 <h1 className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-8 pt-2">
-                    <Logo />
+                    <Logo fill={siteSettings.theme === 'dark' ? 'white' : undefined} />
                 </h1>
 
                 <Tagline />
@@ -371,13 +372,14 @@ function TestHero(): JSX.Element {
 }
 
 function ControlHero(): JSX.Element {
+    const { siteSettings } = useApp()
     return (
         <>
             <div className="text-center @xl:text-left mb-12">
                 <ControlHeroImage />
 
                 <h1 className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-8 pt-2">
-                    <Logo />
+                    <Logo fill={siteSettings.theme === 'dark' ? 'white' : undefined} />
                 </h1>
 
                 <ControlTagline />


### PR DESCRIPTION
## Changes

The homepage hero rendered a plain `<Logo />` whose text paths default to `#000` (black), making the **"PostHog" wordmark invisible** against the dark background in dark mode. The colored square mark stayed visible, but the letters disappeared.

This passes `fill="white"` when the theme is dark — the same pattern already used on the `/about` letterhead (`components/About/v2/Letterhead.tsx`). Applied to both hero variants in `components/Home/Test/index.tsx` (`TestHero` and `ControlHero`).

| Mode | Logo |
|---|---|
| Light | full-color wordmark (unchanged) |
| Dark | white wordmark (now visible) |

<!-- Before/after screenshots of the homepage hero logo in dark mode: -->

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (N/A — no page moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

### 1. Homepage hero logo in dark mode – Before
<img width="1920" height="1080" alt="pr-17609-hero-logo-dark-before" src="https://github.com/user-attachments/assets/87a54b7c-03b2-49d4-a2f0-a9818c5d64b4" />

### 2. Homepage hero logo in dark mode – After
<img width="1920" height="1080" alt="pr-17609-hero-logo-dark-after" src="https://github.com/user-attachments/assets/39022ca3-24ed-4e45-aece-e83cf3952f90" />
