### PR TITLE
docs: correct project move requirements to match product behavior

### DIFF
--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -74,7 +74,7 @@ If both organizations are in the **same region** (e.g., both on US Cloud or both
 3. Select the destination organization
 4. Confirm the move
 
-This option is **free and available to all customers** regardless of plan level. You can do this even if the project you're moving is the only one in your organization — there's no need to create a second project or upgrade first. Since both organizations are in the same data center, the move simply transfers project ownership without needing to physically relocate any data.
+This option is **free and available to all customers** regardless of plan level. You can do this even if the project you're moving is the only one in your organization. There's no need to create a second project or upgrade first. Since both organizations are in the same data center, the move simply transfers project ownership without needing to physically relocate any data.
 
 ### Cross-region (requires Scale or Enterprise)
 

--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -60,11 +60,8 @@ You can move a project from one organization to another through [project setting
 
 Before moving a project, keep these requirements in mind:
 
-- You need to be an owner or admin of the originating organization to transfer a project
-- You need to be a member of the target organization
-- The originating organization must have at least two projects before you can move one
-- Since free organizations are limited to one project, you may need to temporarily upgrade your plan and add billing details to create a second project
-- After the move is complete, you can downgrade the original organization back to the free plan if desired
+- You need to be an owner or admin of the originating organization to move a project
+- You need to be an owner or admin of the target organization as well
 
 > Moving a project will mean all original organization members will lose access (including via things like API keys) unless they also are part of the target organization.
 
@@ -77,7 +74,7 @@ If both organizations are in the **same region** (e.g., both on US Cloud or both
 3. Select the destination organization
 4. Confirm the move
 
-This option is **free and available to all customers** regardless of plan level. Since both organizations are in the same data center, the move simply transfers project ownership without needing to physically relocate any data.
+This option is **free and available to all customers** regardless of plan level. You can do this even if the project you're moving is the only one in your organization — there's no need to create a second project or upgrade first. Since both organizations are in the same data center, the move simply transfers project ownership without needing to physically relocate any data.
 
 ### Cross-region (requires Scale or Enterprise)
 


### PR DESCRIPTION
## Changes

The "Moving projects between organizations" section listed requirements the product doesn't actually enforce, which can send users down an unnecessary paid-upgrade path just to move their only project.

- Removed the false requirements: that the originating org must have **at least two projects**, and that free orgs must **temporarily upgrade and add billing** to create a second project (plus the now-orphaned downgrade note).
- Corrected "you need to be a **member** of the target organization" → **owner or admin of both** the source and target orgs — this is what the `change_organization` API actually enforces.
- Added a line to the same-region (self-serve) section clarifying you can move your only project, with no second project or upgrade needed.

**Why:** A free-plan user following these docs to move their single project into their company's org hit the (nonexistent) two-project rule and went through a temporary subscribe → create project → move → cancel cycle that wasn't required. The product allows the move directly.

## History — was this ever true?

It looks like the "≥2 projects" rule was **never enforced by the product**, so this corrects a never-true statement rather than documenting a newly-relaxed limit:

- Self-service project moving shipped in PostHog/posthog#28187 (2025-02-04). The original `change_organization` endpoint checked only that you're an **admin or owner of both** orgs — no project-count check. That logic (and its tests) is unchanged today.
- This docs section was added ~2 months later, in #11158 (2025-04-02), and introduced the two-project + temporary-upgrade guidance.
- A `git log -S` pickaxe across the monorepo's full history finds "at least two projects" **only** in the docs — it has never appeared in product code (backend or frontend). The frontend's only move-gate (PostHog/posthog#42648, 2025-12-04) just disables the control when you aren't a member of any other org.

Most likely it conflated two things that *are* real — you can't delete an org's **last** project, and the free plan is capped at **1** project — but a move only reassigns ownership (it never deletes from the source, which is allowed to end with zero projects; the happy-path API test moves a single-project org's only project and asserts `200`). Worth a quick sanity-check from the author of #11158.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
