### PR TITLE
docs(web-analytics): add guide for managing bot and AI traffic

### DIFF
--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -23,6 +23,17 @@ Live is a continuously updating feed of recent events. Each row includes:
 
 Use the filter controls at the top of the tab to narrow the feed by host, path, referrer, or any other property. Filters apply to the live stream so you can isolate exactly what you want to watch.
 
+## Bot traffic
+
+Live separates automated traffic from human visitors, so a crawl or scrape doesn't look like a launch. Requests are classified by user agent using the same [bot and traffic detection](/docs/web-analytics/bot-detection) as the rest of Web Analytics, and surfaced in two places:
+
+- **Bot requests per minute** – a chart alongside the live users chart, so you can see automated load at a glance and tell a crawl apart from real traffic.
+- **Bot traffic tile** – the bots hitting you right now, ranked by share of recent events and tagged with their category (AI agent, search crawler, automation, and so on). Select a row to open a breakdown for that specific bot.
+
+This is handy when an AI crawler or scraper spikes your numbers and you want to confirm it's automated before reacting. To pull bots out of the rest of the live feed, filter on `$virt_is_bot` – see [bot and traffic detection](/docs/web-analytics/bot-detection) for the full set of properties.
+
+> **Note:** The live bot tiles are rolling out and may not be enabled for your project yet. Bot classification in queries and Product Analytics is available to everyone today.
+
 ## When to use Live
 
 Use Live when you're:
