### PR TITLE
docs(blog): fix what-is-a-scout post CTAs and wording

### DIFF
--- a/contents/blog/what-is-a-scout.mdx
+++ b/contents/blog/what-is-a-scout.mdx
@@ -344,7 +344,7 @@ The scout's verdict: *"steady multi-day drip, not a spike… all generic, low-re
 
 <details>
 
-<summary><strong>"Don't make the AI the first thing I see"</strong> – Max-as-landing-page</summary>
+<summary><strong>"Don't make the AI the first thing I see"</strong> – PostHog-AI-as-landing-page</summary>
 
 > *"as much as i love the posthog ai it shouldn't be the first thing i see when i go to posthog… not the thing i wanna see"*
 
@@ -401,7 +401,7 @@ The pattern here is to lean in and embrace being agent pilled, keep the core tin
 
 Scouts are still rolling out gradually and are invite-only for now while we shake out the rough edges – wider access is coming soon. If you want in early, email [team-self-driving@posthog.com](mailto:team-self-driving@posthog.com) and we'll get you set up.
 
-Once they're available to you, the home base is [PostHog Code](/code), our desktop coding agent – download it, sign in, and the PostHog MCP is wired up for you. From there you can navigate to the Agents section and explore the set of [canonical scouts](/docs/self-driving/scouts) PostHog ships with as well as make your own custom scouts.
+Once they're available to you, the home base is [PostHog](https://app.posthog.com) – your scouts and the signals they surface land in your [Inbox](https://app.posthog.com/inbox). You can drive them from any agent surface with the [PostHog MCP](/docs/model-context-protocol) wired up – [PostHog Code](/code), Claude Code, Cursor, whatever you use – where you can explore the set of [canonical scouts](/docs/self-driving/scouts) PostHog ships with as well as make your own custom scouts. The [Self-driving docs](/docs/self-driving) are the place to go deeper.
 
 ## AGI Buzzword bingo
 


### PR DESCRIPTION
Small fixes to the [What is a Scout?](https://posthog.com/blog/what-is-a-scout) blog post, from feedback in the [announcement thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782297703180969):

- **`Max-as-landing-page` → `PostHog-AI-as-landing-page`** in the brand-mentions example (Michael flagged LLMs still conflate PostHog AI with Max; this was a scout self-note that leaked into the post).
- **Reworked the closing CTA** so the home base is **PostHog** (not PostHog Code), pointed readers at the **Inbox** (`app.posthog.com/inbox`) and the **Self-driving docs**, and noted the MCP works from any agent surface (PostHog Code, Claude Code, Cursor).

Scout-hog artwork (the hero-hedgehogs-aren't-scouts note) is being handled separately by Cleo.