### PR TITLE
Add Q3 2026 objectives for Agents team

### DIFF
--- a/contents/teams/agents/index.mdx
+++ b/contents/teams/agents/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Agents
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+## What this team does
+
+We build the tools that let anyone go from "I wish I had an agent for that" to a working agent in production — without having to babysit it.
+
+That covers two things:
+
+- **Agent builder** — a smooth, end-to-end experience for creating agents from wherever people already work (the PostHog app, Slack, MCP, PostHog Code). Includes the integrations agents need to be useful (Slack, GitHub, Discord, etc.).
+- **Self-improving agents** — agents that get better on their own using product data, so builders aren't bottlenecked on problems the agent could solve itself.
+
+## Slack channel
+
+[#team-agents](https://posthog.slack.com/messages/team-agents)
+
+## Feature ownership
+
+You can find out more about the [features we own](/handbook/engineering/feature-ownership).

--- a/contents/teams/agents/index.mdx
+++ b/contents/teams/agents/index.mdx
@@ -8,12 +8,12 @@ template: team
 
 ## What this team does
 
-We build the tools that let anyone go from "I wish I had an agent for that" to a working agent in production — without having to babysit it.
+We build the tools that let anyone go from "I wish I had an agent for that" to a working agent in production – without having to babysit it.
 
 That covers two things:
 
-- **Agent builder** — a smooth, end-to-end experience for creating agents from wherever people already work (the PostHog app, Slack, MCP, PostHog Code). Includes the integrations agents need to be useful (Slack, GitHub, Discord, etc.).
-- **Self-improving agents** — agents that get better on their own using product data, so builders aren't bottlenecked on problems the agent could solve itself.
+- **Agent builder** – a smooth, end-to-end experience for creating agents from wherever people already work (the PostHog app, Slack, MCP, PostHog Code). Includes the integrations agents need to be useful (Slack, GitHub, Discord, etc.).
+- **Self-improving agents** – agents that get better on their own using product data, so builders aren't stuck babysitting problems the agent could solve itself.
 
 ## Slack channel
 

--- a/contents/teams/agents/objectives.mdx
+++ b/contents/teams/agents/objectives.mdx
@@ -1,22 +1,22 @@
 ### Q3 2026 Objectives
 
-#### Everything you need to build a Really Good Agent from wherever you work
+#### Everything you need to build a really good agent from wherever you work
 
-PostHog users have a vision of what they want to automate — in their work, in their life — and today the path from that vision to a working agent is too long and too lumpy. If we close that gap, we unblock a huge category of users who otherwise give up or build something fragile themselves. The win condition is: someone with an idea can get to a working agent from the app, Slack, MCP, or PostHog Code without hitting a wall.
+PostHog users have a vision of what they want to automate – in their work, in their life – and today the path from that vision to a working agent is too long and too lumpy. If we close that gap, we unblock a huge category of users who otherwise give up or build something fragile themselves. The win condition is: someone with an idea can get to a working agent from the app, Slack, MCP, or PostHog Code without hitting a wall.
 
 **What we'll ship:**
 
-- **Agent builder platform core** — the underlying primitives every agent builder surface depends on
-- **Agent builder user experience** — could be concierge, could be PostHog Code, could be MCP; the surface that turns an idea into a working agent
-- **Integrations with Slack, GitHub, Discord, and other useful tools** — agents need to read from and act on the places where work actually happens
-- **End-to-end smoothness** — connections work as close to first-try as possible; we don't ship something that requires babysitting to set up
-- **MCP parity** — anything you can do in the agent builder, you can do via MCP (e.g., from Claude cowork)
+- **Agent builder platform core** – the underlying primitives every agent builder surface depends on
+- **Agent builder user experience** – could be concierge, could be PostHog Code, could be MCP; the surface that turns an idea into a working agent
+- **Integrations with Slack, GitHub, Discord, and other useful tools** – agents need to read from and act on the places where work actually happens
+- **End-to-end smoothness** – connections work as close to first-try as possible; we don't ship something that requires babysitting to set up
+- **MCP parity** – anything you can do in the agent builder, you can do via MCP (e.g., from Claude Code)
 
 #### The agent improves itself based on product data
 
-The better the agent builder gets, the more people will build agents — and the more important it becomes for those agents to improve themselves. If every agent needs a human to fix it every time it goes off the rails, building agents collapses into babysitting agents, and we lose. We want a loop where product data flows back into the agent and makes it better without the builder having to intervene.
+The better the agent builder gets, the more people will build agents – and the more important it becomes for those agents to improve themselves. If every agent needs a human to fix it every time it goes off the rails, building agents collapses into babysitting agents, and we lose. We want a loop where product data flows back into the agent and makes it better without the builder having to intervene.
 
 **What we'll ship:**
 
-- **Agent observability loop with AI Observability integration** — every agent emits the traces, evals, and signals needed to know what's working and what isn't
-- **Agent self-improvement loop** — agents use that data to improve themselves, so builders aren't the bottleneck on every regression
+- **Agent observability loop with AI Observability integration** – every agent emits the traces, evals, and signals needed to know what's working and what isn't
+- **Agent self-improvement loop** – agents use that data to improve themselves, so builders aren't the bottleneck on every regression

--- a/contents/teams/agents/objectives.mdx
+++ b/contents/teams/agents/objectives.mdx
@@ -1,0 +1,22 @@
+### Q3 2026 Objectives
+
+#### Everything you need to build a Really Good Agent from wherever you work
+
+PostHog users have a vision of what they want to automate — in their work, in their life — and today the path from that vision to a working agent is too long and too lumpy. If we close that gap, we unblock a huge category of users who otherwise give up or build something fragile themselves. The win condition is: someone with an idea can get to a working agent from the app, Slack, MCP, or PostHog Code without hitting a wall.
+
+**What we'll ship:**
+
+- **Agent builder platform core** — the underlying primitives every agent builder surface depends on
+- **Agent builder user experience** — could be concierge, could be PostHog Code, could be MCP; the surface that turns an idea into a working agent
+- **Integrations with Slack, GitHub, Discord, and other useful tools** — agents need to read from and act on the places where work actually happens
+- **End-to-end smoothness** — connections work as close to first-try as possible; we don't ship something that requires babysitting to set up
+- **MCP parity** — anything you can do in the agent builder, you can do via MCP (e.g., from Claude cowork)
+
+#### The agent improves itself based on product data
+
+The better the agent builder gets, the more people will build agents — and the more important it becomes for those agents to improve themselves. If every agent needs a human to fix it every time it goes off the rails, building agents collapses into babysitting agents, and we lose. We want a loop where product data flows back into the agent and makes it better without the builder having to intervene.
+
+**What we'll ship:**
+
+- **Agent observability loop with AI Observability integration** — every agent emits the traces, evals, and signals needed to know what's working and what isn't
+- **Agent self-improvement loop** — agents use that data to improve themselves, so builders aren't the bottleneck on every regression


### PR DESCRIPTION
## Summary

- Adds `contents/teams/agents/index.mdx` with a short "What this team does" overview, mirroring the pattern used by other team pages (e.g. [feature-flags](contents/teams/feature-flags/index.mdx), [ai-observability](contents/teams/ai-observability/index.mdx)).
- Adds `contents/teams/agents/objectives.mdx` with the two Q3 2026 objectives:
  1. Everything you need to build a Really Good Agent from wherever you work (agent builder platform, integrations, MCP parity).
  2. The agent improves itself based on product data (observability loop + AIO integration, self-improvement loop).