### PR TITLE
docs(feature-flags): call device-property customization in loaded callback

### DIFF
--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -189,15 +189,20 @@ Other campaign parameters (`gad_source`, `mc_cid`, `dclid`, `gbraid`, `wbraid`, 
 
 #### Including browser and device properties
 
-To include current browser and device properties (like `$browser`, `$os`, `$device_type`) with flag requests, use the `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` customization.
+To include current browser and device properties (like `$browser`, `$os`, `$device_type`) with flag requests, use the `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` customization. Call it inside the `loaded` callback so it runs **before the first flag evaluation** (see the note below on why this matters).
 
 **Using npm:**
 
 ```js
+import posthog from 'posthog-js'
 import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/src/customizations'
 
-// Call after PostHog is initialized
-setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)
+posthog.init('<ph_project_api_key>', {
+    api_host: '<ph_client_api_host>',
+    loaded: (posthog) => {
+        setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)
+    },
+})
 ```
 
 **Using the snippet:**
@@ -205,9 +210,20 @@ setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)
 ```html
 <script type="text/javascript" src="https://us.i.posthog.com/static/customizations.full.js"></script>
 <script>
-  posthogCustomizations.setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)
+  posthog.init('<ph_project_api_key>', {
+    api_host: '<ph_client_api_host>',
+    loaded: function (posthog) {
+      posthogCustomizations.setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)
+    },
+  })
 </script>
 ```
+
+> **Why the `loaded` callback?** `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` is a function that takes a one-time snapshot of the current browser and device properties and attaches them to flag requests. It only affects requests sent **after** it runs. The web SDK fires its first flag request automatically during initialization, so if you call the customization as a bare statement right after `posthog.init(...)` it can run too late — and with the asynchronous snippet loader, `posthog` may still be the loading stub, in which case the call is silently skipped. Either way, the **first** flag evaluation goes out without these properties. The `loaded` callback runs once the SDK is ready and before that first request, so the properties are included from the very first evaluation.
+>
+> This is especially important for **exclusion** conditions such as "`$os` is not `Android`": a missing `$os` does not match `Android`, so a visitor whose `$os` hasn't been sent yet is **included** on that first evaluation rather than excluded. Sending the property on the first request avoids this.
+>
+> For a stronger guarantee that the very first network evaluation carries these properties, also set [`advanced_disable_feature_flags_on_first_load: true`](/docs/libraries/js/config) and call `posthog.reloadFeatureFlags()` after the customization inside `loaded`. This suppresses the automatic first request so the only flag evaluation is the one you trigger with the properties already attached.
 
 This adds the following properties to flag requests:
 

--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -189,7 +189,7 @@ Other campaign parameters (`gad_source`, `mc_cid`, `dclid`, `gbraid`, `wbraid`, 
 
 #### Including browser and device properties
 
-To include current browser and device properties (like `$browser`, `$os`, `$device_type`) with flag requests, use the `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` customization. Call it inside the `loaded` callback so it runs **before the first flag evaluation** (see the note below on why this matters).
+To include current browser and device properties (like `$browser`, `$os`, `$device_type`) with flag requests, use the `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` customization. Call it inside the `loaded` callback so it runs before the SDK's first flag request and those properties are included from the very first evaluation.
 
 **Using npm:**
 
@@ -218,12 +218,6 @@ posthog.init('<ph_project_api_key>', {
   })
 </script>
 ```
-
-> **Why the `loaded` callback?** `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` is a function that takes a one-time snapshot of the current browser and device properties and attaches them to flag requests. It only affects requests sent **after** it runs. The web SDK fires its first flag request automatically during initialization, so if you call the customization as a bare statement right after `posthog.init(...)` it can run too late — and with the asynchronous snippet loader, `posthog` may still be the loading stub, in which case the call is silently skipped. Either way, the **first** flag evaluation goes out without these properties. The `loaded` callback runs once the SDK is ready and before that first request, so the properties are included from the very first evaluation.
->
-> This is especially important for **exclusion** conditions such as "`$os` is not `Android`": a missing `$os` does not match `Android`, so a visitor whose `$os` hasn't been sent yet is **included** on that first evaluation rather than excluded. Sending the property on the first request avoids this.
->
-> For a stronger guarantee that the very first network evaluation carries these properties, also set [`advanced_disable_feature_flags_on_first_load: true`](/docs/libraries/js/config) and call `posthog.reloadFeatureFlags()` after the customization inside `loaded`. This suppresses the automatic first request so the only flag evaluation is the one you trigger with the properties already attached.
 
 This adds the following properties to flag requests:
 


### PR DESCRIPTION
## Problem

The [Including browser and device properties](https://posthog.com/docs/feature-flags/property-overrides#including-browser-and-device-properties) docs show `setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)` as a **bare statement after `posthog.init(...)`** ("Call after PostHog is initialized").

That pattern bites anonymous traffic: the customization is an imperative function that snapshots browser/device properties and attaches them only to flag requests sent **after** it runs. The web SDK fires its first flag request automatically during init, and with the **async snippet loader** `posthog` is still the loading stub when the bare statement runs — so the call is silently skipped and the **first** flag evaluation goes out without `$os`/`$browser`/etc.

The practical failure: an exclusion condition like "`$os` is not `Android`" doesn't exclude Android visitors on first load, because a *missing* `$os` doesn't match `Android`. (Came up in a customer ticket — Android users were shown an experiment despite the exclusion; first touch failed, second worked.)

## Change

In the web SDK section only: show the customization called inside the `loaded` callback (npm + snippet), so it runs once the SDK is ready and **before** the first flag request, and the properties are included from the very first evaluation.

Validated end-to-end (real Chrome with an Android UA → official async snippet → real flags backend): the bare-statement pattern showed the flag enabled (Android wrongly included) 5/5 runs; the `loaded`-callback pattern showed it disabled (correctly excluded) 5/5 runs.

## 🤖 Agent context

Documentation-only change to `contents/docs/feature-flags/property-overrides.mdx`. No code or behavior change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
