### PR TITLE
Fix team page 404s

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -58,6 +58,10 @@ export const onCreatePage: GatsbyNode['onCreatePage'] = async ({ page, actions }
         page.matchPath = '/next-steps/*'
         createPage(page)
     }
+    if (page.path.match(/^\/teams\//) && !page.path.match(/^\/teams\/new/)) {
+        page.matchPath = '/teams/*'
+        createPage(page)
+    }
     // Add client-side routing for custom presentations
     if (page.path.match(/^\/for\//)) {
         page.matchPath = '/for/*'

--- a/src/pages/teams/[slug].tsx
+++ b/src/pages/teams/[slug].tsx
@@ -143,7 +143,7 @@ type TeamPageProps = {
 }
 
 export default function TeamPage(props: TeamPageProps) {
-    const { slug } = props?.params || {}
+    const slug = props?.params?.slug || (props?.params as any)?.['*']
     const [editing, setEditing] = useState(false)
     const [saving, setSaving] = useState(false)
     const [activeProfile, setActiveProfile] = useState<boolean | ProfileData>(false)


### PR DESCRIPTION
## Changes

- Add client-only route matching for `/teams/*` in `gatsby-node.ts` so team pages resolve instead of 404ing