### PR TITLE
fix: Use correct link formatting

### DIFF
--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -236,9 +236,15 @@ function QuestionFormMain({
 
                             {disclaimer && (
                                 <p className="text-xs text-center mt-4 ml-[50px] [text-wrap:_balance] opacity-60 mb-0 text-primary">
-                                    [Community questions are independent of PostHog support](/handbook/support/customer-support#community).
-                                    If you have access to support through your PostHog plan, especially if you need to share personal info,
-                                    you can file a support ticket [in the app](https://app.posthog.com#panel=support) instead.
+                                    <Link to="/handbook/support/customer-support#community">
+                                        Community questions are independent of PostHog support
+                                    </Link>
+                                    . If you have access to support through your PostHog plan, especially if you need to
+                                    share personal info, you can file a support ticket{' '}
+                                    <Link to="https://app.posthog.com#panel=support" externalNoIcon>
+                                        in the app
+                                    </Link>{' '}
+                                    instead.
                                 </p>
                             )}
                         </Form>

--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -238,6 +238,7 @@ function QuestionFormMain({
                                 <p className="text-xs text-center mt-4 ml-[50px] [text-wrap:_balance] opacity-60 mb-0 text-primary">
                                     <Link
                                         to="/handbook/support/customer-support#community"
+                                        state={{ newWindow: true }}
                                         className="font-semibold underline"
                                     >
                                         Community questions are independent of PostHog support

--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -14,6 +14,7 @@ import { fetchTopicGroups, topicGroupsSorted } from '../util/topicGroups'
 import usePostHog from 'hooks/usePostHog'
 import { navigate } from 'gatsby'
 import { useAppStatus } from 'hooks/useAppStatus'
+import { useApp } from '../../../context/App'
 import Link from 'components/Link'
 import Input from 'components/OSForm/input'
 import { OSSelect } from 'components/OSForm'
@@ -126,6 +127,7 @@ function QuestionFormMain({
     const posthog = usePostHog()
     const { user, logout } = useUser()
     const { status } = useAppStatus()
+    const { websiteMode } = useApp()
 
     return (
         <div className={`flex-1 mb-1`}>
@@ -236,13 +238,24 @@ function QuestionFormMain({
 
                             {disclaimer && (
                                 <p className="text-xs text-center mt-4 ml-[50px] [text-wrap:_balance] opacity-60 mb-0 text-primary">
-                                    <Link
-                                        to="/handbook/support/customer-support#community"
-                                        state={{ newWindow: true }}
-                                        className="font-semibold underline"
-                                    >
-                                        Community questions are independent of PostHog support
-                                    </Link>
+                                    {websiteMode ? (
+                                        <a
+                                            href="/handbook/support/customer-support#community"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="font-semibold underline"
+                                        >
+                                            Community questions are independent of PostHog support
+                                        </a>
+                                    ) : (
+                                        <Link
+                                            to="/handbook/support/customer-support#community"
+                                            state={{ newWindow: true }}
+                                            className="font-semibold underline"
+                                        >
+                                            Community questions are independent of PostHog support
+                                        </Link>
+                                    )}
                                     . If you have access to support through your PostHog plan, especially if you need to
                                     share personal info, you can file a support ticket{' '}
                                     <Link

--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -236,12 +236,19 @@ function QuestionFormMain({
 
                             {disclaimer && (
                                 <p className="text-xs text-center mt-4 ml-[50px] [text-wrap:_balance] opacity-60 mb-0 text-primary">
-                                    <Link to="/handbook/support/customer-support#community">
+                                    <Link
+                                        to="/handbook/support/customer-support#community"
+                                        className="font-semibold underline"
+                                    >
                                         Community questions are independent of PostHog support
                                     </Link>
                                     . If you have access to support through your PostHog plan, especially if you need to
                                     share personal info, you can file a support ticket{' '}
-                                    <Link to="https://app.posthog.com#panel=support" externalNoIcon>
+                                    <Link
+                                        to="https://app.posthog.com#panel=support"
+                                        externalNoIcon
+                                        className="font-semibold underline"
+                                    >
                                         in the app
                                     </Link>{' '}
                                     instead.


### PR DESCRIPTION
https://posthog.slack.com/archives/C090RCG671C/p1781711000983059?thread_ts=1773675282.567659&cid=C090RCG671C

<img width="1178" height="1008" alt="CleanShot 2026-06-23 at 09 31 47@2x" src="https://github.com/user-attachments/assets/3cb274d7-298d-41b8-b876-70692bc4e2a7" />
