### PR TITLE
docs: add Laravel batch size guidance

### DIFF
--- a/contents/docs/libraries/laravel.md
+++ b/contents/docs/libraries/laravel.md
@@ -136,6 +136,18 @@ For older Laravel versions, call `PostHog::captureException()` from your excepti
 
 In normal PHP request lifecycles, queued events flush when the client is destroyed. In long-running Laravel processes such as queue workers, Horizon, or Octane, call `PostHog::flush()` after capturing important events or at the end of a job/request.
 
+If you prefer immediate delivery in queue workers, configure the PHP SDK with `batch_size` set to `1` for those workers:
+
+```php
+PostHog::init(
+    '<ph_project_token>',
+    [
+        'host' => config('services.posthog.host'),
+        'batch_size' => 1,
+    ]
+);
+```
+
 ## Next steps
 
 See the [PHP SDK docs](/docs/libraries/php) for usage examples and the full API reference.


### PR DESCRIPTION
## Changes

- Add guidance for setting the PHP SDK `batch_size` to `1` for Laravel queue workers when immediate delivery is preferred.
- Use the standard `<ph_project_token>` template placeholder in the SDK initialization snippet.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
