### PR TITLE
Move Salesforce to SSO tools list in sales & CS tools handbook

### DIFF
--- a/contents/handbook/growth/sales/sales-and-cs-tools.md
+++ b/contents/handbook/growth/sales/sales-and-cs-tools.md
@@ -14,6 +14,7 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
   - [PostHog App + Website](https://us.posthog.com/project/2) reference within PostHog US instance
 - [Pylon](https://usepylon.com/) - use Slack SSO
 - [QuoteHog](https://quote.posthog.net/)
+- [Salesforce](https://posthog.lightning.force.com/)
 - [Vitally](https://posthog.vitally-eu.io/) - once you've logged in once with Google ask your Team Lead to upgrade your role to Team Member
 - [Zendesk](https://posthoghelp.zendesk.com/agent/dashboard)
 - [Zoom](https://zoom.com/)
@@ -25,7 +26,6 @@ You can self-serve access requests to the following tools using Zluri through Sl
   - Download the [Gong Meeting Manager](https://workspace.google.com/marketplace/app/gong_meeting_manager/779001639133) extension to trigger a user consent page when joining calls
   - Connect your Calendly link (if using one) with the Gong consent page [through this guide on Slack](https://posthog.slack.com/archives/C01MGUHFH6G/p1770157267662229?thread_ts=1770157176.458439&cid=C01MGUHFH6G)
 - [PostHog Billing](https://billing.posthog.com) 
-- [Salesforce](https://posthog.lightning.force.com/) 
 - [Stripe](https://dashboard.stripe.com/)
 - [PandaDoc](https://app.pandadoc.com/)
 - [Pitch](https://app.pitch.com/)


### PR DESCRIPTION
## Changes

Moved the **Salesforce** bullet from the "Tools requiring approval" list to the "Tools through Google and Single Sign-On (SSO)" list on the [Sales & CS Tools](https://posthog.com/handbook/growth/sales/sales-and-cs-tools) handbook page (placed alphabetically). No other content changed.

**Why:** Salesforce access is via Google/SSO, not the Zluri approval flow, so it was listed under the wrong section.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A — content moved within a page, not a page move)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BALLBBKAB/p1781719013277919?thread_ts=1781719013.277919&cid=C0BALLBBKAB)*
