### PR TITLE
DO NOT MERGE feat(homepage): reframe homepage around "self-driving" positioning

### DIFF
--- a/contents/index.mdx
+++ b/contents/index.mdx
@@ -43,22 +43,22 @@ Here are some of our paying customers. (Yes they actually use us, no it's not ju
 
 <div id="customer-infrastructure">
 
-## PostHog data stack, built for data teams and loved by product teams
+## One context warehouse, feeding every agent
 
 <div class="@lg:float-right text-sm @lg:max-w-xs bg-accent p-4 rounded-sm @lg:ml-6 @lg:mb-2 relative pb-[120px] @md:pb-4 @md:pr-[220px] @lg:pr-6 @lg:pb-[120px]">
 
 <p class="my-0 [&_p]:my-0">
 
-**Built-in, Product OS ships with:**
+**Your context warehouse includes:**
 
 </p>
 
 <span class="[&_ul]:mb-0">
 
-- A data warehouse <TooltipDW />
-- 120+ sources/destinations
+- Events, recordings & traces <TooltipDW />
+- 120+ imports & sources
+- MCP access for any agent
 - SQL editor + BI + data viz
-- User activity feed (CDP-lite)
 - API, webhooks
 
 </span>
@@ -67,39 +67,19 @@ Here are some of our paying customers. (Yes they actually use us, no it's not ju
 
 </div>
 
-When you're analyzing how customers use your product, you should be operating from _the full set of data_.
+Self-driving only works if PostHog actually _knows_ your product. That's the job of the context warehouse.
 
-This includes customer information that happens _outside your product_:
+It pulls together all the data that matters – events, session recordings, traces, and more – straight from your products through SDKs, third-party imports, and MCPs:
 
 - payments from Stripe
 - exceptions in an error tracking tool
 - tickets in your support platform
 
-Having all the data in one place means you can make more informed decisions about what to build next.
+That shared context is what lets your agents, Skills, and products work together instead of in silos – a Scout that spots a bug, the data that proves it, and the agent that ships the fix all read from the same source of truth.
 
-PostHog's Product OS isn't just analytics – it's the entire suite of tools built to give you a single source of truth about your customers.
+It's not just analytics – it's the single source of truth that makes everything else self-driving.
 
 <ButtonDataStack />
-
-</div>
-
-<div id="pricing">
-
-## Usage-based pricing
-
-<ImageMoney />
-
-Our whole philosophy is that you shouldn't have to worry about pricing.
-
-All our paid products are pay-per-use with generous monthly free tiers. In fact, 98% of our customers use PostHog for free.
-
-We aim to match the cheapest option at scale – PostHog should be a no-brainer. You never have to "jump on a quick call" with sales.
-
-Here are some examples of how we charge for most popular products:
-
-<Pricing />
-
-<ButtonPricing />
 
 </div>
 
@@ -109,6 +89,7 @@ Here are some examples of how we charge for most popular products:
 
 We're different from most companies for a bunch of reasons:
 
+- **We're going all-in on self-driving.** We'd rather build the future of autonomous product development than protect a list of products. Read our [company strategy](/handbook/why-does-posthog-exist).
 - **Transparency.** You can read our [company handbook](/handbook), our [sales manual](/handbook/growth/sales/overview), and [company strategy](/handbook/why-does-posthog-exist).
 - **We ship fast.** See our [changelog](/changelog).
 - **_Actually_-technical support.** Our <SupportSmallTeamLink /> all have engineering backgrounds.

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -117,6 +117,15 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({ sta
                     'Docs',
                     'OnboardingContentWrapper.tsx'
                 ),
+                // Upstream monorepo moved this wrapper under /shared/; keep the old key above for
+                // older sourced content and alias the new path to the same posthog.com shim.
+                'scenes/onboarding/shared/OnboardingDocsContentWrapper': path.resolve(
+                    __dirname,
+                    'src',
+                    'components',
+                    'Docs',
+                    'OnboardingContentWrapper.tsx'
+                ),
             },
         },
     })

