### PR TITLE
docs: document project secret API keys

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -17,9 +17,10 @@ The API is available for all users and instances. It contains two types of endpo
 
 ## Authentication
 
-Private endpoints require authentication. There are two ways to authenticate, and which one you should use depends on who the integration is for:
+Private endpoints require authentication. There are three ways to authenticate, and which one you should use depends on who the integration is for:
 
 - **[Personal API keys](/docs/api/personal-api-keys)** – Use these when you're using PostHog from your own scripts, automations, or any integration tied to your own account. This is the right choice if you're just building something for your own project.
+- **[Project secret API keys](/docs/api/project-secret-api-keys)** – Use these for server-to-server access that isn't tied to a user, such as a backend service executing [Endpoints](/docs/endpoints). They're scoped to a single project and only have the scopes you grant them.
 - **[OAuth](/docs/api/oauth)** – Use this when you're building an app that other PostHog users will install or connect to. OAuth lets users grant your app scoped access without sharing their personal API key.
 
 ## Rate limiting
@@ -158,7 +159,7 @@ You can then just call the `"next"` URL to get the next set of results.
 PostHog partners with GitHub to automatically detect exposed API keys in public repositories. When GitHub detects a leaked key, we take immediate action:
 
 - **Personal API keys** (`phx_`): The key is automatically rolled and the user is notified via email.
-- **Feature flags secure API keys** (`phs_`): Project admins and owners are notified via email so they can rotate the key.
+- **Project secret API keys and team secret tokens** (`phs_`): Project admins and owners are notified via email so they can rotate the key.
 - **OAuth access tokens** (`pha_`): The key and its associated refresh token are automatically revoked and the user is notified via email.
 - **OAuth refresh tokens** (`phr_`): The key and its associated access token are automatically revoked and the user is notified via email.
 

