### PR TITLE
Handbook: Update content brand messaging for more self-driving

### DIFF
--- a/contents/handbook/content/brand-message.mdx
+++ b/contents/handbook/content/brand-message.mdx
@@ -1,16 +1,12 @@
 ---
-title: Content brand guidelines and messaging
+title: Content brand messaging
 sidebar: Handbook
 showTitle: true
 ---
 
-## What should we be trying to communicate about PostHog? 
+## What should we be trying to communicate about PostHog?
 
-PostHog is a developer platform that helps people build successful products. We provide a suite of dev tools to help them do this.
-
-The way we describe what that adds up to is **self-driving**: PostHog has all your product's data in one place, turns it into signals, and uses agents to find problems and opportunities — and ship the fix.
-
-The nuance to get right: **PostHog makes _your_ product self-driving.** The customer's product is the thing that becomes self-driving; PostHog is what makes that happen. Don't frame it as "PostHog is self-driving software" in customer-facing copy — that centers us instead of the outcome the customer gets. (We do also use these same capabilities to make PostHog itself self-driving, but that's a proof point, not the pitch.)
+PostHog makes your product self-driving. It pairs all the context needed to build a successful product with agents that find opportunities and ship fixes. You can use our desktop (Code), web, Slack, and MCP products to leverage our apps like product analytics, session replay, feature flags, experiments, error tracking, AI observability, logs, and more.
 
 Beyond literally communicating what PostHog is and what it does, we want to [equip developers to build successful products](/handbook/why-does-posthog-exist). We do this by communicating the following:
 
@@ -34,19 +30,17 @@ An important subset of this persona is technical founders. Great product enginee
 
 When we are working on content (like blogs, docs, and tutorials) for a specific product, we should write it for the persona of that product, which might be different from our primary persona.
 
-> Learn more in [Who are we building for](/handbook/who-we-are-building-for).
+> Learn more in [Who we build for](/handbook/who-we-are-building-for).
 
 ## Why do developers, product engineers, and technical founders pick PostHog?
 
 We help them debug and ship their product faster.
 
-- The first part we do with automated error tracking and session replays, both of which let them discover and understand issues and their context.
+PostHog already has all the data about how people use your product and how your product performs, like usage analytics, error tracking, session replays, logs, traces, and more. This lets them discover and understand issues and their context, but also feeds our product autonomy loop.
 
-- The second part we do with feature flags to rollout new features, experimentation to measure impact, and surveys to get feedback.
+This loops turns that data into signals, feeds those signals to an agent running in a sandbox, and automatically opens PRs that improve your product. Both our agents and the use can then use feature flags to rollout new features, experiments to measure impact, surveys to get feedback, and evals as checks.
 
-- As a bonus, we combine all this with product, web, and AI Observability.
-
-We have all the apps in one. This means less time spent patching these tools together and paying for them all separately. When engineers need a new tool, they can just use PostHog.
+We have all the apps and context in one. This means less time spent patching these tools together and paying for them all separately. When engineers need a new tool, they can just use PostHog.
 
 Our team is technical and speaks the language of developers. Our engineers talk with customers to figure out what to build. Our support team are all former engineers and get into the nitty-gritty of issues. Our sales and CS teams are very technical too. They focus more on your use cases and implementation than steak dinners.
 
@@ -68,4 +62,4 @@ PostHog could be a lot of things. We also have a lot of terms for the same thing
 
 5. We should assume our audience either has to do technical work or wants to, regardless of whether they can code. Most of them are developers, and for the rest, we're the bridge, giving everyone direct access to data and the power to ship.
 
-6. We don't say "PostHog is self-driving software" in customer-facing copy. PostHog makes _your_ product self-driving. Keep the customer's product as the subject of the sentence — they get a product that improves itself; PostHog is how.
+6. We don't say PostHog is "self-driving software" or "a self-driving product." PostHog makes _your_ product self-driving. Keep the customer's product as the subject of the sentence.


### PR DESCRIPTION
## Changes

Updating content brand messaging to include more self-driving. 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
