### PR TITLE
Fix spelling/capitalization of hogpiled

### DIFF
--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -64,9 +64,9 @@ You can also configure [batch exports](/docs/cdp/batch-exports/s3) to a data war
 
 PostHog exists to help you build more successful products and we provide a lot of tools to get the job done.
 
-If you have no idea where to start, we recommend reading our guide to [Winning with PostHog](/docs/new-to-posthog/getting-hogpilled). It will guide you through:
+If you have no idea where to start, we recommend reading our guide to [Winning with PostHog](/docs/new-to-posthog/getting-hogpiled). It will guide you through:
 
-- [Creating a tracking plan](/docs/new-to-posthog/getting-hogpilled) by defining your North Star metric.
+- [Creating a tracking plan](/docs/new-to-posthog/getting-hogpiled) by defining your North Star metric.
 - [How to track and measure activation](/docs/new-to-posthog/activation) – aka one of the most important metrics ever.
 - [How to think about and track retention](/docs/new-to-posthog/retention) of users and customers.
 - [Capturing revenue in PostHog](/docs/new-to-posthog/revenue), so you can monitor the health of your whole business.

--- a/contents/docs/new-to-posthog/getting-hogpiled.mdx
+++ b/contents/docs/new-to-posthog/getting-hogpiled.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Getting HogPilled: Winning with PostHog"
+title: "Getting HogPiled: Winning with PostHog"
 nextPage: ./activation.mdx
 ---
 

--- a/contents/docs/new-to-posthog/switch-guide/planning-your-pilot.mdx
+++ b/contents/docs/new-to-posthog/switch-guide/planning-your-pilot.mdx
@@ -39,7 +39,7 @@ So it's all upside when you invite everyone who cares about user behavior. As yo
 
 With the basics in place, you have a few decisions to make to build a strong foundation for your reporting and data collection.
 
-- **Decide**: Your [North Star metric](/docs/new-to-posthog/getting-hogpilled)  
+- **Decide**: Your [North Star metric](/docs/new-to-posthog/getting-hogpiled)  
 - **Decide**: Make an event tracking plan, or rely on autocapture?  
 - **Decide**: Use [identified or anonymous events](/docs/data/anonymous-vs-identified-events)
 

--- a/contents/newsletter/what-nobody-tells-devs-about-docs.md
+++ b/contents/newsletter/what-nobody-tells-devs-about-docs.md
@@ -36,7 +36,7 @@ When users start with your product, you want them to go from “nothing” to �
 
 Start by writing the most basic, obvious doc to help someone use your product. What would you send to a friend to help them get started with this feature?
 
-If this means helping them [install and set up](/docs/getting-started/install) your product, do it. If this means teaching them the concepts [necessary to succeed](/docs/new-to-posthog/getting-hogpilled), do it. Either way, having a beginner’s mindset to your own product reveals the most important docs you need to write.
+If this means helping them [install and set up](/docs/getting-started/install) your product, do it. If this means teaching them the concepts [necessary to succeed](/docs/new-to-posthog/getting-hogpiled), do it. Either way, having a beginner’s mindset to your own product reveals the most important docs you need to write.
 
 For example, our new [error tracking docs](/docs/error-tracking) have less content than our other products, but it does include the core of installation, monitoring errors, and viewing stack traces. This gives users enough to get started and we can build on it from there.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2914,8 +2914,8 @@ export const docsMenu = {
                     name: 'Winning with PostHog',
                 },
                 {
-                    name: 'Getting HogPilled',
-                    url: '/docs/new-to-posthog/getting-hogpilled',
+                    name: 'Getting Hogpiled',
+                    url: '/docs/new-to-posthog/getting-hogpiled',
                     icon: 'IconCrown',
                 },
                 {

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -29,7 +29,7 @@ const processDocsMenu = (activeFlags: string[] | null) => {
         'Advanced',
         'Tools',
         'AI engineering',
-        'Getting HogPilled',
+        'Getting Hogpiled',
     ]
 
     const featuredAIPlatformItems = [

--- a/src/pages/ko/_translations.ts
+++ b/src/pages/ko/_translations.ts
@@ -745,7 +745,7 @@ const koDeepMenuTranslations: Record<string, string> = {
     'Model Context Protocol (MCP)': '모델 컨텍스트 프로토콜(MCP)',
     'Code editors': '코드 편집기',
     Platforms: '플랫폼',
-    'Getting HogPilled': 'Getting HogPilled',
+    'Getting Hogpiled': 'Getting Hogpiled',
     'Measuring activation': '활성화 측정',
     'Tracking retention': '리텐션 추적',
     'Capturing revenue': '수익 캡처',

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -172,7 +172,7 @@ export default function PostHogMCPLanding(): JSX.Element {
 
                         <QuestLogItem title="Talk to me, baby" subtitle="Natural language navigation" icon="IconChat">
                             <p>
-                                Once you connect to the PostHog MCP server, see how Hogpilled your agent has become. For
+                                Once you connect to the PostHog MCP server, see how Hogpiled your agent has become. For
                                 example:
                             </p>
 
@@ -243,7 +243,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                                     to="/docs/model-context-protocol"
                                     state={{ newWindow: true }}
                                 >
-                                    Get your agents Hogpilled
+                                    Get your agents Hogpiled
                                 </CallToAction>
                             </div>
                         </QuestLogItem>

--- a/src/pages/r/product-analytics.tsx
+++ b/src/pages/r/product-analytics.tsx
@@ -582,7 +582,7 @@ export default function ProductAnalyticsLanding(): JSX.Element {
                                                 {item.url && (
                                                     <>
                                                         <p className="text-secondary !mb-2">
-                                                            ...or just use the MCP and ask your hogpilled agent to get
+                                                            ...or just use the MCP and ask your hogpiled agent to get
                                                             your answer.
                                                         </p>
                                                         <Link

--- a/vercel.json
+++ b/vercel.json
@@ -126,6 +126,11 @@
         { "source": "/docs/tracing", "destination": "/docs/distributed-tracing", "statusCode": 301 },
         { "source": "/docs/tracing/:path*", "destination": "/docs/distributed-tracing/:path*", "statusCode": 301 },
         {
+            "source": "/docs/new-to-posthog/getting-hogpilled",
+            "destination": "/docs/new-to-posthog/getting-hogpiled",
+            "statusCode": 301
+        }
+        {
             "source": "/docs/posthog-code/inbox/triage",
             "destination": "/docs/posthog-code/inbox/implementation",
             "statusCode": 301


### PR DESCRIPTION
Hogpile/hogpiled seems to be the intended meaning here (rather than hogpilled): 
 - https://www.google.com/search?q=hogpile+def&oq=hogpile+

(The closest standard dictionary term is dogpile, whose variants include dog pile and dog-pile, meaning people piled on top of one another, like for a victory celebration.)

On capitalization: in a title, Hogpiled is the cleanest if written as one word. If hyphenated, style guides differ, but major style logic would usually allow Hog-Piled or Hog-piled.

## Changes

Renamed file and fixed references for getting-hogpiled.mdx

Added a redirect in vercel.json

Not yet checked Vercel preview build. 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
