### PR TITLE
docs(wizard): document CLI commands and old→new mapping

### DIFF
--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -48,6 +48,41 @@ The AI wizard integrating both the JS Web SDK and Node SDK into a Next.js applic
 
 <WizardInstall />
 
+## Commands
+
+Running `npx @posthog/wizard` with no arguments starts the default integration flow. The wizard also exposes focused commands:
+
+| Command | What it does |
+|---|---|
+| `wizard` | Default flow — installs and instruments PostHog |
+| `wizard audit [skill]` | Audit an existing integration (e.g. `wizard audit events`, `wizard audit all`) |
+| `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
+| `wizard migrate` | Migrate from another analytics or feature-flag vendor |
+| `wizard upload-source-maps` | Upload source maps to PostHog Error Tracking |
+| `wizard mcp add` / `wizard mcp remove` | Manage the PostHog MCP server for your AI agent |
+
+### Command changes
+
+The CLI was overhauled to consolidate commands into a smaller, more consistent surface. If you used an older command name, here's where it went:
+
+| Old command | New command | What changed |
+|---|---|---|
+| `wizard integrate` | `wizard` | The default flow now runs the integration |
+| `wizard events-audit` | `wizard audit events` | Now an `audit` subcommand |
+| `wizard audit` | `wizard audit [skill]` | Now takes a subcommand; `wizard audit all` runs a full audit |
+| `wizard revenue` | `wizard revenue-analytics` | Renamed — update any scripts using `revenue` |
+| `wizard upload-sourcemaps` | `wizard upload-source-maps` | Renamed (the old `upload-sourcemaps` still works) |
+
+```mermaid
+graph LR
+    A1["wizard integrate"] --> B1["wizard"]
+    A2["wizard events-audit"] --> B2["wizard audit events"]
+    A3["wizard audit"] --> B3["wizard audit &lt;skill&gt;"]
+    A4["wizard revenue"] --> B4["wizard revenue-analytics"]
+    A5["wizard upload-sourcemaps"] --> B5["wizard upload-source-maps"]
+    A6["wizard audit-3000"] --> B6["removed"]
+```
+
 We think flows like the AI wizard are pretty cool and the future of developer experience. The AI wizard is our recommended and default method for [installing PostHog](/docs/getting-started/install?tab=wizard) and getting started.
 
 If you have any feedback or requests, we would love to hear from you. Feel free to comment on this page or open an issue on [GitHub](https://github.com/PostHog/wizard/issues).

--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -50,16 +50,34 @@ The AI wizard integrating both the JS Web SDK and Node SDK into a Next.js applic
 
 ## Commands
 
-Running `npx @posthog/wizard` with no arguments starts the default integration flow. The wizard also exposes focused commands:
+Running `npx @posthog/wizard` starts the default integration flow. The wizard also supports the following commands:
 
 | Command | What it does |
 |---|---|
-| `wizard` | Default flow — installs and instruments PostHog |
-| `wizard audit [skill]` | Audit an existing integration (e.g. `wizard audit events`, `wizard audit all`) |
+| `wizard` | Default flow – installs and instruments PostHog |
+| `wizard audit <subcommand>` | Audit an existing integration – see [Audit subcommands](#audit-subcommands) |
 | `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
 | `wizard migrate` | Migrate from another analytics or feature-flag vendor |
 | `wizard upload-source-maps` | Upload source maps to PostHog Error Tracking |
 | `wizard mcp add` / `wizard mcp remove` | Manage the PostHog MCP server for your AI agent |
+| `wizard slack add` | Connect PostHog to your Slack |
+| `wizard skill <skill-name>` | Run a single context-mill skill by name (`wizard skill list` lists them all) |
+
+### Audit subcommands
+
+`wizard audit` on its own opens an interactive picker. Pass a subcommand to run one directly; pressing Enter on the picker runs `events` (the default).
+
+| Command | What it does |
+|---|---|
+| `wizard audit events` | Audit event capture quality and cost (default) |
+| `wizard audit all` | Comprehensive audit across every area |
+| `wizard audit autocapture` | Audit autocapture setup and cost |
+| `wizard audit feature-flags` | Audit feature flag usage and cost |
+| `wizard audit identify` | Audit your `$identify` implementation |
+| `wizard audit session-replay` | Audit session replay setup |
+| `wizard audit web-analytics` | Audit web analytics setup |
+
+> **`wizard audit <subcommand>` chooses an audit area — it does not take a skill name.** Each audit subcommand is a PostHog skill exposed as a command. The separate `wizard skill <skill-name>` command runs any skill directly by name (`wizard skill list` shows them all).
 
 ### Command changes
 
