### PR TITLE
docs: fix SDK public API snippets

### DIFF
--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -109,7 +109,7 @@ PostHogSDK.shared.capture("user_signed_up")
 // the `$groups` property to any event you want to associate with
 // the group.
 PostHogSDK.shared.capture(
-    event: "user_signed_up",
+    "user_signed_up",
     properties: [
         "$groups": [
             "company": "company_id_in_your_db"

--- a/contents/docs/_snippets/how-to-link-events-to-groups.mdx
+++ b/contents/docs/_snippets/how-to-link-events-to-groups.mdx
@@ -34,8 +34,8 @@ posthog.capture('user_signed_up')
 ```python
 # ❌ Not possible
 posthog.capture(
-    'user_distinct_id',
     'user_signed_up',
+    distinct_id='user_distinct_id',
     groups={
         'company': 'company_id_in_your_db',
         'company': 'another_company_id_in_your_db'
@@ -44,8 +44,8 @@ posthog.capture(
 
 # ✅ Allowed
 posthog.capture(
-    'user_distinct_id',
     'user_signed_up',
+    distinct_id='user_distinct_id',
     groups={
         'company': 'company_id_in_your_db',
         'channel': 'channel_id_in_your_db'

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -74,7 +74,7 @@ PostHog::groupIdentify([
 PostHogSDK.shared.group(
     type: "company", 
     key: "company_id_in_your_db",
-    properties: [
+    groupProperties: [
         "name": "PostHog",
         "subscription": "subscription",
         "date_joined": "2020-01-23"
@@ -84,7 +84,7 @@ PostHogSDK.shared.group(
 // Option 2: Set properties using capture
 // This method doesn't have the side-effect of associating the session's events to the group
 PostHogSDK.shared.capture(
-    event: "$groupidentify",
+    "$groupidentify",
     properties: [
         "$group_type": "company",
         "$group_key": "company_id_in_your_db",

--- a/contents/docs/ai-observability/installation/openclaw.mdx
+++ b/contents/docs/ai-observability/installation/openclaw.mdx
@@ -43,7 +43,7 @@ tableOfContents: [
 
 You need:
 
-- A running [OpenClaw](https://github.com/openclaw/openclaw) gateway (Node.js >= 22)
+- A running [OpenClaw](https://github.com/openclaw/openclaw) gateway (the PostHog plugin supports Node.js >= 20)
 - A [PostHog account](https://us.posthog.com/signup) with a project API key
 
 ## Install the PostHog plugin

--- a/contents/docs/ai-observability/installation/pi.mdx
+++ b/contents/docs/ai-observability/installation/pi.mdx
@@ -94,7 +94,7 @@ You can configure the extension with environment variables or a `~/.pi/agent/pos
 | `POSTHOG_TRACE_GROUPING` | `message` | `message`: one trace per user prompt. `session`: group all generations in a session into one trace. |
 | `POSTHOG_SESSION_WINDOW_MINUTES` | `60` | Minutes of inactivity before starting a new session window |
 | `POSTHOG_PROJECT_NAME` | cwd basename | Project name included in all events |
-| `POSTHOG_AGENT_NAME` | project name | Agent name. Defaults to the project name and auto-detects subagent names when available. |
+| `POSTHOG_AGENT_NAME` | agent name | Agent name. Defaults to the project name and auto-detects subagent names when available. |
 | `POSTHOG_TAGS` | _(none)_ | Custom tags added to all events (format: `key1:val1,key2:val2`) |
 | `POSTHOG_MAX_ATTRIBUTE_LENGTH` | `12000` | Max length for serialized tool input/output attributes |
 

--- a/contents/docs/ai-observability/installation/pi.mdx
+++ b/contents/docs/ai-observability/installation/pi.mdx
@@ -83,7 +83,7 @@ After running a few prompts through pi:
 
 ## Configuration options
 
-All configuration is done via environment variables:
+You can configure the extension with environment variables or a `~/.pi/agent/posthog.json` config file. Environment variables take precedence over config file values.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -94,7 +94,7 @@ All configuration is done via environment variables:
 | `POSTHOG_TRACE_GROUPING` | `message` | `message`: one trace per user prompt. `session`: group all generations in a session into one trace. |
 | `POSTHOG_SESSION_WINDOW_MINUTES` | `60` | Minutes of inactivity before starting a new session window |
 | `POSTHOG_PROJECT_NAME` | cwd basename | Project name included in all events |
-| `POSTHOG_AGENT_NAME` | agent name | Agent name (auto-detects subagent names) |
+| `POSTHOG_AGENT_NAME` | project name | Agent name. Defaults to the project name and auto-detects subagent names when available. |
 | `POSTHOG_TAGS` | _(none)_ | Custom tags added to all events (format: `key1:val1,key2:val2`) |
 | `POSTHOG_MAX_ATTRIBUTE_LENGTH` | `12000` | Max length for serialized tool input/output attributes |
 

--- a/contents/docs/experiments/running-experiments-without-feature-flags.mdx
+++ b/contents/docs/experiments/running-experiments-without-feature-flags.mdx
@@ -106,18 +106,18 @@ variant = your_flag_system.get_variant('new-checkout-flow')
 
 # Send exposure event
 posthog.capture(
-    'user_id',
     '$pageview',
-    {
+    distinct_id='user_id',
+    properties={
         '$feature/new-checkout-flow': variant
     }
 )
 
 # Later, send metric events
 posthog.capture(
-    'user_id',
     'purchase_completed',
-    {
+    distinct_id='user_id',
+    properties={
         '$feature/new-checkout-flow': variant,
         'revenue': 99.99
     }

--- a/contents/docs/feature-flags/bootstrapping.mdx
+++ b/contents/docs/feature-flags/bootstrapping.mdx
@@ -148,7 +148,7 @@ Bootstrapped feature flag values are temporary and are disregarded after PostHog
 <MultiLanguage selector="tabs">
 
 ```node
-posthog.overrideFeatureFlag('my-feature-flag', true)
+posthog.overrideFeatureFlags({ 'my-feature-flag': true })
 ```
 
 ```js-web

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -116,7 +116,7 @@ Search your codebase for the flag key as a string. Common SDK patterns:
 | Python | `posthog.evaluate_flags(...)` followed by `flags.is_enabled('key')` or `flags.get_flag('key')`, plus older `posthog.feature_enabled('key')` and `posthog.get_feature_flag('key')` calls |
 | Node | `evaluateFlags(...)` followed by `flags.isEnabled('key')` or `flags.getFlag('key')`, plus older `isFeatureEnabled('key')` and `getFeatureFlag('key')` calls |
 | Ruby | `evaluate_flags(...)` followed by `flags.enabled?('key')` or `flags.get_flag('key')`, plus older `is_feature_enabled('key')` and `get_feature_flag('key')` calls |
-| Go | `EvaluateFlags(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabled("key")` and `GetFeatureFlag("key")` calls |
+| Go | `EvaluateFlags(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabled(posthog.FeatureFlagPayload{Key: "key", ...})` and `GetFeatureFlag(posthog.FeatureFlagPayload{Key: "key", ...})` calls |
 | Java | `evaluateFlags(...)` followed by `flags.isEnabled("key")` or `flags.getFlag("key")`, plus older `isFeatureEnabled("key")` and `getFeatureFlag("key")` calls |
 | .NET | `EvaluateFlagsAsync(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabledAsync("key")` and `GetFeatureFlagAsync("key")` calls |
 | Rust | `evaluate_flags(...)` followed by `flags.is_enabled("key")` or `flags.get_flag("key")`, plus older `is_feature_enabled("key")` and `get_feature_flag("key")` calls |

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -116,7 +116,7 @@ Search your codebase for the flag key as a string. Common SDK patterns:
 | Python | `posthog.evaluate_flags(...)` followed by `flags.is_enabled('key')` or `flags.get_flag('key')`, plus older `posthog.feature_enabled('key')` and `posthog.get_feature_flag('key')` calls |
 | Node | `evaluateFlags(...)` followed by `flags.isEnabled('key')` or `flags.getFlag('key')`, plus older `isFeatureEnabled('key')` and `getFeatureFlag('key')` calls |
 | Ruby | `evaluate_flags(...)` followed by `flags.enabled?('key')` or `flags.get_flag('key')`, plus older `is_feature_enabled('key')` and `get_feature_flag('key')` calls |
-| Go | `EvaluateFlags(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabled(posthog.FeatureFlagPayload{Key: "key", ...})` and `GetFeatureFlag(posthog.FeatureFlagPayload{Key: "key", ...})` calls |
+| Go | `EvaluateFlags(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabled(...)` and `GetFeatureFlag(...)` calls |
 | Java | `evaluateFlags(...)` followed by `flags.isEnabled("key")` or `flags.getFlag("key")`, plus older `isFeatureEnabled("key")` and `getFeatureFlag("key")` calls |
 | .NET | `EvaluateFlagsAsync(...)` followed by `flags.IsEnabled("key")` or `flags.GetFlag("key")`, plus older `IsFeatureEnabledAsync("key")` and `GetFeatureFlagAsync("key")` calls |
 | Rust | `evaluate_flags(...)` followed by `flags.is_enabled("key")` or `flags.get_flag("key")`, plus older `is_feature_enabled("key")` and `get_feature_flag("key")` calls |

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -78,11 +78,11 @@ Surveys rely on feature flags internally. Using `advanced_disable_feature_flags`
 
 ## Reducing local evaluation costs
 
-If you're using [local evaluation](/docs/feature-flags/local-evaluation), your bill may be high because of too many requests to fetch feature flag definitions. By default, PostHog fetches these every 30 seconds.
+If you're using [local evaluation](/docs/feature-flags/local-evaluation), your bill may be high because of too many requests to fetch feature flag definitions. By default, most SDKs fetch these every 30 seconds.
 
-Each request charges 10 credits, so assuming your server is constantly running and making 2 requests per minute (the default setting), this will charge `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
+Each request charges 10 credits, so assuming your server is constantly running and making 2 requests per minute, this will charge `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
 
-You can reduce this by increasing the [feature flag polling interval](/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-personal-api-key) when initializing PostHog. For example, every 5 minutes instead of every 30 seconds.
+You can reduce this by increasing the [feature flag polling interval](/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-personal-api-key) when initializing PostHog in SDKs that expose a polling interval option. For example, every 5 minutes instead of every 30 seconds.
 
 The drawback of this approach is that whenever you make an update to a feature flag using the PostHog UI, it takes 5 minutes (instead of 30 seconds) for that change to roll to your server.
 
@@ -189,10 +189,9 @@ if isTestEnv {
 
 PostHogSDK.shared.setup(config)
 
-// Override flags locally if needed
-if isTestEnv {
-    PostHogSDK.shared.overrideFeatureFlag("your-flag", value: true)
-}
+// The iOS SDK doesn't support local feature flag overrides.
+// If tests need deterministic values, wrap your own flag reads in test code
+// or use a separate PostHog project/environment with fixed flag rules.
 ```
 
 ```dart
@@ -218,10 +217,12 @@ await Posthog().setup(config);
 ```
 
 ```react-native
+import PostHog from 'posthog-react-native'
+
 // Detect test/CI environment
 const isTestEnv = process.env.NODE_ENV === 'test' || process.env.CI === 'true'
 
-const posthog = await Posthog.initAsync('<ph_project_token>', {
+const posthog = new PostHog('<ph_project_token>', {
     host: '<ph_client_api_host>',
     ...(isTestEnv && {
         preloadFeatureFlags: false,
@@ -233,7 +234,7 @@ const posthog = await Posthog.initAsync('<ph_project_token>', {
 
 // Override flags locally if needed
 if (isTestEnv) {
-    posthog.overrideFeatureFlag('your-flag', true)
+    posthog.updateFlags({ 'your-flag': true })
 }
 ```
 

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -78,11 +78,11 @@ Surveys rely on feature flags internally. Using `advanced_disable_feature_flags`
 
 ## Reducing local evaluation costs
 
-If you're using [local evaluation](/docs/feature-flags/local-evaluation), your bill may be high because of too many requests to fetch feature flag definitions. By default, most SDKs fetch these every 30 seconds.
+If you're using [local evaluation](/docs/feature-flags/local-evaluation), your bill may be high because of too many requests to fetch feature flag definitions. By default, PostHog fetches these every 30 seconds.
 
-Each request charges 10 credits, so assuming your server is constantly running and making 2 requests per minute, this will charge `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
+Each request charges 10 credits, so assuming your server is constantly running and making 2 requests per minute (the default setting), this will charge `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
 
-You can reduce this by increasing the [feature flag polling interval](/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-personal-api-key) when initializing PostHog in SDKs that expose a polling interval option. For example, every 5 minutes instead of every 30 seconds.
+You can reduce this by increasing the [feature flag polling interval](/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-personal-api-key) when initializing PostHog. For example, every 5 minutes instead of every 30 seconds.
 
 The drawback of this approach is that whenever you make an update to a feature flag using the PostHog UI, it takes 5 minutes (instead of 30 seconds) for that change to roll to your server.
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -10,7 +10,7 @@ availability:
 
 > **Note:** Local evaluation is only available in the [Node](/docs/libraries/node), [Ruby](/docs/libraries/ruby), [Go](/docs/libraries/go), [Python](/docs/libraries/python), [C#/.NET](/docs/libraries/dotnet), [PHP](/docs/libraries/php), [Java](/docs/libraries/java), and [Rust](/docs/libraries/rust) SDKs.
 
-> **Note:** In edge/lambda environments, local evaluation with the default in-memory cache causes performance issues and inflated costs due to per-request initialization. For these environments, use an [external cache provider](/docs/feature-flags/local-evaluation/distributed-environments) to share flag definitions across requests, or use regular flag evaluation instead.
+> **Note:** In edge/lambda environments and stateless PHP applications, local evaluation with the default in-memory cache causes performance issues and inflated costs due to per-request initialization. For these environments, use an [external cache provider](/docs/feature-flags/local-evaluation/distributed-environments) to share flag definitions across requests, or use regular flag evaluation instead.
 
 Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -10,9 +10,9 @@ availability:
 
 > **Note:** Local evaluation is only available in the [Node](/docs/libraries/node), [Ruby](/docs/libraries/ruby), [Go](/docs/libraries/go), [Python](/docs/libraries/python), [C#/.NET](/docs/libraries/dotnet), [PHP](/docs/libraries/php), [Java](/docs/libraries/java), and [Rust](/docs/libraries/rust) SDKs.
 
-> **Note:** In edge/lambda environments, local evaluation with the default in-memory cache causes performance issues and inflated costs due to per-request initialization. For SDKs that support it, use an [external cache provider](/docs/feature-flags/local-evaluation/distributed-environments) to share flag definitions across requests, or use regular flag evaluation instead. PHP doesn't currently expose an external flag definition cache provider.
+> **Note:** In edge/lambda environments, local evaluation with the default in-memory cache causes performance issues and inflated costs due to per-request initialization. For these environments, use an [external cache provider](/docs/feature-flags/local-evaluation/distributed-environments) to share flag definitions across requests, or use regular flag evaluation instead.
 
-Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog stores feature flag definitions locally, enabling you to evaluate flags without making additional requests. Most SDKs refresh these definitions periodically; PHP loads them during initialization and when you manually call `loadFlags()`.
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
 
 It is best practice to use local evaluation flags when possible, since this enables you to resolve flags faster and with fewer API calls.
 
@@ -36,14 +36,14 @@ sequenceDiagram
 
 Every flag check is a network round trip. PostHog already has all the data it needs, so you just pass the flag key and a user ID.
 
-With local evaluation, the SDK fetches **flag definitions** from PostHog's `/flags/definitions` endpoint and stores them locally. Most SDKs periodically refresh them in the background. When you check a flag, **you provide the properties** and the SDK evaluates locally — no round trip:
+With local evaluation, the SDK periodically fetches **flag definitions** from PostHog's `/flags/definitions` endpoint in the background. When you check a flag, **you provide the properties** and the SDK evaluates locally — no round trip:
 
 ```mermaid
 sequenceDiagram
     participant App as Your app
     participant SDK as PostHog SDK
     participant PH as PostHog
-    Note over SDK,PH: Background refresh (most SDKs)
+    Note over SDK,PH: Background (every 30s)
     SDK->>PH: GET /flags/definitions
     PH-->>SDK: Flag definitions
     Note over App,SDK: At evaluation time
@@ -68,7 +68,7 @@ import ObtainFeatureFlagsSecureAPIKey from "../../integrate/_snippets/obtain-fla
 
 When you initialize PostHog with your feature flags secure API key, PostHog will use the key to automatically fetch feature flag definitions. These definitions are then used to evaluate feature flags locally.
 
-By default, most SDKs fetch these definitions every 30 seconds (or 5 minutes in the Go SDK). However, you can change this frequency in SDKs that expose a polling interval option. PHP loads definitions on initialization and when you call `loadFlags()` manually.
+By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in the Go SDK). However, you can change this frequency by specifying a different value in the polling interval argument.
 
 > **Note:** For billing purposes, we count the request to fetch the feature flag definitions as being equivalent to `10 flags` requests.
 >
@@ -82,13 +82,13 @@ import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-s
 
 To evaluate the feature flag, call the flag evaluation method for your SDK. In server-side APIs, evaluate flags once and read values from the returned snapshot. The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
 
-Then, by default, PostHog attempts to evaluate the flag locally using cached definitions. If this fails, PostHog then makes a server request to fetch the flag value.
+Then, by default, PostHog attempts to evaluate the flag locally using definitions it loads on initialization and at the `poll interval`. If this fails, PostHog then makes a server request to fetch the flag value.
 
-You can disable this behavior by setting `onlyEvaluateLocally` to `true`. In this case, PostHog will **only** attempt to evaluate the flag locally, and return the SDK's empty value (`undefined`, `None`, `nil`, or `null`) if it was unable to.
+You can disable this behavior by setting `onlyEvaluateLocally` to `true`. In this case, PostHog will **only** attempt to evaluate the flag locally, and return `undefined` / `None` / `nil` if it was unable to.
 
 ### Cold start and fallback defaults
 
-When most SDKs first start, they need up to one polling interval (30 seconds by default) to fetch flag definitions. During this window, local evaluation returns the SDK's empty value because no definitions are loaded yet. Use per-flag defaults to control what users see during this period:
+When the SDK first starts, it needs up to one polling interval (30 seconds by default) to fetch flag definitions. During this window, local evaluation returns `undefined` / `None` because no definitions are loaded yet. Use per-flag defaults to control what users see during this period:
 
 ```javascript
 // Without a default, undefined is falsy — users see nothing

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -10,9 +10,9 @@ availability:
 
 > **Note:** Local evaluation is only available in the [Node](/docs/libraries/node), [Ruby](/docs/libraries/ruby), [Go](/docs/libraries/go), [Python](/docs/libraries/python), [C#/.NET](/docs/libraries/dotnet), [PHP](/docs/libraries/php), [Java](/docs/libraries/java), and [Rust](/docs/libraries/rust) SDKs.
 
-> **Note:** In edge/lambda environments and stateless PHP applications, local evaluation with the default in-memory cache causes performance issues and inflated costs due to per-request initialization. For these environments, use an [external cache provider](/docs/feature-flags/local-evaluation/distributed-environments) to share flag definitions across requests, or use regular flag evaluation instead.
+> **Note:** In edge/lambda environments, local evaluation with the default in-memory cache causes performance issues and inflated costs due to per-request initialization. For SDKs that support it, use an [external cache provider](/docs/feature-flags/local-evaluation/distributed-environments) to share flag definitions across requests, or use regular flag evaluation instead. PHP doesn't currently expose an external flag definition cache provider.
 
-Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog stores feature flag definitions locally, enabling you to evaluate flags without making additional requests. Most SDKs refresh these definitions periodically; PHP loads them during initialization and when you manually call `loadFlags()`.
 
 It is best practice to use local evaluation flags when possible, since this enables you to resolve flags faster and with fewer API calls.
 
@@ -36,14 +36,14 @@ sequenceDiagram
 
 Every flag check is a network round trip. PostHog already has all the data it needs, so you just pass the flag key and a user ID.
 
-With local evaluation, the SDK periodically fetches **flag definitions** from PostHog's `/flags/definitions` endpoint in the background. When you check a flag, **you provide the properties** and the SDK evaluates locally — no round trip:
+With local evaluation, the SDK fetches **flag definitions** from PostHog's `/flags/definitions` endpoint and stores them locally. Most SDKs periodically refresh them in the background. When you check a flag, **you provide the properties** and the SDK evaluates locally — no round trip:
 
 ```mermaid
 sequenceDiagram
     participant App as Your app
     participant SDK as PostHog SDK
     participant PH as PostHog
-    Note over SDK,PH: Background (every 30s)
+    Note over SDK,PH: Background refresh (most SDKs)
     SDK->>PH: GET /flags/definitions
     PH-->>SDK: Flag definitions
     Note over App,SDK: At evaluation time
@@ -68,7 +68,7 @@ import ObtainFeatureFlagsSecureAPIKey from "../../integrate/_snippets/obtain-fla
 
 When you initialize PostHog with your feature flags secure API key, PostHog will use the key to automatically fetch feature flag definitions. These definitions are then used to evaluate feature flags locally.
 
-By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in the Go SDK). However, you can change this frequency by specifying a different value in the polling interval argument.
+By default, most SDKs fetch these definitions every 30 seconds (or 5 minutes in the Go SDK). However, you can change this frequency in SDKs that expose a polling interval option. PHP loads definitions on initialization and when you call `loadFlags()` manually.
 
 > **Note:** For billing purposes, we count the request to fetch the feature flag definitions as being equivalent to `10 flags` requests.
 >
@@ -82,13 +82,13 @@ import ConfigureFlagsSecureKey from "../../integrate/_snippets/configure-flags-s
 
 To evaluate the feature flag, call the flag evaluation method for your SDK. In server-side APIs, evaluate flags once and read values from the returned snapshot. The only difference is that you must provide any `person properties`, `groups`, or `group properties` used to evaluate the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) of the flag.
 
-Then, by default, PostHog attempts to evaluate the flag locally using definitions it loads on initialization and at the `poll interval`. If this fails, PostHog then makes a server request to fetch the flag value.
+Then, by default, PostHog attempts to evaluate the flag locally using cached definitions. If this fails, PostHog then makes a server request to fetch the flag value.
 
-You can disable this behavior by setting `onlyEvaluateLocally` to `true`. In this case, PostHog will **only** attempt to evaluate the flag locally, and return `undefined` / `None` / `nil` if it was unable to.
+You can disable this behavior by setting `onlyEvaluateLocally` to `true`. In this case, PostHog will **only** attempt to evaluate the flag locally, and return the SDK's empty value (`undefined`, `None`, `nil`, or `null`) if it was unable to.
 
 ### Cold start and fallback defaults
 
-When the SDK first starts, it needs up to one polling interval (30 seconds by default) to fetch flag definitions. During this window, local evaluation returns `undefined` / `None` because no definitions are loaded yet. Use per-flag defaults to control what users see during this period:
+When most SDKs first start, they need up to one polling interval (30 seconds by default) to fetch flag definitions. During this window, local evaluation returns the SDK's empty value because no definitions are loaded yet. Use per-flag defaults to control what users see during this period:
 
 ```javascript
 // Without a default, undefined is falsy — users see nothing

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -238,7 +238,7 @@ Mobile SDKs (React Native, iOS, Android, and Flutter) include common device and 
 | `$app_version` | App version from bundle/package info |
 | `$app_build` | App build number |
 | `$app_namespace` | App bundle identifier/namespace |
-| `$os` | Operating system name ("macOS", "iOS", "iPadOS", "tvOS", "watchOS", "visionOS", "Android") |
+| `$os_name` | Operating system name ("macOS", "iOS", "iPadOS", "tvOS", "watchOS", "visionOS", "Android") |
 | `$os_version` | Operating system version |
 | `$device_type` | Device type ("Mobile", "Tablet", "TV", "CarPlay", "Desktop", "Vision") |
 | `$lib` | SDK identifier (e.g., "posthog-ios") |

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -238,7 +238,7 @@ Mobile SDKs (React Native, iOS, Android, and Flutter) include common device and 
 | `$app_version` | App version from bundle/package info |
 | `$app_build` | App build number |
 | `$app_namespace` | App bundle identifier/namespace |
-| `$os_name` | Operating system name ("macOS", "iOS", "iPadOS", "tvOS", "watchOS", "visionOS", "Android") |
+| `$os` / `$os_name` | Operating system name ("macOS", "iOS", "iPadOS", "tvOS", "watchOS", "visionOS", "Android") |
 | `$os_version` | Operating system version |
 | `$device_type` | Device type ("Mobile", "Tablet", "TV", "CarPlay", "Desktop", "Vision") |
 | `$lib` | SDK identifier (e.g., "posthog-ios") |

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -44,13 +44,13 @@ config = posthog.get_remote_config_payload('landing-page-config')
 ```
 
 ```go
-config, err := posthog.GetRemoteConfigPayload("landing-page-config")
+config, err := client.GetRemoteConfigPayload("landing-page-config")
 // config is a JSON encoded string. It will need to be parsed as a JSON object.
 ```
 
 ```ruby
 config = posthog.get_remote_config_payload('landing-page-config')
-# config is a JSON encoded string. It will need to be parsed as a JSON object.
+# config is returned as a parsed object.
 ```
 
 ```csharp

--- a/contents/docs/feature-flags/snippets/groups-ingestion-python.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-python.mdx
@@ -2,7 +2,7 @@ Update [posthog-python](/docs/integrate/server/python) to version 1.4.3 or above
 
 ```python
 # Capturing an event with groups
-posthog.capture('user_distinct_id', 'some_event', groups={'company': 'id:5'})
+posthog.capture('some_event', distinct_id='user_distinct_id', groups={'company': 'id:5'})
 
 # Updating group properties
 posthog.group_identify('company', 'id:5', {

--- a/contents/docs/getting-started/_snippets/identify-user-backend.mdx
+++ b/contents/docs/getting-started/_snippets/identify-user-backend.mdx
@@ -11,9 +11,9 @@ client.identify({
 ```
 
 ```python
-posthog.identify(
-    'distinct_id',
-    {
+posthog.set(
+    distinct_id='distinct_id',
+    properties={
         'name': 'Max Hedgehog',
         'email': 'max@hedgehogmail.com'
     }

--- a/contents/docs/getting-started/_snippets/send-event-backend.mdx
+++ b/contents/docs/getting-started/_snippets/send-event-backend.mdx
@@ -14,9 +14,9 @@ client.capture({
 
 ```python
 posthog.capture(
-    'distinct_id',
     'order_created',
-    {
+    distinct_id='distinct_id',
+    properties={
         'order_id': '#0054',
         'subtotal': 3599,
         'customer_name': 'Max Hedgehog',

--- a/contents/docs/getting-started/_snippets/set-person-properties.mdx
+++ b/contents/docs/getting-started/_snippets/set-person-properties.mdx
@@ -17,9 +17,9 @@ client.identify({
 
 ```python
 posthog.capture(
-  'distinct_id',
   'order_created',
-  {
+  distinct_id='distinct_id',
+  properties={
       'order_id': '#0054',
       'subtotal': 3599,
       'customer_name': 'Max Hedgehog',

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -92,7 +92,7 @@ PostHogInterface posthog = PostHog.with(config);
 use posthog_rs::ClientOptionsBuilder;
 
 let options = ClientOptionsBuilder::default()
-    .api_key("<ph_project_token>".to_string())
+    .api_key("<ph_project_token>")
     .personal_api_key("your feature flags secure API key from step 1")
     .enable_local_evaluation(true)
     .poll_interval_seconds(30) // Optional. Measured in seconds. Defaults to 30.

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -92,7 +92,7 @@ PostHogInterface posthog = PostHog.with(config);
 use posthog_rs::ClientOptionsBuilder;
 
 let options = ClientOptionsBuilder::default()
-    .api_key("<ph_project_token>")
+    .api_key("<ph_project_token>".to_string())
     .personal_api_key("your feature flags secure API key from step 1")
     .enable_local_evaluation(true)
     .poll_interval_seconds(30) // Optional. Measured in seconds. Defaults to 30.

--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -22,7 +22,7 @@ config :posthog,
 
 You can see all the available configuration options in the [PostHog.Config](https://hexdocs.pm/posthog/PostHog.Config.html) module.
 
-Optionally, you might want to enable the [Plug integration](https://hexdocs.pm/posthog/PostHog.Integrations.Plug.html) to automatically capture events from your Plug-based applications including Phoenix.
+Optionally, you might want to enable the [Plug integration](https://hexdocs.pm/posthog/PostHog.Integrations.Plug.html) to attach request metadata and tracing context in Plug-based applications including Phoenix. You still need to capture events explicitly with `PostHog.capture/2` or `PostHog.capture/3`.
 
 
 #### Development/Test mode

--- a/contents/docs/integrate/_snippets/install-rust.mdx
+++ b/contents/docs/integrate/_snippets/install-rust.mdx
@@ -2,13 +2,13 @@ Install the `posthog-rs` crate by adding it to your `Cargo.toml`.
 
 ```toml file=Cargo.toml
 [dependencies]
-posthog-rs = "0.3.5"
+posthog-rs = "0.13.1"
 ```
 
 Next, set up the client with your PostHog project key.
 
 ```rust
-let client = posthog_rs::client(env!("<ph_project_token>"));
+let client = posthog_rs::client("<ph_project_token>").await;
 ```
 
 ### Blocking client
@@ -19,7 +19,7 @@ If you need to use a synchronous client instead – like we do in our [CLI](http
 
 ```toml
 [dependencies]
-posthog-rs = { version = "0.3.5", default-features = false }
+posthog-rs = { version = "0.13.1", default-features = false }
 ```
 
 In blocking mode, calls to `capture` and related methods will block until the PostHog event capture API returns – generally this is on the order of tens of milliseconds, but you may want to `thread::spawn` a background thread when you send an event.

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-elixir.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-elixir.mdx
@@ -62,7 +62,7 @@ To reduce event property bloat, put a filtered snapshot in context:
 ```elixir
 {:ok, snapshot} = PostHog.FeatureFlags.evaluate_flags("distinct_id_of_your_user")
 
-# Attach only flags accessed with enabled?/2, get_flag/2, or get_flag_payload/2 before this call
+# Attach only flags accessed with enabled?/2 or get_flag/2 before this call
 PostHog.FeatureFlags.Evaluations.enabled?(snapshot, "flag-key")
 PostHog.FeatureFlags.set_in_context(
   PostHog.FeatureFlags.Evaluations.only_accessed(snapshot)
@@ -74,7 +74,7 @@ PostHog.FeatureFlags.set_in_context(
 )
 ```
 
-`only_accessed/1` is order-dependent. If you call it before accessing any flags with `enabled?/2`, `get_flag/2`, or `get_flag_payload/2`, no feature flag properties are attached.
+`only_accessed/1` is order-dependent. If you call it before accessing any flags with `enabled?/2` or `get_flag/2`, no feature flag properties are attached.
 
 #### Method 2: Include the `$feature/feature_flag_name` property manually
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go-set-send-feature-flags-to-true.mdx
@@ -8,7 +8,7 @@ Setting `SendFeatureFlags` to `true` will include feature flag information with 
 client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id_of_your_user",
   Event:      "event_name",
-  SendFeatureFlags: true,
+  SendFeatureFlags: posthog.SendFeatureFlags(true),
 })
 ```
 
@@ -20,12 +20,12 @@ As of version 1.6.1, `SendFeatureFlags` can also accept a `SendFeatureFlagsOptio
 client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id_of_your_user",
   Event:      "event_name",
-  SendFeatureFlags: posthog.SendFeatureFlagsOptions{
+  SendFeatureFlags: &posthog.SendFeatureFlagsOptions{
     OnlyEvaluateLocally: true,
-    PersonProperties: map[string]interface{}{
+    PersonProperties: posthog.Properties{
       "plan": "premium",
     },
-    GroupProperties: map[string]map[string]interface{}{
+    GroupProperties: map[string]posthog.Properties{
       "org": {
         "tier": "enterprise",
       },
@@ -36,7 +36,7 @@ client.Enqueue(posthog.Capture{
 
 #### Performance considerations
 
-- **With local evaluation**: When [local evaluation](/docs/feature-flags/local-evaluation) is configured, setting `SendFeatureFlags: true` will **not** make additional server requests. Instead, it uses the locally cached feature flags, and it provides an interface for including person and/or group properties needed to evaluate the flags in the context of the event, if required.
+- **With local evaluation**: When [local evaluation](/docs/feature-flags/local-evaluation) is configured, setting `SendFeatureFlags: posthog.SendFeatureFlags(true)` will **not** make additional server requests. Instead, it uses the locally cached feature flags, and it provides an interface for including person and/or group properties needed to evaluate the flags in the context of the event, if required.
 
 - **Without local evaluation**: PostHog will make an additional request to fetch feature flag information before capturing the event, which adds delay.
 
@@ -44,4 +44,4 @@ client.Enqueue(posthog.Capture{
 
 Prior to version 1.6.1, feature flags were automatically sent with events when using local evaluation, even when `SendFeatureFlags` was not explicitly set. This behavior has been **removed** in v1.6.1 to be more predictable and explicit.
 
-If you were relying on this automatic behavior, you must now explicitly set `SendFeatureFlags: true` to continue sending feature flags with your events.
+If you were relying on this automatic behavior, you must now explicitly set `SendFeatureFlags: posthog.SendFeatureFlags(true)` to continue sending feature flags with your events.

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -136,12 +136,14 @@ import GoOverrideServerProperties from './override-server-properties/go.mdx'
 You can configure the `FeatureFlagRequestTimeout` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
 
 ```go
+// import "time"
+
 client, _ := posthog.NewWithConfig(
     os.Getenv("<ph_project_token>"),
     posthog.Config{
         PersonalApiKey:            "your personal API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
         Endpoint:                  "<ph_client_api_host>",
-        FeatureFlagRequestTimeout: 3, // Time in seconds. Defaults to 3.
+        FeatureFlagRequestTimeout: 3 * time.Second, // Defaults to 3 seconds.
     },
 )
 ```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
@@ -118,11 +118,11 @@ import NodeOverrideServerProperties from './override-server-properties/node.mdx'
 
 ### Request timeout
 
-You can configure the `feature_flag_request_timeout_ms` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
+You can configure the `featureFlagsRequestTimeoutMs` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
 
 ```js
 const client = new PostHog('<ph_project_token>', {
-    api_host: '<ph_client_api_host>',
-    feature_flag_request_timeout_ms: 3000, // Time in milliseconds. Defaults to 3000 (3 seconds).
+    host: '<ph_client_api_host>',
+    featureFlagsRequestTimeoutMs: 3000, // Time in milliseconds. Defaults to 3000 (3 seconds).
 })
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-rust.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-rust.mdx
@@ -6,7 +6,7 @@ import Intro from "./intro.mdx"
 
 ```rust
 let mut event = Event::new("user_signed_up", "distinct_id_of_the_user");
-client.capture(event).unwrap();
+client.capture(event).await.unwrap();
 ```
 
 <NamingTip />
@@ -19,16 +19,16 @@ let mut event = Event::new("user_signed_up", "distinct_id_of_the_user");
 event.insert_prop("login_type", "email").unwrap();
 event.insert_prop("is_free_trial", true).unwrap();
 
-client.capture(event).unwrap();
+client.capture(event).await.unwrap();
 ```
 
 ### Batching events
 
-To capture multiple events at once, use `batch()`:
+To capture multiple events at once, use `capture_batch()`:
 
 ```rust
 let event1 = posthog_rs::Event::new("event 1", "distinct_id_of_user_A");
 let event2 = posthog_rs::Event::new("event 2", "distinct_id_of_user_B");
 
-client.capture_batch(vec![event1, event2]).unwrap();
+client.capture_batch(vec![event1, event2], false).await.unwrap();
 ```

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -178,8 +178,8 @@ You can completely opt-out users from data capture. To do this, there are two op
 
 ```kotlin
 val config = PostHogAndroidConfig(
-    apiKey = <ph_project_token>,
-    host = <ph_client_api_host> 
+    apiKey = "<ph_project_token>",
+    host = "<ph_client_api_host>"
 )
 config.optOut = true
 PostHogAndroid.setup(this, config)
@@ -403,7 +403,7 @@ val config = PostHogAndroidConfig(
 | `getAnonymousId` | generated UUID | Optional hook to customize anonymous ID generation. |
 | `reuseAnonymousId` | `false` | Reuses one anonymous ID across user changes on the same device. |
 | `personProfiles` | `PersonProfiles.IDENTIFIED_ONLY` | Controls when person profiles are processed: `IDENTIFIED_ONLY`, `ALWAYS`, or `NEVER`. |
-| `setDefaultPersonProperties` | `true` | Includes default person properties for person profile updates. |
+| `setDefaultPersonProperties` | `true` | Includes default device and app properties in feature flag evaluation requests. |
 | `releaseIdentifier` | app/version fallback | Release identifier used by error tracking and uploaded ProGuard/R8 mappings. The Android Gradle plugin can inject this automatically. |
 | `tracingHeaders` | `null` | Exact hostnames that should receive PostHog tracing headers when using `PostHogOkHttpInterceptor`. |
 

--- a/contents/docs/libraries/ios/configuration.mdx
+++ b/contents/docs/libraries/ios/configuration.mdx
@@ -241,7 +241,7 @@ The [`PostHogConfig` object](https://github.com/PostHog/posthog-ios/blob/main/Po
 | Attribute | Description |
 |-----------|-------------|
 | `flushAt`<br/><br/>**Type:** Integer<br/>**Default:** `20` (`5` on tvOS) | The number of queued events that the posthog client should flush at. Setting this to `1` will not queue any events and will use more battery. |
-| `flushIntervalSeconds`<br/><br/>**Type:** Integer<br/>**Default:** `30` | The amount of time to wait before each tick of the flush timer. Smaller values will make events delivered in a more real-time manner and also use more battery. A value smaller than 10 seconds will seriously degrade overall performance. |
+| `flushIntervalSeconds`<br/><br/>**Type:** TimeInterval<br/>**Default:** `30` | The amount of time to wait before each tick of the flush timer, in seconds. Smaller values will make events delivered in a more real-time manner and also use more battery. A value smaller than 10 seconds will seriously degrade overall performance. |
 | `maxQueueSize`<br/><br/>**Type:** Integer<br/>**Default:** `1000` (`100` on tvOS) | The maximum number of items to queue before starting to drop old ones. This should be a value greater than zero, the behavior is undefined otherwise. |
 | `maxBatchSize`<br/><br/>**Type:** Integer<br/>**Default:** `50` | Number of maximum events in a batch call. |
 | `maxRetries`<br/><br/>**Type:** Integer<br/>**Default:** `3` | Maximum number of consecutive flush attempts before the entire queue is dropped to avoid infinite retries against a permanently-broken backend (e.g. wrong API key, exhausted quota, deterministic 5xx). Increments on every retriable failure including HTTP 413 cap halving; resets on a successful 2xx response. |
@@ -256,7 +256,7 @@ The [`PostHogConfig` object](https://github.com/PostHog/posthog-ios/blob/main/Po
 | `debug`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Logs the SDK messages to the Xcode console. |
 | `optOut`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Prevents capturing any data if enabled. |
 | `getAnonymousId`<br/><br/>**Type:** Function<br/>**Default:** `undefined` | Hook that allows for modification of the default mechanism for generating anonymous id (which as of now is just random UUID v7). |
-| `dataMode`<br/><br/>**Type:** Enum<br/>**Default:** `.any` | Allows to send your data only if the data mode matches your configuration such as wifi only, cellular only or any. |
+| `dataMode`<br/><br/>**Type:** Enum<br/>**Default:** `.any` | Controls when queued data is flushed. Use `.wifi` to flush only on Wi-Fi; `.cellular` is a legacy value and behaves like `.any`. |
 | `personProfiles`<br/><br/>**Type:** Enum<br/>**Default:** `.identifiedOnly` | Determines the behavior for processing user profiles. |
 | `setDefaultPersonProperties`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Automatically set common device and app properties (such as `$app_version`, `$os_name`, and `$device_type`) as person properties for feature flag evaluation. See [property overrides](/docs/feature-flags/property-overrides) for more details. |
 | `sessionReplay`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Enable Recording of Session Replays. |

--- a/contents/docs/libraries/js/usage.mdx
+++ b/contents/docs/libraries/js/usage.mdx
@@ -289,7 +289,7 @@ posthog.getEarlyAccessFeatures((previewItemData) => {
 ```
 
 ```js-web
-posthog.updateEarlyAccessFeatureEnrollment(flagKey, 'true')
+posthog.updateEarlyAccessFeatureEnrollment(flagKey, true)
 ```
 
 ## Surveys

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -258,7 +258,7 @@ All possible options below:
 | `verify_batch_events_request`<br/><br/>**Type:** Boolean<br/>**Default:** `true` | Whether to verify successful delivery of batch events (true, synchronous) or fire and forget (false, asynchronous) with the `lib_curl` consumer. |
 | `feature_flag_request_timeout_ms`<br/><br/>**Type:** Integer<br/>**Default:** `3000` | Request timeout for feature flags in milliseconds. |
 | `maximum_backoff_duration`<br/><br/>**Type:** Integer<br/>**Default:** `10000` | Request retry backoff. Retries stop after this duration is hit. |
-| `consumer`<br/><br/>**Type:** String<br/>**Default:** `lib_curl` | One of `socket`, `file`, `lib_curl`, and `fork_curl`. Determines what transport option to use for analytics capture. |
+| `consumer`<br/><br/>**Type:** String<br/>**Default:** `lib_curl` | One of `socket`, `file`, `lib_curl`, `fork_curl`, and `noop`. Determines what transport option to use for analytics capture. |
 | `debug`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Output debug logs or not. |
 | `max_queue_size`<br/><br/>**Type:** Integer<br/>**Default:** `1000` | Maximum number of events to queue before rejecting new events. Applies to queued consumers. |
 | `batch_size`<br/><br/>**Type:** Integer<br/>**Default:** `100` | Number of queued events to send in each batch. Applies to queued consumers. |

--- a/contents/docs/libraries/python/_snippets/capture.mdx
+++ b/contents/docs/libraries/python/_snippets/capture.mdx
@@ -1,6 +1,6 @@
 ```python
-posthog.capture("distinct_id", "movie_played", {
-  movie_id: "123",
-  category: "romcom",
-});
+posthog.capture("movie_played", distinct_id="distinct_id", properties={
+  "movie_id": "123",
+  "category": "romcom",
+})
 ```

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -305,7 +305,7 @@ def scrub_pii(event: dict[str, Any]) -> dict[str, Any] | None:
 
 
 client = posthog.Client(
-    api_key="<ph_project_api_key>",
+    "<ph_project_api_key>",
     before_send=scrub_pii,
 )
 ```

--- a/contents/docs/libraries/ruby-on-rails.mdx
+++ b/contents/docs/libraries/ruby-on-rails.mdx
@@ -26,7 +26,7 @@ This guide walks you through integrating PostHog into your Rails app using the [
 Add both gems to your Gemfile:
 
 ```ruby file=Gemfile
-gem 'posthog-ruby'
+gem 'posthog-ruby', require: 'posthog'
 gem 'posthog-rails'
 ```
 

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -50,7 +50,7 @@ To enable local evaluation, you need a [personal API key](/docs/api#how-to-obtai
 use posthog_rs::ClientOptionsBuilder;
 
 let options = ClientOptionsBuilder::default()
-    .api_key("your-project-api-key".to_string())
+    .api_key("your-project-api-key")
     .personal_api_key("your-personal-api-key")
     .enable_local_evaluation(true)
     .poll_interval_seconds(30) // Optional, defaults to 30

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -50,7 +50,7 @@ To enable local evaluation, you need a [personal API key](/docs/api#how-to-obtai
 use posthog_rs::ClientOptionsBuilder;
 
 let options = ClientOptionsBuilder::default()
-    .api_key("your-project-api-key")
+    .api_key("your-project-api-key".to_string())
     .personal_api_key("your-personal-api-key")
     .enable_local_evaluation(true)
     .poll_interval_seconds(30) // Optional, defaults to 30

--- a/contents/docs/libraries/unity/index.mdx
+++ b/contents/docs/libraries/unity/index.mdx
@@ -96,7 +96,7 @@ PostHog.Setup(new PostHogConfig
 ```
 
 Available options:
-- `PersonProfiles.IdentifiedOnly` (default) – Only creates person profiles when `Identify` is called
+- `PersonProfiles.IdentifiedOnly` (default) – Only creates person profiles when `IdentifyAsync` is called
 - `PersonProfiles.Always` – Creates person profiles for all events
 - `PersonProfiles.Never` – Never creates person profiles (anonymous events only)
 
@@ -278,22 +278,22 @@ You can manually start and stop session recording:
 
 ```csharp
 // Check if Session Replay is active
-if (PostHog.IsSessionReplayActive)
+if (PostHogSDK.IsSessionReplayActive)
 {
     // Stop recording
-    PostHog.StopSessionReplay();
+    PostHogSDK.StopSessionReplay();
 }
 
 // Start recording (if not already active)
-PostHog.StartSessionReplay();
+PostHogSDK.StartSessionReplay();
 ```
 
 ### Recording network requests
 
-Network requests are automatically captured when `CaptureNetworkTelemetry` is enabled. For custom HTTP clients, you can manually record requests:
+You can manually record request metadata when `CaptureNetworkTelemetry` is enabled:
 
 ```csharp
-PostHog.RecordNetworkRequest(
+PostHogSDK.RecordNetworkRequest(
     url: "https://api.example.com/data",
     method: "GET",
     statusCode: 200,

--- a/contents/docs/libraries/vercel.mdx
+++ b/contents/docs/libraries/vercel.mdx
@@ -43,9 +43,9 @@ Finally, import and add PostHog to your function. We use the `captureImmediate` 
 // app/api/hello/route.js
 import PostHogClient from '../../posthog'
 
-export function GET(request) {
+export async function GET(request) {
   const posthogClient = PostHogClient()
-  posthogClient.captureImmediate({
+  await posthogClient.captureImmediate({
     distinctId: 'ian@posthog.com',
     event: 'vercel_function_called',
     properties: {
@@ -56,7 +56,7 @@ export function GET(request) {
 }
 ```
 
-We use `captureImmediate` because it guarantees the HTTP request finishes before your function continues (or shuts downs). `flushAt` and `flushInterval` mean events are sent immediately, but `capture` is still async and serverless environments can freeze or terminate before it completes.
+We use `captureImmediate` with `await` because it guarantees the HTTP request finishes before your function continues (or shuts downs). `flushAt` and `flushInterval` mean events are sent immediately, but `capture` is still async and serverless environments can freeze or terminate before it completes.
 
 Finally, to ensure all your requests complete you can combine PostHog's `shutdown()` method with Next.js's [`after`](https://nextjs.org/docs/app/api-reference/functions/after) function for Next.js 15.1 and above, or Vercel's [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) helper method for older versions. 
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-backend-and-api.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-backend-and-api.mdx
@@ -14,9 +14,9 @@ client.capture({
 
 ```python
 posthog.capture(
-    "distinct_id_of_the_user", 
-    "your_event_name", 
-    {
+    "your_event_name",
+    distinct_id="distinct_id_of_the_user",
+    properties={
         "$process_person_profile": false
     }
 )
@@ -37,7 +37,7 @@ posthog.capture({
     distinct_id: 'distinct_id_of_the_user',
     event: 'your_event_name',
     properties: {
-        $process_person_profile: false
+        '$process_person_profile': false
     }
 })
 ```
@@ -64,7 +64,7 @@ let mut event = Event::new("your_event_name", "distinct_id_of_the_user");
 
 event.insert_prop("$process_person_profile", false).unwrap();
 
-client.capture(event).unwrap();
+client.capture(event).await.unwrap();
 ```
 
 ```elixir

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-backend.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-backend.mdx
@@ -11,8 +11,8 @@ client.capture({
 
 ```python
 posthog.capture(
-    "distinct_id_of_the_user", 
-    "your_event_name", 
+    "your_event_name",
+    distinct_id="distinct_id_of_the_user",
 )
 ```
 
@@ -44,7 +44,7 @@ posthog.capture("distinct_id_of_the_user", "your_event_name", new HashMap<String
 ```rust
 let mut event = Event::new("your_event_name", "distinct_id_of_the_user");
 
-client.capture(event).unwrap();
+client.capture(event).await.unwrap();
 ```
 
 ```elixir

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
@@ -1,4 +1,4 @@
-If you've set the [`personProfiles` config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the [`personProfiles` config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `PostHogPersonProfiles.identifiedOnly` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
@@ -6,4 +6,4 @@ If you've set the [`personProfiles` config](/docs/libraries/flutter#person-profi
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
 
-Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.
+Alternatively, you can set `personProfiles` to `PostHogPersonProfiles.always` to capture identified events by default.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
@@ -1,4 +1,4 @@
-If you've set the [`personProfiles` config](/docs/libraries/ios/configuration#all-configuration-options) to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the [`personProfiles` config](/docs/libraries/ios/configuration#all-configuration-options) to `.identifiedOnly` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
@@ -6,4 +6,4 @@ If you've set the [`personProfiles` config](/docs/libraries/ios/configuration#al
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
 
-Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.
+Alternatively, you can set `personProfiles` to `.always` to capture identified events by default.

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -164,8 +164,8 @@ posthog.capture('user_signed_up')
 ```python
 # Not possible
 posthog.capture(
-    'user_distinct_id',
     'user_signed_up',
+    distinct_id='user_distinct_id',
     groups={
         'company': 'company_id_in_your_db',
         'company': 'another_company_id_in_your_db'
@@ -174,8 +174,8 @@ posthog.capture(
 
 # Allowed
 posthog.capture(
-    'user_distinct_id',
     'user_signed_up',
+    distinct_id='user_distinct_id',
     groups={
         'company': 'company_id_in_your_db',
         'channel': 'channel_id_in_your_db'
@@ -248,8 +248,9 @@ posthog.capture({
 ```
 
 ```python
-posthog.capture('static_string_for_group_events', 
-    'group_event_name', 
+posthog.capture(
+    'group_event_name',
+    distinct_id='static_string_for_group_events',
     groups={'company': 'company_id_in_your_db'}
 )
 ```

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -164,7 +164,8 @@ posthog.capture(
 posthog.Capture(
     "distinct_id", // the same distinct ID you use on the frontend
     "event_name",
-    personPropertiesToSet: new() { ["email"] = "max@hedgehogmail.com", ["name"] = "Max Hedgehog" } // optional: set person properties
+    personPropertiesToSet: new() { ["email"] = "max@hedgehogmail.com", ["name"] = "Max Hedgehog" }, // optional: set person properties
+    personPropertiesToSetOnce: new()
 );
 ```
 
@@ -179,7 +180,7 @@ PostHog.capture("event_name", %{
 let mut event = Event::new("event_name", "distinct_id"); // the same distinct ID you use on the frontend
 // optional: set person properties
 event.insert_prop("$set", serde_json::json!({ "email": "max@hedgehogmail.com", "name": "Max Hedgehog" })).unwrap();
-client.capture(event).unwrap();
+client.capture(event).await.unwrap();
 ```
 
 </MultiLanguage>
@@ -369,7 +370,7 @@ posthog.alias('user1', 'user2');
 ```
 
 ```python
-# Assume we previously identified a user with 'user1' using posthog.identify('user1')
+# Assume 'user1' was previously used as a distinct_id
 # You should not use user1 as an alias for user2
 posthog.alias(previous_id='user2', distinct_id='user1')
 ```
@@ -385,7 +386,7 @@ PostHog::alias([
 ```
 
 ```ruby
-# Assume we previously identified a user with 'user1' using posthog.identify('user1')
+# Assume we previously identified a user with 'user1' using posthog.identify({ distinct_id: 'user1' })
 # You should not use user1 as an alias for user2
 posthog.alias({
   distinct_id: "user2",

--- a/contents/docs/revenue-analytics/capture-revenue-events.mdx
+++ b/contents/docs/revenue-analytics/capture-revenue-events.mdx
@@ -57,9 +57,9 @@ posthog.capture("purchase_completed", {
 
 ```python
 posthog.capture(
-    "user_distinct_id",
     "purchase_completed",
-    {
+    distinct_id="user_distinct_id",
+    properties={
         "revenue": 1000,
         "currency": "USD",
         "product": "Premium Plan",

--- a/contents/docs/session-replay/_snippets/ios-network.mdx
+++ b/contents/docs/session-replay/_snippets/ios-network.mdx
@@ -9,7 +9,7 @@ import PostHog
 
 func fetchData(from url: URL) async throws -> Data {
     // let (data, _) = try await URLSession.shared.data(from: url)      // ⬅ replace this
-    let (data, _) = try await URLSession.shared.postHogData(from: url)  // 🦔 with this
+    let (data, _) = try await URLSession.shared.postHogData(from: url, postHog: PostHogSDK.shared)  // 🦔 with this
 
     // your logic here...
     return data

--- a/contents/docs/session-replay/_snippets/ios-network.mdx
+++ b/contents/docs/session-replay/_snippets/ios-network.mdx
@@ -9,7 +9,7 @@ import PostHog
 
 func fetchData(from url: URL) async throws -> Data {
     // let (data, _) = try await URLSession.shared.data(from: url)      // ⬅ replace this
-    let (data, _) = try await URLSession.shared.postHogData(from: url, postHog: PostHogSDK.shared)  // 🦔 with this
+    let (data, _) = try await URLSession.shared.postHogData(from: url)  // 🦔 with this
 
     // your logic here...
     return data

--- a/contents/docs/session-replay/installation/_snippets/unity-installation.tsx
+++ b/contents/docs/session-replay/installation/_snippets/unity-installation.tsx
@@ -53,7 +53,7 @@ const getUnitySteps = (ctx: any) => {
                 <>
                     <Markdown>
                         {
-                            'Add `SessionReplay = true` to your PostHog configuration.'
+                            'Add `SessionReplay = true` to your PostHog configuration. You can also configure it via the Unity Inspector in **Edit > Project Settings > PostHog**.'
                         }
                     </Markdown>
                     <CodeBlock
@@ -114,8 +114,8 @@ const getUnitySteps = (ctx: any) => {
                     <CalloutBox type="info" title="Limitations">
                         <Markdown>
                             Unity Session Replay is controlled by local SDK configuration. Options like
-                            `CaptureNetworkTelemetry`, `CaptureLogs`, and sampling must be set locally in code at
-                            initialization time.
+                            `CaptureNetworkTelemetry`, `CaptureLogs`, and sampling are **not** remotely configurable
+                            and must be set locally in code at initialization time.
                         </Markdown>
                     </CalloutBox>
                 </>

--- a/contents/docs/session-replay/installation/_snippets/unity-installation.tsx
+++ b/contents/docs/session-replay/installation/_snippets/unity-installation.tsx
@@ -53,7 +53,7 @@ const getUnitySteps = (ctx: any) => {
                 <>
                     <Markdown>
                         {
-                            'Add `SessionReplay = true` to your PostHog configuration. You can also configure it via the Unity Inspector in **Edit > Project Settings > PostHog**.'
+                            'Add `SessionReplay = true` to your PostHog configuration.'
                         }
                     </Markdown>
                     <CodeBlock
@@ -98,8 +98,8 @@ const getUnitySteps = (ctx: any) => {
                     <CalloutBox type="fyi" title="How it works">
                         <Markdown>
                             The Unity SDK captures screenshots using `AsyncGPUReadback` to avoid blocking the main
-                            thread. It also records touch/mouse input, network requests, and console logs alongside each
-                            screenshot. Session replay requires `AsyncGPUReadback` support and is automatically disabled
+                            thread. It also records touch/mouse input and console logs alongside each screenshot. You can
+                            manually record network request metadata with `PostHogSDK.RecordNetworkRequest`. Session replay requires `AsyncGPUReadback` support and is automatically disabled
                             on WebGL.
                         </Markdown>
                     </CalloutBox>
@@ -113,9 +113,9 @@ const getUnitySteps = (ctx: any) => {
                     </CalloutBox>
                     <CalloutBox type="info" title="Limitations">
                         <Markdown>
-                            The Unity SDK reads the **Record user sessions** toggle from PostHog project settings, but
-                            more granular options like `CaptureNetworkTelemetry`, `CaptureLogs`, and sampling are
-                            **not** remotely configurable and must be set locally in code at initialization time.
+                            Unity Session Replay is controlled by local SDK configuration. Options like
+                            `CaptureNetworkTelemetry`, `CaptureLogs`, and sampling must be set locally in code at
+                            initialization time.
                         </Markdown>
                     </CalloutBox>
                 </>

--- a/contents/docs/surveys/installation/flutter.mdx
+++ b/contents/docs/surveys/installation/flutter.mdx
@@ -27,7 +27,7 @@ import { FlutterSurveysInstallationWrapper } from "./_snippets/surveys-installat
 - Make sure to set the minimum platform version to iOS 13.0 in your `Podfile`.
 - Make sure you have disabled automatic SDK initialization.
 - Run a clean build if you experience issues.
-- If surveys are not being displayed when triggered, make sure you have installed the [PostHogObserver](/docs/surveys/installation/flutter#step-two-install-posthogobserver).
-  - Using [`navigationObservers`](/docs/libraries/flutter#capturing-screen-views#using-navigatorobservers)
+- If surveys are not being displayed when triggered, make sure you have installed the [PosthogObserver](/docs/surveys/installation/flutter#step-two-install-posthogobserver).
+  - Using [`navigatorObservers`](/docs/libraries/flutter#capturing-screen-views#using-navigatorobservers)
   - Using [go_router](/docs/libraries/flutter#capturing-screen-views#using-go-router)
 - If you are using multiple navigation observers and encounter a log message `[PostHog] Cannot show survey: No valid context found...`, try placing `PosthogObserver` first in the list of observers. We've noticed that order sometimes matters due to potential interference.


### PR DESCRIPTION
## Changes

- Fix official SDK docs snippets that used stale or incorrect public APIs across Python, Ruby, Go, .NET, Android, iOS, Flutter, Elixir, Rust, Unity, JavaScript/Node.js/React Native, Pi, and OpenClaw.
- Correct method names, option names, argument labels, enum values, async usage, and SDK-specific configuration behavior.
- Leave blog posts, templates, app code, tutorials, and evaluation-context changes out of scope.
- Address PR review feedback by rolling back requested wording and API-specific details.

Validation:

- `git diff --check` passed.
- Confirmed the PR diff no longer includes files under `contents/tutorials/`.
- `pnpm exec prettier --check ...` could not run because `prettier` is not installed in this worktree dependencies.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`