### PR TITLE
docs: prefer @posthog/next in Next.js docs

### DIFF
--- a/contents/docs/error-tracking/_snippets/nextjs-upload-source-maps.mdx
+++ b/contents/docs/error-tracking/_snippets/nextjs-upload-source-maps.mdx
@@ -1,4 +1,4 @@
-We provide a helper package that will hook into the Next.js build process and upload source maps for your client and server code. This process is enabled by default for production builds but you can disable it by setting `enabled` to `false` in the `sourcemaps` object.
+We provide a helper package that works alongside `@posthog/next`, hooks into the Next.js build process, and uploads source maps for your client and server code. This process is enabled by default for production builds but you can disable it by setting `enabled` to `false` in the `sourcemaps` object.
 
 #### 1. Install package
 
@@ -19,7 +19,7 @@ const nextConfig = {
 export default withPostHogConfig(nextConfig, {
   personalApiKey: process.env.POSTHOG_API_KEY, // Personal API Key
   projectId: process.env.POSTHOG_PROJECT_ID, // Project ID
-  host: process.env.NEXT_PUBLIC_POSTHOG_HOST, // (optional), defaults to https://us.posthog.com
+  host: process.env.NEXT_PUBLIC_POSTHOG_HOST, // (optional), reuse the host from @posthog/next
   sourcemaps: { // (optional)
       enabled: true, // (optional) Enable sourcemaps generation and upload, default to true on production builds
       releaseName: "my-application", // (optional) Release name, defaults to repository name
@@ -36,7 +36,7 @@ Where you should set the following environment variables:
 | --- | --- |
 | `POSTHOG_API_KEY` | [Personal API key](https://app.posthog.com/settings/user-api-keys#variables) with at least `write` access on `error tracking` |
 | `POSTHOG_PROJECT_ID` | Project ID you can find in your [project settings](https://app.posthog.com/settings/project#variables) |
-| `NEXT_PUBLIC_POSTHOG_HOST` | Your PostHog instance URL. Defaults to `https://us.posthog.com` |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Your PostHog instance URL. Reuse the same value you use for `@posthog/next`. |
 
 ### That's it!
 

--- a/contents/docs/error-tracking/installation/nextjs.mdx
+++ b/contents/docs/error-tracking/installation/nextjs.mdx
@@ -4,12 +4,125 @@ platformLogo: nextjs
 showStepsToc: true
 ---
 
-<!--
-This page imports shared onboarding content from the main PostHog repo.
-Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/error-tracking/nextjs.tsx
-See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
--->
+import { Steps, Step } from 'components/Docs/Steps'
 
-import { ErrorTrackingNextJSInstallationWrapper } from './_snippets/et-installation-wrapper.tsx'
+Use `@posthog/next` to capture exceptions in Next.js. It enables browser-side exception capture through `PostHogProvider` and exposes a Next.js `onRequestError` handler for server-side request errors, so you don't need to wire `posthog-js` and `posthog-node` separately.
 
-<ErrorTrackingNextJSInstallationWrapper />
+<Steps>
+
+<Step title="Install and configure @posthog/next" badge="required">
+
+If you already followed the [Next.js setup guide](/docs/libraries/next-js), you can skip this step. Otherwise, install `@posthog/next`:
+
+<MultiLanguage>
+
+```bash file=npm
+npm install --save @posthog/next
+```
+
+```bash file=Yarn
+yarn add @posthog/next
+```
+
+```bash file=pnpm
+pnpm add @posthog/next
+```
+
+```bash file=Bun
+bun add @posthog/next
+```
+
+</MultiLanguage>
+
+Add your project token and host to `.env.local` and your hosting provider:
+
+```shell file=.env.local
+NEXT_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
+NEXT_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+```
+
+Then wrap your app with `PostHogProvider` as shown in the [Next.js SDK docs](/docs/libraries/next-js#wrap-your-app-with-posthogprovider).
+
+</Step>
+
+<Step title="Capture client-side exceptions" badge="required">
+
+`@posthog/next` sets `capture_exceptions: true` by default, so unhandled browser errors and unhandled promise rejections are captured once your app is wrapped with `PostHogProvider`.
+
+To capture a handled client-side exception manually, use `usePostHog()` in a client component:
+
+```tsx
+'use client'
+import { usePostHog } from '@posthog/next'
+
+export function SaveButton() {
+    const posthog = usePostHog()
+
+    return (
+        <button
+            onClick={async () => {
+                try {
+                    await saveSettings()
+                } catch (error) {
+                    posthog.captureException(error, { area: 'settings' })
+                    throw error
+                }
+            }}
+        >
+            Save settings
+        </button>
+    )
+}
+```
+
+If you need to disable automatic browser exception capture, pass `clientOptions={{ capture_exceptions: false }}` to `PostHogProvider`.
+
+</Step>
+
+<Step title="Capture server-side request errors" badge="required">
+
+For Next.js versions that support `onRequestError`, export the handler from your root `instrumentation.ts` file:
+
+```ts file=instrumentation.ts
+export { onRequestError } from '@posthog/next'
+```
+
+Next.js calls this hook when a server render, route handler, or server action throws during a request. `@posthog/next` reads the PostHog identity cookie set by the middleware so server-side exceptions are linked to the same person and session as client-side events when possible.
+
+To customize captured properties or filter errors, create the handler yourself:
+
+```ts file=instrumentation.ts
+import { createOnRequestError } from '@posthog/next'
+
+export const onRequestError = createOnRequestError({
+    beforeCapture: ({ error, context, properties }) => {
+        if (context.routePath?.startsWith('/health')) {
+            return false
+        }
+
+        return {
+            ...properties,
+            error_area: 'nextjs-server',
+            error_name: error instanceof Error ? error.name : undefined,
+        }
+    },
+})
+```
+
+</Step>
+
+<Step title="Upload source maps" badge="recommended">
+
+Upload source maps so PostHog can show readable stack traces for minified client and server bundles. Use the [Next.js source map guide](/docs/error-tracking/upload-source-maps/nextjs), which configures `@posthog/nextjs-config` for your build.
+
+</Step>
+
+<Step checkpoint title="Verify exceptions are captured" subtitle="Trigger one client-side and one server-side test error">
+
+1. Trigger a handled client-side error and confirm a `$exception` event appears in PostHog.
+2. Add `export { onRequestError } from '@posthog/next'`, trigger a server route handler error, and confirm the server-side `$exception` event appears.
+3. Open the issue in [Error Tracking](https://app.posthog.com/error_tracking) and confirm stack traces are readable after source maps are uploaded.
+
+</Step>
+
+</Steps>

--- a/contents/docs/error-tracking/installation/nextjs.mdx
+++ b/contents/docs/error-tracking/installation/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js error tracking installation
+title: Next.js Error Tracking installation
 platformLogo: nextjs
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/upload-source-maps/nextjs.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/nextjs.mdx
@@ -9,6 +9,8 @@ import WizardSection from './_snippets/wizard-section.mdx'
 
 ## Manual setup
 
+Use `@posthog/nextjs-config` alongside `@posthog/next` to inject source map identifiers and upload source maps during `next build`.
+
 <Steps>
 <Step title="Install the PostHog Next.js config package" badge="required">
 
@@ -32,7 +34,7 @@ import WizardSection from './_snippets/wizard-section.mdx'
   export default withPostHogConfig(nextConfig, {
     personalApiKey: process.env.POSTHOG_API_KEY!, // Personal API Key
     projectId: process.env.POSTHOG_PROJECT_ID, // Project ID
-    host: process.env.NEXT_PUBLIC_POSTHOG_HOST, // (optional), defaults to https://us.posthog.com
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST, // (optional), reuse the host from @posthog/next
     sourcemaps: { // (optional)
         enabled: true, // (optional) Enable sourcemaps generation and upload, default to true on production builds
         releaseName: "my-application", // (optional) Release name, defaults to repository name
@@ -51,7 +53,7 @@ import WizardSection from './_snippets/wizard-section.mdx'
   | --- | --- |
   | `POSTHOG_API_KEY` | [Personal API key](https://app.posthog.com/settings/user-api-keys#variables) with at least `write` access on `error tracking` |
   | `POSTHOG_PROJECT_ID` | Project ID you can find in your [project settings](https://app.posthog.com/settings/project#variables) |
-  | `NEXT_PUBLIC_POSTHOG_HOST` | Your PostHog instance URL. Defaults to `https://us.posthog.com` |
+  | `NEXT_PUBLIC_POSTHOG_HOST` | Your PostHog instance URL. Reuse the same value you use for `@posthog/next`. |
 
   </div>
 

--- a/contents/docs/libraries/next-js/_snippets/instrumentation-client-access.mdx
+++ b/contents/docs/libraries/next-js/_snippets/instrumentation-client-access.mdx
@@ -1,29 +1,31 @@
-Once initialized in `instrumentation-client.js|ts`, import `posthog` from `posthog-js` anywhere and call the methods you need on the `posthog` object.
+Import PostHog from `@posthog/next` in client components and call the methods you need from the `usePostHog` hook.
 
-```js
-"use client";
-import posthog from "posthog-js";
+```tsx
+'use client'
+import { usePostHog } from '@posthog/next'
 
 export default function Home() {
-  return (
-    <div>
-      <button onClick={() => posthog.capture("test_event")}>Click me for an event</button>
-    </div>
-  );
+    const posthog = usePostHog()
+
+    return (
+        <div>
+            <button onClick={() => posthog.capture('test_event')}>Click me for an event</button>
+        </div>
+    )
 }
 ```
 
-### Using React hooks
+### Using feature flag hooks
 
-The [React feature flag hooks](/docs/libraries/react#feature-flags) work automatically when PostHog is initialized via `instrumentation-client.ts`. The hooks use the initialized posthog-js singleton:
+The feature flag hooks from `@posthog/next` use the initialized `PostHogProvider`. If you enabled `bootstrapFlags`, the first render uses server-evaluated flag values to avoid flicker.
 
-```js
-"use client";
-import { useFeatureFlagEnabled } from "@posthog/react";
+```tsx
+'use client'
+import { useFeatureFlag } from '@posthog/next'
 
 export default function FeatureComponent() {
-  const showNewFeature = useFeatureFlagEnabled("new-feature");
+    const flag = useFeatureFlag('new-feature')
 
-  return showNewFeature ? <NewFeature /> : <OldFeature />;
+    return flag?.enabled ? <NewFeature /> : <OldFeature />
 }
 ```

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
@@ -17,4 +17,4 @@ export default async function DashboardPage() {
 
 > **Note:** `getPostHog()` calls `cookies()` internally, which opts the route into dynamic rendering. Pages using it cannot be statically generated.
 
-**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` via `serverOptions` on the `PostHogProvider`, or events will be batched and flushed normally.
+**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` in the server client options, for example `getPostHog(undefined, { waitUntil })`, or events will be batched and flushed normally.

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
@@ -1,7 +1,20 @@
-Use `getPostHog()` in server components, route handlers, and server actions to capture events and evaluate feature flags. The client is automatically scoped to the current user via the identity cookie set by the middleware.
+Create a shared PostHog module with `createPostHog()`, then use the returned `getPostHog` in server components, route handlers, and server actions to capture events and evaluate feature flags.
 
-```tsx
-import { getPostHog } from '@posthog/next'
+```ts file=lib/posthog.ts
+import 'server-only'
+import { createPostHog } from '@posthog/next'
+import { auth } from '@/auth'
+
+export const { getPostHog } = createPostHog({
+    // Optional: resolve the current user from your auth session. When set, server-side
+    // events and feature flags are attributed to this user instead of the client-provided
+    // identity, which can be spoofed. Return null/undefined to fall back to the cookie identity.
+    getDistinctId: async () => (await auth())?.user?.id,
+})
+```
+
+```tsx file=app/dashboard/page.tsx
+import { getPostHog } from '@/lib/posthog'
 
 export default async function DashboardPage() {
     const posthog = await getPostHog()
@@ -15,6 +28,8 @@ export default async function DashboardPage() {
 }
 ```
 
-> **Note:** `getPostHog()` calls `cookies()` internally, which opts the route into dynamic rendering. Pages using it cannot be statically generated.
+Without `getDistinctId`, the client is automatically scoped to the current user via the identity cookie set by the middleware. With it, the server-resolved distinct id takes precedence — use this when you can't rely on client-provided identity. Session and device linkage stays client-provided, so server events still correlate with the browser session and replays. The resolver is never called for users who have opted out of capture.
 
-**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` in the server client options, for example `getPostHog(undefined, { waitUntil })`, or events will be batched and flushed normally.
+> **Note:** `getPostHog()` calls `cookies()` internally, which opts the route into dynamic rendering. Pages using it cannot be statically generated. Keep `import 'server-only'` at the top of your shared module so accidentally importing it from a client component fails with a clear build-time error.
+
+**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` in the server client options, for example `createPostHog({ options: { waitUntil } })`, or events will be batched and flushed normally.

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 }
 ```
 
-**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` via `serverOptions` on the `PostHogProvider`, or events will be batched and flushed normally.
+**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` in the server client options, for example `getServerSidePostHog(ctx, undefined, { waitUntil })`, or events will be batched and flushed normally.
 
 Then wire the bootstrap data into the provider:
 

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
@@ -1,11 +1,11 @@
-Create a shared PostHog module with `createPostHog()`, then use the returned `getServerSidePostHog` inside `getServerSideProps` to capture events and evaluate feature flags for the current user.
+Create a shared PostHog module with `createPostHog()`, then call the returned `getPostHog` with the request context inside `getServerSideProps` to capture events and evaluate feature flags for the current user.
 
 ```ts file=lib/posthog.ts
 import { createPostHog } from '@posthog/next/pages'
 import { getServerSession } from 'next-auth'
 import { authOptions } from './auth'
 
-export const { getServerSidePostHog } = createPostHog({
+export const { getPostHog } = createPostHog({
     // Optional: resolve the current user from your auth session. The GetServerSidePropsContext
     // is passed so you can read the session from the request. When set, server-side events and
     // feature flags are attributed to this user instead of the client-provided identity, which
@@ -17,10 +17,10 @@ export const { getServerSidePostHog } = createPostHog({
 
 ```tsx file=pages/dashboard.tsx
 import type { GetServerSideProps } from 'next'
-import { getServerSidePostHog } from '@/lib/posthog'
+import { getPostHog } from '@/lib/posthog'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const posthog = await getServerSidePostHog(ctx)
+    const posthog = await getPostHog(ctx)
 
     const flags = await posthog.getAllFlags()
     posthog.capture({ event: 'dashboard_viewed' })
@@ -33,7 +33,7 @@ To bootstrap feature flags and eliminate flicker on page load, pass the flag dat
 
 ```tsx file=pages/dashboard.tsx
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const posthog = await getServerSidePostHog(ctx)
+    const posthog = await getPostHog(ctx)
     const bootstrap = await posthog.getAllFlagsAndPayloads()
     return { props: { posthogBootstrap: bootstrap } }
 }

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
@@ -1,8 +1,23 @@
-Use `getServerSidePostHog` inside `getServerSideProps` to capture events and evaluate feature flags for the current user:
+Create a shared PostHog module with `createPostHog()`, then use the returned `getServerSidePostHog` inside `getServerSideProps` to capture events and evaluate feature flags for the current user.
+
+```ts file=lib/posthog.ts
+import { createPostHog } from '@posthog/next/pages'
+import { getServerSession } from 'next-auth'
+import { authOptions } from './auth'
+
+export const { getServerSidePostHog } = createPostHog({
+    // Optional: resolve the current user from your auth session. The GetServerSidePropsContext
+    // is passed so you can read the session from the request. When set, server-side events and
+    // feature flags are attributed to this user instead of the client-provided identity, which
+    // can be spoofed. Return null/undefined to fall back to the cookie identity.
+    getDistinctId: async (ctx) =>
+        ctx ? (await getServerSession(ctx.req, ctx.res, authOptions))?.user?.id : undefined,
+})
+```
 
 ```tsx file=pages/dashboard.tsx
 import type { GetServerSideProps } from 'next'
-import { getServerSidePostHog } from '@posthog/next/pages'
+import { getServerSidePostHog } from '@/lib/posthog'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
     const posthog = await getServerSidePostHog(ctx)
@@ -24,7 +39,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 }
 ```
 
-**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` in the server client options, for example `getServerSidePostHog(ctx, undefined, { waitUntil })`, or events will be batched and flushed normally.
+**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` in the server client options, for example `createPostHog({ options: { waitUntil } })`, or events will be batched and flushed normally.
 
 Then wire the bootstrap data into the provider:
 

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -22,7 +22,7 @@ import PagesProviderSetup from "./_snippets/posthog-next-pages-provider.mdx"
 import AppServerSetup from "./_snippets/posthog-next-app-server-setup.mdx"
 import PagesServerSetup from "./_snippets/posthog-next-pages-server-setup.mdx"
 
-PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom event capture, session recordings, feature flags, error tracking, and more.
+PostHog helps you collect data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom event capture, session recordings, Feature Flags, Error Tracking, and more.
 
 This guide uses `@posthog/next`, the recommended PostHog package for Next.js apps. It wraps the browser and server SDKs with Next.js-specific defaults, so new apps should install and import `@posthog/next` instead of configuring `posthog-js` on the client and `posthog-node` on the server separately.
 
@@ -140,7 +140,7 @@ export function TrackButton() {
 }
 ```
 
-**Feature flags:**
+**Feature Flags:**
 
 ```tsx
 'use client'
@@ -174,7 +174,7 @@ export function NewBanner() {
 
 <Step title="Identify your user" badge="recommended">
 
-Call `posthog.identify()` on the client after login to link events to a known user. This connects event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), and [error tracking](/docs/error-tracking) to the same person across client and server.
+Call `posthog.identify()` on the client after login to link events to a known user. This connects event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), and [Error Tracking](/docs/error-tracking) to the same person across client and server.
 
 ```tsx
 'use client'
@@ -226,15 +226,15 @@ See our guide on [identifying users](/docs/getting-started/identify-users) for m
 export { onRequestError } from '@posthog/next'
 ```
 
-Next.js calls this hook when a server render, route handler, or server action throws during a request. See the [Next.js error tracking guide](/docs/error-tracking/installation/nextjs) for filtering and source map setup.
+Next.js calls this hook when a server render, route handler, or server action throws during a request. See the [Next.js Error Tracking guide](/docs/error-tracking/installation/nextjs) for filtering and source map setup.
 
 </Step>
 
 <Step title="Configure advanced options" badge="optional">
 
-### Feature flag bootstrap
+### Feature Flags bootstrapping
 
-Set `bootstrapFlags` to evaluate feature flags on the server and pass the results to the client, which avoids flag flicker on first render:
+Set `bootstrapFlags` to evaluate Feature Flags on the server and pass the results to the client, which avoids flag flicker on first render:
 
 ```tsx
 <PostHogProvider bootstrapFlags>{children}</PostHogProvider>
@@ -270,7 +270,7 @@ export default postHogMiddleware({
 })
 ```
 
-Then initialize the client with capture disabled until the user opts in:
+Then initialize the client with capture disabled until consent is granted:
 
 ```tsx
 <PostHogProvider clientOptions={{ opt_out_capturing_by_default: true }}>{children}</PostHogProvider>
@@ -299,10 +299,10 @@ When you change the proxy path, use the same path in `clientOptions.api_host`:
 
 <Step title="Further reading" badge="recommended">
 
-- [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
-- [How to set up Next.js pages router analytics, feature flags, and more](/tutorials/nextjs-pages-analytics)
+- [How to set up Next.js analytics, Feature Flags, and more](/tutorials/nextjs-analytics)
+- [How to set up Next.js pages router analytics, Feature Flags, and more](/tutorials/nextjs-pages-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
-- [Upload source maps for Next.js error tracking](/docs/error-tracking/upload-source-maps/nextjs)
+- [Upload source maps for Next.js Error Tracking](/docs/error-tracking/upload-source-maps/nextjs)
 
 </Step>
 

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Next.js
 platformLogo: nextjs
+showStepsToc: true
 features:
   eventCapture: true
   userIdentification: true
@@ -13,95 +14,296 @@ features:
   errorTracking: true
 ---
 
-import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
-import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
-import DetailPostHogIPs from "../../integrate/_snippets/details/posthog-ips.mdx"
+import { Steps, Step } from 'components/Docs/Steps'
+import Tab from "components/Tab"
+import AgentIntegrationSection from "../../components/AgentIntegrationSection.mdx"
+import AppProviderSetup from "./_snippets/posthog-next-app-provider.mdx"
+import PagesProviderSetup from "./_snippets/posthog-next-pages-provider.mdx"
+import AppServerSetup from "./_snippets/posthog-next-app-server-setup.mdx"
+import PagesServerSetup from "./_snippets/posthog-next-pages-server-setup.mdx"
 
-PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
+PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom event capture, session recordings, feature flags, error tracking, and more.
 
-This guide walks you through integrating PostHog into your Next.js app using the [React](/docs/libraries/react) and the [Node.js](/docs/libraries/node) SDKs.
+This guide uses `@posthog/next`, the recommended PostHog package for Next.js apps. It wraps the browser and server SDKs with Next.js-specific defaults, so new apps should install and import `@posthog/next` instead of configuring `posthog-js` on the client and `posthog-node` on the server separately.
 
-> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/main/playground/nextjs).
+> Maintaining an older manual setup? The lower-level [React](/docs/libraries/react), [JavaScript](/docs/libraries/js), and [Node.js](/docs/libraries/node) SDK docs still apply, but we recommend migrating new Next.js work to `@posthog/next`.
 
-Next.js has both client and server-side rendering, as well as pages and app routers. We'll cover all of these options in this guide.
-
-> **Try `@posthog/next` (pre-release):** A simplified Next.js integration with synchronized client/server identity, server-side flag bootstrapping, and a built-in API proxy. [Read the setup guide →](/docs/libraries/next-js/posthog-next)
+You can see a working App Router example in the [`@posthog/next` example app](https://github.com/PostHog/posthog-js/tree/main/examples/example-next-app-router).
 
 ## Prerequisites
 
-To follow this guide along, you need:
+To follow this guide, you need:
 
 1. A PostHog instance (either [Cloud](https://app.posthog.com/signup) or [self-hosted](/docs/self-host))
-2. A Next.js application
-
-import AgentIntegrationSection from "../../components/AgentIntegrationSection.mdx"
+2. A Next.js 13.0.0+ application
 
 <AgentIntegrationSection framework="Next.js" />
 
-## Client-side setup
+<Steps>
 
-import NextJSInstall from "../../integrate/_snippets/nextjs/install-nextjs.mdx"
+<Step title="Install @posthog/next" badge="required">
 
-<NextJSInstall />
+<MultiLanguage>
 
-## Identifying users
+```bash file=npm
+npm install --save @posthog/next
+```
 
-import IdentifyFrontendCallout from '../../_snippets/identify-frontend-callout.mdx'
+```bash file=Yarn
+yarn add @posthog/next
+```
 
-<IdentifyFrontendCallout />
+```bash file=pnpm
+pnpm add @posthog/next
+```
 
-<DetailSetUpReverseProxy />
+```bash file=Bun
+bun add @posthog/next
+```
 
-<DetailGroupProductsInOneProject />
+</MultiLanguage>
 
-<DetailPostHogIPs />
+</Step>
 
-## Accessing PostHog
+<Step title="Add your environment variables" badge="required">
 
-import InstrumentationClientSetup from "./_snippets/instrumentation-client-access.mdx"
+Add these to your `.env.local` file and to your hosting provider (for example, Vercel, Netlify, or AWS). You can find your project token in your [project settings](https://app.posthog.com/project/settings).
 
-<InstrumentationClientSetup />
+```shell file=.env.local
+NEXT_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
+NEXT_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+```
 
-### Usage
+`NEXT_PUBLIC_POSTHOG_HOST` is optional and defaults to `https://us.i.posthog.com`.
 
-See the [React SDK docs](/docs/libraries/react) for examples of how to use:
+</Step>
 
-- [`posthog-js` functions like custom event capture, user identification, and more.](/docs/libraries/react#using-posthog-js-functions)
-- [Feature flags including variants and payloads.](/docs/libraries/react#feature-flags)
+<Step title="Add the middleware" badge="recommended">
 
-You can also read [the full `posthog-js` documentation](/docs/libraries/js/features) for all the usable functions.
+The middleware seeds an identity cookie on first visit so the client and server share the same user. It can also proxy PostHog API requests through your domain.
 
-## Server-side analytics
+```ts file=middleware.ts
+import { postHogMiddleware } from '@posthog/next'
 
-import NextJSInstallServer from "../../integrate/_snippets/nextjs/install-nextjs-server.mdx"
+export default postHogMiddleware({ proxy: true })
 
-<NextJSInstallServer />
+export const config = {
+    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}
+```
 
-### Server-side configuration
+Setting `proxy: true` routes PostHog API calls through your domain at `/ingest`, which helps avoid ad blockers. You can customize the path prefix with `proxy: { pathPrefix: '/analytics' }`.
 
-Next.js overrides the default `fetch` behavior on the server to introduce their own cache. PostHog ignores that cache by default, as this is Next.js's default behavior for any fetch call.
+> Middleware requires a server runtime and is not available with `output: 'export'` (fully static sites). If you can't use middleware, set up a [reverse proxy](/docs/advanced/proxy) separately and point `clientOptions.api_host` at it.
 
-You can override that configuration when initializing PostHog, but make sure you understand the pros/cons of using Next.js's cache and that you might get cached results rather than the actual result our server would return. This is important for feature flags, for example.
+</Step>
+
+<Step title="Wrap your app with PostHogProvider" badge="required">
+
+<Tab.Group tabs={['App Router', 'Pages Router']}>
+    <Tab.List>
+        <Tab>App Router</Tab>
+        <Tab>Pages Router</Tab>
+    </Tab.List>
+    <Tab.Panels>
+        <Tab.Panel>
+            <AppProviderSetup />
+        </Tab.Panel>
+        <Tab.Panel>
+            <PagesProviderSetup />
+        </Tab.Panel>
+    </Tab.Panels>
+</Tab.Group>
+
+</Step>
+
+<Step checkpoint title="Verify events are captured" subtitle="Confirm that events arrive in your PostHog project">
+
+Visit your app and click around. Within a minute or two, you should see `$pageview` and [autocaptured](/docs/product-analytics/autocapture) events (like clicks) appear in the [activity tab](https://app.posthog.com/activity/explore).
+
+</Step>
+
+<Step title="Access PostHog in client components" badge="required">
+
+All hooks must be used in client components (`'use client'`).
+
+**Capture events:**
 
 ```tsx
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
-  // ... your configuration
-  fetch_options: {
-    cache: 'force-cache', // Use Next.js cache
-    next_options: {       // Passed to the `next` option for `fetch`
-      revalidate: 60,     // Cache for 60 seconds
-      tags: ['posthog'],  // Can be used with Next.js `revalidateTag` function
-    },
-  }
+'use client'
+import { usePostHog } from '@posthog/next'
+
+export function TrackButton() {
+    const posthog = usePostHog()
+
+    return <button onClick={() => posthog.capture('button_clicked')}>Track</button>
+}
+```
+
+**Feature flags:**
+
+```tsx
+'use client'
+import { useFeatureFlag } from '@posthog/next'
+
+export function MyComponent() {
+    const flag = useFeatureFlag('new-feature')
+
+    return flag?.enabled ? <NewFeature /> : <OldFeature />
+}
+```
+
+**Conditional rendering with `PostHogFeature`:**
+
+```tsx
+'use client'
+import { PostHogFeature } from '@posthog/next'
+
+export function NewBanner() {
+    return (
+        <PostHogFeature flag="show-banner" match={true}>
+            <div>New feature available!</div>
+        </PostHogFeature>
+    )
+}
+```
+
+`@posthog/next` re-exports the PostHog React hooks, backed by the Next.js-aware provider above.
+
+</Step>
+
+<Step title="Identify your user" badge="recommended">
+
+Call `posthog.identify()` on the client after login to link events to a known user. This connects event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), and [error tracking](/docs/error-tracking) to the same person across client and server.
+
+```tsx
+'use client'
+import { usePostHog } from '@posthog/next'
+
+export function LoginButton() {
+    const posthog = usePostHog()
+
+    const handleLogin = async () => {
+        const user = await signIn()
+        posthog.identify(user.id, {
+            email: user.email,
+            name: user.name,
+        })
+    }
+
+    return <button onClick={handleLogin}>Log in</button>
+}
+```
+
+See our guide on [identifying users](/docs/getting-started/identify-users) for more details.
+
+</Step>
+
+<Step title="Use PostHog on the server" badge="recommended">
+
+<Tab.Group tabs={['App Router', 'Pages Router']}>
+    <Tab.List>
+        <Tab>App Router</Tab>
+        <Tab>Pages Router</Tab>
+    </Tab.List>
+    <Tab.Panels>
+        <Tab.Panel>
+            <AppServerSetup />
+        </Tab.Panel>
+        <Tab.Panel>
+            <PagesServerSetup />
+        </Tab.Panel>
+    </Tab.Panels>
+</Tab.Group>
+
+</Step>
+
+<Step title="Capture server-side request errors" badge="recommended">
+
+`@posthog/next` enables client-side exception capture by default through `PostHogProvider`. To capture server-side request errors handled by Next.js, export `onRequestError` from your `instrumentation.ts` file:
+
+```ts file=instrumentation.ts
+export { onRequestError } from '@posthog/next'
+```
+
+Next.js calls this hook when a server render, route handler, or server action throws during a request. See the [Next.js error tracking guide](/docs/error-tracking/installation/nextjs) for filtering and source map setup.
+
+</Step>
+
+<Step title="Configure advanced options" badge="optional">
+
+### Feature flag bootstrap
+
+Set `bootstrapFlags` to evaluate feature flags on the server and pass the results to the client, which avoids flag flicker on first render:
+
+```tsx
+<PostHogProvider bootstrapFlags>{children}</PostHogProvider>
+```
+
+You can also limit the flags evaluated and provide properties used for evaluation:
+
+```tsx
+<PostHogProvider
+    bootstrapFlags={{
+        flags: ['new-ui', 'pricing-v2'],
+        groups: { company: 'posthog' },
+        personProperties: { plan: 'enterprise' },
+        groupProperties: {
+            company: { industry: 'tech' },
+        },
+    }}
+>
+    {children}
+</PostHogProvider>
+```
+
+Enabling `bootstrapFlags` calls `cookies()` internally, which opts the route into dynamic rendering.
+
+### Consent-aware setup
+
+If your app requires consent before setting cookies, disable anonymous cookie seeding in middleware:
+
+```ts file=middleware.ts
+export default postHogMiddleware({
+    proxy: true,
+    seedAnonymousCookie: false,
 })
 ```
 
-## Configuring a reverse proxy to PostHog
+Then initialize the client with capture disabled until the user opts in:
 
-To improve the reliability of client-side tracking and make requests less likely to be intercepted by tracking blockers, you can setup a reverse proxy in Next.js. Read more about deploying a reverse proxy using [Next.js rewrites](/docs/advanced/proxy/nextjs), [Next.js middleware](/docs/advanced/proxy/nextjs-middleware), and [Vercel rewrites](/docs/advanced/proxy/vercel).
+```tsx
+<PostHogProvider clientOptions={{ opt_out_capturing_by_default: true }}>{children}</PostHogProvider>
+```
 
-## Further reading
+### API proxy options
+
+Pass an object to `proxy` to customize the ingest path or host:
+
+```ts file=middleware.ts
+export default postHogMiddleware({
+    proxy: {
+        pathPrefix: '/analytics',
+        host: 'https://eu.i.posthog.com',
+    },
+})
+```
+
+When you change the proxy path, use the same path in `clientOptions.api_host`:
+
+```tsx
+<PostHogProvider clientOptions={{ api_host: '/analytics' }}>{children}</PostHogProvider>
+```
+
+</Step>
+
+<Step title="Further reading" badge="recommended">
 
 - [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
 - [How to set up Next.js pages router analytics, feature flags, and more](/tutorials/nextjs-pages-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
+- [Upload source maps for Next.js error tracking](/docs/error-tracking/upload-source-maps/nextjs)
+
+</Step>
+
+</Steps>

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -94,6 +94,8 @@ export const config = {
 
 Setting `proxy: true` routes PostHog API calls through your domain at `/ingest`, which helps avoid ad blockers. You can customize the path prefix with `proxy: { pathPrefix: '/analytics' }`.
 
+> **Consent-sensitive apps:** The default middleware seeds an anonymous identity cookie before client-side consent code runs. If your GDPR/ePrivacy posture requires opt-in before setting analytics identifiers, use `postHogMiddleware({ proxy: true, seedAnonymousCookie: false })` and initialize the provider with `clientOptions={{ opt_out_capturing_by_default: true }}` until consent is granted. With this setting, anonymous server-side flag bootstrapping and server captures won't be linked to a PostHog identity until after consent.
+
 > Middleware requires a server runtime and is not available with `output: 'export'` (fully static sites). If you can't use middleware, set up a [reverse proxy](/docs/advanced/proxy) separately and point `clientOptions.api_host` at it.
 
 </Step>

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -199,6 +199,8 @@ export function LoginButton() {
 
 See our guide on [identifying users](/docs/getting-started/identify-users) for more details.
 
+On the server, you don't need to call `identify()` — configure `getDistinctId` in `createPostHog()` (next step) and server-side events and feature flags are attributed to the logged-in user automatically. This is also the safest option when you can't rely on client-provided identity, since cookies and headers can be spoofed.
+
 </Step>
 
 <Step title="Use PostHog on the server" badge="recommended">

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -140,6 +140,8 @@ export const config = {
 
 Setting `proxy: true` routes PostHog API calls through your domain at `/ingest`, which helps avoid ad blockers. You can customize the path prefix by passing `proxy: { pathPrefix: '/analytics' }` instead.
 
+> **Consent-sensitive apps:** The default middleware seeds an anonymous identity cookie before client-side consent code runs. If your GDPR/ePrivacy posture requires opt-in before setting analytics identifiers, use `postHogMiddleware({ proxy: true, seedAnonymousCookie: false })` and initialize the provider with `clientOptions={{ opt_out_capturing_by_default: true }}` until consent is granted. With this setting, anonymous server-side flag bootstrapping and server captures won't be linked to a PostHog identity until after consent.
+
 > **Note:** Middleware requires a server runtime and is not available with `output: 'export'` (fully static sites). If you can't use middleware, you can set up a [reverse proxy](/docs/advanced/proxy) separately to route traffic through your domain.
 
 </Step>

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -270,15 +270,15 @@ See our guide on [identifying users](/docs/getting-started/identify-users) for m
 export { onRequestError } from '@posthog/next'
 ```
 
-Next.js calls this hook when a server render, route handler, or server action throws during a request. See the [Next.js error tracking guide](/docs/error-tracking/installation/nextjs) for filtering and source map setup.
+Next.js calls this hook when a server render, route handler, or server action throws during a request. See the [Next.js Error Tracking guide](/docs/error-tracking/installation/nextjs) for filtering and source map setup.
 
 </Step>
 
 <Step title="Configure advanced options" badge="optional">
 
-### Feature flag bootstrap
+### Feature Flags bootstrapping
 
-Set `bootstrapFlags` to evaluate feature flags on the server and pass the results to the client, which avoids flag flicker on first render:
+Set `bootstrapFlags` to evaluate Feature Flags on the server and pass the results to the client, which avoids flag flicker on first render:
 
 ```tsx
 <PostHogProvider bootstrapFlags>{children}</PostHogProvider>
@@ -314,7 +314,7 @@ export default postHogMiddleware({
 })
 ```
 
-Then initialize the client with capture disabled until the user opts in:
+Then initialize the client with capture disabled until consent is granted:
 
 ```tsx
 <PostHogProvider clientOptions={{ opt_out_capturing_by_default: true }}>{children}</PostHogProvider>
@@ -343,9 +343,9 @@ When you change the proxy path, use the same path in `clientOptions.api_host`:
 
 <Step title="Further reading" badge="recommended">
 
-- [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
+- [How to set up Next.js analytics, Feature Flags, and more](/tutorials/nextjs-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
-- [Upload source maps for Next.js error tracking](/docs/error-tracking/upload-source-maps/nextjs)
+- [Upload source maps for Next.js Error Tracking](/docs/error-tracking/upload-source-maps/nextjs)
 
 </Step>
 

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -41,6 +41,16 @@ tableOfContents: [
         depth: 1,
     },
     {
+        url: 'capture-server-side-request-errors',
+        value: 'Capture server-side request errors',
+        depth: 1,
+    },
+    {
+        url: 'configure-advanced-options',
+        value: 'Configure advanced options',
+        depth: 1,
+    },
+    {
         url: 'further-reading',
         value: 'Further reading',
         depth: 1,
@@ -59,20 +69,13 @@ features:
 ---
 
 import { Steps, Step } from 'components/Docs/Steps'
-import { CalloutBox } from 'components/Docs/CalloutBox'
 import Tab from "components/Tab"
 import AppProviderSetup from "./_snippets/posthog-next-app-provider.mdx"
 import PagesProviderSetup from "./_snippets/posthog-next-pages-provider.mdx"
 import AppServerSetup from "./_snippets/posthog-next-app-server-setup.mdx"
 import PagesServerSetup from "./_snippets/posthog-next-pages-server-setup.mdx"
 
-<CalloutBox icon="IconInfo" type="fyi" title="Pre-release">
-
-`@posthog/next` is currently in pre-release. The API may change before the stable release. For production apps, see the [standard Next.js setup guide](/docs/libraries/next-js).
-
-</CalloutBox>
-
-`@posthog/next` is a unified package for integrating PostHog into your Next.js app. It provides a simplified interface that handles common patterns out of the box:
+`@posthog/next` is the recommended package for integrating PostHog into your Next.js app. It provides a simplified interface that handles common patterns out of the box:
 
 - **Synchronized identity across client and server**, so both sides share the same user automatically
 - **Server-side feature flag bootstrapping** so hooks return real values immediately with no flicker
@@ -209,7 +212,7 @@ export function NewBanner() {
 }
 ```
 
-You can also read [the full `posthog-js` documentation](/docs/libraries/js/features) for all the usable functions.
+`@posthog/next` re-exports the PostHog React hooks, backed by the Next.js-aware provider above.
 
 </Step>
 
@@ -256,6 +259,18 @@ See our guide on [identifying users](/docs/getting-started/identify-users) for m
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>
+
+</Step>
+
+<Step title="Capture server-side request errors" badge="recommended">
+
+`@posthog/next` enables client-side exception capture by default through `PostHogProvider`. To capture server-side request errors handled by Next.js, export `onRequestError` from your `instrumentation.ts` file:
+
+```ts file=instrumentation.ts
+export { onRequestError } from '@posthog/next'
+```
+
+Next.js calls this hook when a server render, route handler, or server action throws during a request. See the [Next.js error tracking guide](/docs/error-tracking/installation/nextjs) for filtering and source map setup.
 
 </Step>
 
@@ -328,8 +343,9 @@ When you change the proxy path, use the same path in `clientOptions.api_host`:
 
 <Step title="Further reading" badge="recommended">
 
-- [How to set up Next.js analytics, Feature Flags, and more](/tutorials/nextjs-analytics)
+- [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
+- [Upload source maps for Next.js error tracking](/docs/error-tracking/upload-source-maps/nextjs)
 
 </Step>
 

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -78,6 +78,7 @@ import PagesServerSetup from "./_snippets/posthog-next-pages-server-setup.mdx"
 `@posthog/next` is the recommended package for integrating PostHog into your Next.js app. It provides a simplified interface that handles common patterns out of the box:
 
 - **Synchronized identity across client and server**, so both sides share the same user automatically
+- **Server-side identity resolution** via your auth session, so server events and feature flags are attributed to the authenticated user without trusting client-provided identity
 - **Server-side feature flag bootstrapping** so hooks return real values immediately with no flicker
 - **Eager client initialization** ensures PostHog is always available when your components render
 - **Built-in API proxy** that routes SDK traffic through your domain to avoid ad blockers
@@ -242,6 +243,8 @@ export function LoginButton() {
 ```
 
 See our guide on [identifying users](/docs/getting-started/identify-users) for more details.
+
+On the server, you don't need to call `identify()` — configure `getDistinctId` in `createPostHog()` (next step) and server-side events and feature flags are attributed to the logged-in user automatically. This is also the safest option when you can't rely on client-provided identity, since cookies and headers can be spoofed.
 
 </Step>
 

--- a/contents/docs/logs/installation/nextjs.mdx
+++ b/contents/docs/logs/installation/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js logs installation
+title: Next.js Logs installation
 platformLogo: nextjs
 showStepsToc: true
 ---
@@ -79,7 +79,7 @@ export function register() {
 }
 ```
 
-> **Note:** The `loggerProvider` is created outside of `register()` so it can be exported and used to flush logs in route handlers. This pattern is necessary because Route Handlers complete execution before batched logs have a chance to be sent to the collector. By exporting the provider, we can manually flush logs at the end of each request.
+> **Note:** The `loggerProvider` is created outside of `register()` so it can be exported and used to flush telemetry in route handlers. This pattern is necessary because Route Handlers complete execution before batched telemetry has a chance to be sent to the collector. By exporting the provider, we can manually flush telemetry at the end of each request.
 
 > **Important:** The `Content-Type: application/json` header is required.
 
@@ -126,20 +126,20 @@ export async function GET() {
 }
 ```
 
-> **Important:** Without calling `forceFlush()`, your logs may not be sent. Route Handlers complete execution before the OpenTelemetry batch processor has a chance to send logs to the collector. The `after()` function from `next/server` runs code after the response is sent, ensuring logs are flushed before the serverless function freezes.
+> **Important:** Without calling `forceFlush()`, telemetry may not be sent. Route Handlers complete execution before the OpenTelemetry batch processor has a chance to send telemetry to the collector. The `after()` function from `next/server` runs code after the response is sent, ensuring telemetry is flushed before the serverless function freezes.
 
 </Step>
 
 <Step title="Test your setup" badge="recommended">
 
-Once everything is configured, test that logs are flowing into PostHog:
+Once everything is configured, test that telemetry is flowing into PostHog Logs:
 
 1. Send a test log from your application
 2. Check the PostHog Logs interface for your log entries
-3. Verify the logs appear in your project
+3. Verify the log entries appear in your project
 
 <CallToAction type="primary" to="https://app.posthog.com/logs">
-View your logs in PostHog
+View Logs in PostHog
 </CallToAction>
 
 </Step>

--- a/contents/docs/logs/installation/nextjs.mdx
+++ b/contents/docs/logs/installation/nextjs.mdx
@@ -19,11 +19,11 @@ npm install @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @open
 
 <Step title="Get your project token" badge="required">
 
-You'll need your PostHog project token to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
+You'll need your PostHog project token to authenticate log requests. This is the same key you use for capturing events and exceptions with `@posthog/next`.
 
 > **Important:** Use your **project token** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
 
-You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
+If your app already uses `@posthog/next`, reuse `NEXT_PUBLIC_POSTHOG_KEY` for the token and `NEXT_PUBLIC_POSTHOG_HOST` for the host. You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
 
 </Step>
 
@@ -62,9 +62,9 @@ export const loggerProvider = new LoggerProvider({
   processors: [
     new BatchLogRecordProcessor(
       new OTLPLogExporter({
-        url: '<ph_client_api_host>/i/v1/logs',
+        url: `${process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com'}/i/v1/logs`,
         headers: {
-          Authorization: 'Bearer <ph_project_token>',
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
           'Content-Type': 'application/json',
         },
       })
@@ -87,7 +87,7 @@ Alternatively, you can pass the API key as a query parameter:
 
 ```typescript
 new OTLPLogExporter({
-  url: '<ph_client_api_host>/i/v1/logs?token=<ph_project_token>',
+  url: `${process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com'}/i/v1/logs?token=${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Changes

- Makes the main Next.js library docs recommend `@posthog/next` as the default setup instead of separate `posthog-js` and `posthog-node` wiring.
- Updates the `@posthog/next` subpage to remove pre-release language and include server-side request error capture.
- Rewrites the Next.js error tracking installation page around `@posthog/next` (`PostHogProvider`, `onRequestError`, and source maps).
- Aligns Next.js logs and source map docs with the `@posthog/next` env vars where those references are pulled into Context Mill.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

No pages were moved, so no redirect was needed. I ran Prettier over the changed MDX files and `git diff --check`.
