### PR TITLE
docs: bump posthog-js defaults snippets to 2026-05-30

### DIFF
--- a/contents/docs/integrate/_snippets/install-web.mdx
+++ b/contents/docs/integrate/_snippets/install-web.mdx
@@ -183,7 +183,7 @@ if (!window.location.host.includes('127.0.0.1') && !window.location.host.include
 <details id="defaults-option">
 <summary>What is the `defaults` option?</summary>
 
-The `defaults` is a date, such as `2026-01-30`, for a configuration snapshot used as defaults to initialize PostHog. This default is overridden when you explicitly set a value for any of the options.
+The `defaults` is a date, such as `2026-05-30`, for a configuration snapshot used as defaults to initialize PostHog. This default is overridden when you explicitly set a value for any of the options.
 
 </details>
 

--- a/contents/docs/integrate/_snippets/vuejs/composition-install.mdx
+++ b/contents/docs/integrate/_snippets/vuejs/composition-install.mdx
@@ -15,7 +15,7 @@ const app = createApp(App);
 
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN || '<ph_project_token>', {
   api_host: import.meta.env.VITE_POSTHOG_HOST || '<ph_client_api_host>',
-  defaults: '2026-01-30',
+  defaults: '2026-05-30',
 });
 
 app.use(createPinia())

--- a/contents/docs/libraries/react-router/react-router-v6.mdx
+++ b/contents/docs/libraries/react-router/react-router-v6.mdx
@@ -116,7 +116,7 @@ import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react' // +
 // Initialize PostHog
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
-  defaults: '2026-01-30', // +
+  defaults: '2026-05-30', // +
 }); // +
 
 const root = document.getElementById("root");
@@ -207,7 +207,7 @@ To help PostHog track your user sessions across the client and server, you'll ne
 ```tsx
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
-  defaults: '2026-01-30',
+  defaults: '2026-05-30',
   tracing_headers: [ window.location.hostname, 'localhost' ], // +
 });
 ```

--- a/contents/docs/libraries/react-router/react-router-v7-data-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-data-mode.mdx
@@ -115,7 +115,7 @@ import { PostHogProvider } from '@posthog/react' // +
 
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST,
-  defaults: '2026-01-30', // +
+  defaults: '2026-05-30', // +
 }); // +
 
 const router = createBrowserRouter([...]);
@@ -198,7 +198,7 @@ To help PostHog track your user sessions across the client and server, you'll ne
 ```tsx
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
-  defaults: '2026-01-30',
+  defaults: '2026-05-30',
   tracing_headers: [ window.location.hostname, 'localhost' ], // +
 });
 ```

--- a/contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-declarative-mode.mdx
@@ -116,7 +116,7 @@ import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react' // +
 // Initialize PostHog
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
-  defaults: '2026-01-30', // +
+  defaults: '2026-05-30', // +
 }); // +
 
 const root = document.getElementById("root");
@@ -207,7 +207,7 @@ To help PostHog track your user sessions across the client and server, you'll ne
 ```tsx
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
-  defaults: '2026-01-30',
+  defaults: '2026-05-30',
   tracing_headers: [ window.location.hostname, 'localhost' ], // +
 });
 ```

--- a/contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx
+++ b/contents/docs/libraries/react-router/react-router-v7-framework-mode.mdx
@@ -137,7 +137,7 @@ import { PostHogProvider } from '@posthog/react'  // +
 
 posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, { // +
   api_host: import.meta.env.VITE_POSTHOG_HOST, // +
-  defaults: '2026-01-30', // +
+  defaults: '2026-05-30', // +
   tracing_headers: [ window.location.hostname, 'localhost' ], // +
 }); // +
 

--- a/contents/docs/libraries/tanstack-start.mdx
+++ b/contents/docs/libraries/tanstack-start.mdx
@@ -52,7 +52,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           apiKey="<ph_project_token>"
           options={{
             api_host: '<ph_client_api_host>',
-            defaults: '2026-01-30',
+            defaults: '2026-05-30',
             capture_exceptions: true
           }}
         >

