### PR TITLE
docs: migrate client feature-flag snippets to getFeatureFlagResult

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
@@ -56,8 +56,8 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 
-// Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+// Optional: fetch the payload (returns 'JsonType' or undefined if not loaded yet or if there was a problem loading)
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
@@ -5,7 +5,7 @@ if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
 
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -16,7 +16,7 @@ if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-
     // Do something differently for this user
     
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 


### PR DESCRIPTION
## Changes

Migrates the canonical client feature-flag code snippets to `getFeatureFlagResult` instead of the deprecated `getFeatureFlagPayload`:
- `feature-flags-code-web.mdx` (`posthog.getFeatureFlagResult('flag-key')?.payload`)
- `feature-flags-code-react-native.mdx`

These are imported by the JS and React Native library docs, so it fixes those pages too. Android (#17712), iOS, and Flutter already use `getFeatureFlagResult`.

Scope: **client SDKs only**. Backend SDKs (node/python/php/ruby/java/go/rust) have a different deprecation (`evaluateFlags`) and are intentionally not changed here. A separate `posthog/posthog` PR handles the in-app snippet generator.

## Checklist

- [x] I've read the docs style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
