### PR TITLE
docs(ai-gateway): set Q3 2026 objectives

### DIFF
--- a/contents/teams/ai-gateway/index.mdx
+++ b/contents/teams/ai-gateway/index.mdx
@@ -10,7 +10,7 @@ The AI gateway is PostHog's internal routing layer for calling LLM providers. It
 
 ## Working with other teams
 
-The gateway sits underneath PostHog's AI features, so most internal teams shipping AI functionality will end up calling it instead of providers directly. We work closely with <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="ai-observability" />, and any small team adding AI features to their product.
+The gateway sits underneath PostHog's AI features, so most internal teams shipping AI functionality call it instead of providers directly — and as we move to general availability, external customers route through the same gateway. We work closely with <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, <SmallTeam slug="self-driving" />, <SmallTeam slug="ai-observability" />, and any small team adding AI features to their product.
 
 Come to us if you:
 
@@ -18,3 +18,14 @@ Come to us if you:
 - Need a new provider, model, or capability added to the gateway
 - Are debugging gateway latency, errors, or cost attribution
 - Want gateway-level features like caching, fallbacks, structured outputs, or rate-limit handling
+
+## Who we're building for
+
+Teams and companies building AI features who want a single endpoint in front of their LLM providers, with auth, cost attribution, spend controls, failover, and observability handled for them — instead of calling providers directly.
+
+**The gateway is a good fit if you:**
+
+- Call one or more LLM providers and want shared auth, cost attribution, and failover in front of them
+- Need per-team or per-customer spend controls and accurate cost attribution
+- Want automatic failover to a hosted equivalent when a provider has an incident
+- Already send AI traffic through PostHog and want traces, evals, and cost analytics on it without extra setup

--- a/contents/teams/ai-gateway/objectives.mdx
+++ b/contents/teams/ai-gateway/objectives.mdx
@@ -2,27 +2,27 @@
 
 #### Goal 1: General availability
 
-*Description*: Get the gateway from built to depended-on — all internal AI traffic running through it and the first paying customers live.
+*Description*: Carry all of PostHog's internal AI traffic on the gateway, and go live with the first paying customers.
 
 *What we will ship*:
-- **100% internal traffic** - <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground all routed through the gateway, with the original gateway retired
-- **Alpha/beta paying customers** - first external orgs live on the gateway behind a controlled rollout
-- **Billing concept** - the spend, balance, and enablement foundation needed to charge real usage
+- **100% internal traffic** - <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground all routed through the gateway, with the old one switched off
+- **Alpha/beta paying customers** - a handful of external orgs live and billed
+- **Billing** - track spend and balances so we can charge for usage
 
 #### Goal 2: $1M ARR
 
-*Description*: Prove people will actually pay for the gateway — customers pay at cost while we earn our margin on the volume discounts we negotiate with model providers, validated by real revenue rather than a hunch.
+*Description*: Show people will pay for the gateway. Customers pay at cost; we earn on the volume discounts we negotiate with providers.
 
 *What we will ship*:
-- **Pricing and margin model** - customers pay at provider cost; our margin comes from the volume discounts we negotiate with model providers, with credit-card-fee and bank-transfer economics worked out
-- **Billing integration** - wired into PostHog's existing billing stack, with reconciliation and overspend handling
-- **BYOK investigation** - explore whether to offer a bring-your-own-key path for enterprises and customers with existing provider discounts
+- **Pricing and margins** - charge at provider cost and earn the spread from negotiated volume discounts, with credit-card and bank-transfer fees accounted for
+- **Billing integration** - hooked into PostHog's billing stack, with reconciliation and overspend handling
+- **BYOK** - look into bring-your-own-key for enterprises and customers with their own provider discounts
 
 #### Goal 3: Auth and attribution as the product
 
-*Description*: Turn auth and attribution into the core product surface — generalized for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers, with per-user spend controls.
+*Description*: Auth and attribution are the real product. Generalize them for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers, with per-user spend controls.
 
 *What we will ship*:
-- **Per-user spend controls** - rate limits, spend caps, overspend, and sub-wallets scoped per user
-- **Free and paid usage** - usage tiers that cleanly separate free from paid
-- **PostHog Code and Agent Platform on it** - both consuming the generalized auth/attribution model in production
+- **Per-user spend controls** - rate limits, spend caps, overspend, and sub-wallets, all per user
+- **Free and paid usage** - meter free and paid usage separately
+- **PostHog Code and Agent Platform on it** - both using it in production

--- a/contents/teams/ai-gateway/objectives.mdx
+++ b/contents/teams/ai-gateway/objectives.mdx
@@ -5,7 +5,7 @@
 *Description*: Get the gateway from built to depended-on — all internal AI traffic running through it and the first paying customers live.
 
 *What we will ship*:
-- **100% internal traffic** - PostHog AI, PostHog Code, the Agent Platform, and the AI Observability Playground all routed through the gateway, with the original gateway retired
+- **100% internal traffic** - <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground all routed through the gateway, with the original gateway retired
 - **Alpha/beta paying customers** - first external orgs live on the gateway behind a controlled rollout
 - **Billing concept** - the spend, balance, and enablement foundation needed to charge real usage
 