--- a/contents/handbook/docs-and-wizard/mdx-and-components.mdx
+++ b/contents/handbook/docs-and-wizard/mdx-and-components.mdx
@@ -111,7 +111,7 @@ You can use magic placeholders or strings to replace the project token, project 
 | `<ph_app_host>`            | Your PostHog instance URL     | n/a                                             |
 | `<ph_client_api_host>`     | Your PostHog client API host  | `https://us.i.posthog.com`                      |
 | `<ph_region>`              | Your PostHog region (us/eu)   | n/a                                             |
-| `<ph_posthog_js_defaults>` | Default values for posthog-js | `2026-01-30`                                    |
+| `<ph_posthog_js_defaults>` | Default values for posthog-js | `2026-05-30`                                    |
 | `<ph_proxy_path>`          | Your proxy path               | `relay-XXXX` (last 4 digits of project token)   |
 
 You can use these placeholders in the code block like this:

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -41,7 +41,7 @@ Although autocapture is a great way to get started, it can be limiting for more 
 
 3. **Customization**. Although it is possible to [add properties to autocapture](/docs/product-analytics/autocapture#capturing-additional-properties-in-autocapture-events), getting exactly the data you want at the exact moment you want requires customization.
 
-4. **Pageviews rely on page loads**. Pageview captures rely on page load events. This means they don't work well with [single-page apps (SPAs)](/tutorials/single-page-app-pageviews). To fix this, you can rely on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to capture pageviews by setting the `capture_pageview` configuration option to `history_change` or by using the most recent `defaults: '2026-01-30'`.
+4. **Pageviews rely on page loads**. Pageview captures rely on page load events. This means they don't work well with [single-page apps (SPAs)](/tutorials/single-page-app-pageviews). To fix this, you can rely on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to capture pageviews by setting the `capture_pageview` configuration option to `history_change` or by using the most recent `defaults`.
 
 ## Setting up custom events
 

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -41,7 +41,7 @@ Although autocapture is a great way to get started, it can be limiting for more 
 
 3. **Customization**. Although it is possible to [add properties to autocapture](/docs/product-analytics/autocapture#capturing-additional-properties-in-autocapture-events), getting exactly the data you want at the exact moment you want requires customization.
 
-4. **Pageviews rely on page loads**. Pageview captures rely on page load events. This means they don't work well with [single-page apps (SPAs)](/tutorials/single-page-app-pageviews). To fix this, you can rely on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to capture pageviews by setting the `capture_pageview` configuration option to `history_change` or by using the most recent `defaults: '2026-01-30'`.
+4. **Pageviews rely on page loads**. Pageview captures rely on page load events. This means they don't work well with [single-page apps (SPAs)](/tutorials/single-page-app-pageviews). To fix this, you can rely on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to capture pageviews by setting the `capture_pageview` configuration option to `history_change` or by using the most recent `defaults: '2026-05-30'`.
 
 ## Setting up custom events
 

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -41,7 +41,7 @@ Although autocapture is a great way to get started, it can be limiting for more 
 
 3. **Customization**. Although it is possible to [add properties to autocapture](/docs/product-analytics/autocapture#capturing-additional-properties-in-autocapture-events), getting exactly the data you want at the exact moment you want requires customization.
 
-4. **Pageviews rely on page loads**. Pageview captures rely on page load events. This means they don't work well with [single-page apps (SPAs)](/tutorials/single-page-app-pageviews). To fix this, you can rely on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to capture pageviews by setting the `capture_pageview` configuration option to `history_change` or by using the most recent `defaults: '2026-05-30'`.
+4. **Pageviews rely on page loads**. Pageview captures rely on page load events. This means they don't work well with [single-page apps (SPAs)](/tutorials/single-page-app-pageviews). To fix this, you can rely on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to capture pageviews by setting the `capture_pageview` configuration option to `history_change` or by using the most recent `defaults: '2026-01-30'`.
 
 ## Setting up custom events
 

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -96,7 +96,7 @@ import posthog from 'posthog-js'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2026-01-30',
+  defaults: '<ph_posthog_js_defaults>',
 });
 ```
 

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -96,7 +96,7 @@ import posthog from 'posthog-js'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2026-05-30',
+  defaults: '2026-01-30',
 });
 ```
 

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -96,7 +96,7 @@ import posthog from 'posthog-js'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2026-01-30',
+  defaults: '2026-05-30',
 });
 ```
 

--- a/contents/tutorials/nextjs-pages-analytics.md
+++ b/contents/tutorials/nextjs-pages-analytics.md
@@ -295,7 +295,7 @@ import posthog from 'posthog-js'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2026-01-30'
+  defaults: '<ph_posthog_js_defaults>'
 });
 ```
 

