### PR TITLE
fix: show Inbox beta pricing label

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -370,7 +370,7 @@ export default function Tabbed() {
                     <h4 className="m-0 md:pl-3 pb-1 font-normal text-sm opacity-70">Products</h4>
                     <ul className="list-none m-0 p-0 pb-2 flex flex-row md:flex-col gap-px overflow-x-auto w-screen @md:w-auto -mx-4 px-4 @md:px-0 @md:mx-0">
                         {products.map(
-                            ({ name, Icon, cost, color, billingData, handle, categoryName, status }, index) => {
+                            ({ name, Icon, cost, color, billingData, handle, categoryName, pricingBadge }, index) => {
                                 const active = activeTab === index
                                 const addonsPrice = productAddons
                                     .filter(
@@ -395,9 +395,9 @@ export default function Tabbed() {
                                                 )}
                                                 <span className="flex items-center gap-1.5">
                                                     <span>{categoryName || name}</span>
-                                                    {status === 'beta' && (
+                                                    {pricingBadge && (
                                                         <span className="bg-yellow uppercase text-2xs rounded-xs px-0.5 py-0.5 font-semibold text-black leading-none">
-                                                            Beta
+                                                            {pricingBadge}
                                                         </span>
                                                     )}
                                                 </span>

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -369,42 +369,51 @@ export default function Tabbed() {
                 <div className="col-span-12 @2xl:col-span-4 md:pr-6 mb-4 md:mb-0">
                     <h4 className="m-0 md:pl-3 pb-1 font-normal text-sm opacity-70">Products</h4>
                     <ul className="list-none m-0 p-0 pb-2 flex flex-row md:flex-col gap-px overflow-x-auto w-screen @md:w-auto -mx-4 px-4 @md:px-0 @md:mx-0">
-                        {products.map(({ name, Icon, cost, color, billingData, handle, categoryName }, index) => {
-                            const active = activeTab === index
-                            const addonsPrice = productAddons
-                                .filter(
-                                    (addon) =>
-                                        addon.checked &&
-                                        billingData?.addons.some((billingAddon) => addon.type === billingAddon.type)
-                                )
-                                .reduce((acc, addon) => acc + addon.totalCost, 0)
-                            return (
-                                <li key={name} className="flex-1">
-                                    <button
-                                        onClick={() => setActiveTab(index)}
-                                        className={`p-2 rounded-md font-semibold text-sm flex flex-col md:flex-row space-x-2 whitespace-nowrap items-start md:items-center justify-between w-full click ${
-                                            active ? 'font-bold bg-accent' : 'hover:bg-accent'
-                                        }`}
-                                    >
-                                        <div className="flex items-center space-x-2">
-                                            {Icon && (
-                                                <span>
-                                                    <Icon className={`w-5 h-6 text-${color}`} />
+                        {products.map(
+                            ({ name, Icon, cost, color, billingData, handle, categoryName, status }, index) => {
+                                const active = activeTab === index
+                                const addonsPrice = productAddons
+                                    .filter(
+                                        (addon) =>
+                                            addon.checked &&
+                                            billingData?.addons.some((billingAddon) => addon.type === billingAddon.type)
+                                    )
+                                    .reduce((acc, addon) => acc + addon.totalCost, 0)
+                                return (
+                                    <li key={name} className="flex-1">
+                                        <button
+                                            onClick={() => setActiveTab(index)}
+                                            className={`p-2 rounded-md font-semibold text-sm flex flex-col md:flex-row space-x-2 whitespace-nowrap items-start md:items-center justify-between w-full click ${
+                                                active ? 'font-bold bg-accent' : 'hover:bg-accent'
+                                            }`}
+                                        >
+                                            <div className="flex items-center space-x-2">
+                                                {Icon && (
+                                                    <span>
+                                                        <Icon className={`w-5 h-6 text-${color}`} />
+                                                    </span>
+                                                )}
+                                                <span className="flex items-center gap-1.5">
+                                                    <span>{categoryName || name}</span>
+                                                    {status === 'beta' && (
+                                                        <span className="bg-yellow uppercase text-2xs rounded-xs px-0.5 py-0.5 font-semibold text-black leading-none">
+                                                            Beta
+                                                        </span>
+                                                    )}
                                                 </span>
-                                            )}
-                                            <span>{categoryName || name}</span>
-                                        </div>
-                                        {name == 'Experiments' ? (
-                                            <span className="opacity-25">--</span>
-                                        ) : (
-                                            <div className="opacity-70 pl-5 md:pl-0">
-                                                {formatUSD(cost + addonsPrice)}
                                             </div>
-                                        )}
-                                    </button>
-                                </li>
-                            )
-                        })}
+                                            {name == 'Experiments' ? (
+                                                <span className="opacity-25">--</span>
+                                            ) : (
+                                                <div className="opacity-70 pl-5 md:pl-0">
+                                                    {formatUSD(cost + addonsPrice)}
+                                                </div>
+                                            )}
+                                        </button>
+                                    </li>
+                                )
+                            }
+                        )}
                     </ul>
                 </div>
                 <div className="col-span-12 @2xl:col-span-8 md:pl-0">

--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -105,8 +105,9 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
             />
             <FreeTierItem
                 name="Inbox"
+                badge="Beta"
                 allocation="3 PRs"
-                icon={<Icons.IconSparkles className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
+                icon={<Icons.IconNotification className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
                 size={size}
             />
             <FreeTierItem

--- a/src/components/Pricing/Test/FreeTierItem.tsx
+++ b/src/components/Pricing/Test/FreeTierItem.tsx
@@ -4,6 +4,7 @@ interface FreeTierItemProps {
     icon: React.ReactNode
     icon2?: React.ReactNode
     name: string
+    badge?: string
     allocation?: string | React.ReactNode
     description?: string
     size?: 'normal' | 'large'
@@ -13,6 +14,7 @@ const FreeTierItem = ({
     icon,
     icon2,
     name,
+    badge,
     allocation,
     description,
     size = 'normal',
@@ -24,11 +26,16 @@ const FreeTierItem = ({
                 {icon2 && <>+ {icon2}</>}
             </div>
             <strong
-                className={`text-center leading-none mt-2 mb-1 ${size === 'normal' && 'text-[15px]'} ${
-                    size === 'large' && 'text-xl'
-                }`}
+                className={`text-center leading-none mt-2 mb-1 flex items-center gap-1.5 ${
+                    size === 'normal' && 'text-[15px]'
+                } ${size === 'large' && 'text-xl'}`}
             >
-                {name}
+                <span>{name}</span>
+                {badge && (
+                    <span className="bg-yellow uppercase text-2xs rounded-xs px-0.5 py-0.5 font-semibold text-black leading-none">
+                        {badge}
+                    </span>
+                )}
             </strong>
             <div
                 className={`text-center text-balance leading-none ${description ? 'opacity-75' : 'text-green'} ${

--- a/src/hooks/productData/inbox.tsx
+++ b/src/hooks/productData/inbox.tsx
@@ -6,7 +6,7 @@ export const inbox = {
     handle: 'inbox',
     type: 'inbox',
     color: 'blue',
-    status: 'beta',
+    pricingBadge: 'Beta',
     // No category or slug yet: keep this visible on pricing surfaces, not product/app navigation.
     slider: {
         marks: [3, 10, 50, 100],

--- a/src/hooks/productData/inbox.tsx
+++ b/src/hooks/productData/inbox.tsx
@@ -1,11 +1,12 @@
-import { IconSparkles } from '@posthog/icons'
+import { IconNotification } from '@posthog/icons'
 
 export const inbox = {
     name: 'Inbox',
-    Icon: IconSparkles,
+    Icon: IconNotification,
     handle: 'inbox',
     type: 'inbox',
     color: 'blue',
+    status: 'beta',
     // No category or slug yet: keep this visible on pricing surfaces, not product/app navigation.
     slider: {
         marks: [3, 10, 50, 100],


### PR DESCRIPTION
## Changes

- Replaces the Inbox sparkle icon with the notification-style Inbox icon on the pricing page.
- Adds an explicit `pricingBadge: 'Beta'` for Inbox and renders pricing calculator badges from that pricing-only field.
- Keeps the free-tier Inbox beta label and calculator chip styling aligned with the latest yellow uppercase beta chip styling used for data stack.
- Avoids showing a pricing beta chip for products that only have generic product `status: 'beta'`, such as Managed warehouse.

Right now there isn't a consistent shared component or styling system for these pricing/product badges, and we're in a rush, so this follows the latest badge styling that was already used for data stack.

Free-tier pricing section showing Inbox with the notification-style icon and beta label:

![Pricing free-tier Inbox beta label](https://res.cloudinary.com/dhryoknc9/image/upload/v1782229218/inbox-pricing-beta-label/pr-17856/001-pricing-free-tier-inbox-beta.png)

Pricing calculator showing Inbox selected with the pricing-only beta label:

![Pricing calculator Inbox beta label](https://res.cloudinary.com/dhryoknc9/image/upload/v1782229221/inbox-pricing-beta-label/pr-17856/002-pricing-calculator-inbox-beta.png)

## How did you test this code?

- Checked the local pricing page in the browser with Billing pointed at local Billing.
- Verified the pricing calculator DOM shows `InboxBeta$0` and `Managed warehouse$0`, so the chip is driven by `pricingBadge` rather than generic `status: 'beta'`.
- Captured the screenshots above from the local pricing page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`