### PR TITLE
docs(subscriptions): drop early access callout for GA prompt subscriptions

### DIFF
--- a/contents/docs/product-analytics/subscriptions.mdx
+++ b/contents/docs/product-analytics/subscriptions.mdx
@@ -197,12 +197,6 @@ For example, you could create a prompt subscription with "Summarize weekly signu
 
 Prompt subscriptions support the same delivery options as other subscriptions – email or Slack – and the same scheduling frequencies (daily, weekly, monthly).
 
-<CalloutBox icon="IconInfo" title="Early access" type="fyi">
-
-Prompt subscriptions are currently in early access behind a feature flag. To try them out, enable the **AI subscriptions** feature preview in your [project settings](https://app.posthog.com/settings).
-
-</CalloutBox>
-
 ### Prerequisites
 
 - **PostHog Cloud only** – prompt subscriptions aren't available on self-hosted deployments


### PR DESCRIPTION
## Changes

Removes the "Early access" callout from the prompt subscriptions docs, which told readers to enable an **AI subscriptions** feature preview that no longer exists now that the feature has shipped to everyone.

**Why:** Users following the docs were being told to enable a feature preview that's no longer there, since prompt subscriptions are now GA.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1782510716439769?thread_ts=1782510716.439769&cid=C09BDQLM8KA)*