### PR TITLE
feat(mcp-analytics): mark wizard support in development

### DIFF
--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -6,7 +6,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Beta SDK" type="fyi">
 
-`@posthog/mcp` is in beta (pre-1.0). The API may still change — including breaking changes in minor `0.x` releases — until `v1`, so pin a version while we iterate. A wizard-driven install (`npx @posthog/wizard mcp-analytics add`) is on the roadmap and will replace most of this page once it ships.
+`@posthog/mcp` is in beta (pre-1.0). The API may still change — including breaking changes in minor `0.x` releases — until `v1`, so pin a version while we iterate. A wizard-driven install (`npx @posthog/wizard mcp-analytics`) is on the roadmap and will replace most of this page once it ships.
 
 </CalloutBox>
 

--- a/src/hooks/productData/mcp_analytics.tsx
+++ b/src/hooks/productData/mcp_analytics.tsx
@@ -27,6 +27,9 @@ export const mcpAnalytics = {
     color: 'blue',
     colorSecondary: 'sky-blue',
     category: 'analytics',
+    // Wizard install (`npx @posthog/wizard mcp-analytics`) ships via a context-mill
+    // release. Flip to `true` once that release is live; 'In development' until then.
+    wizardSupport: 'In development',
     // Alpha, gated behind the `mcp-analytics` early access feature. 'beta' renders the badge on
     // the overview slide and keeps the product clickable in nav (only 'WIP' is disabled).
     status: 'beta',


### PR DESCRIPTION
## What

- Sets `wizardSupport: 'In development'` on the MCP analytics product (`src/hooks/productData/mcp_analytics.tsx`) so it shows in the wizard's supported-products list.
- Corrects the docs install callout (`contents/docs/mcp-analytics/installation.mdx`) from `npx @posthog/wizard mcp-analytics add` to the flat command `npx @posthog/wizard mcp-analytics`.

## Why

The wizard now supports instrumenting an MCP server via `wizard mcp-analytics` (skill + command). `'In development'` is the honest interim state until the context-mill release ships.

## Follow-up (after the context-mill release)

Flip `wizardSupport` to `true` and rewrite the install page to document the wizard path as live rather than roadmap.

## Related

- context-mill skill: PostHog/context-mill#202
- wizard command: PostHog/wizard#731
- workbench fixtures: PostHog/wizard-workbench#2158

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
