### PR TITLE
Growth team: Q3 2026 objectives

### DIFF
--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -1,8 +1,41 @@
-## Q2 2026 objectives
+## Q3 2026 objectives
+
+These are the primary goals the team is prioritizing this quarter.
+
+<details>
+<summary>Improved onboarding flow focused on our new pillars (<TeamMember name="Fernando Gomes" photo />)</summary>
+
+- AI-first
+- Slack/GitHub integrations
+- Run the enrichment model in the background while the slower parts of onboarding are happening
+- Help guide people towards PostHog Code or not, new AI-first UI or not, send directly to Sales team or not
+
+</details>
+
+<details>
+<summary>Measure success of the AI positioning at the company level (<TeamMember name="Rafael Audibert" photo />)</summary>
+
+- Establish baseline of Code activation
+- Monitor impact on existing revenue streams
+- PostHog Code onboarding
+- Implement all of the tracking that's probably lacking on their end
+
+</details>
+
+<details>
+<summary>Streamlined data layer for the RevOps flow (<TeamMember name="Matt Brooker" photo />)</summary>
+
+- Model what kind of customer someone is to guide them towards the right onboarding process (<TeamMember name="Mine Kansu" photo />)
+- Avoid keeping stale enriched data
+- Marketing should also be able to base their decisions off of this data
+
+</details>
+
+## Q2 2026 recap
 
 **North star:** 20% of sign ups should happen outside posthog.com/signup
 
-These are the primary goals the team is prioritizing this quarter.
+These were the primary goals the team prioritized this quarter.
 
 <details>
 <summary>Make agentic sign ups first-citizen of PostHog (<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo />)</summary>

--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -85,7 +85,4 @@ These were the primary goals the team prioritized this quarter.
 Non-exhaustive list of things we want to work on eventually:
 - One-click migration away from competitors
 - Demo environment for customers to try out PostHog with existing data (and relatable to their own business domain)
-- PostHog-billed AI SDK
-  - Don't need to setup an AI account in each provider, just use PostHog's AI SDK.
 - Improved ingestion URL (dynamic, harder to block/guess)
-- New products playground

--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -3,7 +3,7 @@
 These are the primary goals the team is prioritizing this quarter.
 
 <details>
-<summary>Improved onboarding flow focused on our new pillars (<TeamMember name="Fernando Gomes" photo />)</summary>
+<summary>Improved onboarding flow focused on our new pillars - <TeamMember name="Fernando Gomes" photo /></summary>
 
 - AI-first
 - Slack/GitHub integrations
@@ -13,7 +13,7 @@ These are the primary goals the team is prioritizing this quarter.
 </details>
 
 <details>
-<summary>Measure success of the AI positioning at the company level (<TeamMember name="Rafael Audibert" photo />)</summary>
+<summary>Measure success of the AI positioning at the company level - <TeamMember name="Rafael Audibert" photo /></summary>
 
 - Establish baseline of Code activation
 - Monitor impact on existing revenue streams
@@ -23,9 +23,9 @@ These are the primary goals the team is prioritizing this quarter.
 </details>
 
 <details>
-<summary>Streamlined data layer for the RevOps flow (<TeamMember name="Matt Brooker" photo />)</summary>
+<summary>Streamlined data layer for the RevOps flow - <TeamMember name="Matt Brooker" photo /></summary>
 
-- Model what kind of customer someone is to guide them towards the right onboarding process (<TeamMember name="Mine Kansu" photo />)
+- Model what kind of customer someone is to guide them towards the right onboarding process - <TeamMember name="Mine Kansu" photo />
 - Avoid keeping stale enriched data
 - Marketing should also be able to base their decisions off of this data
 
@@ -79,19 +79,6 @@ These were the primary goals the team prioritized this quarter.
 - Launching MCP Analytics alongside Lucas/Surveys team - <TeamMember name="Rafael Audibert" photo />
 - With the wizard getting context from posthog, foster cross-selling - TBD
 - Something fun? - <TeamMember name="Matt Brooker" photo />
-
-## Q1 2026 recap
-
-- Onboarded <TeamMember name="Fernando Gomes" photo /> to the team
-- Shipped MCP Apps
-- Shipped Stripe projects
-- Shipped Vercel integration
-- A bunch of MCP improvements alongside the PostHog AI team
-- Shipped VSCode extension
-- Shipped HogSpy
-- Reverse proxy revival (mostly Daniel, but we made it more relevant in-app)
-- MCP got featured as connector in a bunch of different marketplaces
-- ...and much more, look at the [changelog](/changelog)
 
 ## Next quarters
 

--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -3,9 +3,9 @@
 These are the primary goals the team is prioritizing this quarter.
 
 <details>
-<summary>Improved onboarding flow focused on our new pillars – <TeamMember name="Fernando Gomes" photo /></summary>
+<summary>Redesign the authentication and onboarding flows – <TeamMember name="Fernando Gomes" photo /></summary>
 
