### PR TITLE
Add ingestion warning docs for invalid_heatmap_data

### DIFF
--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -35,6 +35,7 @@ List of ingestion warnings:
 - [Replay event timestamp is invalid](#replay-event-timestamp-is-invalid)
 - [Replay event timestamp was too far in the future](#replay-event-timestamp-was-too-far-in-the-future)
 - [$set or $set_once is ignored on exception events and should not be sent](#set-or-set_once-is-ignored-on-exception-events-and-should-not-be-sent)
+- [Invalid heatmap data](#invalid-heatmap-data)
 
 ## Refused to merge with an illegal distinct ID
 
@@ -85,3 +86,9 @@ The replay event timestamp is more than 7 days in the future and the session rep
 ## Invalid set operations on exception events
 
 The `$set` or `$set_once` properties are ignored on exception events and should not be sent.
+
+## Invalid heatmap data
+
+PostHog couldn't process the `$heatmap_data` attached to an event, so no [heatmap](/docs/toolbar/heatmaps) data was extracted from it. The event itself is still ingested as normal.
+
+This indicates the `$heatmap_data` property was malformed, which is usually a sign of an instrumentation bug. If you're capturing heatmap data with [posthog-js](/docs/libraries/js), make sure you're on a recent version of the SDK and aren't manually constructing or modifying `$heatmap_data` yourself.


### PR DESCRIPTION
## Changes

Adds an **Invalid heatmap data** section to the [ingestion warnings](https://posthog.com/docs/data/ingestion-warnings) docs, which previously had no entry for the `invalid_heatmap_data` warning. The in-product "docs" link for this warning currently 404s because the section didn't exist.

This warning fires when PostHog can't process the `$heatmap_data` property on an event (the heatmap extraction step throws), so no heatmap data is extracted, though the event itself is still ingested.

**Why:** A user reported that the docs link for `invalid_heatmap_data` pointed to a non-existent section, and the warning wasn't listed in the ingestion warnings docs.

> [!NOTE]
> The in-app link is also built incorrectly (it points to `/docs/data#invalid_heatmap_data` rather than `/docs/data/ingestion-warnings#invalid-heatmap-data`). That fix lives in the PostHog monorepo and is tracked separately.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782119203020039?thread_ts=1782119203.020039&cid=C0ACRAMJUAG)*