### PR TITLE
Update infrastructure team contact methods

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,1 +1,5 @@
-{}
+{
+  "permissions": {
+    "defaultMode": "acceptEdits"
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,1 @@
-{
-  "permissions": {
-    "defaultMode": "acceptEdits"
-  }
-}
+{}

--- a/contents/handbook/engineering/cloud-providers.md
+++ b/contents/handbook/engineering/cloud-providers.md
@@ -58,7 +58,7 @@ See the [AWS self-host deployment guide](/docs/self-host/deploy/aws).
 
 ### How do I get access?
 
-Ask in the `#team-infrastructure` Slack channel for someone to add you.
+Ask in the `#support-infrastructure` Slack channel for someone to add you.
 
 To give someone access: Navigate to [PostHog project IAM](https://console.cloud.google.com/iam-admin/iam?project=posthog-301601&supportedpurview=project) and use the `+Add` button at the top to add their PostHog email address and toggle `Basic` -> `Editor` role.
 
@@ -71,7 +71,7 @@ See the [GCP self-host deployment guide](/docs/self-host/deploy/gcp).
 
 ### How do I get access?
 
-Ask in the `#team-infrastructure` Slack channel for someone to add you.
+Ask in the `#support-infrastructure` Slack channel for someone to add you.
 
 To give someone access: navigate to [PostHog team settings page](https://cloud.digitalocean.com/account/team?i=7cfa7c) and use the `Invite Members` button to add their PostHog email address.
 

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -332,7 +332,7 @@ If `state.yaml` shows a newer commit than what's running on pods, check ArgoCD:
 | Pods running old commit | Rollout stuck or image not built | Check deployment rollout status; verify CI built the image |
 | Can't find your service in ArgoCD | Looking at wrong app grouping | Search for your specific service + environment (e.g., `ingestion-events-prod-us`) |
 
-If a deployment appears stuck, reach out in `#team-infrastructure`.
+If a deployment appears stuck, reach out in `#support-infrastructure` or ping `@infra-folks`.
 
 ## Documenting
 

--- a/contents/handbook/product/per-product-cost-margin-analysis.md
+++ b/contents/handbook/product/per-product-cost-margin-analysis.md
@@ -62,7 +62,7 @@ Direct costs are easy. Shared costs require estimating your product's share of u
 
 ### 3. Work with infra on tagging
 
-Reach out to #team-infrastructure to kick off the process – they can help you estimate your product's traffic share and navigate the tooling.
+Reach out to #support-infrastructure to kick off the process – they can help you estimate your product's traffic share and navigate the tooling.
 
 We use a FinOps tool for cost allocation. The infrastructure team sets up allocation tags that group AWS resources by product/function.
 
@@ -212,7 +212,7 @@ See the [Session Replay unit economics RFC](https://github.com/PostHog/requests-
 
 ## Contacts
 
-- **Infrastructure / cost tooling:** #team-infrastructure
+- **Infrastructure / cost tooling:** #support-infrastructure
 - **ClickHouse cost attribution:** #team-clickhouse
 - **Billing data:** Billing team
 

--- a/contents/teams/cloud-foundations/index.mdx
+++ b/contents/teams/cloud-foundations/index.mdx
@@ -9,3 +9,15 @@ template: team
 ## Slack channel
 
 [#team-cloud-foundations](https://posthog.slack.com/archives/C01MM7VT7MG)
+
+## How to get in touch
+
+We have a bit of overlapping ownership across infra, so you don't need to know "who owns what" — use these and we'll pull in the right person/team:
+
+- **Need our eyes on something, not urgent:** `@support-hero-infra`
+- **Need context or someone in your timezone:** `@infra-folks`
+- **Something is burning and you need to page us:** escalate to **Escalation (manual): Infrastructure** in incident.io
+
+General channel: `#support-infrastructure`. Not sure which infra team to post to? Use `#group-infrastructure`.
+
+If you know exactly which team you need, you can use the specific `@cloud-foundations-folks` / `@cloud-platform-folks` handles or the `#team-cloud-foundations` / `#team-cloud-platform` channels directly.

--- a/contents/teams/cloud-platform/index.mdx
+++ b/contents/teams/cloud-platform/index.mdx
@@ -9,3 +9,15 @@ template: team
 ## Slack channel
 
 [#team-cloud-platform](https://posthog.slack.com/archives/C0B0XG26C2G)
+
+## How to get in touch
+
+We have a bit of overlapping ownership across infra, so you don't need to know "who owns what" — use these and we'll pull in the right person/team:
+
+- **Need our eyes on something, not urgent:** `@support-hero-infra`
+- **Need context or someone in your timezone:** `@infra-folks`
+- **Something is burning and you need to page us:** escalate to **Escalation (manual): Infrastructure** in incident.io
+
+General channel: `#support-infrastructure`. Not sure which infra team to post to? Use `#group-infrastructure`.
+
+If you know exactly which team you need, you can use the specific `@cloud-foundations-folks` / `@cloud-platform-folks` handles or the `#team-cloud-foundations` / `#team-cloud-platform` channels directly.


### PR DESCRIPTION
## Changes

Consolidates how people get in touch with infra (Cloud Foundations + Cloud Platform). Overlapping ownership was causing "who owns what" confusion, so this documents one simple interface.

- Added a **How to get in touch** section to both team pages (`contents/teams/cloud-foundations/index.mdx`, `contents/teams/cloud-platform/index.mdx`):
  - Non-urgent eyes → `@support-hero-infra`
  - Context / someone in your timezone → `@infra-folks`
  - Burning, need a page → escalate to **Escalation (manual): Infrastructure** in incident.io
  - Know the exact team → specific `@cloud-foundations-folks` / `@cloud-platform-folks` handles or `#team-cloud-foundations` / `#team-cloud-platform` channels
  - General channel `#support-infrastructure`; `#group-infrastructure` if unsure which team
- Migrated scattered `#team-infrastructure` mentions → `#support-infrastructure` in `cloud-providers.md`, `development-process.md`, and `per-product-cost-margin-analysis.md` (also added `@infra-folks` to the stuck-deployment note).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.

- [x] Words are spelled using American English

- [x] Use relative URLs for internal links

- [ ] I've checked the pages added or changed in the Vercel preview build

- [ ] If I moved a page, I added a redirect in `vercel.json`

---

Note: last two boxes unchecked — no page moved (no redirect needed), and Vercel preview check is on you after push. Want me to commit + open the PR?

Generated-By: PostHog Code