### PR TITLE
Add data trust check to customer audit guidance

### DIFF
--- a/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
+++ b/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
@@ -36,6 +36,23 @@ In their project(s), check the data management tab:
 
 Also worth running through the [basic account review](/handbook/cs-and-onboarding/foundation-check) checklist.
 
+### Trust the data before you trust the dashboards
+
+A customer can be busy in PostHog and still not trust PostHog. Dashboards, saved insights, and regular logins are useful signals, but they do not prove the data matches how the business actually works.
+
+Before your first outreach, take a quick look at the basics:
+
+- Is the project mostly `$pageview` and raw `$autocapture`, or have they defined the events and actions that describe their real funnel?
+- Are users being identified consistently?
+- Do important events have useful properties, or are they too thin to break down later?
+- If they sell to teams, companies, or workspaces, are groups set up where relevant?
+- Do event and property names look deliberate, or are there duplicates and one-off names everywhere?
+- Do the dashboards answer questions the customer clearly cares about, or just report what was easiest to capture?
+
+This matters because bad instrumentation usually shows up before churn does. A customer might still have active users, dashboards, and session replays while quietly losing confidence in the numbers. If the data looks thin, make that your opener: "I noticed your team is using PostHog, but most of the data is still pageviews and autocapture. I think we can make these dashboards much more useful by defining a few events around your actual funnel."
+
+Do not turn this into a full audit before every intro. It is a quick sniff test. If something looks off, use the [foundation check](/handbook/cs-and-onboarding/foundation-check) or [health check](/handbook/cs-and-onboarding/health-checks) as the deeper follow-up.
+
 ## 2. Reach out
 
 How you reach out depends on whether you're inheriting an existing contact or starting cold.


### PR DESCRIPTION
Added a short section to the customer audit guidance about checking whether a customer's PostHog data is trustworthy before relying on dashboards or usage signals.

cc/ @danazou 

## Changes

- Added "Trust the data before you trust the dashboards" to the customer audit workflow
- Called out quick checks for event mix, identify usage, event properties, groups, naming consistency, and dashboard usefulness
- Linked to the existing foundation check and health check for deeper follow-up

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

