### PR TITLE
docs(handbook): fix broken revenue metrics link in finance page

### DIFF
--- a/contents/handbook/finance.md
+++ b/contents/handbook/finance.md
@@ -61,4 +61,4 @@ We group them into **monthly financials** (the basics — what we made, what we 
 
 **Cash runway (quarters)** — how many quarters our cash lasts at our current burn. The cash balance question, framed against how fast we're spending. Relevant to everyone, especially anyone making hiring or major spend decisions. Longer is better. Default alive means we reach profitability before this hits zero.
 
-[Curious about our revenue metrics?]([url](https://posthog.com/handbook/growth/revops/retention-metrics))
+[Curious about our revenue metrics?](/handbook/growth/revops/retention-metrics)


### PR DESCRIPTION
## Problem

The "Curious about our revenue metrics?" link at the bottom of the finance handbook page was broken. The markdown link had a nested `[url](...)` inside the link target:

```markdown
[Curious about our revenue metrics?]([url](https://posthog.com/handbook/growth/revops/retention-metrics))
```

This rendered incorrectly instead of producing a working link.

## Fix

Corrected the markdown syntax and switched to a relative URL to match the repo convention for internal links (877 relative vs 67 absolute handbook links; also mandated by repo guidelines):

```markdown
[Curious about our revenue metrics?](/handbook/growth/revops/retention-metrics)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)