### PR TITLE
docs: document getAllFeatureFlags() on iOS and Android

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
@@ -28,7 +28,7 @@ if (result?.variant == "variant-key") { // replace "variant-key" with the key of
 
 ### Inspecting all feature flags
 
-You can inspect all currently loaded feature flags with `PostHog.getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event:
+You can inspect all currently loaded feature flags with `PostHog.getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event, so calling it won't affect your experiment results or flag usage analytics:
 
 ```kotlin
 import com.posthog.PostHog

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-android.mdx
@@ -28,7 +28,15 @@ if (result?.variant == "variant-key") { // replace "variant-key" with the key of
 
 ### Inspecting all feature flags
 
-You can inspect all currently loaded feature flags with `PostHog.getAllFeatureFlags()`.
+You can inspect all currently loaded feature flags with `PostHog.getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event:
+
+```kotlin
+import com.posthog.PostHog
+
+PostHog.getAllFeatureFlags()?.forEach { flag ->
+    println("${flag.key} ${flag.enabled} ${flag.variant} ${flag.payload}")
+}
+```
 
 ### Ensuring flags are loaded before usage
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
@@ -37,7 +37,7 @@ if let result = PostHogSDK.shared.getFeatureFlagResult("flag-key"),
 
 ### Inspecting all feature flags
 
-You can inspect all currently loaded feature flags with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event:
+You can inspect all currently loaded feature flags with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event, so calling it won't affect your experiment results or flag usage analytics:
 
 ```swift
 for flag in PostHogSDK.shared.getAllFeatureFlags() ?? [] {

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
@@ -35,6 +35,14 @@ if let result = PostHogSDK.shared.getFeatureFlagResult("flag-key"),
 }
 ```
 
+You can also inspect all currently loaded feature flags at once with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event:
+
+```swift
+for flag in PostHogSDK.shared.getAllFeatureFlags() ?? [] {
+    print(flag.key, flag.enabled, flag.variant as Any, flag.payload as Any)
+}
+```
+
 ### Reloading feature flags
 
 Feature flag values are cached. If something has changed with your user and you'd like to refetch their flag values, call:

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
@@ -35,7 +35,9 @@ if let result = PostHogSDK.shared.getFeatureFlagResult("flag-key"),
 }
 ```
 
-You can also inspect all currently loaded feature flags at once with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event:
+### Inspecting all feature flags
+
+You can inspect all currently loaded feature flags with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event:
 
 ```swift
 for flag in PostHogSDK.shared.getAllFeatureFlags() ?? [] {


### PR DESCRIPTION
## Changes

Documents the `getAllFeatureFlags()` bulk accessor on the **iOS** SDK (newly shipped in [posthog-ios#672](https://github.com/PostHog/posthog-ios/pull/672)) and brings the existing **Android** docs in line.

Both platforms now have a matching `### Inspecting all feature flags` section that:
- shows `getAllFeatureFlags()` returning each loaded flag's `key`, `enabled` state, `variant`, and `payload`,
- calls out that it does **not** send a `$feature_flag_called` event (the property that makes it safe for debug panels / log enrichment), and
- includes a short iteration example.

The snippets are shared by both `feature-flags/adding-feature-flag-code` and `libraries/{ios,android}/usage`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links (none added)
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)
