### PR TITLE
docs(endpoints): document required breakdown variables

### DIFF
--- a/contents/docs/endpoints/guide-breakdown.mdx
+++ b/contents/docs/endpoints/guide-breakdown.mdx
@@ -55,9 +55,11 @@ The response will only include data where `$os` equals "Mac OS X".
   classes="rounded"
 />
 
-<CalloutBox icon="IconInfo" type="info" title="Variable required for materialized endpoints">
+<CalloutBox icon="IconWarning" type="caution" title="Breakdown variables are required">
 
-If your endpoint is [materialized](/docs/endpoints/materialization), you **must** provide the breakdown variable. This prevents accidentally returning all breakdown values when you intended to filter.
+By default, every breakdown variable on an insight-based endpoint is **required** — calls to `/run` that omit one fail with `400 Required variable(s) … not provided`. This is a safety feature to prevent accidentally returning data aggregated across every value of the breakdown.
+
+You can opt individual breakdowns out by marking them as optional in the endpoint configuration (or by passing `optional_breakdown_properties` on the API). When a breakdown is optional and the caller omits it, the response aggregates across every value of that dimension.
 
 </CalloutBox>
 

--- a/contents/docs/endpoints/troubleshooting.mdx
+++ b/contents/docs/endpoints/troubleshooting.mdx
@@ -39,6 +39,13 @@ If you get `"Version X not found for endpoint"`:
 - SQL endpoints only accept variables explicitly defined in the query
 - Insight endpoints accept the breakdown property name and `date_from`/`date_to` (non-materialized only)
 
+`"Required variable(s) '$browser' not provided"`
+
+- Your endpoint has a breakdown variable that the caller must supply on every `/run` request
+- Pass the variable: `{"variables": {"$browser": "Chrome"}}`
+- OR mark the breakdown as optional in the endpoint configuration if you genuinely want callers to be able to omit it. An optional breakdown returns data aggregated across every value of that dimension.
+- This applies to both inline and materialized insight endpoints — the requirement protects against accidentally returning data that hasn't been filtered to a single customer / segment / etc.
+
 `"Query references undefined variable(s): X, Y"`
 
 - Your query uses `{variables.X}` placeholder(s) that don't have matching variable definitions

--- a/contents/docs/endpoints/variables.mdx
+++ b/contents/docs/endpoints/variables.mdx
@@ -85,6 +85,14 @@ WHERE event LIKE {variables.event_pattern}
 
 For insight-based endpoints, variables work differently. Instead of defining them in your query, certain **magic variables** are automatically available based on your insight configuration.
 
+<CalloutBox icon="IconWarning" type="caution" title="Breakdown variables are required">
+
+By default, every breakdown variable on an insight-based endpoint is **required** — calls to `/run` that omit one fail. This is a safety feature: omitting the value would otherwise return data aggregated across every value of that breakdown, which is rarely what you want when exposing an endpoint to customers.
+
+You can opt individual breakdowns out by marking them as optional in the endpoint configuration. An optional breakdown can be omitted on `/run`; the response then aggregates across every value of that dimension.
+
+</CalloutBox>
+
 ### Breakdown property variables
 
 If your insight has breakdowns configured, each breakdown property name automatically becomes a variable. For example, if your TrendsQuery breaks down by `$browser`, you can filter results by passing that property as a variable:


### PR DESCRIPTION
Splits the endpoint-docs changes out of #17707 so they ship independently of the data modeling Q3 objectives.

Two docs updates for the Endpoints product:

- **Required breakdown variables** — documents that every breakdown variable on an insight-based endpoint is required by default (a `/run` call that omits one returns `400`), and how to opt a breakdown out via the optional setting. Touches `variables.mdx`, `guide-breakdown.mdx`, and `troubleshooting.mdx`.
- **API key options** — the getting-started auth step now presents both project secret API keys (recommended for backend services) and personal API keys.

Docs-only; no code changes.