### PR TITLE
Add weeks-to-live entry to company lore

### DIFF
--- a/contents/handbook/company/lore.md
+++ b/contents/handbook/company/lore.md
@@ -47,3 +47,5 @@ A beginner's guide to some of our custom Slack emojis and various anecdotes you'
 * <TeamMember name="Anna-Marie Doudova" photo /> did a presentation at our Barbados offsite about Gen Z slang which encouraged everyone to do Gen Z slangmaxxing like an unc that's cooked 💀. 
 
 * Hire movers. Whenever someone asks the team for moving or packing tips, the unanimous, handbook-sanctioned answer is: hire movers. (And, while you're at it, hire packers.) This was settled in a lengthy thread where someone moving to a second-floor apartment a four-minute drive away — with a flight of stairs and lots of heavy furniture — asked for _packing_ hacks and instead received an avalanche of "hire movers" from everyone.
+
+* We're going to die in around 1,646 weeks, maybe earlier. Someone will periodically remind you in Slack of exactly how many weeks we all have left to live. It's a reference to [Your Life in Weeks](https://waitbutwhy.com/2014/05/life-weeks.html) — a memento mori to keep us shipping. Welcome to the lore.


### PR DESCRIPTION
## Changes

Adds the "we're going to die in around 1,646 weeks, maybe earlier" bit to the [company lore page](https://posthog.com/handbook/company/lore) as a new entry, matching the existing list's tone and format. Links it back to Tim Urban's *Your Life in Weeks*.

**Why:** A Slack thread joked about the recurring weeks-to-live countdown and noted it wasn't yet captured as lore. This documents the inside joke.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C085FD96WAK/p1781874903428089?thread_ts=1781874903.428089&cid=C085FD96WAK)*