-- AI-first
+- Self-driving
 - Slack/GitHub integrations
 - Run the enrichment model in the background while the slower parts of onboarding are happening
 - Help guide people towards PostHog Code or not, new AI-first UI or not, send directly to Sales team or not

--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -38,7 +38,7 @@ These are the primary goals the team is prioritizing this quarter.
 These were the primary goals the team prioritized this quarter.
 
 <details>
-<summary>Make agentic sign ups first-citizen of PostHog (<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo />)</summary>
+<summary>Make agentic sign ups first-citizen of PostHog - <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /></summary>
 
 - **Rationale:** Agents are increasingly the ones picking and setting up tools. If our sign-up assumes a human clicking through a dashboard, we miss the fastest-growing top of funnel.
 - **Things we could do:** Agentic onboarding by default — headless onboarding, Wizard, Stripe projects, AI-first flows. Wizard should be able to create orgs + projects on its own with no UI clicks. Expand the pattern beyond Stripe (done) to Vercel, Lovable, Supabase, and Replit.
@@ -47,7 +47,7 @@ These were the primary goals the team prioritized this quarter.
 </details>
 
 <details>
-<summary>Allow anyone to integrate/provision an org + project in PostHog (<TeamMember name="Rafael Audibert" photo /> <TeamMember name="Matt Brooker" photo />)</summary>
+<summary>Allow anyone to integrate/provision an org + project in PostHog - <TeamMember name="Rafael Audibert" photo /> <TeamMember name="Matt Brooker" photo /></summary>
 
 - **Rationale:** Every partner, every embedded platform, and every agentic flow needs a programmatic way to spin up a PostHog org or project. One-off integrations don't scale — a generic path does.
 - **Things we could do:** Lean on the soon-to-come Partnerships Wrangler. Market it as either PostHog Marketplace or PostHog as a platform. Review what Agentic Provisioning needs to become generic (just an API). Write docs and settle on how to do it. Stand up the right application process — probably Support Hero-driven.
@@ -56,7 +56,7 @@ These were the primary goals the team prioritized this quarter.
 </details>
 
 <details>
-<summary>Activation rate across all onboarding experiences should be 60%+ (<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo />)</summary>
+<summary>Activation rate across all onboarding experiences should be 60%+ - <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /></summary>
 
 - **Rationale:** A single numerical bar pulls every onboarding experience towards the same outcome. Different channels — warm, lukewarm, cold, frozen — need different treatment, and a unified target forces us to treat them as one system.
 - **Things we could do:** Settle the activation metric alongside PMs — we're currently on "soft activation" per-product; global activation is still TBD. Implement channel-specific onboarding: website (warm), Wizard (lukewarm), agentic provisioning (cold), Lovable/Replit auto-adding Analytics (frozen). Explicitly de-scope PostHog Code activation for now — Signals + PostHog Code team will handle that.
@@ -65,7 +65,7 @@ These were the primary goals the team prioritized this quarter.
 </details>
 
 <details>
-<summary>Shape the external interface for Signals (<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo />)</summary>
+<summary>Shape the external interface for Signals - <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /></summary>
 
 - **Rationale:** Signals is still early and its external surface isn't settled. Getting the shape right now — before partners depend on it — avoids painful contract breaks later. Partner vibecoding app builders are the most credible early validators.
 - **Things we could do:** Write a spec for the external interface and validate with partner vibecoding app builders. We believe these partners want Signals, but Signals may not be ready to expose yet — first check feasibility. Once that's done, stop and reflect: how do we make this the next big thing after MCP?

--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -3,7 +3,7 @@
 These are the primary goals the team is prioritizing this quarter.
 
 <details>
-<summary>Improved onboarding flow focused on our new pillars - <TeamMember name="Fernando Gomes" photo /></summary>
+<summary>Improved onboarding flow focused on our new pillars – <TeamMember name="Fernando Gomes" photo /></summary>
 
 - AI-first
 - Slack/GitHub integrations
@@ -13,7 +13,7 @@ These are the primary goals the team is prioritizing this quarter.
 </details>
 
 <details>
-<summary>Measure success of the AI positioning at the company level - <TeamMember name="Rafael Audibert" photo /></summary>
+<summary>Measure success of the AI positioning at the company level – <TeamMember name="Rafael Audibert" photo /></summary>
 
 - Establish baseline of Code activation
 - Monitor impact on existing revenue streams
@@ -23,9 +23,9 @@ These are the primary goals the team is prioritizing this quarter.
 </details>
 
 <details>
-<summary>Streamlined data layer for the RevOps flow - <TeamMember name="Matt Brooker" photo /></summary>
+<summary>Streamlined data layer for the RevOps flow – <TeamMember name="Matt Brooker" photo /></summary>
 
