### PR TITLE
Q3 2026 objectives for IRL Events team

### DIFF
--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -77,7 +77,7 @@ Sidequests are important areas of focus or things the team cares a lot about, bu
 
 **Owner:** <TeamMember name="Kliment Minchev" photo />
 
-**Motivation:** Slowly increase footprint, but stay as an experiment until next steps and goals are clear.
+**Motivation:** Slowly increase footprint, pilot campus ambassador recruitment, but stay as an experiment until next steps and goals are clear.
 
 </details>
 

--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -1,117 +1,87 @@
-### Q2 2026 objectives
+### Q3 2026 objectives
 
-These are the primary goals the team is prioritizing this quarter. 
+These are the primary goals the team is prioritizing this quarter.
 
-<details> 
-<summary>Build event planning systems to double event volume and quality</summary>
-
-**Owner:** <TeamMember name="Daniel Zaltsman" photo /> <TeamMember name="Kliment Minchev" photo />
-
-**Motivation:** We did 25–30 events in Q1 and it already stretched our capacity. Doubling volume requires removing rote work so the team can focus on the creative, product-driven, and relational work that makes events impactful.
-
-**What we'll ship:**
-- Event description, promo email, merch order, and audience segmentation generators
-- Speaker picker and preparer app 
-- Events CRM poster/parser (for partners, venues, and vendors)
-- Event recap capture app 
-- Public-facing event list for partners
-- Tracking mechanism linking event attendance (Luma or equivalent) to PostHog activation data, check-ins
-- Universal feedback form 
-- Clay integration for increasing pipeline for demand gen
-
-**We'll know we're successful when:**
-- Planning time per event is reduced by half
-- Able to say yes to more opportunistic events
-- We see an increase in inbound interest from preferred partners
-
-</details> 
-
-<details> 
-<summary>Create a repeatable playbook for conferences, 1>n hackathons, and product-specific events</summary>
+<details>
+<summary>Launch a signature self-driving event series</summary>
 
 **Owner:** <TeamMember name="Daniel Zaltsman" photo />
 
-**Motivation:** We want to make sure that PostHog events are never stale and always aligned with the quickly evolving needs of our ICP. We’ll keep introducing new formats and retiring ones that are no longer delivering value. 
+**Rationale:** Conferences are (still) wasteful; the weird, owned, curated format is the way we win (with weird).
 
-**What we'll ship:**
-- Conference playbook covering: booth setup and staffing, pre-event outreach, on-the-ground sales and community motions, lead capture process, and post-event follow-up. Playbook executed at both Stripe Sessions and AI Engineer Europe
-- 1>n hackathon format to compliment incoming AI products
-- New formats introduced to support priority products: AI Observability, Error Tracking, MCP, Wizard, Data Stack
-- City drop-in template (dinners, meetups, conferences)  and at least one city take-over executed against the template
-- Event format for testing a Student program
+**Things we could do:**
+- Test 3 formats
+- Pitch our format to partners
+- Curate ICP guest lists
 
 **We'll know we're successful when:**
-- Any organizer (internal or external) could run these events to perfection
-- City drop-in generates stronger local engagement than a standalone event in the same city
-- Sales see positive impact from conferences
-- Events are helping users learn about and try specific products
-
-</details> 
-
-<details> 
-<summary>Test Discord as an online channel for builder community engagement</summary>
-
-**Owner:** <TeamMember name="Kliment Minchev" photo /> <TeamMember name="Daniel Zaltsman" photo /> 
-
-**Motivation:** Before committing to a broader community strategy or hire, we'll be running disciplined experiments to learn whether [Discord](https://discord.gg/6b8upjDs) generates genuine, durable participation — not just sign-ups — and whether PostHog can sustain it without over-investing upfront.
-
-**What we'll ship:**
-- Server structure and channel architecture (purpose-built, not default Discord layout)
-- Onboarding flow that clearly sets expectations on what the space is and isn't for
-- Handbook bot for self-serve answers
-- PostHog API integration to link Discord handles to PostHog user accounts where possible
-- Bi-weekly virtual events (session replay parties, product demos, mini talks) to give members a reason to show up
-- Pulse survey cadence for members who stick around past week 2
-- Lightweight moderation playbook and role system based on engagement level
-
-**We'll know we're successful when:**
-- DAU/MAU ratio reaches or exceeds 20% (the benchmark for a default-alive community)
-- At least 25% of new members send 3 or more messages within their first two weeks
-- We can point to at least one meaningful signal we couldn't have gotten elsewhere — a product insight, a super-user, a cross-user collaboration, or a partner co-event lead
-- The team feels like it's worth continuing, not just maintaining
+- One format clearly wins because of glowing response and partner interest
 
 </details>
 
-<details> 
-<summary>Build a global, self-sustaining builder groups network</summary>
+<details>
+<summary>Build the event-to-content flywheel</summary>
 
-**Owner:**<TeamMember name="Kliment Minchev" photo />
+**Owner:** <TeamMember name="Daniel Zaltsman" photo /> <TeamMember name="Kliment Minchev" photo />
 
