### PR TITLE
fix(handbook): Cache warming owned by Query performance team

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -88,7 +88,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'cache-warming': {
         feature: 'Cache warming',
-        owner: ['analytics-platform'],
+        owner: ['query-performance'],
     },
     cli: {
         feature: 'CLI',


### PR DESCRIPTION
## Changes

Updates the Feature ownership handbook table so **Cache warming** is owned by the [Query performance](https://posthog.com/teams/query-performance) team instead of Analytics platform.

**Why:** The feature ownership page incorrectly attributed cache warming to the Analytics platform team — that work belongs to the Query performance team.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1781714742486059?thread_ts=1781714742.486059&cid=C09BDQLM8KA)*