### PR TITLE
docs(logs): document drop rules for reducing log volume

### DIFF
--- a/contents/docs/logs/best-practices.mdx
+++ b/contents/docs/logs/best-practices.mdx
@@ -337,6 +337,19 @@ PostHog Logs is billed by GB ingested per month with volume-based pricing. Use t
 
 </details>
 
+## Drop and rate-limit logs in PostHog
+
+The strategies above reduce volume in your own logging pipeline, before logs ever leave your infrastructure. When you can't change the source — a third-party service, a noisy dependency, or a team that hasn't adopted sampling yet — you can reduce volume in PostHog instead, with **drop rules**.
+
+Drop rules run during ingestion, before logs are stored, so noisy or sensitive lines never reach your storage. Find them under **Logs → Configuration → Drop rules**. There are two actions:
+
+- **Drop** — remove every log line matching the rule. Use it for high-frequency, low-value logs like health checks, load balancer pings, and liveness probes.
+- **Rate limit** — cap a service's throughput in KB/s. Lines above the limit are dropped, so a single chatty service can't dominate your volume while quieter services keep flowing.
+
+Match rules by service name, severity, or any log attribute. Rules run top to bottom in ingestion order (after optional PII scrubbing and JSON parsing), so order them from most to least specific — drag the handle on each row to reorder.
+
+Because drop rules apply before storage, they're the fastest way to cut volume without shipping a code change. Pair them with the client-side practices above: sample at the source where you can, and use drop rules to catch the noise you can't.
+
 ## Add trace and session context
 
 Isolated logs are hard to correlate. Adding trace IDs and session IDs connects individual log events to the broader request journey.

--- a/contents/docs/logs/pricing.mdx
+++ b/contents/docs/logs/pricing.mdx
@@ -22,6 +22,7 @@ We aim to be significantly cheaper than our competitors. Below are tips to reduc
 - **Use structured JSON logs.** Easier to query, so you log less "just in case." ([Structured logging](/docs/logs/best-practices#use-structured-logging))
 - **Get log levels right.** Keep INFO for outcomes, push verbose detail to DEBUG (off by default). ([Log levels](/docs/logs/best-practices#use-log-levels-correctly))
 - **Filter noisy endpoints.** Drop or downsample health checks and load balancer pings. ([What not to log](/docs/logs/best-practices#what-not-to-log))
+- **Drop or rate-limit logs in PostHog.** Remove or cap noisy services during ingestion, no code change required. ([Drop rules](/docs/logs/best-practices#drop-and-rate-limit-logs-in-posthog))
 - **Sample successful traffic.** Keep 100% of errors/slow requests; sample the boring stuff. ([Sampling](/docs/logs/best-practices#sample-strategically))
 - **Don't log payloads.** Skip request/response bodies and large objects — log metadata instead. ([What not to log](/docs/logs/best-practices#what-not-to-log), [Context bloat](/docs/logs/best-practices#build-events-throughout-the-request-lifecycle))
 - **Avoid duplicate logging across services.** Log the outcome once; don't replay the same event everywhere. ([What not to log](/docs/logs/best-practices#what-not-to-log))


### PR DESCRIPTION
## Changes

Documents the in-product **drop rules** feature (Logs → Configuration → Drop rules), which had no docs despite being live. Drop rules let users reduce log volume server-side during ingestion — complementing the existing client-side sampling guidance.

- **`best-practices.mdx`** — new section *"Drop and rate-limit logs in PostHog"* after the client-side sampling section. Explains the two actions (Drop, Rate limit), where to find them, matching by service/severity/attribute, and ingestion-order semantics. Positioned as the server-side complement to source-side sampling.
- **`pricing.mdx`** — new bullet in the cost-reduction tips list pointing at the new section, consistent with the existing "filter noisy endpoints" framing.

Kept to volume/feature framing per the existing docs voice; no new billing-mechanism prose.

## Checklist

- [x] I've read the docs style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
