### PR TITLE
Fix team ownership links on feature ownership page

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -170,7 +170,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'embedding-worker': {
         feature: 'Embedding worker',
-        owner: ['signals'],
+        owner: ['self-driving'],
         label: false,
     },
     'early-access-features': {
@@ -197,7 +197,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'github-integration': {
         feature: 'GitHub integration',
-        owner: ['signals'],
+        owner: ['self-driving'],
     },
     'group-analytics': {
         feature: 'Group analytics',
@@ -251,7 +251,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'mcp-server': {
         feature: 'MCP server',
-        owner: ['signals'],
+        owner: ['self-driving'],
         label: 'feature/mcp',
     },
     notebooks: {
@@ -318,12 +318,12 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'PostHog.com': {
         feature: 'PostHog.com',
-        owner: ['brand'],
+        owner: ['website'],
         label: false,
     },
     'posthog-ai': {
         feature: 'PostHog AI platform',
-        owner: ['signals'],
+        owner: ['self-driving'],
         label: 'feature/posthog-ai',
     },
     'posthog-code': {
@@ -403,7 +403,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     security: {
         feature: 'Security',
-        owner: ['infrastructure'],
+        owner: ['security'],
         notes: <>It's every team's job to consider and react to security issues.</>,
     },
     'self-hosting': {
@@ -433,7 +433,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     signals: {
         feature: 'Signals',
-        owner: ['signals'],
+        owner: ['self-driving'],
         label: 'feature/signals',
     },
     signup: {
@@ -443,7 +443,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'slack-app': {
         feature: 'Slack app',
-        owner: ['signals'],
+        owner: ['self-driving'],
         label: 'feature/slack-app',
     },
     settings: {


### PR DESCRIPTION
## Changes

Updates the owner links in the [feature ownership table](https://posthog.com/handbook/engineering/feature-ownership) so they point at teams that actually have pages:

- Every `Signals` owner (Signals, Slack app, MCP server, GitHub integration, PostHog AI platform, Embedding worker) now links to the **Self-Driving** team.
- **PostHog.com** now links to the **Website** team (was Brand).
- **Security** now links to the **Security** team (was Infrastructure).

The previous `signals` and `brand` slugs no longer resolve to team pages, so they were rendering as plain text instead of links.

**Why:** Charles asked to fix the feature ownership page so Signals points at the Self-Driving team page, PostHog.com points at the Website team, and Security points at the Security team — part of updating feature ownership.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782731107727969?thread_ts=1782731107.727969&cid=C09SK2PAGKF)*