### PR TITLE
Clarify peer team interviews in hiring process handbook

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -394,6 +394,20 @@ In advance of the SuperDay, we will need to do some additional prep to ensure th
 
 > For some roles, we may occasionally set a task that goes over multiple days. For example, we have set Content Marketer tasks that last 3 days in order to create a piece of content.
 
+#### Peer team interviews
+
+During a SuperDay, it's common for a candidate to meet 1-2 colleagues they'd end up working with for a short (~30 minute) call. We call this a peer team interview. It gives the candidate a chance to meet the wider team and get a feel for the culture, and it gives colleagues a chance to ask questions and test cultural and technical fit.
+
+The colleagues who join don't have to be from the immediate team the role sits in. For example, for a Product Marketer role it's common to have a peer team interview with another Product Marketer, as well as a Product Manager from the team the new role would join.
+
+If you're joining a peer team interview, use the time to test cultural fit, technical knowledge, and taste. Arrive with some questions in mind that let you do this. Don't use the call just to check the candidate's overall vibes — that only leads to surface-level feedback, and leaving feedback that amounts to "this candidate seems nice" isn't useful.
+
+Peer team interviews should also give the candidate time to ask their own questions and explore whether the team and culture are a fit from their perspective. It's a two-way conversation, not just an assessment.
+
+Reviewing the SuperDay output itself is _not_ part of a peer team interview. That review is owned by the hiring manager and Small Team lead, who are the most calibrated on what good output looks like and who ultimately own the hire.
+
+Peer team interviews are optional — hiring managers don't need to include them. We don't run them by default for engineering roles, for example, but we generally find them helpful for marketing, CS, and sales roles, where they're useful for catching red flags as well as testing fit.
+
 ### Decide if we will hire
 
 > We aim to make a decision within 48 hours of SuperDay - being decisive is important at this stage, as great candidates will probably be fielding multiple job offers.


### PR DESCRIPTION
## Changes

Adds a new **Peer team interviews** section to the SuperDay explanation in the hiring process handbook. It clarifies:

- What a peer team interview is — a short (~30 min) call during a SuperDay where a candidate meets 1-2 colleagues they would work with, who can be from outside the immediate team.
- The purpose and expectations: interviewers should test cultural fit, technical knowledge, and taste, arriving with questions in mind rather than just checking vibes. "This candidate seems nice" feedback isn't useful.
- That the call should also give the candidate time to ask their own questions and assess fit from their perspective.
- That reviewing SuperDay output is owned by the hiring manager / Small Team lead, not peer interviewers.
- That peer team interviews are optional — not run by default for engineering, but generally helpful for marketing, CS, and sales roles.

**Why:** A Slack discussion surfaced that interviewers treat peer team calls inconsistently (vibes-only vs. structured), and that expectations around who reviews SuperDay output and whether peer interviews are even required were never written down.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09FJ89FVCK/p1781687733234999?thread_ts=1781687733.234999&cid=C09FJ89FVCK)*