### PR TITLE
fix(docs): inbox link 404 in AppsList

### DIFF
--- a/src/components/Docs/AppsList/index.tsx
+++ b/src/components/Docs/AppsList/index.tsx
@@ -8,6 +8,7 @@ const docsUrlOverrides: Record<string, string> = {
     data_warehouse: '/docs/data-warehouse',
     realtime_destinations: '/docs/cdp/destinations',
     posthog_ai: '/docs/posthog-ai',
+    inbox: '/docs/self-driving/inbox',
 }
 
 const docsUrlFor = (product: any): string => docsUrlOverrides[product.handle] || `/docs/${product.slug}`


### PR DESCRIPTION
AppsList component renders a 404 for the inbox link on posthog.com/docs because of the slug. added to exceptions