### PR TITLE
chore(team objectives): platform features Q3 2026 goals

### DIFF
--- a/contents/teams/platform-features/objectives.mdx
+++ b/contents/teams/platform-features/objectives.mdx
@@ -1,73 +1,31 @@
-### Q2 2026 objectives
+### Q3 2026 objectives
 
 - Yasen
-    - Platform features data as inputs to AI tools
-    - Expose Metalytics to select orgs as part of the sales toolkit
-    - Guest mode - allow orgs to share a specific object with a user and nothing else
-    - Explore platform packages midpoint options
-    - Access control scopes
-        - Destinations or Workflows
-    - AI tools
-        - `auditing-instance-security` — guided posture review and prioritized hardening steps
-        - `enforcing-2fa-sso` — lock down auth org-wide before something bad happens
-        - `configuring-approval-policies` — add change-control gating to risky actions
-        - `reviewing-pending-approvals` — triage and decide on pending approval requests
-        - `setting-up-reminders` — offload recurring or time-based check-ins to PostHog
-        - `cleaning-up-unused-dashboards` — prune stale dashboards cluttering the workspace
-        - `discovering-value-add-features` — surface relevant capabilities the user doesn't yet know exist
-        - `reviewing-team-usage` — usage picture of a team for renewal / churn calls
-
-- Alex
-    - Survey/experiment about white-labeling
-    - Update the docs about the B2B2C case
-    - Agent-native notebooks
-    - Fix notebook papercuts
-    - Help with data access control
-    - SQL editor access control
-    - AI tools
-        - `invite-a-user` — get a teammate into the org without leaving chat
-        - `setting-up-saml` — wire up SSO end-to-end without misreading a doc
-        - `setting-up-reverse-proxy` — improve capture reliability and ad-blocker resistance
-        - `dumping-research-to-markdown` — turn a sprawling chat session into a clean notebook summary
-        - `running-notebook-analysis` — run a structured analysis (e.g. correlation) inside a notebook
+    - Multi-project dashboards
+    - Activity logs -> SIEM
+    - Billing activity logs
+    - Auth flows for MCP (e.g. MFA trips users up, so we need to move to code-based verifications)
+    - Access control scope expansion
+    - Fix the broken US/EU redirects
+    - Support Grow plan launch
 
 - Reece
-    - Access control
-        - Customer analytics
-        - Field-level access control
-    - Fix settings
-        - Entire products in settings
-        - Notifications
-    - Expand project->project transfers to more resources
-    - Help with notebook papercuts
-    - AI tools
-        - `granting-access` — bestow or inspect roles on people, projects, and resources
-        - `creating-access-rules` — carve out scoped project access for members or roles
-        - `auditing-permission-anomalies` — spot users whose access drifted broader than it should be
-        - `explaining-created-resources` — leave future readers context on agent-created resources
-        - `exploring-integrations` — discover and turn on the right integration for the user's stack
-        - `suggesting-resource-access` — recommend who should see a new resource so the user doesn't have to guess
-        - `sharing-with-roles` — hand a dashboard or insight to the right people in one step
-
-
-### Q1 2026 objectives
-
-- Yasen
-    - Approvals GA
-    - Activity logs -> Posthog AI
-    - In-app notifications
-    - Email MFA improve UX
+    - Multi-domain SAML/SCIM support
+    - Redesign the org domain and IdP config settings UI
+    - OIDC
+    - Access control all the things
+        - Event access controls for HogQL
+        - Cover all products with resource access controls
+        - Resource <-> HogQL parity
+        - Fully remove the access control settings UI v1
+    - Update the docs for SAML, SCIM, and access control for the new PostHog and Okta UIs, with demo videos showing how to set it up
 
 - Alex
-    - Roll out SCIM to all Enterprise customers and improve the docs
-    - Make event definitions available to everyone, ship image previews for custom events
-    - Finish PostHog AI access control
-    - Run an email upsell growth experiment
-
-- Reece
-    - Passkeys
-    - Project to project resource transfers (haha jk..unless... 😳)
-    - RBAC UI redesign
-    - Platform packages revenue optimization
-
-
+    - RBAC v2 - always apply the more specific rule
+    - Guest mode (aka the contractor use case) - share a specific object or resource without giving access to everything else in the project
+    - MCP read/write tools for access controls
+    - Access controls for tasks (sharing conversations with a team)
+    - Figure out how access controls should work for the Slack bot and Inbox
+    - Simplify activity logs tools (Claude struggles to use them)
+    - Reverse proxy troubleshooting skill
+    - Write 2 blog posts about collaborative notebooks and the upselling workflow


### PR DESCRIPTION
## Changes

Updates the Platform features team page (`/teams/platform-features`) goals to the **Q3 2026 objectives**, grouped by person. The now-stale Q1 and Q2 2026 objectives have been removed.