@@ -20,9 +20,9 @@
 
 #### Goal 3: Auth and attribution as the product
 
-*Description*: Turn auth and attribution into the core product surface — generalized for PostHog Code, the Agent Platform, and external customers, with per-user spend controls.
+*Description*: Turn auth and attribution into the core product surface — generalized for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers, with per-user spend controls.
 
 *What we will ship*:
 - **Per-user spend controls** - rate limits, spend caps, overspend, and sub-wallets scoped per user
 - **Free and paid usage** - usage tiers that cleanly separate free from paid
-- **PHC and Agent Platform on it** - both consuming the generalized auth/attribution model in production
+- **PostHog Code and Agent Platform on it** - both consuming the generalized auth/attribution model in production

--- a/contents/teams/ai-gateway/objectives.mdx
+++ b/contents/teams/ai-gateway/objectives.mdx
@@ -5,24 +5,24 @@
 *Description*: Carry all of PostHog's internal AI traffic on the gateway, and go live with the first paying customers.
 
 *What we will ship*:
-- **100% internal traffic** – <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground all routed through the gateway, with the old one switched off
-- **Alpha/beta paying customers** – a handful of external orgs live and billed
-- **Accurate, secure billing** – get usage, spend, and balance tracking correct and locked down before we charge real money
+- **100% internal traffic** – route <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground through the gateway and switch off the old one
+- **Alpha/beta paying customers** – get the first external orgs live and billed
+- **Accurate, secure billing** – track usage, spend, and balances correctly and securely before we charge real money
 
 #### Goal 2: $1M ARR
 
-*Description*: Show people will pay for the gateway, and figure out the pricing and monetization to get there.
+*Description*: Show people will pay for the gateway, and build the pricing and monetization behind it.
 
 *What we will ship*:
-- **Pricing and monetization** – figure out how we price and monetize the features we want to support
-- **Billing integration** – hooked into PostHog's billing stack, with reconciliation and overspend handling
-- **BYOK** – look into bring-your-own-key for enterprises and customers with their own provider discounts
+- **Pricing and monetization** – build a pricing and monetization strategy that scales and supports the features we want
+- **Billing integration** – wire it into PostHog's billing stack with reconciliation and overspend handling
+- **BYOK** – evaluate bring-your-own-key for enterprises and customers with their own provider discounts
 
 #### Goal 3: Auth and attribution
 
 *Description*: Generalize our authentication and attribution solutions for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers.
 
 *What we will ship*:
-- **Per-user spend controls** – rate limits, spend caps, overspend, and sub-wallets, all per user
+- **Per-user spend controls** – enforce rate limits, spend caps, overspend, and sub-wallets per user
 - **Free and paid usage** – meter free and paid usage separately
-- **PostHog Code and Agent Platform on it** – both using it in production
+- **PostHog Code and Agent Platform on it** – get both consuming it in production

--- a/contents/teams/ai-gateway/objectives.mdx
+++ b/contents/teams/ai-gateway/objectives.mdx
@@ -1,55 +1,28 @@
-### Q2 2026 objectives
+### Q3 2026 objectives
 
-#### Goal 1: Rebuild the gateway
+#### Goal 1: General availability
 
-*Description*: Replace today's single-process gateway with a horizontally scalable service that internal PostHog teams can rely on for AI traffic.
-
-*What we will ship*:
-- **Horizontally scalable service** - capacity adds by replica count
-- **True-proxy per provider shape** - native OpenAI and Anthropic shapes, no cross-shape translation
-- **Core modules** - auth, rate limiting, routing, cost, quota, dispatch, and the post-call recording path into AI Observability
-- **Load characterization** - so we can size the fleet from observed throughput
-
-#### Goal 2: Spending controls
-
-*Description*: Make sure a runaway caller can't quietly run up provider cost.
+*Description*: Get the gateway from built to depended-on — all internal AI traffic running through it and the first paying customers live.
 
 *What we will ship*:
-- **Pre-call spending guardrails** - decide whether a request is admitted before it reaches the provider
-- **Runaway-cost protection** - cap how much damage a misbehaving caller can do
+- **100% internal traffic** - PostHog AI, PostHog Code, the Agent Platform, and the AI Observability Playground all routed through the gateway, with the original gateway retired
+- **Alpha/beta paying customers** - first external orgs live on the gateway behind a controlled rollout
+- **Billing concept** - the spend, balance, and enablement foundation needed to charge real usage
 
-#### Goal 3: Provider coverage and failover
+#### Goal 2: $1M ARR
 
