### PR TITLE
Fix typo in blog

### DIFF
--- a/contents/blog/what-if-your-product-built-itself.mdx
+++ b/contents/blog/what-if-your-product-built-itself.mdx
@@ -55,7 +55,7 @@ So we group signals, and assign weights to something we call a report. When a re
 
 When it comes to this grouping, our first instinct was the obvious one: embed every signal and cluster on those embeddings to find related ones. It worked poorly.
 
-Say you've got an error from checkout, an error from onboarding, and a Slack message about onboarding breaking. The two onboarding signals are the same problem and should land together. But an off-the-shelf embedding model groups text that is **structurally similar**, instead of using it's **meaning**, so it files the two errors together (both are stack traces) and leaves the Slack message off on its own.
+Say you've got an error from checkout, an error from onboarding, and a Slack message about onboarding breaking. The two onboarding signals are the same problem and should land together. But an off-the-shelf embedding model groups text that is **structurally similar**, instead of using its **meaning**, so it files the two errors together (both are stack traces) and leaves the Slack message off on its own.
 
 ![filtering and normalization](https://res.cloudinary.com/dmukukwp6/image/upload/self_driving_pipeline_technical_diagram_ingestion_f0a54bfc0c.png)
 


### PR DESCRIPTION
Corrected a typo in the text regarding the embedding model's functionality.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
