### PR TITLE
Edit Replay Vision page copy

### DIFF
--- a/src/pages/replay-vision.tsx
+++ b/src/pages/replay-vision.tsx
@@ -30,14 +30,14 @@ const scannerCards = [
         color: 'text-red',
         bgColor: 'bg-red/10',
         title: 'Dead ends',
-        description: 'Detect sessions where the user gets stuck on a page with no clear path forward.',
+        description: 'Catch the moment someone hits a wall, stares at it, and rage-quits.',
     },
     {
         icon: IconDocument,
         color: 'text-seagreen',
         bgColor: 'bg-green/10',
         title: 'Session summary',
-        description: 'Generate a short narrative of what the user actually did in the session.',
+        description: "The TL;DR of the session, so you don't have to sit through 14 minutes of someone scrolling.",
     },
     {
         icon: IconCursorClick,
@@ -51,7 +51,7 @@ const scannerCards = [
         color: 'text-yellow',
         bgColor: 'bg-yellow/10',
         title: 'Frustration score',
-        description: 'Score how much friction or frustration the user appeared to experience.',
+        description: 'Rate how mad the page made someone, from mild sigh to keyboard-smash.',
     },
     {
         icon: IconCheckCircle,
@@ -68,20 +68,21 @@ const useCaseCards = [
         color: 'text-red',
         title: 'Find the bugs that hurt',
         description:
-            'Surface errors that were actually visible to users and blocked them from finishing a task. Eliminate the console noise nobody saw.',
+            'Surface errors that were actually visible to users and blocked them from finishing a task.',
     },
     {
         icon: IconTrending,
         color: 'text-yellow',
-        title: 'Triage by frustration, not guesswork',
-        description: "Let the scorer rank your sessions so you watch the 10 that matter, not 10,000 that don't.",
+        title: 'Stop watching sessions at random',
+        description:
+            "The scorer ranks your sessions according to relevance, so you won't waste time watching sessions that don't matter.",
     },
     {
         icon: IconCursorClick,
         color: 'text-blue',
-        title: 'Spot patterns at scale',
+        title: 'Spot patterns without losing your afternoon',
         description:
-            'Sessions get tagged automatically, so "where are people getting stuck on mobile checkout?" becomes a search, not hours of watching.',
+            'Sessions get tagged automatically, so finding out where people get stuck on mobile checkout is just a search away.',
     },
 ]
 
@@ -162,7 +163,7 @@ function HowItWorks() {
 
             <p className="text-sm text-secondary">
                 Every observation comes with a confidence score and links straight to the exact moment in the recording,
-                so you can verify it in one click, not go hunting.
+                so you can verify it in one click.
             </p>
         </section>
     )


### PR DESCRIPTION
## Changes

Copy edits to the Replay Vision landing page (`src/pages/replay-vision.tsx`):

- **Use-case cards** — reworded the "bugs that hurt" card, renamed "Triage by frustration, not guesswork" → "Stop watching sessions at random" with a clearer relevance-ranking description, and renamed "Spot patterns at scale" → "Spot patterns without losing your afternoon" with a punchier mobile-checkout line.
- **Observation-type cards** — punchier copy for "Dead ends", "Frustration score", and "Session summary".
- Removed the trailing "not go hunting." from the observation footer.

**Why:** Sara wants the Replay Vision page copy to be more concrete and punchy.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BA574QMPG/p1782817761831779)*
