### PR TITLE
Capitalize "MCP Analytics" product name and fix overview slide title

### DIFF
--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -1,23 +1,23 @@
 ---
-title: MCP analytics
+title: MCP Analytics
 ---
 
 import CalloutBox from 'components/Docs/CalloutBox'
 import OSButton from 'components/OSButton'
 
-<CalloutBox icon="IconInfo" title="MCP analytics is in alpha" type="fyi">
+<CalloutBox icon="IconInfo" title="MCP Analytics is in alpha" type="fyi">
 
 `@posthog/mcp` is a TypeScript SDK for instrumenting Model Context Protocol (MCP) servers with PostHog analytics. It's published on npm as a `0.1.x` release while we build it in public. The API, event names, properties, and tracing behavior may change before the SDK reaches `1.0`. Don't depend on it for production reporting yet. Today, only TypeScript MCP servers are supported – a Python SDK is on the roadmap.
 
 </CalloutBox>
 
-MCP analytics helps you understand how AI agents actually use the MCP server you ship: which tools get called, how often, what intent the agent had, where calls are failing, what tools the agent asked for but you don't offer yet, and how individual sessions flow end to end.
+MCP Analytics helps you understand how AI agents actually use the MCP server you ship: which tools get called, how often, what intent the agent had, where calls are failing, what tools the agent asked for but you don't offer yet, and how individual sessions flow end to end.
 
 The SDK wraps your existing MCP server and emits PostHog events on every tool call, resource read, prompt fetch, and initialize handshake. You can keep using whatever tooling you already have on top of PostHog – insights, dashboards, alerts, Error Tracking – without any additional ingestion plumbing.
 
-<CalloutBox icon="IconInfo" title="A dedicated MCP analytics view is in preview" type="fyi">
+<CalloutBox icon="IconInfo" title="A dedicated MCP Analytics view is in preview" type="fyi">
 
-PostHog has a purpose-built **MCP analytics** view – a dashboard, a sessions explorer, per-tool quality breakdowns, and intent clustering, all built on the `$mcp_*` events the SDK sends. It's in preview behind a feature flag while we build it in public. Because every signal is a normal PostHog event, you don't have to wait for it: you can query and visualize the same data today through [Product Analytics](/docs/product-analytics) for trends and funnels, the [SQL editor](/docs/data-warehouse/sql) for ad-hoc HogQL, [Dashboards](/docs/product-analytics/dashboards) for at-a-glance views, and [Error Tracking](/docs/error-tracking) for `$exception` events. The events on this page won't change shape as the view matures.
+PostHog has a purpose-built **MCP Analytics** view – a dashboard, a sessions explorer, per-tool quality breakdowns, and intent clustering, all built on the `$mcp_*` events the SDK sends. It's in preview behind a feature flag while we build it in public. Because every signal is a normal PostHog event, you don't have to wait for it: you can query and visualize the same data today through [Product Analytics](/docs/product-analytics) for trends and funnels, the [SQL editor](/docs/data-warehouse/sql) for ad-hoc HogQL, [Dashboards](/docs/product-analytics/dashboards) for at-a-glance views, and [Error Tracking](/docs/error-tracking) for `$exception` events. The events on this page won't change shape as the view matures.
 
 </CalloutBox>
 
@@ -34,12 +34,12 @@ Get started
 - Did an agent hit `get_more_tools` because the right capability didn't exist?
 - How does a single MCP session unfold across tool calls?
 
-The MCP analytics dashboard answers most of these at a glance – tool call volume, error rate, p95 latency, and the share of traffic per client:
+The MCP Analytics dashboard answers most of these at a glance – tool call volume, error rate, p95 latency, and the share of traffic per client:
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_dashboard_light_0907967b56.png"
   imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_dashboard_dark_5023c584d4.png"
-  alt="MCP analytics dashboard showing sessions, tool calls, error rate, p95 latency, daily activity, and share of calls by client"
+  alt="MCP Analytics dashboard showing sessions, tool calls, error rate, p95 latency, daily activity, and share of calls by client"
   classes="rounded"
 />
 