@@ -69,19 +87,11 @@ The CLI was overhauled to consolidate commands into a smaller, more consistent s
 |---|---|---|
 | `wizard integrate` | `wizard` | The default flow now runs the integration |
 | `wizard events-audit` | `wizard audit events` | Now an `audit` subcommand |
-| `wizard audit` | `wizard audit [skill]` | Now takes a subcommand; `wizard audit all` runs a full audit |
+| `wizard audit` | `wizard audit <subcommand>` | Now takes a subcommand; `wizard audit all` runs a full audit |
 | `wizard revenue` | `wizard revenue-analytics` | Renamed — update any scripts using `revenue` |
 | `wizard upload-sourcemaps` | `wizard upload-source-maps` | Renamed (the old `upload-sourcemaps` still works) |
 
-```mermaid
-graph LR
-    A1["wizard integrate"] --> B1["wizard"]
-    A2["wizard events-audit"] --> B2["wizard audit events"]
-    A3["wizard audit"] --> B3["wizard audit &lt;skill&gt;"]
-    A4["wizard revenue"] --> B4["wizard revenue-analytics"]
-    A5["wizard upload-sourcemaps"] --> B5["wizard upload-source-maps"]
-    A6["wizard audit-3000"] --> B6["removed"]
-```
+## Feedback
 
 We think flows like the AI wizard are pretty cool and the future of developer experience. The AI wizard is our recommended and default method for [installing PostHog](/docs/getting-started/install?tab=wizard) and getting started.
 

--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -65,7 +65,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 
 ### Audit subcommands
 
-`wizard audit` on its own opens an interactive picker. Pass a subcommand to run one directly; pressing Enter on the picker runs `events` (the default).
+`wizard audit` on its own runs the `events` audit (the default). Pass a subcommand to run a specific one.
 
 | Command | What it does |
 |---|---|

--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -4,9 +4,9 @@ title: AI wizard
 
 import WizardInstall from 'getting-started/_snippets/wizard.mdx'
 
-The PostHog wizard automatically installs and instruments PostHog into your application codebase using AI. It's an agentic CLI tool that handles the entire PostHog integration process on your behalf.
+The PostHog wizard is an agentic CLI tool that uses AI to set up and manage PostHog in your codebase. By default, it installs and instruments PostHog for you with a single command: `npx @posthog/wizard`.
 
-Set up the PostHog platform in minutes, with a single command.
+It does more than installation, though. The wizard can also audit an existing integration, migrate you from another vendor, upload source maps, set up Revenue Analytics, and diagnose configuration issues – so it's just as useful after you're up and running as it is on day one.
 
 <WizardCommand slim />
 
@@ -61,11 +61,11 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard upload-source-maps` | Upload source maps to PostHog Error Tracking |
 | `wizard mcp add` / `wizard mcp remove` | Manage the PostHog MCP server for your AI agent |
 | `wizard slack add` | Connect PostHog to your Slack |
-| `wizard skill <skill-name>` | Run a single context-mill skill by name (`wizard skill list` lists them all) |
+| `wizard skill <skill-name>` | Run a single skill by name – browse the available skills in the [context-mill releases](https://github.com/PostHog/context-mill/releases/latest) |
 
 ### Audit subcommands
 
-`wizard audit` on its own runs the `events` audit (the default). Pass a subcommand to run a specific one.
+`@npx @posthog/wizard audit` on its own runs the `events` audit. Pass a subcommand to run a specific one.
 
 | Command | What it does |
 |---|---|
@@ -77,8 +77,6 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard audit session-replay` | Audit session replay setup |
 | `wizard audit web-analytics` | Audit web analytics setup |
 
-> **`wizard audit <subcommand>` chooses an audit area — it does not take a skill name.** Each audit subcommand is a PostHog skill exposed as a command. The separate `wizard skill <skill-name>` command runs any skill directly by name (`wizard skill list` shows them all).
-
 ### Command changes
 
 The CLI was overhauled to consolidate commands into a smaller, more consistent surface. If you used an older command name, here's where it went:
@@ -88,7 +86,7 @@ The CLI was overhauled to consolidate commands into a smaller, more consistent s
 | `wizard integrate` | `wizard` | The default flow now runs the integration |
 | `wizard events-audit` | `wizard audit events` | Now an `audit` subcommand |
 | `wizard audit` | `wizard audit <subcommand>` | Now takes a subcommand; `wizard audit all` runs a full audit |
