### PR TITLE
docs: Use $groups in PHP group capture example

### DIFF
--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -164,13 +164,13 @@ PostHog::groupIdentify([
 
 If the optional `distinctId` parameter is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior results in each group appearing as a separate person in PostHog. To avoid this, use a consistent `distinctId`, such as `group_identifier`, or a real user distinct ID.
 
-Once a group is created, you can use the `capture` method and pass in the `groups` parameter to capture an event with group analytics.
+Once a group is created, you can use the `capture` method and pass in the `$groups` property to capture an event with group analytics.
 
 ```php
 PostHog::capture([
     'distinctId' => 'user_distinct_id',
     'event' => 'some_event',
-    'groups' => ['company' => 'company_id_in_your_db']
+    '$groups' => ['company' => 'company_id_in_your_db']
 ]);
 ```
 


### PR DESCRIPTION
## Changes

Fix the PHP group analytics capture example to use the `$groups` event property instead of the unsupported `groups` parameter, and update the surrounding prose to match.

No screenshots — docs-only change.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
