### PR TITLE
Fix localhost link on Voice & tone handbook page

### DIFF
--- a/contents/handbook/brand/tone.md
+++ b/contents/handbook/brand/tone.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> Writing for PostHog? Be sure to check out our full [writing style guide](http://localhost:8002/handbook/content/posthog-style-guide).
+> Writing for PostHog? Be sure to check out our full [writing style guide](/handbook/content/posthog-style-guide).
 
 ## The core principle
 


### PR DESCRIPTION
## Changes

The "writing style guide" link on the [Voice & tone](https://posthog.com/handbook/brand/tone) handbook page pointed to `http://localhost:8002/handbook/content/posthog-style-guide`. Replaced it with the relative internal URL `/handbook/content/posthog-style-guide`.

**Why:** The link was a leftover absolute localhost URL, so it was broken for anyone visiting the live site.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1781801580277759?thread_ts=1781801580.277759&cid=C09GU689J1X)*