-**Motivation:** Scaling to many global chapters requires organizers who run independently, connect with each other, and attract our ICP without hand-holding. Shift the trajectory so builder groups don’t depend on us to thrive. 
+**Rationale:** Our biggest unused leverage currently. We mostly lean on partners for video and social.
 
-**What we'll ship:**
-- Builder groups v2 playbook: application, vetting, and onboarding automation
-- Online space connecting builder group organizers globally (Slack or equivalent)
-- Cross-border online builder group pilot and at least one cross-border event
-- Templatized event series (e.g. demo night collab) tested in at least two new cities
+**Things we could do:**
+- Creator network
+- Handhelds at hacker houses
+- Footage-to-social pipeline
+- Feed s*itposts
 
 **We'll know we're successful when:**
-- Time to first builder group decreases by 50%
-- Builder group organizers are actively communicating with each other, not just with us
-- The event series template is replicable by a new city organizer without starting from scratch
+- Events ship content we drove and buzz from events climbs
 
-</details> 
+</details>
+
+<details>
+<summary>Turn builder groups into curated collectives</summary>
+
+**Owner:** <TeamMember name="Kliment Minchev" photo />
+
+**Rationale:** Builder groups are unfocused and passive; collectives and hacker houses are rising.
+
+**Things we could do:**
+- Rebrand to collectives
+- More curator partnerships (Bond)
+- Embed in hacker houses
+- Target by ICP data
+
+**We'll know we're successful when:**
+- More collectives, more self-organization, and motion without our input
+
+</details>
 
 ### Sidequests
 
 Sidequests are important areas of focus or things the team cares a lot about, but which aren't their primary goal.
 
-<details> 
-<summary>Activate Student pilot</summary>
+<details>
+<summary>Discord</summary>
 
-**Owner:**<TeamMember name="Kliment Minchev" photo /> 
+**Owner:** <TeamMember name="Daniel Zaltsman" photo />
 
-**Motivation:** We're already supporting student builders and future founders in a small capacity. We'd like to expand this into a controlled experiment that delivers more data on what a student program might look like. 
+**Motivation:** Held in a working state (Daniel maintains until handoff) until the dev who talks to devs is hired. Adding engagement mechanisms and events.
 
-</details> 
+</details>
 
-<details> 
-<summary>Explore live streaming</summary>
+<details>
+<summary>Student program</summary>
 
-**Owner:**<TeamMember name="Daniel Zaltsman" photo /> 
+**Owner:** <TeamMember name="Kliment Minchev" photo />
 
-**Motivation:** Live streaming allows us to connect to a broader subset of our users than IRL events. 
+**Motivation:** Continuing to stay as an experiment until next steps and goals are clear.
 
-</details> 
+</details>
 
+<details>
+<summary>Dreamforce</summary>
 
+**Owner:** <TeamMember name="Daniel Zaltsman" photo />
+
+**Motivation:** Explore a major presence at the event in order to accelerate adoption of PostHog Slack product.
+
+</details>

--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -31,9 +31,12 @@ These are the primary goals the team is prioritizing this quarter.
 - Handhelds at hacker houses
 - Footage-to-social pipeline
 - Feed s*itposts
+- Feed/feature builders and event guests in brand channels
+- Higher visibility partnerships and co-marketing
 
 **We'll know we're successful when:**
 - Events ship content we drove and buzz from events climbs
+- Deepen our partnerships via IRL events co-hosting
 
 </details>
 
@@ -46,12 +49,13 @@ These are the primary goals the team is prioritizing this quarter.
 
 **Things we could do:**
 - Rebrand to collectives
-- More curator partnerships (Bond)
+- Reach a higher profile organizer
 - Embed in hacker houses
-- Target by ICP data
+- Target by ICP data [dashboard here](https://us.posthog.com/project/2/dashboard/1329163)
 
 **We'll know we're successful when:**
 - More collectives, more self-organization, and motion without our input
+- 
 
 </details>
 
@@ -73,7 +77,7 @@ Sidequests are important areas of focus or things the team cares a lot about, bu
 
 **Owner:** <TeamMember name="Kliment Minchev" photo />
 
-**Motivation:** Continuing to stay as an experiment until next steps and goals are clear.
+**Motivation:** Slowly increase footprint, but stay as an experiment until next steps and goals are clear.
 
 </details>
 


### PR DESCRIPTION
## Changes

Replaces the IRL Events team's Q2 2026 objectives with their Q3 2026 goals on the [team page](https://posthog.com/teams/irl-events). Three primary goals (signature self-driving event series, event-to-content flywheel, builder groups → curated collectives) plus sidequests for Discord, the student program, and Dreamforce. Uses the existing `<details>` styling and `<TeamMember>` linking conventions.

**Why:** New quarter — the team page should reflect what IRL Events is prioritizing in Q3.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AB78YBCNA/p1782740851144399?thread_ts=1782740851.144399&cid=C0AB78YBCNA)*
