### PR TITLE
Update outbound sales BDR references to current team

### DIFF
--- a/contents/handbook/growth/sales/outbound-sales.md
+++ b/contents/handbook/growth/sales/outbound-sales.md
@@ -38,7 +38,7 @@ We’ll call 1-3 ‘warm’ outbound and 4-6 ‘cold’ outbound.
 Our model is:
 
 - TAMs do warm outbound to group 1-2
-- BDRs do warmish outound to groups 3-5
+- BDRs (<TeamMember name="Lorena Viana" />, <TeamMember name="Andreas Ford" />, and <TeamMember name="Melad Khajepour" />) do warmish outbound to groups 3-5
 - TAEs do cold outbound to a top 10 list in groups 5-6
 
 Our focus today is on inbound leads, getting much better at warm outbound (we have a huge number of leads that we could be converting better), and experimenting with colder outbound. <TeamMember name="Lorena Viana" /> is leading our experiments today with the <SmallTeam slug="demand-gen" />.
@@ -75,8 +75,8 @@ Do basic account research:
     * What's their tech stack? (Job postings, BuiltWith/Wappalyzer, 1Password)  
     * Recent company news (funding, launches, hiring)  
     * Their role + tenure (LinkedIn, their website)  
-* Why did they agree to this meeting? (Read <TeamMember name="Dmytro Sitalo" />’s notes in the New Business Slack)  
-* What problem or pain did <TeamMember name="Dmytro Sitalo" /> flag?
+* Why did they agree to this meeting? (Read the sourcing BDR’s notes in the New Business Slack)  
+* What problem or pain did the BDR flag?
 
 Use this to form a call hypothesis.
 
@@ -84,13 +84,13 @@ Use this to form a call hypothesis.
 
 *We* contacted *them*. This call only makes sense if we can solve a real problem for them. Start with:
 
-    *"Hey [name], thanks for making the time. I know this was a cold outreach from [Dmytro/our team], so I really appreciate you giving me 30 minutes."*
+    *"Hey [name], thanks for making the time. I know this was a cold outreach from our team, so I really appreciate you giving me 30 minutes."*
 
     *"Before we dive in, I'm curious - what made you decide to take this call?*
 
 Often this is enough. If they’re vague or skeptical, get specific with your pre-prepared hypothesis:
 
-    *"[Dmytro mentioned/I saw] that [specific trigger - e.g. you're growing team/launching new product/scaling analytics]. We work with companies at your stage who struggle with [specific pain - e.g. fragmented analytics tools/poor data quality/lack of actionable insights]. I wanted to understand if that's actually a problem you're facing."*
+    *"[Our BDR mentioned/I saw] that [specific trigger - e.g. you're growing team/launching new product/scaling analytics]. We work with companies at your stage who struggle with [specific pain - e.g. fragmented analytics tools/poor data quality/lack of actionable insights]. I wanted to understand if that's actually a problem you're facing."*
 
     *"If it is, I can share how other companies like yours have solved it. If it's not a problem, I'll tell you honestly (or you can tell me) and we'll keep this short. Will that work for you?"*
 
@@ -189,7 +189,7 @@ This is internal hygiene. Track tasks to reflect the opportunity:
 
 - If qualified + next step, create an opportunity in `Problem Agreement` and use stage exit criteria  
 - If marginal/no next step, switch task from `In progress` to `Nurturing` and progress them toward an opportunity  
-- If not qualified, disqualify with reason and share feedback with <TeamMember name="Dmytro Sitalo" /> in Slack  
+- If not qualified, disqualify with reason and share feedback with the sourcing BDR in Slack  
 ### 9. Rinse, lather, and repeat
 
 You should always aim to get them into a shared Slack channel or establish a regular communication cadence with them (call/email). Nothing will happen if we aren't talking.


### PR DESCRIPTION
## Changes

The [outbound sales handbook page](https://posthog.com/handbook/growth/sales/outbound-sales) still referenced a team member who left in February. This removes those references and replaces them with generic "the BDR" / "sourcing BDR" wording, since meetings can now be sourced by any of our BDRs.

The current BDR team (Lorena Viana, Andreas Ford, and Melad Khajepour) is named once where BDRs are introduced in the "What we're doing today" section, rather than in every BDR reference.

**Why:** Keeps the page accurate now that the BDR function is a three-person team rather than a single individual.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ARYP7U22D/p1782841224888799?thread_ts=1782841224.888799&cid=C0ARYP7U22D)*