### PR TITLE
Docs: Simplify workflow builder triggers and remove unused import

### DIFF
--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -2,8 +2,6 @@
 title: Workflow builder
 ---
 
-import CalloutBox from "components/Docs/CalloutBox";
-
 Workflows are a collection of steps that automate a process or deliver messages to your users based on your configured logic. In PostHog, you can create a workflow using our no-code workflow builder.
 
 <ProductScreenshot
@@ -15,14 +13,14 @@ Workflows are a collection of steps that automate a process or deliver messages 
 
 Workflows are composed of the following components:
 
-| Component                             | Description                                                                                                                                 |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Triggers](#triggers)                 | What starts the workflow. You can trigger a workflow from an event, a recurring schedule, a batch audience, a webhook, or a tracking pixel. |
-| [Dispatches](#dispatches)             | The messages you send, mail, slack, SMS, webhook, or any PostHog real time destinations.                                                    |
-| [Delays](#delays)                     | Wait steps such as "wait 2 days" or "wait until condition is true."                                                                         |
-| [Audience splits](#audience-splits)   | Target and split your users so you can automate some action for them or send a message with more specificity.                               |
-| [PostHog actions](#posthog-actions)   | Change a person's properties, or trigger other events, once a person reaches a specific point in your workflow.                             |
-| [Output variables](#output-variables) | Store data from step results in workflow variables for use in later steps.                                                                  |
+| Component                             | Description                                                                                                           |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [Triggers](#triggers)                 | What starts the workflow. You can trigger a workflow from an event, a batch audience, a webhook, or a tracking pixel. |
+| [Dispatches](#dispatches)             | The messages you send, mail, slack, SMS, webhook, or any PostHog real time destinations.                              |
+| [Delays](#delays)                     | Wait steps such as "wait 2 days" or "wait until condition is true."                                                   |
+| [Audience splits](#audience-splits)   | Target and split your users so you can automate some action for them or send a message with more specificity.         |
+| [PostHog actions](#posthog-actions)   | Change a person's properties, or trigger other events, once a person reaches a specific point in your workflow.       |
+| [Output variables](#output-variables) | Store data from step results in workflow variables for use in later steps.                                            |
 
 ## Draft and enabled workflows
 
@@ -43,13 +41,12 @@ Draft workflows can also be archived, even if they contain invalid configuration
 
 Every workflow starts with a trigger. Triggers define what kicks off the workflow.
 
-| Trigger type           | Description                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------ |
-| Event trigger          | A captured [PostHog event](/docs/data/events) (e.g. `signed up`)               |
-| Webhook trigger        | Programmatically start a workflow with an HTTP request                         |
-| Schedule trigger       | Run a workflow on a recurring schedule (e.g. daily, weekly, monthly)           |
-| Batch trigger          | Run the workflow for each person matching an audience, on a recurring schedule |
-| Tracking pixel trigger | Start the workflow when a 1x1 tracking pixel is loaded (e.g. in an email)      |
+| Trigger type           | Description                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| Event trigger          | A captured [PostHog event](/docs/data/events) (e.g. `signed up`)                          |
+| Webhook trigger        | Programmatically start a workflow with an HTTP request                                    |
+| Batch trigger          | Run the workflow for each person matching an audience, optionally on a recurring schedule |
+| Tracking pixel trigger | Start the workflow when a 1x1 tracking pixel is loaded (e.g. in an email)                 |
 
 ### Event triggers
 
@@ -77,42 +74,37 @@ To set this up:
 3. Optionally add delays, branching, person property updates, or dispatches.
 4. Enable the workflow and point your external system at the webhook URL which can be copied from the trigger step.
 
-### Schedule triggers
-
-Schedule triggers run a workflow on a recurring basis, independent of user actions. Use them for cron-style automations like "run every Monday at 9am" or "run daily at midnight."
-
-Unlike event and webhook triggers, schedule triggers don't require a person audience. When you select **Schedule** as the trigger type, configure a recurring pattern using the schedule picker (e.g. daily, weekly, or monthly).
-
-Schedule triggers display a status badge next to the trigger type:
-
-| Status    | Description                                                  |
-| --------- | ------------------------------------------------------------ |
-| Active    | The schedule is running and will fire at the next occurrence |
-| Paused    | The schedule is paused because the workflow is disabled      |
-| Completed | The schedule has finished all its occurrences                |
-
-If you update a completed schedule's configuration, its status resets to **Active**.
-
-If your workflow needs to target specific users on a schedule, use a [batch trigger](#batch-triggers) instead.
-
 ### Batch triggers
 
-<CalloutBox icon="IconInfo" title="Batch triggers are in beta" type="fyi">
-
-Batch triggers are currently in beta. We're always looking for feedback, please [reach out to us directly](https://app.posthog.com/workflows#panel=support%3Afeedback%3A%3Alow%3Atrue) in app.
-
-</CalloutBox>
-
-Batch triggers let you run a workflow for each person in an audience you define, on a recurring schedule.
-At each scheduled time, PostHog evaluates your audience filters and executes the workflow once per matching person.
-
-You define the audience using person properties, cohorts, or feature flag filters.
-The trigger shows an estimate of how many persons will be affected before you enable the workflow.
+Batch triggers let you run a workflow for each person in an audience you define, optionally on a recurring schedule.
+When the batch runs, PostHog evaluates your audience filters and executes the workflow once per matching person.
 
 A batch trigger combines two things:
 
-- **Audience filters** — who should enter the workflow (e.g. person properties, cohorts, feature flags)
-- **A recurring schedule** — when the batch should run (same schedule picker as schedule triggers)
+- **Audience filters** — who should enter the workflow
+- **A schedule (optional)** — when the batch should run
+
+#### Audience filters
+
+You define the audience using person properties, cohorts, or distinct IDs. Multiple conditions are combined with **OR** logic, so a person matches if they meet any of them.
+
+The trigger shows a real-time estimate of how many persons will be affected (e.g. "approximately 1,200 of 50,000 persons") before you enable the workflow. If the audience is too large, you'll see a warning prompting you to add filters to narrow it down.
+
+#### Recurring schedule
+
+By default, a batch trigger runs once. Add an optional schedule to run it on a recurring basis, like "every Monday at 9am" or "the last day of every month." Use this for time-based, audience-targeted automations such as a weekly digest email or a monthly re-engagement campaign.
+
+Configure the recurrence with the schedule picker:
+
+| Setting   | Options                                                                                                                               |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Frequency | Daily, weekly, monthly, or yearly, with an interval (e.g. every 2 weeks)                                                              |
+| Weekly    | Choose which days of the week to run on (e.g. Monday and Wednesday)                                                                   |
+| Monthly   | Run on a specific day of the month (e.g. the 15th), on an ordinal weekday (e.g. the 3rd Wednesday), or on the last day of every month |
+| Start     | The date and time the schedule begins, in a timezone you select                                                                       |
+| Ends      | Never, on a specific date, or after a set number of occurrences                                                                       |
+
+You can also type the recurrence in plain English (e.g. "every week on Monday and Wednesday"), and the picker shows a preview of the next occurrences so you can confirm the schedule before enabling the workflow.
 
 ### Tracking pixel triggers
 

--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -13,14 +13,14 @@ Workflows are a collection of steps that automate a process or deliver messages 
 
 Workflows are composed of the following components:
 
-| Component                             | Description                                                                                                           |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| [Triggers](#triggers)                 | What starts the workflow. You can trigger a workflow from an event, a batch audience, a webhook, or a tracking pixel. |
-| [Dispatches](#dispatches)             | The messages you send, mail, slack, SMS, webhook, or any PostHog real time destinations.                              |
-| [Delays](#delays)                     | Wait steps such as "wait 2 days" or "wait until condition is true."                                                   |
-| [Audience splits](#audience-splits)   | Target and split your users so you can automate some action for them or send a message with more specificity.         |
-| [PostHog actions](#posthog-actions)   | Change a person's properties, or trigger other events, once a person reaches a specific point in your workflow.       |
-| [Output variables](#output-variables) | Store data from step results in workflow variables for use in later steps.                                            |
+| Component                             | Description                                                                                                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Triggers](#triggers)                 | What starts the workflow. You can trigger a workflow from an event, a batch audience (optionally on a recurring schedule), a webhook, or a tracking pixel. |
+| [Dispatches](#dispatches)             | The messages you send, mail, slack, SMS, webhook, or any PostHog real time destinations.                                                                   |
+| [Delays](#delays)                     | Wait steps such as "wait 2 days" or "wait until condition is true."                                                                                        |
+| [Audience splits](#audience-splits)   | Target and split your users so you can automate some action for them or send a message with more specificity.                                              |
+| [PostHog actions](#posthog-actions)   | Change a person's properties, or trigger other events, once a person reaches a specific point in your workflow.                                            |
+| [Output variables](#output-variables) | Store data from step results in workflow variables for use in later steps.                                                                                 |
 
 ## Draft and enabled workflows
 
@@ -92,7 +92,9 @@ The trigger shows a real-time estimate of how many persons will be affected (e.g
 
 #### Recurring schedule
 
-By default, a batch trigger runs once. Add an optional schedule to run it on a recurring basis, like "every Monday at 9am" or "the last day of every month." Use this for time-based, audience-targeted automations such as a weekly digest email or a monthly re-engagement campaign.
+By default, a batch trigger runs once, when you start it manually. Click **Trigger** in the top right of the workflow editor and then **Run workflow** to evaluate the audience and run the workflow for each matching person right away.
+
+Add an optional schedule to run the batch on a recurring basis instead, like "every Monday at 9am" or "the last day of every month." Use this for time-based, audience-targeted automations such as a weekly digest email or a monthly re-engagement campaign.
 
 Configure the recurrence with the schedule picker:
 


### PR DESCRIPTION
## Changes

Updated the workflow builder documentation to:

1. **Removed unused import** – Deleted the `CalloutBox` import that was no longer being used in the document
2. **Simplified trigger types table** – Removed the "Schedule trigger" row from the main triggers table, as schedule functionality is now integrated into batch triggers
3. **Consolidated schedule and batch trigger documentation** – Merged schedule trigger content into the batch triggers section, explaining how batch triggers support both one-time and recurring execution
4. **Improved batch trigger explanation** – Expanded the batch triggers section with clearer subsections for:
   - Audience filters (with details on OR logic and person matching estimates)
   - Recurring schedule (with a detailed configuration table for frequency, weekly/monthly options, start time, and end conditions)
   - Plain English schedule input capability
5. **Removed CalloutBox beta notice** – Deleted the beta callout for batch triggers as they appear to be out of beta
6. **Updated table formatting** – Adjusted column widths in tables for better readability

These changes streamline the documentation by consolidating related trigger types and removing outdated beta notices, making it clearer how users can configure both simple and recurring batch workflows.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide.md) style guides
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A – no pages moved)

https://claude.ai/code/session_01TmAwPjz19Q81Ya3WuknVcS