### PR TITLE
Add Gamut as an MCP client platform

### DIFF
--- a/contents/docs/model-context-protocol/_snippets/mcp-clients.tsx
+++ b/contents/docs/model-context-protocol/_snippets/mcp-clients.tsx
@@ -61,6 +61,11 @@ const MCPClients = () => {
             url: '/docs/integrations/v0',
             icon: 'IconApps',
         },
+        {
+            label: 'Gamut',
+            url: '/docs/model-context-protocol/gamut',
+            icon: 'IconApps',
+        },
     ]
 
     return (

--- a/contents/docs/model-context-protocol/gamut.mdx
+++ b/contents/docs/model-context-protocol/gamut.mdx
@@ -1,0 +1,22 @@
+---
+title: PostHog MCP for Gamut
+sidebarTitle: Gamut
+---
+
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables [Gamut](https://www.gamut.so/mcp/analytics-marketing/posthog) agents to directly interact with your PostHog data – managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+`https://mcp.posthog.com/mcp`
+
+The PostHog authentication server automatically routes you to the correct data region (US or EU) based on the account you log in with.
+
+## Setup
+
+1. In your Gamut agent, go to **Connections** and click **Add Connection**.
+2. Search for **PostHog** and click **+** to add it.
+3. When prompted, log in to PostHog to authenticate.
+
+<SharedContent />


### PR DESCRIPTION
Adds [Gamut](https://gamut.so) to the MCP client platforms list and creates a setup guide page.

Gamut is an AI agent hosting platform with native support for remote MCP servers, including PostHog. Users connect through the Gamut UI (Connections > Add Connection > search PostHog) and authenticate via OAuth.

Changes:
- Added Gamut to the platforms grid in 
- Created  setup page following the existing client page pattern