### PR TITLE
docs(self-driving): document scout memory + MCP access, add scout examples page

### DIFF
--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -17,19 +17,19 @@ A [scout](/docs/self-driving/scouts) can watch almost anything you land in PostH
 
 ## Canonical scouts
 
-PostHog ships around 20 canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Here's a sample of what they watch:
+PostHog ships around 20 canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Each scout is just a skill you can read – the table links straight to its `SKILL.md` in the [PostHog repo](https://github.com/PostHog/posthog/tree/master/products/signals/skills). Here's a sample of what they watch:
 
 | Scout | What it looks for |
 |---|---|
-| `signals-scout-error-tracking` | Error spikes and new issues, triaged by how many users they hit |
-| `signals-scout-experiments` | Validity threats like sample-ratio mismatch and zombie experiments |
-| `signals-scout-revenue-analytics` | MRR and churn shifts, and broken Stripe syncs |
-| `signals-scout-surveys` | NPS and CSAT regressions, plus recurring themes in open-text responses |
-| `signals-scout-web-analytics` | Acquisition channels diverging, attribution breakage, and 404 spikes |
-| `signals-scout-feature-flags` | Evaluation cliffs, ghost flags, and flag debt |
-| `signals-scout-session-replay` | Friction patterns like rage-clicks and dead-ends across sessions |
+| [`signals-scout-error-tracking`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-error-tracking/SKILL.md) | Error spikes and new issues, triaged by how many users they hit |
+| [`signals-scout-experiments`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-experiments/SKILL.md) | Validity threats like sample-ratio mismatch and zombie experiments |
+| [`signals-scout-revenue-analytics`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-revenue-analytics/SKILL.md) | MRR and churn shifts, and broken Stripe syncs |
+| [`signals-scout-surveys`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-surveys/SKILL.md) | NPS and CSAT regressions, plus recurring themes in open-text responses |
+| [`signals-scout-web-analytics`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-web-analytics/SKILL.md) | Acquisition channels diverging, attribution breakage, and 404 spikes |
+| [`signals-scout-feature-flags`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-feature-flags/SKILL.md) | Evaluation cliffs, ghost flags, and flag debt |
+| [`signals-scout-session-replay`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-session-replay/SKILL.md) | Friction patterns like rage-clicks and dead-ends across sessions |
 
-The full set covers more surfaces, including logs, AI observability, and APM. A cross-product generalist also watches the seams between surfaces – a deploy, then an error burst, then a conversion dip – that no single specialist would catch on its own.
+The full set covers more surfaces, including logs, AI observability, and APM. A cross-product [generalist](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-general/SKILL.md) also watches the seams between surfaces – a deploy, then an error burst, then a conversion dip – that no single specialist would catch on its own. Browse them all in the [`products/signals/skills`](https://github.com/PostHog/posthog/tree/master/products/signals/skills) directory.
 
 ## Ideas for custom scouts
 

--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -17,19 +17,32 @@ A [scout](/docs/self-driving/scouts) can watch almost anything you land in PostH
 
 ## Canonical scouts
 
-PostHog ships around 20 canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Each scout is just a skill you can read (named `signals-scout-*`) – the table links straight to its `SKILL.md` in the [PostHog repo](https://github.com/PostHog/posthog/tree/master/products/signals/skills). Here's a sample of what they watch:
+PostHog ships a fleet of canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Each scout is just a skill you can read (named `signals-scout-*`) – the table links straight to its `SKILL.md` in the [PostHog repo](https://github.com/PostHog/posthog/tree/master/products/signals/skills). Here's the full set:
 
 | Scout | What it looks for |
 |---|---|
-| [Error tracking](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-error-tracking/SKILL.md) | Error spikes and new issues, triaged by how many users they hit |
-| [Experiments](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-experiments/SKILL.md) | Validity threats like sample-ratio mismatch and zombie experiments |
-| [Revenue analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-revenue-analytics/SKILL.md) | MRR and churn shifts, and broken Stripe syncs |
+| [AI observability](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-ai-observability/SKILL.md) | Cost, latency, error, eval, and tool-usage trends and spikes across your AI traffic |
+| [Anomaly detection](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-anomaly-detection/SKILL.md) | Bursts, drops, flat-lines, and trend breaks in your most-viewed dashboards and insights |
+| [APM](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-apm/SKILL.md) | RED-metric regressions (error rate, p95 latency, volume) and new errors per service and operation |
+| [CSP violations](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-csp-violations/SKILL.md) | Content Security Policy violation clusters, per-directive bursts, and suspicious third-party domains |
+| [Customer analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-customer-analytics/SKILL.md) | Churn-risk shapes on named accounts – engagement cliffs, dormancy, single-threaded champions |
+| [Data pipelines](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-data-pipelines/SKILL.md) | Delivery failures across CDP destinations, batch exports, and workflows, where config and reality disagree |
+| [Error tracking](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-error-tracking/SKILL.md) | Error spikes, stuck loops, and fingerprint clusters, triaged by how many users they hit |
+| [Experiments](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-experiments/SKILL.md) | Validity threats like sample-ratio mismatch, plus zombie experiments running past their useful life |
+| [Feature flags](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-feature-flags/SKILL.md) | Evaluation cliffs, ghost flags (keys no longer in code), and flag debt |
+| [General](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-general/SKILL.md) | Cross-product correlations and any surface no specialist covers |
+| [Health checks](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-health-checks/SKILL.md) | Setup health issues – no live events, outdated SDKs, missing reverse proxy, failing warehouse models |
+| [Inbox validation](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-inbox-validation/SKILL.md) | Whether a merged fix actually held, re-measured after a deployment soak window |
+| [Logs](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-logs/SKILL.md) | Volume bursts, severity-distribution shifts, service silence, and new error message patterns |
+| [Observability gaps](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-observability-gaps/SKILL.md) | Coverage gaps – high-volume events with no insight, dashboard, or alert |
+| [Product analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-product-analytics/SKILL.md) | Regressions in your funnels, retention, lifecycle, stickiness, and paths |
+| [Replay Vision](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-replay-vision/SKILL.md) | Whether Replay Vision scanners are still observing, and what their observations surface |
+| [Revenue analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-revenue-analytics/SKILL.md) | MRR and churn shifts, broken Stripe syncs, and revenue config drift |
+| [Session replay](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-session-replay/SKILL.md) | Recording capture integrity, plus rage-click and dead-click friction clusters |
 | [Surveys](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-surveys/SKILL.md) | NPS and CSAT regressions, plus recurring themes in open-text responses |
 | [Web analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-web-analytics/SKILL.md) | Acquisition channels diverging, attribution breakage, and 404 spikes |
-| [Feature flags](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-feature-flags/SKILL.md) | Evaluation cliffs, ghost flags, and flag debt |
-| [Session replay](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-session-replay/SKILL.md) | Friction patterns like rage-clicks and dead-ends across sessions |
 
-The full set covers more surfaces, including logs, AI observability, and APM. A cross-product [generalist](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-general/SKILL.md) also watches the seams between surfaces – a deploy, then an error burst, then a conversion dip – that no single specialist would catch on its own. Browse them all in the [`products/signals/skills`](https://github.com/PostHog/posthog/tree/master/products/signals/skills) directory.
+Most are specialists that watch one surface in depth; the [general](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-general/SKILL.md) scout is the exception – it watches the seams between surfaces, like a deploy, then an error burst, then a conversion dip, that no single specialist would catch on its own. Browse them all in the [`products/signals/skills`](https://github.com/PostHog/posthog/tree/master/products/signals/skills) directory.
 
 ## Ideas for custom scouts
 

--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -1,0 +1,61 @@
+---
+title: Scout examples
+sidebarTitle: Examples
+sidebar: Docs
+showTitle: true
+---
+
+import { CallToAction } from 'components/CallToAction'
+
+<CalloutBox icon="IconInfo" title="Open beta" type="fyi">
+
+Self-driving is currently in open beta.
+
+</CalloutBox>
+
+A [scout](/docs/self-driving/scouts) can watch almost anything you land in PostHog. There are two kinds: the **canonical** scouts PostHog ships with, and **custom** scouts you write for the patterns specific to your product. This page is a catalog of both, to spark ideas for what to point a scout at.
+
+## Canonical scouts
+
+PostHog ships around 20 canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Here's a sample of what they watch:
+
+| Scout | What it looks for |
+|---|---|
+| `signals-scout-error-tracking` | Error spikes and new issues, triaged by how many users they hit |
+| `signals-scout-experiments` | Validity threats like sample-ratio mismatch and zombie experiments |
+| `signals-scout-revenue-analytics` | MRR and churn shifts, and broken Stripe syncs |
+| `signals-scout-surveys` | NPS and CSAT regressions, plus recurring themes in open-text responses |
+| `signals-scout-web-analytics` | Acquisition channels diverging, attribution breakage, and 404 spikes |
+| `signals-scout-feature-flags` | Evaluation cliffs, ghost flags, and flag debt |
+| `signals-scout-session-replay` | Friction patterns like rage-clicks and dead-ends across sessions |
+
+The full set covers more surfaces, including logs, AI observability, and APM. A cross-product generalist also watches the seams between surfaces – a deploy, then an error burst, then a conversion dip – that no single specialist would catch on its own.
+
+## Ideas for custom scouts
+
+You can write your own scout for anything you care about. The job is the same each time: pick a surface you wish someone was watching, write down what "worth my attention" means for it in plain English, and let the scout hold that bar for you. Some directions to steal:
+
+| Use case | What it does |
+|---|---|
+| **Mine any Slack channel** | Sync a channel into the [data warehouse](/docs/data-warehouse) and a scout reads it like any other table – a user-feedback channel, an on-call channel, even a community Discord relay. The moment it's a table, it's fair game. |
+| **Watch any custom event** | Point a scout at any event you capture – a support event, a feedback submission, a domain-specific action – and have it turn that stream into findings. |
+| **Keep an eye on what you already care about** | Hand a scout a curated set of *your* dashboards, insights, and alerts – the metrics your team checks every morning – and have it stay quiet until one moves against its own baseline. |
+| **Own a funnel or a journey** | A scout can watch your key funnels and activation flows, flag a conversion or retention regression against the flow's own trailing baseline, and even propose the [experiment](/docs/experiments) to fix the weakest step. |
+| **Have it read your codebase** | Give a scout a repo and a job: catch docs that have drifted out of date, flag a feature shipped with no instrumentation, spot a deprecated API, or run a static-analysis tool over the last week's diffs. |
+| **Point a scout at your scouts** | A meta-scout that audits the rest of the fleet for miscalibration, plus a follow-up that re-checks "resolved" reports after a soak window to confirm the fix actually held. |
+
+The common thread is that a scout isn't limited to product analytics. Any source you land in PostHog – a warehouse table, a Slack relay, a third-party feed – becomes something a scout can watch.
+
+## Make your own
+
+You don't write a scout by hand. In [PostHog Code](/code), open the scouts page and pick the "Make a scout" suggestion: it scans your project and proposes custom scouts grounded in your actual data. You can also ask any agent connected to the PostHog MCP to build one.
+
+For a deep dive – two real scouts traced end to end, with a walkthrough video – read [What is a scout?](/blog/what-is-a-scout).
+
+## Next step
+
+See what a scout emits when it finds something.
+
+<CallToAction type="primary" to="/docs/self-driving/signals">
+  Signals
+</CallToAction>

--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -17,17 +17,17 @@ A [scout](/docs/self-driving/scouts) can watch almost anything you land in PostH
 
 ## Canonical scouts
 
-PostHog ships around 20 canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Each scout is just a skill you can read – the table links straight to its `SKILL.md` in the [PostHog repo](https://github.com/PostHog/posthog/tree/master/products/signals/skills). Here's a sample of what they watch:
+PostHog ships around 20 canonical scouts out of the box, each watching a common pattern. You turn each one on or off per project. Each scout is just a skill you can read (named `signals-scout-*`) – the table links straight to its `SKILL.md` in the [PostHog repo](https://github.com/PostHog/posthog/tree/master/products/signals/skills). Here's a sample of what they watch:
 
 | Scout | What it looks for |
 |---|---|
-| [`signals-scout-error-tracking`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-error-tracking/SKILL.md) | Error spikes and new issues, triaged by how many users they hit |
-| [`signals-scout-experiments`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-experiments/SKILL.md) | Validity threats like sample-ratio mismatch and zombie experiments |
-| [`signals-scout-revenue-analytics`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-revenue-analytics/SKILL.md) | MRR and churn shifts, and broken Stripe syncs |
-| [`signals-scout-surveys`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-surveys/SKILL.md) | NPS and CSAT regressions, plus recurring themes in open-text responses |
-| [`signals-scout-web-analytics`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-web-analytics/SKILL.md) | Acquisition channels diverging, attribution breakage, and 404 spikes |
-| [`signals-scout-feature-flags`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-feature-flags/SKILL.md) | Evaluation cliffs, ghost flags, and flag debt |
-| [`signals-scout-session-replay`](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-session-replay/SKILL.md) | Friction patterns like rage-clicks and dead-ends across sessions |
+| [Error tracking](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-error-tracking/SKILL.md) | Error spikes and new issues, triaged by how many users they hit |
+| [Experiments](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-experiments/SKILL.md) | Validity threats like sample-ratio mismatch and zombie experiments |
+| [Revenue analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-revenue-analytics/SKILL.md) | MRR and churn shifts, and broken Stripe syncs |
+| [Surveys](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-surveys/SKILL.md) | NPS and CSAT regressions, plus recurring themes in open-text responses |
+| [Web analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-web-analytics/SKILL.md) | Acquisition channels diverging, attribution breakage, and 404 spikes |
+| [Feature flags](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-feature-flags/SKILL.md) | Evaluation cliffs, ghost flags, and flag debt |
+| [Session replay](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-session-replay/SKILL.md) | Friction patterns like rage-clicks and dead-ends across sessions |
 
 The full set covers more surfaces, including logs, AI observability, and APM. A cross-product [generalist](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-general/SKILL.md) also watches the seams between surfaces – a deploy, then an error burst, then a conversion dip – that no single specialist would catch on its own. Browse them all in the [`products/signals/skills`](https://github.com/PostHog/posthog/tree/master/products/signals/skills) directory.
 

--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -19,11 +19,15 @@ A scout is a scheduled agent that explores your PostHog data and raises a hand w
 
 A scout runs on a schedule. Each run, it looks at one slice of your data, decides whether anything is worth surfacing, and if so emits a [signal](/docs/self-driving/signals): a structured finding with the evidence behind it and a suggested action.
 
+A scout reads your data through the same [PostHog MCP](/docs/model-context-protocol) you can connect to Claude Code or Cursor, so it can see anything in PostHog out of the box – events, [data warehouse](/docs/data-warehouse) tables, insights, dashboards – with nothing to wire up per scout. Because any source you land in PostHog becomes queryable, a scout isn't limited to product analytics: a Slack channel, a billing system, or a support inbox synced to your warehouse is fair game too.
+
+A scout also keeps a durable memory between runs. Each run, it reads back what earlier runs learned and recorded – what's normal, what it's already surfaced, what it decided to hold – so it dedupes against itself and gets sharper over time instead of starting cold. That memory is what makes a scout a long-running agent rather than a one-shot check.
+
 Because scouts run on a schedule, the loop keeps noticing problems and opportunities on its own, instead of waiting for someone to file a ticket.
 
 ## Built-in and custom scouts
 
-PostHog ships with a set of scouts that watch common patterns out of the box. You can turn each on or off per project, and teams can add their own scouts for the patterns specific to their product.
+PostHog ships with a set of scouts that watch common patterns out of the box. You can turn each on or off per project, and teams can add their own scouts for the patterns specific to their product. See [scout examples](/docs/self-driving/scout-examples) for the scouts PostHog ships with and ideas for your own.
 
 ## Scouts and signal sources
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2206,6 +2206,16 @@ export const docsMenu = {
                 {
                     name: 'Scouts',
                     url: '/docs/self-driving/scouts',
+                    children: [
+                        {
+                            name: 'Overview',
+                            url: '/docs/self-driving/scouts',
+                        },
+                        {
+                            name: 'Examples',
+                            url: '/docs/self-driving/scout-examples',
+                        },
+                    ],
                 },
                 {
                     name: 'Signals',


### PR DESCRIPTION
## What

Two changes to the [Scouts](https://posthog.com/docs/self-driving/scouts) docs, grounded in the actual Signals implementation in the monorepo and the `what-is-a-scout` blog post:

1. **Expand `scouts.mdx`** with two durable facts that were only in the blog/skills, not the docs:
   - **MCP access** — scouts read your data through the same PostHog MCP you connect to Claude Code/Cursor, so anything in PostHog is watchable out of the box (events, data warehouse tables, insights, dashboards), and scouts aren't limited to product analytics.
   - **Memory** — scouts keep a durable scratchpad between runs, which is what makes them long-running, self-deduping agents rather than one-shot checks.
   - Plus a pointer from "Built-in and custom scouts" to the new examples page.

2. **New `scout-examples.mdx` page** — an evergreen catalog of the canonical scouts PostHog ships with and ideas for custom scouts (distilled from the blog's "what else to point a scout at" section), with a "Make your own" pointer to PostHog Code and the blog deep-dive.

3. **Nav** — gives Scouts an Overview/Examples `children` array, mirroring the existing Inbox pattern.

## Why

The scratchpad-memory and out-of-box MCP-access points are core to what makes scouts powerful, but they only lived in the blog post (which gets buried) and the shipped skills (which only agents read). Both are durable facts verified against the harness code (`SignalScratchpad`, the MCP read scopes + scout-only emit/scratchpad/profile tools). The new examples page gives the conceptual pages a "okay, what could I point this at?" destination that's discoverable from the docs nav.

## Notes

- Canonical-scouts table is framed as "a sample of ~20" so it won't go stale as the fleet grows; I listed the blog's five plus error-tracking and session-replay.
- Kept the new page's voice plainer than the blog to match the surrounding self-driving docs.
- Verified both pages return 200 locally and the nav nests under Scouts.