### PR TITLE
Move brand messaging page into Brand handbook section

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -533,6 +533,10 @@ export const handbookSidebar = [
                 url: '/handbook/brand/foundations',
             },
             {
+                name: 'Brand guidelines and messaging',
+                url: '/handbook/content/brand-message',
+            },
+            {
                 name: 'Voice & tone',
                 url: '/handbook/brand/tone',
             },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -582,10 +582,6 @@ export const handbookSidebar = [
                 url: '/handbook/content',
             },
             {
-                name: 'Brand guidelines and messaging',
-                url: '/handbook/content/brand-message',
-            },
-            {
                 name: 'Video',
                 url: '/handbook/marketing/video',
                 children: [


### PR DESCRIPTION
Moves the **Brand guidelines and messaging** page (`/handbook/content/brand-message`) out of the Content section of the handbook sidebar and into the **Brand** section, positioned right after **Brand foundations**. Only the sidebar nav changes — the page URL is unchanged, so no redirect is needed.

**Why:** The brand messaging content belongs alongside the rest of the brand book rather than under Content, per the Slack discussion on consolidating brand pages.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ALU3889A6/p1781347740357039?thread_ts=1781347740.357039&cid=C0ALU3889A6)*