### PR TITLE
docs: Document Rust SDK user identification

### DIFF
--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -86,6 +86,23 @@ posthog.capture("distinct_id", "$set", new HashMap<String, Object>() {
 });
 ```
 
+```rust
+use std::collections::HashMap;
+use posthog_rs::Event;
+
+let mut event = Event::new("$set", "distinct_id");
+
+let mut set = HashMap::new();
+set.insert("name", "Max Hedgehog");
+event.insert_prop("$set", set).unwrap();
+
+let mut set_once = HashMap::new();
+set_once.insert("initial_url", "/blog");
+event.insert_prop("$set_once", set_once).unwrap();
+
+client.capture(event).await.unwrap();
+```
+
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_token>",

--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -1,4 +1,4 @@
-The recommended way to set person properties is to send a `$set` event with a `$set` property. For SDKs that provide helper methods (such as `posthog.setPersonProperties`), we recommend using them, as they handle important side effects like switching the user to identified mode.
+The recommended way to set person properties is to send a `$set` event with a `$set` property. For SDKs that provide helper methods (such as `posthog.setPersonProperties`), we recommend using them, as they handle important side effects like switching to identified mode.
 
 <MultiLanguage selector="tabs">
 
@@ -133,4 +133,4 @@ Person property values can be strings, booleans, numbers, objects, or arrays.  F
 > - Mobile apps batching events while the device is offline
 > - Server-side SDKs with delayed flushes or network retries
 >
-> In these cases, a late-arriving event can overwrite a `$set` value or claim a `$set_once` key before the "true first" event is ingested. If ordering matters for your use case, prefer `$set_once` for values that should not change (though note that `$set_once` is still subject to ingestion ordering — the first ingested event claims the key, not necessarily the earliest event by timestamp). Be aware that `$set` always reflects the last *ingested* value, not the last *timestamped* value.
+> In these cases, a late-arriving event can overwrite a `$set` value or claim a `$set_once` key before the "true first" event is ingested. If ordering matters for your use case, prefer `$set_once` for values that should not change (though note that `$set_once` is still subject to ingestion ordering – the first ingested event claims the key, not necessarily the earliest event by timestamp). Be aware that `$set` always reflects the last *ingested* value, not the last *timestamped* value.

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -38,18 +38,7 @@ To capture [anonymous events](/docs/data/anonymous-vs-identified-events) without
 
 ## Alias
 
-The Rust SDK doesn't currently expose an `alias` helper. If you need to assign multiple distinct IDs to the same user from Rust, send a `$create_alias` event manually:
-
-```rust
-use posthog_rs::Event;
-
-let mut event = Event::new("$create_alias", "frontend_id");
-event.insert_prop("alias", "backend_id").unwrap();
-
-client.capture(event).await.unwrap();
-```
-
-We strongly recommend reading our docs on [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+The Rust SDK doesn't currently expose an `alias` helper. If you need to assign multiple distinct IDs to the same user from Rust, see the [Rust example in the alias docs](/docs/product-analytics/identify?tab=Rust#alias-assigning-multiple-distinct-ids-to-the-same-user).
 
 ## Feature flags
 

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -4,7 +4,7 @@ github: 'https://github.com/PostHog/posthog-rs'
 platformLogo: rust
 features:
   eventCapture: true
-  userIdentification: false
+  userIdentification: true
   featureFlags: true
   groupAnalytics: true
   surveys: false
@@ -29,6 +29,27 @@ import IdentifyBackendCallout from '../../_snippets/identify-backend-callout.mdx
 import RustSendEvents from '../../integrate/send-events/_snippets/send-events-rust.mdx'
 
 <RustSendEvents />
+
+## Person profiles and properties
+
+The Rust SDK captures identified events when you pass a `distinct_id` to `Event::new`. These create [person profiles](/docs/data/persons). To set [person properties](/docs/product-analytics/person-properties), include `$set` and `$set_once` properties when capturing an event.
+
+To capture [anonymous events](/docs/data/anonymous-vs-identified-events) without person profiles, use `Event::new_anon`.
+
+## Alias
+
+The Rust SDK doesn't currently expose an `alias` helper. If you need to assign multiple distinct IDs to the same user from Rust, send a `$create_alias` event manually:
+
+```rust
+use posthog_rs::Event;
+
+let mut event = Event::new("$create_alias", "frontend_id");
+event.insert_prop("alias", "backend_id").unwrap();
+
+client.capture(event).await.unwrap();
+```
+
+We strongly recommend reading our docs on [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ## Feature flags
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -333,6 +333,17 @@ client.Enqueue(posthog.Alias{
 posthog.alias("frontend_id", "backend_id");
 ```
 
+```rust
+use posthog_rs::Event;
+
+// The Rust SDK doesn't currently expose an alias helper.
+// See /docs/libraries/rust#alias for more details.
+let mut event = Event::new("$create_alias", "frontend_id");
+event.insert_prop("alias", "backend_id").unwrap();
+
+client.capture(event).await.unwrap();
+```
+
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_token>",
@@ -346,8 +357,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
 ```
 
 </MultiLanguage>
-
-The Rust SDK doesn't currently expose an `alias` helper. If you're using Rust, see the [Rust SDK alias docs](/docs/libraries/rust#alias) for how to send the `$create_alias` event manually.
 
 There are two requirements when assigning an `alias_id`:
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -347,6 +347,8 @@ curl -v -L --header "Content-Type: application/json" -d '{
 
 </MultiLanguage>
 
+The Rust SDK doesn't currently expose an `alias` helper. If you're using Rust, see the [Rust SDK alias docs](/docs/libraries/rust#alias) for how to send the `$create_alias` event manually.
+
 There are two requirements when assigning an `alias_id`:
 
 1. It cannot be associated with more than one `distinct_id`.


### PR DESCRIPTION
## Changes

- Mark the Rust SDK as supporting user identification in the SDK comparison metadata.
- Add a concise Rust SDK section explaining identified events, person profiles, anonymous events, and linking to the Rust alias example.
- Add a Rust tab to the shared person properties snippet used by the person properties docs.
- Add a Rust-only alias example to the general identify docs so the Rust workaround only appears when the Rust tab is selected.
- Address Vale feedback in the shared person properties snippet.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
