### PR TITLE
Update Replay team objectives to Q3 2026 goals

### DIFF
--- a/contents/teams/replay/objectives.mdx
+++ b/contents/teams/replay/objectives.mdx
@@ -1,5 +1,7 @@
 ## 🚀 Goal 1: Make Replay Vision the fastest growing PostHog product by revenue
 
+Replay Vision is our biggest bet this quarter. We want it to be the product people reach for first — the fastest way for a team to understand what's actually happening in their sessions, and the fastest growing line on our revenue chart.
+
 ## 💰 Goal 2: Solve cost and pricing
 
 Get Replay Vision to general availability.
@@ -13,6 +15,8 @@ Get Replay Vision to general availability.
 - Slack integration
 
 ## 👥 Goal 4: Build group summaries
+
+Everyone is asking for it, so let's build it.
 
 ## 🧠 Goal 5: Contribute AI improvements back into Session Replay
 

--- a/contents/teams/replay/objectives.mdx
+++ b/contents/teams/replay/objectives.mdx
@@ -1,6 +1,6 @@
 ## 🚀 Goal 1: Make Replay Vision the fastest growing PostHog product by revenue
 
-Replay Vision is our biggest bet this quarter. We want it to be the product people reach for first — the fastest way for a team to understand what's actually happening in their sessions, and the fastest growing line on our revenue chart.
+We know there's massive revenue potential here, so let's seize it.
 
 ## 💰 Goal 2: Solve cost and pricing
 

--- a/contents/teams/replay/objectives.mdx
+++ b/contents/teams/replay/objectives.mdx
@@ -1,71 +1,20 @@
-## 🧠 Goal 1: Nail single-session on-demand summaries
+## 🚀 Goal 1: Make Replay Vision the fastest growing PostHog product by revenue
 
-Ship a reliable, on-demand AI summary for individual sessions. Users should be able to hit a button and get a useful natural-language summary of what happened in a session — key user actions, errors, frustration signals, and outcomes.
+## 💰 Goal 2: Solve cost and pricing
 
-- Wire up the rasterizer → AI pipeline end-to-end
-- Iterate on summary quality (prompt tuning, frame selection, context enrichment)
-- Configurable customer-specific context (let customers provide their own domain context to make summaries more relevant)
-- Measure latency and cost per summary, set targets for both
+Get Replay Vision to general availability.
 
-## 🎬 Goal 2: Scale video export pipeline
+## 🛠️ Goal 3: Build out Replay Vision
 
-The rasterizer can render sessions to video — now make it production-ready at scale.
+- Smart sampling
+- Signals integration
+- Scanner actions
+- Alerts and notifications
+- Slack integration
 
-- Harden the Temporal worker for reliability and throughput
-- Optimize resource usage (browser concurrency, memory, CPU)
-- Explore GPU acceleration for further speedup
+## 👥 Goal 4: Build group summaries
 
-## 🏷️ Goal 3: Build session categorizer
+## 🧠 Goal 5: Contribute AI improvements back into Session Replay
 
-Train a binary classifier that can label sessions as "interesting" or not. Use this model to power a categorizer that groups sessions by properties (rage clicks, errors, conversion flows, etc.) but only surfaces the ones the model flags as interesting.
-
-- Extend the session summarizer (Goal 1) to also classify sessions as interesting/not — this becomes our training dataset
-- Train and evaluate the binary classifier
-- Build the categorizer layer on top: group by session properties, filter by interestingness
-- Run classifier on a schedule
-
-## 📡 Goal 4: Replay as a Signal source
-
-Make Replay a first-class signal source for the Signals product. Today, session summarization is tightly coupled to the clustering workflow and doesn't scale. We need to own the summarization pipeline end-to-end so it works independently, scales to thousands of teams, and gives customers control over which sessions get analyzed.
-
-- Own the session summarization pipeline on the Replay team — decouple from clustering
-- Per-team configuration: let customers choose which sessions to summarize (filters, sampling rate)
-- Intelligent session selection via the categorizer model (Goal 3)
-
-## 🖥️ Goal 5: Build new AI-native frontend for Replay
-
-Reimagine the Replay UI around AI-first workflows. Move away from recency as the primary way to rank recordings — instead, leverage the session categorizer (Goal 3) to surface interesting recordings across categories.
-
-- Augment the chronological recording list with category-driven views
-- Surface AI-generated summaries and labels directly in the list UI
-- Design the UX for exploring sessions by category rather than scrolling by time
-
-## 🔌 Goal 6: Basic MCP for Session Replay
-
-Expose Session Replay as MCP tools so AI agents (Claude Desktop, etc.) can search, retrieve, and summarize sessions programmatically.
-
-## 💰 Goal 7: Business model for AI features
-
-Figure out how to price and sustain AI-powered Replay features.
-
-- Map out costs per session for summaries, categorization, and video export
-- Identify break-even points at different usage tiers
-- Propose a pricing model that works for customers and for us
-
-## 🔒 Goal 8: Map out PII, data retention, and IP concerns
-
-Before we begin using machine learning we need to figure out the compliance, legal, and brand concerns around training future models on recording data.
-
-- What PII risks exist when sending session data to LLMs?
-- How do data retention policies interact with AI-generated artifacts?
-- What are the IP implications of training on customer recordings?
-- What do customers expect and what do we need to communicate?
-- What does s-tier consent look like?
-
-## 🗂️ Goal 9: Set up data labelling system for replays
-
-Build the infrastructure for labelling replay data at scale — needed to train and evaluate future models on session data.
-
-- Evaluate labelling tools / build internal tooling
-- Design the labelling workflow and quality controls
-- Start building a labelled dataset
+- Natural language search
+- Surfacing model


### PR DESCRIPTION
Replaces the Replay team's Q2 objectives with our Q3 2026 goals:

1. Make Replay Vision the fastest growing PostHog product by revenue
2. Solve cost and pricing — get Replay Vision to general availability
3. Build out Replay Vision (smart sampling, Signals integration, scanner actions, alerts, notifications, Slack integration)
4. Build group summaries
5. Contribute AI improvements back into Session Replay (natural language search, surfacing model)

The previous objectives covered the initial Replay Vision build-out, which has largely shipped — Q3 shifts focus to growth, GA, and contributing AI improvements back to core Session Replay.