### PR TITLE
Add Microsoft identity association well-known file

### DIFF
--- a/static/.well-known/microsoft-identity-association.json
+++ b/static/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "072cc1c1-6d09-419a-9645-33ccdf8ff5af"
+    }
+  ]
+}

--- a/static/.well-known/microsoft-identity-association.json
+++ b/static/.well-known/microsoft-identity-association.json
@@ -2,6 +2,12 @@
   "associatedApplications": [
     {
       "applicationId": "072cc1c1-6d09-419a-9645-33ccdf8ff5af"
+    },
+    {
+      "applicationId": "d33c2b07-c456-4540-95d8-5d87eb340e79"
+    },
+    {
+      "applicationId": "e51758d0-47a6-402c-93aa-8742aee64350"
     }
   ]
 }


### PR DESCRIPTION
Serves the Microsoft identity association file at `/.well-known/microsoft-identity-association.json` for Microsoft application verification.

```json
{
  "associatedApplications": [
    {
      "applicationId": "072cc1c1-6d09-419a-9645-33ccdf8ff5af"
    }
  ]
}
```

Added as a static file under `static/.well-known/`, following the same pattern as the existing `security.txt`. No `vercel.json` rewrites intercept `.well-known`, so it's served directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



test here: https://7dfb8062.posthog-preview.pages.dev/.well-known/microsoft-identity-association.json