### PR TITLE
docs(android): use getFeatureFlagResult instead of deprecated getFeatureFlagPayload

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
@@ -7,7 +7,7 @@ if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
 
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -20,7 +20,7 @@ if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-k
     // Do something differently for this user
 
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 


### PR DESCRIPTION
## Changes

Migrates the Android feature-flags code snippets to `getFeatureFlagResult` instead of the now-deprecated `getFeatureFlagPayload` (`PostHog.getFeatureFlagResult("flag-key")?.payload`), matching the iOS and Flutter docs.

Companion to the SDK deprecation in [PostHog/posthog-android#579](https://github.com/PostHog/posthog-android/pull/579).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