-| `wizard revenue` | `wizard revenue-analytics` | Renamed — update any scripts using `revenue` |
+| `wizard revenue` | `wizard revenue-analytics` | Renamed – update any scripts using `revenue` |
 | `wizard upload-sourcemaps` | `wizard upload-source-maps` | Renamed (the old `upload-sourcemaps` still works) |
 
 ## Feedback

--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -59,7 +59,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
 | `wizard migrate` | Migrate from another analytics or feature-flag vendor |
 | `wizard upload-source-maps` | Upload source maps to PostHog Error Tracking |
-| `wizard mcp add` / `wizard mcp remove` | Manage the PostHog MCP server for your AI agent |
+| `wizard mcp add` / `wizard mcp remove` / `wizard mcp tutorial` | Manage the PostHog MCP server for your AI agent, or explore the MCP tutorial |
 | `wizard slack add` | Connect PostHog to your Slack |
 | `wizard skill <skill-name>` | Run a single skill by name – browse the available skills in the [context-mill releases](https://github.com/PostHog/context-mill/releases/latest) |
 
@@ -77,7 +77,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard audit session-replay` | Audit session replay setup |
 | `wizard audit web-analytics` | Audit web analytics setup |
 
-### Command changes
+### Legacy commands
 
 The CLI was overhauled to consolidate commands into a smaller, more consistent surface. If you used an older command name, here's where it went:
 

--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -4,7 +4,7 @@ title: AI wizard
 
 import WizardInstall from 'getting-started/_snippets/wizard.mdx'
 
-The PostHog wizard is an agentic CLI tool that uses AI to set up and manage PostHog in your codebase. By default, it installs and instruments PostHog for you with a single command: `npx @posthog/wizard`.
+The PostHog wizard is an agentic CLI tool that uses AI to set up and manage PostHog in your codebase. By default, it installs and instruments PostHog for you with a single command: `npx -y @posthog/wizard@latest`.
 
 It does more than installation, though. The wizard can also audit an existing integration, migrate you from another vendor, upload source maps, set up Revenue Analytics, and diagnose configuration issues – so it's just as useful after you're up and running as it is on day one.
 

--- a/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
+++ b/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
@@ -22,6 +22,14 @@ To direct the agent, the wizard uses the PostHog [context mill repository](https
 
 The context mill repo generates a zip file and manifest that determines the structure of the skills packages.
 
+### Commands and skills
+
+The wizard's command surface comes from context mill, not hardcoded in the wizard. A skill becomes a command when its `config.yaml` declares a `cli:` block with `role: command` – so `wizard audit events` *is* the `audit-events` skill, promoted to a command. A skill without that block stays reachable only via `wizard skill <name>`. Same machinery, two surfaces — which is why `wizard audit <subcommand>` chooses an audit area rather than taking a skill name (the `[skill]` label in `wizard audit --help` is an internal positional name, not a prompt for a skill).
+
+Because these entries are read from the published manifest at runtime, adding or renaming a skill-backed command is a **context mill release – no wizard release required**. Family parents (like `audit`) and their picker behavior live in the wizard; their subcommands resolve at runtime.
+
+The full `cli:` block schema (roles, `parentCommand`, the `default` leaf, naming rules) lives in [context mill's CONTRIBUTING.md](https://github.com/PostHog/context-mill/blob/main/CONTRIBUTING.md); the wizard side (command registration, families, aliases) is documented in the wizard repo's [AGENTS.md](https://github.com/PostHog/wizard/blob/main/AGENTS.md).
+
 ## Developing the wizard
 
 Use the [wizard workbench](https://github.com/PostHog/wizard-workbench) for local, end-to-end development of the wizard. The workbench can run the full wizard stack in local development mode, with hot reload where supported.


### PR DESCRIPTION
Adds a **Commands** section to the [AI wizard docs page](https://posthog.com/docs/ai-engineering/ai-wizard) + wizard handbook pages:

- The current command list (`wizard`, `audit [skill]`, `revenue-analytics`, `migrate`, `upload-source-maps`, `mcp`).
- An **old → new command mapping** table from the CLI overhaul.

Pairs with the wizard CLI overhaul ([wizard#617](https://github.com/PostHog/wizard/pull/617)) and context-mill ([#178](https://github.com/PostHog/context-mill/pull/178)). Kept in draft until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)