### PR TITLE
Fix WizardCommand button corners when Learn more tab is shown

### DIFF
--- a/src/components/WizardCommand/index.tsx
+++ b/src/components/WizardCommand/index.tsx
@@ -54,8 +54,8 @@ export default function WizardCommand({
                     onClick={handleCopy}
                     className={`group inline-flex items-center gap-2 ${
                         variantStyles[variant] || variantStyles.default
-                    } font-mono text-sm px-2 py-1.5 rounded-md cursor-pointer ${
-                        !slim ? 'relative z-10' : ''
+                    } font-mono text-sm px-2 py-1.5 cursor-pointer ${
+                        !slim ? 'rounded-t-md relative z-10' : 'rounded-md'
                     } ${className}`}
                 >
                     <IconChevronRight className="size-4 opacity-50" />

--- a/src/components/WizardCommand/index.tsx
+++ b/src/components/WizardCommand/index.tsx
@@ -55,7 +55,7 @@ export default function WizardCommand({
                     className={`group inline-flex items-center gap-2 ${
                         variantStyles[variant] || variantStyles.default
                     } font-mono text-sm px-2 py-1.5 cursor-pointer ${
-                        !slim ? 'rounded-t-md relative z-10' : 'rounded-md'
+                        !slim ? 'rounded-t-md relative z-10 border border-primary' : 'rounded-md'
                     } ${className}`}
                 >
                     <IconChevronRight className="size-4 opacity-50" />


### PR DESCRIPTION
## Summary

- The `WizardCommand` button used `rounded-md` (all corners rounded) regardless of whether the "Learn more" tab was visible, making it look like a disconnected pill floating above the tab
- When `slim=false` (Learn more shown), the button now uses `rounded-t-md` so its flat bottom edge connects seamlessly with the tab's top
- When `slim=true`, the button keeps `rounded-md` for a complete standalone pill appearance

Fixes GROW-77

## Test plan

- [ ] Visit `/docs/getting-started/install` → AI wizard tab, confirm the command button and "Learn more" tab look connected
- [ ] Visit `/wizard` page, confirm standalone WizardCommand still looks correct (rounded on all sides)
- [ ] Check dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)