### PR TITLE
Add /self-driving redirect to /docs/self-driving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -56,6 +56,7 @@
         { "source": "/posts/:path*", "destination": "/posts/[slug]/index.html" }
     ],
     "redirects": [
+        { "source": "/self-driving", "destination": "/docs/self-driving", "statusCode": 302 },
         {
             "source": "/docs/sdk-doctor/keeping-sdks-current",
             "destination": "/docs/health-checks/keeping-sdks-current",


### PR DESCRIPTION
## Changes

Adds a redirect from `/self-driving` to `/docs/self-driving` in `vercel.json` so we have a stable top-level URL to link to (e.g. from PostHog-made PRs) until a proper `/self-driving` marketing page exists. Uses a 302 (temporary) since it's an explicit stopgap.

**Why:** Folks want to link to a top-level `/self-driving` page from PRs, and linking directly to the docs feels like a temporary workaround.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1782335177470119?thread_ts=1782335177.470119&cid=C09GTQY5RLZ)*