### PR TITLE
Update ToS and Privacy Policy: add model training opt-out section

### DIFF
--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -53,6 +53,9 @@ const privacyClasses = cntl`
   [&>div:nth-child(odd)_ul]:pb-4
   [&>div:nth-child(odd)_li]:text-[15px]
   [&>div:nth-child(even)>p]:text-lg
+  [&>div>*:first-child]:!mt-0
+  [&>div>h2]:!mt-0
+  [&>div>h3]:!mt-0
 `
 
 function Privacy() {
@@ -130,15 +133,15 @@ function Privacy() {
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
                         Our privacy policy covers it all – from cookies 🍪 to your data protection rights under your
-                        country’s law 🌍. Read it carefully as using our site means you agree to it!
+                        country's law 🌍. Read it carefully as using our site means you agree to it!
                     </Tweet>
 
                     <Tweet
                         className="mx-auto"
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
-                        🔓 As an open-source project, some info you share might be public for our awesome community’s
-                        collaboration. But don't worry, we’re committed to collecting and sharing the minimum amount of
+                        🔓 As an open-source project, some info you share might be public for our awesome community's
+                        collaboration. But don't worry, we're committed to collecting and sharing the minimum amount of
                         personal info. We're the Data Controller for all this!
                     </Tweet>
 
@@ -147,7 +150,7 @@ function Privacy() {
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
                         💻 We collect data like your IP address, device info, and pages/content you view to improve your
-                        experience. We do not use third party cookies.
+                        experience. We do not use third-party cookies.
                     </Tweet>
 
                     <Tweet
@@ -155,8 +158,8 @@ function Privacy() {
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
                         🛠️ We gather usage data from our self-managed instances to analyze and improve our site, but you
-                        can opt out. We do not collect 
-                        sensitive info like genetic data here, and definitely no under-18 data!
+                        can opt out. We do not collect sensitive info like genetic data here, and definitely no under-18
+                        data!
                     </Tweet>
 
                     <Tweet
@@ -180,8 +183,8 @@ function Privacy() {
                         className="mx-auto"
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
-                        🌐 We share your information with trusted service providers to run our site and product.
-                        We’re part of the EU-US Data Privacy Framework, ensuring your data is safe.
+                        🌐 We share your information with trusted service providers to run our site and product. We're
+                        part of the EU-US Data Privacy Framework, ensuring your data is safe.
                     </Tweet>
 
                     <Tweet
@@ -234,7 +237,7 @@ function Privacy() {
                     <p className="">
                         You probably realize this, but the summaries{' '}
                         <span className="md:hidden">
-                            below each section in blockquotes (under the <em>"What it means</em> subheaders)
+                            below each section in blockquotes (under the <em>"What it means"</em> subheaders)
                         </span>
                         <span className="hidden md:inline-block">in the right-hand column</span> exist solely to aid
                         your comprehension and alleviate boredom. They're not legally binding.
@@ -286,24 +289,25 @@ function Privacy() {
                     <div className="hidden md:block">
                         <h3 className="hidden md:block">What it means</h3>
                     </div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
-                            This privacy policy ("<b>Privacy Policy</b>") applies to all visitors, users and customers of the
-                            PostHog.com hosted services and websites (collectively, the "<b>Website</b>" or "<b>Websites</b>") and
-                            self-managed installations, which are offered by PostHog Inc. (formerly known as Hiberly Inc.) and/or
-                            any of its subsidiaries and/or affiliates ("<b>PostHog</b>" or "<b>we</b>" or "<b>us</b>") and describes how we process your personal
-                            information in connection with those Websites or self managed installations, customer events
+                            This privacy policy ("<b>Privacy Policy</b>") applies to all visitors, users and customers
+                            of the PostHog.com hosted services and websites (collectively, the "<b>Website</b>" or "
+                            <b>Websites</b>") and self-managed installations, which are offered by PostHog Inc.
+                            (formerly known as Hiberly Inc.) and/or any of its subsidiaries and/or affiliates ("
+                            <b>PostHog</b>" or "<b>we</b>" or "<b>us</b>") and describes how we process your personal
+                            information in connection with those Websites or self-managed installations, customer events
                             and demos, and how we collect information through the use of cookies and related
                             technologies. It also tells you how you can access and update your personal information and
-                            describes the data protection rights that may be available under your country’s or state's
-                            laws, including (in the European Economic Area ("<b>EEA</b>"), and UK), a right to object to some
-                            processing that we carry out or, where we rely on consent, how to withdraw that consent.
-                            Please read this Privacy Policy carefully. By accessing or using any part of the Websites or
-                            self-managed installations, you acknowledge you have been informed of and consent to our
-                            practices with regard to your personal information and data.
+                            describes the data protection rights that may be available under your country's or state's
+                            laws, including (in the European Economic Area ("<b>EEA</b>"), and UK), a right to object to
+                            some processing that we carry out or, where we rely on consent, how to withdraw that
+                            consent. Please read this Privacy Policy carefully. By accessing or using any part of the
+                            Websites or self-managed installations, you acknowledge you have been informed of and
+                            consent to our practices with regard to your personal information and data.
                         </p>
                         <p>
-                            PostHog is an open source project and collaborative community, as well as a company. This
+                            PostHog is an open-source project and collaborative community, as well as a company. This
                             means that many portions of our Websites, including information you voluntarily provide,
                             will be public-facing for the open sharing of innovative developments, ideas, and
                             information that makes our collaborative community so great. While we are committed to open
@@ -319,7 +323,7 @@ function Privacy() {
                             described in this Privacy Policy.
                         </p>
                         <p>
-                            We may provide additional information about our privacy practices in other places - for
+                            We may provide additional information about our privacy practices in other places – for
                             example, when we ask you to provide personal information in connection with a particular
                             service or when you apply for a job with us.
                         </p>
@@ -329,10 +333,10 @@ function Privacy() {
                             This policy describes how we use your personal information when you use the PostHog app or
                             visit our website. It includes:
                         </p>
-                        <ul className="pb-4 [&_p]:mb-0 [&_li]:text-lg">
+                        <ul className="mt-4 list-disc pl-4 space-y-1 [&_p]:mb-0 [&_li]:text-lg">
                             <li>Use of cookies</li>
                             <li>How you can access your personal info</li>
-                            <li>Your data protection rights under your country’s or state’s law.</li>
+                            <li>Your data protection rights under your country's or state's law.</li>
                         </ul>
                         <p>
                             We suggest you read the privacy policy carefully as by using our website you are agreeing to
@@ -340,7 +344,7 @@ function Privacy() {
                         </p>
                         <p>
                             PostHog is an open-source project, so some of the information you voluntarily provide will
-                            be public facing for sharing ideas – it’s what makes us such a great collaborative
+                            be public facing for sharing ideas – it's what makes us such a great collaborative
                             community.
                         </p>
                         <p>
@@ -383,7 +387,7 @@ function Privacy() {
                     </div>
                     <div>
                         <p>We collect things like:</p>
-                        <ul className="pb-4 [&_p]:mb-0 [&_li]:text-lg">
+                        <ul className="mt-4 list-disc pl-4 space-y-1 [&_p]:mb-0 [&_li]:text-lg">
                             <li>IP address</li>
                             <li>Information about your device</li>
                             <li>Pages you have viewed</li>
@@ -394,11 +398,11 @@ function Privacy() {
                             experience.
                         </p>
                         <p>
-                            We use our own products to do this. eg we will use our Session Replay tool to debug user
+                            We use our own products to do this. E.g., we will use our Session Replay tool to debug user
                             issues or understand how to improve our product.
                         </p>
                         <p>
-                            FYI, we don’t use any third-party cookies at all. This means we don’t run any retargeting ad
+                            FYI, we don't use any third-party cookies at all. This means we don't run any retargeting ad
                             campaigns, or use any other invasive tracking techniques that follow you around the
                             internet.
                         </p>
@@ -442,13 +446,14 @@ function Privacy() {
                         <p>
                             The amount and type of information that PostHog gathers depends on the nature of your
                             interaction with us, as well as the amount of information you choose to share. For example,
-                            we ask visitors who use our community group to provide a username and email address. We 
-                            also collect the information you provide to us in connection with creating an account on
-                            the Websites. You may voluntarily provide personal information when you fill in forms on our 
-                            Websites, such as when you request a demo, contact sales, subscribe to our newsletter, or participate 
-                            in other marketing activities or events. The information you provide may include, but is not limited 
-                            to, email addresses, names, organization or company names, and roles and titles at such organizations 
-                            or companies. If you use a single sign-on partner like Google, we'll collect the information from them that you authorize.&nbsp;
+                            we ask visitors who use our community group to provide a username and email address. We also
+                            collect the information you provide to us in connection with creating an account on the
+                            Websites. You may voluntarily provide personal information when you fill in forms on our
+                            Websites, such as when you request a demo, contact sales, subscribe to our newsletter, or
+                            participate in other marketing activities or events. The information you provide may
+                            include, but is not limited to, email addresses, names, organization or company names, and
+                            roles and titles at such organizations or companies. If you use a single sign-on partner
+                            like Google, we'll collect the information from them that you authorize.&nbsp;
                         </p>
                         <p>
                             Certain profile information (such as your username) may be shared publicly, as well as
@@ -460,18 +465,22 @@ function Privacy() {
                         <p>
                             In each case, PostHog collects such personal information only insofar as is necessary or
                             appropriate to fulfill the purpose of your interaction with or your request to PostHog. We
-                            may also collect certain personal information during live in-person or virtual events and demos. We
-                            will not disclose your personal information other than as described in this Privacy Policy.
+                            may also collect certain personal information during live in-person or virtual events and
+                            demos. We will not disclose your personal information other than as described in this
+                            Privacy Policy.
                         </p>
                         <p>
-                            We may also collect limited personal data from third-party sources and publicly available platforms to help identify 
-                            potential customers, enhance our business contact database, and otherwise support our sales and marketing efforts.
+                            We may also collect limited personal data from third-party sources and publicly available
+                            platforms to help identify potential customers, enhance our business contact database, and
+                            otherwise support our sales and marketing efforts.
                         </p>
                         <p>
                             We may aggregate all information (including your personal information) collected from our
-                            Websites and self-managed installations for our own statistical and analytics purposes and
-                            share such aggregated information with third parties for our own promotional purposes (e.g.
-                            by publishing a report on trends in the usage of our Websites).
+                            Websites and self-managed installations for our own statistical, analytics, product
+                            improvement, and service development purposes (including improving and developing our
+                            products, features, and internal systems) and share such aggregated information with third
+                            parties for our own promotional purposes (e.g., by publishing a report on trends in the
+                            usage of our Websites).
                         </p>
                     </div>
                     <div>
@@ -487,19 +496,67 @@ function Privacy() {
 
                         <p>
                             If you report a security vulnerability publicly then we may disclose your personal info, but
-                            only if the action requires it – e.g. to provide recognition for your reporting of a
+                            only if the action requires it – e.g., to provide recognition for your reporting of a
                             security vulnerability.
                         </p>
 
                         <p>We aggregate the info we collect to analyze usage and improve our website.</p>
                     </div>
                     <div>
+                        <h3>
+                            <strong>Product and model development</strong>
+                        </h3>
+                    </div>
+                    <div></div>
+                    <div>
+                        <p>
+                            Where Customer Content (meaning any software, information, content, data, or related
+                            materials provided by or on behalf of Customer or made available through use of PostHog's
+                            products or services ("<b>Customer Content</b>")) is submitted to PostHog or the Websites,
+                            PostHog may use such Customer Content for "<b>Product and Model Development</b>", meaning
+                            the development, testing, training, evaluation, and improvement of PostHog's products,
+                            services, features, analytics systems, and machine learning models.
+                        </p>
+                        <p>
+                            Where Customer Content is used for Product and Model Development, PostHog will aggregate or
+                            de-identify such data so that it cannot reasonably be used to identify Customer, its Users,
+                            or any individual (the "<b>Derived Data</b>"). PostHog will not permit third parties to use
+                            Customer Content to train their machine learning models; any use of Customer Content for
+                            Product and Model Development will be solely for PostHog's own products, services, and
+                            internal models.
+                        </p>
+                        <p>
+                            Customer Content may be used for Product and Model Development unless (a) otherwise agreed
+                            to between Customer and PostHog or (b) Customer has opted out through the applicable service
+                            settings within the Licensed Materials and/or product or services interface. PostHog will
+                            honor such elections on a prospective basis only. PostHog has no obligation to modify,
+                            retrain, or delete any models or Derived Data that utilized Customer Content prior to the
+                            effective date of any opt-out, except to the extent required by applicable law.
+                        </p>
+                    </div>
+                    <div>
+                        <p>
+                            We may use data you submit through PostHog to help improve our products and train our own
+                            internal models. Before we do, we anonymize it so it can't be traced back to you or your
+                            users.
+                        </p>
+                        <p>
+                            We won't share your data with outside companies to train their models – anything we use
+                            stays internal to PostHog.
+                        </p>
+                        <p>
+                            You can opt out at any time through the app settings. If you do, we'll stop using your data
+                            going forward – but we can't undo any model training that's already taken place.
+                        </p>
+                    </div>
+
+                    <div>
                         <h2 id="we-dont-collect">
                             <strong>Information PostHog does not collect</strong>
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             PostHog does not intentionally collect sensitive or special category personal information,
                             such as genetic data, biometric data for the purposes of uniquely identifying a natural
@@ -513,11 +570,11 @@ function Privacy() {
                     </div>
                     <div>
                         <p>
-                            We don’t collect any seriously sensitive information, like genetic or biometric data, and
-                            definitely no data on children under 18.{' '}
+                            We don't collect any seriously sensitive information, like genetic or biometric data, and
+                            definitely no data on children under 18.
                         </p>
 
-                        <p>If we think you’re under 18, we will close your account. </p>
+                        <p>If we think you're under 18, we will close your account.</p>
                     </div>
 
                     <div>
@@ -533,18 +590,32 @@ function Privacy() {
                             <br />
                             We use your personal information to:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>administer access to our Websites and your accounts;</li>
                             <li>manage our customer relationships;</li>
                             <li>
                                 process orders, provide our products and services and send you service-related
-                                communications; and
+                                communications;
                             </li>
-                            <li>provide you with customer support.</li>
+                            <li>provide you with customer support;</li>
+                            <li>process billing, invoicing, and subscription management;</li>
+                            <li>
+                                send transactional communications such as confirmations, invoices, technical notices,
+                                and security alerts;
+                            </li>
+                            <li>onboard you and facilitate your use of our products and services; and</li>
+                            <li>
+                                verify your identity, manage authentication, and maintain the security of your account.
+                            </li>
                         </ul>
                     </div>
                     <div>
-                        <p>This explains how we use your personal information to fulfill our contract(s) with you.</p>
+                        <p>
+                            When you sign up and use PostHog, we enter into a contract with you. Everything in this
+                            section is what we need your data for to actually deliver that – keeping your account
+                            running, processing payments, sending you important updates, and making sure you can get
+                            help when you need it.
+                        </p>
                     </div>
 
                     <div>
@@ -552,7 +623,7 @@ function Privacy() {
                             <strong>Legitimate interests</strong> <br />
                             We use your personal information:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 to improve and personalize your experience with us and our Websites and to tailor
                                 communications to you;
@@ -566,32 +637,47 @@ function Privacy() {
                                 research and analytics;
                             </li>
                             <li>
-                                to enforce compliance with our <Link href="/terms">terms of use</Link> and other
+                                to aggregate or de-identify personal information and use the resulting data for
+                                improving and developing our products, services, and internal systems;
+                            </li>
+                            <li>
+                                to send you marketing and promotional communications about our products, features, and
+                                events, where you have not opted out of receiving such communications;
+                            </li>
+                            <li>
+                                to enforce compliance with our <Link href="/terms">Terms of Service</Link> and other
                                 policies or otherwise in connection with legal claims, compliance, regulatory and
                                 investigatory purposes as necessary (including disclosure of such information in
-                                connection with legal process or litigation); and
+                                connection with legal process or litigation).
                             </li>
                         </ul>
                     </div>
                     <div>
-                        <p>We only use your information for stuff we actually need.</p>
+                        <p>
+                            "Legitimate interest" covers everything we need your data for to run a real business –
+                            improving the product, keeping things secure, letting you know about new features, and
+                            staying out of legal trouble. We only do this where it's reasonable and where your privacy
+                            rights aren't outweighed.
+                        </p>
                     </div>
 
-                    <div className="md:pb-12">
+                    <div>
                         <p className="">
                             <strong>Consent</strong>
                             <br />
                             We may rely on your consent:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
-                                Where you ask us to send marketing information (e.g. newsletter updates) via a medium
+                                Where you ask us to send marketing information (e.g., newsletter updates) via a medium
                                 where we need your consent under applicable law (for example email marketing in some
                                 countries);
                             </li>
                             <li>Where you give us consent to place cookies or similar technologies;</li>
+                            <li>To deliver marketing or advertisements via third-party platforms such as LinkedIn;</li>
                             <li>
-                                To deliver marketing or advertisements via third-party platforms such as LinkedIn;
+                                To involve you in user research, interviews, surveys, or beta programs where we record
+                                or collect feedback beyond normal product use; and
                             </li>
                             <li>
                                 On other occasions where we ask for your consent, for the purpose we explain at the
@@ -599,17 +685,26 @@ function Privacy() {
                             </li>
                         </ul>
                         <p>
-                            You may withdraw your consent to marketing emails at any time through the unsubscribe feature provided with the
-                            relevant marketing email or by contacting us using the details in the ‘Contacting PostHog
-                            About Your Privacy’ section of this Privacy Policy. You may withdraw your consent for us to 
-                            use your personal information to market or advertise to you via third-party platforms at any time by sending an email to <a href="mailto:Brian@GetPostHog.com">Brian@GetPostHog.com</a>.
+                            You may withdraw your consent to marketing emails at any time through the unsubscribe
+                            feature provided with the relevant marketing email or by contacting us using the details in
+                            the "
+                            <Link href="#contact-us" className="font-normal underline">
+                                Contacting PostHog about your privacy
+                            </Link>
+                            " Section of this Privacy Policy. You may withdraw your consent for us to use your personal
+                            information to market or advertise to you via third-party platforms at any time by sending
+                            an email to <a href="mailto:Brian@GetPostHog.com">Brian@GetPostHog.com</a>.
                         </p>
                     </div>
                     <div>
-                        <p>We always rely on your consent.</p>
                         <p>
-                            You can withdraw consent at any time following the process in the section below about
-                            contacting us.
+                            We only rely on consent where it's the right legal basis for what we're doing. Where we do,
+                            you can withdraw it at any time – just use the unsubscribe link in any marketing email, or
+                            get in touch using the details in the "
+                            <Link href="#contact-us" className="font-normal underline">
+                                Contacting PostHog about your privacy
+                            </Link>
+                            " Section of this Privacy Policy.
                         </p>
                     </div>
 
@@ -628,10 +723,11 @@ function Privacy() {
                             purposes that are described in this Privacy Policy or otherwise with your consent.
                         </p>
                         <p>
-                            PostHog only shares your personal information with those of its service providers, employees, contractors, and
-                            affiliated organizations that (i) need to know that personal information in order to process
-                            it on PostHog's behalf, help power our products and operate our business or to provide services available on the Websites, and (ii) that have
-                            agreed to follow data privacy and security requirements and to follow our instructions.
+                            PostHog only shares your personal information with those of its service providers,
+                            employees, contractors, and affiliated organizations that (i) need to know that personal
+                            information in order to process it on PostHog's behalf, help power our products and operate
+                            our business or to provide services available on the Websites, and (ii) that have agreed to
+                            follow data privacy and security requirements and to follow our instructions.
                         </p>
                     </div>
                     <div>
@@ -644,24 +740,26 @@ function Privacy() {
                     <div></div>
                     <div>
                         <p className="">
-                            <strong>Service Providers and partners</strong>. PostHog engages a number of trusted third-party service
-                            providers and partners to manage or support certain aspects of our business operations. 
-                            These service providers may process your personal information on our behalf for purposes such as 
-                            cloud hosting, analytics, marketing, advertising, customer support, communication, or internal operations.
+                            <strong>Service Providers and partners</strong>. PostHog engages a number of trusted
+                            third-party service providers and partners to manage or support certain aspects of our
+                            business operations. These service providers may process your personal information on our
+                            behalf for purposes such as cloud hosting, analytics, marketing, advertising, customer
+                            support, communication, or internal operations.
                         </p>
                         <p>
-                            We may also share some of your account information that you provide to us (including email addresses) with third-party advertising 
-                            platforms to create or target marketing and advertising audiences on our behalf. We do not share any of your 
-                            user content that you have uploaded or have enabled our products to access for these purposes. You have the 
-                            option to opt out of your personal information being sent to third-party platforms for targeted marketing or advertising purposes by sending an email to <a href="mailto:Brian@GetPostHog.com">Brian@GetPostHog.com</a>.
+                            We may also share some of your account information that you provide to us (including email
+                            addresses) with third-party advertising platforms to create or target marketing and
+                            advertising audiences on our behalf. We do not share any of your user content that you have
+                            uploaded or have enabled our products to access for these purposes. You have the option to
+                            opt out of your personal information being sent to third-party platforms for targeted
+                            marketing or advertising purposes by sending an email to{' '}
+                            <a href="mailto:Brian@GetPostHog.com">Brian@GetPostHog.com</a>.
                         </p>
-                        <p>
-                            Examples of the service providers and partners we currently use include:
-                        </p>
-                        <ul>
+                        <p>Examples of the service providers and partners we currently use include:</p>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>Amazon Web Services (AWS) - cloud data hosting</li>
                             <li>Clay - marketing data engine</li>
-                            <li>GitHub - open source repositories and internal project management tool</li>
+                            <li>GitHub - open-source repositories and internal project management tool</li>
                             <li>Google Cloud Platform - cloud data infrastructure</li>
                             <li>Google Workspace - internal collaboration tools</li>
                             <li>Salesforce - customer relationship management</li>
@@ -669,36 +767,38 @@ function Privacy() {
                             <li>Zendesk - customer support tool</li>
                         </ul>
                         <p>
-                          <strong>This list is meant to be representative and not exhaustive</strong>. We may engage additional or different service providers and partners over time as we see fit to support our business needs. 
-                            Our service providers and partners are required by contract to safeguard any personal
-                            information they receive from us and are prohibited from using the personal information for
-                            any purpose other than to perform the services as instructed by PostHog.
+                            <strong>This list is meant to be representative and not exhaustive</strong>. We may engage
+                            additional or different service providers and partners over time as we see fit to support
+                            our business needs. Our service providers and partners are required by contract to safeguard
+                            any personal information they receive from us and are prohibited from using the personal
+                            information for any purpose other than to perform the services as instructed by PostHog.
                         </p>
                     </div>
                     <div>
                         <p>
-                            Here is a list of examples of the types of companies we use to manage and support our business. This applies to your personal data, not the data of
-                            your users.
+                            Here is a list of examples of the types of companies we use to manage and support our
+                            business. This applies to your personal data, not the data of your users.
                         </p>
                     </div>
 
                     <div>
                         <p>
-                            <strong>Subsidiaries and Affiliates.</strong> PostHog is a global business, headquartered in the United
-                            States. Your personal information collected by us in accordance with this Privacy Policy is
-                            used and shared by PostHog with our subsidiaries and affiliates, including our subsidiaries based in the UK (Hiberly Ltd) and in Germany (PostHog GmbH) for
-                            the purposes of providing the Websites, delivering our Products and services, managing your
-                            accounts, hosting, IT, security, support, billing, marketing, advertising and communications.
+                            <strong>Subsidiaries and Affiliates.</strong> PostHog is a global business, headquartered in
+                            the United States. Your personal information collected by us in accordance with this Privacy
+                            Policy is used and shared by PostHog with our subsidiaries and affiliates, including our
+                            subsidiaries based in the UK (Hiberly Ltd) and in Germany (PostHog GmbH) for the purposes of
+                            providing the Websites, delivering our Products and services, managing your accounts,
+                            hosting, IT, security, support, billing, marketing, advertising and communications.
                         </p>
                     </div>
                     <div>
                         <p>PostHog is a US business, but we also have both a UK and German company.</p>
                     </div>
 
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             <strong>Legal Requirements.</strong> We may disclose personal information to government
-                            authorities or other third-parties if required to do so by law or in the good faith belief
+                            authorities or other third parties if required to do so by law or in the good faith belief
                             that such action is necessary to: (a) comply with a subpoena, court order or similar legal
                             obligation, (b) protect and defend our rights or property, (c) act in urgent circumstances
                             to protect the personal safety of users of any Website or the public, (d) protect against
@@ -714,13 +814,14 @@ function Privacy() {
                             unauthorized access, use, alteration, or destruction.
                         </p>
                         <p>
-                            PostHog at its sole discretion may make use of company logos where those companies are using
-                            the software that we provide. If you have concerns over the use of your logo, please email
-                            logos@posthog.com.
+                            PostHog may use the name and logo of companies using our products or services for
+                            promotional and marketing purposes, unless otherwise agreed to in writing. If you would like
+                            to opt out of or restrict such use, please email{' '}
+                            <a href="mailto:logos@posthog.com">logos@posthog.com</a>.
                         </p>
                     </div>
                     <div>
-                        <p>We will disclose information to government authorities if we’re legally obliged to do so.</p>
+                        <p>We will disclose information to government authorities if we're legally obliged to do so.</p>
                     </div>
 
                     <div>
@@ -734,37 +835,42 @@ function Privacy() {
                             The Websites are hosted in the United States, or in Germany if you are a PostHog Cloud
                             customer who has selected EU hosting, and the personal information we collect about our
                             customers' users will be stored and processed on our servers in either the United States or
-                            Germany. Information about our customers is processed in the United States by us, and may
-                            be processed elsewhere by the service providers and partners that we use to manage and support our business. Our service providers, employees, contractors and
-                            affiliated organizations that process information for us as described above may be located
-                            in the United States or in other countries outside of your home country which may have
-                            different data protection standards to those which apply in your home country.
+                            Germany. Information about our customers is processed in the United States by us, and may be
+                            processed elsewhere by the service providers and partners that we use to manage and support
+                            our business. Our service providers, employees, contractors and affiliated organizations
+                            that process information for us as described above may be located in the United States or in
+                            other countries outside of your home country which may have different data protection
+                            standards to those which apply in your home country.
                         </p>
                         <p>
                             Where your personal information is transferred outside of the EEA, Switzerland and UK and
                             where this is to a country which is not subject to an adequacy decision by the EU Commission
                             or considered adequate as determined by applicable data protection laws, we will take steps
                             to ensure your personal information is adequately protected by safeguards such as Standard
-                            Contractual Clauses approved by the EU Commission or by the UK Government ("<b>SCCs</b>"). A copy
-                            of the relevant mechanism can be obtained for your review on request by using the contact
-                            details in the ‘Contacting PostHog About Your Privacy’ section of this Privacy Policy.
+                            Contractual Clauses approved by the EU Commission or by the UK Government ("<b>SCCs</b>"). A
+                            copy of the relevant mechanism can be obtained for your review on request by using the
+                            contact details in the "
+                            <Link href="#contact-us" className="font-normal underline">
+                                Contacting PostHog about your privacy
+                            </Link>
+                            " Section of this Privacy Policy.
                         </p>
                         <p>
-                            Posthog complies with the EU-U.S. Data Privacy Framework ("<b>EU-U.S. DPF</b>"), the UK Extension
-                            to the EU-U.S. Data Privacy Framework ("<b>UK Extension to the EU-U.S. DPF</b>"), and the
-                            Swiss-U.S. Data Privacy Framework ("<b>Swiss-U.S. DPF</b>") as set forth by the U.S. Department of
-                            Commerce. Posthog has certified to the U.S. Department of Commerce that it adheres to the
-                            EU-U.S. DPF Principles with regard to the processing of personal data received from the
-                            European Union in reliance on the EU-U.S. DPF and that it adheres to the UK Extension to the
-                            EU-U.S. DPF Principles with regard to the processing of personal data received from the
-                            United Kingdom (and Gibraltar) in reliance on the UK Extension to the EU-U.S. DPF. Posthog
-                            has certified to the U.S. Department of Commerce that it adheres to the Swiss-U.S. DPF
-                            Principles with regard to the processing of personal data received from Switzerland in
-                            reliance on the Swiss-U.S. DPF. If there is any conflict between the terms in this privacy
-                            policy and the EU-U.S. DPF Principles, the UK Extension to the EU-U.S. DPF Principles,
-                            and/or the Swiss-U.S. DPF Principles (together, the "<b>DPF Principles</b>"), the DPF Principles
-                            shall govern. To learn more about the Data Privacy Framework ("<b>DPF</b>") program, and to view
-                            our certification, please visit&nbsp;
+                            PostHog complies with the EU-U.S. Data Privacy Framework ("<b>EU-U.S. DPF</b>"), the UK
+                            Extension to the EU-U.S. Data Privacy Framework ("<b>UK Extension to the EU-U.S. DPF</b>"),
+                            and the Swiss-U.S. Data Privacy Framework ("<b>Swiss-U.S. DPF</b>") as set forth by the U.S.
+                            Department of Commerce. PostHog has certified to the U.S. Department of Commerce that it
+                            adheres to the EU-U.S. DPF Principles with regard to the processing of personal data
+                            received from the European Union in reliance on the EU-U.S. DPF and that it adheres to the
+                            UK Extension to the EU-U.S. DPF Principles with regard to the processing of personal data
+                            received from the United Kingdom (and Gibraltar) in reliance on the UK Extension to the
+                            EU-U.S. DPF. PostHog has certified to the U.S. Department of Commerce that it adheres to the
+                            Swiss-U.S. DPF Principles with regard to the processing of personal data received from
+                            Switzerland in reliance on the Swiss-U.S. DPF. If there is any conflict between the terms in
+                            this privacy policy and the EU-U.S. DPF Principles, the UK Extension to the EU-U.S. DPF
+                            Principles, and/or the Swiss-U.S. DPF Principles (together, the "<b>DPF Principles</b>"),
+                            the DPF Principles shall govern. To learn more about the Data Privacy Framework ("<b>DPF</b>
+                            ") program, and to view our certification, please visit&nbsp;
                             <Link href="https://www.dataprivacyframework.gov/" externalNoIcon>
                                 <u>https://www.dataprivacyframework.gov/</u>
                             </Link>
@@ -772,16 +878,16 @@ function Privacy() {
                         </p>
                         <p>
                             In compliance with the EU-U.S. DPF, the UK Extension to the EU-U.S. DPF, and the Swiss-U.S.
-                            DPF. PostHog Inc commits to cooperate and comply with the advice of the panel established by
-                            the EU data protection authorities (DPAs), the UK Information Commissioner’s Office (ICO),
-                            and the Swiss Federal Data Protection and Information Commissioner (FDPIC) with regard to
-                            unresolved complaints concerning our handling of human resources data received in reliance
-                            on the EU-U.S. DPF, the UK Extension to the EU-U.S. DPF, and the Swiss-U.S. DPF in the
-                            context of the employment relationship.
+                            DPF. PostHog Inc. commits to cooperate and comply with the advice of the panel established
+                            by the EU data protection authorities (DPAs), the UK Information Commissioner's Office
+                            (ICO), and the Swiss Federal Data Protection and Information Commissioner (FDPIC) with
+                            regard to unresolved complaints concerning our handling of human resources data received in
+                            reliance on the EU-U.S. DPF, the UK Extension to the EU-U.S. DPF, and the Swiss-U.S. DPF in
+                            the context of the employment relationship.
                         </p>
                         <p>
-                            For the actions of third party agents PostHog engages to process data on our behalf, PostHog
-                            remains responsible and liable under the DPF Principles if a third party agent processes the
+                            For the actions of third-party agents PostHog engages to process data on our behalf, PostHog
+                            remains responsible and liable under the DPF Principles if a third-party agent processes the
                             Personal Data in a manner inconsistent with the DPF Principles, unless PostHog proves that
                             it is not responsible for the event giving rise to the damage.
                         </p>
@@ -798,20 +904,24 @@ function Privacy() {
                     </div>
 
                     <div>
-                        <h3>Disputes</h3>
+                        <h3>
+                            <strong>Disputes</strong>
+                        </h3>
                     </div>
                     <div></div>
                     <div>
                         <p>
                             As part of our commitment to the DPF Principles, if you are a resident of the European
                             Union, UK, or Switzerland and you have a privacy or data use concern, please contact PostHog
-                            directly at privacy@posthog.com and PostHog will use its best efforts to address your
-                            concern within 45 days of receipt of your complaint. For an unresolved privacy or data use
-                            concern that PostHog has not addressed satisfactorily, please contact our U.S. based third
-                            party dispute resolution provider (free of charge) at&nbsp;
+                            directly at <a href="mailto:privacy@posthog.com">privacy@posthog.com</a> and PostHog will
+                            use its best efforts to address your concern within 45 days of receipt of your complaint.
+                            For an unresolved privacy or data use concern that PostHog has not addressed satisfactorily,
+                            please contact our U.S. based third party dispute resolution provider (free of charge)
+                            at&nbsp;
                             <Link href="https://www.jamsadr.com/dpf-dispute-resolution" externalNoIcon>
                                 <u>https://www.jamsadr.com/dpf-dispute-resolution</u>
                             </Link>
+                            .
                         </p>
                         <p>
                             For any DPF disputes that cannot be resolved by the methods above, you may be able to invoke
@@ -825,12 +935,12 @@ function Privacy() {
                                     https://www.dataprivacyframework.gov/s/article/Participation-Requirements-Data-Privacy-Framework-DPF-Principles-dpf
                                 </u>
                             </Link>
-                            . The Federal Trade Commission has investigation and enforcement authority over PostHog’s
+                            . The Federal Trade Commission has investigation and enforcement authority over PostHog's
                             compliance with EU-U.S. DPF, the UK Extension to the EU-U.S. DPF, and the Swiss-U.S. DPF.
                         </p>
                     </div>
                     <div>
-                        <p>If you dispute anything we’ve done, you can use the links provided to resolve this. </p>
+                        <p>If you dispute anything we've done, you can use the links provided to resolve this.</p>
                     </div>
 
                     <div>
@@ -839,7 +949,7 @@ function Privacy() {
                         </h3>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             If you are a registered user of the Websites and have supplied your email address, PostHog
                             may occasionally send you an email to tell you about security, system information, new
@@ -858,7 +968,7 @@ function Privacy() {
                     </div>
                     <div>
                         <p>
-                            PostHog will contact you, mainly over email, from time to time. We promise we won’t spam
+                            PostHog will contact you, mainly over email, from time to time. We promise we won't spam
                             you, but you can unsubscribe whenever you like.
                         </p>
                     </div>
@@ -884,7 +994,7 @@ function Privacy() {
                     </div>
                     <div>
                         <p>
-                            To remember you, our system will give you a cookie. It's safe. We’re very careful to only
+                            To remember you, our system will give you a cookie. It's safe. We're very careful to only
                             have first-party cookies on our site, including when we embed content from other websites,
                             such as YouTube.
                         </p>
@@ -902,8 +1012,8 @@ function Privacy() {
                     <div>
                         <p>
                             We hope this part is pretty clear. However, thanks for actually reading our Privacy Policy,
-                            as a reward we’d love to send you a free toilet roll with our Privacy Policy printed on it,
-                            send us an email to tpsandcs@posthog.com.
+                            as a reward we'd love to send you a free toilet roll with our Privacy Policy printed on it,
+                            send us an email to <a href="mailto:tpsandcs@posthog.com">tpsandcs@posthog.com</a>.
                         </p>
                     </div>
 
@@ -913,22 +1023,22 @@ function Privacy() {
                         </h3>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             "Do Not Track" is a privacy preference you can set in your browser if you do not want online
                             services to collect and share certain kinds of information about your online activity from
-                            third party tracking services. PostHog does not track your online browsing activity on other
+                            third-party tracking services. PostHog does not track your online browsing activity on other
                             online services over time and we do not permit third-party services to track your activity
-                            on our site. Because we do not share this kind of data with third party services or permit
-                            this kind of third party data collection for any of our users, and we do not track our users
+                            on our site. Because we do not share this kind of data with third-party services or permit
+                            this kind of third-party data collection for any of our users, and we do not track our users
                             on third-party websites ourselves, we do not need to respond differently to an individual
                             browser's Do Not Track setting.
                         </p>
                     </div>
                     <div>
                         <p>
-                            Because PostHog doesn’t use third-party tracking services, we don’t need to do anything
-                            different when it comes to ‘Do Not Track’ settings on an individual's browser.
+                            Because PostHog doesn't use third-party tracking services, we don't need to do anything
+                            different when it comes to 'Do Not Track' settings on an individual's browser.
                         </p>
                     </div>
 
@@ -938,14 +1048,14 @@ function Privacy() {
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             Information we collect may be stored and processed in the United States in accordance with
                             this Privacy Policy but we understand that users from other countries may have different
                             expectations and rights with regard to their privacy. For all Website visitors and
                             customers, no matter their country of location, we will:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 provide clear methods of unambiguous, informed consent when we do collect your personal
                                 information and where required by applicable law;
@@ -971,7 +1081,7 @@ function Privacy() {
                             personal information of individuals located in the EEA, Switzerland or the UK, you are
                             entitled to the following rights with regards to your personal information:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 Right of access to your personal information, to know what information we hold about
                                 you.
@@ -987,7 +1097,7 @@ function Privacy() {
                             </li>
                         </ul>
                         <p>Additional rights that may apply to you in certain instances:</p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 Right of data portability (if our processing is based on consent or a contract and the
                                 processing carried out by automated means);
@@ -1018,14 +1128,17 @@ function Privacy() {
                             where the information is needed for those purposes.
                         </p>
                         <p>
-                            To exercise your privacy rights, you can email us at the address given below in the
-                            ‘Contacting PostHog About Your Privacy’ section of this Privacy Policy.
+                            To exercise your privacy rights, you can email us at the address given below in the "
+                            <Link href="#contact-us" className="font-normal underline">
+                                Contacting PostHog about your privacy
+                            </Link>
+                            " Section of this Privacy Policy.
                         </p>
                     </div>
                     <div>
                         <p>
-                            PostHog is a US company, with UK and German subsidiaries, however our users are based all over the
-                            world and you still hold lots of rights that we respect.{' '}
+                            PostHog is a US company, with UK and German subsidiaries, however our users are based all
+                            over the world and you still hold lots of rights that we respect.
                         </p>
                     </div>
 
@@ -1035,7 +1148,7 @@ function Privacy() {
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             If you already have an account on the Websites, you may access, update, alter, or delete
                             your basic customer profile information by logging into your account and updating profile
@@ -1053,16 +1166,20 @@ function Privacy() {
                             maintain our commercial relationships and how recent our interactions are with you. We may
                             rectify, update or remove incomplete or inaccurate information, at any time and at our own
                             discretion. For more information on our retention periods you can contact us using the
-                            details in the “Contacting PostHog About Your Privacy” section of this Privacy Policy.
+                            details in the "
+                            <Link href="#contact-us" className="font-normal underline">
+                                Contacting PostHog about your privacy
+                            </Link>
+                            " Section of this Privacy Policy.
                         </p>
                         <p>
-                            Please note that due to the open source nature of our products, services, and community, we
+                            Please note that due to the open-source nature of our products, services, and community, we
                             may retain limited personal information indefinitely in order to ensure transactional
                             integrity and nonrepudiation. For example, if you provide your information in connection
                             with a blog post, GitHub issue or comment, we may display that information even if you have
                             deleted your account as we do not automatically delete community posts. Also, as described
-                            in our <Link href="/terms">Terms of Use</Link>, if you contribute to a PostHog project and
-                            provide your personal information in connection with that contribution, that information
+                            in our <Link href="/terms">Terms of Service</Link>, if you contribute to a PostHog project
+                            and provide your personal information in connection with that contribution, that information
                             (including your name) will be embedded and publicly displayed with your contribution and we
                             will not be able to delete or erase it because doing so would break the project code.
                         </p>
@@ -1070,7 +1187,7 @@ function Privacy() {
                     <div>
                         <p>
                             PostHog will keep your information as long as you have an active account, but you can delete
-                            this at any time by logging in and updating your profile settings.{' '}
+                            this at any time by logging in and updating your profile settings.
                         </p>
 
                         <p>
@@ -1085,15 +1202,16 @@ function Privacy() {
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <h3>Introduction</h3>
                         <p>
-                            This Addendum (“<b>Addendum</b>”) forms part of the Privacy Policy, and of any superseding written
-                            agreement, entered by and between you, the Customer (as defined in the Agreement)
-                            (“<b>Customer</b>”), and PostHog Inc. (“<b>PostHog</b>”; and collectively – the “<b>Agreement</b>”).
+                            This Addendum (“<b>Addendum</b>”) forms part of the Privacy Policy, and of any superseding
+                            written agreement, entered by and between you, the Customer (as defined in the Agreement) (“
+                            <b>Customer</b>”), and PostHog Inc. (“<b>PostHog</b>”; and collectively – the “
+                            <b>Agreement</b>”).
                         </p>
                         <p>
-                            This Addendum reflects the parties’ desire and intent to modify and amend the Agreement, in
+                            This Addendum reflects the parties' desire and intent to modify and amend the Agreement, in
                             accordance with the terms and conditions hereinafter set forth, with regard to the
                             processing of Customer Personal Information (as defined below) by PostHog on behalf of the
                             Customer.
@@ -1113,40 +1231,34 @@ function Privacy() {
                             Personal Information under the Agreement (“<b>Addendum Effective Date</b>”).
                         </p>
                         <p>
-                            If you need a signed copy of this Addendum you can download a{' '}
-                            <Link
-                                href="https://docs.google.com/document/d/17VawApHNJzXNkxYiDidw7UTQBJr347FfL6nVDxEYgsg/edit?usp=sharing"
-                                external
-                            >
-                                template
-                            </Link>
-                            , enter your details, send a request to{' '}
+                            If you need a signed copy of this Addendum, please send a request to{' '}
                             <a rel="noopener noreferrer" href="mailto:privacy@posthog.com">
                                 privacy@posthog.com
-                            </a>{' '}
-                            and we’ll provide you a countersigned copy.
+                            </a>
+                            .
                         </p>
                         <h3>Definitions</h3>
                         <p>
-                            “<strong>CCPA</strong>” means the California Consumer Privacy Act of 2018, Cal. Civ. Code
-                            §1798.100 et. seq., and its implementing regulations.{' '}
+                            “<b>CCPA</b>” means the California Consumer Privacy Act of 2018, Cal. Civ. Code §1798.100
+                            et. seq., and its implementing regulations.
                         </p>
                         <p>
-                            “<strong>Customer Personal Information</strong>” means any Customer Data maintained by
-                            Customer and processed by PostHog solely on Customer’s behalf, that identifies, relates to,
-                            describes, is capable of being associated with, or could reasonably be linked, directly or
-                            indirectly, with a particular consumer or household, to the extent that such information is
-                            protected as “personal information” (or an analogous variation of such term) under
-                            applicable U.S. Data Protection Laws.{' '}
+                            “<b>Customer Personal Information</b>” means any Customer Data maintained by Customer and
+                            processed by PostHog solely on Customer's behalf, that identifies, relates to, describes, is
+                            capable of being associated with, or could reasonably be linked, directly or indirectly,
+                            with a particular consumer or household, to the extent that such information is protected as
+                            “personal information” (or an analogous variation of such term) under applicable U.S. Data
+                            Protection Laws. For the avoidance of doubt, de-identified or aggregated data that cannot
+                            reasonably be used to identify any individual does not constitute Customer Personal
+                            Information.
                         </p>
                         <p>
-                            “<strong>U.S. Data Protection Laws</strong>” means all laws and regulations of the United
-                            States of America, including the CCPA, applicable to the processing of personal information
-                            (or an analogous variation of such term).
+                            “<b>U.S. Data Protection Laws</b>” means all laws and regulations of the United States of
+                            America, including the CCPA, applicable to the processing of personal information (or an
+                            analogous variation of such term).
                         </p>
                         <p>
-                            “<strong>Service Provider</strong>” has the meaning set forth in Section 1798.140(v) of the
-                            CCPA.
+                            “<b>Service Provider</b>” has the meaning set forth in Section 1798.140(v) of the CCPA.
                         </p>
                         <h3>Amendments</h3>
                         <h4>Roles</h4>
@@ -1221,7 +1333,7 @@ function Privacy() {
                         </p>
                         <p>
                             We use{' '}
-                            <Link href="https://www.ashbyhq.com/" external>
+                            <Link href="https://www.ashbyhq.com/" externalNoIcon>
                                 Ashby
                             </Link>
                             , an online application provided by Ashby Inc., to assist with our recruitment process. We
@@ -1232,17 +1344,17 @@ function Privacy() {
                             Where you apply for a job opening posted by us, these provisions will apply to our
                             processing of your personal information. When you apply for a job opening via the
                             application function on a job site like LinkedIn or similar online service provider
-                            (referred to below as a “<b>Partner</b>”), you should note that the relevant Partner may retain
-                            your personal data and may also collect data from us in respect of the progress of your
-                            application. Any use by the Partner of your data will be in accordance with the Partner’s
-                            privacy policy.
+                            (referred to below as a “<b>Partner</b>”), you should note that the relevant Partner may
+                            retain your personal data and may also collect data from us in respect of the progress of
+                            your application. Any use by the Partner of your data will be in accordance with the
+                            Partner's privacy policy.
                         </p>
                         <h3 id="information-we-collect-from-applicants">Information we collect from applicants</h3>
                         <h4 id="information-we-collect-from-you">Information we collect from you</h4>
                         <p className="">
                             We collect and process some or all of the following types of information from you:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 Information you provide when you apply for a role, including contact details such as
                                 name, email address, physical address, telephone number
@@ -1254,15 +1366,15 @@ function Privacy() {
                             <li>If you contact us, we may keep a record of that correspondence</li>
                             <li>A record of your progress through any hiring process that we may conduct</li>
                             <li>
-                                Details of your visits to Ashby’s Website including, but not limited to, traffic data,
+                                Details of your visits to Ashby's Website including, but not limited to, traffic data,
                                 location data, weblogs and other communication data, the site that referred you to
-                                Ashby’s Website and the resources that you access.
+                                Ashby's Website and the resources that you access.
                             </li>
                         </ul>
                         <h4 id="information-we-collect-from-other-sources">
                             Information we collect from other sources
                         </h4>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 Ashby provides PostHog with the ability to link the data you provide to us, with other
                                 publicly available information about you that you have published online, such as on
@@ -1294,34 +1406,34 @@ function Privacy() {
                         <p className="">
                             We <em>only</em> collect and use your personal information for the following purposes:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>
                                 To communicate with you about the role you have applied for and to manage the
                                 recruitment process
                             </li>
                             <li>To consider your application for potential future job opportunities</li>
                         </ul>
-                        <p>We will never use a candidate's personal information for marketing purposes. </p>
+                        <p>We will never use a candidate's personal information for marketing purposes.</p>
                         <h3 id="lawful-basis-and-purposes-for-processing-applicant-personal-information">
                             Lawful basis and purposes for processing applicant personal information
                         </h3>
                         <p>
-                            If you are a national of countries in the EEA, United Kingdom, or
-                            Switzerland, we collect and process your personal information on the following legal bases
-                            set out by applicable law:
+                            If you are a national of countries in the EEA, United Kingdom, or Switzerland, we collect
+                            and process your personal information on the following legal bases set out by applicable
+                            law:
                         </p>
                         <p>
-                            <strong>Consent:</strong> We may ask you for your consent to process your personal
+                            <strong>Consent</strong>: We may ask you for your consent to process your personal
                             information. You can withdraw your consent at any time, which will not affect the lawfulness
                             of the processing before your consent was withdrawn.
                         </p>
                         <p>
-                            <strong>Legitimate Interest:</strong> We process certain personal information for our
+                            <strong>Legitimate interest</strong>: We process certain personal information for our
                             legitimate interests. These legitimate interests include, for example, running our
                             recruitment process and managing applicants.
                         </p>
                         <p>
-                            <strong>Compliance with Legal Obligations</strong>: In some cases, we may have a legal
+                            <strong>Compliance with legal obligations</strong>: In some cases, we may have a legal
                             obligation to process your personal information, such as to meet our legal requirements or
                             in response to a court or regulatory order. We also may need to process your personal
                             information to protect vital interests, or to exercise, establish, or defend legal claims.
@@ -1339,25 +1451,24 @@ function Privacy() {
                         </h3>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             Your personal information may be processed in the United States, the country where you have
                             applied for a job, or any other country where PostHog has team members or operations.
                         </p>
                         <p>
                             PostHog may transfer, store, or process your personal information in a country outside your
-                            jurisdiction, including countries outside the EEA, Switzerland,
-                            and the United Kingdom. If we transfer personal information from the EEA, Switzerland, or
-                            United Kingdom to a country outside it, such as the United States, we will enter into SCCs, 
-                            with the data importer, or take other measures to provide an adequate level of data
-                            protection.
+                            jurisdiction, including countries outside the EEA, Switzerland, and the United Kingdom. If
+                            we transfer personal information from the EEA, Switzerland, or United Kingdom to a country
+                            outside it, such as the United States, we will enter into SCCs with the data importer, or
+                            take other measures to provide an adequate level of data protection.
                         </p>
                         <h3 id="how-long-we-keep-applicant-personal-data">How long we keep applicant personal data</h3>
                         <p>
                             We will hold all the data for 24 months. Prior to that, your personal information will be
                             deleted if:
                         </p>
-                        <ul>
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
                             <li>You delete your personal information; or</li>
                             <li>You write to us asking us to delete your personal information.</li>
                         </ul>
@@ -1392,7 +1503,7 @@ function Privacy() {
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             If you need to enter into a Data Processing Agreement with us, the version you need will
                             depend on whether you have signed up for PostHog Cloud in the US or EU. Please visit our{' '}
@@ -1413,7 +1524,7 @@ function Privacy() {
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             You can{' '}
                             <Link href="/handbook/company/security">view our complete set of security measures</Link>{' '}
@@ -1430,10 +1541,10 @@ function Privacy() {
                         </h2>
                     </div>
                     <div></div>
-                    <div className="md:pb-12">
+                    <div>
                         <p>
                             The relevant data controller for any personal information processed in connection with our
-                            Websites or self-managed installations is PostHog Inc, 2261 Market Street #4008, San
+                            Websites or self-managed installations is PostHog Inc., 2261 Market Street #4008, San
                             Francisco, CA 94114. If you apply for a job with us, the relevant data controller is the
                             country-specific PostHog entity which will be your employer.
                         </p>
@@ -1461,7 +1572,9 @@ function Privacy() {
                         </p>
 
                         <p>
-                            If you would like to opt out of your personal information being sent to third party platforms for marketing or advertising purposes, please reach out to <a href="mailto:Brian@GetPostHog.com">Brian@GetPostHog.com</a>.
+                            If you would like to opt out of your personal information being sent to third-party
+                            platforms for marketing or advertising purposes, please reach out to{' '}
+                            <a href="mailto:Brian@GetPostHog.com">Brian@GetPostHog.com</a>.
                         </p>
 
                         <p>
@@ -1472,15 +1585,19 @@ function Privacy() {
                     <div>
                         <p>
                             If you have questions or concerns about your privacy or want to file a complaint, email us
-                            at privacy@posthog.com.
+                            at <a href="mailto:privacy@posthog.com">privacy@posthog.com</a>.
                         </p>
-                        <p>For job applications, email careers@posthog.com.</p>
+                        <p>
+                            For job applications, email <a href="mailto:careers@posthog.com">careers@posthog.com</a>.
+                        </p>
                     </div>
                     <div>
-                        <h3>Privacy policy changes</h3>
+                        <h3>
+                            <strong>Privacy policy changes</strong>
+                        </h3>
                     </div>
-                    <div>&nbsp;</div>
-                    <div className="md:pb-12">
+                    <div></div>
+                    <div>
                         <p>
                             Although most changes are likely to be minor, PostHog may change this Privacy Policy from
                             time to time, and in PostHog's sole discretion.
@@ -1488,22 +1605,22 @@ function Privacy() {
 
                         <p>
                             We may also provide notification to customers who have provided us email addresses of
-                            material changes to this Privacy Policy by sending an email or by displaying a notice through our Websites or products, or otherwise. PostHog encourages visitors to
-                            frequently check this page for any minor changes to its Privacy Policy. Your continued use
-                            of this site, any of the Websites, self-managed installations, deployments, or other PostHog products after any change in this Privacy Policy will constitute your acceptance of such
+                            material changes to this Privacy Policy by sending an email or by displaying a notice
+                            through our Websites or products, or otherwise. PostHog encourages visitors to frequently
+                            check this page for any minor changes to its Privacy Policy. Your continued use of this
+                            site, any of the Websites, self-managed installations, deployments, or other PostHog
+                            products after any change in this Privacy Policy will constitute your acceptance of such
                             change and acknowledgement of the updated Policy.
-                        </p>
-                        <p>
-                            Last Updated: January 19, 2026
                         </p>
                     </div>
                     <div>
                         <p>
-                            We might change our privacy policy, so check our website often. Your use of our site or products means
-                            you accept any changes.
+                            We might change our privacy policy, so check our website often. Your use of our site or
+                            products means you accept any changes.
                         </p>
                     </div>
                 </div>
+                <p className="text-center text-sm opacity-60 mt-8 pb-12">Last Updated: June 29, 2026</p>
             </div>
         </Layout>
     )

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -40,6 +40,7 @@ const termsClasses = cntl`
   @2xl:[&>div:nth-child(even)>ul]:border-l-0
   [&>div:nth-child(even)>ul]:border-primary
   [&>div:nth-child(even)>ul]:pl-3
+  [&>div>h2]:mt-2
   [&>div:nth-child(even)_li]:ml-4
   @2xl:[&>div:nth-child(even)]:border-l
   [&>div:nth-child(odd)]:pr-8
@@ -49,6 +50,67 @@ const termsClasses = cntl`
   [&>div:nth-child(odd)_p]:text-[15px]
   [&>div:nth-child(even)>p]:text-lg
 `
+
+const sectionAnchors: Record<string, string> = {
+    '1': 'license',
+    '1.1': 'section-1-1',
+    '1.2': 'license',
+    '2': 'restrictions',
+    '2.1': 'section-2-1',
+    '2.2': 'restrictions',
+    '2.3': 'restrictions',
+    '3': 'confidentiality',
+    '3.1': 'confidentiality',
+    '3.2': 'section-3-2',
+    '3.3': 'confidentiality',
+    '3.4': 'confidentiality',
+    '3.5': 'confidentiality',
+    '3.6': 'confidentiality',
+    '4': 'ip',
+    '4.1': 'ip',
+    '4.2': 'ip',
+    '4.3': 'ip',
+    '4.4': 'section-4-4',
+    '4.5': 'section-4-5',
+    '5': 'models',
+    '5.1': 'models',
+    '5.2': 'models',
+    '6': 'payment',
+    '6.1': 'payment',
+    '6.2': 'section-6-2',
+    '6.3': 'section-6-3',
+    '6.4': 'payment',
+    '7': 'termination',
+    '7.1': 'section-7-1',
+    '7.2': 'section-7-2',
+    '7.3': 'termination',
+    '7.4': 'termination',
+    '8': 'warranty',
+    '9': 'disclaimer',
+    '10': 'liability',
+    '11': 'government',
+    '12': 'misc',
+    '13': 'privacy',
+    '14': 'sla',
+}
+
+function SectionLink({ section, label }: { section: string; label?: string }) {
+    const anchor = sectionAnchors[section]
+    const display = label ?? `Section ${section}`
+    if (!anchor) return <>{display}</>
+    return (
+        <a
+            href={`#${anchor}`}
+            className="underline underline-offset-2 font-normal cursor-pointer hover:opacity-70"
+            onClick={(e) => {
+                e.preventDefault()
+                document.querySelector(`#${anchor}`)?.scrollIntoView({ behavior: 'smooth' })
+            }}
+        >
+            {display}
+        </a>
+    )
+}
 
 function Terms() {
     const [headers, setHeaders] = useState<HTMLElement[]>([])
@@ -252,7 +314,7 @@ function Terms() {
                 <div className={`${termsClasses}`}>
                     <div>
                         <h2 id="intro" className="mb-1 text-4xl">
-                            The full terms
+                            The full Terms of Service
                         </h2>
                         <p className="text-sm opacity-75 md:hidden">
                             (with handy summaries at the end of each section)
@@ -263,32 +325,53 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            These terms apply to any Customer on PostHog Cloud. Separate terms for users of PostHog FOSS
-                            can be found here:&nbsp;
+                            These PostHog Terms of Service (the "<b>Terms of Service</b>", "<b>Terms</b>" or "
+                            <b>Agreement</b>") apply to any Customer (as defined below) accessing or using PostHog
+                            cloud-based software, products or services ("<b>PostHog Cloud</b>"). Separate terms for
+                            users of PostHog Free and Open Source Software ("<b>PostHog FOSS</b>") can be found
+                            here:&nbsp;
                             <Link href="https://github.com/PostHog/posthog-foss/blob/master/LICENSE" externalNoIcon>
                                 https://github.com/PostHog/posthog-foss/blob/master/LICENSE
                             </Link>
+                            .
                         </p>
                         <p>
-                            By signing up to PostHog Cloud, you and any entity that you represent ("Customer") are
-                            unconditionally consenting to be bound by and are becoming a party to these PostHog
-                            Subscription Terms ("Agreement") as of the date of Customer's first download of the licensed
-                            materials (the "effective date").&nbsp;
+                            By signing up to, creating an account, using or otherwise accessing PostHog Cloud, you and
+                            any entity that you represent ("<b>Customer</b>", "<b>you</b>" or "<b>your</b>") are
+                            unconditionally consenting to be bound by and are becoming a party to these Terms of Service
+                            as of the date of your first signup, account creation, use, download or other acceptance
+                            (the "<b>Effective Date</b>") of the Licensed Materials (as defined below) provided by
+                            PostHog Inc. or one of its Affiliates (collectively, "<b>PostHog</b>", "<b>us</b>", "
+                            <b>we</b>" or "<b>our</b>"), on a free or pay-as-you-go basis, or in accordance with and
+                            pursuant to one or more order forms, quotes or other ordering documents referencing these
+                            Terms (each an "<b>Order Form</b>").&nbsp;
                         </p>
                         <p>
-                            Customer's continued use of the software or any licensed materials provided by PostHog,
-                            Inc., trading as PostHog ("PostHog") (or one of its affiliates and/or subsidiaries, as
-                            specified on an order form or quote), shall also constitute assent to the terms of this
-                            agreement.&nbsp;
+                            These Terms may be updated from time to time at our discretion. Subject to the terms herein,
+                            Customer’s use or continued use of the Licensed Materials also constitutes Customer’s
+                            ongoing and continued assent to the terms of this Agreement. If you do not accept this
+                            Agreement, and/or any related modifications or new terms as may be updated from time to
+                            time, please refrain from accessing or using PostHog Cloud or the Licensed Materials.&nbsp;
                         </p>
                         <p>
-                            If these terms are considered an offer, acceptance is expressly limited to these terms. If
-                            you are executing this agreement on behalf of an organization, you represent that you have
-                            authority to do so.
+                            If these Terms are considered an offer, acceptance is expressly limited to these Terms. If
+                            you are executing, entering into or otherwise accepting the terms of this Agreement on
+                            behalf of a company, organization, or other legal entity (each, an "<b>Entity</b>"), you
+                            hereby represent that you have full legal authority to bind that Entity to this Agreement
+                            and all references to "you" and "your" and related language in these Terms will refer to
+                            that Entity, unless we indicate otherwise.
                         </p>
                     </div>
                     <div>
-                        <p className="mb-2">By signing into PostHog, you agree to all these terms.</p>
+                        <p className="mb-2">
+                            By signing into or using PostHog, you agree to all these terms. That includes anyone signing
+                            up on behalf of a company - so if you're doing this for your employer, make sure you
+                            actually have the authority to do that.
+                        </p>
+                        <p>
+                            We may update these terms occasionally. If you keep using PostHog after an update, that
+                            counts as agreeing to the new version.
+                        </p>
                         <p className="!text-base text-opacity-80">
                             {' '}
                             (See our&nbsp;
@@ -300,32 +383,36 @@ function Terms() {
                     </div>
                     <div>
                         <h2 id="license">1. License and support</h2>
-                        <p>
-                            1.1 Subject to the terms and conditions of this Agreement, PostHog hereby grants to Customer
-                            and its Affiliates (as defined below) a limited, non-exclusive, non-transferable,
-                            non-sublicensable license for Customer’s and its Affiliates’ employees and contractors to
-                            (1) internally (a) use, reproduce, modify, prepare derivative works based upon, and display
-                            the code of PostHog Cloud at the tier level selected by Customer (or set forth on a Quote
-                            (as defined below), if applicable with the specifications generally promulgated by PostHog
-                            from time to time (the “Software”), solely (i) for its internal use in connection with the
-                            development of Customer’s and/or its Affiliates’ own software, and (ii) at the level of
-                            usage for which Customer has paid PostHog; and (b) use the documentation, training materials
-                            or other materials supplied by PostHog (the “Other PostHog Materials”); and (2) modify the
-                            Software and publish patches to the Software, solely at the level of usage for which
-                            Customer has paid PostHog. Notwithstanding anything to the contrary, Customer agrees that
-                            PostHog and/or its licensors (as applicable) retain all right, title and interest in and to
-                            all Software incorporated in such modifications and/or patches, and all such Software may
-                            only be used, copied, modified, displayed, distributed, or otherwise exploited in full
-                            compliance with this Agreement, and with a valid PostHog Cloud subscription for the correct
-                            level of usage.&nbsp;
+                        <p id="section-1-1">
+                            1.1 Subject to the terms and conditions of this Agreement (including, any and all payment
+                            obligations), PostHog hereby grants to Customer and its Affiliates (as defined below) a
+                            limited, non-exclusive, non-transferable, non-sublicensable and revocable (as provided
+                            herein) right for Customer, its Affiliates, and their Users (as defined below) to (a)
+                            internally (i) use, reproduce, modify, prepare derivative works based upon, and display the
+                            code of PostHog Cloud at the plan type and/or tier level selected by Customer (or as
+                            specified in an applicable Order Form), in accordance with the specifications and guidance
+                            generally promulgated by PostHog from time to time (the "<b>Software</b>"), solely (x) for
+                            its internal use in connection with the development of Customer’s and/or its Affiliates’ own
+                            software, and (y) at the level of usage for which Customer has paid PostHog; and (ii) use
+                            the documentation, training materials or other materials, products or services supplied or
+                            provided by PostHog (the "<b>Other PostHog Materials</b>"); and (b) modify the Software and
+                            publish patches to the Software, solely at the level of usage for which Customer has paid
+                            PostHog. Notwithstanding anything to the contrary, Customer agrees that PostHog and/or its
+                            licensors (as applicable) shall retain all right, title and interest in and to all Software
+                            incorporated in such modifications and/or patches, and all such Software may only be used,
+                            copied, modified, displayed, distributed, or otherwise exploited in full compliance with
+                            this Agreement, and with a valid PostHog Cloud subscription for the correct level of
+                            usage.&nbsp;
                         </p>
                         <p>
-                            The Software and Other PostHog Materials are collectively referred to herein as the
-                            “Licensed Materials.” “Affiliate” means any entity(ies) controlling, controlled by, and/or
-                            under common control with a party hereto, where “control” means the ownership of more than
-                            50% of the voting securities in such entity. “User” means each individual end-user (person
-                            or machine) of Customer and/or its Affiliates (including, without limitation, employees,
-                            agents or consultants thereof) with access to the Licensed Materials hereunder.
+                            The Software and Other PostHog Materials are collectively referred to herein as the "
+                            <b>Licensed Materials</b>". As used herein, "<b>Affiliate</b>" means any entity that
+                            directly or indirectly controls, is controlled by, and/or is under common control with the
+                            subject entity, where "control" means the ownership or control of more than fifty percent
+                            (50%) of the voting interests in such subject entity. "<b>User</b>" means each individual
+                            end user (person or machine) of Customer and/or its Affiliates (including, without
+                            limitation, employees, agents or consultants thereof) with access to the Licensed Materials
+                            hereunder.
                         </p>
                     </div>
                     <div className="md:pt-10">
@@ -334,7 +421,7 @@ function Terms() {
                             and tutorials to help you.
                         </p>
                         <p>
-                            You can make pull requests on Github to help us make changes, but we own the rights to any
+                            You can make pull requests on GitHub to help us make changes, but we own the rights to any
                             modifications.
                         </p>
                         <p>
@@ -344,17 +431,25 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            1.2 Subject to the terms hereof, PostHog will provide reasonable support to Customer for the
-                            Licensed Materials as set forth on the 'Pricing' page, for the support plan selected and
-                            paid for by Customer.&nbsp;
+                            1.2 Subject to this Agreement, PostHog will provide reasonable support to Customer for the
+                            Licensed Materials as set forth on the 'Support options' page and in accordance with the
+                            plan selected by and paid for by Customer, or as otherwise specified in an applicable Order
+                            Form.&nbsp;
                         </p>
                         <p>
                             Notwithstanding anything to the contrary, in the event that Customer does not reasonably
                             comply with written specifications or instructions from PostHog’s service engineers
-                            regarding any support issue or request (including without limitation, failure to make
-                            backups of Customer’s Licensed Materials) (each, a “Support Issue”), PostHog may terminate
-                            its support obligations to Customer with respect to such Support Issue upon fifteen (15)
-                            days’ written notice if Customer does not cure such noncompliance within the notice period.
+                            regarding any support issue or request (including without limitation, maintaining
+                            appropriate backups of Customer’s Licensed Materials) (each, a "<b>Support Issue</b>"),
+                            PostHog may terminate or suspend its support obligations to Customer with respect to such
+                            Support Issue upon fifteen (15) days’ written notice if Customer does not cure such
+                            noncompliance within such notice period.&nbsp;
+                        </p>
+                        <p>
+                            PostHog will use commercially reasonable efforts to respond to support inquiries submitted
+                            via Slack, email or in-app chat. The number of support questions is not limited, provided
+                            that Customer’s use of support is reasonable and consistent with the intended use of the
+                            support channels.&nbsp;
                         </p>
                     </div>
                     <div>
@@ -363,14 +458,6 @@ function Terms() {
                             We can close a support ticket if you fail to respond to a request from one of our engineers
                             within 15 days.
                         </p>
-                    </div>
-                    <div>
-                        <p>
-                            1.2.1 PostHog will use reasonable commercial efforts to respond to support questions by
-                            Slack, email, or community forums. The number of support questions is not limited.
-                        </p>
-                    </div>
-                    <div>
                         <p>
                             We will aim to answer your questions as fast as we can, using a few different
                             channels.&nbsp;
@@ -378,31 +465,49 @@ function Terms() {
                     </div>
                     <div>
                         <h2 id="restrictions">2. Restrictions and responsibilities</h2>
-                        <p>
-                            2.1 Except as expressly authorized in Section 1.1, Customer will not, and will not permit
-                            any third party to: use the Licensed Materials for any purpose other than as specifically
-                            authorized in Section 1, or in such a manner that would enable any unlicensed person to
-                            access the Licensed Materials; use the Licensed Materials or any other PostHog software for
-                            timesharing or service bureau purposes or for any purpose other than its and its Affiliates’
-                            own internal use (including without limitation, sublicensing, distributing, selling,
-                            reselling any of the foregoing); except as expressly permitted herein; use the Licensed
-                            Materials in connection with any high risk or strict liability activity (including, without
-                            limitation, space travel, firefighting, police operations, power plant operation, military
-                            operations, rescue operations, hospital and medical operations or the like); use the
-                            Licensed Materials or software other than in accordance with this Agreement and in
-                            compliance with all applicable laws and regulations (including but not limited to any
-                            privacy laws, and laws and regulations concerning intellectual property, consumer and child
-                            protection, obscenity or defamation); or use the Licensed Materials in any manner that (1)
-                            is harmful, fraudulent, deceptive, threatening, abusive, harassing, tortious, defamatory,
-                            vulgar, obscene, or libelous (including without limitation, accessing any computer, computer
-                            system, network, software, or data without authorization, breaching the security of another
-                            user or system, and/or attempting to circumvent any User authentication or security
-                            process), (2) impersonates any person or entity, including without limitation any employee
-                            or representative of PostHog, or (3) contains a virus, trojan horse, worm, time bomb,
-                            unsolicited bulk, commercial, or “spam” message, or other harmful computer code, file, or
-                            program (including without limitation, password guessing programs, decoders, password
-                            gatherers, keystroke loggers, cracking tools, packet sniffers, and/or encryption
-                            circumvention programs).
+                        <p id="section-2-1">
+                            2.1 Customer and its Affiliates will not, and will not permit any third party to: (a) use
+                            the Licensed Materials for any purpose other than as specifically authorized in{' '}
+                            <SectionLink section="1.1" /> or in such a manner that would enable any unlicensed entity,
+                            individual or person to access the Licensed Materials; (b) use the Licensed Materials or any
+                            other PostHog software for timesharing, service bureau, managed service, or similar
+                            purposes, or otherwise make the Licensed Materials available to any third party other than
+                            Users, including without limitation, by selling, reselling, sublicensing, distributing,
+                            leasing or otherwise commercially exploiting the Licensed Materials; (c) remove, obscure, or
+                            alter any copyright, trademark, or other proprietary notices contained in or on the Licensed
+                            Materials; (d) access or use the Licensed Materials in a manner intended to circumvent or
+                            exceed any usage limits, service capacity limits, account limitations, or other restrictions
+                            applicable to Customer’s subscription or Order Form; (e) access or use the Licensed
+                            Materials to interfere with, disrupt, or attempt to gain unauthorized access to any systems,
+                            networks, accounts, or data of PostHog or any third party, including by attempting to
+                            circumvent authentication or security mechanisms; (f) use the Licensed Materials to store,
+                            transmit, or distribute any content or material that (i) infringes or violates the
+                            intellectual property or other rights of any third party, (ii) is unlawful, harmful,
+                            fraudulent, deceptive, threatening, abusive, harassing, tortious, defamatory, vulgar,
+                            obscene, libelous or otherwise objectionable or (iii) contains any virus, trojan horse,
+                            worm, time bomb, unsolicited bulk commercial, or "spam" message, malware, or other harmful
+                            code, file or program (including without limitation, password guessing programs, decoders,
+                            password gatherers, keystroke loggers, cracking tools, packet sniffers, and/or encryption
+                            circumvention programs) designed to interrupt, damage, or limit the functionality of any
+                            software, hardware, or telecommunications equipment; (g) use the Licensed Materials in
+                            violation of any applicable laws or regulations, including without limitation laws relating
+                            to privacy, data protection, export controls, consumer and child protection, obscenity or
+                            defamation, intellectual property, or the transmission of technical or personal data; (h)
+                            access or use the Licensed Materials from jurisdictions subject to comprehensive U.S. export
+                            embargoes or in violation of applicable export control or sanctions laws; (i) use the
+                            Licensed Materials for the purpose of monitoring their availability, performance, or
+                            functionality for benchmarking or competitive analysis, or publicly disclose the results of
+                            any benchmarking or performance testing of the Licensed Materials without PostHog’s prior
+                            written consent; (j) impersonate any person or entity, including any employee or
+                            representative of PostHog, or misrepresent Customer’s affiliation with any person or entity;
+                            or (k) use the Licensed Materials in connection with any high-risk or strict liability
+                            activity in which the failure of the Licensed Materials could lead to death, personal
+                            injury, or severe environmental damage (including, without limitation, space travel,
+                            firefighting, police operations, power plant operation, military operations, air traffic
+                            control, rescue operations, emergency medical services, hospitals, life-support systems or
+                            similar activities). Customer is responsible for all activity conducted under its accounts
+                            and for ensuring that its Affiliates and Users comply with the restrictions set forth in
+                            this <SectionLink section="2.1" />.
                         </p>
                     </div>
                     <div className="md:pt-10">
@@ -414,19 +519,31 @@ function Terms() {
                                 <p>Let other companies use your PostHog instance.</p>
                             </li>
                             <li>
+                                <p>Try to exceed your plan’s usage limits or account restrictions.</p>
+                            </li>
+                            <li>
                                 <p>Use PostHog for some things, like military operations or policing.</p>
                             </li>
                             <li>
                                 <p>Use PostHog in the space rocket you’re building.</p>
                             </li>
                             <li>
-                                <p>Use PostHog to do anything illegal or harmful to other people.</p>
+                                <p>
+                                    Use PostHog to do anything illegal or harmful to other people, including storing or
+                                    spreading malware, spam, or infringing content.
+                                </p>
                             </li>
                             <li>
                                 <p>Pretend to be somebody else, including a PostHog employee.</p>
                             </li>
                             <li>
                                 <p>Try to hack PostHog, or use PostHog to do bad internet things.</p>
+                            </li>
+                            <li>
+                                <p>Use PostHog from a country subject to U.S. sanctions.</p>
+                            </li>
+                            <li>
+                                <p>Publish benchmarking results about PostHog without our permission.</p>
                             </li>
                         </ul>
                         <p>
@@ -436,23 +553,25 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            2.2 Customer will cooperate with PostHog in connection with the performance of this
-                            Agreement by making available such personnel and information as may be reasonably required,
-                            and taking such other actions as PostHog may reasonably request. Customer will also
-                            cooperate with PostHog in establishing a password or other procedures for verifying that
-                            only designated employees of Customer have access to any administrative functions of the
-                            Licensed Materials.&nbsp;
+                            2.2 Customer will cooperate with PostHog in connection with PostHog’s provision of the
+                            Licensed Materials under this Agreement by making available such personnel and information
+                            as may be reasonably required, and taking such other actions as PostHog may reasonably
+                            request. Customer will also cooperate with PostHog in establishing passwords or other
+                            authentication procedures reasonably designed to ensure that only authorized Users of
+                            Customer have access to any administrative functions of the Licensed Materials.&nbsp;
                         </p>
                         <p>
                             Customer shall maintain during the term of this Agreement and through the end of the third
-                            year after the date on which the final payment is made under this Agreement, books, records,
-                            contracts and accounts relating to the payments due PostHog under this Agreement
-                            (collectively, the “Customer Records”). PostHog may, at its sole expense, upon 30 days’
-                            prior written notice to Customer and during Customer’s normal business hours and subject to
+                            year after the date on which the final payment is made under this Agreement or an applicable
+                            Order Form, books, records, contracts, and accounts relating to the payments paid or payable
+                            to PostHog under this Agreement or an applicable Order Form (collectively, the "
+                            <b>Customer Records</b>"). PostHog may, at its sole expense, upon thirty (30) days’ prior
+                            written notice to Customer and during Customer’s normal business hours and subject to
                             industry-standard confidentiality obligations, hire an independent third party auditor to
-                            audit the Customer Records only to verify the amounts payable under this Agreement. If an
-                            audit reveals underpayment, then Customer shall promptly pay the deficiency to PostHog plus
-                            late fees pursuant to Section 5.2. PostHog shall bear the cost of an audit unless the audit
+                            audit the Customer Records only to verify the amounts paid or payable under this Agreement
+                            or an applicable Order Form. If an audit reveals underpayment, then Customer shall promptly
+                            pay the deficiency to PostHog plus late fees in accordance with{' '}
+                            <SectionLink section="6.2" />. PostHog shall bear the cost of an audit unless the audit
                             reveals underpayment by more than 5% for the audited period, in which case Customer shall
                             promptly pay PostHog for the reasonable costs of the audit.
                         </p>
@@ -467,25 +586,34 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            2.3 Customer will be responsible for maintaining the security of Customer’s account,
-                            passwords (including but not limited to administrative and User passwords) and files, and
-                            for all uses of Customer account with or without Customer’s knowledge or consent.
+                            2.3 Customer is responsible for maintaining the security of Customer’s accounts, passwords
+                            (including but not limited to administrative and User passwords) and files, and for all uses
+                            and activities occurring under Customer accounts, whether or not authorized by Customer.
+                            Customer shall ensure that all Users of Customer’s accounts are authorized by Customer and
+                            comply with the terms of this Agreement.
                         </p>
                     </div>
                     <div>
                         <p>
-                            You need to keep your account secure with passwords and not sharing all your data with
-                            anybody you don’t want to.
+                            You’re responsible for keeping your account secure. That means protecting your passwords and
+                            making sure anyone with access to your account is authorized and follows these terms. If
+                            something happens under your account, it’s on you, whether you authorized it or not.
                         </p>
                     </div>
                     <div>
                         <h2 id="confidentiality">3. Confidentiality</h2>
                         <p>
-                            3.1 Each party (the “Receiving Party”) understands that the other party (the “Disclosing
-                            Party”) has disclosed or may disclose information relating to the Disclosing Party’s
-                            technology or business (hereinafter referred to as “Proprietary Information” of the
-                            Disclosing Party). Without limiting the foregoing, the Licensed Materials are PostHog
-                            Proprietary Information.
+                            3.1 Each party (the "<b>Receiving Party</b>") understands that the other party (the "
+                            <b>Disclosing Party</b>") has disclosed or may disclose information relating to the
+                            Disclosing Party’s technology, products, services, business, operations, or other affairs
+                            (collectively, the "<b>Proprietary Information</b>" of the Disclosing Party). Proprietary
+                            Information includes any non-public information disclosed in any form or medium that (a) is
+                            designated as confidential or proprietary at the time of disclosure or within a reasonable
+                            time thereafter, or (b) reasonably should be understood to be confidential given the nature
+                            of the information or the circumstances of disclosure. Without limiting the foregoing, the
+                            terms and conditions of this Agreement and all Order Forms, the Licensed Materials, and any
+                            information relating to the performance or operation of the Licensed Materials constitute
+                            PostHog Proprietary Information.
                         </p>
                     </div>
                     <div className="md:pt-10">
@@ -495,44 +623,87 @@ function Terms() {
                         </p>
                     </div>
                     <div>
-                        <p>
-                            3.2 The Receiving Party agrees: (i) not to divulge to any third person any such Proprietary
-                            Information, (ii) to give access to such Proprietary Information solely to those employees
-                            with a need to have access thereto for purposes of this Agreement, and (iii) to take the
-                            same security precautions to protect against disclosure or unauthorized use of such
-                            Proprietary Information that the party takes with its own proprietary information, but in no
-                            event will a party apply less than reasonable precautions to protect such Proprietary
-                            Information.&nbsp;
+                        <p id="section-3-2">
+                            3.2 The Receiving Party agrees: (a) to use the Disclosing Party’s Proprietary Information
+                            solely for the purpose of performing its obligations or exercising its rights under this
+                            Agreement; (b) not to disclose such Proprietary Information to any third party except to its
+                            and its Affiliates’ employees, contractors, consultants, advisors, or agents who have a need
+                            to know such information for purposes of this Agreement and who are bound by confidentiality
+                            obligations at least as protective as those contained herein; and (c) to take the same
+                            security precautions to protect against disclosure or unauthorized use of such Proprietary
+                            Information that it uses to protect its own proprietary information of a similar nature, but
+                            in no event less than reasonable precautions.&nbsp;
                         </p>
                         <p>
-                            The Disclosing Party agrees that the foregoing will not apply with respect to any
-                            information that the Receiving Party can document (a) is or becomes generally available to
-                            the public without any action by, or involvement of, the Receiving Party, or (b) was in its
-                            possession or known by it prior to receipt from the Disclosing Party, or (c) was rightfully
-                            disclosed to it without restriction by a third party, or (d) was independently developed
-                            without use of any Proprietary Information of the Disclosing Party.&nbsp;
+                            The Receiving Party will be responsible for any breach of this <SectionLink section="3.2" />{' '}
+                            by its employees, contractors, consultants, advisors, or agents. The Receiving Party will
+                            promptly notify the Disclosing Party upon becoming aware of any unauthorized use or
+                            disclosure of Proprietary Information and will reasonably cooperate with the Disclosing
+                            Party to help regain possession of such Proprietary Information and prevent further
+                            unauthorized use or disclosure. The foregoing obligations will not apply with respect to any
+                            information that the Receiving Party can document: (w) is or becomes generally available to
+                            the public without breach of this Agreement; (x) was in its possession or known by it prior
+                            to receipt from the Disclosing Party; (y) was rightfully disclosed to it without restriction
+                            by a third party; or (z) was independently developed by the Receiving Party without use of
+                            or reference to the Disclosing Party’s Proprietary Information.&nbsp;
                         </p>
                         <p>
                             Nothing in this Agreement will prevent the Receiving Party from disclosing Proprietary
-                            Information pursuant to any judicial or governmental order, provided that the Receiving
-                            Party gives the Disclosing Party reasonable prior notice of such disclosure to contest such
-                            order. In any event, PostHog may collect data with respect to and report on the aggregate
-                            response rate and other aggregate measures of the Licensed Materials’ performance and
-                            Customer’s usage of the Licensed Materials; provided that PostHog will not identify Customer
-                            as the source of any such data without Customer’s prior written consent. For the avoidance
-                            of doubt, use of a third party to host the data collected shall not be deemed a disclosure.
+                            Information to the extent required by law, regulation, or court order, provided that, to the
+                            extent legally permitted, the Receiving Party gives the Disclosing Party prompt written
+                            notice of such requirement and reasonably cooperates with the Disclosing Party’s efforts to
+                            seek a protective order or otherwise limit such disclosure. The obligations of this{' '}
+                            <SectionLink section="3.2" /> will survive termination or expiration of this Agreement for a
+                            period of one (1) year; provided, however, that with respect to Proprietary Information
+                            constituting a trade secret under applicable law, such obligations will survive for so long
+                            as such information remains a trade secret.
                         </p>
                     </div>
                     <div>
                         <p>
-                            We both agree not to tell anybody else about these things, unless it was already obvious –
-                            we all share some stuff on the internet, right?&nbsp;
+                            We both agree not to tell anybody else about confidential things we share with each other —
+                            unless it was already public knowledge to begin with (we all share some stuff on the
+                            internet, right?).
                         </p>
                         <p>
-                            We should try hard to make sure we keep the secrets safe and take extra steps to do that. We
-                            both agree that if anybody official, like a judge or the government, asks to see anything
-                            you want kept secret, that we let the other person know before we share.&nbsp;
+                            We should both take reasonable steps to keep each other's secrets safe, and make sure anyone
+                            we do share them with (like employees or contractors who need to know) is held to the same
+                            standard.
                         </p>
+                        <p>
+                            If anyone official (like a judge or the government) asks either of us to hand over the
+                            other's confidential information, we agree to give the other party a heads up before we
+                            share anything, so they have a chance to push back or limit what gets disclosed.
+                        </p>
+                    </div>
+                    <div>
+                        <p>
+                            3.3 Notwithstanding the foregoing and anything else contained in this{' '}
+                            <SectionLink section="3" /> to the contrary, PostHog may collect data with respect to and
+                            report on aggregate response rates and other aggregated measures of the Licensed Materials’
+                            performance and Customer’s usage of the Licensed Materials; provided that PostHog will not
+                            identify Customer as the source of any such data without Customer’s prior written consent.
+                            PostHog may also generate aggregated and de-identified data derived from Customer Content in
+                            connection with the Product and Model Development activities described in{' '}
+                            <SectionLink section="5" /> of this Agreement.&nbsp;
+                        </p>
+                    </div>
+                    <div>
+                        <p>
+                            We may track and report on how PostHog is performing overall, including things like response
+                            rates and usage patterns, but we'll never identify you as the source of that aggregated data
+                            without your permission.
+                        </p>
+                    </div>
+                    <div>
+                        <p>
+                            3.4 For the avoidance of doubt, the use of a third party to host the data collected by
+                            PostHog pursuant to this Agreement shall not be deemed a disclosure under this{' '}
+                            <SectionLink section="3" />
+                            .&nbsp;
+                        </p>
+                    </div>
+                    <div>
                         <p>
                             Hopefully it’s obvious that Jeff Bezos doesn’t count – well, AWS anyway, Jeff’s too busy on
                             a boat to care.&nbsp;
@@ -540,27 +711,29 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            3.3 Each party acknowledges and agrees that the other may suffer irreparable damage in the
-                            event of a breach of the terms of Sections 1.1, 2.1 or 3.2 of this Agreement and that such
-                            party will be entitled to seek injunctive relief (without the necessity of posting a bond)
-                            in the event of any such breach.
+                            3.5 Each party acknowledges and agrees that the other may suffer irreparable damage in the
+                            event of a breach of the terms of Sections <SectionLink section="1.1" label="1.1" />,{' '}
+                            <SectionLink section="2.1" label="2.1" />, or <SectionLink section="3.2" label="3.2" /> of
+                            this Agreement and that such party will be entitled to seek injunctive relief (without the
+                            necessity of posting a bond) in the event of any such breach.&nbsp;
                         </p>
                     </div>
                     <div>
                         <p>
-                            We both agree that giving away all the other’s secrets can lead to serious legal
-                            issues.&nbsp;
+                            We both agree that leaking each other’s secrets could cause serious, hard-to-fix damage.
+                            That’s why either party can go straight to court to get an injunction to stop a breach.
                         </p>
                     </div>
                     <div>
                         <p>
-                            3.4 Both parties will have the right to disclose the existence of the relationship between
-                            the parties, but not the terms and conditions of this Agreement, unless such disclosure of
-                            the Agreement terms is approved in writing by both Parties prior to such disclosure, or is
-                            included in a filing required to be made by a party with a governmental authority (provided
-                            such party will use reasonable efforts to obtain confidential treatment or a protective
-                            order) or is made on a confidential basis as reasonably necessary to potential investors or
-                            acquirers.
+                            3.6 Both parties will have the right to disclose the existence of the relationship between
+                            the parties, but not the terms and conditions of this Agreement or an applicable Order Form,
+                            unless such disclosure of the Agreement terms is approved in writing by both parties prior
+                            to such disclosure, or is included in a filing required to be made by a party with a
+                            governmental authority (provided such party will use reasonable efforts to obtain
+                            confidential treatment or a protective order in accordance with{' '}
+                            <SectionLink section="3.2" />) or is made on a confidential basis as reasonably necessary to
+                            potential investors or acquirers.
                         </p>
                     </div>
                     <div>
@@ -573,12 +746,13 @@ function Terms() {
                         <h2 id="ip">4. Intellectual property rights</h2>
                         <p>
                             4.1 Except as expressly set forth herein, PostHog alone (and its licensors, where
-                            applicable) will retain all intellectual property rights relating to the Licensed Materials
-                            and any suggestions, ideas, enhancement requests, feedback, code, or other recommendations
-                            provided by Customer, its Affiliates or any third party relating to the Licensed Materials,
-                            which are hereby assigned to PostHog. This Agreement is not a sale and does not convey to
-                            Customer any rights of ownership in or related to the Licensed Materials, or any
-                            intellectual property rights.
+                            applicable) will retain all right, title and interest in and to the Licensed Materials,
+                            Usage Data (as defined below) and Derived Data (as defined below), and any suggestions,
+                            ideas, enhancement requests, feedback, code, or other recommendations provided by Customer,
+                            its Affiliates, their Users or any third party relating to the Licensed Materials, which are
+                            hereby assigned to PostHog. This Agreement is not a sale and does not convey to Customer,
+                            its Affiliates or its Users any rights of ownership or other intellectual property rights in
+                            or related to the Licensed Materials, or any other intellectual property rights of PostHog.
                         </p>
                     </div>
                     <div className="md:pt-10">
@@ -589,13 +763,13 @@ function Terms() {
                             4.2 Customer shall not remove, alter or obscure any of PostHog’s (or its licensors’)
                             copyright notices, proprietary legends, trademark or service mark attributions, patent
                             markings or other indicia of PostHog’s (or its licensors’) ownership or contribution from
-                            the Licensed Materials. Additionally, Customer agrees to reproduce and include PostHog’s
-                            (and its licensors’) proprietary and copyright notices on any copies of the Licensed
-                            Materials, or on any portion thereof, including reproduction of the copyright notice.
-                            Notwithstanding anything to the contrary herein, certain components of the Licensed
-                            Materials, including without limitation, any component of the Licensed Materials distributed
-                            by PostHog as part of the PostHog FOSS Edition, are licensed by third parties pursuant to
-                            the terms of certain third party licenses described in such source code annotations.
+                            the Licensed Materials. Customer agrees to reproduce and include PostHog’s (and its
+                            licensors’) proprietary and copyright notices on any copies of the Licensed Materials, or on
+                            any portion thereof, including reproduction of the copyright notice. Notwithstanding
+                            anything to the contrary herein, certain components of the Licensed Materials, including
+                            without limitation, any component of the Licensed Materials distributed by PostHog as part
+                            of PostHog FOSS, are licensed by third parties pursuant to their respective third-party
+                            licenses, as described in the applicable source code annotations.
                         </p>
                     </div>
                     <div>
@@ -611,76 +785,200 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            4.3 Customer and its licensors shall (and Customer hereby represents and warrants that they
-                            do) have and retain all right, title and interest (including, without limitation, sole
-                            ownership of) all software, information, content and data provided by or on behalf of
-                            Customer or made available or otherwise distributed through use of the Licensed Materials
-                            (“Content”) and the intellectual property rights with respect to that Content. If PostHog
-                            receives any notice or claim that any Content, or Customer’s activities hereunder (including
-                            without limitation, with respect to any Content), infringes or violates the rights of a
-                            third party or any applicable law or regulation (a “Claim”), Customer will indemnify, defend
-                            and hold PostHog harmless from all liability, damages, settlements, attorney fees and other
-                            costs and expenses in connection with any such Claim, as incurred. The immediately foregoing
-                            indemnity obligations are expressly conditioned on PostHog providing Customer with prompt
-                            notice of, and reasonable cooperation and sole control over the defense and/or settlement of
-                            the applicable Claim. Subject to the foregoing, PostHog may participate in the defense
-                            and/or settlement of any applicable Claim with counsel of its choosing at its own expense.
+                            4.3 Customer hereby represents and warrants that it has all necessary rights, licenses, and
+                            consents, including from its end users where applicable, to provide, upload, store, or
+                            otherwise make available any software, information, content, data, or related materials
+                            provided by or on behalf of Customer or made available through use of the Licensed Materials
+                            (the "<b>Customer Content</b>") and to grant the rights set forth herein. Customer hereby
+                            grants PostHog a non-exclusive, worldwide, royalty-free right and license during the term of
+                            this Agreement to access, process, store, transmit, and use the Customer Content as
+                            reasonably necessary to provide, operate, maintain, support and secure the Licensed
+                            Materials and to perform its obligations under this Agreement. Notwithstanding anything else
+                            contained in this Agreement to the contrary, PostHog may collect and use technical logs,
+                            telemetry, metadata, and other information relating to Customer’s use of the Licensed
+                            Materials (the "<b>Usage Data</b>") for any lawful purpose, including operating,
+                            maintaining, improving, testing, securing, and supporting the Licensed Materials. Usage Data
+                            does not include Customer Content.&nbsp;
                         </p>
                     </div>
                     <div>
                         <p>
-                            You will own all the data you receive through your use of PostHog. However, if PostHog
-                            learns that somebody else owns that data, you will tell the other party that we had nothing
-                            to do with it, and protect PostHog from any legal issues.
+                            You confirm that you have the rights to any content you upload or send through PostHog —
+                            including any necessary permissions from your own end users. You’re giving us a license to
+                            use that content to run and improve the service, but you keep ownership.
+                        </p>
+                        <p>
+                            We’ll also collect technical usage data (like logs and telemetry) to keep things running
+                            smoothly. It’s separate from your content and doesn’t identify you.
+                        </p>
+                    </div>
+                    <div>
+                        <p id="section-4-4">
+                            4.4 If PostHog receives any notice, demand, or claim that any Customer Content, or
+                            Customer’s, its Affiliates’ or its Users’ activities hereunder (including without
+                            limitation, Customer’s provision, use or distribution of Customer Content), infringe,
+                            misappropriate, or otherwise violate the intellectual property or other rights of any third
+                            party, or violate any applicable laws or regulations (a "<b>Claim Against PostHog</b>"),
+                            Customer will indemnify, defend and hold PostHog and its officers, directors, employees,
+                            agents, and Affiliates harmless from and against all losses, liabilities, damages,
+                            settlements, judgments, fines, penalties, costs, and expenses (including reasonable
+                            attorneys’ fees) arising from such Claim Against PostHog. The indemnification obligations in
+                            this <SectionLink section="4.4" /> are conditioned on PostHog providing Customer with prompt
+                            written notice of the Claim Against PostHog, reasonable cooperation, and full control over
+                            the defense and/or settlement of the Claim Against PostHog, provided that any settlement
+                            obligating PostHog to pay money, admit liability, or make any material change to its
+                            business requires PostHog’s prior written consent. Subject to the foregoing, PostHog may
+                            participate in the defense and/or settlement of any Claim Against PostHog with counsel of
+                            its choosing at its own expense.
                         </p>
                     </div>
                     <div>
                         <p>
-                            4.4 PostHog will defend, indemnify and hold Customer harmless from liability and other
-                            amounts paid or payable to unaffiliated third parties resulting from the infringement or
-                            violation of any intellectual property or proprietary rights by the Licensed Materials,
-                            provided PostHog is promptly notified of any and all threats, claims and proceedings related
-                            thereto and given reasonable assistance and the opportunity to assume sole control over
-                            defense and settlement thereof. Subject to the foregoing, Customer may participate in the
-                            defense and/or settlement of any claim that is indemnifiable by PostHog with counsel of its
-                            choosing at its own expense. The foregoing obligations do not apply with respect to portions
-                            or components of the Licensed Materials (i) not created by PostHog, (ii) that are modified
-                            after delivery by PostHog, (iii) combined with other products, processes or materials where
-                            the alleged infringement relates to such combination, (iv) where Customer continues
-                            allegedly infringing activity after being notified thereof or after being informed of
-                            modifications that would have avoided the alleged infringement, or (v) where Customer’s use
-                            of the Licensed Materials is not strictly in accordance with this Agreement and all related
-                            documentation.
+                            If someone claims that your content or how you’re using PostHog violates their rights or
+                            breaks the law, you’ll need to cover PostHog’s costs and handle the defense. We’ll let you
+                            know quickly if that happens and give you full control over how it’s resolved, though any
+                            settlement that affects PostHog will need our sign-off first.
+                        </p>
+                    </div>
+                    <div>
+                        <p id="section-4-5">
+                            4.5 PostHog will defend, indemnify and hold Customer and its officers, directors, employees,
+                            agents, and Affiliates harmless from and against all losses, liabilities, damages,
+                            settlements, judgments, fines, penalties, costs and expenses (including reasonable
+                            attorneys’ fees) finally awarded or agreed to in settlement (with the consent of PostHog)
+                            arising from any claim that the Licensed Materials, as provided by PostHog and used strictly
+                            in accordance with this Agreement, infringe or misappropriate an unaffiliated third party’s
+                            intellectual property rights (a "<b>Claim Against Customer</b>"), provided that Customer:
+                            (a) provides prompt written notice of the Claim Against Customer to PostHog; (b) provides
+                            reasonable assistance at PostHog’s request; (c) gives PostHog sole control over the defense
+                            and/or settlement of the Claim Against Customer; and (d) refrains from admitting any
+                            liability or otherwise compromising the defense in whole or in part, without the express
+                            prior written consent of PostHog. Subject to the foregoing, Customer may participate in the
+                            defense and/or settlement of the Claim Against Customer with counsel of its choosing at its
+                            own expense. The foregoing indemnification obligations in this <SectionLink section="4.5" />{' '}
+                            do not apply to the extent a claim arises from: (i) portions or components of the Licensed
+                            Materials not created by PostHog, (ii) modifications made by Customer or any third party
+                            after delivery by PostHog, (iii) combination or use of the Licensed Materials with other
+                            products, processes, or materials where the alleged infringement relates to such
+                            combination, (iv) continued use after notification of alleged infringement or after PostHog
+                            provides modifications that would have avoided the alleged infringement; or (v) Customer’s
+                            use of the Licensed Materials not strictly in accordance with this Agreement or the related
+                            documentation. If the Licensed Materials become, or in PostHog’s reasonable opinion are
+                            likely to become, the subject of a Claim Against Customer, PostHog may, at its sole
+                            discretion and expense: (x) procure for Customer the right to continue using the Licensed
+                            Materials; (y) replace or modify the Licensed Materials so that they become non-infringing
+                            while remaining functionally equivalent; or (z) if neither (x) nor (y) is commercially
+                            reasonable, terminate Customer’s right to use the affected portion of the Licensed Materials
+                            and refund any prepaid, unused fees attributable to such portion. The indemnification
+                            obligations set forth in this <SectionLink section="4.5" /> constitute Customer’s sole and
+                            exclusive remedy with respect to any third-party claim of intellectual property infringement
+                            relating to the Licensed Materials.
                         </p>
                     </div>
                     <div>
                         <p>
-                            If somebody tells you PostHog has done anything wrong, and it turns out we have, when it
-                            comes to using PostHog, we will let them know you didn’t know about it.&nbsp;
+                            Think of it as the flip side of 4.4. If someone comes after you claiming PostHog itself
+                            violates their rights, we’ve got you covered. Just note that our protection doesn’t extend
+                            to problems caused by your own modifications, mixing PostHog with other products, or using
+                            it outside the terms of this agreement.
                         </p>
                     </div>
                     <div>
-                        <h2 id="payment">5. Payment of fees</h2>
+                        <h2 id="models">5. Product and model development</h2>
                         <p>
-                            5.1 Customer will pay PostHog the then applicable fees described in the Order Form or Quote
-                            for the Licensed Materials in accordance with the terms therein (the “Fees”). If Customer’s
-                            use of the Licensed Materials exceeds the Service Capacity set forth on the Order Form or
-                            Quote or otherwise requires the payment of additional fees (per the terms of this
-                            Agreement), Customer shall be billed for such usage and Customer agrees to pay the
-                            additional fees in the manner provided herein. PostHog reserves the right to increase the
-                            Fees or applicable charges and to institute new charges and Fees at the end of the Initial
-                            Service Term or then current renewal term, upon thirty (30) days prior notice to Customer
-                            (which may be sent by email). PostHog reserves the right to reduce the Fees or applicable
-                            charges during the Initial Service Term or then current renewal term, immediately with
-                            notice to Customer (which may be sent by email). If Customer believes that PostHog has
-                            billed Customer incorrectly, Customer must contact PostHog no later than 60 days after the
-                            closing date on the first billing statement in which the error or problem appeared, in order
-                            to receive an adjustment or credit. Inquiries should be submitted via an in-app support
-                            ticket to the Company's customer success department.
+                            5.1 As used herein, "<b>Product and Model Development</b>" means the development, testing,
+                            training, evaluation, and improvement of PostHog products, services, features, analytics
+                            systems, and machine learning models. Subject to the terms of this{' '}
+                            <SectionLink section="5" />, Customer grants PostHog a non-exclusive, worldwide,
+                            royalty-free license to use Customer Content submitted to the Licensed Materials for Product
+                            and Model Development. Customer Content may be used for Product and Model Development unless
+                            (a) otherwise agreed to between Customer and PostHog or (b) Customer has opted out through
+                            the applicable service settings within the Licensed Materials and/or product or services
+                            interface; PostHog will honor any such agreement or election on a prospective basis. Use of
+                            Customer Content for Product and Model Development is separate from and independent of use
+                            to provide the Licensed Materials. Where Customer Content is used for Product and Model
+                            Development, PostHog will aggregate or de-identify such data so that it cannot reasonably be
+                            used to identify Customer, its Users, or any individual (the "<b>Derived Data</b>"). For the
+                            avoidance of doubt, any such agreement or election will apply on a prospective basis only,
+                            and PostHog shall have no obligation to modify, retrain, or delete any models, derived
+                            outputs or other Derived Data that utilized Customer Content prior to the effective date of
+                            such agreement or election, except to the extent required by applicable laws.&nbsp;
                         </p>
                     </div>
                     <div className="md:pt-10">
-                        <p>You will pay for using PostHog on time – usually via credit card.</p>
+                        <p>
+                            We may use data you upload or generate through your use of PostHog to help improve PostHog’s
+                            features and train our own models. Any data we use gets anonymized so it can’t be traced
+                            back to you, your users, or any individual. You can opt in or out at any time via the
+                            settings in the app (
+                            <a
+                                href="https://us.posthog.com/settings/organization-details"
+                                className="underline underline-offset-2 hover:opacity-70"
+                            >
+                                US
+                            </a>{' '}
+                            or{' '}
+                            <a
+                                href="https://eu.posthog.com/settings/organization-details"
+                                className="underline underline-offset-2 hover:opacity-70"
+                            >
+                                EU
+                            </a>
+                            ).
+                        </p>
+                        <p>
+                            If you opt out, that applies going forward. We won’t go back and undo any models already
+                            trained on your data.
+                        </p>
+                    </div>
+                    <div>
+                        <p>
+                            5.2 PostHog will not permit third parties to use Customer Content to train their machine
+                            learning models. Any use of Customer Content for Product and Model Development will be
+                            solely for PostHog’s products, services, and internal models.
+                        </p>
+                    </div>
+                    <div>
+                        <p>
+                            We’ll never share your data with outside companies to train their models. Anything we use
+                            stays internal to PostHog.
+                        </p>
+                    </div>
+                    <div>
+                        <h2 id="payment">6. Payment of fees</h2>
+                        <p>
+                            6.1 Customer will pay PostHog the then-applicable fees for its use of the Licensed Materials
+                            (the "<b>Fees</b>") in accordance with PostHog’s then-current pricing and billing policies
+                            published at the time of use (the "<b>Pricing Terms</b>"), and, if applicable, as set forth
+                            in an Order Form or as otherwise agreed through the services interface. Unless otherwise
+                            specified in an Order Form, Fees are based on Customer’s actual usage of the Licensed
+                            Materials. Customer may prepay for usage by purchasing credits to be applied against future
+                            usage via an Order Form or through the services interface ("<b>Prepaid Credits</b>"), in
+                            each case on the terms specified therein. Unless otherwise agreed in writing, Prepaid
+                            Credits are non-refundable and expire twelve (12) months from the date of purchase.&nbsp;
+                        </p>
+                        <p>
+                            If Customer’s use of the Licensed Materials exceeds any usage threshold, service capacity,
+                            or prepaid credits specified in an Order Form or through the services interface, or
+                            otherwise results in additional usage-based Fees, Customer will be billed for such usage and
+                            agrees to pay the additional Fees. PostHog may increase Fees or introduce new charges at the
+                            end of the Initial Credit Term (as defined below) or any then-current renewal term upon
+                            thirty (30) days’ prior notice to Customer, which may be sent via email or through the
+                            services interface or otherwise at PostHog's discretion. PostHog may also reduce Fees at any
+                            time without notice. If Customer believes that PostHog has billed incorrectly, Customer must
+                            notify PostHog no later than sixty (60) days after the closing date on the first billing
+                            statement in which the error or problem appeared, in order to receive an adjustment or
+                            credit. Billing inquiries should be submitted via an in-app support ticket to PostHog’s
+                            customer success team.
+                        </p>
+                    </div>
+                    <div className="md:pt-10">
+                        <p>You will pay for using PostHog on time, usually via credit card.</p>
+                        <p>
+                            You can prepay by purchasing credits, but keep in mind they’re non-refundable and expire
+                            after 12 months. If you go over your usage or run out of credits, we’ll bill you for the
+                            difference.
+                        </p>
                         <p>
                             If we’re going to increase prices, we need to give you 30 days notice, giving you the chance
                             to cancel with us.
@@ -692,36 +990,38 @@ function Terms() {
                         <p>If you think we’ve billed you incorrectly, let us know within 60 days so we can sort it.</p>
                     </div>
                     <div>
-                        <p>
-                            5.2 PostHog may choose to bill through an invoice, in which case, full payment for invoices
-                            issued in any given month must be received by PostHog according to the payment terms
-                            specified in the invoice. Unpaid amounts are subject to a finance charge of 1.5% per month
-                            on any outstanding balance, or the maximum permitted by law, whichever is lower, plus all
-                            expenses of collection and may result in immediate termination of Service. Customer shall be
-                            responsible for all taxes associated with the Licenses Materials other than U.S. taxes based
+                        <p id="section-6-2">
+                            6.2 PostHog may charge Fees using a payment method provided by Customer (such as a credit
+                            card) or may issue invoices. If invoiced, full payment for invoices issued in any given
+                            month must be received by PostHog according to the payment terms specified in the invoice.
+                            Unpaid amounts are subject to a finance charge of 1.5% per month on any outstanding balance,
+                            or the maximum permitted by law, whichever is lower, plus all expenses of collection, and
+                            may result in immediate termination of access to the Licensed Materials. Customer shall be
+                            responsible for all taxes associated with the Licensed Materials other than U.S. taxes based
                             on PostHog’s net income.
                         </p>
                     </div>
                     <div>
                         <p>
-                            If you choose annual payments, we will send an invoice. Please pay on time or it could lead
-                            to late fees.&nbsp;
+                            If you prepay (whether annually or otherwise), we may send an invoice rather than charging
+                            your card. Pay on time, because late payments can result in late fees and, in the worst
+                            case, losing access to PostHog.
                         </p>
                     </div>
                     <div>
-                        <p>
-                            5.3 Our fees do not include any taxes, levies, duties or similar governmental assessments of
-                            any nature, including, for example, value-added, sales, GST, use or withholding taxes,
+                        <p id="section-6-3">
+                            6.3 Our fees do not include any taxes, levies, duties or similar governmental assessments of
+                            any nature, including, for example, value-added, sales, GST, use, or withholding taxes,
                             assessable by any jurisdiction whatsoever in relation to your purchases under this Agreement
-                            (collectively, the “Taxes”). You are solely responsible for paying all Taxes associated with
-                            your purchases hereunder. If we have a legal obligation to pay or collect Taxes for which
-                            you are responsible for under this Clause 4.3, we shall invoice you and you shall pay that
-                            amount to us unless you provide us with a valid tax exemption certificate authorized by the
-                            appropriate taxing authority. We shall calculate applicable Taxes based on your billing
-                            address as detailed on the relevant Order Form or Quote (it is your duty to inform us if
-                            Taxes should be assessed on a different address). You shall promptly notify us of any
-                            changes to any of your addresses specified in an Order Form or Quote. Taxes shall not be
-                            deducted from or set-off against the fees in the applicable Order Form or Quote.
+                            (collectively, the "<b>Taxes</b>"). You are solely responsible for paying all Taxes
+                            associated with your purchases hereunder. If we have a legal obligation to pay or collect
+                            Taxes for which you are responsible for under this <SectionLink section="6.3" />, we shall
+                            invoice you and you shall pay that amount to us unless you provide us with a valid tax
+                            exemption certificate authorized by the appropriate taxing authority. We shall calculate
+                            applicable Taxes based on your billing address as detailed on the relevant Order Form or
+                            Customer account (it is your duty to inform us if Taxes should be assessed on a different
+                            address). You shall promptly notify us of any changes to any of your addresses. Taxes shall
+                            not be deducted from or set off against the Fees owed to PostHog.
                         </p>
                     </div>
                     <div>
@@ -735,67 +1035,93 @@ function Terms() {
                     </div>
                     <div>
                         <p>
-                            5.4 Subject to earlier termination as provided below, this Agreement is for the Initial
-                            Service Term as specified in the Order Form or Quote, and shall be automatically renewed for
-                            additional periods of the same duration as the Initial Service Term (collectively, the
-                            “Term”), unless either party requests termination with at least thirty (30) days notice.
+                            6.4 Unless earlier terminated in accordance with this Agreement, this Agreement will
+                            continue for the Initial Credit Term specified in the Order Form, or through the services
+                            interface ("<b>Initial Credit Term</b>"), and will automatically renew for successive terms
+                            of the same duration (collectively, the "<b>Term</b>") unless either party provides at least
+                            thirty (30) days’ notice of non-renewal. If no Initial Credit Term is specified in an Order
+                            Form, or otherwise through the services interface, the Initial Credit Term will be deemed
+                            one (1) month and this Agreement will continue on a month-to-month basis, terminable by
+                            either party in accordance with <SectionLink section="7.1" />. During any month-to-month
+                            period (whether as the Initial Credit Term or following expiration of a fixed-term Order
+                            Form), Customer may continue to access and use the Licensed Materials subject to PostHog’s
+                            then-current usage-based Fees.
                         </p>
                     </div>
                     <div>
                         <p>
-                            PostHog is a monthly subscription that renews each month. You can cancel at any time with 30
-                            days notice. PostHog can do the same.&nbsp;
+                            By default, PostHog is month-to-month and renews automatically. Unless you've prepaid for
+                            credits or agreed to a fixed term, in which case that term applies instead.
                         </p>
                     </div>
                     <div>
-                        <h2 id="termination">6. Termination</h2>
-                        <p>
-                            6.1 This Agreement shall continue until terminated in accordance with this Section 6. Either
-                            party may terminate this Agreement upon 30 days’ written notice to the other party hereto in
-                            the event that Customer has no then-current subscription with respect to the Licensed
-                            Materials.
+                        <h2 id="termination">7. Termination</h2>
+                        <p id="section-7-1">
+                            7.1 This Agreement shall continue until terminated in accordance with this{' '}
+                            <SectionLink section="7" />. Customer may terminate this Agreement at any time upon thirty
+                            (30) days’ written notice to PostHog, provided, however, that for the avoidance of doubt,
+                            the termination of this Agreement pursuant to this sentence shall not absolve Customer of
+                            the obligation to pay to PostHog any Fees for usage already incurred or otherwise due
+                            hereunder, or agreed to pursuant to an Order Form or as otherwise specified through the
+                            services interface, and any Prepaid Credits shall remain non-refundable. PostHog may
+                            terminate this Agreement upon thirty (30) days’ written notice to Customer in the event that
+                            Customer does not have, at such time, any existing and usable Prepaid Credits purchased via
+                            an Order Form or otherwise.
                         </p>
                     </div>
                     <div className="md:pt-10">
                         <p>
-                            Your contract with PostHog runs until either you cancel it, or PostHog does. You can do this
-                            in the app, or just email us
+                            You can cancel at any time with 30 days notice, but any fees already incurred are still
+                            owed, and prepaid credits are non-refundable. PostHog can also cancel with 30 days notice if
+                            you're on a month-to-month plan with no prepaid credits.
+                        </p>
+                    </div>
+                    <div>
+                        <p id="section-7-2">
+                            7.2 Either party may terminate this Agreement upon thirty (30) days’ written notice to the
+                            other party in the event of any curable material breach of this Agreement (including without
+                            limitation, any breach of <SectionLink section="2.1" /> and/or failure to pay any amounts
+                            when due hereunder) by such party where such material breach is not cured during such notice
+                            period. In the event of a non-curable material breach, either party may terminate this
+                            Agreement immediately upon written notice to the other party.
                         </p>
                     </div>
                     <div>
                         <p>
-                            6.2. Either party may terminate this Agreement immediately upon 30 days’ written notice to
-                            the other party in the event of any material breach of this Agreement (including without
-                            limitation, any breach of Section 2.2 and/or failure to pay any amounts when due hereunder)
-                            by such party where such material breach is not cured during such notice period.
+                            If either party seriously breaks the terms, the other can give 30 days notice to fix it. If
+                            it's not fixed in time, the agreement can be terminated. If the breach can't be fixed at
+                            all, termination can happen immediately.
                         </p>
                     </div>
                     <div>
-                        <p>If either party breaks the contract, they can terminate the contract immediately.&nbsp;</p>
-                    </div>
-                    <div>
                         <p>
-                            6.3 Either party may terminate this Agreement, without notice, (i) upon the institution by
+                            7.3 Either party may terminate this Agreement, without notice, (a) upon the institution by
                             or against the other party of insolvency, receivership or bankruptcy proceedings (provided
                             such proceedings are not dismissed within one hundred twenty (120) days of such
-                            institution), (ii) upon the other party’s making an assignment for the benefit of creditors,
-                            or (iii) upon the other party’s dissolution or ceasing to do business without a successor.
+                            institution), (b) upon the other party’s making an assignment for the benefit of creditors,
+                            or (c) upon the other party’s dissolution or ceasing to do business without a successor.
                         </p>
                     </div>
                     <div>
                         <p>
                             If either of us go bust, or similar, the agreement ends immediately. No need to panic
-                            though, we’re default alive and growing as fast as ever&nbsp;
+                            though, we’re default alive and growing as fast as ever.
                         </p>
                     </div>
                     <div>
                         <p>
-                            6.4 Customer’s rights to the Licensed Materials, and any licenses granted hereunder, shall
+                            7.4 Customer’s rights to the Licensed Materials, and any licenses granted hereunder, shall
                             terminate upon any termination of this Agreement. In the event that Customer terminates this
-                            Agreement pursuant to the second sentence of Section 6.2 above, PostHog will refund to
-                            Customer a pro-rated portion of pre-paid Fees for Services not actually received by Customer
-                            as of the date of such termination. The following Sections will survive any termination of
-                            this Agreement: 2 through 6 (except for Section 4.3), and 8 through 11.
+                            Agreement pursuant to <SectionLink section="7.2" /> above, PostHog will refund to Customer:
+                            (a) with respect to any Prepaid Credits, an amount equal to the proportion of unused credits
+                            remaining as of the date of termination, applied to the fees actually paid for such credits;
+                            and (b) with respect to any prepaid flat fees that are not usage-based (including without
+                            limitation fees for add-ons), a pro-rated refund based on the portion of the applicable
+                            subscription period remaining as of the date of termination. For the avoidance of doubt,
+                            Customers that have not prepaid for credits or add-ons are not entitled to any refund upon
+                            termination. The provisions of this Agreement which by their nature should survive
+                            termination shall survive, including without limitation confidentiality, indemnification,
+                            and payment obligations.
                         </p>
                     </div>
                     <div>
@@ -805,21 +1131,22 @@ function Terms() {
                         </p>
                     </div>
                     <div>
-                        <h2 id="warranty">7. Warranty; Customer Software Security</h2>
+                        <h2 id="warranty">8. Warranty</h2>
                         <p>
-                            PostHog represents and warrants that (i) it has all rights and licenses necessary for it to
-                            perform its obligations hereunder, and (ii) it will not knowingly include, in any PostHog
+                            PostHog represents and warrants that (a) it has all rights and licenses necessary for it to
+                            perform its obligations hereunder, and (b) it will not knowingly include, in any PostHog
                             software released to the public and provided to Customer hereunder, any computer code or
                             other computer instructions, devices or techniques, including without limitation those known
                             as disabling devices, trojans, or time bombs, that are intentionally designed to disrupt,
                             disable, harm, infect, defraud, damage, or otherwise impede in any manner, the operation of
                             a network, computer program or computer system or any component thereof, including its
-                            security or user data. If, at any time, PostHog fails to comply with the warranty in this
-                            Section, Customer may promptly notify PostHog in writing of any such noncompliance. PostHog
-                            will, within thirty (30) days of receipt of such written notification, either correct the
-                            noncompliance or provide Customer with a plan for correcting the noncompliance. If the
-                            noncompliance is not corrected or if a reasonably acceptable plan for correcting them is not
-                            established during such period, Customer may terminate this Agreement as its sole and
+                            security or user data. If, at any time, PostHog fails to comply with the warranty in this{' '}
+                            <SectionLink section="8" />, Customer may promptly notify PostHog in writing of any such
+                            noncompliance. PostHog will, within thirty (30) days of receipt of such written
+                            notification, either correct the noncompliance or provide Customer with a plan for
+                            correcting the noncompliance. If the noncompliance is not corrected or if a reasonably
+                            acceptable plan for correcting it is not established during such period, Customer may
+                            terminate this Agreement in accordance with <SectionLink section="7" /> as its sole and
                             exclusive remedy for such noncompliance.
                         </p>
                     </div>
@@ -830,99 +1157,150 @@ function Terms() {
                         </p>
                     </div>
                     <div>
-                        <h2 id="disclaimer">8. Warranty Disclaimer</h2>
+                        <h2 id="disclaimer">9. Warranty disclaimer</h2>
                         <p>
                             EXCEPT AS EXPRESSLY STATED HEREIN, THE LICENSED MATERIALS, SOFTWARE AND POSTHOG PROPRIETARY
-                            INFORMATION AND ANYTHING PROVIDED IN CONNECTION WITH THIS AGREEMENT ARE PROVIDED “AS-IS,”
+                            INFORMATION AND ANYTHING PROVIDED IN CONNECTION WITH THIS AGREEMENT ARE PROVIDED "AS-IS,"
                             WITHOUT ANY WARRANTIES OF ANY KIND. POSTHOG AND ITS LICENSORS HEREBY DISCLAIM ALL
                             WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ALL IMPLIED WARRANTIES OF
-                            MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+                            MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT AND ANY
+                            WARRANTIES IMPLIED BY ANY COURSE OF PERFORMANCE, USAGE OF TRADE, OR COURSE OF DEALING.
                         </p>
                     </div>
                     <div className="md:pt-10">
                         <p>Whoa, if we have to shout then it must be important. You should read this carefully.</p>
                     </div>
                     <div>
-                        <h2 id="liability">9. Limitation of liability</h2>
+                        <h2 id="liability">10. Limitation of liability</h2>
                         <p>
-                            EXCEPT WITH RESPECT TO BREACH(ES) OF SECTION 1.1 AND/OR 2.1, IN NO EVENT WILL EITHER PARTY
-                            OR THEIR LICENSORS BE LIABLE FOR ANY INDIRECT, PUNITIVE, INCIDENTAL, SPECIAL, OR
-                            CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN ANY WAY CONNECTED WITH THE USE OF THE LICENSED
-                            MATERIALS OR ANYTHING PROVIDED IN CONNECTION WITH THIS AGREEMENT, ANY DELAY OR INABILITY TO
-                            USE THE LICENSED MATERIALS OR ANYTHING PROVIDED IN CONNECTION WITH THIS AGREEMENT OR
-                            OTHERWISE ARISING FROM THIS AGREEMENT, INCLUDING WITHOUT LIMITATION, LOSS OF REVENUE OR
-                            ANTICIPATED PROFITS OR LOST BUSINESS OR LOST SALES, WHETHER BASED IN CONTRACT, TORT
-                            (INCLUDING NEGLIGENCE), STRICT LIABILITY, OR OTHERWISE, EVEN IF SUCH PARTY HAS BEEN ADVISED
-                            OF THE POSSIBILITY OF DAMAGES. EXCEPT WITH RESPECT TO BREACH(ES) OF SECTION 1.1 AND/OR 2.1,
-                            THE TOTAL LIABILITY OF EACH PARTY AND ITS LICENSORS, WHETHER BASED IN CONTRACT, TORT
-                            (INCLUDING NEGLIGENCE OR STRICT LIABILITY), OR OTHERWISE, WILL NOT EXCEED, IN THE AGGREGATE,
-                            THE GREATER OF (i) ONE THOUSAND DOLLARS ($1,000), OR (ii) THE FEES PAID TO POSTHOG HEREUNDER
-                            IN ONE YEAR PERIOD ENDING ON THE DATE THAT A CLAIM OR DEMAND IS FIRST ASSERTED. THE
-                            FOREGOING LIMITATIONS WILL APPLY NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY
-                            LIMITED REMEDY.
+                            EXCEPT WITH RESPECT TO BREACH(ES) OF <SectionLink section="1.1" label="SECTION 1.1" />{' '}
+                            AND/OR <SectionLink section="2.1" label="2.1" />, IN NO EVENT WILL EITHER PARTY OR THEIR
+                            LICENSORS BE LIABLE FOR ANY INDIRECT, PUNITIVE, INCIDENTAL, SPECIAL, OR CONSEQUENTIAL
+                            DAMAGES ARISING OUT OF OR IN ANY WAY CONNECTED WITH THE USE OF THE LICENSED MATERIALS OR
+                            ANYTHING PROVIDED IN CONNECTION WITH THIS AGREEMENT, ANY DELAY OR INABILITY TO USE THE
+                            LICENSED MATERIALS OR ANYTHING PROVIDED IN CONNECTION WITH THIS AGREEMENT OR OTHERWISE
+                            ARISING FROM THIS AGREEMENT, INCLUDING WITHOUT LIMITATION, LOSS OF REVENUE OR ANTICIPATED
+                            PROFITS OR LOST BUSINESS OR LOST SALES, WHETHER BASED IN CONTRACT, TORT (INCLUDING
+                            NEGLIGENCE), STRICT LIABILITY, OR OTHERWISE, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE
+                            POSSIBILITY OF DAMAGES. EXCEPT WITH RESPECT TO BREACH(ES) OF{' '}
+                            <SectionLink section="1.1" label="SECTION 1.1" /> AND/OR{' '}
+                            <SectionLink section="2.1" label="2.1" />, THE TOTAL MAXIMUM LIABILITY OF EACH PARTY (AND
+                            ITS AFFILIATES AND ITS LICENSORS), WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE OR
+                            STRICT LIABILITY), OR OTHERWISE, WILL NOT EXCEED, IN THE AGGREGATE, THE GREATER OF (i) ONE
+                            THOUSAND DOLLARS ($1,000), OR (ii) THE TOTAL FEES PAID TO POSTHOG HEREUNDER IN THE ONE YEAR
+                            PERIOD ENDING ON THE DATE THAT A CLAIM OR DEMAND IS FIRST ASSERTED. THE FOREGOING
+                            LIMITATIONS WILL APPLY NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED
+                            REMEDY. NOTWITHSTANDING ANYTHING ELSE TO THE CONTRARY IN THIS AGREEMENT, THE LIMITATIONS AND
+                            EXCLUSIONS OF LIABILITY SET FORTH IN THIS SECTION SHALL NOT APPLY WITH RESPECT TO LIABILITY
+                            ARISING OUT OF CUSTOMER’S OBLIGATION TO PAY FEES OWED UNDER THIS AGREEMENT OR ANY APPLICABLE
+                            ORDER FORMS.
                         </p>
                     </div>
                     <div className="md:pt-10">
                         <p>ALL CAPS AGAIN, we’ll get out of the way here. 👀</p>
                     </div>
                     <div>
-                        <h2 id="misc">10. Miscellaneous</h2>
+                        <h2 id="government">11. U.S. Government matters</h2>
+                        <p>
+                            Notwithstanding anything else contained in this Agreement to the contrary, Customer may not
+                            provide to any person or export or re-export or allow the export or re-export of the
+                            Licensed Materials or any software or anything related thereto or any direct product thereof
+                            (collectively "<b>Controlled Subject Matter</b>"), in violation of any restrictions, laws or
+                            regulations of the United States Department of Commerce, the United States Department of
+                            Treasury Office of Foreign Assets Control, or any other United States or foreign agency or
+                            authority. Without limiting the foregoing, Customer acknowledges and agrees that the
+                            Controlled Subject Matter will not be used or transferred or otherwise exported or
+                            re-exported to countries as to which the United States maintains an embargo (collectively, "
+                            <b>Embargoed Countries</b>"), or to or by a national or resident thereof, or any person or
+                            entity on the U.S. Department of Treasury’s List of Specially Designated Nationals or the
+                            U.S. Department of Commerce’s Table of Denial Orders (collectively, "
+                            <b>Designated Nationals</b>"). The lists of Embargoed Countries and Designated Nationals are
+                            subject to change without notice. Use of the Licensed Materials is a representation and
+                            warranty that the User is not located in, under the control of, or a national or resident of
+                            an Embargoed Country or Designated National. The Controlled Subject Matter may use or
+                            include encryption technology that is subject to licensing requirements under the U.S.
+                            Export Administration Regulations. As defined in FAR section 2.101, any software and
+                            documentation provided by PostHog are "commercial items" and according to DFAR section
+                            252.227-7014(a)(1) and (5) are deemed to be "commercial computer software" and "commercial
+                            computer software documentation." Consistent with DFAR section 227.7202 and FAR section
+                            12.212, any use, modification, reproduction, release, performance, display, or disclosure of
+                            such commercial software or commercial software documentation by the U.S. Government will be
+                            governed solely by the terms of this Agreement and will be prohibited except to the extent
+                            expressly permitted by the terms of this Agreement.
+                        </p>
+                    </div>
+                    <div className="md:pt-10">
+                        <p>
+                            Important government stuff. Basically: don't use PostHog if you're in an embargoed country,
+                            on a sanctions list, or trying to export our software somewhere the U.S. government says you
+                            can't. If you're reading this, you're probably fine. But if you're not, this is the kind of
+                            thing we can't look the other way on, and we'll close your account if we find out.
+                        </p>
+                    </div>
+                    <div>
+                        <h2 id="misc">12. Miscellaneous</h2>
                         <p>
                             If any provision of this Agreement is found to be unenforceable or invalid, that provision
                             will be limited or eliminated to the minimum extent necessary so that this Agreement will
                             otherwise remain in full force and effect and enforceable. This Agreement is not assignable,
                             transferable or sublicensable by either party without the other party’s prior written
                             consent, not to be unreasonably withheld or delayed; provided that either party may transfer
-                            and/or assign this Agreement to a successor in the event of a sale of all or substantially
-                            all of its business or assets to which this Agreement relates. Both parties agree that this
-                            Agreement is the complete and exclusive statement of the mutual understanding of the parties
-                            and supersedes and cancels all previous written and oral agreements, communications and
-                            other understandings relating to the subject matter of this Agreement, and that all waivers
-                            and modifications must be in a writing signed or otherwise agreed to by each party, except
-                            as otherwise provided herein. No agency, partnership, joint venture, or employment is
-                            created as a result of this Agreement and neither party has any authority of any kind to
-                            bind the other in any respect whatsoever. In any action or proceeding to enforce rights
-                            under this Agreement, the prevailing party will be entitled to recover costs and attorneys’
-                            fees. All notices under this Agreement will be in writing and will be deemed to have been
-                            duly given when received, if personally delivered; when receipt is electronically confirmed,
-                            if transmitted by facsimile or e-mail; and upon receipt, if sent by certified or registered
-                            mail (return receipt requested), postage prepaid. PostHog will not be liable for any loss
-                            resulting from a cause over which it does not have direct control. This Agreement will be
-                            governed by the laws of the State of California, U.S.A. without regard to its conflict of
-                            laws provisions. The federal and state courts sitting in San Francisco County, California,
-                            U.S.A. will have proper and exclusive jurisdiction and venue with respect to any disputes
-                            arising from or related to the subject matter of this Agreement.
+                            and/or assign this Agreement, in its entirety, to a successor in interest in connection with
+                            a merger, acquisition, consolidation, corporate reorganization, or sale of all or
+                            substantially all of its assets. Both parties agree that this Agreement is the complete and
+                            exclusive statement of the mutual understanding of the parties and supersedes and cancels
+                            all previous written and oral agreements, communications and other understandings relating
+                            to the subject matter of this Agreement, and that all waivers and modifications must be in a
+                            writing signed or otherwise agreed to by each party, except as otherwise provided herein. No
+                            agency, partnership, joint venture, or employment is created as a result of this Agreement
+                            and neither party has any authority of any kind to bind the other in any respect whatsoever.
+                            In any action or proceeding to enforce rights under this Agreement, the prevailing party
+                            will be entitled to recover costs and attorneys’ fees. All notices under this Agreement will
+                            be in writing and will be deemed to have been duly given when received, if personally
+                            delivered; when receipt is electronically confirmed, if transmitted by facsimile or email;
+                            and upon receipt, if sent by certified or registered mail (return receipt requested),
+                            postage prepaid. PostHog will not be liable for any loss resulting from a cause over which
+                            it does not have direct control. This Agreement shall be governed by and construed in
+                            accordance with the laws of the State of California, United States, without regard to its
+                            conflict of law principles. The federal and state courts located in San Francisco County,
+                            California, shall have exclusive jurisdiction and venue over any dispute arising out of or
+                            relating to this Agreement.
                         </p>
                     </div>
                     <div className="md:pt-10">
                         <p>
-                            If something goes wrong then this is what happens, also some other general legal
-                            stuff.&nbsp;
-                        </p>
-                        <p>
-                            The agreement will be covered by the laws of California as this is where PostHog is
-                            based.&nbsp;
+                            The usual legal housekeeping. If part of this agreement turns out to be unenforceable, the
+                            rest still stands. Any disputes will be handled under California law, since that's where
+                            PostHog is based.
                         </p>
                     </div>
-                    <div className="pb-12">
-                        <h2 id="privacy">11. Data privacy</h2>
+                    <div>
+                        <h2 id="privacy">13. Data privacy</h2>
                         <p>
                             Customer shall ensure that any and all information or data, including without limitation,
-                            personal data, used by Customer in connection with the Agreement (“Customer Data”) is
+                            personal data, used by Customer in connection with the Agreement ("<b>Customer Data</b>") is
                             collected, processed, transferred and used in full compliance with Applicable Data
-                            Protection Laws (as defined below) and that it has all obtained all necessary authorizations
-                            and consents from any data subjects to process Customer Data. “Applicable Data Protection
-                            Laws” means any applicable laws, statutes or regulations as may be amended, extended or
-                            re-enacted from time to time which relate to personal data including without limitation (ii)
-                            from and after 25 May 2018, GDPR and any EU Member State laws implementing the GDPR; and
-                            (iii) the e-Privacy Directive 2002/58/EC, as amended and as transposed into EU Member State
-                            law and any legislation replacing the e-Privacy Directive and (b) “GDPR” means the
-                            Regulation (EU) 2016/679 of the European Parliament and of the Counsel of 27 April 2016 on
-                            the protection of natural persons with regard to the processing of personal data and on the
-                            free movement of such data, and repealing Directive 95/46/EC (General Data Protection
-                            Regulation). We may enter into a GDPR Data Processing Agreement with certain Cloud clients,
-                            depending on the nature of the installation, how data is being processed, and where it is
-                            stored. Our standard form agreement can be viewed&nbsp;
+                            Protection Laws (as defined below) and that it has obtained all necessary authorizations and
+                            consents from any data subjects to process Customer Data. For clarity, Customer Data may
+                            include Customer Content submitted as part of the usage of the Licensed Materials and may
+                            contain personal data. Customer is responsible for configuring the Licensed Materials to
+                            avoid the collection of sensitive personal data where appropriate, including through
+                            available masking or filtering features. "<b>Applicable Data Protection Laws</b>" means any
+                            applicable laws, statutes or regulations as may be amended, extended or re-enacted from time
+                            to time which relate to personal data including without limitation (i) all applicable US
+                            federal and state data protection and privacy laws, including without limitation the
+                            California Consumer Privacy Act of 2018 as amended by the California Privacy Rights Act of
+                            2020 (together, the "<b>CCPA</b>"); (ii) the UK Data Protection Act 2018 and the GDPR as
+                            retained in UK domestic law by virtue of the European Union (Withdrawal) Act 2018 (as
+                            amended); (iii) from and after 25 May 2018, GDPR and any EU Member State laws implementing
+                            the GDPR; and (iv) the e-Privacy Directive 2002/58/EC, as amended and as transposed into EU
+                            Member State law and any legislation replacing the e-Privacy Directive; and "<b>GDPR</b>"
+                            means the Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April
+                            2016 on the protection of natural persons with regard to the processing of personal data and
+                            on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection
+                            Regulation). Depending on the nature of the installation, the processing of Customer Data,
+                            and where such data is stored, Customer may request that we enter into a GDPR Data
+                            Processing Agreement. Our standard form agreement can be accessed&nbsp;
                             <Link href="/dpa">here</Link>.
                         </p>
                     </div>
@@ -940,32 +1318,61 @@ function Terms() {
                         </p>
                     </div>
                     <div className="pb-12">
-                        <h2 id="sla">12. Uptime SLA</h2>
+                        <h2 id="sla">14. Uptime SLA</h2>
                         <p>
                             PostHog will use commercially reasonable efforts to make the Software available with all
                             material features and services operating and available for use, in each calendar month with
-                            an uptime percentage of 99.95% as displayed on status.posthog.com only to those customers
-                            who have purchased the Enterprise package or where it has been agreed as a special term in
-                            your annual contract. Uptime SLAs are not otherwise available to customers as standard. If
-                            the uptime percentage for the month is less than 99.95%, we will provide you with credit
-                            during the month as below: - 99.90% to 99.94% inclusive - 5% credit - 99.00% to 99.89%
-                            inclusive - 10% credit - Less than 99% - 20% credit If PostHog fails to maintain an uptime
-                            percentage of greater than 99% for any 3 months in a 6 month period, Customer may terminate
-                            their agreement upon 10 days written notice to PostHog. The calculations of uptime do not
-                            include: - Delays to data ingestion - Scheduled maintenance time: PostHog will notify
-                            Customer in advance of any scheduled routine maintenance - Emergency maintenance time
-                            (non-scheduled): PostHog will promptly notify Customer (via email or through the Software)
-                            of any non-scheduled or emergency maintenance and any other anticipated outages or
-                            performance degradation - Suspension or termination of your account - Failure of Customer or
-                            third-party equipment, software or technology upon which the Software is dependent,
-                            including, but not limited to, cloud infrastructure services upon which the Software
-                            operates, and inaccessibility to the Internet, provided that such failure or inaccessibility
-                            is not caused by PostHog’s infrastructure and is otherwise outside of PostHog’s control -
-                            Force majeure event - An attack on PostHog’s infrastructure, including without limitation, a
-                            denial of service attack or unauthorized access, provided that such attack did not occur as
-                            a result of PostHog’s failure to maintain industry standard organizational controls and
-                            technical measures - Unavailability caused by Customer’s breach of this Agreement
+                            an uptime percentage of 99.95% as displayed on&nbsp;{' '}
+                            <a href="https://posthogstatus.com">https://posthogstatus.com</a>{' '}
+                            <b>
+                                only to those customers who have purchased the Enterprise package or where it has been
+                                agreed as a special term in an Order Form
+                            </b>
+                            . Uptime SLAs are not otherwise available to a Customer as standard. If the uptime
+                            percentage for the month is less than 99.95%, PostHog will provide Customer with credit
+                            during the month as detailed below:
                         </p>
+
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
+                            <li>99.90% to 99.94% inclusive - 5% credit</li>
+                            <li>99.00% to 99.89% inclusive - 10% credit</li>
+                            <li>Less than 99% - 20% credit</li>
+                        </ul>
+
+                        <p>
+                            If PostHog fails to maintain an uptime percentage of greater than 99% for any 3 months in a
+                            6-month period, Customer may terminate this Agreement in accordance with{' '}
+                            <SectionLink section="7" /> upon ten (10) days' written notice to PostHog. The calculations
+                            of uptime do not include:
+                        </p>
+
+                        <ul className="mt-4 list-disc pl-4 space-y-1 text-[15px]">
+                            <li>Delays to data ingestion</li>
+                            <li>
+                                Scheduled maintenance time: PostHog will notify Customer in advance of any scheduled
+                                routine maintenance
+                            </li>
+                            <li>
+                                Emergency maintenance time (non-scheduled): PostHog will promptly notify Customer (via
+                                email or through the Software) of any non-scheduled or emergency maintenance and any
+                                other anticipated outages or performance degradation{' '}
+                            </li>
+                            <li>Suspension or termination of Customer’s account </li>
+                            <li>
+                                Failure of Customer or third-party equipment, software or technology upon which the
+                                Software is dependent, including, but not limited to, cloud infrastructure services upon
+                                which the Software operates, and inaccessibility to the internet, provided that such
+                                failure or inaccessibility is not caused by PostHog’s infrastructure and is otherwise
+                                outside of PostHog’s control
+                            </li>
+                            <li>
+                                Force majeure event - An attack on PostHog’s infrastructure, including without
+                                limitation, a denial of service attack or unauthorized access, provided that such attack
+                                did not occur as a result of PostHog’s failure to maintain industry standard
+                                organizational controls and technical measures
+                            </li>
+                            <li>Unavailability caused by Customer’s breach of this Agreement.</li>
+                        </ul>
                     </div>
                     <div className="md:pt-10 pb-12">
                         <p>
@@ -974,6 +1381,7 @@ function Terms() {
                         </p>
                     </div>
                 </div>
+                <p className="text-center text-sm opacity-60 mt-8 pb-12">Last Updated: June 29, 2026</p>
             </div>
         </Layout>
     )


### PR DESCRIPTION
## Summary

- Adds a new section to the Terms of Service covering PostHog's use of data for AI/ML model training and the opt-out mechanism
- Updates the Privacy Policy with corresponding language around model training data handling
- Includes minor formatting/typography fixes (hyphenation, curly quotes, whitespace cleanup)

## Test plan

- [ ] Review ToS section 5 (model training) language for legal accuracy
- [ ] Review Privacy Policy model training section for consistency with ToS
- [ ] Verify pages render correctly in the browser
- [ ] Check that no layout regressions were introduced by the CSS class additions to `privacyClasses`