--- a/contents/tutorials/nextjs-pages-analytics.md
+++ b/contents/tutorials/nextjs-pages-analytics.md
@@ -295,7 +295,7 @@ import posthog from 'posthog-js'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2026-05-30'
+  defaults: '2026-01-30'
 });
 ```
 

--- a/contents/tutorials/nextjs-pages-analytics.md
+++ b/contents/tutorials/nextjs-pages-analytics.md
@@ -295,7 +295,7 @@ import posthog from 'posthog-js'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2026-01-30'
+  defaults: '2026-05-30'
 });
 ```
 

--- a/contents/tutorials/single-page-app-pageviews.md
+++ b/contents/tutorials/single-page-app-pageviews.md
@@ -17,7 +17,7 @@ A single-page application (or SPA) dynamically loads content for new pages using
 
 PostHog's JavaScript Web SDK automatically captures pageview events on page load. The problem with SPAs is that **page loads don't happen beyond the initial one**. This means user navigation in your SPA isn't tracked.
 
-Luckily, you can opt-in to tracking this behavior by setting `defaults: '2026-01-30'` when initializing PostHog to use the most recent defaults. This default uses `capture_pageview: 'history_change'`, which captures SPA navigation using the browser [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 
+Luckily, you can opt-in to tracking this behavior by setting the `defaults` config option to the most recent date when initializing PostHog. Recent defaults set `capture_pageview: 'history_change'`, which captures SPA navigation using the browser [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 
 
 This tutorial shows you how to follow the recommended approach for the most popular SPA frameworks like [Next.js](#tracking-pageviews-in-nextjs-app-router), [Vue](#tracking-pageviews-in-vue), [Svelte](#tracking-pageviews-in-svelte), and [Angular](#tracking-pageviews-in-angular). 
 

--- a/contents/tutorials/single-page-app-pageviews.md
+++ b/contents/tutorials/single-page-app-pageviews.md
@@ -17,7 +17,7 @@ A single-page application (or SPA) dynamically loads content for new pages using
 
 PostHog's JavaScript Web SDK automatically captures pageview events on page load. The problem with SPAs is that **page loads don't happen beyond the initial one**. This means user navigation in your SPA isn't tracked.
 
-Luckily, you can opt-in to tracking this behavior by setting `defaults: '2026-01-30'` when initializing PostHog to use the most recent defaults. This default uses `capture_pageview: 'history_change'`, which captures SPA navigation using the browser [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 
+Luckily, you can opt-in to tracking this behavior by setting `defaults: '2026-05-30'` when initializing PostHog to use the most recent defaults. This default uses `capture_pageview: 'history_change'`, which captures SPA navigation using the browser [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 
 
 This tutorial shows you how to follow the recommended approach for the most popular SPA frameworks like [Next.js](#tracking-pageviews-in-nextjs-app-router), [Vue](#tracking-pageviews-in-vue), [Svelte](#tracking-pageviews-in-svelte), and [Angular](#tracking-pageviews-in-angular). 
 

--- a/contents/tutorials/single-page-app-pageviews.md
+++ b/contents/tutorials/single-page-app-pageviews.md
@@ -17,7 +17,7 @@ A single-page application (or SPA) dynamically loads content for new pages using
 
 PostHog's JavaScript Web SDK automatically captures pageview events on page load. The problem with SPAs is that **page loads don't happen beyond the initial one**. This means user navigation in your SPA isn't tracked.
 
-Luckily, you can opt-in to tracking this behavior by setting `defaults: '2026-05-30'` when initializing PostHog to use the most recent defaults. This default uses `capture_pageview: 'history_change'`, which captures SPA navigation using the browser [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 
+Luckily, you can opt-in to tracking this behavior by setting `defaults: '2026-01-30'` when initializing PostHog to use the most recent defaults. This default uses `capture_pageview: 'history_change'`, which captures SPA navigation using the browser [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 
 
 This tutorial shows you how to follow the recommended approach for the most popular SPA frameworks like [Next.js](#tracking-pageviews-in-nextjs-app-router), [Vue](#tracking-pageviews-in-vue), [Svelte](#tracking-pageviews-in-svelte), and [Angular](#tracking-pageviews-in-angular). 
 

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -237,7 +237,7 @@ export const CodeBlock = ({
             .replace(/<ph_app_host>/g, removeQuotes(appHost) || '<ph_app_host>')
             .replace(/<ph_client_api_host>/g, removeQuotes(clientApiHost) || 'https://us.i.posthog.com')
             .replace(/<ph_region>/g, removeQuotes(region) || '<ph_region>')
-            .replace(/<ph_posthog_js_defaults>/g, '2026-01-30')
+            .replace(/<ph_posthog_js_defaults>/g, '2026-05-30')
             .replace(
                 /<ph_proxy_path>/g,
                 projectToken ? `relay-${removeQuotes(projectToken)?.slice(-4)}` : '<ph_proxy_path>'


### PR DESCRIPTION
## Changes

The PostHog app already runs the `2026-05-30` SDK defaults, having dogfooded them ahead of customers. This promotes that date to the install snippets people copy from the docs (they were on `2026-01-30`).

- Bumps the `<ph_posthog_js_defaults>` token (`2026-01-30` -> `2026-05-30`) in `handbook/docs-and-wizard/mdx-and-components.mdx`. This token is the single source for every token-based snippet across the docs and tutorials, so the bulk of snippets update from this one line.
- Bumps the remaining hand-written hardcoded literals (react-router v6/v7, tanstack-start, vue composition install, the Next.js tutorials) in place — these snippets use real env-var literals rather than the `<ph_>` placeholder, so a literal date matches their style.
- Bumps the "use the most recent defaults" prose recommendations in the SPA-pageviews and event-tracking tutorials, and the illustrative example in the install-web snippet.

Versus `2026-01-30`, the new defaults turn on `split_storage`, debounced persistence writes (`persistence_save_debounce_ms: 250`), Google Search in-app detection, expanded rageclick filtering, and a `session_recording.canvasCapture.resolutionScale` of 0.6 (a scale knob only — it does **not** enable canvas capture). None increase what's captured.

**Deliberately left untouched:** the version-history table and threshold notes in `docs/libraries/js/config.mdx` (e.g. "`'head'` when `defaults: '2026-01-30'` or later") and the Angular threshold sentence in `docs/libraries/angular.mdx`. Those accurately document *when* each behavior was introduced — `config.mdx` on master already documents the `2026-05-30` entry — so bumping them would make the history wrong.

The matching app-side change is PostHog/posthog#64863.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

> Authored by an agent (PostHog Code), human-directed by @pauldambra. Only automated checks were run; the Vercel preview should be eyeballed before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
