### PR TITLE
docs: add JVM flag definition cache docs

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-intro.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-intro.mdx
@@ -8,7 +8,7 @@ This enables you to:
 - Coordinate fetching so only one worker polls at a time
 - Pre-cache definitions for ultra-low-latency flag evaluation
 
-> **Note:** External cache providers are currently available in the Node.js, Python, and Ruby SDKs.
+> **Note:** External cache providers are currently available in the Node.js, Python, Ruby, and JVM (Java) SDKs.
 
 ## When to use an external cache
 

--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-jvm.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-jvm.mdx
@@ -1,0 +1,114 @@
+## Installation
+
+External flag definition caches are available in `posthog-server` 2.7.0 and later.
+
+Import the cache provider types from the SDK:
+
+```java
+import com.posthog.server.PostHogBlockingFlagDefinitionCacheProvider;
+import com.posthog.server.PostHogFlagDefinitionCacheProvider;
+```
+
+## The interface
+
+The JVM SDK exposes an async-capable `PostHogFlagDefinitionCacheProvider` interface. If your cache client is synchronous, extend `PostHogBlockingFlagDefinitionCacheProvider` instead.
+
+```java
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+public interface PostHogFlagDefinitionCacheProvider {
+    // Retrieve cached flag definitions
+    CompletionStage<Map<String, Object>> getFlagDefinitions();
+
+    // Determine if this instance should fetch new definitions
+    CompletionStage<Boolean> shouldFetchFlagDefinitions();
+
+    // Store definitions after a successful fetch
+    CompletionStage<Void> onFlagDefinitionsReceived(Map<String, ? extends Object> data);
+
+    // Clean up resources on shutdown
+    CompletionStage<Void> shutdown();
+}
+```
+
+For blocking clients, implement the blocking base class:
+
+```java
+import com.posthog.server.PostHogBlockingFlagDefinitionCacheProvider;
+import java.util.Map;
+
+public class YourCacheProvider extends PostHogBlockingFlagDefinitionCacheProvider {
+    @Override
+    public Map<String, Object> getFlagDefinitionsBlocking() {
+        // Return cached definitions, or null if the cache is empty
+        return sharedCache.get("posthog:flag-definitions");
+    }
+
+    @Override
+    public boolean shouldFetchFlagDefinitionsBlocking() {
+        // Return true if this instance owns the distributed fetch lock
+        return lock.acquireOrRefresh("posthog:flag-definitions:lock");
+    }
+
+    @Override
+    public void onFlagDefinitionsReceivedBlocking(Map<String, ? extends Object> data) {
+        // Store the map as JSON in Redis, a database, or another shared cache
+        sharedCache.set("posthog:flag-definitions", data);
+    }
+
+    @Override
+    public void shutdownBlocking() {
+        // Release locks and close cache clients
+        lock.releaseIfOwned("posthog:flag-definitions:lock");
+    }
+}
+```
+
+When the SDK fetches flag definitions from the API, it passes a JSON-compatible `Map<String, Object>` to `onFlagDefinitionsReceived()` for you to store. Return the same shape from `getFlagDefinitions()`:
+
+```json
+{
+    "flags": [],
+    "group_type_mapping": {},
+    "cohorts": {}
+}
+```
+
+- `flags`: Feature flag definitions
+- `group_type_mapping`: Group type index to name mapping
+- `cohorts`: Cohort definitions for local evaluation
+
+### Method details
+
+| Method | Purpose | Return value |
+| :----- | :------ | :----------- |
+| `getFlagDefinitions()` / `getFlagDefinitionsBlocking()` | Retrieve cached definitions. Called when the poller refreshes and `shouldFetchFlagDefinitions()` returns `false`. | Cached data, or `null` if cache is empty |
+| `shouldFetchFlagDefinitions()` / `shouldFetchFlagDefinitionsBlocking()` | Decide if this instance should fetch. Use for distributed coordination (e.g., locks). | `true` to fetch from PostHog and store the result, `false` to read from cache |
+| `onFlagDefinitionsReceived(data)` / `onFlagDefinitionsReceivedBlocking(data)` | Store definitions after a successful API fetch. | void |
+| `shutdown()` / `shutdownBlocking()` | Release locks, close connections, and clean up resources. | void |
+
+> **Note:** Provider methods may throw errors or complete exceptionally. The SDK catches and logs provider errors: failed `shouldFetchFlagDefinitions()` calls fall back to fetching from PostHog, failed cache reads fall back to the API when no definitions are loaded, and failed writes or shutdowns do not stop flag evaluation. Async provider calls are waited on by the SDK and time out after 10 seconds.
+
+## Using your cache provider
+
+Pass your cache provider when initializing PostHog:
+
+```java
+import com.posthog.server.PostHog;
+import com.posthog.server.PostHogConfig;
+import com.posthog.server.PostHogFlagDefinitionCacheProvider;
+import com.posthog.server.PostHogInterface;
+
+PostHogFlagDefinitionCacheProvider cache = new YourCacheProvider();
+
+PostHogConfig config = PostHogConfig
+    .builder("<ph_project_token>")
+    .host("<ph_client_api_host>")
+    .personalApiKey("<ph_personal_api_key>")
+    .localEvaluation(true)
+    .flagDefinitionCacheProvider(cache)
+    .build();
+
+PostHogInterface posthog = PostHog.with(config);
+```

--- a/contents/docs/feature-flags/local-evaluation/distributed-environments.mdx
+++ b/contents/docs/feature-flags/local-evaluation/distributed-environments.mdx
@@ -13,13 +13,15 @@ import LocalEvalDistributedEnvIntro from "./_snippets/distributed-environments-i
 import LocalEvalDistributedEnvCommonPatterns from "./_snippets/distributed-environments-common-patterns.mdx"
 import LocalEvalDistributedEnvNodeContent from "./_snippets/distributed-environments-node.mdx"
 import LocalEvalDistributedEnvPythonContent from "./_snippets/distributed-environments-python.mdx"
+import LocalEvalDistributedEnvJvmContent from "./_snippets/distributed-environments-jvm.mdx"
 
 <LocalEvalDistributedEnvIntro />
 
-<Tab.Group tabs={['Node.js', 'Python']}>
+<Tab.Group tabs={['Node.js', 'Python', 'JVM (Java)']}>
     <Tab.List>
         <Tab>Node.js</Tab>
         <Tab>Python</Tab>
+        <Tab>JVM (Java)</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
@@ -27,6 +29,9 @@ import LocalEvalDistributedEnvPythonContent from "./_snippets/distributed-enviro
         </Tab.Panel>
         <Tab.Panel>
             <LocalEvalDistributedEnvPythonContent />
+        </Tab.Panel>
+        <Tab.Panel>
+            <LocalEvalDistributedEnvJvmContent />
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>


### PR DESCRIPTION
## Changes

- Adds JVM (Java) documentation for external flag definition cache providers in local evaluation distributed environments.
- Adds a JVM tab to the distributed environments guide and updates the availability note.

Live preview: https://6b3186d2.posthog-preview.pages.dev/docs/feature-flags/local-evaluation/distributed-environments?tab=JVM+%28Java%29

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
