### PR TITLE
Fix onboarding docs build after monorepo folder restructure

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -110,7 +110,7 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({ sta
                     'docs',
                     'onboarding'
                 ),
-                'scenes/onboarding/OnboardingDocsContentWrapper': path.resolve(
+                'scenes/onboarding/shared/OnboardingDocsContentWrapper': path.resolve(
                     __dirname,
                     'src',
                     'components',


### PR DESCRIPTION
## Changes

- Updates the Webpack alias for `OnboardingDocsContentWrapper` to match the monorepo's new path (`scenes/onboarding/shared/`) after PostHog/posthog#64917 moved it today
