### PR TITLE
Embed event submission survey on marketing events handbook page

### DIFF
--- a/contents/handbook/marketing/events.md
+++ b/contents/handbook/marketing/events.md
@@ -117,6 +117,6 @@ Sometimes students at varying universities ask us if we are interested in sponso
 
 ## Event submission form
 
-Want PostHog to partner, sponsor, or speak at your event? Fill out the form below and we'll be in touch.
+Want us to partner, sponsor, or speak at your event? Fill out the form below and we'll be in touch.
 
 <EmbeddedSurvey surveyId="019f181c-074f-0000-8240-f190ad8cfdfb" />

--- a/contents/handbook/marketing/events.md
+++ b/contents/handbook/marketing/events.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> Want PostHog to be involved in your event? See how we do [Community events](#community-events). Want to start a co-working group for builders? Check out our [Community incubator](#community-incubator) program and submit the [form](/community-incubator#apply). If you'd like to add an IRL event to the [events page](/events), contact <TeamMember name="Daniel Zaltsman"/> or <TeamMember name="Kliment Minchev"/>.
+> Want PostHog to partner, sponsor, or speak at your event? Submit the [form below](#event-submission-form). Want to start a builder collective? Check out our [Builder collectives](#community-incubator) program and submit the [form](/community-incubator#apply).
 
 We did 45 events in real life (IRL) in 2025 and we're just getting started. While we’re [100% remote](/handbook/company/culture) and set up to work asynchronously–we've found real benefits in getting together with users in real life. All our public events are showcased on the [events page](/events). 
 
@@ -114,3 +114,9 @@ For first-time yappers, reference the [speaker's guide](/handbook/marketing/spea
 ## Sponsoring student organizations
 
 Sometimes students at varying universities ask us if we are interested in sponsoring their career fairs, hackathons, or other student-led initiatives. We don't currently participate in these. Although we don't use specific years of experience as a qualifier for hiring, we rarely hire students straight out of school. If there is a custom partnership you have in mind or it involves an existing employee's alma-mater, ask in the [#team-irl-events](https://posthog.slack.com/archives/C0AB78YBCNA) channel.
+
+## Event submission form
+
+Want PostHog to partner, sponsor, or speak at your event? Fill out the form below and we'll be in touch.
+
+<EmbeddedSurvey surveyId="019f181c-074f-0000-8240-f190ad8cfdfb" />

--- a/src/components/Docs/EmbeddedSurvey.tsx
+++ b/src/components/Docs/EmbeddedSurvey.tsx
@@ -16,7 +16,7 @@ export default function EmbeddedSurvey({ surveyId, host = 'https://us.posthog.co
         iframe.id = `posthog-survey-${surveyId}`
         iframe.width = '100%'
         iframe.frameBorder = '0'
-        iframe.style.cssText = 'border: none; border-radius: 12px; max-width: 720px;'
+        iframe.style.cssText = 'border: none; max-width: 720px;'
 
         let url = `${host}/external_surveys/${surveyId}?embed=true`
         const distinctId = (window as any).posthog?.get_distinct_id?.()

--- a/src/components/Docs/EmbeddedSurvey.tsx
+++ b/src/components/Docs/EmbeddedSurvey.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { useInView } from 'react-intersection-observer'
 
 interface EmbeddedSurveyProps {
     surveyId: string
@@ -6,6 +7,7 @@ interface EmbeddedSurveyProps {
 }
 
 export default function EmbeddedSurvey({ surveyId, host = 'https://us.posthog.com' }: EmbeddedSurveyProps) {
+    const { ref, inView } = useInView({ threshold: 0.1, triggerOnce: true })
     const containerRef = useRef<HTMLDivElement>(null)
     const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
@@ -42,7 +44,7 @@ export default function EmbeddedSurvey({ surveyId, host = 'https://us.posthog.co
         return () => {
             window.removeEventListener('message', handleMessage)
         }
-    }, [surveyId, host])
+    }, [surveyId, host, inView])
 
-    return <div ref={containerRef} />
+    return <div ref={ref}>{inView && <div ref={containerRef} />}</div>
 }

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -19,6 +19,7 @@ import Snippet from '../contents/docs/integrate/snippet.mdx'
 import { CompensationCalculator } from './components/CompensationCalculator'
 import { ContentViewer } from './components/ContentViewer'
 import { Step, Steps } from './components/Docs/Steps'
+import EmbeddedSurvey from './components/Docs/EmbeddedSurvey'
 import { Drawer } from './components/Drawer'
 import { lib } from './components/Edition/lib'
 import { Emoji } from './components/Emoji'
@@ -151,4 +152,5 @@ export const shortcodes = {
     WistiaEmbed,
     WizardCommand,
     WizardCTA,
+    EmbeddedSurvey,
 }


### PR DESCRIPTION
## Changes

Embeds the hosted PostHog event submission survey at the bottom of the [marketing events handbook page](https://posthog.com/handbook/marketing/events), under a new **Event submission form** section.

- Registers the existing `EmbeddedSurvey` component (`src/components/Docs/EmbeddedSurvey.tsx`) as a global MDX shortcode so it can be used directly in handbook content. It renders the survey in a responsive iframe and auto-resizes via the `posthog:survey:height` postMessage — same behavior as the hosted embed snippet.
- Refreshes the intro copy at the top of the page to point people at the embedded form and the Builder collectives program.

**Why:** Gives event organizers a single place to submit partner/sponsor/speaker requests directly on the page, instead of routing them through individual contacts.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AB78YBCNA/p1782825181088689)*