### PR TITLE
Update Slack integration link to new onboarding page

### DIFF
--- a/src/pages/r/ai-observability.tsx
+++ b/src/pages/r/ai-observability.tsx
@@ -303,7 +303,7 @@ export default function AIObservabilityLanding(): JSX.Element {
                                 <CallToAction
                                     type="primary"
                                     size="md"
-                                    to="https://app.posthog.com/settings/project-integrations#integration-slack"
+                                    to="https://app.posthog.com/integrations/slack"
                                 >
                                     Connect Slack
                                 </CallToAction>

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -32,7 +32,7 @@ import {
     IconWrench,
 } from '@posthog/icons'
 
-const CONNECT_SLACK_URL = 'https://app.posthog.com/settings/project-integrations#integration-slack'
+const CONNECT_SLACK_URL = 'https://app.posthog.com/integrations/slack'
 
 type IconComponent = React.ComponentType<{ className?: string }>
 


### PR DESCRIPTION
## Changes

The new Slack onboarding page at `app.posthog.com/integrations/slack` is now the canonical place to set up the Slack app. The docs already use it, but two product pages still linked to the old `settings/project-integrations#integration-slack` anchor:

- `/slack` landing page (`CONNECT_SLACK_URL`)
- AI observability reminder page (`/r/ai-observability`)

Both now point to `https://app.posthog.com/integrations/slack`.

**Why:** Per the Slack thread, `/integrations/slack` is the preferred setup link going forward; these two pages were missed in the earlier sweep.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C043VJ93L3B/p1781719268854679?thread_ts=1781719268.854679&cid=C043VJ93L3B)*