### PR TITLE
docs: document getAllFeatureFlags() for posthog-js and react-native

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
@@ -60,6 +60,16 @@ posthog.getFeatureFlag('key-for-your-multivariate-flag')
 posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
+### Inspecting all feature flags
+
+You can inspect all currently loaded feature flags with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event, so calling it won't affect your experiment results or flag usage analytics:
+
+```react-native
+for (const flag of posthog.getAllFeatureFlags()) {
+    console.log(flag.key, flag.enabled, flag.variant, flag.payload)
+}
+```
+
 ### Ensuring flags are loaded before usage
 
 Every time a user opens the app, we send a request in the background to fetch the feature flags that apply to that user. We store those flags in the storage.

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
@@ -22,6 +22,16 @@ if (result?.variant == 'variant-key') { // replace 'variant-key' with the key of
 }
 ```
 
+### Inspecting all feature flags
+
+You can inspect all currently loaded feature flags with `getAllFeatureFlags()`. It returns each flag's `key`, `enabled` state, `variant`, and `payload`, and does not send a `$feature_flag_called` event, so calling it won't affect your experiment results or flag usage analytics:
+
+```js-web
+for (const flag of posthog.getAllFeatureFlags()) {
+    console.log(flag.key, flag.enabled, flag.variant, flag.payload)
+}
+```
+
 ### Ensuring flags are loaded before usage
 
 Every time a user loads a page, we send a request in the background to fetch the feature flags that apply to that user. We store those flags in your chosen persistence option (local storage by default).


### PR DESCRIPTION
## Changes

Documents the new `getAllFeatureFlags()` accessor on the **posthog-js (web)** and **react-native** SDKs (shipped in [posthog-js#3977](https://github.com/PostHog/posthog-js/pull/3977)), mirroring the iOS/Android docs added earlier in [#17875](https://github.com/PostHog/posthog.com/pull/17875).

Adds an `### Inspecting all feature flags` section to the web and react-native feature-flag code snippets. It shows `getAllFeatureFlags()` returning each loaded flag's `key`, `enabled` state, `variant`, and `payload`, and calls out that it does **not** send a `$feature_flag_called` event — so it's safe for debug panels / log enrichment without affecting experiment results or flag usage analytics.

These snippets render on the "Adding feature flag code" page and on the `posthog-js` and `react-native` library usage pages. node is unaffected (server-side SDK).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links (none added)
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)
