### PR TITLE
fix: center align heads up banner on DPA page

### DIFF
--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -297,7 +297,7 @@ function DpaGenerator() {
                         </Link>
                     </div>
 
-                    <div className="bg-yellow/25 py-3 px-4 text-sm -mx-4 @3xl:-mx-8 mt-0 border-b border-light dark:text-black">
+                    <div className="bg-yellow/25 py-3 px-4 text-sm text-center -mx-4 @3xl:-mx-8 mt-0 border-b border-light dark:text-black">
                         <strong>Heads up:</strong> This is a preview. To get a countersigned, valid DPA, generate it
                         inside your PostHog organization at{' '}
                         <a


### PR DESCRIPTION
## Summary

The "Heads up" and "Notice" banners on the posthog.com/dpa had inconsistent alignment — the "Notice" banners were center aligned while the "Heads up" banner was left aligned. This adds `text-center` to the "Heads up" banner so both are consistently center aligned.

<img width="1233" height="256" alt="image" src="https://github.com/user-attachments/assets/ce7f81bf-c37f-4fbc-9c9a-eecee15600ea" />

Serious shareholder value PR.

## Changes

- Added `text-center` to the "Heads up" preview banner in `src/pages/dpa.tsx`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*