### PR TITLE
Clarify how to repay a personal expense on the company card

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -111,7 +111,9 @@ Joining an offsite? _Only use the offsite budget_, not your User Limit - it help
 - What if I'm driving for work-related purposes?
   - You can claim a mileage reimbursement through Brex. **Do not** separately expense fuel.
 - What if I accidentally used the company card for a personal expense?
-  - Login to Brex > find the charge > click on 'Repay'. This won't move any money on its own – Brex only tracks the expense. You then need to manually transfer the amount **from your personal bank account to PostHog's bank account**, using the details provided in [our banking runbook](https://github.com/PostHog/company-internal/blob/37179f74a66e8b779f8e6f116172511709646157/finance/banking.md). (Don't connect your own bank account in Brex – that's not how repayments work.)
+  - Login to Brex > find the charge > click on 'Repay'.
+    - **US and Canada:** Brex's auto repay function works, so it'll pull the money from your connected bank account for you.
+    - **International:** auto repay isn't available, so the 'Repay' button only tracks the expense. You need to manually transfer the amount **from your personal bank account to PostHog's bank account**, using the details provided in [our banking runbook](https://github.com/PostHog/company-internal/blob/37179f74a66e8b779f8e6f116172511709646157/finance/banking.md).
   - For Revolut charges, repay to the bank account details provided in [our banking runbook](https://github.com/PostHog/company-internal/blob/37179f74a66e8b779f8e6f116172511709646157/finance/banking.md#repayments-to-revolut)
 - How do I get access to WeWork?
   - We have a company All Access account - ask [Kendal](https://posthog.com/community/profiles/28628) in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ).

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -111,7 +111,7 @@ Joining an offsite? _Only use the offsite budget_, not your User Limit - it help
 - What if I'm driving for work-related purposes?
   - You can claim a mileage reimbursement through Brex. **Do not** separately expense fuel.
 - What if I accidentally used the company card for a personal expense?
-  - Login to Brex > find the charge > click on 'Repay' > Repay to the bank account details provided in [our banking runbook](https://github.com/PostHog/company-internal/blob/37179f74a66e8b779f8e6f116172511709646157/finance/banking.md)
+  - Login to Brex > find the charge > click on 'Repay'. This won't move any money on its own – Brex only tracks the expense. You then need to manually transfer the amount **from your personal bank account to PostHog's bank account**, using the details provided in [our banking runbook](https://github.com/PostHog/company-internal/blob/37179f74a66e8b779f8e6f116172511709646157/finance/banking.md). (Don't connect your own bank account in Brex – that's not how repayments work.)
   - For Revolut charges, repay to the bank account details provided in [our banking runbook](https://github.com/PostHog/company-internal/blob/37179f74a66e8b779f8e6f116172511709646157/finance/banking.md#repayments-to-revolut)
 - How do I get access to WeWork?
   - We have a company All Access account - ask [Kendal](https://posthog.com/community/profiles/28628) in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ).


### PR DESCRIPTION
## Changes

Clarifies the "What if I accidentally used the company card for a personal expense?" FAQ in the spending money handbook. Clicking 'Repay' in Brex doesn't actually move money – it only tracks the expense – so the doc now spells out that you have to manually transfer the amount from your personal account to PostHog's account, and that you should not connect your own bank account in Brex.

**Why:** A team member got confused and connected their personal bank account in Brex instead of transferring the repayment, because the existing wording made it sound like the Repay button handles the transfer.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1781701089665689?thread_ts=1781701089.665689&cid=C017WDX3BFZ)*
