### PR TITLE
Remove "Payment via invoicing" row from platform packages table

### DIFF
--- a/src/pages/platform-packages/index.tsx
+++ b/src/pages/platform-packages/index.tsx
@@ -22,7 +22,7 @@ export default function PlatformPackages() {
         new Set(
             platformAddons.flatMap((addon: any) =>
                 (addon.plans[0].features || [])
-                    .filter((f: any) => f.key !== 'support_response_time')
+                    .filter((f: any) => f.key !== 'support_response_time' && f.key !== 'invoice_payments')
                     .map((f: any) => f.name)
             )
         )


### PR DESCRIPTION
## Changes

Removes the **Payment via invoicing** row from the platform packages comparison table on `/platform-packages`.

The comparison table is generated dynamically from the billing API. This filters the `invoice_payments` feature out of the row set, matching the existing pattern that already excludes `support_response_time`.

**Why:** We don't offer invoicing as a payment method for monthly self-serve customers (including those on the Enterprise add-on), and annual customers are invoiced as standard — so listing it as an Enterprise feature is misleading.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C093XHYMGBE/p1782130118717579?thread_ts=1782130118.717579&cid=C093XHYMGBE)*
