### PR TITLE
fix(experiments): update documentation for custom exposure criteria and troubleshooting guide

### DIFF
--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -33,6 +33,14 @@ For example, if a user makes a purchase before being exposed to your pricing exp
 
 </CalloutBox>
 
+## Metric events don't need a variant property
+
+Only the **exposure event** determines which variant a user belongs to. Once a user is exposed, all of their metric events are attributed to that variant by matching on the user (and falling within the [conversion window](/docs/experiments/metrics#conversion-windows)).
+
+You do **not** need to add `$feature/<flag-key>` or any other flag property to your metric events. The variant tag matters only on the exposure event, and only for [custom exposure events](#custom-exposure-events). This is true for all metric types (mean, funnel, and ratio).
+
+If you've seen experiment results that look wrong, it's worth checking whether the variant on your **exposure** event is correct, see [exposure fired before the flag was ready](/docs/experiments/troubleshooting#my-exposure-event-has-the-wrong-variant-because-the-flag-wasnt-ready-when-it-fired).
+
 ## Exposure visualization
 
 The experiment view displays real-time exposure data to help you monitor participation:
@@ -193,7 +201,7 @@ You can exclude internal team members and test accounts from your experiment by 
 
 - Verify your feature flag is active and returning variants
 - Check that `$feature_flag_called` events are being sent (or your custom exposure event)
-- Ensure the event includes the correct `$feature/<flag-key>` property
+- Ensure the **exposure event** carries the correct variant value: `$feature_flag_response` on `$feature_flag_called` events (set automatically by PostHog SDKs), or `$feature/<flag-key>` on a custom exposure event (which you must set yourself)
 
 ### Uneven variant distribution
 
@@ -204,5 +212,6 @@ You can exclude internal team members and test accounts from your experiment by 
 ### Metrics not updating
 
 - Remember that only post-exposure events count toward metrics
-- Confirm your metric events include the required variant property
+- Confirm the user has a valid exposure event (metric events are matched to a variant through the user's exposure, not through properties on the metric event itself)
 - Check that events are ordered correctly (exposure must come first)
+- Confirm metric events fall within the [conversion window](/docs/experiments/metrics#conversion-windows) after the user's first exposure

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -158,7 +158,7 @@ PostHog automatically calculates SRM once your experiment has at least 100 total
 - **Green checkmark**: Distribution matches your split percentages. The observed difference is within normal random variation.
 - **Yellow warning**: Sample ratio mismatch detected. The distribution is significantly different from expected.
 
-PostHog uses a significance threshold of p < 0.001 to flag mismatches. The p-value is displayed alongside the status—a lower p-value indicates stronger evidence of a mismatch.
+PostHog uses a significance threshold of p < 0.001 to flag mismatches. The p-value is displayed alongside the status. A lower p-value indicates stronger evidence of a mismatch.
 
 ### What to do if SRM is detected
 
@@ -212,6 +212,6 @@ You can exclude internal team members and test accounts from your experiment by 
 ### Metrics not updating
 
 - Remember that only post-exposure events count toward metrics
-- Confirm the user has a valid exposure event (metric events are matched to a variant through the user's exposure, not through properties on the metric event itself)
+- Confirm there's a valid exposure event for the person (metric events are matched to a variant through that exposure, not through properties on the metric event itself)
 - Check that events are ordered correctly (exposure must come first)
-- Confirm metric events fall within the [conversion window](/docs/experiments/metrics#conversion-windows) after the user's first exposure
+- Confirm metric events fall within the [conversion window](/docs/experiments/metrics#conversion-windows) after the first exposure

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -84,13 +84,13 @@ To fix this, you make sure flags are immediately available on a page load. There
 
 ## My exposure event has the wrong variant because the flag wasn't ready when it fired
 
-This is the most damaging version of the problem above, and it's easy to miss because the experiment still produces results, they're just biased.
+This is the most damaging version of the problem above, and it often goes unnoticed because the experiment still produces results, they're just biased.
 
 It happens when the variant on your exposure event is decided before the data needed to evaluate the flag is available. The exposure event then carries `false` or `None` instead of `control` or `test`, and PostHog only counts users whose exposure event has a valid variant. Those incorrectly evaluated users are silently dropped from the experiment. If the dropped users aren't random, and they usually aren't, your results are skewed, not just smaller.
 
 This is about the variant value on the **exposure event** specifically. Metric events don't carry a variant and aren't affected, see [metric events don't need a variant property](/docs/experiments/exposures#metric-events-dont-need-a-variant-property).
 
-A common version of this is a client that evaluates a flag whose release conditions depend on person properties your server sets. The client can fire its exposure event before those properties have been ingested, so the flag isn't yet evaluatable and the variant comes back wrong:
+A common version of this is a client that evaluates a flag whose release conditions depend on person properties your server sets. The client can fire its exposure event before those properties have been ingested, so the flag can't be evaluated yet and the variant comes back wrong:
 
 ```mermaid
 sequenceDiagram
@@ -108,8 +108,8 @@ sequenceDiagram
 Common ways this happens:
 
 - **A client evaluates a flag that depends on server-set person properties.** If your flag's release conditions filter on properties your backend sets (for example `signup_date` or `app_version`), a client that evaluates before those properties are ingested can't determine the variant. With [local evaluation](/docs/feature-flags/local-evaluation), the flag is omitted and the exposure event shows `None` (see [`None` vs `false`](#my-feature-flag-called-events-dont-show-my-variant-names) above). This is most likely for **new users in onboarding**, exactly where many high-stakes experiments run.
-- **A flag is evaluated long before the user reaches the change.** For example, a screen prefetches data on app launch, so the exposure fires before the relevant person properties are set.
-- **A flag is evaluated in parallel with another gate.** For example, an app version or capability check, so the variant on the event can disagree with what the user actually saw.
+- **A flag is evaluated long before the change is reached.** For example, a screen fetches data ahead of time on app launch, so the exposure fires before the relevant person properties are set.
+- **A flag is evaluated in parallel with another gate.** For example, an app version or capability check, so the variant on the event can disagree with what was actually shown.
 
 To detect it, break down an insight of your exposure event by `$feature/<flag-key>` (or break down `$feature_flag_called` by `$feature_flag_response`) and look for a `false`, `None`, or `(empty string)` cohort. A large or variant-imbalanced missing cohort is the signature, and it often shows up as [sample ratio mismatch](#diagnosing-sample-ratio-mismatch-srm).
 

--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -82,6 +82,44 @@ To fix this, you make sure flags are immediately available on a page load. There
 1. [Wait for feature flags to load](/docs/feature-flags/adding-feature-flag-code#ensuring-flags-are-loaded-before-usage) before showing the page (low engineering effort, but slows page down by ~200ms).
 2. Use [client-side bootstrapping](/docs/feature-flags/bootstrapping) (high engineering effort, but keeps the page blazing fast).
 
+## My exposure event has the wrong variant because the flag wasn't ready when it fired
+
+This is the most damaging version of the problem above, and it's easy to miss because the experiment still produces results, they're just biased.
+
+It happens when the variant on your exposure event is decided before the data needed to evaluate the flag is available. The exposure event then carries `false` or `None` instead of `control` or `test`, and PostHog only counts users whose exposure event has a valid variant. Those incorrectly evaluated users are silently dropped from the experiment. If the dropped users aren't random, and they usually aren't, your results are skewed, not just smaller.
+
+This is about the variant value on the **exposure event** specifically. Metric events don't carry a variant and aren't affected, see [metric events don't need a variant property](/docs/experiments/exposures#metric-events-dont-need-a-variant-property).
+
+A common version of this is a client that evaluates a flag whose release conditions depend on person properties your server sets. The client can fire its exposure event before those properties have been ingested, so the flag isn't yet evaluatable and the variant comes back wrong:
+
+```mermaid
+sequenceDiagram
+    participant Client as Your client
+    participant Server as Your server
+    participant PH as PostHog
+    Server->>PH: Set person properties (signup_date, app_version)
+    Note over Server,PH: Sent asynchronously, ingested with a delay
+    Client->>PH: Reload flags + fire exposure event
+    Note over Client,PH: Properties not ingested yet,<br/>flag can't be evaluated
+    PH-->>Client: Variant is None / false
+    Note over Client: Exposure event recorded with the wrong variant,<br/>user dropped from the experiment
+```
+
+Common ways this happens:
+
+- **A client evaluates a flag that depends on server-set person properties.** If your flag's release conditions filter on properties your backend sets (for example `signup_date` or `app_version`), a client that evaluates before those properties are ingested can't determine the variant. With [local evaluation](/docs/feature-flags/local-evaluation), the flag is omitted and the exposure event shows `None` (see [`None` vs `false`](#my-feature-flag-called-events-dont-show-my-variant-names) above). This is most likely for **new users in onboarding**, exactly where many high-stakes experiments run.
+- **A flag is evaluated long before the user reaches the change.** For example, a screen prefetches data on app launch, so the exposure fires before the relevant person properties are set.
+- **A flag is evaluated in parallel with another gate.** For example, an app version or capability check, so the variant on the event can disagree with what the user actually saw.
+
+To detect it, break down an insight of your exposure event by `$feature/<flag-key>` (or break down `$feature_flag_called` by `$feature_flag_response`) and look for a `false`, `None`, or `(empty string)` cohort. A large or variant-imbalanced missing cohort is the signature, and it often shows up as [sample ratio mismatch](#diagnosing-sample-ratio-mismatch-srm).
+
+To fix it, in rough order of preference:
+
+1. **Fire the exposure event from the surface that knows the correct variant.** If a flag depends on server-set person properties, evaluate it and emit exposure server-side, where those properties are available synchronously.
+2. **Stamp the correct variant onto the exposure event explicitly.** Have your server provide the resolved `$feature/<flag-key>` value and set it on your [custom exposure event](/docs/experiments/exposures#custom-exposure-events), rather than relying on a separate client evaluation.
+3. **Make the flag's inputs available before it's evaluated.** [Wait for flags to load](/docs/feature-flags/adding-feature-flag-code#ensuring-flags-are-loaded-before-usage), [bootstrap](/docs/feature-flags/bootstrapping) the client with known values, or set the properties the flag depends on locally.
+4. **Avoid release conditions that depend on data unavailable at evaluation time.** If a flag enrolls new users only, make sure the property encoding "new user" is reliably present wherever the flag is evaluated.
+
 ## Why am I seeing unexpected results in my A/A test?
 
 If you're [running an A/A test](/tutorials/aa-testing) (where both variants are identical) and seeing significant differences between variants, there are a few things to check:


### PR DESCRIPTION
## Changes

Corrects a misleading claim in the experiments docs about feature flag values on metric events, and documents the exposure timing race that most commonly biases experiment results.

### Clarify that metric events don't need a variant property

Added a dedicated section to `exposures.mdx` stating plainly that only the exposure event determines the variant, metric events need no `$feature/<flag-key>`, and this holds for mean, funnel, and ratio metrics. Fixed the two troubleshooting bullets that implied otherwise, and scoped the "No exposures appearing" guidance correctly: `$feature_flag_response` on `$feature_flag_called` (SDK-set) versus `$feature/<flag-key>` on a custom exposure event (self-set).

- `contents/docs/experiments/exposures.mdx`

### Document the exposure timing race

Added a troubleshooting FAQ for the real failure mode behind wrong results: when the variant on the exposure event is decided before the flag's inputs are available (for example, a client evaluating a flag that depends on person properties the server sets asynchronously), the exposure carries `None`/`false`, and PostHog drops that user. The drop is non-random, so results are skewed rather than just smaller. Includes a Mermaid sequence diagram of the race, detection steps (break down by `$feature/<flag-key>`, look for the missing cohort, link to SRM), and fixes in priority order.

- `contents/docs/experiments/troubleshooting.mdx`

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)

## 🤖 Agent context

Model: Opus 4.8
Manually refactored: **no**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Grounded every claim in the experiment query builders before writing. Confirmed variant attribution comes only from the exposure CTE (`exposures.variant`), metric events join by `entity_id` plus conversion window, and the funnel path reads the variant only from `step_0 = 1` (exposure) rows, so a wrong flag value on a metric or conversion event is ignored.
- Framed the failure as biased exclusion, not metric-event corruption, so the new FAQ doesn't reinforce the same misconception the docs fix is correcting.
- Matched the existing Mermaid `sequenceDiagram` convention from `feature-flags/local-evaluation` and kept all cross-link anchors (`#metric-events-dont-need-a-variant-property`, `#diagnosing-sample-ratio-mismatch-srm`, the `None`/`false` snippet) resolving.