### PR TITLE
Expand CS handbook with proactive engagement and a data trust diagnostic

### DIFF
--- a/contents/handbook/cs-and-onboarding/churn-reasons.md
+++ b/contents/handbook/cs-and-onboarding/churn-reasons.md
@@ -51,9 +51,26 @@ Flag the churn risk openly in the team channel. We never want to lose a customer
 
 ### Lack of trust in PostHog data
 
-If a customer says PostHog data conflicts with what they see elsewhere, dig in. What stats are they comparing? Where's the implementation issue?
+If a customer says PostHog data conflicts with what they see elsewhere, dig in immediately. This is one of the most dangerous churn signals: a customer who trusts a different source of truth has no reason to stay.
 
-Customers who rely on a different source of truth are at long-term risk — they're not tied to PostHog. Fix this even when it's not an immediate threat.
+Almost every "the numbers are wrong" complaint is one of two things: an apples to oranges comparison, or a real implementation bug. Rule out the first before assuming the second.
+
+**Apples to oranges: are they even measuring the same thing?** Most discrepancies are definitional, not errors. Line the two tools up side by side and check:
+
+- **Metric definitions.** "Session," "active user," and "pageview" mean something different in every tool. A PostHog session times out after 30 minutes of inactivity, and GA4 and others differ. Confirm you're comparing the same concept before anything else.
+- **Time zone and date boundaries.** PostHog reports in your project's time zone, while the other tool may use UTC or the viewer's local time. A day that starts at a different hour produces different daily totals.
+- **Bot and internal traffic filtering.** Is one tool filtering bots, internal IPs, or your own team while the other isn't?
+- **Ad blockers.** Without a [reverse proxy](/docs/advanced/proxy), ad blockers drop events in the browser, so PostHog can legitimately read lower than a tool that collects on the server.
+- **Deduplication and attribution windows.** Different dedup logic and lookback windows change conversion and unique user counts.
+- **Sampling.** Some tools sample at scale. PostHog doesn't, so the "truth" they trust may itself be an estimate.
+
+**Check the math: reproduce the number.** Once you know you're comparing like for like, verify the figure itself:
+
+- Recreate their metric in PostHog yourself and click into the underlying events and persons to confirm they're firing correctly.
+- Look for implementation issues like duplicate or missing events, properties that aren't sent, or `identify`/group calls misfiring. The [implementation health check](/handbook/cs-and-onboarding/health-checks#have-they-implemented-tracking-incorrectly) lists the usual culprits.
+- Trace one concrete user journey from start to finish in both tools. A single reconciled example builds more trust than any dashboard.
+
+Customers who rely on a different source of truth are at long term risk even when there's no immediate threat. Fix this proactively.
 
 ### Privacy, compliance, or data governance
 

--- a/contents/handbook/cs-and-onboarding/lifecycle-csm.md
+++ b/contents/handbook/cs-and-onboarding/lifecycle-csm.md
@@ -16,7 +16,7 @@ See [getting started with customers](/handbook/cs-and-onboarding/getting-started
 
 Once you've worked through your book of business, focus on building trust with your champions.
 
-- **Show, don't tell.** When a customer has a question or goal, build the solution rather than linking to docs. Create the insight or dashboard, then share what you did so they can do it themselves next time. Don't create dependency — they should be able to do it without you.
+- **Show, don't tell.** When a customer has a question or goal, build the solution rather than linking to docs. Create the insight or dashboard, then share what you did so they can do it themselves next time. For anything visual or involving several steps, record a short [Loom](https://www.loom.com/) walkthrough instead of writing it up. It's faster for you, easier for them to follow, and they can rewatch it on their own time. Don't create dependency - they should be able to do it without you. When you catch yourself explaining the same thing across accounts (building a funnel, setting up an alert, reading session replays), record it once and keep a shared library of clips to drop into channels.
 - **Be timely on alerts.** Our automated alerts flag event spikes, drops, and other unusual behavior. Reach out quickly so the customer can investigate. If a customer's company raises funding or gets press, send congrats.
 - **Push beyond the basics.** Look at what they're not using yet. Have they set up tracking funnels for key metrics? Created alerts on important actions? Tried PostHog AI? Implemented error tracking to explain conversion drops? Cross-sell here, but frame it as helping them get more value.
 - **Regularly invite new users to the Slack channel.** The more people on the customer side who know you exist, the more come to you when they hit issues. Monthly is a good cadence — Vitally shows you who's new.
@@ -33,3 +33,9 @@ Two examples:
 - **Real-time alerts.** Customers have wanted notifications when a visitor abandons a purchase, when a download fails, or when high-value actions happen. Each needed custom implementation work.
 
 If your champion can push these changes through, great. If not, ask for an intro to the decision maker — or reach out directly to the head of engineering or product with their quarterly goals and offer to help. Either way, showing you understand their goal helps them justify prioritizing the work internally.
+
+**Stay proactive once you're embedded.** Being deeply embedded only lasts if you keep showing up when nothing is wrong. The trap at this stage is letting every touchpoint become routine, where you only appear when an alert fires or the customer asks a question. Customers drift when the relationship goes purely reactive (see [engaging unengaged customers](/handbook/cs-and-onboarding/engaging-unengaged-customers)). Build a habit of reaching out when there's no problem to solve:
+
+- Review their billing and usage even when no spike alert fired. Catch overspend, unused products, or a plan mismatch before they do.
+- Forward PostHog blog posts, changelog items, and new features that map to *their* goals. Not a newsletter blast, but something specific enough that it's obvious you were thinking about them.
+- Flag bugs or improvements you spot, including ones unrelated to their PostHog setup. You're on their team as much as you're on PostHog's, and that's what earns you the benefit of the doubt later.


### PR DESCRIPTION
## Changes
This PR covers a few expansions in the CS & Onboarding sections of the handbook and updates two pages:

  **`lifecycle-csm.md`**
  - Added a Loom walkthrough tactic to the "Show, don't tell" principle (Stage 2)
  - Added a "Stay proactive once you're embedded" principle to Stage 3, covering proactive outreach when nothing is wrong

  **`churn-reasons.md`**
  - Expanded the "Lack of trust in PostHog data" section with guidance on common data misrepresentations that can cause confusion.

I have found these proactive additions to be helpful through my experience working with both commercial and enterprise level publications.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` <!-- n/a, no pages moved -->
