### PR TITLE
Make US↔EU Cloud region migrations self-serve in docs

### DIFF
--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -110,7 +110,18 @@ python3 ./migrate.py \
 
 ### Migrating events between Cloud instances (e.g. US -> EU Cloud)
 
-You must raise a [support ticket in-app](https://us.posthog.com/home#supportModal) with the **Data pipelines** topic for the PostHog team to do this migration for you. This option is **only available to customers on the Scale or Enterprise package** as it requires significant engineering time.  
+You can self-serve a migration between Cloud regions using an [HTTP batch export](/docs/cdp/batch-exports) that points from your source project at the destination region.
+
+Before you start, make sure you're a member of both the source and destination projects, and create a project in your destination region if you don't have one already.
+
+1. Log into your **source** project (the one you're migrating away from).
+2. Create a new **HTTP batch export** (in [Data pipelines](https://us.posthog.com/pipeline/destinations) -> **Destinations** -> **New destination**).
+3. Set the destination region to the **US** or **EU** PostHog instance you're migrating to, and set the API key to your **destination** project's [Project API key](https://us.posthog.com/settings/project#variables).
+4. Set the interval to **hourly** if you have large event volumes, or **daily** otherwise.
+5. To migrate your historical data, click **Backfill batch export** and choose the time range. Check your data for the earliest ingested event so you don't miss anything, unless you only want a specific period.
+6. If you want to keep both regions in sync during the cutover, **enable** the batch export so it continuously exports new events. Once you've [switched tracking in your product](#switching-tracking-in-your-product) to the new region, you can disable it.
+
+> **Transferring billing credits between regions?** Credits (for example from a YC or startup deal) don't move automatically when you migrate. If you have credit on your source account that you want moved to your destination region, [contact support](https://us.posthog.com/home#supportModal) and our billing team will transfer it for you. This is the one part of a region migration that isn't yet self-serve.
 
 ## Switching tracking in your product
 


### PR DESCRIPTION
## Changes

Updates the cross-region Cloud migration docs (`migrate-to-cloud.mdx`) so users can self-serve a US ↔ EU migration instead of raising a support ticket gated to Scale/Enterprise. The section now walks through creating an HTTP batch export from the source project to the destination region, backfilling historical data, and optionally keeping both regions in sync during cutover. It also makes clear that **billing credit transfers between regions still require contacting support** — that's the one part that isn't yet self-serve.

**Why:** A Zendesk migration request surfaced that, apart from the billing/credit step, cross-region migrations are just a batch export and can be fully self-served. The old "significant engineering time, Scale/Enterprise only" framing was outdated.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1781603836592639?thread_ts=1781603836.592639&cid=C075D3C5HST)*