-*Description*: Cover the providers PostHog's internal AI features need, with automatic failover when a primary has an incident.
-
-*What we will ship*:
-- **OpenAI and Anthropic at launch** - chat, responses, and messages routes
-- **Failover to a hosted equivalent** - Anthropic to Bedrock, OpenAI to Azure
-- **Best-effort model resolution** - so clients we don't control work without custom config
-
-#### Goal 4: Land gateway calls in AI Observability
-
-*Description*: Every gateway call lands in the existing `$ai_generation` pipeline so traces, evals, and cost analytics work on gateway traffic.
+*Description*: Prove people will actually pay for the gateway — customers pay at cost while we earn our margin on the volume discounts we negotiate with model providers, validated by real revenue rather than a hunch.
 
 *What we will ship*:
-- **No schema change** - same event surface, dashboards keep working
-- **Normalized cached vs billable input split** - one shape across providers
-- **Single cost-calculation path** - converge the two we have today
+- **Pricing and margin model** - customers pay at provider cost; our margin comes from the volume discounts we negotiate with model providers, with credit-card-fee and bank-transfer economics worked out
+- **Billing integration** - wired into PostHog's existing billing stack, with reconciliation and overspend handling
+- **BYOK investigation** - explore whether to offer a bring-your-own-key path for enterprises and customers with existing provider discounts
 
-#### Goal 5: Take ownership of the AI Observability Playground
+#### Goal 3: Auth and attribution as the product
 
-*Description*: Pick up the [AI Observability Playground](/docs/ai-observability/playground) from <SmallTeam slug="ai-observability" /> and keep it moving as gateway capabilities grow.
-
-*What we will ship*:
-- **Clean handover** - clear ownership, on-call, and triage path for Playground bugs and requests
-- **Gateway-aligned model coverage** - Playground keeps pace with the providers and models the gateway supports
-
-#### Goal 6: Migration off the current gateway
-
-*Description*: Cut traffic over from the existing gateway gradually, starting with internal callers, so we shake out failure modes before more services depend on it.
+*Description*: Turn auth and attribution into the core product surface — generalized for PostHog Code, the Agent Platform, and external customers, with per-user spend controls.
 
 *What we will ship*:
-- **Per-team feature flag at ingress** - one-flag rollback per team
-- **Phased rollout** - start with PostHog AI and PostHog Code, then bring more PostHog services on
-- **Production readiness** - observability, admin surfaces, and graceful shutdown for in-flight streams
-- **Retire the original gateway** - once the new one carries all traffic
+- **Per-user spend controls** - rate limits, spend caps, overspend, and sub-wallets scoped per user
+- **Free and paid usage** - usage tiers that cleanly separate free from paid
+- **PHC and Agent Platform on it** - both consuming the generalized auth/attribution model in production

--- a/contents/teams/ai-gateway/objectives.mdx
+++ b/contents/teams/ai-gateway/objectives.mdx
@@ -5,24 +5,24 @@
 *Description*: Carry all of PostHog's internal AI traffic on the gateway, and go live with the first paying customers.
 
 *What we will ship*:
-- **100% internal traffic** - <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground all routed through the gateway, with the old one switched off
-- **Alpha/beta paying customers** - a handful of external orgs live and billed
-- **Billing** - track spend and balances so we can charge for usage
+- **100% internal traffic** – <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground all routed through the gateway, with the old one switched off
+- **Alpha/beta paying customers** – a handful of external orgs live and billed
+- **Accurate, secure billing** – get usage, spend, and balance tracking correct and locked down before we charge real money
 
 #### Goal 2: $1M ARR
 
-*Description*: Show people will pay for the gateway. Customers pay at cost; we earn on the volume discounts we negotiate with providers.
+*Description*: Show people will pay for the gateway, and figure out the pricing and monetization to get there.
 
 *What we will ship*:
-- **Pricing and margins** - charge at provider cost and earn the spread from negotiated volume discounts, with credit-card and bank-transfer fees accounted for
-- **Billing integration** - hooked into PostHog's billing stack, with reconciliation and overspend handling
-- **BYOK** - look into bring-your-own-key for enterprises and customers with their own provider discounts
+- **Pricing and monetization** – figure out how we price and monetize the features we want to support
+- **Billing integration** – hooked into PostHog's billing stack, with reconciliation and overspend handling
+- **BYOK** – look into bring-your-own-key for enterprises and customers with their own provider discounts
 
-#### Goal 3: Auth and attribution as the product
+#### Goal 3: Auth and attribution
 
-*Description*: Auth and attribution are the real product. Generalize them for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers, with per-user spend controls.
+*Description*: Generalize our authentication and attribution solutions for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers.
 
 *What we will ship*:
-- **Per-user spend controls** - rate limits, spend caps, overspend, and sub-wallets, all per user
-- **Free and paid usage** - meter free and paid usage separately
-- **PostHog Code and Agent Platform on it** - both using it in production
+- **Per-user spend controls** – rate limits, spend caps, overspend, and sub-wallets, all per user
+- **Free and paid usage** – meter free and paid usage separately
+- **PostHog Code and Agent Platform on it** – both using it in production


### PR DESCRIPTION
## Changes

Replace the Q2 2026 objectives on the AI Gateway team page with Q3: general availability, $1M ARR, and auth/attribution as the product. The six Q2 "stand up the gateway" goals collapse into three "make it a product" goals.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`