--- a/src/components/Home/HeroCarousel/homeSlides.tsx
+++ b/src/components/Home/HeroCarousel/homeSlides.tsx
@@ -30,13 +30,14 @@ export const SlackSlide = () => {
                 <div className="flex flex-col gap-3">
                     <div className="space-y-2">
                         <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
-                            <IconAtSign className="size-4" /> PostHog Slackbot
+                            <IconAtSign className="size-4" /> Access surfaces
                         </p>
-                        <h2 className="text-2xl font-bold m-0">Create pull requests in Slack</h2>
+                        <h2 className="text-2xl font-bold m-0">Meet PostHog where you work</h2>
                     </div>
                     <p className="text-secondary m-0">
-                        Tag <code>@PostHog</code> in a thread to analyze customer behavior or create a PR – all without
-                        ever leaving Slack. Triage and build with your team in your existing tools.
+                        Tag <code>@PostHog</code> in Slack for quick, proactive help, or open PostHog on Desktop to dig
+                        into the bigger jobs. Either way it analyzes behavior, triages work, and ships PRs – without
+                        leaving your tools.
                     </p>
                     <OSButton to="/slack" state={{ newWindow: true }} variant="secondary" asLink>
                         Explore PostHog Slackbot
@@ -70,7 +71,7 @@ export const FixBugsSlide = () => {
                     hideTitle
                     options={[
                         { label: <span className="whitespace-nowrap">Slack</span>, value: 'slack' },
-                        { label: <span className="whitespace-nowrap">PostHog Code</span>, value: 'code' },
+                        { label: <span className="whitespace-nowrap">Desktop</span>, value: 'code' },
                     ]}
                     value={view}
                     onValueChange={(v) => v && setView(v as 'slack' | 'code')}
@@ -92,13 +93,13 @@ export const FixBugsSlide = () => {
                     <div className="flex flex-col gap-3">
                         <div className="space-y-2">
                             <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
-                                <IconAtSign className="size-4" /> PostHog Slackbot
+                                <IconAtSign className="size-4" /> Scouts
                             </p>
-                            <h2 className="text-2xl font-bold m-0">Fix bugs automatically</h2>
+                            <h2 className="text-2xl font-bold m-0">Scouts that never sleep</h2>
                         </div>
                         <p className="text-secondary m-0">
-                            PostHog Signals runs analysis on errors, logs, and summarized session recordings to detect
-                            and fix bugs without any human prompting.
+                            Scouts are long-running agents that watch your errors, logs, and session recordings – using
+                            memory and your data to find and fix issues before anyone files a ticket.
                         </p>
                         {/* TODO: re-enable once /signals (or equivalent) lands.
                         <OSButton to="/signals" state={{ newWindow: true }} variant="primary" asLink>
@@ -110,12 +111,12 @@ export const FixBugsSlide = () => {
                     <div className="flex flex-col gap-3">
                         <div className="space-y-2">
                             <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
-                                <IconCoffee className="size-4" /> PostHog Code (beta)
+                                <IconCoffee className="size-4" /> PostHog on Desktop (beta)
                             </p>
-                            <h2 className="text-2xl font-bold m-0">Fix bugs automatically</h2>
+                            <h2 className="text-2xl font-bold m-0">Scouts that never sleep</h2>
                         </div>
                         <p className="text-secondary m-0">
-                            <strong>PostHog Code</strong>, our AI code editor:
+                            <strong>PostHog on Desktop</strong>, our AI code editor:
                         </p>
                         <ul className="list-none p-0 m-0 space-y-1.5">
                             <li className="flex items-center gap-2 text-secondary">
@@ -183,15 +184,15 @@ export const AskAnythingSlide = () => {
                             <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
                                 <IconSparkles className="size-4" /> PostHog AI
                             </p>
-                            <h2 className="text-2xl font-bold m-0">Ask PostHog anything</h2>
+                            <h2 className="text-2xl font-bold m-0">Ask anything – or teach it new Skills</h2>
                         </div>
                         <p className="text-secondary m-0">
                             PostHog has 250+ data and analysis tools that are stitched together on-the-fly to answer any
                             customer usage or data question you have.
                         </p>
                         <p className="text-secondary m-0">
-                            Pipe in third party data to analyze alongside customer usage data for a more complete
-                            picture of product usage.
+                            Teach it new Skills to handle the jobs you do over and over – so it goes from answering
+                            questions to doing the work.
                         </p>
                         <OSButton to="/ai" state={{ newWindow: true }} variant="secondary" asLink>
                             Explore PostHog AI
@@ -203,15 +204,15 @@ export const AskAnythingSlide = () => {
                             <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
                                 <IconSparkles className="size-4" /> PostHog AI
                             </p>
-                            <h2 className="text-2xl font-bold m-0">Ask PostHog anything</h2>
+                            <h2 className="text-2xl font-bold m-0">Ask anything – or teach it new Skills</h2>
                         </div>
                         <p className="text-secondary m-0">
                             PostHog has 250+ data and analysis tools that are stitched together on-the-fly to answer any
                             customer usage or data question you have.
                         </p>
                         <p className="text-secondary m-0">
-                            Pipe in third party data to analyze alongside customer usage data for a more complete
-                            picture of product usage.
+                            Teach it new Skills to handle the jobs you do over and over – so it goes from answering
+                            questions to doing the work.
                         </p>
                         <OSButton to="/ai" state={{ newWindow: true }} variant="secondary" asLink>
                             Explore PostHog AI

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -93,13 +93,14 @@ const PostHogMention = () => {
 
 const Tagline = () => (
     <>
-        <h1 className="!text-3xl pt-4">
-            Just ask <PostHogMention />.
+        <h1 className="!text-3xl pt-4 @2xl:pr-[20rem] @3xl:pr-[22rem] @4xl:pr-[26rem]">
+            PostHog makes your product self-driving.
         </h1>
         <HeroImage />
         <p className="text-balance @xl:text-wrap text-lg">
-            <PostHogMention /> knows your product, customers, and what needs fixing. It answers questions, triages work,
-            writes code, and is always working even when you don't prompt it.
+            It knows your product, customers, and what needs fixing – and it's always working, even when you don't
+            prompt it. Tag <PostHogMention /> in Slack, dig into the hard stuff in PostHog on Desktop, and let Scouts
+            ship fixes before you do.
         </p>
 
         <p className="text-balance @xl:text-wrap text-secondary">
@@ -431,7 +432,9 @@ function Hero(): JSX.Element {
         <RenderInClient
             placeholder={<></>}
             render={() =>
-                posthog?.getFeatureFlag?.('homepage-slack-test', { fresh: true }) === 'test' ? (
+                // Local override: force the "test" (Slack) homepage experience for previewing
+                // eslint-disable-next-line no-constant-condition
+                true || posthog?.getFeatureFlag?.('homepage-slack-test', { fresh: true }) === 'test' ? (
                     <TestHero />
                 ) : (
                     <ControlHero />
@@ -502,7 +505,7 @@ export default function HomeTest() {
             <SEO
                 title="PostHog – We make dev tools for product engineers"
                 updateWindowTitle={false}
-                description="All your developer tools in one place. PostHog gives engineers everything to build, test, measure, and ship successful products faster. Get started free."
+                description="PostHog is self-driving – autonomous agents that know your product and customers, and do the work for you in Slack, on your desktop, and on their own. Get started free."
                 image="/images/og/default.png"
             />
             <MDXEditor

--- a/src/components/Products/ProductsTest.tsx
+++ b/src/components/Products/ProductsTest.tsx
@@ -361,7 +361,9 @@ export default function ProductsTest(): JSX.Element {
                     <RenderInClient
                         placeholder={<></>}
                         render={() =>
-                            posthog?.getFeatureFlag?.('homepage-slack-test', { fresh: true }) === 'test' ? (
+                            // Local override: force the "test" (Slack) homepage experience for previewing
+                            // eslint-disable-next-line no-constant-condition
+                            true || posthog?.getFeatureFlag?.('homepage-slack-test', { fresh: true }) === 'test' ? (
                                 <HeroCarousel tabs={productUsageTabs} />
                             ) : (
                                 <></>


### PR DESCRIPTION
THIS JUST EXISTS FOR CORY TO COPY SOME COPY OUT OF IT!!! DO NOT MERGE

just these two sections are worth lifting the copy from imho:


<img width="470" height="489" alt="Screenshot 2026-06-22 at 22 20 58" src="https://github.com/user-attachments/assets/234f7dc5-9605-48ad-93b8-6df7919bd754" />

<img width="864" height="449" alt="Screenshot 2026-06-22 at 22 21 23" src="https://github.com/user-attachments/assets/46a303bc-6f9d-46b7-a909-022b1dd06580" />


## What & why



Following the marketing meeting on the **self-driving** strategy, this reframes the homepage (test variant) away from a product-suite/data-stack story toward the new positioning: PostHog as autonomous agents that do the work.

### Changes
- **Hero** (`Home/Test/index.tsx`): headline → **"PostHog makes your product self-driving."** with proactive, multi-surface sub-copy (Slack, PostHog on Desktop, Scouts). Headline reserves space so it no longer overlaps the floating Slack card.
- **Carousel** (`HeroCarousel/homeSlides.tsx`): reframed to **Access surfaces** (Slack + Desktop), **Scouts**, and **Skills**.
- **Body** (`contents/index.mdx`): data-stack section rewritten as a **"context warehouse"** (events/recordings/traces pulled via SDKs, imports, MCPs to feed agents, Skills, and products); **pricing section removed**; added a self-driving bullet to *Why PostHog?*.
- **SEO** description updated.
- **`gatsby-node.ts`**: alias the upstream-moved `scenes/onboarding/shared/OnboardingDocsContentWrapper` to the posthog.com shim — fixes a current build break on `master` (the monorepo moved this file under `/shared/`).

### ⚠️ Do not merge as-is
This branch also includes a **local preview hack**: a `true ||` override in `Home/Test/index.tsx` and `ProductsTest.tsx` that force-enables the `homepage-slack-test` experiment for **all** users. It's here so the copy can be previewed; **revert those two `true ||` lines before merging** so the experiment flag keeps controlling exposure. (`ProductsTest.tsx` contains *only* that override.)

### Testing
Runs locally via `pnpm start` (Node 22) at `localhost:8001`; homepage compiles cleanly and renders the new copy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*