@@ -48,7 +48,7 @@ Drill into any single MCP session to step through its tool calls, intents, and e
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_sessions_light_bdd1eb84cb.png"
   imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_sessions_dark_d5b4aa4577.png"
-  alt="MCP analytics sessions explorer showing a session's tool calls, intents, and an errored call"
+  alt="MCP Analytics sessions explorer showing a session's tool calls, intents, and an errored call"
   classes="rounded"
 />
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installing the MCP analytics SDK
+title: Installing the MCP Analytics SDK
 ---
 
 import CalloutBox from 'components/Docs/CalloutBox'

--- a/contents/docs/mcp-analytics/intent.mdx
+++ b/contents/docs/mcp-analytics/intent.mdx
@@ -4,7 +4,7 @@ title: Capturing agent intent
 
 import CalloutBox from 'components/Docs/CalloutBox'
 
-Knowing *what* a tool was called is one thing. Knowing *why* the agent called it is what makes MCP analytics useful for product decisions.
+Knowing *what* a tool was called is one thing. Knowing *why* the agent called it is what makes MCP Analytics useful for product decisions.
 
 The SDK captures intent as a single property — `$mcp_intent` — that can come from one of two sources:
 

--- a/contents/docs/mcp-analytics/queries.mdx
+++ b/contents/docs/mcp-analytics/queries.mdx
@@ -2,7 +2,7 @@
 title: Sample queries
 ---
 
-A starter set of HogQL queries for the most common MCP analytics questions. All of them assume the SDK is installed and at least a few `$mcp_tool_call` events have landed. See the [event reference](/docs/mcp-analytics/events) for the full property list.
+A starter set of HogQL queries for the most common MCP Analytics questions. All of them assume the SDK is installed and at least a few `$mcp_tool_call` events have landed. See the [event reference](/docs/mcp-analytics/events) for the full property list.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_sql_editor_light_94f83dc27e.png"

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting started with MCP analytics
+title: Getting started with MCP Analytics
 hideRightSidebar: true
 contentMaxWidthClass: max-w-5xl
 ---
@@ -9,13 +9,13 @@ import { IconGraph, IconWarning, IconAIText, IconWrench, IconPlug } from '@posth
 import OSButton from 'components/OSButton'
 import CalloutBox from 'components/Docs/CalloutBox'
 
-<CalloutBox icon="IconInfo" title="MCP analytics is in alpha" type="fyi">
+<CalloutBox icon="IconInfo" title="MCP Analytics is in alpha" type="fyi">
 
 `@posthog/mcp` is published as a `0.1.x` release on npm. We're building it in public – the event shape, options, and tracing behavior may still change before `1.0`. Pin a specific version and don't depend on it for production reporting yet. A Python SDK and a `npx @posthog/wizard mcp-analytics add` installer are on the roadmap.
 
 </CalloutBox>
 
-<QuestLog firstSpeechBubble="Let's instrument your MCP server!" lastSpeechBubble="Time to ship MCP analytics!">
+<QuestLog firstSpeechBubble="Let's instrument your MCP server!" lastSpeechBubble="Time to ship MCP Analytics!">
 
 <QuestLogItem
     title="Add @posthog/mcp to your MCP server"
@@ -23,7 +23,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
     icon="IconPlug"
 >
 
-MCP analytics gives you visibility into how AI agents actually use the MCP server you ship. With one wrapper call you can track:
+MCP Analytics gives you visibility into how AI agents actually use the MCP server you ship. With one wrapper call you can track:
 
 - 🛠️ Every tool call (parameters, response, duration, errors)
 - 🎯 Agent intent – the *why* behind each call, not just the *what*
@@ -87,7 +87,7 @@ See every event the SDK emits
     icon="IconAIText"
 >
 
