### PR TITLE
Update managed warehouse objectives for Q3 2026

### DIFF
--- a/contents/teams/managed-warehouse/objectives.mdx
+++ b/contents/teams/managed-warehouse/objectives.mdx
@@ -1,28 +1,30 @@
-## Q2 2026 objectives
+## Q3 2026 objectives
 
-### Objective 1: Self serve ducklings
-- **Motivation:** It is PostHog's pattern to allow self serve of all features. Be scalable
-- **Goal:** Complete an open beta where teams given access to beta can self-serve Ducklings end to end — provisioning, event data bootstrapping, and external source connector data landing in the warehouse
+### Objective 1: 10 stans on the PostHog beta
 - **What we'll ship:**
-  - Multitenant Control Plane deployment of duckgres/duckling
-  - Data Pipelines to move PostHog data into customer ducklings
-  - Metrics
-  - UI in PostHog app to allow for provisioning
-  - Pricing scheme for duckling
-  - System for attributing usage costs
+  - Pricing estimate rolled out for customers to see
+  - Ingress
+  - Backfills
+  - Warehouse sources
+  - UI in the PostHog app
+  - External documentation
+  - Documentation on tooling support
+  - Usage-based billing system reporting
+  - CNPG used in PostHog and Portola
+  - PostHog revenue models on a deployed dashboard
+  - Stretch goal: deployment for EU
 
-### Objective 2: Warehouse used across PostHog
-- **Motivation:** Better experience for modeled/external data across PostHog
+### Objective 2: System for shipping fast and reliably
 - **What we'll ship:**
-  - Support data modeling
-  - Support API Endpoints
-  - UI to select "golden" tables that should be available in Product Analytics & Experiments
-  - Pipe to copy those "golden tables" from duckling to "vanilla S3 parquet" store that CH can query
+  - Monitor for regressions with a full integration test system across all connected services
+  - Observability/alerts on clusters, both internally and signaling clearly to users
+  - Internal documentation on the architecture
+  - Runbooks
+  - Work with the security team to figure out requirements
 
 ### Objective 3: Docs and dev rel
 - **Motivation:** Socialize the capabilities, limitations, and features of Ducklings, Duckgres, DuckHog, and DuckLake
 - **What we'll ship:**
   - Docs for system and usage pattern
-  - Onboard product marketer
   - Do "talks and demos" for teams inside PostHog
   - More demos externally as well


### PR DESCRIPTION
Updates the [managed warehouse team page](https://posthog.com/teams/managed-warehouse) objectives section, replacing the Q2 2026 objectives with the Q3 2026 objectives.

## Q3 2026 objectives
- **10 stans on the PostHog beta** — pricing estimate, ingress, backfills, warehouse sources, in-app UI, external docs, tooling support docs, usage-based billing reporting, CNPG in PostHog/Portola, revenue models dashboard, and EU deployment as a stretch goal.
- **System for shipping fast and reliably** — full integration test system, observability/alerts, architecture docs, runbooks, and security requirements.
- **Docs and dev rel** — system/usage docs, internal talks and demos, and external demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)