### PR TITLE
docs(api): add error tracking API link

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2771,6 +2771,10 @@ export const docsMenu = {
                             url: '/docs/api/environments',
                         },
                         {
+                            name: 'Error tracking',
+                            url: '/docs/api/error-tracking',
+                        },
+                        {
                             name: 'Evaluation runs',
                             url: '/docs/api/evaluation-runs',
                         },
@@ -5375,8 +5379,8 @@ export const docsMenu = {
                             url: '/docs/references/posthog-python?filter=error-tracking',
                         },
                         {
-                            name: 'Error Tracking API',
-                            url: '/docs/api',
+                            name: 'Error tracking API',
+                            url: '/docs/api/error-tracking',
                         },
                     ],
                 },

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -96,6 +96,7 @@ const titleMap: Record<string, string> = {
     datasets: 'Datasets',
     early_access_feature: 'Early access features',
     environments: 'Environments',
+    error_tracking: 'Error tracking',
     evaluation_runs: 'Evaluation runs',
     evaluations: 'Evaluations',
     event_definitions: 'Event definitions',
@@ -582,7 +583,8 @@ interface ApiEndpointData {
 export default function ApiEndpoint({ data }: { data: ApiEndpointData }): JSX.Element {
     const { allMdx } = data
     const name = data.data.name
-    const title = titleMap[name] || humanReadableName(name)
+    const baseName = name.replace(/-\d+$/, '')
+    const title = titleMap[baseName] || humanReadableName(baseName)
     const nextURL = data.data.nextURL
     const previousURL = data.data.previousURL
     const paths = {}


### PR DESCRIPTION
## Changes

- Add Error tracking to the generated API reference sidebar.
- Point the Error tracking docs reference link directly to `/docs/api/error-tracking`.
- Fix generated API titles for chunked pages such as `/docs/api/error-tracking-2`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`