### PR TITLE
Add Mike Warren to query performance team

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -71,6 +71,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 
 -   <SmallTeam slug="analytics-platform" />
 -   <SmallTeam slug="product-analytics" />
+-   <SmallTeam slug="query-performance" />
 -   <SmallTeam slug="web-analytics" />
 
 


### PR DESCRIPTION
Adds the query performance small team to Mike Warren's PM section on the [product team handbook page](https://posthog.com/handbook/product/product-team).

🤖 Generated with [Claude Code](https://claude.com/claude-code)