### PR TITLE
docs(session-replay): document event trigger SDK support and mobile behavior

### DIFF
--- a/contents/docs/session-replay/_snippets/flutter-manual-replay-control.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-manual-replay-control.mdx
@@ -10,4 +10,4 @@ You can manually control when to start and stop session recordings using the fol
 - `stopSessionRecording()`
   - Stops/pauses the current session recording.
 
-> **Note:** Calling these methods will have no effect if session recordings are disabled in your PostHog [Project Settings](https://app.posthog.com/project/settings).
+> **Note:** Calling these methods will have no effect if session recordings are disabled in your PostHog [Project Settings](https://app.posthog.com/project/settings). Manual starts still respect project ingestion controls, including sampling and event triggers.

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -70,8 +70,8 @@ The client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger
 
 ## With Event trigger conditions
 
-Since posthog-js version 1.186.0, you can opt to only start recordings once your user emits a particular event. After the event is captured, the recording continues even after they leave the matching page.
-The client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see activity leading up to that event.
+You can opt to only start recordings once your user emits a particular event. After the event is captured, the recording continues for the rest of the session.
+On the web, the client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see activity leading up to that event.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/event_trigger_light_21a531edbb.png"
@@ -79,6 +79,15 @@ The client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger
   alt="Adding event trigger to control session recordings"
   classes="rounded"
 />
+
+Event triggers are supported on the following SDKs:
+
+- **Web** - posthog-js 1.186.0+
+- **iOS** - 3.48.0+
+- **Android** - 3.40.1+
+- **Flutter** - 5.25.0+
+
+> On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.
 
 ### Triggering on exceptions
 


### PR DESCRIPTION
## Summary

Documents event trigger support across SDKs and clarifies how event triggers behave on mobile.

- Add an SDK support list for event triggers (Web, iOS, Android, Flutter) with minimum versions.
- Reword the event trigger intro to be SDK-agnostic (drop the explicit posthog-js-only callout) and scope the in-memory buffer description to web.
- Add a note explaining mobile platforms have no URL/in-memory pre-buffer: recording starts when the matching event is captured and continues for the rest of the session, and a new session re-arms the trigger.
- Note in the Flutter manual replay control snippet that manual starts still respect project ingestion controls (sampling, event triggers).