### PR TITLE
docs: automatic secret detection for Python code variables

### DIFF
--- a/contents/docs/error-tracking/code-variables/python.mdx
+++ b/contents/docs/error-tracking/code-variables/python.mdx
@@ -87,6 +87,29 @@ with new_context():
     mask_patterns_will_only_apply_to_this_method()
 ```
 
+### Detecting secrets automatically
+
+As a last resort, the SDK also scans captured variable *values* for high-entropy secrets that name-based masking misses — API keys, tokens, and strong passwords in innocuously-named variables — and replaces them with `***`. It recognizes common key formats (OpenAI, Anthropic, AWS, Stripe, GitHub, and more) and random high-entropy strings, while leaving identifiers like UUIDs, hashes, file paths, and URLs untouched.
+
+This is enabled by default. To disable it globally:
+
+```python
+posthog = Posthog(
+    "<ph_project_token>",
+    enable_exception_autocapture=True,
+    capture_exception_code_variables=True,
+    code_variables_detect_secrets=False,
+)
+```
+
+Or for a specific code block using contexts:
+
+```python
+with new_context():
+    set_code_variables_detect_secrets_context(False)
+    detection_disabled_only_here()
+```
+
 ### Ignoring variables
 
 Variable names matching ignore patterns are not captured at all. This is useful for excluding internal variables, temporary data, or framework-specific variables that don't provide debugging value.

--- a/contents/docs/error-tracking/code-variables/python.mdx
+++ b/contents/docs/error-tracking/code-variables/python.mdx
@@ -110,6 +110,34 @@ with new_context():
     detection_disabled_only_here()
 ```
 
+### Masking connection string credentials
+
+Credentials embedded in connection strings and URLs are scrubbed automatically, regardless of the variable name. Only the credentials are replaced — the scheme, host, and path are kept so the value stays useful for debugging:
+
+```
+postgresql://user:password@db.example.com:5432/mydb
+→ postgresql://***@db.example.com:5432/mydb
+```
+
+This is enabled by default. To disable it globally:
+
+```python
+posthog = Posthog(
+    "<ph_project_token>",
+    enable_exception_autocapture=True,
+    capture_exception_code_variables=True,
+    code_variables_mask_url_credentials=False,
+)
+```
+
+Or for a specific code block using contexts:
+
+```python
+with new_context():
+    set_code_variables_mask_url_credentials_context(False)
+    masking_disabled_only_here()
+```
+
 ### Ignoring variables
 
 Variable names matching ignore patterns are not captured at all. This is useful for excluding internal variables, temporary data, or framework-specific variables that don't provide debugging value.


### PR DESCRIPTION
Documents the new `code_variables_detect_secrets` option in the Python SDK, which adds entropy-based detection of secret-looking values (API keys, tokens, strong passwords) in captured exception code variables — as a last resort after name-based masking.

Adds a concise **Detecting secrets automatically** section to the [code variables / Python](/docs/error-tracking/code-variables/python) page covering: what it catches vs. ignores, that it's on by default, and how to disable it globally or per-context.

Pairs with posthog/posthog-python#692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)