### PR TITLE
Link integration installs to new /integrations landing pages

### DIFF
--- a/contents/docs/error-tracking/integrations.mdx
+++ b/contents/docs/error-tracking/integrations.mdx
@@ -15,8 +15,8 @@ PostHog integrates with GitHub, GitLab, Linear, and Jira to enhance error tracki
 
 To set up the GitHub integration:
 
-1. Go to [Error tracking settings](https://app.posthog.com/settings/project-error-tracking) in the PostHog app and find **Integrations**
-2. Under **GitHub**, click **Connect organization**
+1. Go to the [GitHub integration page](https://app.posthog.com/integrations/github) in the PostHog app
+2. Click **Connect organization**
 3. Authorize PostHog to access your repositories
 4. Select the repositories you want to link
 
@@ -48,8 +48,8 @@ Connect your Linear workspace to create and track Linear issues directly from er
 
 To set up the Linear integration:
 
-1. Go to [Error tracking settings](https://app.posthog.com/settings/project-error-tracking) in the PostHog app and find **Integrations**
-2. Under **Linear**, click **Connect workspace**
+1. Go to the [Linear integration page](https://app.posthog.com/integrations/linear) in the PostHog app
+2. Click **Connect workspace**
 3. Authorize PostHog to access your Linear workspace
 
 PostHog connects to Linear using a [third-party app](https://linear.app/docs/third-party-application-approvals). PostHog needs the following permissions:
@@ -64,8 +64,8 @@ Connect your Jira workspace to create and track Jira issues directly from error 
 
 To set up the Jira integration:
 
-1. Go to [Error tracking settings](https://app.posthog.com/settings/project-error-tracking) in the PostHog app and find **Integrations**
-2. Under **Jira**, click **Connect workspace**
+1. Go to the [Jira integration page](https://app.posthog.com/integrations/jira) in the PostHog app
+2. Click **Connect workspace**
 3. Authorize PostHog to access your Jira site
 
 PostHog connects to Jira using OAuth 2.0. PostHog needs the following permissions:

--- a/contents/docs/slack/setup.mdx
+++ b/contents/docs/slack/setup.mdx
@@ -49,7 +49,7 @@ A personal GitHub integration is **required** for the coding agent to run. Witho
 
 > I can't start this task yet – you haven't connected your personal GitHub. Connect it so I can open the pull request as you, then mention me again.
 
-This is a hard block on the whole task, not just the PR step – the agent doesn't plan, edit, or run anything until you've connected GitHub. Each teammate who wants to ship code connects their own account on the [**GitHub integration page**](https://app.posthog.com/integrations/github) and clicks **Connect GitHub**. You can connect multiple accounts or organizations – the agent uses them for repo access, commit attribution, and pull request authorship.
+This is a hard block on the whole task, not just the PR step – the agent doesn't plan, edit, or run anything until you've connected GitHub. Each teammate who wants to ship code connects their own account at [**Settings → Personal integrations**](https://app.posthog.com/settings/user-personal-integrations) and clicks **Connect GitHub**. You can connect multiple accounts or organizations – the agent uses them for repo access, commit attribution, and pull request authorship.
 
 PRs can't be authored under the bot itself – the agent always commits and opens PRs as whichever teammate triggered the task.
 

--- a/contents/docs/slack/setup.mdx
+++ b/contents/docs/slack/setup.mdx
@@ -17,7 +17,7 @@ You need two integrations to use `@PostHog` in Slack: one workspace-wide Slack c
 
 <Step title="Connect Slack to your project" badge="required">
 
-Head to [**Settings → Integrations**](https://app.posthog.com/settings/project-integrations #selectedSetting=integration-slack&setting=integration-slack) in your PostHog project and click **Add to Slack** in the Slack integration section. Approve the requested scopes – you'll need to be a project admin to install.
+Head to the [**Slack integration page**](https://app.posthog.com/integrations/slack) in PostHog and click **Add to Slack**. Approve the requested scopes – you'll need to be a project admin to install.
 
 <ProductScreenshot
 imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto,w_800/slack_integration_settings_3396ec1b7d.png"
@@ -49,7 +49,7 @@ A personal GitHub integration is **required** for the coding agent to run. Witho
 
 > I can't start this task yet – you haven't connected your personal GitHub. Connect it so I can open the pull request as you, then mention me again.
 
-This is a hard block on the whole task, not just the PR step – the agent doesn't plan, edit, or run anything until you've connected GitHub. Each teammate who wants to ship code connects their own account at [**Settings → Personal integrations**](https://app.posthog.com/settings/user-personal-integrations) and clicks **Connect GitHub**. You can connect multiple accounts or organizations – the agent uses them for repo access, commit attribution, and pull request authorship.
+This is a hard block on the whole task, not just the PR step – the agent doesn't plan, edit, or run anything until you've connected GitHub. Each teammate who wants to ship code connects their own account on the [**GitHub integration page**](https://app.posthog.com/integrations/github) and clicks **Connect GitHub**. You can connect multiple accounts or organizations – the agent uses them for repo access, commit attribution, and pull request authorship.
 
 PRs can't be authored under the bot itself – the agent always commits and opens PRs as whichever teammate triggered the task.
 

--- a/contents/docs/support/github.mdx
+++ b/contents/docs/support/github.mdx
@@ -13,7 +13,7 @@ The GitHub Issues channel connects your GitHub repositories to PostHog Support, 
 
 <CalloutBox icon="IconInfo" title="GitHub App required" type="action">
 
-You need a PostHog GitHub App installation before connecting the GitHub channel. If you don't have one yet, go to [**Settings** > **Integrations**](https://app.posthog.com/settings/project-integrations) and install the GitHub App first.
+You need a PostHog GitHub App installation before connecting the GitHub channel. If you don't have one yet, go to the [**GitHub integration page**](https://app.posthog.com/integrations/github) and install the GitHub App first.
 
 </CalloutBox>
 

--- a/contents/docs/workflows/_snippets/add-posthog-to-slack-workspace.mdx
+++ b/contents/docs/workflows/_snippets/add-posthog-to-slack-workspace.mdx
@@ -1,4 +1,4 @@
-Starting in PostHog, you can add the PostHog Slack app to your workspace in [your project settings](https://app.posthog.com/settings/project-integrations#integration-slack).
+Starting in PostHog, you can add the PostHog Slack app to your workspace on the [Slack integration page](https://app.posthog.com/integrations/slack).
 
 <ProductScreenshot
     imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/allow_slack_bb68272218.png" 

--- a/src/pages/r/ai-observability.tsx
+++ b/src/pages/r/ai-observability.tsx
@@ -300,11 +300,7 @@ export default function AIObservabilityLanding(): JSX.Element {
                             </p>
 
                             <div className="flex flex-wrap gap-2 mt-4">
-                                <CallToAction
-                                    type="primary"
-                                    size="md"
-                                    to="https://app.posthog.com/settings/project-integrations#integration-slack"
-                                >
+                                <CallToAction type="primary" size="md" to="https://app.posthog.com/integrations/slack">
                                     Connect Slack
                                 </CallToAction>
                                 <CallToAction type="secondary" size="md" to="/slack-app" state={{ newWindow: true }}>

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -578,7 +578,7 @@ const faqItems = [
                 <code>Generated-By: PostHog Code</code> line plus a <code>Task-Id</code> so you can trace it back. PRs
                 are authored under your name via your{' '}
                 <Link
-                    to="https://app.posthog.com/integrations/github"
+                    to="https://app.posthog.com/settings/user-personal-integrations"
                     external
                     className="text-red dark:text-yellow font-semibold hover:underline"
                 >

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -32,7 +32,7 @@ import {
     IconWrench,
 } from '@posthog/icons'
 
-const CONNECT_SLACK_URL = 'https://app.posthog.com/settings/project-integrations#integration-slack'
+const CONNECT_SLACK_URL = 'https://app.posthog.com/integrations/slack'
 
 type IconComponent = React.ComponentType<{ className?: string }>
 
@@ -578,7 +578,7 @@ const faqItems = [
                 <code>Generated-By: PostHog Code</code> line plus a <code>Task-Id</code> so you can trace it back. PRs
                 are authored under your name via your{' '}
                 <Link
-                    to="https://app.posthog.com/settings/user-personal-integrations"
+                    to="https://app.posthog.com/integrations/github"
                     external
                     className="text-red dark:text-yellow font-semibold hover:underline"
                 >


### PR DESCRIPTION
## Changes

Updates places that redirected people to **install** Linear, Slack, Jira, or GitHub via a settings page so they now point at the new `app.posthog.com/integrations/<slug>` landing pages.

### Docs
- `contents/docs/slack/setup.mdx` — Slack → `/integrations/slack`
- `contents/docs/workflows/_snippets/add-posthog-to-slack-workspace.mdx` — Slack → `/integrations/slack`
- `contents/docs/support/github.mdx` — GitHub App install → `/integrations/github`
- `contents/docs/error-tracking/integrations.mdx` — GitHub/Linear/Jira now point at their landing pages, and the numbered steps were reworded to match the "connect from the landing page" flow

### Source pages
- `src/pages/slack/index.tsx` — `CONNECT_SLACK_URL` → `/integrations/slack`
- `src/pages/r/ai-observability.tsx` — "Connect Slack" CTA → `/integrations/slack`

### Left untouched
- **Personal GitHub integrations** — only the global/project-level GitHub install moves to the landing page; personal GitHub connections stay on the settings page (`user-personal-integrations`)
- **GitLab** in the error-tracking doc — no landing page exists for it, and it's not part of this change
- Vercel org-level integration link and the exception-autocapture setting link — not integration installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)