### PR TITLE
Add self-driving section to AI wizard docs and product page

### DIFF
--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -48,6 +48,24 @@ The AI wizard integrating both the JS Web SDK and Node SDK into a Next.js applic
 
 <WizardInstall />
 
+## Self-driving
+
+<CalloutBox icon="IconInfo" title="Open beta" type="fyi">
+
+Self-driving is currently in open beta.
+
+</CalloutBox>
+
+The wizard is also how you turn on [self-driving](/docs/self-driving). A self-driving product can prompt itself: PostHog turns your product data into signals, and agents act on those signals to ship improvements – all inside the guardrails you set.
+
+Once PostHog is installed and capturing events, run the self-driving setup. It enables your signal sources, sets up your scouts, and hands you a link to your inbox:
+
+<WizardCommand command="self-driving" />
+
+From there, scouts run on a schedule and emit signals, related signals group into reports, and those reports land in your inbox ranked by priority – with a pull request ready to review whenever a report is actionable.
+
+For the full walkthrough, see the [self-driving setup guide](/docs/self-driving/setup).
+
 ## Commands
 
 Running `npx @posthog/wizard` starts the default integration flow. The wizard also supports the following commands:
@@ -55,6 +73,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | Command | What it does |
 |---|---|
 | `wizard` | Default flow – installs and instruments PostHog |
+| `wizard self-driving` | Turn on [self-driving](/docs/self-driving) – enable signal sources, set up scouts, and get your inbox link |
 | `wizard audit <subcommand>` | Audit an existing integration – see [Audit subcommands](#audit-subcommands) |
 | `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
 | `wizard migrate` | Migrate from another analytics or feature-flag vendor |

--- a/contents/wizard.mdx
+++ b/contents/wizard.mdx
@@ -39,6 +39,12 @@ The better your PostHog instrumentation, the more helpful PostHog can be. You ca
 
 <ExplainerVideo />
 
+## Make your product self-driving
+
+The wizard doesn't stop at instrumentation. Once PostHog is capturing events, it can turn on self-driving – where PostHog watches your product data and ships improvements for you to review.
+
+<SelfDriving />
+
 ## Open source
 
 Like almost everything we make, PostHog Wizard is open source. Want to fork it and adapt it for your projects, or add support for your preferred frameworks or AI workflows? [Go ahead](https://github.com/PostHog/wizard).

--- a/src/components/WizardPage/index.tsx
+++ b/src/components/WizardPage/index.tsx
@@ -202,6 +202,27 @@ function GetStarted(): JSX.Element {
     )
 }
 
+function SelfDriving(): JSX.Element {
+    return (
+        <div className="not-prose border border-border rounded-md p-5 bg-accent/40 my-6">
+            <p className="text-sm font-semibold mb-2 opacity-70">Open beta</p>
+            <p className="mb-3">
+                Once PostHog is installed and capturing events, the wizard can turn on{' '}
+                <Link to="/docs/self-driving" state={{ newWindow: true }} className="font-bold hover:opacity-75">
+                    self-driving
+                </Link>
+                . A self-driving product can prompt itself: PostHog turns your product data into signals, and agents act
+                on those signals to ship improvements – all inside the guardrails you set.
+            </p>
+            <p className="mb-4">
+                The self-driving setup enables your signal sources, sets up your scouts, and hands you a link to your
+                inbox, where reports land ranked by priority with a pull request ready to review.
+            </p>
+            <WizardCommand command="self-driving" latest={false} slim />
+        </div>
+    )
+}
+
 function ExplainerVideo(): JSX.Element {
     return (
         <div className="not-prose">
@@ -252,6 +273,12 @@ const jsxComponentDescriptors: JsxComponentDescriptor[] = [
         kind: 'flow',
         props: [],
         Editor: () => <SupportedFrameworks />,
+    },
+    {
+        name: 'SelfDriving',
+        kind: 'flow',
+        props: [],
+        Editor: () => <SelfDriving />,
     },
     {
         name: 'ExplainerVideo',


### PR DESCRIPTION
## Changes

Adds a dedicated **self-driving** section to both the AI wizard docs and the wizard product page, now that self-driving has launched in open beta and is reachable via the `npx @posthog/wizard self-driving` program.

- `/docs/ai-engineering/ai-wizard` – new "Self-driving" section (with open-beta callout) plus a `wizard self-driving` row in the commands table.
- `/wizard` – new "Make your product self-driving" section with a `SelfDriving` component and the `self-driving` command as a CTA.

Copy borrows explainers from the [self-driving docs](https://posthog.com/docs/self-driving).

**Why:** People directed to the self-driving beta may not have used the wizard yet (and self-driving may be how some start with PostHog), so the wizard surfaces need to point them at it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1782322305466489?thread_ts=1782322305.466489&cid=C09GTQY5RLZ)*
