### PR TITLE
docs: move skills store out of AI observability section

### DIFF
--- a/contents/blog/everything-is-build-mode.md
+++ b/contents/blog/everything-is-build-mode.md
@@ -122,7 +122,7 @@ Build mode isn't a solo act. Some of the best work happening at PostHog is in pu
 
 And that know-how compounds. The old way to pass on how you do something was to write a standard operating procedure – a document that tells you how to do the thing but can't do it itself. A [skill](/docs/posthog-code/skills) can: it's your judgment written down in a form an agent can actually run, so the next person doesn't start from scratch.
 
-If your company is *cautiously* adopting AI, this is the cleanest way to let people work outside their lane – the agent runs on your colleagues' codified judgment, not a blank prompt. We keep ours in a few places: the [skills store](/docs/prompt-management/skills-store), the [`.claude` folder](https://github.com/PostHog/posthog.com/tree/master/.claude) in our website repo, and the company [handbook](/handbook).
+If your company is *cautiously* adopting AI, this is the cleanest way to let people work outside their lane – the agent runs on your colleagues' codified judgment, not a blank prompt. We keep ours in a few places: the [skills store](/docs/ai-engineering/skills-store), the [`.claude` folder](https://github.com/PostHog/posthog.com/tree/master/.claude) in our website repo, and the company [handbook](/handbook).
 
 ![Linear vs exponential growth comic](https://res.cloudinary.com/dmukukwp6/image/upload/linear_vs_exponential_comic_906763385b.webp)
 <Caption>We're wired to expect progress in straight lines, but build mode is exponential.</Caption>

--- a/contents/docs/ai-engineering/skills-store.mdx
+++ b/contents/docs/ai-engineering/skills-store.mdx
@@ -4,7 +4,7 @@ title: Using the PostHog skills store
 
 Your team's coding agents (Claude Code, Cursor, Codex, Windsurf, and others) all support [MCP](/docs/model-context-protocol). PostHog's skills store gives you a centralized, versioned place to store and share reusable agent skills — following the [Agent Skills specification](https://agentskills.io/specification) — across any tool, for any team member.
 
-> **Shortcut: install the PostHog AI plugin.** The [PostHog AI plugin](https://github.com/PostHog/ai-plugin) ships an official [`skills-store` skill](https://github.com/PostHog/ai-plugin/tree/main/skills/skills-store) — maintained alongside the [canonical version in the PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/ai_observability/skills/skills-store) — that teaches your agent exactly how to discover, load, create, and update skills via the PostHog MCP tools. Install the plugin in [Claude Code](/docs/model-context-protocol/claude-code), [Codex](/docs/model-context-protocol/codex), Cursor, or Gemini CLI and your agent already knows how to use the store. The rest of this guide covers the same concepts in case you want to understand what's happening under the hood or roll your own bridge.
+> **Shortcut: install the PostHog AI plugin.** The [PostHog AI plugin](https://github.com/PostHog/ai-plugin) ships an official [`skills-store` skill](https://github.com/PostHog/ai-plugin/tree/main/skills/skills-store) — maintained alongside the [canonical version in the PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/skills/skills/skills-store) — that teaches your agent exactly how to discover, load, create, and update skills via the PostHog MCP tools. Install the plugin in [Claude Code](/docs/model-context-protocol/claude-code), [Codex](/docs/model-context-protocol/codex), Cursor, or Gemini CLI and your agent already knows how to use the store. The rest of this guide covers the same concepts in case you want to understand what's happening under the hood or roll your own bridge.
 
 ## Why use PostHog as your skills store?
 
@@ -38,7 +38,7 @@ Agents use these with progressive disclosure: discover by description, fetch the
 
 ## Prerequisites
 
-- A PostHog account with Prompt Management enabled
+- A PostHog account
 - The [PostHog MCP server](/docs/model-context-protocol) configured in your coding agent
 
 ## Step 1: Create a skill

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2905,6 +2905,10 @@ export const docsMenu = {
                             ],
                         },
                         {
+                            name: 'Skills store',
+                            url: '/docs/ai-engineering/skills-store',
+                        },
+                        {
                             name: 'AI Observability ↗',
                             url: 'https://posthog.com/docs/ai-observability',
                         },
@@ -5962,10 +5966,6 @@ export const docsMenu = {
                         {
                             name: 'Overview',
                             url: '/docs/prompt-management',
-                        },
-                        {
-                            name: 'Skills store',
-                            url: '/docs/prompt-management/skills-store',
                         },
                         {
                             name: 'A/B testing prompts',

--- a/vercel.json
+++ b/vercel.json
@@ -56,6 +56,7 @@
         { "source": "/posts/:path*", "destination": "/posts/[slug]/index.html" }
     ],
     "redirects": [
+        { "source": "/docs/prompt-management/skills-store", "destination": "/docs/ai-engineering/skills-store", "statusCode": 301 },
         { "source": "/docs/site-apps", "destination": "/docs/js-snippets" },
         { "source": "/docs/site-apps/:path*", "destination": "/docs/js-snippets/:path*" },
         { "source": "/code/download", "destination": "/code#download" },
@@ -1880,7 +1881,7 @@
         },
         {
             "source": "/docs/llm-analytics/skills-store",
-            "destination": "/docs/prompt-management/skills-store"
+            "destination": "/docs/ai-engineering/skills-store"
         },
         {
             "source": "/docs/llm-analytics/:path*",


### PR DESCRIPTION
## Changes

The Skills product recently moved out of the **AI observability** section in the PostHog app and is now a standalone product (top-level `/skills` route in the Tools category). This updates the docs to match.

- **Relocated** the skills store doc from `/docs/prompt-management/skills-store` → `/docs/ai-engineering/skills-store`, and moved its nav entry out of *AI Observability → Prompt management* into the *AI engineering* group (alongside MCP), since the skills store is fundamentally an MCP-powered agent feature.
- **Added a 301 redirect** in `vercel.json` for the old URL, and repointed the existing `/docs/llm-analytics/skills-store` redirect at the new destination (avoids a redirect chain).
- **Fixed a stale link**: the doc linked the canonical skills-store skill at `products/ai_observability/skills/skills-store`, which moved with the product to `products/skills/skills/skills-store`.
- **Dropped the inaccurate prerequisite** "A PostHog account with Prompt Management enabled" — Skills is now its own product.
- **Updated the inbound link** in the *everything is build mode* blog post.

*No visual/UI changes — content + nav + redirects only.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09UQMJJX6K/p1781790412750919?thread_ts=1781790412.750919&cid=C09UQMJJX6K)*