### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,3 +158,12 @@ Reference these when working on specific areas:
 - Duplicate code when a shared solution exists
 - Skip verifying parent directories before creating files
 - Move or rename a page without adding a redirect in `vercel.json`
+
+## Cursor Cloud specific instructions
+
+Environment: Node 22 and pnpm 10 are preinstalled; the update script runs `pnpm install`. No secrets are required for normal development — `.env.development` is committed and public.
+
+- **Running the site:** `pnpm start` (runs `./bin/start`, which sets `NODE_OPTIONS=--max_old_space_size=16384` and serves Gatsby develop on `0.0.0.0:8001`). It's a long-running process — start it in a background/tmux session, not a blocking foreground call.
+- **First load is slow:** the dev server prints `success building schema` / `run page queries` well before it actually serves. Gatsby compiles pages on demand, so the very first HTTP request to `/` can take 1–2 minutes (and return nothing until then). Wait for an HTTP 200 from `http://localhost:8001/` before assuming a failure. GraphiQL is at `http://localhost:8001/___graphql`.
+- **Expected harmless warnings** during startup (do not treat as errors): `gatsby-source-ashby: Missing options.apiKey`, `No Algolia keys present`, `Cloudinary data not found ...` (hundreds of lines), `No Mapbox access token`, `YOUTUBE_API_KEY not set`. These features need optional API keys that aren't present; the site runs fine without them.
+- **Testing:** `pnpm test` is a placeholder (always fails). `pnpm test-redirects` currently matches no test files. The real automated test is `pnpm test:bundle`. There is no repo-wide lint script — run ESLint directly on files (e.g. `npx eslint <path>`); `any`/return-type findings are warnings, not errors. `pnpm format` runs Prettier and rewrites files.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cloud Agent development environment for the PostHog.com Gatsby site, and documents non-obvious startup/test caveats for future agents.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering: how to run the dev server, the slow first-load behavior, expected harmless startup warnings, and the actual test/lint/format commands.
- Configures the Cloud Agent update script to `pnpm install`.

No application code was changed.

## Environment verification

- ✅ `pnpm install` — installs cleanly (Node 22, pnpm 10)
- ✅ `npx eslint src/components/TaskBarMenu/menuData.tsx` — runs (warnings only, no errors)
- ✅ `pnpm test:bundle` — 4/4 passing
- ✅ `pnpm start` — Gatsby develop serves `http://localhost:8001/` (HTTP 200)

## Walkthrough

Verified the running site end-to-end in a browser: loaded the homepage, navigated to the Product Analytics docs page, and used the search feature.

[posthog_com_dev_demo.mp4](https://cursor.com/agents/bc-c7c4f9cb-3c1e-4fb6-9e6c-abc227d9a059/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fposthog_com_dev_demo.mp4)

[Homepage loaded](https://cursor.com/agents/bc-c7c4f9cb-3c1e-4fb6-9e6c-abc227d9a059/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Product Analytics docs page](https://cursor.com/agents/bc-c7c4f9cb-3c1e-4fb6-9e6c-abc227d9a059/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_product_analytics.webp)
[Search results for feature flags](https://cursor.com/agents/bc-c7c4f9cb-3c1e-4fb6-9e6c-abc227d9a059/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_feature_flags.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7c4f9cb-3c1e-4fb6-9e6c-abc227d9a059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7c4f9cb-3c1e-4fb6-9e6c-abc227d9a059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

