### PR TITLE
docs(error-tracking): document addExceptionStep across mobile SDKs

### DIFF
--- a/contents/docs/error-tracking/_snippets/exception-properties-table.mdx
+++ b/contents/docs/error-tracking/_snippets/exception-properties-table.mdx
@@ -7,3 +7,4 @@
 | └─ `mechanism` | Object | If the stacktrace is handled and if it's synthetic |
 | `$exception_fingerprint` | String | A fingerprint of the exception |
 | `$exception_level` | String | The level of the severity of the error |
+| `$exception_steps` | List | Breadcrumb-style steps recorded via [`addExceptionStep`](/docs/error-tracking/capture#add-exception-steps) before the exception, each with a `$message`, `$timestamp`, and any custom properties |

--- a/contents/docs/error-tracking/capture.mdx
+++ b/contents/docs/error-tracking/capture.mdx
@@ -139,9 +139,9 @@ PostHog.CaptureException(
 
 ## Add exception steps
 
-> Available in `posthog-js` 1.370.0 and later.
+> Available in `posthog-js` 1.370.0+, `posthog-react-native` 4.50.0+, `posthog-ios` 3.61.0+, `posthog-android` 3.51.0+, and `posthog_flutter` 5.28.0+.
 
-Exception steps are lightweight breadcrumbs you attach to an exception before calling `captureException(...)`. They are buffered in memory, added to the next exception as `$exception_steps`, and shown in the session timeline.
+Exception steps are lightweight breadcrumbs you attach to an exception with `addExceptionStep(...)`. They are buffered in memory, added to the next exception as `$exception_steps`, and shown in the session timeline.
 
 Use them for high-signal checkpoints like:
 
@@ -159,7 +159,9 @@ Use them for high-signal checkpoints like:
 
 ### Example
 
-```javascript
+<MultiLanguage>
+
+```js file=Web
 posthog.addExceptionStep('checkout_started', {
   cart_total: 12900,
   item_count: 3,
@@ -178,11 +180,93 @@ try {
 }
 ```
 
+```react-native file=React Native
+posthog.addExceptionStep('checkout_started', {
+  cart_total: 12900,
+  item_count: 3,
+})
+
+posthog.addExceptionStep('payment_attempted', {
+  provider: 'stripe',
+})
+
+try {
+  await confirmCardPayment(clientSecret)
+} catch (error) {
+  posthog.captureException(error, {
+    checkout_id: 'chk_123',
+  })
+}
+```
+
+```swift file=iOS
+PostHogSDK.shared.addExceptionStep("checkout_started", properties: [
+    "cart_total": 12900,
+    "item_count": 3,
+])
+
+PostHogSDK.shared.addExceptionStep("payment_attempted", properties: [
+    "provider": "stripe",
+])
+
+do {
+    try confirmCardPayment(clientSecret)
+} catch {
+    PostHogSDK.shared.captureException(error, properties: [
+        "checkout_id": "chk_123",
+    ])
+}
+```
+
+```kotlin file=Android
+PostHog.addExceptionStep("checkout_started", mapOf(
+    "cart_total" to 12900,
+    "item_count" to 3,
+))
+
+PostHog.addExceptionStep("payment_attempted", mapOf(
+    "provider" to "stripe",
+))
+
+try {
+    confirmCardPayment(clientSecret)
+} catch (e: Exception) {
+    PostHog.captureException(e, mapOf(
+        "checkout_id" to "chk_123",
+    ))
+}
+```
+
+```dart file=Flutter
+await Posthog().addExceptionStep('checkout_started', properties: {
+  'cart_total': 12900,
+  'item_count': 3,
+});
+
+await Posthog().addExceptionStep('payment_attempted', properties: {
+  'provider': 'stripe',
+});
+
+try {
+  await confirmCardPayment(clientSecret);
+} catch (error, stackTrace) {
+  await Posthog().captureException(
+    error: error,
+    stackTrace: stackTrace,
+    properties: {'checkout_id': 'chk_123'},
+  );
+}
+```
+
+</MultiLanguage>
+
 ### Configure limits
 
 The buffer is byte-aware: when the budget is exceeded, the oldest steps are evicted. The default is 32KB.
 
-```javascript
+<MultiLanguage>
+
+```js file=Web
 posthog.init('<ph_project_token>', {
   api_host: '<ph_api_client_host>',
   defaults: '<ph_posthog_js_defaults>',
@@ -195,12 +279,47 @@ posthog.init('<ph_project_token>', {
 })
 ```
 
+```react-native file=React Native
+const posthog = new PostHog('<ph_project_token>', {
+  host: '<ph_client_api_host>',
+  errorTracking: {
+    exceptionSteps: {
+      enabled: true,
+      maxBytes: 32768,
+    },
+  },
+})
+```
+
+```swift file=iOS
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_client_api_host>")
+config.errorTrackingConfig.exceptionSteps.enabled = true
+config.errorTrackingConfig.exceptionSteps.maxBytes = 32768
+PostHogSDK.shared.setup(config)
+```
+
+```kotlin file=Android
+val config = PostHogAndroidConfig(apiKey = "<ph_project_token>", host = "<ph_client_api_host>").apply {
+    errorTrackingConfig.exceptionSteps.enabled = true
+    errorTrackingConfig.exceptionSteps.maxBytes = 32768
+}
+PostHogAndroid.setup(this, config)
+```
+
+```dart file=Flutter
+final config = PostHogConfig('<ph_project_token>');
+config.errorTrackingConfig.exceptionSteps.enabled = true;
+config.errorTrackingConfig.exceptionSteps.maxBytes = 32768;
+```
+
+</MultiLanguage>
+
 ### Best practices
 
 - Use short step names that describe a checkpoint or action.
 - Keep payloads small and focused.
 - Avoid sensitive data, raw request bodies, and large nested objects.
-- Use the `before_send` callback to redact exception steps before they are sent.
+- Use a `before_send` / `beforeSend` callback to redact exception steps before they are sent.
 - Add steps before the risky operation runs.
 
 ### Troubleshooting missing steps
@@ -208,7 +327,7 @@ posthog.init('<ph_project_token>', {
 If an exception appears in error tracking but not in the timeline with steps:
 
 - Make sure you called `addExceptionStep(...)` before the failure.
-- Use `captureException(...)` or autocapture, not `posthog.capture('$exception', ...)`.
+- Use `captureException(...)` or autocapture, not a manual `$exception` capture.
 - Reduce step payload size if the final event is too large.
 
 ### Error boundaries

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -304,6 +304,8 @@ The `name` is a special property which is used in the PostHog UI for the name of
 
 To set up error tracking in your project, follow the [Android installation guide](/docs/error-tracking/installation/android).
 
+Use `PostHog.addExceptionStep(message, properties)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `errorTrackingConfig.exceptionSteps`. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog-android` 3.51.0 and later.
+
 ## Logs
 
 To set up [logs](/docs/logs) in your Android app, follow the [Android logs installation guide](/docs/logs/installation/android). The SDK exposes `PostHog.logger.{trace,debug,info,warn,error,fatal}` for sending structured records to PostHog Logs, with batching, offline persistence, and a rate cap built in.

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -302,9 +302,7 @@ The `name` is a special property which is used in the PostHog UI for the name of
 
 ## Error tracking
 
-To set up error tracking in your project, follow the [Android installation guide](/docs/error-tracking/installation/android).
-
-Use `PostHog.addExceptionStep(message, properties)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `errorTrackingConfig.exceptionSteps`. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog-android` 3.51.0 and later.
+To set up error tracking in your project, see the [error tracking docs](/docs/error-tracking).
 
 ## Logs
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -153,9 +153,7 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 ## Error tracking
 
-To set up error tracking in your project, follow the [Flutter installation guide](/docs/error-tracking/installation/flutter).
-
-Use `Posthog().addExceptionStep(message, properties: ...)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `config.errorTrackingConfig.exceptionSteps`. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog_flutter` 5.28.0 and later.
+To set up error tracking in your project, see the [error tracking docs](/docs/error-tracking).
 
 ## Logs
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -155,6 +155,8 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 To set up error tracking in your project, follow the [Flutter installation guide](/docs/error-tracking/installation/flutter).
 
+Use `Posthog().addExceptionStep(message, properties: ...)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `config.errorTrackingConfig.exceptionSteps`. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog_flutter` 5.28.0 and later.
+
 ## Logs
 
 To set up [logs](/docs/logs) in your Flutter app, follow the [Flutter logs installation guide](/docs/logs/installation/flutter). The SDK exposes `Posthog().logger.{trace,debug,info,warn,error,fatal}` (and `Posthog().captureLog` for full control) for sending structured records to PostHog Logs, with batching, offline persistence, and a rate cap built in.

--- a/contents/docs/libraries/ios/configuration.mdx
+++ b/contents/docs/libraries/ios/configuration.mdx
@@ -262,7 +262,7 @@ The [`PostHogConfig` object](https://github.com/PostHog/posthog-ios/blob/main/Po
 | `sessionReplay`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Enable Recording of Session Replays. |
 | `sessionReplayConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Session Replay configuration. See [Session Replay installation](/docs/session-replay/installation/ios) for more details. |
 | `tracingHeaders`<br/><br/>**Type:** Array of Strings<br/>**Default:** `nil` | Exact hostnames that should receive PostHog tracing headers when the SDK instruments `URLSession` requests. |
-| `errorTrackingConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Error Tracking configuration. See [Error Tracking installation](/docs/error-tracking/installation/ios) for more details. |
+| `errorTrackingConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Error Tracking configuration. Includes `exceptionSteps` for [breadcrumb-style exception steps](/docs/error-tracking/capture#add-exception-steps) recorded via `addExceptionStep(_:properties:)`. See [Error Tracking installation](/docs/error-tracking/installation/ios) for more details. |
 | `logs`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Structured Logs configuration. See [Logs installation](/docs/logs/installation/ios) for more details. |
 | `surveysConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Surveys configuration, including custom survey delegates and display language overrides. |
 | `urlSessionConfiguration`<br/><br/>**Type:** URLSessionConfiguration<br/>**Default:** `.default` | Custom `URLSessionConfiguration` used by the SDK for PostHog API requests. |

--- a/contents/docs/libraries/ios/configuration.mdx
+++ b/contents/docs/libraries/ios/configuration.mdx
@@ -262,7 +262,7 @@ The [`PostHogConfig` object](https://github.com/PostHog/posthog-ios/blob/main/Po
 | `sessionReplay`<br/><br/>**Type:** Boolean<br/>**Default:** `false` | Enable Recording of Session Replays. |
 | `sessionReplayConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Session Replay configuration. See [Session Replay installation](/docs/session-replay/installation/ios) for more details. |
 | `tracingHeaders`<br/><br/>**Type:** Array of Strings<br/>**Default:** `nil` | Exact hostnames that should receive PostHog tracing headers when the SDK instruments `URLSession` requests. |
-| `errorTrackingConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Error Tracking configuration. Includes `exceptionSteps` for [breadcrumb-style exception steps](/docs/error-tracking/capture#add-exception-steps) recorded via `addExceptionStep(_:properties:)`. See [Error Tracking installation](/docs/error-tracking/installation/ios) for more details. |
+| `errorTrackingConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Error Tracking configuration. See the [error tracking docs](/docs/error-tracking) for more details. |
 | `logs`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Structured Logs configuration. See [Logs installation](/docs/logs/installation/ios) for more details. |
 | `surveysConfig`<br/><br/>**Type:** Object<br/>**Default:** `.init()` | Surveys configuration, including custom survey delegates and display language overrides. |
 | `urlSessionConfiguration`<br/><br/>**Type:** URLSessionConfiguration<br/>**Default:** `.default` | Custom `URLSessionConfiguration` used by the SDK for PostHog API requests. |

--- a/contents/docs/libraries/ios/usage.mdx
+++ b/contents/docs/libraries/ios/usage.mdx
@@ -171,6 +171,12 @@ To set up [session replay](/docs/session-replay/mobile) in your project, all you
 
 [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 
+## Error tracking
+
+To set up error tracking in your project, follow the [iOS installation guide](/docs/error-tracking/installation/ios).
+
+Use `PostHogSDK.shared.addExceptionStep(_:properties:)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `errorTrackingConfig.exceptionSteps`. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog-ios` 3.61.0 and later.
+
 ## Debug mode 
 
 If you're not seeing the expected events being captured, the feature flags being evaluated, or the surveys being shown, you can enable debug mode to see what's happening. 

--- a/contents/docs/libraries/ios/usage.mdx
+++ b/contents/docs/libraries/ios/usage.mdx
@@ -173,9 +173,7 @@ To set up [session replay](/docs/session-replay/mobile) in your project, all you
 
 ## Error tracking
 
-To set up error tracking in your project, follow the [iOS installation guide](/docs/error-tracking/installation/ios).
-
-Use `PostHogSDK.shared.addExceptionStep(_:properties:)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `errorTrackingConfig.exceptionSteps`. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog-ios` 3.61.0 and later.
+To set up error tracking in your project, see the [error tracking docs](/docs/error-tracking).
 
 ## Debug mode 
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -344,6 +344,10 @@ Group analytics allows you to associate the events for that person's session wit
 
 To set up error tracking in your project, follow the [React Native installation guide](/docs/error-tracking/installation/react-native).
 
+### Exception steps
+
+Use `posthog.addExceptionStep(message, properties)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `errorTracking.exceptionSteps`. When native crash capture is enabled, steps are forwarded to the embedded native SDK so native crashes carry the same timeline. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog-react-native` 4.50.0 and later.
+
 ### Native crash autocapture
 
 The JavaScript-level autocapture only covers exceptions thrown in your JS/TS code. To also capture native iOS and Android crashes – for example, a crash inside a native module or the platform runtime – install the optional `@posthog/react-native-plugin` package and enable `errorTracking.autocapture.nativeCrashes`. Native capture is gated by your project's **Enable exception autocapture** setting, and crash reports need native debug symbols uploaded at build time to produce readable stack traces.

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -342,11 +342,7 @@ Group analytics allows you to associate the events for that person's session wit
 
 ## Error tracking
 
-To set up error tracking in your project, follow the [React Native installation guide](/docs/error-tracking/installation/react-native).
-
-### Exception steps
-
-Use `posthog.addExceptionStep(message, properties)` to record breadcrumb-style steps that attach to the next captured `$exception` as `$exception_steps`. Configure the rolling buffer with `errorTracking.exceptionSteps`. When native crash capture is enabled, steps are forwarded to the embedded native SDK so native crashes carry the same timeline. See [exception steps](/docs/error-tracking/capture#add-exception-steps) for details. Available in `posthog-react-native` 4.50.0 and later.
+To set up error tracking in your project, see the [error tracking docs](/docs/error-tracking).
 
 ### Native crash autocapture
 


### PR DESCRIPTION
## Changes

Documents the new `addExceptionStep(message, properties)` breadcrumb API (and its `exceptionSteps` config) now shipped across the mobile SDKs. Previously this was documented for web (`posthog-js`) only.

### `error-tracking/capture.mdx` (primary)
- The "Add exception steps" section is now multi-language across **Web, React Native, iOS, Android, and Flutter** for both the example and the "Configure limits" config block.
- Availability note lists all five SDK versions.
- Generalized SDK-agnostic wording (`before_send`/`beforeSend`, "manual `$exception` capture").

### Library reference docs
- **Android / Flutter / React Native** `index.mdx` — added an `addExceptionStep` note to each Error tracking section.
- **iOS** — added a new "Error tracking" section to `usage.mdx` (iOS had none) and noted `exceptionSteps` in the `errorTrackingConfig` row of `configuration.mdx`.

### Shared snippet
- Added a `$exception_steps` row to `exception-properties-table.mdx`.

## Versions referenced

| SDK | Version |
|---|---|
| `posthog-js` | 1.370.0 (already shipped) |
| `posthog-ios` | 3.61.0 |
| `posthog-android` | 3.51.0 |
| `posthog_flutter` | 5.28.0 |
| `posthog-react-native` | 4.50.0 (next minor — PR [#3861](https://github.com/PostHog/posthog-js/pull/3861) not yet merged) |

## Notes
- React Native exception steps are not yet released; the 4.50.0 version is the assumed next minor and may need confirming once #3861 merges.
- Installation/onboarding flow docs are sourced from the monorepo (`docs/onboarding/error-tracking/*.tsx`) and are out of scope for this repo.