-- Model what kind of customer someone is to guide them towards the right onboarding process - <TeamMember name="Mine Kansu" photo />
+- Model what kind of customer someone is to guide them towards the right onboarding process – <TeamMember name="Mine Kansu" photo />
 - Avoid keeping stale enriched data
 - Marketing should also be able to base their decisions off of this data
 
@@ -38,7 +38,7 @@ These are the primary goals the team is prioritizing this quarter.
 These were the primary goals the team prioritized this quarter.
 
 <details>
-<summary>Make agentic sign ups first-citizen of PostHog - <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /></summary>
+<summary>Make agentic sign ups first-citizen of PostHog – <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /></summary>
 
 - **Rationale:** Agents are increasingly the ones picking and setting up tools. If our sign-up assumes a human clicking through a dashboard, we miss the fastest-growing top of funnel.
 - **Things we could do:** Agentic onboarding by default — headless onboarding, Wizard, Stripe projects, AI-first flows. Wizard should be able to create orgs + projects on its own with no UI clicks. Expand the pattern beyond Stripe (done) to Vercel, Lovable, Supabase, and Replit.
@@ -47,7 +47,7 @@ These were the primary goals the team prioritized this quarter.
 </details>
 
 <details>
-<summary>Allow anyone to integrate/provision an org + project in PostHog - <TeamMember name="Rafael Audibert" photo /> <TeamMember name="Matt Brooker" photo /></summary>
+<summary>Allow anyone to integrate/provision an org + project in PostHog – <TeamMember name="Rafael Audibert" photo /> <TeamMember name="Matt Brooker" photo /></summary>
 
 - **Rationale:** Every partner, every embedded platform, and every agentic flow needs a programmatic way to spin up a PostHog org or project. One-off integrations don't scale — a generic path does.
 - **Things we could do:** Lean on the soon-to-come Partnerships Wrangler. Market it as either PostHog Marketplace or PostHog as a platform. Review what Agentic Provisioning needs to become generic (just an API). Write docs and settle on how to do it. Stand up the right application process — probably Support Hero-driven.
@@ -56,7 +56,7 @@ These were the primary goals the team prioritized this quarter.
 </details>
 
 <details>
-<summary>Activation rate across all onboarding experiences should be 60%+ - <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /></summary>
+<summary>Activation rate across all onboarding experiences should be 60%+ – <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /></summary>
 
 - **Rationale:** A single numerical bar pulls every onboarding experience towards the same outcome. Different channels — warm, lukewarm, cold, frozen — need different treatment, and a unified target forces us to treat them as one system.
 - **Things we could do:** Settle the activation metric alongside PMs — we're currently on "soft activation" per-product; global activation is still TBD. Implement channel-specific onboarding: website (warm), Wizard (lukewarm), agentic provisioning (cold), Lovable/Replit auto-adding Analytics (frozen). Explicitly de-scope PostHog Code activation for now — Signals + PostHog Code team will handle that.
@@ -65,7 +65,7 @@ These were the primary goals the team prioritized this quarter.
 </details>
 
 <details>
-<summary>Shape the external interface for Signals - <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /></summary>
+<summary>Shape the external interface for Signals – <TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /></summary>
 
 - **Rationale:** Signals is still early and its external surface isn't settled. Getting the shape right now — before partners depend on it — avoids painful contract breaks later. Partner vibecoding app builders are the most credible early validators.
 - **Things we could do:** Write a spec for the external interface and validate with partner vibecoding app builders. We believe these partners want Signals, but Signals may not be ready to expose yet — first check feasibility. Once that's done, stop and reflect: how do we make this the next big thing after MCP?
@@ -75,10 +75,10 @@ These were the primary goals the team prioritized this quarter.
 
 ### Stretch goals
 
-- Launching VSCode extension - <TeamMember name="Fernando Gomes" photo />
-- Launching MCP Analytics alongside Lucas/Surveys team - <TeamMember name="Rafael Audibert" photo />
+- Launching VSCode extension – <TeamMember name="Fernando Gomes" photo />
+- Launching MCP Analytics alongside Lucas/Surveys team – <TeamMember name="Rafael Audibert" photo />
 - With the wizard getting context from posthog, foster cross-selling - TBD
-- Something fun? - <TeamMember name="Matt Brooker" photo />
+- Something fun? – <TeamMember name="Matt Brooker" photo />
 
 ## Next quarters
 


### PR DESCRIPTION
Rolls the Growth team goals forward into Q3 2026, following the existing quarter-transition pattern.

## Changes
- Moved the previous **Q2 2026 objectives** down into a new **Q2 2026 recap** section (content preserved).
- Added **Q3 2026 objectives**, attributed to the right people:
  - **Improved onboarding flow focused on our new pillars** — Fernando Gomes
  - **Measure success of the AI positioning at the company level** — Rafael Audibert
  - **Streamlined data layer for the RevOps flow** — Matt Brooker (customer-modeling sub-goal owned by Mine Kansu)

Note: I didn't carry over a North star for Q3 since one wasn't provided — happy to add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)