### PR TITLE
Revert "Add Claude Fable 5 to supported LLMs on /code page"

### DIFF
--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -97,7 +97,7 @@ function AIModelBadge({ innerRef }: { innerRef: React.RefObject<HTMLSpanElement>
             className="inline-flex items-center gap-1.5 border border-primary rounded px-2 py-1 text-xs bg-accent align-middle ml-6 mt-0 mb-2"
         >
             <span className="font-semibold">Supports</span>
-            <span className="text-secondary">Fable, Haiku, Opus, Sonnet, GPT 5.4, GPT 5.5</span>
+            <span className="text-secondary">Haiku, Opus, Sonnet, GPT 5.4, GPT 5.5</span>
         </span>
     )
 }
@@ -1193,9 +1193,6 @@ const TableStakes = () => {
                                 Anthropic
                             </p>
                             <ul className="m-0 mt-1 list-none p-0 space-y-2">
-                                <li className="text-sm font-bold text-primary">
-                                    <code>Claude Fable 5</code>
-                                </li>
                                 <li className="text-sm font-bold text-primary">
                                     <code>Claude Sonnet 4.6</code>
                                 </li>


### PR DESCRIPTION
Reverts #17531.

While reading through the PostHog Code application page, I noticed that Claude Fable 5 still appears in the supported LLMs list and the hero model badge — even though Fable is [currently disabled](https://www.anthropic.com/news/fable-mythos-access). This could confuse users who see Fable listed as an option but are unable to select or use it.

Removing it for now to keep the docs in sync with what's actually available. Can be re-added once Fable is re-enabled.

## Changes

- Removed `Fable` from the inline model badge in the hero copy
- Removed `Claude Fable 5` from the Anthropic column in the "Supported LLMs" section

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links