### PR TITLE
Clarify peer team interviewers should review SuperDay output

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -368,6 +368,8 @@ The final stage of our interview process is what we call a PostHog SuperDay. Thi
 
 The candidate will be working on a task that is similar to the day-to-day work someone in this role does at PostHog. They will also have the chance to meet a few of their potential direct team members, and if they haven’t already, our founders. This gives the candidate a chance to show off their skills, and for us to see the quality, speed and communication of the candidate.
 
+As part of this, it's common for a candidate to have a short (~30 minute) **peer team interview** with one or two colleagues they'd end up working with. These calls give the candidate a chance to meet the wider team and get a feel for the culture, and give colleagues a chance to ask questions and test for culture or technical fit. Peer team interviewers can be from outside the immediate team the role sits in – for example, a Product Marketer SuperDay might include a peer team interview with another Product Marketer as well as a Product Manager from the team the new role would be assigned to.
+
 As we grow, we find the need to hire engineers who are comfortable working with existing codebases to be increasingly fundamental. During SuperDay, Product Engineering candidates will also have a 45-minute debugging session. There is nothing to prepare in advance for this; you'll work with your interviewer in a pairing session to get through a bunch of bugs! It is a demanding day of work.
 
 We pay all candidates a flat rate of $1,000 USD for their efforts on the SuperDay. On rare occasions, if we have to cancel a scheduled superday because we have filled the role with another candidate who was further advanced in the process, we will pay a $500 USD term fee to the candidate for their efforts up until this point.
@@ -400,7 +402,7 @@ In advance of the SuperDay, we will need to do some additional prep to ensure th
 
 After a SuperDay, everyone involved in the day leaves their feedback on Ashby. This is hugely important to us in making a final decision so team members should make an effort in completing their feedback as soon as possible. If there are wildly different opinions, you should open an issue in `company-internal` to discuss.
 
-If you join a candidate's SuperDay for a peer team interview – meeting them as a potential future teammate rather than as their SuperDay buddy – your feedback should be based on _both_ the call and the quality of the SuperDay output, not the call alone. The output is the core of what we're assessing, so make sure you review it before submitting your feedback. How you treat the call itself is up to you, but reviewing the output is not optional.
+If you join a candidate's SuperDay for a peer team interview, your feedback should be based on _both_ the call and the quality of the SuperDay output, not the call alone. The output is the core of what we're assessing, so make sure you review it before submitting your feedback. How you treat the call itself is up to you, but reviewing the output is not optional.
 
 If you don't feel qualified or able to judge the SuperDay output, flag this with the hiring manager. It's usually a good indicator that you're not the right person to be interviewing this candidate.
 

--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -400,6 +400,10 @@ In advance of the SuperDay, we will need to do some additional prep to ensure th
 
 After a SuperDay, everyone involved in the day leaves their feedback on Ashby. This is hugely important to us in making a final decision so team members should make an effort in completing their feedback as soon as possible. If there are wildly different opinions, you should open an issue in `company-internal` to discuss.
 
+If you join a candidate's SuperDay for a peer team interview – meeting them as a potential future teammate rather than as their SuperDay buddy – your feedback should be based on _both_ the call and the quality of the SuperDay output, not the call alone. The output is the core of what we're assessing, so make sure you review it before submitting your feedback. How you treat the call itself is up to you, but reviewing the output is not optional.
+
+If you don't feel qualified or able to judge the SuperDay output, flag this with the hiring manager. It's usually a good indicator that you're not the right person to be interviewing this candidate.
+
 If a decision is made to hire, the People & Ops team will open an onboarding issue once the candidate has accepted and James/Tim will share in our Monday All Hands Meeting a brief overview of the following:
 
 -   Who we ended up hiring and their background: what they will be doing, and a summary of the recruitment process (how long open for, no. of applicants etc.)


### PR DESCRIPTION
## Changes

Clarifies in the hiring handbook that interviewers who join a candidate's SuperDay for a **peer team interview** (meeting them as a potential future teammate, not as their SuperDay buddy) should base their feedback on *both* the call and the quality of the SuperDay output — not the call alone. Also makes clear that if an interviewer doesn't feel qualified to judge the output, they should flag it with the hiring manager, since that's usually a sign they're not the right person to interview the candidate.

**Why:** People have been treating the peer team call inconsistently — some judge purely on the conversation without ever reviewing the SuperDay output. The output is the core of what we're assessing, so reviewing it should be the expectation, not optional.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1781687483598159?thread_ts=1781687483.598159&cid=C017WDX3BFZ)*
