### PR TITLE
Update docs overview hog images across products

### DIFF
--- a/src/components/Docs/Intro.js
+++ b/src/components/Docs/Intro.js
@@ -39,13 +39,13 @@ export default function Intro({
             </div>
 
             {imageUrl && (
-                <figure className="m-0 mt-auto p-0 md:pr-8 flex items-end">
+                <figure className="m-0 mt-auto px-4 pb-4 md:px-8 md:pb-6 flex items-end justify-center">
                     <CloudinaryImage
                         alt=""
                         placeholder="none"
                         quality={100}
                         className={imageColumnClasses}
-                        imgClassName={imageClasses}
+                        imgClassName={imageClasses ?? 'max-h-40 md:max-h-52'}
                         src={imageUrl}
                     />
                 </figure>

--- a/src/hooks/productData/surveys.tsx
+++ b/src/hooks/productData/surveys.tsx
@@ -73,7 +73,7 @@ export const surveys = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png',
         alt: 'A hedgehog looking at survey results',
         classes: 'absolute bottom-0 right-0 max-w-md',
     },

--- a/src/pages/docs/ai-observability.tsx
+++ b/src/pages/docs/ai-observability.tsx
@@ -67,7 +67,6 @@ const AIObservability: React.FC = () => {
                 buttonText="Start capturing LLM data"
                 buttonLink="/docs/ai-observability/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
-                imageClasses="max-h-48 md:max-h-64"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/ai_robo_hog_9c1c225c94.png"
             />
 

--- a/src/pages/docs/ai-observability.tsx
+++ b/src/pages/docs/ai-observability.tsx
@@ -68,7 +68,7 @@ const AIObservability: React.FC = () => {
                 buttonLink="/docs/ai-observability/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
                 imageClasses="max-h-48 md:max-h-64"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/robot_960530c306.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/ai_robo_hog_9c1c225c94.png"
             />
 
             <Content />

--- a/src/pages/docs/customer-analytics.tsx
+++ b/src/pages/docs/customer-analytics.tsx
@@ -86,7 +86,7 @@ export const Content = ({ quickLinks = true }) => {
                 description="Understand your customers without building dashboards from scratch. Track active users, signups, conversions, and engagement."
                 buttonText="Setup guide"
                 buttonLink="/docs/customer-analytics/start-here"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_crm_40195fd72f.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/multiple_puzzle_teamwork_f73168bc7c.png"
             />
             <section className="mb-4">
                 <h2 className="mb-4">Overview</h2>

--- a/src/pages/docs/customer-analytics.tsx
+++ b/src/pages/docs/customer-analytics.tsx
@@ -86,7 +86,6 @@ export const Content = ({ quickLinks = true }) => {
                 description="Understand your customers without building dashboards from scratch. Track active users, signups, conversions, and engagement."
                 buttonText="Setup guide"
                 buttonLink="/docs/customer-analytics/start-here"
-                imageClasses="max-h-48 md:max-h-64"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_crm_40195fd72f.png"
             />
             <section className="mb-4">

--- a/src/pages/docs/data-warehouse.tsx
+++ b/src/pages/docs/data-warehouse.tsx
@@ -59,7 +59,7 @@ const DataWarehouse: React.FC = () => {
                 buttonText="Link your first source"
                 buttonLink="/docs/cdp/sources"
                 imageColumnClasses="mt-4 md:-mt-8"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/products/data-warehouse/warehouse-hog.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/data_warehouse_8e163dfe7f.png"
                 imageClasses="max-h-48 md:max-h-64"
             />
 

--- a/src/pages/docs/data-warehouse.tsx
+++ b/src/pages/docs/data-warehouse.tsx
@@ -60,7 +60,6 @@ const DataWarehouse: React.FC = () => {
                 buttonLink="/docs/cdp/sources"
                 imageColumnClasses="mt-4 md:-mt-8"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/data_warehouse_8e163dfe7f.png"
-                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/endpoints/index.tsx
+++ b/src/pages/docs/endpoints/index.tsx
@@ -142,7 +142,7 @@ const Endpoints: React.FC = () => {
                         description="Create predefined queries from insights or SQL and expose them as optimized API endpoints."
                         buttonText="Get started"
                         buttonLink="/docs/endpoints/start-here"
-                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/multiple_puzzle_teamwork_f73168bc7c.png"
+                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/endpoints_7e459e6202.png"
                     />
                 </section>
 

--- a/src/pages/docs/endpoints/index.tsx
+++ b/src/pages/docs/endpoints/index.tsx
@@ -143,7 +143,7 @@ const Endpoints: React.FC = () => {
                         buttonText="Get started"
                         buttonLink="/docs/endpoints/start-here"
                         imageClasses="max-h-48 md:max-h-64"
-                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_endpoints_8737bb2c29.png"
+                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/multiple_puzzle_teamwork_f73168bc7c.png"
                     />
                 </section>
 

--- a/src/pages/docs/endpoints/index.tsx
+++ b/src/pages/docs/endpoints/index.tsx
@@ -142,7 +142,6 @@ const Endpoints: React.FC = () => {
                         description="Create predefined queries from insights or SQL and expose them as optimized API endpoints."
                         buttonText="Get started"
                         buttonLink="/docs/endpoints/start-here"
-                        imageClasses="max-h-48 md:max-h-64"
                         imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/multiple_puzzle_teamwork_f73168bc7c.png"
                     />
                 </section>

--- a/src/pages/docs/error-tracking/index.tsx
+++ b/src/pages/docs/error-tracking/index.tsx
@@ -189,7 +189,6 @@ const ErrorTracking: React.FC = () => {
                         buttonLink="/docs/error-tracking/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
                         imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/ERROR_TRACKING_2f807c123b.png"
-                        imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>
 

--- a/src/pages/docs/error-tracking/index.tsx
+++ b/src/pages/docs/error-tracking/index.tsx
@@ -188,7 +188,7 @@ const ErrorTracking: React.FC = () => {
                         buttonText="Installation guide"
                         buttonLink="/docs/error-tracking/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
-                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/error_f2df714c47.png"
+                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/ERROR_TRACKING_2f807c123b.png"
                         imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>

--- a/src/pages/docs/experiments.tsx
+++ b/src/pages/docs/experiments.tsx
@@ -118,7 +118,7 @@ const Experiments: React.FC<ExperimentsProps> = ({ data }) => {
                 buttonLink="/docs/experiments/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/EXPERIMENTS_f9f880f1b2.png"
-                imageClasses=""
+                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/experiments.tsx
+++ b/src/pages/docs/experiments.tsx
@@ -118,7 +118,6 @@ const Experiments: React.FC<ExperimentsProps> = ({ data }) => {
                 buttonLink="/docs/experiments/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/EXPERIMENTS_f9f880f1b2.png"
-                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/experiments.tsx
+++ b/src/pages/docs/experiments.tsx
@@ -117,7 +117,7 @@ const Experiments: React.FC<ExperimentsProps> = ({ data }) => {
                 buttonText="Roll out your first experiment"
                 buttonLink="/docs/experiments/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/ab-testing-hog.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/EXPERIMENTS_f9f880f1b2.png"
                 imageClasses=""
             />
 

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -192,7 +192,7 @@ const FeatureFlags: React.FC = () => {
                         buttonText="Start here"
                         buttonLink="/docs/feature-flags/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
-                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/feature-flags-hog.png"
+                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/FEATURE_FLAGS_hog_95e008723c.png"
                     />
                 </section>
 

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -193,7 +193,6 @@ const FeatureFlags: React.FC = () => {
                         buttonLink="/docs/feature-flags/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
                         imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/feature-flags-hog.png"
-                        imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>
 

--- a/src/pages/docs/logs/index.tsx
+++ b/src/pages/docs/logs/index.tsx
@@ -134,7 +134,6 @@ const Logs: React.FC = () => {
                         buttonLink="/docs/logs/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
                         imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_logs_29cd8c8402.png"
-                        imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>
 

--- a/src/pages/docs/posthog-ai/index.tsx
+++ b/src/pages/docs/posthog-ai/index.tsx
@@ -210,7 +210,7 @@ const PostHogAI: React.FC = () => {
                         buttonText="Get started"
                         buttonLink="/docs/posthog-ai/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
-                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/all_knowing_4e50835711.png"
+                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/hogzilla_self_driving_c07e3359f1.png"
                     />
                 </section>
 

--- a/src/pages/docs/posthog-ai/index.tsx
+++ b/src/pages/docs/posthog-ai/index.tsx
@@ -211,7 +211,6 @@ const PostHogAI: React.FC = () => {
                         buttonLink="/docs/posthog-ai/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
                         imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/all_knowing_4e50835711.png"
-                        imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>
 

--- a/src/pages/docs/product-analytics.tsx
+++ b/src/pages/docs/product-analytics.tsx
@@ -48,7 +48,7 @@ export const Content = ({ quickLinks = false }) => {
                 buttonText="Installation guide"
                 buttonLink="/docs/product-analytics/installation"
                 imageColumnClasses="max-w-96"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_hog_23b2808c18.png"
             />
 
             <AskMax

--- a/src/pages/docs/product-analytics.tsx
+++ b/src/pages/docs/product-analytics.tsx
@@ -49,7 +49,6 @@ export const Content = ({ quickLinks = false }) => {
                 buttonLink="/docs/product-analytics/installation"
                 imageColumnClasses="max-w-96"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_hog_23b2808c18.png"
-                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/product-analytics.tsx
+++ b/src/pages/docs/product-analytics.tsx
@@ -49,6 +49,7 @@ export const Content = ({ quickLinks = false }) => {
                 buttonLink="/docs/product-analytics/installation"
                 imageColumnClasses="max-w-96"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_hog_23b2808c18.png"
+                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/revenue-analytics.tsx
+++ b/src/pages/docs/revenue-analytics.tsx
@@ -29,7 +29,7 @@ export const Content = ({ quickLinks = true }) => {
                 description="Track and analyze your revenue metrics to understand your business performance and growth."
                 buttonText="Setup guide"
                 buttonLink="/docs/revenue-analytics/start-here"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_coin_a6fb991e80.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/money_dollars_rich_5a7f1bf7ce.png"
             />
 
             <CalloutBox icon="IconWarning" title="Revenue analytics is being deprecated" type="caution">

--- a/src/pages/docs/revenue-analytics.tsx
+++ b/src/pages/docs/revenue-analytics.tsx
@@ -29,7 +29,6 @@ export const Content = ({ quickLinks = true }) => {
                 description="Track and analyze your revenue metrics to understand your business performance and growth."
                 buttonText="Setup guide"
                 buttonLink="/docs/revenue-analytics/start-here"
-                imageClasses="max-h-48 md:max-h-64"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_coin_a6fb991e80.png"
             />
 

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -136,7 +136,6 @@ const SessionRecording: React.FC<SessionRecordingProps> = ({ data }) => {
                 buttonLink="/docs/session-replay/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/SESSION_REPLAY_a3ca565731.png"
-                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -136,7 +136,7 @@ const SessionRecording: React.FC<SessionRecordingProps> = ({ data }) => {
                 buttonLink="/docs/session-replay/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/SESSION_REPLAY_a3ca565731.png"
-                imageClasses=""
+                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -135,7 +135,7 @@ const SessionRecording: React.FC<SessionRecordingProps> = ({ data }) => {
                 buttonText="Record your first session"
                 buttonLink="/docs/session-replay/start-here"
                 imageColumnClasses="max-w-96 mt-8 md:mt-0"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/session-recording-hog.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/SESSION_REPLAY_a3ca565731.png"
                 imageClasses=""
             />
 

--- a/src/pages/docs/support.tsx
+++ b/src/pages/docs/support.tsx
@@ -23,7 +23,6 @@ const Support: React.FC = () => {
                 description="Built-in customer support with an embeddable chat widget and a unified inbox with session replays and user context."
                 buttonText="Get started"
                 buttonLink="/docs/support/start-here"
-                imageClasses="max-h-48 md:max-h-64"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/support_hog_f7ed8447c9.png"
             />
             <section className="mb-12">

--- a/src/pages/docs/support.tsx
+++ b/src/pages/docs/support.tsx
@@ -24,7 +24,7 @@ const Support: React.FC = () => {
                 buttonText="Get started"
                 buttonLink="/docs/support/start-here"
                 imageClasses="max-h-48 md:max-h-64"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_support_5b92c08b1a.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/support_hog_f7ed8447c9.png"
             />
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Everything you need to help your users</h3>

--- a/src/pages/docs/surveys.tsx
+++ b/src/pages/docs/surveys.tsx
@@ -129,7 +129,6 @@ const Surveys: React.FC<SurveysProps> = () => {
                 buttonLink="/docs/surveys/installation"
                 imageColumnClasses="mt-8 md:mt-0 max-w-96"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png"
-                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/surveys.tsx
+++ b/src/pages/docs/surveys.tsx
@@ -128,7 +128,7 @@ const Surveys: React.FC<SurveysProps> = () => {
                 buttonText="Create your first survey"
                 buttonLink="/docs/surveys/installation"
                 imageColumnClasses="mt-8 md:mt-0 max-w-96"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png"
                 imageClasses=""
             />
 

--- a/src/pages/docs/surveys.tsx
+++ b/src/pages/docs/surveys.tsx
@@ -129,7 +129,7 @@ const Surveys: React.FC<SurveysProps> = () => {
                 buttonLink="/docs/surveys/installation"
                 imageColumnClasses="mt-8 md:mt-0 max-w-96"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png"
-                imageClasses=""
+                imageClasses="max-h-48 md:max-h-64"
             />
 
             <AskMax

--- a/src/pages/docs/web-analytics.tsx
+++ b/src/pages/docs/web-analytics.tsx
@@ -81,7 +81,7 @@ const WebAnalytics: React.FC<WebAnalyticsProps> = ({ data }) => {
                     buttonText="Installation guide"
                     buttonLink="/docs/web-analytics/installation"
                     imageColumnClasses="mt-4 md:-mt-8"
-                    imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_hog_f6db3a01c9.png"
+                    imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/web_cursor_hog_2e5fec02ad.png"
                     imageClasses="max-h-48 md:max-h-64"
                 />
 

--- a/src/pages/docs/web-analytics.tsx
+++ b/src/pages/docs/web-analytics.tsx
@@ -82,7 +82,6 @@ const WebAnalytics: React.FC<WebAnalyticsProps> = ({ data }) => {
                     buttonLink="/docs/web-analytics/installation"
                     imageColumnClasses="mt-4 md:-mt-8"
                     imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/web_cursor_hog_2e5fec02ad.png"
-                    imageClasses="max-h-48 md:max-h-64"
                 />
 
                 <section className="mb-8">

--- a/src/pages/docs/workflows/index.tsx
+++ b/src/pages/docs/workflows/index.tsx
@@ -129,7 +129,7 @@ const Messaging: React.FC = () => {
                         buttonText="Installation guide"
                         buttonLink="/docs/workflows/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
-                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/hoggie_mail_48daf2f4b4.png"
+                        imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/workflows_hog_791169c2d0.png"
                         imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>

--- a/src/pages/docs/workflows/index.tsx
+++ b/src/pages/docs/workflows/index.tsx
@@ -130,7 +130,6 @@ const Messaging: React.FC = () => {
                         buttonLink="/docs/workflows/start-here"
                         imageColumnClasses="mt-4 md:-mt-8"
                         imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/workflows_hog_791169c2d0.png"
-                        imageClasses="max-h-48 md:max-h-64"
                     />
                 </section>
 


### PR DESCRIPTION
## Changes

Swaps in new hog illustrations on the docs overview pages for each product:

- Support, Error tracking, Experiments, Product analytics, Web analytics, Session replay, Data warehouse, AI observability, Workflows, Endpoints, and Surveys
- Also updates the surveys overview slide on the `/surveys` product page (`src/hooks/productData/surveys.tsx`)

**Why:** refreshing the docs overview hero hogs with new artwork.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782309652113759?thread_ts=1782309652.113759&cid=C0B89UWRJDP)*