### PR TITLE
chore: clarify platform-features owns shared email delivery path

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -235,6 +235,12 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         feature: 'Internal messaging (email, notifications)',
         owner: ['platform-features'],
         label: 'feature/notifications',
+        notes: (
+            <>
+                Platform features owns the shared email delivery path (SMTP/sending) used by platform-level emails
+                such as digests. Individual digest content stays with its team (e.g. Growth owns the Weekly digest).
+            </>
+        ),
     },
     'live-events': {
         feature: 'Live events',


### PR DESCRIPTION
## Changes

Adds a clarifying note to the `internal-messaging` feature ownership entry in `useFeatureOwnership.tsx`.

`internal-messaging (email, notifications)` is already owned by **platform features**, but the boundary with team-specific digests wasn't spelled out. The note now makes explicit that platform features owns the shared email delivery path (SMTP/sending) used by platform-level emails such as digests, while individual digest *content* stays with its team (e.g. Growth owns the Weekly digest).

This mirrors a companion change in the posthog repo assigning the shared email-send code to `@PostHog/team-platform-features` in `CODEOWNERS-soft`, so the website's feature-ownership table reflects the same boundary.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1782810580722529?thread_ts=1782810580.722529&cid=C06GG249PR6)*
