### PR TITLE
Add Ruby Childs as PM for Experiments and Feature Flags

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -87,11 +87,17 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
+<legend><TeamMember name="Ruby Childs" photo /></legend>
+
+-   <SmallTeam slug="experiments" />
+-   <SmallTeam slug="feature-flags" />
+
+</fieldset>
+
+<fieldset>
 <legend>Product teams with no PM currently</legend>
 
 -   <SmallTeam slug="conversations" />
--   <SmallTeam slug="experiments" />
--   <SmallTeam slug="feature-flags" />
 
 </fieldset>
 


### PR DESCRIPTION
Adds a PM fieldset for Ruby Childs and moves Experiments and Feature Flags out of "Product teams with no PM currently" (leaving Conversations).

## Changes

Updating the PM page to include me again, as it seems I was removed at some stage. 

<img width="551" height="223" alt="Screenshot 2026-06-23 at 3 40 27 PM" src="https://github.com/user-attachments/assets/6c47d375-dcbf-4c98-8648-69465d67d061" />

## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [X] Use relative URLs for internal links
- [X] I've checked the pages added or changed in the Vercel preview build 
- [X] If I moved a page, I added a redirect in `vercel.json`
