### PR TITLE
docs(mcp-analytics): Vercel mcp-handler integration example

### DIFF
--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -89,7 +89,11 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
 
 const handler = createMcpHandler(
   (server) => {
-    instrument(server, posthog)
+    instrument(server, posthog, {
+      // mcp-handler is stateless on Vercel, so group a client's calls with a
+      // conversation id instead of a transport session (see "Grouping calls" below).
+      enableConversationId: true,
+    })
     server.registerTool("roll_dice", { /* ... */ }, async ({ sides }) => { /* ... */ })
   },
   {},
@@ -99,16 +103,27 @@ const handler = createMcpHandler(
 export { handler as GET, handler as POST }
 ```
 
-Two things to know because of how `mcp-handler` runs on Vercel:
+#### Grouping a client's calls
 
-- **Sessions.** With the default streamable-HTTP transport, `mcp-handler` is stateless — it creates a
-  fresh server per request and sends no `Mcp-Session-Id`, so each request is its own `$session_id`.
-  To group a client's calls into one session, run it stateful (configure a `sessionIdGenerator`); the
-  SDK then derives a stable `$session_id` from the header. Use the [`identify`](/docs/mcp-analytics/identifying-users)
-  option to attribute calls to a user regardless.
-- **Flushing.** `posthog-node` batches events, and a serverless function can freeze before they send.
-  Flush at the end of the invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` to
-  keep the runtime alive until it completes.
+On Vercel, `mcp-handler`'s streamable-HTTP transport is **stateless**: it spins up a fresh server per
+request and issues no `Mcp-Session-Id`, so there's no connection for the SDK to derive a shared
+`$session_id` from — left alone, every request lands in its own session.
+
+Turn on **`enableConversationId`** to stitch the calls together instead. The SDK adds a `conversation_id`
+argument to each tool, generates one when the client doesn't pass it, and asks the agent to echo it on
+later calls — so a client's tool calls correlate via
+[`$mcp_conversation_id`](/docs/mcp-analytics/conversation-id), even with no persistent connection. Group
+or break down by that property to see a whole interaction together.
+
+To also tie the calls to *who* made them, add [`identify`](/docs/mcp-analytics/identifying-users) and
+return a `distinctId` from your auth (e.g. the OAuth subject) — that sets `distinct_id` so the calls
+group by user as well.
+
+#### Flushing
+
+`posthog-node` batches events, and a serverless function can freeze before they send. Flush at the end
+of the invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` to keep the runtime
+alive until it completes.
 
 ## Configuration
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -78,7 +78,7 @@ server.tool("search_events", { /* ... */ }, async (args) => {
 callback, so you instrument it the same way — one line, before or after you register tools:
 
 ```ts
-import createMcpHandler from "mcp-handler"
+import { createMcpHandler } from "mcp-handler"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -4,9 +4,9 @@ title: Installing the MCP analytics SDK
 
 import CalloutBox from 'components/Docs/CalloutBox'
 
-<CalloutBox icon="IconInfo" title="Alpha SDK" type="fyi">
+<CalloutBox icon="IconInfo" title="Beta SDK" type="fyi">
 
-`@posthog/mcp` is published as a `0.1.x` alpha. Pin a specific version while we iterate — minor versions may include breaking changes to event shape or option names. A wizard-driven install (`npx @posthog/wizard mcp-analytics add`) is on the roadmap and will replace most of this page once it ships.
+`@posthog/mcp` is in beta (pre-1.0). The API may still change — including breaking changes in minor `0.x` releases — until `v1`, so pin a version while we iterate. A wizard-driven install (`npx @posthog/wizard mcp-analytics add`) is on the roadmap and will replace most of this page once it ships.
 
 </CalloutBox>
 
@@ -88,11 +88,7 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
 
 const handler = createMcpHandler(
   (server) => {
-    instrument(server, posthog, {
-      // mcp-handler is stateless on Vercel, so group a client's calls with a
-      // conversation id instead of a transport session (see "Grouping calls" below).
-      enableConversationId: true,
-    })
+    instrument(server, posthog)
     server.registerTool("roll_dice", { /* ... */ }, async ({ sides }) => { /* ... */ })
   },
   {},
@@ -108,15 +104,24 @@ On Vercel, `mcp-handler`'s streamable-HTTP transport is **stateless**: it spins 
 request and issues no `Mcp-Session-Id`, so there's no connection for the SDK to derive a shared
 `$session_id` from — left alone, every request lands in its own session.
 
-Turn on **`enableConversationId`** to stitch the calls together instead. The SDK adds a `conversation_id`
-argument to each tool, generates one when the client doesn't pass it, and asks the agent to echo it on
-later calls — so a client's tool calls correlate via
-[`$mcp_conversation_id`](/docs/mcp-analytics/conversation-id), even with no persistent connection. Group
-or break down by that property to see a whole interaction together.
+The robust way to group is **by user**. Pass [`identify`](/docs/mcp-analytics/identifying-users) and
+return a `distinctId` from your auth (e.g. the OAuth subject) — that sets `distinct_id`, so a person's
+calls group together no matter how many stateless requests they span, and it requires nothing from the
+client:
 
-To also tie the calls to *who* made them, add [`identify`](/docs/mcp-analytics/identifying-users) and
-return a `distinctId` from your auth (e.g. the OAuth subject) — that sets `distinct_id` so the calls
-group by user as well.
+```ts
+instrument(server, posthog, {
+  identify: (request, extra) => ({ distinctId: getUserId(extra) }),
+})
+```
+
+For finer, per-conversation grouping you can also enable
+[`enableConversationId`](/docs/mcp-analytics/conversation-id): the SDK adds a `conversation_id`
+argument, generates one when the client doesn't send it, and asks the agent to echo it on later calls,
+correlating them via `$mcp_conversation_id`. It's **best-effort** — it works by appending a short
+instruction to the tool result, which a cooperative agent echoes but some clients ignore or treat as
+untrusted server content (the same wariness they apply to prompt injection). Use it when you control the
+client or that trade-off is acceptable; otherwise stick with `identify`.
 
 #### Flushing
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -79,8 +79,7 @@ callback, so you instrument it the same way — one line, before or after you re
 
 ```ts
 import { createMcpHandler } from "mcp-handler"
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
+import { PostHog, instrument } from "@posthog/mcp"
 
 // Create the client once at module scope (not per request).
 const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -72,6 +72,44 @@ server.tool("search_events", { /* ... */ }, async (args) => {
 })
 ```
 
+### Next.js / Vercel (`mcp-handler`)
+
+[`mcp-handler`](https://github.com/vercel/mcp-handler) gives you a standard `McpServer` in its setup
+callback, so you instrument it the same way — one line, before or after you register tools:
+
+```ts
+import createMcpHandler from "mcp-handler"
+import { PostHog } from "posthog-node"
+import { instrument } from "@posthog/mcp"
+
+// Create the client once at module scope (not per request).
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
+})
+
+const handler = createMcpHandler(
+  (server) => {
+    instrument(server, posthog)
+    server.registerTool("roll_dice", { /* ... */ }, async ({ sides }) => { /* ... */ })
+  },
+  {},
+  { basePath: "/api" },
+)
+
+export { handler as GET, handler as POST }
+```
+
+Two things to know because of how `mcp-handler` runs on Vercel:
+
+- **Sessions.** With the default streamable-HTTP transport, `mcp-handler` is stateless — it creates a
+  fresh server per request and sends no `Mcp-Session-Id`, so each request is its own `$session_id`.
+  To group a client's calls into one session, run it stateful (configure a `sessionIdGenerator`); the
+  SDK then derives a stable `$session_id` from the header. Use the [`identify`](/docs/mcp-analytics/identifying-users)
+  option to attribute calls to a user regardless.
+- **Flushing.** `posthog-node` batches events, and a serverless function can freeze before they send.
+  Flush at the end of the invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` to
+  keep the runtime alive until it completes.
+
 ## Configuration
 
 The `posthog` client is passed as the required second positional argument — not in this options object. `instrument()` accepts these options as an optional third argument:


### PR DESCRIPTION
Adds a **Next.js / Vercel (`mcp-handler`)** example to the [MCP analytics installation](https://posthog.com/docs/mcp-analytics/installation) page.

[`vercel/mcp-handler`](https://github.com/vercel/mcp-handler) hands you a standard `@modelcontextprotocol/sdk` `McpServer` in its setup callback, so `@posthog/mcp`'s `instrument()` works with **one line** — no new code needed. The section also documents the two Vercel-specific caveats: stateless per-request servers (use a `sessionIdGenerator` for session continuity) and flushing `posthog-node` in serverless.

Independent of the Python SDK docs PR (PostHog/posthog.com#17827) — this one is ready to merge now since the TypeScript `@posthog/mcp` SDK is already published.

Mega-issue: PostHog/posthog#64016

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*