--- a/contents/docs/api/project-secret-api-keys/overview.mdx
+++ b/contents/docs/api/project-secret-api-keys/overview.mdx
@@ -1,0 +1,32 @@
+Project secret API keys are server-to-server credentials scoped to a single project. They're the right choice when a backend service needs scoped, project-level access without being tied to anyone's user account.
+
+Unlike a [personal API key](/docs/api/personal-api-keys), a project secret API key doesn't represent a user—it isn't affected when a teammate leaves, and it only has the scopes you grant it. 
+
+Today, they're only supported on a small set of scopes, with more products on the way:
+- Endpoints execution (`endpoint:read` scope)
+
+<CalloutBox icon="IconInfo" title="Migrating from the team secret token" type="fyi">
+
+Project secret API keys will replace the legacy per-team secret token. If you're currently using a team secret token, we'll migrate it to a project secret API key without impacting your application.
+
+</CalloutBox>
+
+## How to obtain a project secret API key
+
+1. Go to the [Project secret API keys](https://app.posthog.com/settings/project-secret-api-keys) section in your project settings.
+2. Click **Create project secret API key**.
+3. Give your key a label to describe its purpose.
+4. Choose the scopes for your key. We recommend selecting only the scopes the service really needs. This is a security best practice.
+5. **Immediately** copy the key's value, as you'll **never** see it again after refreshing the page.
+
+## How to authenticate using the project secret API key
+
+Pass the key in the `Authorization` header using `Bearer` authentication:
+
+```js
+const headers = {
+  Authorization: `Bearer ${POSTHOG_PROJECT_SECRET_API_KEY}`,
+}
+```
+
+PostHog detects the kind of key you sent from its `phs_` prefix and authenticates accordingly.

--- a/contents/docs/endpoints/start-here/retrieve-data/index.mdx
+++ b/contents/docs/endpoints/start-here/retrieve-data/index.mdx
@@ -9,17 +9,22 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <Steps>
 
-<Step title="Create a personal API key" badge="required">
+<Step title="Create an API key" badge="required">
 
-Create a personal API key with the `endpoint:read` scope to authenticate your requests.
+Endpoints support two kinds of keys, both with the `endpoint:read` scope.
 
-1. Go to [Personal API Keys](https://us.posthog.com/settings/user-api-keys) in your PostHog settings
-2. Click **Create personal API key**
+- **[Project secret API key](/docs/api/project-secret-api-keys)** (recommended for backend services): a project-scoped, server-to-server credential that isn't tied to a user. Create one in [Project secret API keys](https://app.posthog.com/settings/project-secret-api-keys).
+- **[Personal API key](/docs/api/personal-api-keys)**: scoped to your user account, useful for interactive or one-off scripts. Create one in [Personal API keys](https://app.posthog.com/settings/user-api-keys).
+
+To create a key:
+
+1. Open the relevant settings page above
+2. Click **Create key**
 3. Give it a name (e.g., "Endpoints")
 4. Select the `endpoint:read` scope
 5. Click **Create key** and copy it somewhere safe
 
-<CalloutBox icon="IconWarning" title="Personal API keys are secret!" type="caution">
+<CalloutBox icon="IconWarning" title="API keys are secret!" type="caution">
 Store your API key securely. Never expose it in client-side code or commit it to version control.
 </CalloutBox>
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2584,6 +2584,10 @@ export const docsMenu = {
                             url: '/docs/api/personal-api-keys',
                         },
                         {
+                            name: 'Project secret API keys',
+                            url: '/docs/api/project-secret-api-keys',
+                        },
+                        {
                             name: 'OAuth integration',
                             url: '/docs/api/oauth',
                         },
@@ -4139,7 +4143,8 @@ export const docsMenu = {
             url: '/docs/replay-vision',
             color: 'yellow',
             icon: 'IconEye',
-            description: 'Use AI to automatically watch your session recordings and turn what it sees into queryable data',
+            description:
+                'Use AI to automatically watch your session recordings and turn what it sees into queryable data',
             children: [
                 {
                     name: 'Replay Vision',

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -638,9 +638,11 @@ export default function ApiEndpoint({ data }: { data: ApiEndpointData }): JSX.El
 
                     {overviewNode?.body && (
                         <div className="article-content mt-6">
-                            <MDXProvider components={components}>
-                                <MDXRenderer>{overviewNode.body}</MDXRenderer>
-                            </MDXProvider>
+                            <div className="text-primary">
+                                <MDXProvider components={components}>
+                                    <MDXRenderer>{overviewNode.body}</MDXRenderer>
+                                </MDXProvider>
+                            </div>
                             <SectionDivider />
                         </div>
                     )}


### PR DESCRIPTION
## Changes

Documents the new **project secret API keys** (`phs_`) — project-scoped, server-to-server credentials.

- **New guide** `contents/docs/api/project-secret-api-keys/overview.mdx` — what they are, supported scopes (`endpoint:read` today), the team-secret-token migration note, how to create one, and how to authenticate. Rendered on the `/docs/api/project-secret-api-keys` reference page via the existing `overview.mdx` mechanism (same pattern as `events/overview.mdx`), so the concept and the OpenAPI reference share one page.
- **`api/index.mdx`** — adds a "Project secret API keys" entry to the `## Authentication` overview, and relabels the GitHub secret-scanning entry for `phs_` from "Feature flags secure API keys" → "Project secret API keys".
- **`src/navs/index.js`** — adds the nav entry under API, between Personal API keys and OAuth.
- **`contents/docs/endpoints/start-here/retrieve-data/index.mdx`** — points the Endpoints "Create an API key" step at both the personal and project secret API key pages.
- **`src/templates/ApiEndpoint.tsx`** — wraps the rendered `overview.mdx` body in `text-primary` so prose renders in the normal docs text colour instead of inheriting the `.article-content` accent (links still render red as intended). Previously unnoticed because the only other overview (`events`) is just a callout.

Built off `master`. Mirrors the structure/tone of the existing `personal-api-keys.mdx`.