### PR TITLE
Serve raw Markdown to AI agents via Edge Middleware

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -12,6 +12,7 @@ import {
     generateRawMarkdownPages,
     generateApiSpecMarkdown,
     generateLlmsTxt,
+    generateLlmsFullTxt,
     generateSdkReferencesMarkdown,
     generatePricingMd,
 } from './rawMarkdownUtils'
@@ -593,6 +594,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
     // Only include docs pages in llms.txt (not handbook)
     const docsPages = filteredPages.filter((page) => page.fields.slug.startsWith('/docs'))
     generateLlmsTxt(docsPages)
+    generateLlmsFullTxt(docsPages)
 
     if (process.env.AWS_CODEPIPELINE !== 'true') {
         console.log('Skipping onPostBuild tasks')

--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -492,6 +492,49 @@ If the wizard doesn't support the framework, see the [SDKs and Libraries](https:
     console.log('Generated: llms.txt')
 }
 
+// Function to generate llms-full.txt: the full text of every docs page concatenated
+// into a single file, for agents that prefer to ingest the whole corpus at once
+// rather than fetching individual `.md` URLs from llms.txt.
+export const generateLlmsFullTxt = (pages: Array<{ fields: { slug: string }; frontmatter: { title: string } }>) => {
+    console.log('Generating llms-full.txt file...')
+
+    const publicPath = path.resolve(__dirname, '../public')
+
+    let content = `# PostHog documentation (full text)
+
+> The complete text of PostHog's documentation, concatenated into a single file for LLM ingestion. Each page is delimited by a heading with its source URL. Individual pages are also available as raw Markdown by appending \`.md\` to any docs URL. See https://posthog.com/llms.txt for a structured index.
+`
+
+    // Sort by slug for deterministic output across builds.
+    const sortedPages = [...pages].sort((a, b) => a.fields.slug.localeCompare(b.fields.slug))
+
+    let included = 0
+    for (const doc of sortedPages) {
+        const { slug } = doc.fields
+        const mdPath = path.join(publicPath, `${slug}.md`)
+
+        if (!fs.existsSync(mdPath)) {
+            continue
+        }
+
+        const markdown = fs.readFileSync(mdPath, 'utf8').trim()
+        if (!markdown) {
+            continue
+        }
+
+        content += `\n\n---\n\n# Source: https://posthog.com${slug}\n\n${markdown}\n`
+        included++
+    }
+
+    const llmsFullTxtPath = path.join(publicPath, 'llms-full.txt')
+    if (!fs.existsSync(publicPath)) {
+        fs.mkdirSync(publicPath, { recursive: true })
+    }
+
+    fs.writeFileSync(llmsFullTxtPath, content, 'utf8')
+    console.log(`Generated: llms-full.txt (${included} pages)`)
+}
+
 // Function to generate pricing.md file for LLM and human consumption
 export const generatePricingMd = (products: any[]) => {
     console.log('Generating pricing.md file...')

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,55 @@
+import { next, rewrite } from '@vercel/edge'
+
+// Vercel Edge Middleware runs *before* the filesystem layer, which is exactly
+// why this lives here instead of in `vercel.json`. Config rewrites only run as a
+// filesystem fallback — and Gatsby emits a static `index.html` for every docs and
+// handbook page, so an Accept-based rewrite in `vercel.json` never fires. Running
+// here lets us intercept the request and serve the pre-generated `.md` instead.
+//
+// The raw Markdown files are produced at build time by `gatsby/rawMarkdownUtils.ts`
+// (`generateRawMarkdownPages`) and live alongside the HTML at `<path>.md`.
+
+export const config = {
+    // Only docs and handbook pages have generated `.md` counterparts.
+    // Keep this in sync with MARKDOWN_CONTENT_PATHS in src/constants/index.ts.
+    matcher: ['/docs/:path*', '/handbook/:path*'],
+}
+
+// Known AI assistant and crawler user-agents that should receive raw Markdown even
+// when they don't send an `Accept: text/markdown` header. Most agents (including
+// plain `fetch`-based tools) won't negotiate, so user-agent matching is what makes
+// this work in practice.
+const AI_USER_AGENTS =
+    /(GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-User|Claude-SearchBot|Claude-Web|anthropic-ai|PerplexityBot|Perplexity-User|Google-Extended|Applebot-Extended|Bytespider|CCBot|cohere-ai|DuckAssistBot|meta-externalagent|Amazonbot|YouBot|AI2Bot|Diffbot|Timpibot|omgili)/i
+
+export default function middleware(request: Request): Response {
+    const url = new URL(request.url)
+    const { pathname } = url
+
+    // Never touch requests that already target a concrete file (e.g. the raw `.md`
+    // itself, sitemaps, images). Doc/handbook slugs never contain a dot.
+    if (/\.[a-z0-9]+$/i.test(pathname)) {
+        return next()
+    }
+
+    const accept = request.headers.get('accept') || ''
+    const userAgent = request.headers.get('user-agent') || ''
+    const wantsMarkdown = accept.includes('text/markdown') || AI_USER_AGENTS.test(userAgent)
+
+    // Markdown files are written without a trailing slash: `/docs/foo.md`.
+    const markdownPath = `${pathname.replace(/\/$/, '')}.md`
+
+    if (wantsMarkdown) {
+        url.pathname = markdownPath
+        return rewrite(url)
+    }
+
+    // For browsers/humans, advertise the Markdown alternate via a Link header. This
+    // mirrors the in-page `<link rel="alternate" type="text/markdown">` from seo.tsx
+    // but is machine-readable without parsing HTML.
+    return next({
+        headers: {
+            Link: `<${markdownPath}>; rel="alternate"; type="text/markdown"`,
+        },
+    })
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "@types/react-slick": "^0.23.10",
         "@types/styled-components": "^5.1.26",
         "@typescript-eslint/eslint-plugin": "^4.20.0",
+        "@vercel/edge": "^1.3.1",
         "@wistia/wistia-player-react": "^0.1.17",
         "ahooks": "^3.7.8",
         "algoliasearch": "^4.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@typescript-eslint/eslint-plugin':
         specifier: ^4.20.0
         version: 4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)
+      '@vercel/edge':
+        specifier: ^1.3.1
+        version: 1.3.1
       '@wistia/wistia-player-react':
         specifier: ^0.1.17
         version: 0.1.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.101.3)
