### PR TITLE
Add info on reserved cross-team meeting slot

### DIFF
--- a/contents/handbook/getting-started/meetings.md
+++ b/contents/handbook/getting-started/meetings.md
@@ -16,7 +16,10 @@ You should have been invited to any relevant meetings as part of your [onboardin
 
 - **Monday** - PostHog News all-hands meeting. Members of the team share company-wide updates about things like recruitment, product metrics and commercial performance - the doc is shared in the #general channel in Slack. We then go around and people are free to demo anything they've been working on recently. _The content of these meetings is always confidential._ All hands meetings are recorded too if you are out. Some teams also do sprint planning on a Monday. 
 - **Tuesday** - Meeting-free - no planned internal meetings allowed. [Learn more](#no-recurring-meeting-days-tuesdaysthursdays).
-- **Wednesday** - some teams do sprint planning here as well. [Engineering tech talks/brown bags](/handbook/engineering/tech-talks) happen every second week, ClickHouse office hours happen on the alternate week. 
+- **Wednesday** - A few things happen on wednesdays:
+    - some teams do sprint planning here as well
+    - [Engineering tech talks/brown bags](/handbook/engineering/tech-talks) happen every other week
+    - There's a reserved slot for cross-team meetings every other week - avoid scheduling recurring meetings (standups, 1:1s, sprint planning) so you can use the slot when necessary
 - **Thursday** - Meeting-free - no planned internal meetings allowed. [Learn more](#no-recurring-meeting-days-tuesdaysthursdays).
 - **Friday** - extracurricular type meetings like [BookHog](/handbook/people/bookhog) often end up here!
 


### PR DESCRIPTION
Add on wednesday meeting schedule:     
- There's a reserved slot for cross-team meetings every other week - avoid scheduling recurring meetings (standups, 1:1s, sprint planning) so you can use the slot when necessary