### PR TITLE
Set up standard site verification

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -67,6 +67,13 @@ export const SEO = ({
             {seo.description && <meta name="description" content={seo.description} />}
             {seo.image && <meta name="image" content={seo.image} />}
             {<link rel="canonical" href={canonicalUrl ? canonicalUrl : seo.url} />}
+            {/* Standard.site publication discovery hint for the blog (https://standard.site) */}
+            {pathname?.startsWith('/blog') && (
+                <link
+                    rel="site.standard.publication"
+                    href="at://did:plc:go7eemqz4y5nhonj4kg5w2p6/site.standard.publication/blog"
+                />
+            )}
             {languageAlternates?.map(({ hrefLang, href }) => (
                 <link
                     key={hrefLang}

--- a/static/.well-known/site.standard.publication/blog
+++ b/static/.well-known/site.standard.publication/blog
@@ -1,0 +1,1 @@
+at://did:plc:go7eemqz4y5nhonj4kg5w2p6/site.standard.publication/blog


### PR DESCRIPTION
## Changes

Sets up standard.site (https://standard.site) which lets blogs be discovered and followed on the AT Protocol network (same network as Bluesky). This registers posthog.com/blog as a publication, owned under our existing posthog.com Bluesky identity.

Changes:
- static/.well-known/site.standard.publication/blog — verification file (the publication's AT-URI). Required for verification.
- src/components/seo.tsx — public <link> discovery hint, on /blog* pages only.
- 
Already live: the publication record is on our PDS (created via the script + a Bluesky app password). No secrets in the repo — the AT-URI/DID are public.

Basically, this will let us get a cool looking link like this on Bluesky:

<img width="1088" height="1124" alt="CleanShot 2026-06-25 at 16 53 26@2x" src="https://github.com/user-attachments/assets/761e1818-71d8-4d1a-802d-19c3412dda4d" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
