### PR TITLE
docs: add workflows broadcasts and delays concept pages

### DIFF
--- a/contents/docs/workflows/broadcasts.mdx
+++ b/contents/docs/workflows/broadcasts.mdx
@@ -14,8 +14,8 @@ When the batch runs, PostHog evaluates your audience filters and executes the wo
 
 A batch trigger combines two things:
 
-- **Audience filters** — who should enter the workflow
-- **A schedule (optional)** — when the batch should run
+- **Audience filters** – who should enter the workflow
+- **A schedule (optional)** – when the batch should run
 
 ## Audience filters
 
@@ -75,6 +75,6 @@ Because broadcasts send through the same dispatch steps as any other workflow, y
 
 ## Further reading
 
-- [Workflow builder](/docs/workflows/workflow-builder) — all the components you can add to a workflow
-- [Delays](/docs/workflows/delays) — control the timing of messages within a workflow
-- [Workflow events](/docs/workflows/engagement-events) — measure opens, clicks, and conversions
+- [Workflow builder](/docs/workflows/workflow-builder) – all the components you can add to a workflow
+- [Delays](/docs/workflows/delays) – control the timing of messages within a workflow
+- [Workflow events](/docs/workflows/engagement-events) – measure opens, clicks, and conversions

--- a/contents/docs/workflows/broadcasts.mdx
+++ b/contents/docs/workflows/broadcasts.mdx
@@ -1,0 +1,80 @@
+---
+title: Broadcasts and batch triggers
+sidebar: Docs
+showTitle: true
+---
+
+Most workflows start when a single person does something, like an [event trigger](/docs/workflows/workflow-builder#event-triggers) that fires the moment a user signs up. A **batch trigger** works the other way around: instead of reacting to one person at a time, it evaluates an audience you define and runs the workflow once for every matching person. This is what powers **broadcasts**, one-time or recurring sends to a whole segment of users at once.
+
+Use a batch trigger when you want to message a group rather than respond to an individual action, for example a one-time product announcement, a weekly digest, or a monthly re-engagement campaign.
+
+## How a batch trigger works
+
+When the batch runs, PostHog evaluates your audience filters and executes the workflow once per matching person. Each person then flows through the rest of the workflow, the dispatches, [delays](/docs/workflows/delays), and audience splits, independently, exactly as they would for an event-triggered workflow.
+
+A batch trigger combines two things:
+
+- **Audience filters** — who should enter the workflow
+- **A schedule (optional)** — when the batch should run
+
+## Audience filters
+
+You define the audience using person properties, cohorts, or distinct IDs. Multiple conditions are combined with **OR** logic, so a person matches if they meet any of them.
+
+For example, you might broadcast to:
+
+- Everyone in a `power users` cohort
+- People whose `plan` person property is `free` (for an upgrade nudge)
+- A specific list of distinct IDs (for a targeted send)
+
+The trigger shows a real-time estimate of how many persons will be affected (e.g. "approximately 1,200 of 50,000 persons") before you enable the workflow. If the audience is too large, you'll see a warning prompting you to add filters to narrow it down. It's good practice to confirm this estimate looks right before launching, since a broadcast sends to everyone who matches at once.
+
+## One-time broadcasts
+
+By default, a batch trigger runs once, when you start it manually. This is the simplest kind of broadcast, send a single message to an audience and you're done.
+
+To run a one-time broadcast, click **Trigger** in the top right of the workflow editor and then **Run workflow**. PostHog evaluates the audience and runs the workflow for each matching person right away.
+
+Use this for sends like:
+
+- A product launch or feature announcement
+- A one-off survey invitation
+- A time-sensitive notice (maintenance window, policy change)
+
+## Recurring broadcasts
+
+Add an optional schedule to run the batch on a recurring basis instead. On each tick, PostHog re-evaluates the audience and runs the workflow for whoever matches at that moment, so a recurring broadcast automatically picks up people who newly enter the segment and drops people who leave it.
+
+Use this for time-based, audience-targeted automations such as a weekly digest email or a monthly re-engagement campaign.
+
+Configure the recurrence with the schedule picker:
+
+| Setting   | Options                                                                                                                               |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Frequency | Daily, weekly, monthly, or yearly, with an interval (e.g. every 2 weeks)                                                              |
+| Weekly    | Choose which days of the week to run on (e.g. Monday and Wednesday)                                                                   |
+| Monthly   | Run on a specific day of the month (e.g. the 15th), on an ordinal weekday (e.g. the 3rd Wednesday), or on the last day of every month |
+| Start     | The date and time the schedule begins, in a timezone you select                                                                       |
+| Ends      | Never, on a specific date, or after a set number of occurrences                                                                       |
+
+You can also type the recurrence in plain English (e.g. "every week on Monday and Wednesday"), and the picker shows a preview of the next occurrences so you can confirm the schedule before enabling the workflow.
+
+## Batch triggers vs. event triggers
+
+| | Batch trigger (broadcast) | Event trigger |
+| --- | --- | --- |
+| **Who enters** | Everyone matching an audience, evaluated together | One person, when they perform an event |
+| **When it runs** | Manually, once, or on a recurring schedule | In real time, as events arrive |
+| **Best for** | Announcements, digests, re-engagement campaigns | Welcome flows, [drip campaigns](/docs/workflows/email-drip-campaign), lifecycle messaging |
+
+If you want to message people based on what they do, use an event trigger. If you want to message a defined segment all at once, use a batch trigger.
+
+## Tracking broadcast performance
+
+Because broadcasts send through the same dispatch steps as any other workflow, you can measure them with [workflow events](/docs/workflows/engagement-events). Enable email engagement events to chart `$workflows_email_opened` and `$workflows_email_link_clicked` broken down by `$workflow_id`, and add a [conversion goal](/docs/workflows/workflow-builder#conversion-goals) to track who acted on the broadcast.
+
+## Further reading
+
+- [Workflow builder](/docs/workflows/workflow-builder) — all the components you can add to a workflow
+- [Delays](/docs/workflows/delays) — control the timing of messages within a workflow
+- [Workflow events](/docs/workflows/engagement-events) — measure opens, clicks, and conversions

--- a/contents/docs/workflows/delays.mdx
+++ b/contents/docs/workflows/delays.mdx
@@ -1,0 +1,63 @@
+---
+title: Delays
+sidebar: Docs
+showTitle: true
+---
+
+Delays control the timing of a workflow. They let you pause a person's journey, either for a set amount of time, until something becomes true about them, or until the right moment in the week, before moving on to the next step. Delays are what turn a sequence of messages into a campaign that unfolds over time rather than firing everything at once.
+
+There are three types of delay:
+
+| Delay type             | Description                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Fixed wait             | Wait for a fixed amount of time (minutes/hours/days).                                    |
+| Wait until condition   | Wait until a specific condition is met (e.g. user has a property set to a specific value). |
+| Wait until time window | Wait until a specific time window (e.g. only send on weekdays 9–5).                      |
+
+## Fixed wait
+
+A fixed wait pauses the person for a set amount of time, then continues to the next step. You choose the duration in minutes, hours, or days.
+
+Use it to space out a sequence so it doesn't all arrive at once, for example wait 3 days between the second and third email in an onboarding series.
+
+## Wait until condition
+
+A wait until condition pauses the person until a condition becomes true, or until a maximum wait time elapses, whichever comes first. It has two branches:
+
+- **Match** — the condition became true within the wait time
+- **No match** — the wait time elapsed without the condition being met
+
+You configure two things on the block:
+
+- **Wait time** — the maximum time to wait for the condition (e.g. 1 day)
+- **Conditions to wait for** — the condition that, once true, moves the person down the **match** branch (e.g. the [person property](/docs/product-analytics/person-properties) `onboarding_completed` is set to `true`)
+
+This is the key step for behavior-based branching. Instead of messaging everyone the same way, you wait to see what each person does and react accordingly, sending a follow-up only to people who *didn't* take the action you were waiting for.
+
+### Using wait until condition for drip campaigns
+
+A [drip campaign](/docs/workflows/email-drip-campaign) is a series of messages sent over time, where later messages depend on what the user has (or hasn't) done. The wait until condition step is what makes a drip "smart": it lets the campaign branch on real behavior rather than blasting every message on a fixed timer.
+
+A typical onboarding drip looks like this:
+
+1. **Trigger** on `user signed up`
+2. Send a **welcome email**
+3. **Wait until condition**: wait up to 1 day for the person property `onboarding_completed` to become `true`
+4. On the **no match** branch (they didn't finish onboarding in time), send a **follow-up email** nudging them to complete it
+5. On the **match** branch (they did finish), let them exit, no nagging needed
+
+Because the people who already converted flow down the **match** branch and exit, only those who still need a nudge get the follow-up. You can chain several wait-until-condition steps to build a multi-day sequence, each one waiting for the next milestone and only escalating when a user stalls.
+
+For a full walkthrough, see [Set up an email drip campaign](/docs/workflows/email-drip-campaign).
+
+## Wait until time window
+
+A wait until time window holds the person until the next allowed time window, then continues. Use it to make sure messages only go out at appropriate times, for example only send on weekdays between 9am and 5pm, so an email triggered at 2am waits until business hours.
+
+This is useful to combine with the other delay types: a fixed wait gets the timing roughly right, and a time window makes sure the message actually lands during waking hours.
+
+## Further reading
+
+- [Set up an email drip campaign](/docs/workflows/email-drip-campaign) — a step-by-step tutorial using wait until condition
+- [Workflow builder](/docs/workflows/workflow-builder) — all the components you can add to a workflow
+- [Broadcasts and batch triggers](/docs/workflows/broadcasts) — send to a whole audience at once

--- a/contents/docs/workflows/delays.mdx
+++ b/contents/docs/workflows/delays.mdx
@@ -24,13 +24,13 @@ Use it to space out a sequence so it doesn't all arrive at once, for example wai
 
 A wait until condition pauses the person until a condition becomes true, or until a maximum wait time elapses, whichever comes first. It has two branches:
 
-- **Match** — the condition became true within the wait time
-- **No match** — the wait time elapsed without the condition being met
+- **Match** – the condition became true within the wait time
+- **No match** – the wait time elapsed without the condition being met
 
 You configure two things on the block:
 
-- **Wait time** — the maximum time to wait for the condition (e.g. 1 day)
-- **Conditions to wait for** — the condition that, once true, moves the person down the **match** branch (e.g. the [person property](/docs/product-analytics/person-properties) `onboarding_completed` is set to `true`)
+- **Wait time** – the maximum time to wait for the condition (e.g. 1 day)
+- **Conditions to wait for** – the condition that, once true, moves the person down the **match** branch (e.g. the [person property](/docs/product-analytics/person-properties) `onboarding_completed` is set to `true`)
 
 This is the key step for behavior-based branching. Instead of messaging everyone the same way, you wait to see what each person does and react accordingly, sending a follow-up only to people who *didn't* take the action you were waiting for.
 
@@ -58,6 +58,6 @@ This is useful to combine with the other delay types: a fixed wait gets the timi
 
 ## Further reading
 
-- [Set up an email drip campaign](/docs/workflows/email-drip-campaign) — a step-by-step tutorial using wait until condition
-- [Workflow builder](/docs/workflows/workflow-builder) — all the components you can add to a workflow
-- [Broadcasts and batch triggers](/docs/workflows/broadcasts) — send to a whole audience at once
+- [Set up an email drip campaign](/docs/workflows/email-drip-campaign) – a step-by-step tutorial using wait until condition
+- [Workflow builder](/docs/workflows/workflow-builder) – all the components you can add to a workflow
+- [Broadcasts and batch triggers](/docs/workflows/broadcasts) – send to a whole audience at once

--- a/contents/docs/workflows/metrics.mdx
+++ b/contents/docs/workflows/metrics.mdx
@@ -53,6 +53,6 @@ Metrics are the per-step counters shown inside the Workflows product, ideal for 
 
 ## Further reading
 
-- [Workflow events](/docs/workflows/engagement-events) — measure opens, clicks, and conversions across PostHog
-- [Broadcasts and batch triggers](/docs/workflows/broadcasts) — one-time and recurring sends to an audience
-- [Best practices](/docs/workflows/best-practices) — what to monitor once a workflow is live
+- [Workflow events](/docs/workflows/engagement-events) – measure opens, clicks, and conversions across PostHog
+- [Broadcasts and batch triggers](/docs/workflows/broadcasts) – one-time and recurring sends to an audience
+- [Best practices](/docs/workflows/best-practices) – what to monitor once a workflow is live

--- a/contents/docs/workflows/metrics.mdx
+++ b/contents/docs/workflows/metrics.mdx
@@ -1,0 +1,58 @@
+---
+title: Metrics
+sidebar: Docs
+showTitle: true
+---
+
+Every workflow has a **Metrics** tab that shows how it's performing, how many people entered it, how many messages were sent and delivered, where things failed, and (if you've set a conversion goal) how many people converted. Metrics are recorded automatically for every enabled workflow, so there's nothing to configure to start seeing them.
+
+Metrics reflect **production traffic only**. [Test sends](/docs/workflows/launch-workflow) from the workflow builder are excluded so your numbers reflect real users, not your own testing.
+
+## What the metrics show
+
+The Metrics tab presents a set of cards and line charts over the date range you select. The exact tiles depend on what your workflow does (a Slack-only workflow won't show email opens, for example), but the common ones are:
+
+| Metric | What it counts |
+| --- | --- |
+| Triggered | Workflow runs that started, i.e. people who entered the workflow |
+| Succeeded | Runs that completed their steps without error |
+| Sent | Emails handed to the provider for delivery |
+| Delivered | Emails accepted by the recipient's mail server |
+| Opened | Emails opened (requires engagement events) |
+| Clicked | Tracked links clicked (requires engagement events) |
+| Bounced | Emails that hard- or soft-bounced |
+| Blocked | Emails marked as spam or otherwise blocked |
+| Failed | Steps that errored for another reason |
+| Converted | People who met the [conversion goal](/docs/workflows/workflow-builder#conversion-goals) |
+| Conversion rate | Converted divided by started runs, capped at 100% |
+
+Open and click metrics depend on [email engagement events](/docs/workflows/engagement-events) being enabled. Without them, you'll still see operational metrics like triggered, sent, delivered, and bounced.
+
+## How to use metrics
+
+Use the Metrics tab to answer questions like:
+
+- **Is the workflow running?** Check **Triggered** and **Succeeded** are climbing after you enable it.
+- **Are messages landing?** Compare **Sent**, **Delivered**, and **Bounced**. A high bounce or block rate points to a deliverability or list-quality problem.
+- **Are people engaging?** Watch **Opened** and **Clicked** to gauge whether your content is resonating.
+- **Is it working?** If you've set a conversion goal, **Converted** and **Conversion rate** tell you whether the workflow is actually moving the metric you care about.
+
+### Drill into individual invocations
+
+The failure tiles are clickable. Click **Bounced** or **Blocked** to jump straight to the **Invocations** tab, filtered to the invocations that experienced that failure within the selected timeframe, so you can debug specific messages. Click **View converted users** on the conversion cards to see the list of people who completed the goal.
+
+## Metrics for batch triggers
+
+For [batch-triggered workflows](/docs/workflows/broadcasts), metrics are **aggregated by run** rather than streamed continuously. Each time the batch executes, whether it's a one-time send or one tick of a recurring schedule, it counts as a run, and the metrics for that run summarize how the whole audience fared: how many people were triggered, how many messages sent and delivered, how many bounced, and how many converted.
+
+This makes it easy to compare one send against another. For a recurring broadcast, you can see at a glance whether last Monday's digest had a better open or conversion rate than this Monday's, because each run rolls its audience up into a single set of numbers instead of blending every send together.
+
+## Metrics vs. workflow events
+
+Metrics are the per-step counters shown inside the Workflows product, ideal for operational monitoring of a single workflow. For cross-product analysis, PostHog also captures [workflow events](/docs/workflows/engagement-events) (like `$workflows_email_opened` and `$workflows_conversion`) as standard events you can use in insights, funnels, retention reports, and dashboards anywhere in PostHog. The two are complementary: metrics for in-product monitoring, events for everything else.
+
+## Further reading
+
+- [Workflow events](/docs/workflows/engagement-events) — measure opens, clicks, and conversions across PostHog
+- [Broadcasts and batch triggers](/docs/workflows/broadcasts) — one-time and recurring sends to an audience
+- [Best practices](/docs/workflows/best-practices) — what to monitor once a workflow is live

--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -79,6 +79,8 @@ To set this up:
 Batch triggers let you run a workflow for each person in an audience you define, optionally on a recurring schedule.
 When the batch runs, PostHog evaluates your audience filters and executes the workflow once per matching person.
 
+For a deeper guide to one-time and recurring sends to a whole audience, see [Broadcasts and batch triggers](/docs/workflows/broadcasts).
+
 A batch trigger combines two things:
 
 - **Audience filters** — who should enter the workflow
@@ -171,7 +173,7 @@ Delays help you control the timing of your messages. There are 3 types of delays
 | Wait until condition   | Wait until a specific condition is met (e.g. user has property set to a specific value). |
 | Wait until time window | Wait until a specific time window (e.g. only send on weekdays 9-5).                      |
 
-You can see an example of a delay in the [email drip campaign](/docs/workflows/email-drip-campaign) tutorial.
+For a deeper guide to each delay type, including how to use **wait until condition** to build drip campaigns, see [Delays](/docs/workflows/delays). You can also see an example of a delay in the [email drip campaign](/docs/workflows/email-drip-campaign) tutorial.
 
 ## Audience splits
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7040,6 +7040,12 @@ export const docsMenu = {
                     color: 'orange',
                 },
                 {
+                    name: 'Metrics',
+                    url: '/docs/workflows/metrics',
+                    icon: 'IconGraph',
+                    color: 'orange',
+                },
+                {
                     name: 'Content library and message templates',
                     url: '/docs/workflows/library',
                     icon: 'IconDatabase',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7028,6 +7028,18 @@ export const docsMenu = {
                     color: 'orange',
                 },
                 {
+                    name: 'Broadcasts and batch triggers',
+                    url: '/docs/workflows/broadcasts',
+                    icon: 'IconMegaphone',
+                    color: 'orange',
+                },
+                {
+                    name: 'Delays',
+                    url: '/docs/workflows/delays',
+                    icon: 'IconClock',
+                    color: 'orange',
+                },
+                {
                     name: 'Content library and message templates',
                     url: '/docs/workflows/library',
                     icon: 'IconDatabase',


### PR DESCRIPTION
## Changes

Adds two new concept pages under **Workflows**, expanding on content that currently only lives as short sections in the [workflow builder](/docs/workflows/workflow-builder) page:

- **Broadcasts and batch triggers** (`/docs/workflows/broadcasts`) — how batch triggers work, audience filters, one-time vs. recurring broadcasts, batch vs. event triggers, and measuring broadcast performance.
- **Delays** (`/docs/workflows/delays`) — fixed wait, wait until condition (with a dedicated section on using it for drip campaigns), and wait until time window.

Also cross-links the workflow builder page to both and adds them to the docs nav under Concepts.

**Why:** A teammate noted we should break the workflows concepts out into their own pages so the recent broadcast/batch-trigger and delay/wait-until functionality is easier to find and reference, rather than being buried in the builder overview.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new pages only)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1782851810153719)*