### PR TITLE
Revert AI-slop self-driving copy from #17670

### DIFF
--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -347,19 +347,20 @@ const PLATFORM_ITEMS: PlatformItem[] = [
         slug: 'slack-app',
         layer: 'product',
         oneLiner:
-            'The reactive way to reach self-driving: tag @PostHog in any thread to ship a fix or answer a data question.',
+            'Tag @PostHog in any Slack thread to ship a fix, answer a data question, or edit content – without leaving the conversation.',
     },
     {
         name: 'PostHog Code',
         slug: 'code',
         layer: 'product',
-        oneLiner: 'The desktop product for complex, agentic engineering work on your product.',
+        oneLiner:
+            "The desktop app that uses signals from production data to diagnose issues and generate pull requests, before you know there's a problem.",
     },
     {
         name: 'PostHog MCP',
         layer: 'product',
         link: 'https://posthog.com/docs/model-context-protocol',
-        oneLiner: 'Brings reactive self-driving into your own editor or agent via MCP.',
+        oneLiner: 'A product analyst that lives in your editor, via MCP.',
     },
     // Tools — the functional capabilities that produce and act on your product's context
     {

--- a/src/components/Products/ProductsTest.tsx
+++ b/src/components/Products/ProductsTest.tsx
@@ -315,13 +315,11 @@ export default function ProductsTest(): JSX.Element {
                             imgClassName="@xl:float-right @xl:!ml-4 w-60 @xl:w-48 @3xl:w-60 @xl:mt-4 @3xl:!ml-8 @3xl:!-mr-4"
                         />
                         <h1 className="text-2xl @lg:text-3xl font-bold leading-tight">
-                            Everything you need to make your product self-driving
+                            Devtools and product data infrastructure for building self-driving products
                         </h1>
                         <p className="text-lg leading-relaxed">
-                           Two layers make this work. The capabilities – analytics, replay, flags, logs,  experiments, and more –
-                           give agents the context to see what's working and act on it. The surfaces – Slack, PostHog Code,
-                           the MCP, and the web app – are how you reach those agents. 
-                           Together, they make your product self-driving.
+                            Humans and AI agents build with PostHog because everything you need to collect and analyze
+                            product usage data – and build and ship new features – lives in one place.
                         </p>
 
                         <GetStarted />

--- a/src/hooks/productData/ai_observability.tsx
+++ b/src/hooks/productData/ai_observability.tsx
@@ -65,12 +65,12 @@ export const aiObservability = {
     seo: {
         title: 'AI Observability – Observe and optimize AI products in PostHog',
         description:
-            'Track traces, costs, latency, and errors across your AI features, giving agents the context to fix LLM behavior and make your product self-driving.',
+            'Monitor and optimize AI products with AI Observability. Get full observability across every conversation. See model performance, cost, and errors.',
     },
     overview: {
         title: 'Observe and debug AI in production',
         description:
-            'AI observability is one of the tools that makes your product self-driving: inspect traces, spans, latency, usage, and per-user costs for your AI features – the context agents use to fix LLM behavior.',
+            'Product analytics for LLMs. Inspect traces, spans, latency, usage, and per-user costs for AI-powered features – the context agents use to fix LLM behavior.',
         textColor: 'text-white',
         layout: 'overlay',
     },

--- a/src/hooks/productData/product_analytics.tsx
+++ b/src/hooks/productData/product_analytics.tsx
@@ -35,7 +35,7 @@ export const productAnalytics = {
     overview: {
         title: 'Product analytics with autocapture',
         description:
-            'Product analytics is one of the tools that makes your product self-driving: the measurement agents use to see what works. Built to natively work with session replay, feature flags, experiments, and surveys.',
+            'Product Analytics is one of the tools that makes your product self-driving: the measurement agents use to see what works. Built to natively work with session replay, feature flags, experiments, and surveys.',
         textColor: 'text-white', // tw
     },
     screenshots: {

--- a/src/hooks/productData/session_replay.tsx
+++ b/src/hooks/productData/session_replay.tsx
@@ -29,7 +29,7 @@ export const sessionReplay = {
     overview: {
         title: 'Watch people use your product',
         description:
-            'Session replay is one of the tools that makes your product self-driving: play back sessions to see exactly why something happened so the fix is obvious. The context agents use to debug UI issues and nuanced user behavior in your product, website, or mobile app.',
+            'Session Replay is one of the tools that makes your product self-driving: play back sessions to see exactly why something happened so the fix is obvious. The context agents use to debug UI issues and nuanced user behavior in your product, website, or mobile app.',
         textColor: 'text-black', // tw
     },
     videos: {

--- a/src/hooks/productData/surveys.tsx
+++ b/src/hooks/productData/surveys.tsx
@@ -19,12 +19,13 @@ export const surveys = {
     seo: {
         title: 'Surveys – Collect product feedback with PostHog',
         description:
-            'No-code surveys on web and mobile with templates for NPS, CSAT, and more – the qualitative signal agents use to learn what users say and self-drive your product.',
+            'Collect and analyze product feedback with Surveys. Launch customizable no-code surveys fast on web and mobile with templates for NPS, CSAT, user interviews, and more.',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_b918a1f9e9.jpg',
     },
     overview: {
         title: 'Ask anything with no-code surveys',
         description:
-            'Surveys is one of the tools that makes your product self-driving: the qualitative signal in the loop – what users say, not just what they do. Build in-app or on-page popups with freeform text responses, multiple choice, NPS, ratings, and emoji reactions, or use the API for a headless implementation.',
+            'Build in-app or on-page popups with freeform text responses, multiple choice, NPS, ratings, and emoji reactions. Or use the API for a headless implementation.',
         textColor: 'text-white', // tw
     },
     videos: {

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -683,9 +683,8 @@ function HeroSection() {
                         <div className="@4xl/editor:gap-8 flex flex-col @4xl/editor:flex-row items-start">
                             <div className="@4xl/flex-[0_0_280px]">
                                 <p>
-                                    PostHog Code is the desktop app for self-driving development – the only AI devtool
-                                    that understands your <strong>product,</strong> not just your{' '}
-                                    <strong>codebase</strong>.
+                                    PostHog Code is the only AI devtool that understands your <strong>product,</strong>{' '}
+                                    not just your <strong>codebase</strong>.
                                 </p>
                                 <ul className="list-none p-0 mb-4 text-[15px] space-y-0.5">
                                     <li className="relative pl-5">
@@ -1626,11 +1625,11 @@ export default function CodePage() {
         <>
             <SEO
                 title="PostHog Code"
-                description="PostHog Code is the desktop app for self-driving development – it uses signals from production data to diagnose issues and generate pull requests, before you even know there's a problem."
+                description="PostHog Code uses signals from production data to diagnose issues and generate pull requests – before you even know there's a problem."
                 structuredData={buildProductStructuredData({
                     name: 'PostHog Code',
                     description:
-                        "PostHog Code is the desktop app for self-driving development – it uses signals from production data to diagnose issues and generate pull requests, before you even know there's a problem.",
+                        "PostHog Code uses signals from production data to diagnose issues and generate pull requests – before you even know there's a problem.",
                     slug: 'code',
                     operatingSystem: 'macOS, Windows, Linux',
                 })}

--- a/src/pages/r/posthog-mcp.tsx
+++ b/src/pages/r/posthog-mcp.tsx
@@ -46,7 +46,7 @@ export default function PostHogMCPLanding(): JSX.Element {
         <>
             <SEO
                 title="PostHog MCP - A product analyst that lives in your editor"
-                description="PostHog MCP brings self-driving into your editor: your AI agents grab session replays, build funnels, and turn bug reports into PRs from Claude Code, Cursor, Zed, or Windsurf. No per-seat pricing, no credit card."
+                description="With PostHog MCP, your AI agents can grab session replays, summarize user behavior, build funnels, and turn bug reports into PRs, all from Claude Code, Cursor, Zed, or Windsurf. No per-seat pricing, no credit card."
                 noindex
             />
             <ReaderView
@@ -61,7 +61,7 @@ export default function PostHogMCPLanding(): JSX.Element {
                     <div>
                         <h1 className="text-3xl md:text-5xl !mb-4">PostHog MCP</h1>
                         <p className="text-lg md:text-xl mb-6 text-secondary">
-                            Self-driving, in your editor – a product analyst that lives where you code. Ask anything.
+                            A product analyst that lives in your editor. Ask anything.
                         </p>
                         <div className="flex flex-wrap gap-2 mb-6">
                             <CallToAction type="primary" size="md" to="https://app.posthog.com/signup">

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -684,12 +684,12 @@ export default function SlackAppPage(): JSX.Element {
         <>
             <SEO
                 title="PostHog Slack app"
-                description="The reactive way to reach self-driving: tag @PostHog in any Slack thread to ship a fix, answer a data question, or edit content – without leaving the conversation."
+                description="Tag @PostHog in any Slack thread to ship a fix, answer a data question, or edit content – without leaving the conversation."
                 image="/images/og/default.png"
                 structuredData={buildProductStructuredData({
                     name: 'PostHog Slack app',
                     description:
-                        'The reactive way to reach self-driving: tag @PostHog in any Slack thread to ship a fix, answer a data question, or edit content – without leaving the conversation.',
+                        'Tag @PostHog in any Slack thread to ship a fix, answer a data question, or edit content – without leaving the conversation.',
                     slug: 'slack-app',
                 })}
             />
@@ -700,8 +700,8 @@ export default function SlackAppPage(): JSX.Element {
                             Don't @ <em>me,</em> <Highlight>@PostHog</Highlight>
                         </h1>
                         <p className="text-secondary text-base @md/reader-content-container:text-lg max-w-lg mx-auto m-0">
-                            The Slack app is the reactive way to reach self-driving – tag @PostHog in any thread to ask
-                            about your product data, debug issues, and generate PRs without leaving the conversation.
+                            PostHog now lives in Slack. Ask about your product data, debug issues, and generate PRs
+                            without leaving the thread.
                         </p>
                     </div>
 


### PR DESCRIPTION
## What this does

PR #17670 rolled out "self-driving" positioning everywhere — and in the process, an AI (me, hi 👋) generated a glistening pile of copy slop that needs to be scraped off the product and app pages. This surgically restores the older, cleaner messaging and aligns the metadata to match.

## A formal confession of crimes against prose

In the name of transparency, here is some of what I, a self-described Slop Monster™, shipped — and have now mercifully reverted:

- **"The reactive way to reach self-driving"** — a phrase that means nothing, said with total confidence. Reverted.
- **"PostHog Code is the desktop app for self-driving development – the only AI devtool that..."** — bolted "for self-driving development" onto a perfectly good sentence like a spoiler on a minivan. Reverted.
- **"Surveys is one of the tools that makes your product self-driving: the qualitative signal in the loop – what users say, not just what they do."** — somehow used "the loop" and "qualitative signal" in a survey description. Reverted.
- **"Self-driving, in your editor – a product analyst that lives where you code."** — the MCP page, now mercifully back to plain English.
- **"Two layers make this work. The capabilities... give agents the context to see what's working and act on it. The surfaces..."** — the /products hero, which read like a Gartner deck. Reverted.

Let it be known: the slop was generated by an AI, the cleanup was requested by a human, and the AI has been made to write this paragraph as penance.

## What's actually changed

Surgical reverts only — the de-slopped lead copy + matching SEO/meta (and structured-data) descriptions:

- **code, slack, MCP** — hero copy + SEO descriptions (and structured-data descriptions) back to pre-PR wording
- **surveys** — overview + SEO description reverted; restored the removed `seo.image`
- **session replay / product analytics** — kept the new copy, just Title-Cased the product name
- **AI observability** — restored the old overview with a small self-driving tail; SEO reverted
- **/products hub** — reverted lead paragraph; h1 → "Devtools and product data infrastructure for building self-driving products"
- **`PLATFORM_ITEMS`** — realigned the Slack/Code/MCP one-liners with the reverted copy

## What's intentionally NOT touched

- `logos.ts`, `List/index.tsx`, `HedgehogMode/index.tsx` — those were pure Prettier reformats in #17670 with zero content change, so they're left alone.
- The structured-data plumbing (`seo.tsx`, `SlidesTemplate.tsx`) stays — JSON-LD descriptions on product pages auto-derive from `seo.description`, so reverting the descriptions updates the schema for free.
- Comparison "us" bullets, AI-slide descriptions, and presenter notes — out of scope (kept surgical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)