### PR TITLE
fix: include avatar in SqueakProfile contentDigest so avatar updates aren't cached away

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.ts
+++ b/plugins/gatsby-source-squeak/gatsby-node.ts
@@ -49,7 +49,10 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
                 id: createNodeId(`squeak-profile-${profile.id}`),
                 squeakId: profile.id,
                 internal: {
-                    contentDigest: createContentDigest(profileData),
+                    // Digest the full attributes (including avatar) so an avatar-only
+                    // update to an existing profile invalidates the cached node and the
+                    // new avatar gets picked up on the next build.
+                    contentDigest: createContentDigest(profile.attributes),
                     type: `SqueakProfile`,
                 },
                 avatar: avatar.data?.attributes,


### PR DESCRIPTION
## Changes

One-line fix in `plugins/gatsby-source-squeak/gatsby-node.ts`: compute the `SqueakProfile` node's `contentDigest` from the full `profile.attributes` (which includes `avatar`) instead of from `profileData`, which destructured `avatar` out.

```ts
// before
const { avatar, ...profileData } = profile.attributes
contentDigest: createContentDigest(profileData),  // avatar excluded

// after
contentDigest: createContentDigest(profile.attributes),  // avatar included
```

**Why:** A blog author's avatar isn't stored in `src/data/authors.json` — author entries only carry a `profile_id`, and the avatar is pulled at build time from the linked community (Squeak) profile via `profile: SqueakProfile @link(by: "squeakId", from: "profile_id")`, then baked into the static page. None of the author entries have an `image` fallback, so if the profile's avatar doesn't resolve at build time, no picture renders at all.

We hit this with a recently-added author whose community profile *did* have an avatar, but it never showed on their post. Root cause: Gatsby keys node freshness off `contentDigest`. Because `avatar` was excluded from the digest, adding an avatar to an *existing* profile (without changing any other field) produced an identical digest, so Gatsby reused the stale cached node on incremental builds and the new avatar was never picked up. Including `avatar` in the digest means an avatar-only change now invalidates the node and resolves on the next build — no manual cache clear required.

Scope is limited to the `SqueakProfile` node digest; no schema or query changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9AKT9NTY/p1781778166251629)*
