### PR TITLE
Add profile details for Josh Snyder in authors.json

### DIFF
--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -489,7 +489,10 @@
     {
         "handle": "josh-snyder",
         "name": "Josh Snyder",
-        "role": "Product Engineer"
+        "role": "Product Engineer",
+        "link_type": "github",
+        "link_url": "https://github.com/joshsny",
+        "profile_id": 32497
     },
     {
         "handle": "posthog-team",


### PR DESCRIPTION
## Changes

Adds the missing `profile_id` (32497), `link_type` (github), and `link_url` (https://github.com/joshsny) for Josh Snyder in `authors.json`, so his byline renders an avatar and social link like other authors.

**Why:** Josh was recently added as a blog author but his entry only had `name` + `role`, so his byline was missing the avatar and link.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1782155934533939?thread_ts=1782155934.533939&cid=C01V9AT7DK4)*
