### PR TITLE
Remove /mcp → /docs/model-context-protocol redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1979,7 +1979,6 @@
         },
         { "source": "/professional-services", "destination": "/services" },
         { "source": "/posthug", "destination": "/" },
-        { "source": "/mcp", "destination": "/docs/model-context-protocol" },
         {
             "source": "/handbook/strategy/brand",
             "destination": "/handbook/brand/foundations"


### PR DESCRIPTION
## Changes

Removes the `/mcp` → `/docs/model-context-protocol` redirect from `vercel.json` so `/mcp` no longer redirects to the docs page.

**Why:** The redirect was sending `posthog.com/mcp` to the docs, which conflicts with using `/mcp` as a standalone landing page. Removing it frees the path up.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1781297751005569?thread_ts=1781297751.005569&cid=C08CG24E3SR)*
