### PR TITLE
Redirect /apps to /products instead of /cdp

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1564,7 +1564,7 @@
         { "source": "/docs/session-replay/flutter", "destination": "/docs/session-replay/installation/flutter" },
         { "source": "/teams/customer-comms", "destination": "/teams/support" },
         { "source": "/teams/customer-analytics", "destination": "/teams/web-analytics" },
-        { "source": "/apps", "destination": "/cdp", "statusCode": 302 },
+        { "source": "/apps", "destination": "/products", "statusCode": 302 },
         { "source": "/docs/data-warehouse/setup/azure-blob", "destination": "/docs/cdp/sources/azure-blob" },
         { "source": "/docs/data-warehouse/setup/azure-db", "destination": "/docs/cdp/sources/azure-db" },
         {


### PR DESCRIPTION
## Changes

Changes the `/apps` redirect to point to `/products` instead of `/cdp`. As we move toward referring to products as "apps", `/products` is a more fitting destination than the CDP page.

**Why:** Surfaced in a Slack thread — `/apps` currently 302s to the CDP page, but `/products` is the more appropriate target given the direction of calling products "apps".

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ALU3889A6/p1781777924163979?thread_ts=1781777924.163979&cid=C0ALU3889A6)*