@@ -55,4 +66,5 @@ For deeper analysis like funnels, retention, or breakdowns, use [Product Analyti
 ## Related
 
 - [Web Analytics dashboard](/docs/web-analytics/dashboard) – aggregated views over longer time ranges
+- [Bot and traffic detection](/docs/web-analytics/bot-detection) – classify and filter bots, crawlers, and AI agents
 - [Troubleshooting](/docs/web-analytics/troubleshooting) – when events aren't showing up

--- a/contents/docs/web-analytics/managing-bot-traffic.mdx
+++ b/contents/docs/web-analytics/managing-bot-traffic.mdx
@@ -1,0 +1,47 @@
+---
+title: Managing bot and AI traffic
+---
+
+Bots, crawlers, and AI agents make up a growing share of web traffic, and not all of it is noise. PostHog lets you decide – per type of traffic – whether to welcome it, measure it, or keep it out of your numbers. This guide covers those decisions and where to act on them. For the underlying functions and properties, see [bot and traffic detection](/docs/web-analytics/bot-detection).
+
+## Decide what to keep
+
+The right move depends on the kind of automated traffic. A useful starting point:
+
+| Traffic | Examples | Typical decision |
+| --- | --- | --- |
+| **AI agents** | GPTBot, ClaudeBot, PerplexityBot, ChatGPT-User | Increasingly worth measuring – these visits are how AI tools find and cite your content. Often you want to *see* them, not drop them. |
+| **Search crawlers** | Googlebot, Bingbot | Keep out of human metrics, but worth tracking for SEO. |
+| **SEO and monitoring tools** | AhrefsBot, SemrushBot, Pingdom, UptimeRobot | Usually noise – exclude from analytics. |
+| **HTTP clients and headless browsers** | curl, Python requests, Puppeteer, Selenium | Usually noise – exclude from analytics. |
+
+You don't have to treat every bot the same. Because classification happens at query time, you can exclude monitoring tools from a dashboard while still breaking down AI agent traffic in a separate insight.
+
+## Three places to act
+
+There are three points where you can deal with bots, from most aggressive to most flexible:
+
+1. **Block at capture (client-side).** The [PostHog JavaScript SDK](/docs/libraries/js) blocks known bots before they ever send an event. Lowest effort, but you lose the data entirely, and it only affects traffic that runs JavaScript. See [blocking bots](/docs/web-analytics/troubleshooting#do-stats-include-bots-and-crawlers).
+2. **Exclude at query time.** Keep the events and filter them out where you don't want them – add a `$virt_is_bot` is `false` filter to an insight or dashboard. Flexible and reversible: the underlying data stays intact, so you can include or break down bot traffic whenever you want.
+3. **Capture server-side to measure bots.** Most bots and AI agents never run JavaScript, so the SDK never sees them. To measure that traffic, forward your server logs as [`$http_log` events](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) – they carry the user agent and get classified the same way.
+
+## Exclude bots from an insight or dashboard
+
+In any [Product Analytics](/docs/product-analytics) insight or [Web Analytics](/docs/web-analytics/dashboard) view, add a filter where `$virt_is_bot` equals `false`. Your visitor, session, and pageview counts then reflect human traffic only, without changing the stored data.
+
+To exclude a narrower set – say, only automation and HTTP clients while keeping AI agents – filter on `$virt_traffic_type` or `$virt_traffic_category` instead.
+
+## See which bots are hitting you
+
+- **Right now** – open the [Live tab](/docs/web-analytics/live#bot-traffic) and check the bot traffic tile to see which bots are crawling you in real time.
+- **Over time** – build a trend filtered to `$virt_is_bot` is `true` and broken down by `$virt_bot_name`. See [example queries](/docs/web-analytics/bot-detection#example-queries) for the SQL equivalent.
+
+## Measure AI crawler traffic
+
+AI agents are worth watching on their own: they're how assistants and AI search surface your content. To track them, filter to `$virt_traffic_type` equals `AI Agent` and break down by `$virt_bot_name` or `$virt_bot_operator` to see which tools (OpenAI, Anthropic, Perplexity, and others) are reading your site, and which pages they hit most.
+
+## Related
+
+- [Bot and traffic detection](/docs/web-analytics/bot-detection) – the classification functions and virtual properties
+- [Live](/docs/web-analytics/live) – watch bot traffic in real time
+- [Troubleshooting](/docs/web-analytics/troubleshooting) – why your counts differ from other tools

--- a/contents/docs/web-analytics/troubleshooting.mdx
+++ b/contents/docs/web-analytics/troubleshooting.mdx
@@ -31,11 +31,13 @@ All good web analytics dashboards need to include a world map. Ours includes it 
 
 ## Do stats include bots and crawlers?
 
-No, we automatically block bots and crawlers. You can see exactly which ones [we block here](https://github.com/PostHog/posthog-js/blob/main/packages/browser/src/utils/blocked-uas.ts).
+By default, no. The PostHog JavaScript SDK blocks known bots and crawlers client-side, so they never send events – you can see the [list of blocked user agents](https://github.com/PostHog/posthog-js/blob/main/packages/browser/src/utils/blocked-uas.ts) (pull requests welcome).
+
+This only covers events captured by the JavaScript SDK. Most crawlers and AI agents don't run JavaScript, so they never trigger a client-side `$pageview` in the first place. To measure that traffic instead of dropping it, forward your server logs as `$http_log` events and classify them at query time with [bot and traffic detection](/docs/web-analytics/bot-detection).
 
 ### Analyzing bot traffic with HogQL
 
-While PostHog blocks known bots from analytics by default, you can use HogQL functions to analyze bot traffic patterns or build custom filtering logic. These functions are available anywhere HogQL runs, including the [SQL editor](/docs/product-analytics/sql), trends, and custom queries.
+While PostHog blocks known bots from analytics by default, you can use [bot and traffic detection](/docs/web-analytics/bot-detection) functions to analyze bot traffic patterns or build custom filtering logic. These functions are available anywhere HogQL runs, including the [SQL editor](/docs/product-analytics/sql), trends, and custom queries.
 
 | Function                                         | Returns                                                            |
 | ------------------------------------------------ | ------------------------------------------------------------------ |

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3939,6 +3939,12 @@ export const docsMenu = {
                     color: 'purple',
                 },
                 {
+                    name: 'Managing bot and AI traffic',
+                    url: '/docs/web-analytics/managing-bot-traffic',
+                    icon: 'IconShieldPeople',
+                    color: 'purple',
+                },
+                {
                     name: 'Path cleaning',
                     url: '/docs/web-analytics/path-cleaning',
                     icon: 'IconFilter',


### PR DESCRIPTION
## Changes

Fills the task-oriented gaps around bot/AI traffic in the web analytics docs. The existing [bot detection](/docs/web-analytics/bot-detection) page is a solid function reference; this adds the "what should I do about bots?" guidance and brings two adjacent pages up to date.

- **New page – Managing bot and AI traffic** (`managing-bot-traffic.mdx`): decision-oriented guide covering which traffic to keep vs exclude, the three places to act (client-side block / query-time exclude / server-side `$http_log` capture), how to exclude bots from an insight or dashboard, and how to measure AI crawler traffic. Links out to the reference rather than repeating functions. Added to the web analytics nav.
- **Live** (`live.mdx`): documents the bot traffic surfaces — the *bot requests per minute* chart and the *bot traffic tile* (ranked, categorized, drill-into-a-bot). Notes that the live bot tiles are still rolling out (behind `WEB_ANALYTICS_BOT_ANALYSIS`), while query-time classification is GA today.
- **Troubleshooting** (`troubleshooting.mdx`): the "Do stats include bots?" answer no longer implies client-side blocking is the whole story — it now explains that most crawlers/AI agents never run JS, and points to server-side `$http_log` classification. Linked the dedicated bot detection page from the HogQL subsection.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] No pages moved (new page, no redirect needed)

> **Reviewer note:** the Live "Bot traffic" section describes flag-gated UI. Time the merge with the `WEB_ANALYTICS_BOT_ANALYSIS` rollout, or I can gate that section's wording further if you'd rather ship the GA bits first.


https://a018bbf2.posthog-preview.pages.dev/docs/web-analytics/live