### PR TITLE
Reassign Data colors & themes feature ownership to Platform UX

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -138,7 +138,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'data-colors-themes': {
         feature: 'Data colors & themes',
-        owner: ['analytics-platform'],
+        owner: ['platform-ux'],
         label: 'feature/colors-and-themes',
     },
     'data-management': {


### PR DESCRIPTION
## Changes

Reassigns ownership of the **Data colors & themes** feature in the engineering [Feature Ownership table](/handbook/engineering/feature-ownership) from `analytics-platform` to `platform-ux`.

This is a single-value change in `src/hooks/useFeatureOwnership.tsx`, the data source the `FeatureOwnershipTable` reads from. `platform-ux` is an existing team slug already used by several other features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)