### PR TITLE
docs: Update useFeatureOwnership.tsx

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -251,13 +251,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     notebooks: {
         feature: 'Notebooks',
-        notes: (
-            <>
-                Owns the notebooks feature and triages other tickets out to the right owner (e.g. insights in notebooks
-                is owned by product analytics)
-            </>
-        ),
-        owner: ['platform-features'],
+        owner: ['data-tools'],
         label: 'feature/notebooks',
     },
     oauth: {


### PR DESCRIPTION
## Changes

Move Notebooks ownership from Platform Features to Data Tools.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