-The single most useful signal in MCP analytics is **intent**: the user goal that led the agent to call this tool. The SDK injects a required `context` argument into every tool's schema and captures it as `$mcp_intent`. Your tool implementation never sees it.
+The single most useful signal in MCP Analytics is **intent**: the user goal that led the agent to call this tool. The SDK injects a required `context` argument into every tool's schema and captures it as `$mcp_intent`. Your tool implementation never sees it.
 
 ```ts
 instrument(server, posthog, {
@@ -120,7 +120,7 @@ Learn about intent capture
     icon="IconLineGraph"
 >
 
-Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the preview [MCP analytics view](/docs/mcp-analytics) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
+Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the preview [MCP Analytics view](/docs/mcp-analytics) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
 
 - ### <IconGraph className="text-blue w-7 -mt-1 inline-block"/> Top tools per server
   Where is your agent traffic concentrated? Which tools earn their keep?
@@ -139,7 +139,7 @@ The tool quality tab surfaces error rate and latency percentiles per tool, with 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_tool_quality_light_f91f27f6e1.png"
   imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_tool_quality_dark_add2659eaa.png"
-  alt="MCP analytics tool quality tab showing calls and errors, success rate, latency percentiles, and a per-tool table"
+  alt="MCP Analytics tool quality tab showing calls and errors, success rate, latency percentiles, and a per-tool table"
   classes="rounded"
 />
 
@@ -233,7 +233,7 @@ Privacy & redaction
 That's it. You're ready to ship `@posthog/mcp` to production agents – within the alpha caveats above.
 
 <OSButton variant="primary" asLink to="/docs/mcp-analytics/installation">
-Install MCP analytics
+Install MCP Analytics
 </OSButton>
 
 </QuestLogItem>

--- a/contents/teams/surveys/objectives.mdx
+++ b/contents/teams/surveys/objectives.mdx
@@ -19,13 +19,13 @@ Talk to customers and explore a new pricing model:
 
 Ship Surveys MCP tools and skills so users can create and manage surveys from AI clients. Add it as an Early Access feature so users can opt in and signal interest.
 
-### 📊 Goal 3: MCP analytics
+### 📊 Goal 3: MCP Analytics
 
 > Why: As MCP usage grows, we want to capture the *why* behind MCP calls – not just cost/latency – and whether users accomplished their goal.
 
 > Who: <TeamMember name="Lucas Faria" photo />
 
-Build bare-bones infrastructure for MCP analytics:
+Build bare-bones infrastructure for MCP Analytics:
 - Ship an initial version in the PostHog MCP server
 - Capture user context around MCP calls (intent, outcome), not just telemetry
 - Work closely with the analytics and growth teams

--- a/src/hooks/productData/mcp_analytics.tsx
+++ b/src/hooks/productData/mcp_analytics.tsx
@@ -41,20 +41,17 @@ export const mcpAnalytics = {
     overview: {
         title: 'See how agents use your MCP server',
         description:
-            'Product analytics for your MCP server. Wrap it in one line and every tool call, agent intent, and failure lands in PostHog as a normal event you can query, chart, and alert on.',
+            'Product analytics for your MCP server. Wrap it in one line and every tool call, agent intent, and failure lands in PostHog as a normal event.',
         textColor: 'text-white',
-        layout: 'columns',
+        layout: 'stacked',
     },
     // TODO (asset step): add `images` on the feature cards below.
     screenshots: {
         overview: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_dashboard_light_0907967b56.png',
             alt: 'MCP Analytics dashboard',
-            // Position absolutely (bottom-left) so the image doesn't push the title and
-            // description out of the slide — matches the columns-overview pattern session
-            // replay uses. The text block reserves the top-right via its @2xl padding.
-            imgClasses:
-                'absolute bottom-0 left-0 max-w-[95%] @2xl:max-w-[560px] rounded-tr-md overflow-hidden shadow-2xl',
+            classes: '',
+            imgClasses: 'rounded-tl-md shadow-2xl',
         },
     },
     features: [

--- a/src/hooks/productData/mcp_analytics.tsx
+++ b/src/hooks/productData/mcp_analytics.tsx
@@ -10,7 +10,7 @@ import {
 } from '@posthog/icons'
 import OSButton from 'components/OSButton'
 
-// MCP analytics is an alpha product (@posthog/mcp on npm) with a dedicated scene in the app
+// MCP Analytics is an alpha product (@posthog/mcp on npm) with a dedicated scene in the app
 // gated behind the `mcp-analytics` early access feature. Copy here is sourced from the docs in
 // contents/docs/mcp-analytics/. There are no marketing screenshots yet, so the slides are
 // text/icon-driven — drop Cloudinary image URLs into `screenshots.overview` and the per-feature
@@ -18,7 +18,7 @@ import OSButton from 'components/OSButton'
 // opt-in links to the early access feature in the app (identity isn't shared with the website).
 
 export const mcpAnalytics = {
-    name: 'MCP analytics',
+    name: 'MCP Analytics',
     Icon: IconPlug,
     description: 'See how agents actually use your MCP server',
     handle: 'mcp_analytics',
@@ -34,7 +34,7 @@ export const mcpAnalytics = {
     // the overview slide and keeps the product clickable in nav (only 'WIP' is disabled).
     status: 'beta',
     seo: {
-        title: 'MCP analytics – See how agents use your MCP server in PostHog',
+        title: 'MCP Analytics – See how agents use your MCP server in PostHog',
         description:
             "Understand how agents actually use your MCP server: which tools get called, what the agent wanted, where calls fail, and which capabilities are missing. It's all normal PostHog events.",
     },
@@ -49,8 +49,12 @@ export const mcpAnalytics = {
     screenshots: {
         overview: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_dashboard_light_0907967b56.png',
-            alt: 'MCP analytics dashboard',
-            classes: '',
+            alt: 'MCP Analytics dashboard',
+            // Position absolutely (bottom-left) so the image doesn't push the title and
+            // description out of the slide — matches the columns-overview pattern session
+            // replay uses. The text block reserves the top-right via its @2xl padding.
+            imgClasses:
+                'absolute bottom-0 left-0 max-w-[95%] @2xl:max-w-[560px] rounded-tr-md overflow-hidden shadow-2xl',
         },
     },
     features: [
@@ -231,7 +235,7 @@ export const mcpAnalytics = {
     ],
     presenterNotes: {
         overview:
-            'MCP analytics is alpha (<code>@posthog/mcp</code> on npm). Lead with the one-line wrap and "it\'s all just PostHog events." No new tooling to learn.',
+            'MCP Analytics is alpha (<code>@posthog/mcp</code> on npm). Lead with the one-line wrap and "it\'s all just PostHog events." No new tooling to learn.',
     },
 }
 

--- a/src/pages/mcp-analytics/index.tsx
+++ b/src/pages/mcp-analytics/index.tsx
@@ -7,7 +7,7 @@ import EarlyAccessOptIn from 'components/EarlyAccessOptIn'
 // Product configuration - change this to adapt for different products
 const PRODUCT_HANDLE = 'mcp_analytics'
 
-// MCP analytics is gated behind the `mcp-analytics` early access feature in the app. Logins
+// MCP Analytics is gated behind the `mcp-analytics` early access feature in the app. Logins
 // aren't shared between posthog.com and the app, so we can't enroll the visitor's website
 // identity here — instead the opt-in links to the app, where the signed-in user can join the
 // beta. See src/components/EarlyAccessOptIn/README.md.

--- a/src/pages/mcp-analytics/index.tsx
+++ b/src/pages/mcp-analytics/index.tsx
@@ -74,7 +74,7 @@ export default function MCPAnalytics(): JSX.Element {
     const slides = createSlideConfig({
         include: ['overview', 'features', 'answers', 'docs', 'pairs-with'],
         templates: {
-            overview: 'columns',
+            overview: 'stacked',
         },
     })
 


### PR DESCRIPTION
## Changes

- **Capitalize "MCP Analytics" as the product name** everywhere it appears as a product: the `/docs/mcp-analytics` section, the product data hook, and the landing page. Slugs, URLs, and the `@posthog/mcp` npm package name are untouched.
- The generic `contents/tutorials/mcp-analytics.mdx` how-to keeps lowercase — it covers a build-your-own wrapper, not the PostHog product.
- **Fix the landing page's first slide.** The overview screenshot was rendering full-width in normal flow, pushing the title and description below the visible slide so only the image showed. It's now absolutely positioned (bottom-left, constrained width), matching the `columns` overview pattern session replay uses, so the title and description render.

**Why:** "MCP Analytics" is the product name and was inconsistently lowercased, and the first slide of the product page showed only an image with no title.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1782479439140929)*
