### PR TITLE
docs: migrate remaining getFeatureFlagPayload prose to getFeatureFlagResult

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -95,7 +95,7 @@ For multivariate flags, you can configure **different payloads for each variant*
 1. Create a multivariate flag with multiple variants (e.g., `control`, `variant_a`, `variant_b`)
 2. For each variant, configure a unique payload in the **Payloads** section
 3. Use release conditions with **optional overrides** to force specific users to specific variants
-4. Retrieve the payload in your code using `getFeatureFlagPayload('flag-key')`
+4. Retrieve the payload in your code using `getFeatureFlagResult('flag-key')?.payload`
 
 **Example use cases:**
 

--- a/contents/docs/feature-flags/early-access-feature-management.mdx
+++ b/contents/docs/feature-flags/early-access-feature-management.mdx
@@ -69,7 +69,7 @@ Each early access feature can include a JSON payload – custom metadata that is
 The EAF payload is **separate from the feature flag payload**:
 
 - **EAF payload**: Returned when users browse available features via `getEarlyAccessFeatures()`. Use it for metadata your opt-in UI displays, such as descriptions, release notes, or settings.
-- **Feature flag payload**: Returned during flag evaluation via `posthog.getFeatureFlagPayload()`. Use it for runtime configuration that affects feature behavior.
+- **Feature flag payload**: Returned during flag evaluation via `posthog.getFeatureFlagResult()?.payload`. Use it for runtime configuration that affects feature behavior.
 
 ### Example
 

--- a/contents/docs/migrate/statsig.mdx
+++ b/contents/docs/migrate/statsig.mdx
@@ -195,7 +195,7 @@ json=ph_flag
 ).json()
 ```
 
-Once done, you can replace your `statsig.getConfig` call with a `posthog.getFeatureFlagPayload` one.
+Once done, you can replace your `statsig.getConfig` call with a `posthog.getFeatureFlagResult(...)?.payload` one.
 
 > **Note:** As of writing this guide, Statsig does not have an endpoint for listing parameter stores, but you would follow a similar process to migrate them.
 

--- a/contents/docs/migrate/statsig.mdx
+++ b/contents/docs/migrate/statsig.mdx
@@ -195,7 +195,7 @@ json=ph_flag
 ).json()
 ```
 
-Once done, you can replace your `statsig.getConfig` call with a `posthog.getFeatureFlagResult(...)?.payload` one.
+Once done, you can replace your `statsig.getConfig` call with a `posthog.getFeatureFlagResult()?.payload` one.
 
 > **Note:** As of writing this guide, Statsig does not have an endpoint for listing parameter stores, but you would follow a similar process to migrate them.
 

--- a/src/components/Home/CodeBlocks/FeatureFlags/index.tsx
+++ b/src/components/Home/CodeBlocks/FeatureFlags/index.tsx
@@ -8,7 +8,7 @@ function Payloads() {
                 <strong>
                     Turn <em>"this"</em> into <em>"that".</em>
                 </strong>{' '}
-                Test changes on your site without hard-coding the changes with <code>getFeatureFlagPayload()</code>.
+                Test changes on your site without hard-coding the changes with <code>getFeatureFlagResult()</code>.
             </p>
             <div className="flex flex-col lg:flex-row gap-x-6">
                 <div className="flex-1">
@@ -26,7 +26,7 @@ function Payloads() {
                     <CodeBlock
                         code={`posthog.onFeatureFlags(function () {
   if (posthog.isFeatureEnabled('headline-change')) {
-    const swapText = posthog.getFeatureFlagPayload('headline-change');
+    const swapText = posthog.getFeatureFlagResult('headline-change')?.payload;
     document.querySelector('h1').textContent = swapText.title;
     document.querySelector('h2').textContent = swapText.subtitle;
   }
@@ -116,7 +116,7 @@ export default [
         title: 'Payloads',
         body: Payloads,
         bodyType: 'component',
-        code: ['getFeatureFlagPayload()'],
+        code: ['getFeatureFlagResult()'],
     },
     {
         title: 'Bootstrapping',

--- a/src/hooks/productData/feature_flags.tsx
+++ b/src/hooks/productData/feature_flags.tsx
@@ -110,7 +110,7 @@ export const featureFlags = {
             description: (
                 <>
                     JSON payloads let you change text, visuals, or entire blocks of code directly from within PostHog –
-                    no code deployments needed with <code>getFeatureFlagPayload()</code> – or server-side with{' '}
+                    no code deployments needed with <code>getFeatureFlagResult()</code> – or server-side with{' '}
                     <Link
                         to="/docs/feature-flags/remote-config"
                         className="font-bold underline"
@@ -146,7 +146,7 @@ export const featureFlags = {
                         <CodeBlock
                             code={`posthog.onFeatureFlags(function () {
   if (posthog.isFeatureEnabled('headline-change')) {
-    const swapText = posthog.getFeatureFlagPayload('headline-change');
+    const swapText = posthog.getFeatureFlagResult('headline-change')?.payload;
     document.querySelector('h1').textContent = swapText.title;
     document.querySelector('h2').textContent = swapText.subtitle;
   }


### PR DESCRIPTION
## Changes

Catches the remaining `getFeatureFlagPayload` → `getFeatureFlagResult` client references on posthog.com that the snippet-focused PRs missed — both docs prose and the website's own homepage/product source:

**Docs prose** (`contents/`):
- `feature-flags/creating-feature-flags.mdx` — `getFeatureFlagResult('flag-key')?.payload`
- `feature-flags/early-access-feature-management.mdx` — `posthog.getFeatureFlagResult()?.payload`
- `migrate/statsig.mdx` — `posthog.getFeatureFlagResult()?.payload`

**Website source** (`src/`) — displayed code examples on the homepage and Feature Flags product page:
- `src/components/Home/CodeBlocks/FeatureFlags/index.tsx`
- `src/hooks/productData/feature_flags.tsx`

Left unchanged: loader method-list stubs (install snippets), backend SDK notes (Node/Java/PHP use the separate `evaluateFlags()` deprecation), `libraries/convex.mdx` (Convex is server-side), and `src/types/posthog.ts` (internal permissive type with an index signature).

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
