### PR TITLE
docs(session-replay): add React Native to event trigger SDK support

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -85,7 +85,7 @@ Event triggers are supported on the following SDKs:
 - **Web** - posthog-js 1.186.0+
 - **iOS** - 3.48.0+
 - **Android** - 3.40.1+
-- **React Native** - 4.51.0+
+- **React Native** - 4.52.0+
 - **Flutter** - 5.25.0+
 
 > On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -85,6 +85,7 @@ Event triggers are supported on the following SDKs:
 - **Web** - posthog-js 1.186.0+
 - **iOS** - 3.48.0+
 - **Android** - 3.40.1+
+- **React Native** - 4.51.0+
 - **Flutter** - 5.25.0+
 
 > On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.


### PR DESCRIPTION
## Summary

Adds React Native to the list of SDKs that support session replay [event triggers](/docs/session-replay/how-to-control-which-sessions-you-record#with-event-trigger-conditions).

React Native gained client-side event trigger support in [posthog-js#3932](https://github.com/PostHog/posthog-js/pull/3932) (releasing as `posthog-react-native` 4.52.0). The prior docs PR [#17793](https://github.com/PostHog/posthog.com/pull/17793) documented Web/iOS/Android/Flutter but left RN out because it wasn't supported yet.

## Changes

- Add `**React Native** - 4.52.0+` to the event trigger SDK support list, placed after Android to match the tab ordering used elsewhere on the page.

The existing mobile note (no URL/in-memory pre-buffer; new session re-arms the trigger) already describes the RN behavior accurately, so no other changes are needed.

## Notes

- 4.52.0 is the next minor on top of the already-published 4.51.0. If the published version number shifts, this list should track it.
- A companion change is still needed in the monorepo's replay settings UI (`ReplayTriggers.tsx`) to add `reactNative={{ version: '4.52.0' }}` to the Mobile tab's event-trigger `<Since>` badge — that's a separate PR.