### PR TITLE
Add LinkedIn link type for Rishi Raj Jain

### DIFF
--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -656,6 +656,7 @@
         "handle": "rishi-raj-jain",
         "name": "Rishi Raj Jain",
         "role": "Freelance Technical Writer",
+        "link_type": "LinkedIn",
         "link_url": "https://www.linkedin.com/in/rishi-raj-jain/",
         "profile_id": 45748
     }


### PR DESCRIPTION
## Changes

I've added my type: linkedin in the hopes of being able to show my face to be displayed here:

<img width="709" height="150" alt="Screenshot 2026-06-17 at 1 41 19 PM" src="https://github.com/user-attachments/assets/26625ed6-4b52-4321-a163-b9e2776e29a0" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
