### PR TITLE
docs: update platform features team ownership list

### DIFF
--- a/contents/teams/platform-features/index.mdx
+++ b/contents/teams/platform-features/index.mdx
@@ -23,7 +23,10 @@ template: team
     -   Authenticated domains
     -   Organizations / Projects / Environments
     -   Activity logs (audit logs)
-    -   Approvals (coming soon)
+    -   Approvals
+    -   Reminders
+    -   Comments
+    -   Resource transfer (copy between projects)
     -   Emails / notifications
 
 ---


### PR DESCRIPTION
## Problem

The platform features handbook page listed stale ownership for the team.

## Changes

- Add reminders, comments, and resource transfer to the owned features list
- Drop the "coming soon" tag from approvals, which has shipped

## How did you test this code?

Docs-only change; no automated tests. Agent-authored.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?