### PR TITLE
docs(feature-flags): single getFeatureFlagResult call in web and android examples

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
@@ -3,11 +3,12 @@
 ```kotlin
 import com.posthog.PostHog
 
-if (PostHog.isFeatureEnabled("flag-key")) {
+val result = PostHog.getFeatureFlagResult("flag-key")
+if (result?.enabled == true) {
     // Do something differently for this user
 
-    // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
+    // Optional: fetch the payload from the same evaluation result
+    val matchedFlagPayload = result.payload
 }
 ```
 
@@ -16,30 +17,18 @@ if (PostHog.isFeatureEnabled("flag-key")) {
 ```kotlin
 import com.posthog.PostHog
 
-if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
+val result = PostHog.getFeatureFlagResult("flag-key")
+if (result?.variant == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
 
-    // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
+    // Optional: fetch the payload from the same evaluation result
+    val matchedFlagPayload = result.payload
 }
 ```
 
-### Feature flag values and payloads together
+### Inspecting all feature flags
 
-If you need both the flag value and payload, use `getFeatureFlagResult` so both values come from the same evaluation result.
-
-```kotlin
-import com.posthog.PostHog
-
-val result = PostHog.getFeatureFlagResult("flag-key")
-
-if (result?.value == "variant-key") {
-    val payload = result.payload
-    // Do something with the variant and payload
-}
-```
-
-You can also inspect all currently loaded feature flag results with `PostHog.getAllFeatureFlags()`.
+You can inspect all currently loaded feature flags with `PostHog.getAllFeatureFlags()`.
 
 ### Ensuring flags are loaded before usage
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
@@ -1,22 +1,24 @@
 ### Boolean feature flags
 
 ```js-web
-if (posthog.isFeatureEnabled('flag-key') ) {
+const result = posthog.getFeatureFlagResult('flag-key')
+if (result?.enabled) {
     // Do something differently for this user
 
-    // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
+    // Optional: fetch the payload from the same evaluation result
+    const matchedFlagPayload = result?.payload
 }
 ```
 
 ### Multivariate feature flags
 
 ```js-web
-if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
+const result = posthog.getFeatureFlagResult('flag-key')
+if (result?.variant == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
-    
-    // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
+
+    // Optional: fetch the payload from the same evaluation result
+    const matchedFlagPayload = result?.payload
 }
 ```
 


### PR DESCRIPTION
## Changes

The web and Android feature flag code examples evaluated the flag twice to get the value and its payload — calling `isFeatureEnabled` / `getFeatureFlag` and then a separate `getFeatureFlagResult(...)?.payload` for the same key.

This reads both from a single `getFeatureFlagResult` evaluation, matching the existing iOS and Flutter examples in the same snippet set:

- `feature-flags-code-web.mdx` — boolean now reads `result?.enabled`, multivariate reads `result?.variant`, payload comes from the same `result`.
- `feature-flags-code-android.mdx` — same single-call pattern; the standalone "values and payloads together" section is now redundant and folded away, keeping the `getAllFeatureFlags()` note.

These snippets are imported by `feature-flags/adding-feature-flag-code.mdx` and are the upstream source that context-mill turns into the agent-skill references, so the single-call idiom propagates to PostHog/skills and PostHog/ai-plugin on the next sync.

Backend snippets (Node, Python, PHP, Ruby, Go, Java, .NET) and the React Native hook-based examples are unchanged. No prose, links, or redirects affected.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
