### PR TITLE
docs(session-replay): add React Native 4.52.0+ to minimum duration support

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -235,6 +235,7 @@ Supported on the following SDKs:
 - **Web:** posthog-js 1.291.0+
 - **iOS:** 3.53.0+
 - **Android:** 3.44.0+
+- **React Native:** 4.52.0+
 - **Flutter:** 5.24.3+
 
 <ProductScreenshot
@@ -300,9 +301,9 @@ This mode is **more accurate** for filtering out short sessions, especially on s
 - **Use legacy mode** if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes
 - **Use strict mode** if you want to ensure you only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users
 
-### iOS, Android, and Flutter behavior
+### Mobile behavior
 
-On iOS, Android, and Flutter, minimum duration is enforced using **buffer length**, similar to web strict mode:
+On mobile, minimum duration is enforced using **buffer length**, similar to web strict mode:
 
 - Snapshots are buffered, and PostHog checks the duration of buffered replay data (from the oldest to newest buffered snapshot)
 - Recording starts sending only after that buffered duration reaches the configured minimum duration


### PR DESCRIPTION
## Changes

Documents that session replay **minimum recording duration** is supported on React Native from `posthog-react-native` 4.52.0+.

On React Native, minimum duration is enforced entirely by the underlying native SDKs (iOS `posthog-ios` 3.53.0+, Android `posthog-android` 3.44.0+), which fetch their own remote config and buffer snapshots until the configured minimum duration is reached — the same buffer-length behavior already documented for the other mobile SDKs. `posthog-react-native` 4.52.0 is the first version that routes session replay through `@posthog/react-native-plugin`, which pins those min-duration-capable native SDKs.

In `contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx`:

- Added **React Native — 4.52.0+** to the "Minimum duration" supported-SDKs list.
- Collapsed the per-platform behavior subsection to mobile (`### Mobile behavior` / "On mobile, …"), now that React Native joins iOS/Android/Flutter under the same buffer-length behavior.

This is a docs-only change; no screenshots needed.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` _(no pages moved)_