@@ -5890,6 +5893,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@vercel/edge@1.3.1':
+    resolution: {integrity: sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==}
 
   '@vercel/webpack-asset-relocator-loader@1.7.3':
     resolution: {integrity: sha512-vizrI18v8Lcb1PmNNUBz7yxPxxXoOeuaVEjTG9MjvDrphjiSxFZrRJ5tIghk+qdLFRCXI5HBCshgobftbmrC5g==}
@@ -24706,6 +24712,8 @@ snapshots:
       eslint-visitor-keys: 2.1.0
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vercel/edge@1.3.1': {}
 
   '@vercel/webpack-asset-relocator-loader@1.7.3':
     dependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -29,26 +29,6 @@
         }
     ],
     "rewrites": [
-        {
-            "source": "/docs/:path*/",
-            "has": [{ "type": "header", "key": "accept", "value": "(?:.*text/markdown.*)" }],
-            "destination": "/docs/:path*.md"
-        },
-        {
-            "source": "/docs/:path*",
-            "has": [{ "type": "header", "key": "accept", "value": "(?:.*text/markdown.*)" }],
-            "destination": "/docs/:path*.md"
-        },
-        {
-            "source": "/handbook/:path*/",
-            "has": [{ "type": "header", "key": "accept", "value": "(?:.*text/markdown.*)" }],
-            "destination": "/handbook/:path*.md"
-        },
-        {
-            "source": "/handbook/:path*",
-            "has": [{ "type": "header", "key": "accept", "value": "(?:.*text/markdown.*)" }],
-            "destination": "/handbook/:path*.md"
-        },
         { "source": "/community/profiles/:path*", "destination": "/community/profiles/[id]/index.html" },
         { "source": "/next-steps/(.*)", "destination": "/next-steps/index.html" },
         { "source": "/questions/:path((?!topic).*)", "destination": "/questions/[permalink]/index.html" },
@@ -56,7 +36,11 @@
         { "source": "/posts/:path*", "destination": "/posts/[slug]/index.html" }
     ],
     "redirects": [
-        { "source": "/docs/prompt-management/skills-store", "destination": "/docs/ai-engineering/skills-store", "statusCode": 301 },
+        {
+            "source": "/docs/prompt-management/skills-store",
+            "destination": "/docs/ai-engineering/skills-store",
+            "statusCode": 301
+        },
         { "source": "/docs/site-apps", "destination": "/docs/js-snippets" },
         { "source": "/docs/site-apps/:path*", "destination": "/docs/js-snippets/:path*" },
         { "source": "/code/download", "destination": "/code#download" },


### PR DESCRIPTION
## Problem

The Accept-based content negotiation added in #16147 **never actually fires**. Vercel `rewrites` only run as a *filesystem fallback*, but Gatsby emits a static `index.html` for every docs/handbook page — so those pages always match the filesystem first and the `.md` rewrite is dead code.

Verified in production:

```
$ curl -sI -H "Accept: text/markdown" https://posthog.com/docs/libraries/elixir
content-type: text/html        # ❌ expected text/markdown
```

The `.md` files, `Vary: Accept` headers, `llms.txt`, and the in-page `<link rel="alternate">` are all already in place — only the negotiation step itself was broken.

## Fix

Move negotiation into a **Vercel Edge Middleware** (`middleware.ts`), which runs *before* the filesystem layer and can rewrite `/docs/*` and `/handbook/*` to the pre-generated `<path>.md` when either:

- the request sends `Accept: text/markdown`, **or**
- the User-Agent matches a known AI assistant/crawler — most agents (including plain `fetch`-based tools like the one that prompted this) never negotiate via `Accept`, so UA matching is what makes it work in practice.

For normal/browser requests it adds a machine-readable `Link: <…md>; rel="alternate"; type="text/markdown"` response header, mirroring the in-page `<link>` from `seo.tsx`.

## Also in this PR

- Removes the now-dead Accept rewrites from `vercel.json` (kept `Vary: Accept`).
- Adds **`/llms-full.txt`** — the full docs corpus concatenated into one file — alongside the existing `llms.txt`, for agents that prefer to ingest everything at once.
- Adds `@vercel/edge` (zero-dependency leaf; lockfile diff is 8 lines).

## Notes for reviewers

- **Caching:** no `Vary: User-Agent` needed. Middleware re-runs per request and routes markdown requests to a *different path* (`/docs/foo.md`), so the HTML cache entry for `/docs/foo` is only ever served to non-markdown clients — no cross-UA poisoning.
- ⚠️ **Needs a preview-deploy check** I can't do locally: confirm Vercel picks up root `middleware.ts` for this (non-Next) Gatsby project and that the rewrite resolves to the static `.md`. Quick check once deployed:
  ```
  curl -sI -H "Accept: text/markdown" <preview>/docs/libraries/elixir   # → text/markdown
  curl -sI -A "ClaudeBot" <preview>/docs/libraries/elixir               # → text/markdown
  curl -sI <preview>/docs/libraries/elixir                              # → text/html + Link header
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)