### PR TITLE
Add infographic style guide to brand handbook

### DIFF
--- a/contents/handbook/brand/infographic-style-guide.md
+++ b/contents/handbook/brand/infographic-style-guide.md
@@ -1,0 +1,151 @@
+---
+title: 'Infographic style guide'
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+---
+
+> 🎨 **For anyone making charts, data graphics, or infographics for blogs, newsletters, and social.** This covers the _visual styling_ of in-content infographics — not full brand assets (logos, mascots, presentations), which live in [Logos & hedgehogs](/handbook/brand/assets).
+>
+> There are **two style systems** below. Use **pre-build mode** for anything in our current/legacy editorial look. Use **post-build mode** for anything shipping alongside or after the build-mode rebrand. Don't mix the two in one graphic.
+
+## Contents
+
+- [Which style do I use?](#which-style-do-i-use)
+- [Pre-build mode](#pre-build-mode)
+- [Post-build mode](#post-build-mode)
+- [Open questions to verify](#open-questions-to-verify)
+
+## Which style do I use?
+
+| | Pre-build mode | Post-build mode |
+|---|---|---|
+| **Feel** | Editorial, newspaper, zine. Print-inspired, sparse color. | Bold, energetic, data-forward. Orange-dominant. |
+| **Headline font** | Perfectly Nineties (serif) | Kalam (handwritten, all caps) |
+| **Body font** | Matter SQ | Open Runde |
+| **Color** | Near-monochrome; one orange pop | Brand orange dominant + status colors |
+| **Signature cue** | Halftone / crosshatch illustration | Graph-paper grid + "build mode" badge |
+
+## Pre-build mode
+
+_Early mock-up designs (drafts 1–5). Editorial, near-monochromatic._
+
+### Typography
+
+- **Display / headline:** Perfectly Nineties — Regular for plain statements, Italic for emphasis or contrast. Large scale (60px+), tight letter-spacing (≈ −4% on large headlines).
+- **UI / body / labels:** Matter SQ — Medium (500) for body, SemiBold (600) for section labels, Bold (700) for active nav or key labels.
+- **Case:** sentence case throughout. No all-caps.
+- **Fill only** — text is always a flat fill, never stroked.
+- **Color:** `#1f1f1f` near-black on light backgrounds (never pure black). White only inside filled button pills.
+
+### Color
+
+Near-monochromatic and warm. Orange appears in **at most one place** per composition — a single deliberate pop (a subscribe button, one highlighted number).
+
+| Role | Hex |
+|---|---|
+| Background | `#dfdccf` (warm sand) or `#fdfdf9` (off-white cream) |
+| Primary text | `#1f1f1f` |
+| Cards / containers | `#eeefea` |
+| Borders / dividers | `#9fa097` (muted grey-green) or `#1f1f1f` |
+| Accent / CTA | Brand orange — one pop only |
+
+### Shapes & outlines
+
+- Flat 2D only. No gradients, no drop shadows.
+- Shapes are either a 1px `#1f1f1f` stroke with no fill, or `#eeefea` fill with a 1px `#1f1f1f` stroke.
+- Corner radius: 8px for cards and buttons; otherwise square (0 radius).
+- Dividers are thin (1px) `#1f1f1f` or `#9fa097` strokes. No dashes.
+
+### Arrows & connectors
+
+- Thin line vectors, `#1f1f1f` stroke at 1–1.5px, no fill.
+- Straight only — no curves, no rounded ends.
+- No arrowhead decoration beyond the raw line.
+
+### Overall feel
+
+Editorial / newspaper / zine, print-inspired. Sparse color. Personality comes from halftone and crosshatch illustration, not from color.
+
+### Quick do / don't
+
+- ✅ One orange accent, max. ✅ Sentence case. ✅ Flat fills + thin strokes.
+- ❌ Pure black. ❌ Gradients or shadows. ❌ More than one accent color.
+
+## Post-build mode
+
+_Rebrand onwards — the orange era. Bold and data-forward._
+
+### Typography
+
+- **Headline / title:** Kalam Bold — handwritten/chalkboard feel. Always **all caps** (`textCase: UPPER`). ~28–30px for titles, 14–16px for table column headers.
+- **Body / labels / data:** Open Runde — Medium for data cells and body, Semibold for status labels and descriptors, Bold for CTA/badge text. ~10–12px in tables, ~18px for card headings.
+- **Fill only** — text is always a flat fill, never stroked.
+- **Color:**
+  - On colored backgrounds: always `#ffffff`.
+  - On white/cream backgrounds: `#000000` for titles and data body; colored text only for status labels (matching their status color).
+
+### Color
+
+Orange-dominant, with a defined status system. **Every filled shape uses a darker shade of its own fill as its stroke — never a neutral or black stroke on a colored shape.**
+
+| Role | Hex | Usage |
+|---|---|---|
+| Background | `#fdfdf9` (cream) or `#ffffff` | Canvas / frame |
+| Brand orange | `#ff5c1c` | Primary accent — headers, shapes, badges, arrows |
+| Orange stroke | `#e54000` | 1–2px stroke on orange fills |
+| Status: positive | `#47c861` | Green dot + label ("planned" / "covered"); stroke `#35b14e` |
+| Status: in-progress | `#ffa81c` | Amber dot + label |
+| Status: warning | implied red | Heatmaps / "not addressed" |
+| Process blue | `#2bb3df` | Step color in multi-step flows; stroke `#1a89ad` |
+| Dark | `#2c2c2d` | Near-black — screenshot overlays, image containers |
+| Pure white | `#ffffff` | Text on colored shapes |
+
+### Shapes & outlines
+
+- Flat 2D. Depth comes from shape-to-stroke color contrast, not shadows or gradients.
+- **Strokes always present on colored shapes** — 1–2px in a darker shade of the fill (orange → `#e54000`, green → `#35b14e`, blue → `#1a89ad`).
+- Corner radius: colored blocks/badges ≈ 8–9px; the build-mode badge pill is fully rounded; grid cells are sharp (0 radius).
+- **Graph-paper grid motif:** white cells with `#ff5c1c` 1px strokes, square, no radius — background texture on chart/experimental frames. This is a signature post-rebrand cue.
+- **One** subtle drop shadow is allowed — on the table's outer container, to lift the whole graphic off the page. Never on individual cells or data shapes.
+- No dashed lines.
+
+### Arrows & lines
+
+- Solid-filled vector arrows in the **same color as the element they connect** (orange → orange, green → green).
+- Arrows are flat 2D with no outline stroke on the arrow itself.
+- Straight or angled — no curved connectors.
+- Table divider lines: `#ff5c1c` at 1px, no dashes.
+
+### Signature elements
+
+**"Build mode" badge** — include on every infographic:
+
+- Top-right corner of the frame, always.
+- Orange (`#ff5c1c`) fill + gradient overlay on the background rectangle + `#e54000` stroke, pill shape.
+- White Open Runde Bold text at ~10px reading "build mode", with the PostHog logomark.
+
+**Status dot system** (for tables):
+
+- Colored filled ellipse + matching-color Open Runde Bold label.
+- Orange = planned, green = mostly covered, amber = in progress, red (implied) = not addressed.
+- Body data text stays `#000000` Open Runde Medium.
+
+### Overall feel
+
+Bold, energetic, data-forward. Handwritten headline for personality, rounded sans for legibility, orange dominant. The graph-paper grid signals "data / analytical thinking." Everything is flat and 2D.
+
+### Quick do / don't
+
+- ✅ Darker-shade stroke on every colored fill. ✅ Grid motif on chart frames. ✅ Build-mode badge top-right.
+- ❌ Black/neutral strokes on colored shapes. ❌ Shadows on individual cells. ❌ Curved connectors. ❌ Mixed-color arrows.
+
+## Open questions to verify
+
+A few values pulled from the source mock-ups diverge from our core brand tokens. These are flagged rather than reconciled — confirm against the real assets before treating this page as final:
+
+1. **Orange hex mismatch.** The core brand red/orange is `#F54E00` (see [brand assets](/handbook/brand/assets)), but these infographics use `#ff5c1c`. Confirm whether build-mode infographics intentionally use a brighter orange or should snap to `#F54E00`.
+2. **Text near-black.** Brand text is `#151515`; the pre-build infographics use `#1f1f1f`. Pick one so graphics match site text.
+3. **Background cream.** Brand background is `#EEEFE9`; pre-build uses `#dfdccf` / `#fdfdf9` and cards use `#eeefea`. Worth aligning the card fill to the brand `#EEEFE9` token.
+4. **Implied red.** No hex was captured for the warning / "not addressed" status — needs a defined value.
+5. **Fonts.** Confirm Perfectly Nineties, Matter SQ, Kalam, and Open Runde are all licensed for web/social use and available to whoever's generating these.

--- a/contents/handbook/brand/infographic-style-guide.md
+++ b/contents/handbook/brand/infographic-style-guide.md
@@ -7,7 +7,7 @@ hideAnchor: false
 
 > 🎨 **For anyone making charts, data graphics, or infographics for blogs, newsletters, and social.** This covers the _visual styling_ of in-content infographics — not full brand assets (logos, mascots, presentations), which live in [Logos & hedgehogs](/handbook/brand/assets).
 >
-> There are **two style systems** below. Use **pre-build mode** for anything in our current/legacy editorial look. Use **post-build mode** for anything shipping alongside or after the build-mode rebrand. Don't mix the two in one graphic.
+> There are **two style systems** below. Use **pre-build mode** for our current/legacy newsletter look. Use **post-build mode** for anything shipping alongside or after the build-mode rebrand. Don't mix the two in one graphic.
 
 ## Contents
 
@@ -20,132 +20,122 @@ hideAnchor: false
 
 | | Pre-build mode | Post-build mode |
 |---|---|---|
-| **Feel** | Editorial, newspaper, zine. Print-inspired, sparse color. | Bold, energetic, data-forward. Orange-dominant. |
-| **Headline font** | Perfectly Nineties (serif) | Kalam (handwritten, all caps) |
-| **Body font** | Matter SQ | Open Runde |
-| **Color** | Near-monochrome; one orange pop | Brand orange dominant + status colors |
-| **Signature cue** | Halftone / crosshatch illustration | Graph-paper grid + "build mode" badge |
+| **Feel** | Chunky, bold, comic-book energy. Thick borders, multiple warm accents. | Cleaner, data-forward. Thin strokes, orange does the heavy lifting. |
+| **Content font** | Squeak Bold / ExtraBold, all caps | Open Runde |
+| **Headline font** | Squeak (titles in Matter SQ Medium) | Kalam, all caps |
+| **Stroke weight** | Thick — 4–6px | Thin — 1–2px |
+| **Color** | Multiple accents (teal, peach, amber, blue) | Brand orange dominant + status colors |
+| **Connectors** | Understated grey, dashed dividers, curved loops | Solid, color-matched, straight |
+| **Signature cue** | Heavy outlined shapes + knockout headlines | Graph-paper grid + "build mode" badge |
 
 ## Pre-build mode
 
-_Early mock-up designs (drafts 1–5). Editorial, near-monochromatic._
+_Existing PostHog newsletter content (Daniel Hawkins / Lottie Coxon). Chunky, bold, graphic._
 
 ### Typography
 
-- **Display / headline:** Perfectly Nineties — Regular for plain statements, Italic for emphasis or contrast. Large scale (60px+), tight letter-spacing (≈ −4% on large headlines).
-- **UI / body / labels:** Matter SQ — Medium (500) for body, SemiBold (600) for section labels, Bold (700) for active nav or key labels.
-- **Case:** sentence case throughout. No all-caps.
-- **Fill only** — text is always a flat fill, never stroked.
-- **Color:** `#1f1f1f` near-black on light backgrounds (never pure black). White only inside filled button pills.
+- **All infographic content:** Squeak Bold or Squeak ExtraBold — always **all caps**, 24–64px depending on hierarchy. This is the defining font of this era.
+- **Chart titles / frame labels only:** Matter SQ Medium — sentence case, for top-level titles like "How Bolt works" at ~50px. Not used inside diagrams.
+- No italic. No mixed weight within a single diagram.
+- **Text stroke: yes** — large display headlines (e.g. an "ENGINEERINGIFICATION" title) use Squeak ExtraBold with a **6px solid black stroke on white fill** for a knockout/outlined effect. This is a deliberate style choice, not an error.
+- Body text color: `#1e1e1e` near-black on light fills.
 
 ### Color
 
-Near-monochromatic and warm. Orange appears in **at most one place** per composition — a single deliberate pop (a subscribe button, one highlighted number).
+Multiple accent colors coexist in the same graphic. Each box is a **light tint fill + pure-hue stroke** pair.
 
 | Role | Hex |
 |---|---|
-| Background | `#dfdccf` (warm sand) or `#fdfdf9` (off-white cream) |
-| Primary text | `#1f1f1f` |
-| Cards / containers | `#eeefea` |
-| Borders / dividers | `#9fa097` (muted grey-green) or `#1f1f1f` |
-| Accent / CTA | Brand orange — one pop only |
+| Frame background | `#eeefe9` (warm grey-green) |
+| Frame border | `#c3c5bf` at 4px |
+| Teal / mint (primary accent) | `#29dbbb` |
+| Peach / warm cream (box fill) | `#fceed7` / `#fbead4` |
+| Amber (box stroke on peach) | `#f1a82c` / `#eca44c` |
+| Blue (secondary accent) | `#2f80fa` |
+| Blue light (box fill on blue) | `#e5f0ff` |
+| Near-black text | `#1e1e1e` |
+| Grey connectors | `#888888` |
+| Grey divider | `#d2d2d2` |
 
 ### Shapes & outlines
 
-- Flat 2D only. No gradients, no drop shadows.
-- Shapes are either a 1px `#1f1f1f` stroke with no fill, or `#eeefea` fill with a 1px `#1f1f1f` stroke.
-- Corner radius: 8px for cards and buttons; otherwise square (0 radius).
-- Dividers are thin (1px) `#1f1f1f` or `#9fa097` strokes. No dashes.
+- **Thick strokes — 4–6px on all shape outlines. This is the signature of this era.**
+- Each shape color gets its own stroke: teal box → `#000000` 4px stroke; peach box → amber `#f1a82c` 5px stroke; blue box → `#2f80fa` 5px stroke.
+- Corner radius: 8px on flow-chart boxes, ~11px on loop-diagram nodes. Consistently rounded — never sharp squares for content boxes.
+- Flat 2D. No drop shadows, no gradients.
+- Frame containers carry a `#c3c5bf` 4px stroke border on the outer edge.
 
-### Arrows & connectors
+### Arrows, lines & connectors
 
-- Thin line vectors, `#1f1f1f` stroke at 1–1.5px, no fill.
-- Straight only — no curves, no rounded ends.
-- No arrowhead decoration beyond the raw line.
+- **Connecting arrows:** `#888888` grey, 5px weight, straight lines with arrowheads. Deliberately _not_ colored to match boxes — so the colored boxes stay dominant.
+- **Dashed dividers** (separating left/right sections): `#d2d2d2`, 4px weight, `[8, 8]` dash pattern.
+- **Curved loop connectors:** black `#000000`, 6px weight, `[20, 20]` dash pattern, drawn on a high-radius path. Used for cyclical diagrams.
+- No hairline strokes — everything is visually heavy and bold.
 
 ### Overall feel
 
-Editorial / newspaper / zine, print-inspired. Sparse color. Personality comes from halftone and crosshatch illustration, not from color.
-
-### Quick do / don't
-
-- ✅ One orange accent, max. ✅ Sentence case. ✅ Flat fills + thin strokes.
-- ❌ Pure black. ❌ Gradients or shadows. ❌ More than one accent color.
+Chunky, bold, graphic. Squeak gives it a playful-but-technical comic-book energy. Thick borders on every shape, multiple warm accents (teal, peach, amber, blue) used together, with understated grey connectors so the colored boxes lead.
 
 ## Post-build mode
 
-_Rebrand onwards — the orange era. Bold and data-forward._
+_Rebrand onwards — the build-mode newsletter brand. Cleaner and data-forward._
 
 ### Typography
 
-- **Headline / title:** Kalam Bold — handwritten/chalkboard feel. Always **all caps** (`textCase: UPPER`). ~28–30px for titles, 14–16px for table column headers.
-- **Body / labels / data:** Open Runde — Medium for data cells and body, Semibold for status labels and descriptors, Bold for CTA/badge text. ~10–12px in tables, ~18px for card headings.
-- **Fill only** — text is always a flat fill, never stroked.
-- **Color:**
-  - On colored backgrounds: always `#ffffff`.
-  - On white/cream backgrounds: `#000000` for titles and data body; colored text only for status labels (matching their status color).
+- **Headline / title:** Kalam Bold — handwritten/chalkboard feel, always **all caps**. ~28–30px for graphic titles, 14–16px for table column headers.
+- **Body / data / labels:** Open Runde — Medium for data cells and body, Semibold for status labels and descriptors, Bold for badge text and CTA.
+- **No text stroke** — text is always a flat fill.
+- White text on any colored shape; black `#000000` text on white/cream backgrounds.
+- Status labels (e.g. "Planned", "Mostly covered") are colored to match their status dot, in Open Runde Bold.
 
 ### Color
 
-Orange-dominant, with a defined status system. **Every filled shape uses a darker shade of its own fill as its stroke — never a neutral or black stroke on a colored shape.**
+Orange-dominant; every other color is a functional status signal. **Every filled shape uses a darker shade of its own fill as its stroke — never a neutral or black stroke on a colored shape.**
 
-| Role | Hex | Usage |
-|---|---|---|
-| Background | `#fdfdf9` (cream) or `#ffffff` | Canvas / frame |
-| Brand orange | `#ff5c1c` | Primary accent — headers, shapes, badges, arrows |
-| Orange stroke | `#e54000` | 1–2px stroke on orange fills |
-| Status: positive | `#47c861` | Green dot + label ("planned" / "covered"); stroke `#35b14e` |
-| Status: in-progress | `#ffa81c` | Amber dot + label |
-| Status: warning | implied red | Heatmaps / "not addressed" |
-| Process blue | `#2bb3df` | Step color in multi-step flows; stroke `#1a89ad` |
-| Dark | `#2c2c2d` | Near-black — screenshot overlays, image containers |
-| Pure white | `#ffffff` | Text on colored shapes |
+| Role | Hex |
+|---|---|
+| Background | `#fdfdf9` (cream) or `#ffffff` |
+| Brand orange (primary) | `#ff5c1c` |
+| Orange stroke / darker shade | `#e54000` |
+| Status: positive | `#47c861` (green); stroke `#35b14e` |
+| Status: in progress | `#ffa81c` (amber) |
+| Status: not addressed | implied red |
+| Process blue | `#2bb3df` with `#1a89ad` stroke |
+| Near-black | `#2c2c2d` |
 
 ### Shapes & outlines
 
-- Flat 2D. Depth comes from shape-to-stroke color contrast, not shadows or gradients.
-- **Strokes always present on colored shapes** — 1–2px in a darker shade of the fill (orange → `#e54000`, green → `#35b14e`, blue → `#1a89ad`).
-- Corner radius: colored blocks/badges ≈ 8–9px; the build-mode badge pill is fully rounded; grid cells are sharp (0 radius).
-- **Graph-paper grid motif:** white cells with `#ff5c1c` 1px strokes, square, no radius — background texture on chart/experimental frames. This is a signature post-rebrand cue.
-- **One** subtle drop shadow is allowed — on the table's outer container, to lift the whole graphic off the page. Never on individual cells or data shapes.
-- No dashed lines.
+- **Thin strokes — 1–2px. The opposite of the pre-rebrand era.**
+- Every filled shape uses a darker shade of the same color as its stroke (orange fill → `#e54000`, green fill → `#35b14e`). Never a black or neutral stroke on a colored shape.
+- Corner radius: ~8–9px on colored blocks; the build-mode badge is a full pill; grid cells are 0 radius (sharp squares).
+- **Graph-paper grid motif:** white cells with `#ff5c1c` 1px strokes as background texture. Cells are square, sharp corners. A signature post-rebrand cue.
+- **One** subtle drop shadow on the overall table container to lift it off the page — never on individual cells or shapes.
+- Flat 2D throughout.
 
-### Arrows & lines
+### Arrows, lines & connectors
 
-- Solid-filled vector arrows in the **same color as the element they connect** (orange → orange, green → green).
-- Arrows are flat 2D with no outline stroke on the arrow itself.
-- Straight or angled — no curved connectors.
-- Table divider lines: `#ff5c1c` at 1px, no dashes.
+- Solid-filled vector arrows matching the color of the element they connect (orange step → orange arrow).
+- Table row dividers: `#ff5c1c` 1px — no dashes.
+- No dashed lines. No grey connectors.
+- Arrows are straight — no curves.
 
-### Signature elements
+### Status dot system
 
-**"Build mode" badge** — include on every infographic:
+Colored filled ellipse + matching-color Open Runde Bold label. Orange dot = planned, green = mostly covered, amber = in progress.
 
-- Top-right corner of the frame, always.
-- Orange (`#ff5c1c`) fill + gradient overlay on the background rectangle + `#e54000` stroke, pill shape.
-- White Open Runde Bold text at ~10px reading "build mode", with the PostHog logomark.
+### Build mode badge
 
-**Status dot system** (for tables):
-
-- Colored filled ellipse + matching-color Open Runde Bold label.
-- Orange = planned, green = mostly covered, amber = in progress, red (implied) = not addressed.
-- Body data text stays `#000000` Open Runde Medium.
+Top-right corner of every graphic: orange `#ff5c1c` pill with Open Runde Bold white text at ~10px, PostHog logomark in white.
 
 ### Overall feel
 
-Bold, energetic, data-forward. Handwritten headline for personality, rounded sans for legibility, orange dominant. The graph-paper grid signals "data / analytical thinking." Everything is flat and 2D.
-
-### Quick do / don't
-
-- ✅ Darker-shade stroke on every colored fill. ✅ Grid motif on chart frames. ✅ Build-mode badge top-right.
-- ❌ Black/neutral strokes on colored shapes. ❌ Shadows on individual cells. ❌ Curved connectors. ❌ Mixed-color arrows.
+Cleaner, data-forward, restrained in shape weight but bold in color. The graph-paper grid signals "analytical / data." Handwritten Kalam adds personality without losing legibility. Everything is thinner and lighter than the pre-rebrand era — the orange does the heavy lifting instead of thick strokes.
 
 ## Open questions to verify
 
-A few values pulled from the source mock-ups diverge from our core brand tokens. These are flagged rather than reconciled — confirm against the real assets before treating this page as final:
+A few values pulled from the source mock-ups are worth confirming before treating this page as final:
 
-1. **Orange hex mismatch.** The core brand red/orange is `#F54E00` (see [brand assets](/handbook/brand/assets)), but these infographics use `#ff5c1c`. Confirm whether build-mode infographics intentionally use a brighter orange or should snap to `#F54E00`.
-2. **Text near-black.** Brand text is `#151515`; the pre-build infographics use `#1f1f1f`. Pick one so graphics match site text.
-3. **Background cream.** Brand background is `#EEEFE9`; pre-build uses `#dfdccf` / `#fdfdf9` and cards use `#eeefea`. Worth aligning the card fill to the brand `#EEEFE9` token.
-4. **Implied red.** No hex was captured for the warning / "not addressed" status — needs a defined value.
-5. **Fonts.** Confirm Perfectly Nineties, Matter SQ, Kalam, and Open Runde are all licensed for web/social use and available to whoever's generating these.
+1. **Orange hex.** The core brand red/orange is `#F54E00` (see [brand assets](/handbook/brand/assets)), but post-build infographics use `#ff5c1c`. Confirm whether the brighter orange is intentional or should snap to `#F54E00`.
+2. **Text near-black.** Brand text is `#151515`; pre-build infographics use `#1e1e1e` and post-build uses `#2c2c2d` / `#000000`. Worth settling on consistent values.
+3. **Implied red.** No hex was captured for the post-build warning / "not addressed" status — needs a defined value.
+4. **Fonts.** Squeak and Matter SQ are existing brand fonts; confirm Kalam and Open Runde are licensed for web/social use and available to whoever's generating these.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -564,6 +564,10 @@ export const handbookSidebar = [
                 url: '/handbook/brand/assets',
             },
             {
+                name: 'Infographic style guide',
+                url: '/handbook/brand/infographic-style-guide',
+            },
+            {
                 name: 'Requesting custom art',
                 url: '/handbook/brand/art-requests',
             },


### PR DESCRIPTION
## Changes

Adds a new brand handbook page — **Infographic style guide** — covering the visual styling of in-content infographics (charts and data graphics for blogs, newsletters, and social). It documents two style systems: **pre-build mode** (editorial, near-monochromatic) and **post-build mode** (orange-dominant, data-forward), each with typography, color, shapes, arrows, and do/don't rules. Registered in the handbook brand nav after "Brand assets".

An **Open questions** section flags where values pulled from the source mock-ups diverge from our core brand tokens (orange `#ff5c1c` vs `#F54E00`, text/background near-blacks, undefined warning red, font licensing) — these need confirming before the page is treated as final.

**Why:** Now that charts/infographics are easy to generate, we want a shared styling reference so generated graphics land on-brand without manual polish each time. Drafted from a Figma agent's extraction, refined, and opened as a draft for review/sample-generation.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1781721890515599?thread_ts=1781721890.515599&cid=C09GU689J1X)*