### PR TITLE
Point MCP Analytics early access opt-in at public feature previews page

### DIFF
--- a/src/components/EarlyAccessOptIn/README.md
+++ b/src/components/EarlyAccessOptIn/README.md
@@ -6,10 +6,10 @@ A small opt-in button that points visitors at a PostHog **early access feature i
 import EarlyAccessOptIn from 'components/EarlyAccessOptIn'
 
 // Gathering interest before the beta opens:
-<EarlyAccessOptIn to="https://us.posthog.com/early_access_features/<id>" state="register_interest" />
+<EarlyAccessOptIn to="https://us.posthog.com/settings/user-feature-previews#<feature>" state="register_interest" />
 
 // Beta is open, people can request access:
-<EarlyAccessOptIn to="https://us.posthog.com/early_access_features/<id>" state="request_access" />
+<EarlyAccessOptIn to="https://us.posthog.com/settings/user-feature-previews#<feature>" state="request_access" />
 ```
 
 It's used in the header of product landing pages via `SlidesTemplate`'s `rightActionButtons` prop – see `src/pages/mcp-analytics/index.tsx`.
@@ -40,7 +40,7 @@ So instead, this component is a plain link to the early access feature in the ap
 
 | Prop        | Type                                       | Default            | Notes                                                              |
 | ----------- | ------------------------------------------ | ------------------ | ------------------------------------------------------------------ |
-| `to`        | `string` (required)                        | –                  | URL of the early access feature in the app. Must point at the app. |
+| `to`        | `string` (required)                        | –                  | URL of the feature previews surface in the app. Must point at the app. |
 | `state`     | `'register_interest' \| 'request_access'`  | `'request_access'` | Sets the default CTA copy (see above).                             |
 | `label`     | `string`                                   | label for `state`  | Override the CTA copy.                                             |
 | `className` | `string`                                   | `''`               | Extra classes for the button.                                     |
@@ -48,4 +48,6 @@ So instead, this component is a plain link to the early access feature in the ap
 
 ## Finding the `to` URL
 
-In the app, open the early access feature you want people to join and copy its URL – it looks like `https://us.posthog.com/early_access_features/<id>`. That page is where a signed-in user registers interest / enrolls.
+Point `to` at the public **feature previews** surface – `https://us.posthog.com/settings/user-feature-previews`, anchored to the feature (e.g. `#mcp-analytics`). That page is accessible to any signed-in user and is where they register interest / enroll.
+
+Avoid linking to the internal `/early_access_features/<id>` management page: it's only accessible to your PostHog team, so external visitors hit an error there.

--- a/src/components/EarlyAccessOptIn/index.tsx
+++ b/src/components/EarlyAccessOptIn/index.tsx
@@ -15,11 +15,12 @@ const DEFAULT_LABELS: Record<EarlyAccessState, string> = {
 
 export interface EarlyAccessOptInProps {
     /**
-     * URL of the early access feature in the PostHog app (e.g. an
-     * `/early_access_features/{id}` page). This MUST point at the app, not a local
-     * enrollment call: logins are not shared between posthog.com and the app, so the
-     * visitor's website identity is anonymous and enrolling it here would be meaningless.
-     * The signed-in user opts into the beta in the app instead.
+     * URL of the early access feature in the PostHog app — typically the public feature
+     * previews surface (e.g. `/settings/user-feature-previews#<feature>`), where any
+     * signed-in user can opt in. This MUST point at the app, not a local enrollment call:
+     * logins are not shared between posthog.com and the app, so the visitor's website
+     * identity is anonymous and enrolling it here would be meaningless. The signed-in user
+     * opts into the beta in the app instead.
      */
     to: string
     /**

--- a/src/pages/mcp-analytics/index.tsx
+++ b/src/pages/mcp-analytics/index.tsx
@@ -9,14 +9,13 @@ const PRODUCT_HANDLE = 'mcp_analytics'
 
 // MCP analytics is gated behind the `mcp-analytics` early access feature in the app. Logins
 // aren't shared between posthog.com and the app, so we can't enroll the visitor's website
-// identity here — instead the opt-in links to the early access feature in the app, where the
-// signed-in user can join the beta. See src/components/EarlyAccessOptIn/README.md.
+// identity here — instead the opt-in links to the app, where the signed-in user can join the
+// beta. See src/components/EarlyAccessOptIn/README.md.
 //
-// This is the canonical URL for the "MCP Analytics" early access feature (project 2, where
-// PostHog dogfoods its own site). It's currently in `concept` stage, gated to the PostHog Team
-// cohort. When the beta opens to everyone, swap this for the public early-access surface.
-const EARLY_ACCESS_URL =
-    'https://us.posthog.com/early_access_features/019ecd58-7e9b-0000-60b6-98b487153c0e'
+// This points at the public feature previews surface (anchored to the MCP Analytics feature),
+// where any signed-in user can opt in — not the internal `/early_access_features/<id>`
+// management page, which is only accessible to the PostHog team.
+const EARLY_ACCESS_URL = 'https://us.posthog.com/settings/user-feature-previews#mcp-analytics'
 
 export default function MCPAnalytics(): JSX.Element {
     // Get content data from multiple directories


### PR DESCRIPTION
## Changes

The MCP Analytics "Register interest" button linked to the internal `/early_access_features/<id>` management page, which only PostHog team members can open. Everyone else — including teammates testing on personal accounts — hit an error instead of an opt-in flow.

This points the opt-in at the public **feature previews** surface, `https://us.posthog.com/settings/user-feature-previews#mcp-analytics`, which any signed-in user can access to opt in.

- `src/pages/mcp-analytics/index.tsx` — swap `EARLY_ACCESS_URL` to the feature-previews link
- `src/components/EarlyAccessOptIn/index.tsx` — update the `to`-prop JSDoc to describe the feature-previews URL pattern
- `src/components/EarlyAccessOptIn/README.md` — update examples, props table, and guidance (with a note to avoid the team-only management page)

**Why:** Reported in Slack — clicking "Register interest" on the MCP Analytics page errored out for users without team access to the management page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1781883107556409?thread_ts=1781883107.556409&cid=C0B3E1Y576X)*