### PR TITLE
Fix malformed strategy link in actual-marketing-budget-2026

### DIFF
--- a/contents/founders/actual-marketing-budget-2026.md
+++ b/contents/founders/actual-marketing-budget-2026.md
@@ -19,7 +19,7 @@ So how much does a typical scale-up [like PostHog](/about) spend on marketing. A
 
 “But Charles, you naive idiot, surely competitors will use this information against you?”
 
-Um, sure I guess? But especially if you’re into product-led growth (like we are), how you spend marketing $ seems pretty far down the list of competitive advantages. We're open source and we already tell everyone [our strategy](/handbook] and [what we’re going to build next](/roadmap). That doesn’t seem to have hurt us so far. 
+Um, sure I guess? But especially if you’re into product-led growth (like we are), how you spend marketing $ seems pretty far down the list of competitive advantages. We're open source and we already tell everyone [our strategy](/handbook) and [what we’re going to build next](/roadmap). That doesn’t seem to have hurt us so far. 
 
 By sharing some of this info, I’m hoping it’ll help others as a data point. **I am not saying this is the best way to spend your marketing budget.** I have no idea! That’s the point!! But I’m hoping _maybe_ someone will see this and tell us how we could do better...
 


### PR DESCRIPTION
Fixes a Markdown syntax error in the `/founders/actual-marketing-budget-2026` post: the `[our strategy](/handbook]` link had a mismatched closing bracket `]` instead of `)`, so it rendered as broken text instead of a link.

**Why:** Cory reported the broken link in the post.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1782490961400449?thread_ts=1782490961.400449&cid=C09GU689J1X)*