### PR TITLE
docs(handbook): add the two test layers to the add-a-command example

### DIFF
--- a/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
+++ b/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
@@ -32,6 +32,11 @@ A **brand-new top-level command word is the exception – it also needs a wizard
 
 > **Worked example — adding `wizard mcp-analytics`.** This flat top-level command was added across four PRs and is the canonical reference for the pattern: the skill ([context-mill#202](https://github.com/PostHog/context-mill/pull/202)), the wizard command stub ([wizard#731](https://github.com/PostHog/wizard/pull/731)), the test fixtures ([wizard-workbench#2158](https://github.com/PostHog/wizard-workbench/pull/2158)), and the docs/`wizardSupport` label ([posthog.com#17939](https://github.com/PostHog/posthog.com/pull/17939)). Copy that shape rather than inferring from the `cli:` schema alone.
 
+Cover **both test layers** when you add a command:
+
+- **Unit (wizard repo)** — a per-command test in [`programs-cli.test.ts`](https://github.com/PostHog/wizard/blob/main/src/__tests__/programs-cli.test.ts) asserting the command registers in the expected shape (flat vs. family) and dispatches the right `skillId`. Fast, runs in the wizard's CI.
+- **End-to-end (workbench)** — a PostHog-less fixture app under [`apps/<command>/`](https://github.com/PostHog/wizard-workbench/tree/main/apps) plus an entry in `apps/manifest.json`, so the workbench can drive the real agent run via `phrocs`. Add a fixture per distinct path the skill handles (mcp-analytics ships one for the SDK-wrap path and one for the custom-dispatcher path).
+
 The full `cli:` block schema (roles, `parentCommand`, the `default` leaf, naming rules) lives in [context mill's CONTRIBUTING.md](https://github.com/PostHog/context-mill/blob/main/CONTRIBUTING.md); the wizard side (command registration, families, aliases) is documented in the wizard repo's [AGENTS.md](https://github.com/PostHog/wizard/blob/main/AGENTS.md). The command surface is **curated, not inclusive** — new `role: command` promotions want a wizard-maintainer sign-off, since a public command name is hard to deprecate.
 
 ## Developing the wizard


### PR DESCRIPTION
## What

Follow-up to the [add-a-command handbook fix](https://github.com/PostHog/posthog.com/pull/17941). The worked example linked the test PRs but never told you *how* to test a new command — so this spells out the two layers:

- **Unit (wizard repo)** — a per-command test in `programs-cli.test.ts` (shape + dispatched `skillId`).
- **End-to-end (workbench)** — a fixture app under `apps/<command>/` + a `manifest.json` entry, driven via `phrocs`; one fixture per distinct path the skill handles.

## Why

Makes the "how to add a product to the wizard" reference fully self-teaching — a contributor (or agent) copying the mcp-analytics shape now sees the testing step, not just the implementation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
