### PR TITLE
docs: add wizard signup and agent discovery (auth.md) pages

### DIFF
--- a/contents/docs/ai-engineering/wizard-signup.mdx
+++ b/contents/docs/ai-engineering/wizard-signup.mdx
@@ -1,0 +1,60 @@
+---
+title: Sign up with the wizard
+sidebarTitle: Sign up with the wizard
+---
+
+You don't need to fill out a signup form to start using PostHog. The [AI wizard](/docs/ai-engineering/ai-wizard) can create a brand-new PostHog account, spin up a project, and wire up the SDK in your codebase, all from one command.
+
+This is the fastest way to go from zero to sending events. It's a good fit if you're starting a new project, trying PostHog for the first time, or you'd rather stay in your terminal than click through a browser.
+
+If you already have a PostHog account, run the wizard without `--signup` and it'll authenticate against your existing account instead. If you're a partner provisioning accounts for your own users programmatically, use the [provisioning API](/docs/integrate/provisioning) directly.
+
+## Run it
+
+```bash
+npx @posthog/wizard@latest --signup --email you@example.com --region us
+```
+
+That's everything. The wizard creates the account tied to `you@example.com`, provisions a project in the region you pick, drops the project credentials into your codebase, and installs the SDK.
+
+### Flags
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--signup` | Yes | Creates a new account instead of authenticating against an existing one. |
+| `--email` | Yes | The email address for the new account. The welcome email goes here. |
+| `--region` | Yes | Where your data lives. Use `us` ([us.posthog.com](https://us.posthog.com)) or `eu` ([eu.posthog.com](https://eu.posthog.com)). |
+
+## What happens when you sign up
+
+The wizard handles account creation for you, so you never touch a signup form. Behind the scenes it talks to PostHog's [provisioning API](/docs/integrate/provisioning) over OAuth 2.0 with PKCE, which means there are no secrets to copy around. There are three steps:
+
+1. **Request the account.** The wizard sends your email and region to PostHog and gets back a short-lived authorization code.
+2. **Exchange the code for a token.** The wizard trades that code for an access token, proving it started the request.
+3. **Provision the project.** Using the token, the wizard creates a project and gets back the project API key and host.
+
+From there the wizard installs the relevant SDK, writes the project API key and host into your config, and instruments your code, exactly like it would for an existing account. See [how the wizard works](/docs/ai-engineering/ai-wizard#how-it-works) for the full rundown of what it changes in your project.
+
+## Set your password to log in later
+
+The account exists the moment the wizard finishes, but the session it uses is short-lived. To log in to the PostHog app in your browser, check your inbox for the welcome email and follow the link to set a password.
+
+Once you've set a password, sign in at [us.posthog.com](https://us.posthog.com) or [eu.posthog.com](https://eu.posthog.com) (whichever region you chose) to see your events, build insights, and explore the rest of PostHog.
+
+## Things to know
+
+### Pick the right region up front
+
+Your region is fixed when the account is created, and `us` and `eu` are separate. You can't move data between them later, so choose the one that matches where you want your data to live before you run the command.
+
+### No personal API key by default
+
+The wizard authenticates with an OAuth access token, not a [personal API key](/docs/api/personal-api-keys). Signing up this way doesn't mint a personal API key, so if you need one for scripts or the REST API, create it from your project settings after you've set a password and logged in.
+
+### The interactive wizard is the supported path
+
+The wizard has a `--ci` mode, but it's turned off in published builds. Run the wizard interactively, which is the default.
+
+## Feedback
+
+If something doesn't work or you've got a request, comment on this page or open an issue on [GitHub](https://github.com/PostHog/wizard/issues).

--- a/contents/docs/settings/agent-discovery.mdx
+++ b/contents/docs/settings/agent-discovery.mdx
@@ -1,0 +1,100 @@
+---
+title: Agent discovery (auth.md)
+sidebarTitle: Agent discovery
+---
+
+PostHog publishes machine-readable metadata so AI agents can discover how to authenticate and create accounts, with no PostHog-specific SDK and no hardcoded endpoints. An agent starts from a single unauthenticated API request and follows a standard discovery chain to find the available options.
+
+This page covers discovery. For the flows themselves, see:
+
+- [AI wizard](/docs/ai-engineering/ai-wizard) to create an account from the command line
+- [OAuth](/docs/api/oauth) and [personal API keys](/docs/api#authentication) for an existing user
+- [Provisioning API](/docs/integrate/provisioning) for partners creating accounts for their users
+- [ID-JAG (XAA)](/docs/settings/id-jag) for agent registration via identity assertion (Enterprise plan, beta)
+
+## How discovery works
+
+An agent does not need to be told where PostHog's endpoints are. It finds them by following the metadata chain, starting from one unauthenticated request to the API.
+
+```
+1. Call the PostHog API with no credentials
+   →  401 with WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"
+
+2. Read the protected resource metadata (RFC 9728)
+   →  the authorization server, supported scopes, and bearer method
+
+3. Read the authorization server metadata (RFC 8414)
+   →  the agent_auth block names the auth.md manifest and the identity endpoint
+
+4. Read the auth.md manifest at /auth.md
+   →  the available ways to create an account and authenticate, plus the scope inventory
+```
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant PH as PostHog
+
+    A->>PH: GET /api/... (no credentials)
+    PH-->>A: 401 WWW-Authenticate: Bearer resource_metadata="..."
+    A->>PH: GET /.well-known/oauth-protected-resource
+    PH-->>A: authorization server, scopes, bearer method
+    A->>PH: GET /.well-known/oauth-authorization-server
+    PH-->>A: agent_auth block (auth.md manifest + identity endpoint)
+    A->>PH: GET /auth.md
+    PH-->>A: account-creation and auth options, scopes
+```
+
+### Protected resource metadata
+
+A request to the PostHog API without credentials returns `401` with a `WWW-Authenticate` header pointing at the protected resource metadata document ([RFC 9728](https://datatracker.ietf.org/doc/rfc9728/)):
+
+```
+WWW-Authenticate: Bearer resource_metadata="https://us.posthog.com/.well-known/oauth-protected-resource"
+```
+
+That document names the authorization server, the supported scopes, and the bearer method:
+
+```json
+{
+  "resource": "https://us.posthog.com",
+  "authorization_servers": ["https://us.posthog.com"],
+  "scopes_supported": ["query:read", "insight:read", "feature_flag:read", "..."],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+### Authorization server metadata
+
+The authorization server metadata ([RFC 8414](https://datatracker.ietf.org/doc/rfc8414/)) carries the standard OAuth endpoints plus an `agent_auth` block that follows the [auth.md](https://workos.com/auth-md) profile:
+
+```json
+{
+  "issuer": "https://us.posthog.com",
+  "agent_auth": {
+    "skill": "https://us.posthog.com/auth.md",
+    "identity_endpoint": "https://us.posthog.com/oauth/token/",
+    "identity_types_supported": ["identity_assertion"],
+    "identity_assertion": {
+      "assertion_types_supported": ["urn:ietf:params:oauth:token-type:id-jag"]
+    }
+  }
+}
+```
+
+- `skill` points at the auth.md manifest.
+- `identity_endpoint` is the token endpoint where an agent exchanges an identity assertion for an access token. PostHog accepts the [ID-JAG](/docs/settings/id-jag) assertion type via the JWT-bearer grant. See the [ID-JAG docs](/docs/settings/id-jag) for the exchange itself.
+
+### The auth.md manifest
+
+The manifest at [`/auth.md`](https://us.posthog.com/auth.md) lists the available ways to create an account (wizard, provisioning API) and authenticate (OAuth, personal API keys, ID-JAG), with the scope inventory, in a format an agent can read. It is the agent-readable index of everything above.
+
+## Regions
+
+PostHog's US and EU regions each serve their own metadata, manifest, and endpoints, pinned per region. Because discovery starts from a single `401` on the API, an agent that follows the chain picks up the right region's URLs without hardcoding any of them.
+
+| | US | EU |
+|---|---|---|
+| Protected resource metadata | `https://us.posthog.com/.well-known/oauth-protected-resource` | `https://eu.posthog.com/.well-known/oauth-protected-resource` |
+| Authorization server metadata | `https://us.posthog.com/.well-known/oauth-authorization-server` | `https://eu.posthog.com/.well-known/oauth-authorization-server` |
+| auth.md manifest | `https://us.posthog.com/auth.md` | `https://eu.posthog.com/auth.md` |

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2847,6 +2847,10 @@ export const docsMenu = {
                             url: '/docs/ai-engineering/ai-wizard',
                         },
                         {
+                            name: 'Sign up with the wizard',
+                            url: '/docs/ai-engineering/wizard-signup',
+                        },
+                        {
                             name: 'Model Context Protocol (MCP)',
                             url: '/docs/model-context-protocol',
                             children: [
@@ -3186,6 +3190,10 @@ export const docsMenu = {
                         {
                             name: 'ID-JAG (XAA)',
                             url: '/docs/settings/id-jag',
+                        },
+                        {
+                            name: 'Agent discovery (auth.md)',
+                            url: '/docs/settings/agent-discovery',
                         },
                         {
                             name: 'Content Security Policy tracking',


### PR DESCRIPTION
## Changes

Adds two docs pages for the agent-auth / auth.md work that just merged into the main repo (PostHog/posthog #64141 and #64152):

- **Sign up with the wizard** (`/docs/ai-engineering/wizard-signup`) — the consumer flow for creating a brand-new PostHog account from the command line with `npx @posthog/wizard --signup`, including what happens, the welcome-email/set-password step, regions, and the no-PAT-by-default behavior. This path wasn't documented anywhere.
- **Agent discovery (auth.md)** (`/docs/settings/agent-discovery`) — how AI agents discover PostHog's auth over open standards: the `401` -> protected resource metadata (RFC 9728) -> authorization server metadata `agent_auth` block -> `/auth.md` manifest chain. It defers to the existing [ID-JAG docs](/docs/settings/id-jag) for the token exchange rather than duplicating it, and leads with the broadly available options (wizard, OAuth, personal API keys) since ID-JAG is Enterprise/beta.

Both are wired into `src/navs/index.js` (wizard signup under AI engineering, agent discovery under Settings next to ID-JAG).

Draft until the endpoints these reference are deployed to prod.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a, new pages)
