### PR TITLE
docs(rust): document panic autocapture

### DIFF
--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -84,6 +84,35 @@ if let Err(err) = result {
 
 </Step>
 
+<Step title="Capture panics" badge="optional">
+
+Panic autocapture is opt-in and uses the process-global client. Enable `capture_panics` and initialize the global client with `init_global`; the SDK then installs a process-wide `std::panic` hook:
+
+```rust
+use posthog_rs::{ClientOptionsBuilder, ErrorTrackingOptionsBuilder};
+
+let options = ClientOptionsBuilder::default()
+    .api_key("<ph_project_token>".to_string())
+    .host("<ph_client_api_host>")
+    .error_tracking(
+        ErrorTrackingOptionsBuilder::default()
+            .capture_panics(true)
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+// Installs the panic hook and routes panics through the global client.
+posthog_rs::init_global(options).await.unwrap();
+```
+
+Each panic is captured as a personless `$exception` carrying the panic message, the panic-site location (`$exception_panic_file`, `$exception_panic_line`, `$exception_panic_column`), and a call-site stack trace (subject to `capture_stacktrace`). The previously installed hook still runs afterwards.
+
+Because a panic hook is process-global, panic autocapture pairs with the global client — there is no per-`Client` panic API. Capture routes through the SDK's background worker, so it needs no async runtime, and the flush is bounded to a short timeout (2s) so a slow or unreachable PostHog can't freeze the crashing process. Delivery is best-effort: under sustained backpressure the event may not be sent before the process exits.
+
+</Step>
+
 <Step title="Configure stack traces" badge="optional">
 
 Stack trace capture and in-app frame classification are configured per client through `ErrorTrackingOptionsBuilder`:

--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -107,7 +107,7 @@ let options = ClientOptionsBuilder::default()
 posthog_rs::init_global(options).await.unwrap();
 ```
 
-Each panic is captured as a personless `$exception` carrying the panic message, the panic-site location (`$exception_panic_file`, `$exception_panic_line`, `$exception_panic_column`), and a call-site stack trace (subject to `capture_stacktrace`). The previously installed hook still runs afterwards.
+Each panic is captured as a personless `$exception` carrying the panic message, the panic-site location, and a call-site stack trace (subject to `capture_stacktrace`). The previously installed hook still runs afterwards.
 
 Because a panic hook is process-global, panic autocapture pairs with the global client — there is no per-`Client` panic API. Capture routes through the SDK's background worker, so it needs no async runtime, and the flush is bounded to a short timeout (2s) so a slow or unreachable PostHog can't freeze the crashing process. Delivery is best-effort: under sustained backpressure the event may not be sent before the process exits.
 

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -95,7 +95,7 @@ client.capture_exception_with(
 ).await.unwrap();
 ```
 
-For the full setup guide, see the [Rust error tracking installation docs](/docs/error-tracking/installation/rust).
+To also capture unhandled panics, enable `capture_panics` and initialize the global client with `init_global`. For that and the full setup guide, see the [Rust error tracking installation docs](/docs/error-tracking/installation/rust).
 
 ## Observability
 


### PR DESCRIPTION
## Problem

Panic autocapture shipped in the Rust SDK in v0.15.0 (PostHog/posthog-rs#157), but the [Rust error tracking docs](/docs/error-tracking/installation/rust) only cover manual exception capture. The merged API differs from the earlier proposal — it is opt-in through `ErrorTrackingOptions::capture_panics` and global-only (no standalone `install_panic_hook`), so this documents the API as it actually shipped.

## Changes

- New "Capture panics" step in the Rust error tracking installation guide: enable `capture_panics` on `ErrorTrackingOptionsBuilder` and initialize the global client with `init_global`, which installs the process-wide `std::panic` hook
- Notes the captured properties (`$exception_panic_file` / `_line` / `_column`), that panics are personless, that the previous hook is chained, and the best-effort delivery bound (2s flush, no async runtime needed)
- One-line pointer to the panic step from the Rust library page

## Tests

- `node`-free MDX: YAML frontmatter parsed, `<Steps>`/`<Step>` tags balanced (6/6)
- Every API reference verified against the merged SDK source (posthog-rs `4294c51`, v0.15.0): `capture_panics` in the public API, `init_global` is `async` under the default feature, exact panic property names
