### PR TITLE
fix: left-align ReaderView title to match body on wide-content pages

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -837,10 +837,12 @@ function ReaderViewContent({
                                 )}
                                 {title && !hideTitle && (
                                     <h1
-                                        className={`mx-auto transition-all ${
+                                        className={`transition-all ${
                                             fullWidthContent || body?.type !== 'mdx'
-                                                ? 'max-w-full'
-                                                : contentMaxWidthClass || 'max-w-2xl'
+                                                ? 'max-w-full mx-auto'
+                                                : contentMaxWidthClass
+                                                  ? contentMaxWidthClass
+                                                  : 'max-w-2xl mx-auto'
                                         }`}
                                     >
                                         {title}
@@ -848,10 +850,12 @@ function ReaderViewContent({
                                 )}
                                 {(body.date || body.contributors || body.tags) && (
                                     <div
-                                        className={`flex items-center space-x-2 mb-4 flex-wrap mx-auto transition-all ${
+                                        className={`flex items-center space-x-2 mb-4 flex-wrap transition-all ${
                                             fullWidthContent || body?.type !== 'mdx'
-                                                ? 'max-w-full'
-                                                : contentMaxWidthClass || 'max-w-2xl'
+                                                ? 'max-w-full mx-auto'
+                                                : contentMaxWidthClass
+                                                  ? contentMaxWidthClass
+                                                  : 'max-w-2xl mx-auto'
                                         }`}
                                     >
                                         {body.contributors && <ContributorsSmall contributors={body.contributors} />}
@@ -878,10 +882,12 @@ function ReaderViewContent({
                                         <div
                                             id="mobile-toc"
                                             data-scheme="secondary"
-                                            className={`@4xl/app-reader:hidden mt-4 mx-auto transition-all ${
+                                            className={`@4xl/app-reader:hidden mt-4 transition-all ${
                                                 fullWidthContent || body?.type !== 'mdx'
-                                                    ? 'max-w-full'
-                                                    : contentMaxWidthClass || 'max-w-2xl'
+                                                    ? 'max-w-full mx-auto'
+                                                    : contentMaxWidthClass
+                                                      ? contentMaxWidthClass
+                                                      : 'max-w-2xl mx-auto'
                                             }`}
                                         >
                                             <TableOfContents
@@ -919,10 +925,12 @@ function ReaderViewContent({
                                 </div>
                                 {showAbout && (
                                     <div
-                                        className={`mt-8 mx-auto transition-all ${
+                                        className={`mt-8 transition-all ${
                                             fullWidthContent || body?.type !== 'mdx'
-                                                ? 'max-w-full'
-                                                : contentMaxWidthClass || 'max-w-2xl'
+                                                ? 'max-w-full mx-auto'
+                                                : contentMaxWidthClass
+                                                  ? contentMaxWidthClass
+                                                  : 'max-w-2xl mx-auto'
                                         }`}
                                     >
                                         <AboutPostHog />
@@ -930,10 +938,12 @@ function ReaderViewContent({
                                 )}
                                 {showQuestions && (
                                     <div
-                                        className={`mt-8 mx-auto transition-all ${
+                                        className={`mt-8 transition-all ${
                                             fullWidthContent || body?.type !== 'mdx'
-                                                ? 'max-w-full'
-                                                : contentMaxWidthClass || 'max-w-2xl'
+                                                ? 'max-w-full mx-auto'
+                                                : contentMaxWidthClass
+                                                  ? contentMaxWidthClass
+                                                  : 'max-w-2xl mx-auto'
                                         }`}
                                     >
                                         <h3 id="squeak-questions" className="mb-4">
@@ -942,20 +952,24 @@ function ReaderViewContent({
                                         <Questions
                                             slug={appWindow?.path}
                                             parentName={activeInternalMenu?.name}
-                                            className={`mx-auto transition-all ${
+                                            className={`transition-all ${
                                                 fullWidthContent || body?.type !== 'mdx'
-                                                    ? 'max-w-full'
-                                                    : contentMaxWidthClass || 'max-w-2xl'
+                                                    ? 'max-w-full mx-auto'
+                                                    : contentMaxWidthClass
+                                                      ? contentMaxWidthClass
+                                                      : 'max-w-2xl mx-auto'
                                             }`}
                                         />
                                     </div>
                                 )}
                                 {showSurvey && (
                                     <div
-                                        className={`mt-8 mx-auto transition-all ${
+                                        className={`mt-8 transition-all ${
                                             fullWidthContent || body?.type !== 'mdx'
-                                                ? 'max-w-full'
-                                                : contentMaxWidthClass || 'max-w-2xl'
+                                                ? 'max-w-full mx-auto'
+                                                : contentMaxWidthClass
+                                                  ? contentMaxWidthClass
+                                                  : 'max-w-2xl mx-auto'
                                         }`}
                                     >
                                         <DocsPageSurvey filePath={filePath} />


### PR DESCRIPTION
## Changes

The title on the self-driving overview page (and other docs "overview"/"start here" pages) appeared center-aligned while the body content below it sat flush left.

Cause: these pages set `contentMaxWidthClass` in frontmatter (e.g. `max-w-5xl`). In `ReaderView`, the body content applies that width left-aligned, but the title — along with the metadata, mobile TOC, about, questions, and survey blocks — applied it with `mx-auto`, centering their boxes within the wider content area. So the title's box floated to the center while the body stayed left.

This left-aligns those sibling blocks to match the body, but **only** in the `contentMaxWidthClass` branch. The default fixed-width case (`max-w-2xl`, used by blog, tutorials, and most docs) and the full-width reader toggle keep `mx-auto` and are unchanged.

Affects the ~18 pages that set `contentMaxWidthClass` (the per-product "start here" overview pages + self-driving). Worth a look across those in the Vercel preview, since this touches a shared layout component.

Before and after GIF, first clip is before, second after:
<img width="800" height="421" alt="CleanShot 2026-06-30 at 19 07 27" src="https://github.com/user-attachments/assets/9774874d-5606-4584-95d5-a6c967b29a62" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1782840080503019?thread_ts=1782840080.503019&cid=C09GTQY5RLZ)*
