### PR TITLE
docs(mcp-analytics): dedupe callouts, fix staleness, add early-access opt-in

### DIFF
--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -7,19 +7,15 @@ import OSButton from 'components/OSButton'
 
 <CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="action">
 
-`@posthog/mcp` is a TypeScript SDK for instrumenting Model Context Protocol (MCP) servers with PostHog analytics. It's published on npm as a `0.1.x` release while we build it in public. The API, event names, properties, and tracing behavior may change before the SDK reaches `1.0`. Don't depend on it for production reporting yet. Today, only TypeScript MCP servers are supported – a Python SDK is on the roadmap.
+`@posthog/mcp` instruments Model Context Protocol (MCP) servers with PostHog analytics. It's published on npm as a `0.x` release while we build it in public, so the API, event names, properties, and tracing behavior may change before the SDK reaches `1.0` – pin a version and don't depend on it for production reporting yet. Both [TypeScript and Python](/docs/mcp-analytics/installation#python) servers are supported.
+
+PostHog also has a purpose-built **MCP Analytics** view – a dashboard, a sessions explorer, per-tool quality breakdowns, and intent clustering – all built on the `$mcp_*` events the SDK sends. It's in beta behind a feature preview: [enable the MCP Analytics feature preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to turn it on. You don't have to wait for it, though – because every signal is a normal PostHog event, you can query and visualize the same data today through [Product Analytics](/docs/product-analytics), the [SQL editor](/docs/data-warehouse/sql), [Dashboards](/docs/product-analytics/dashboards), and [Error Tracking](/docs/error-tracking).
 
 </CalloutBox>
 
 MCP Analytics helps you understand how AI agents actually use the MCP server you ship: which tools get called, how often, what intent the agent had, where calls are failing, what tools the agent asked for but you don't offer yet, and how individual sessions flow end to end.
 
-The SDK wraps your existing MCP server and emits PostHog events on every tool call, resource read, prompt fetch, and initialize handshake. You can keep using whatever tooling you already have on top of PostHog – insights, dashboards, alerts, Error Tracking – without any additional ingestion plumbing.
-
-<CalloutBox icon="IconFlask" title="A dedicated MCP Analytics view is in preview" type="action">
-
-PostHog has a purpose-built **MCP Analytics** view – a dashboard, a sessions explorer, per-tool quality breakdowns, and intent clustering, all built on the `$mcp_*` events the SDK sends. It's in preview behind a feature flag while we build it in public. Because every signal is a normal PostHog event, you don't have to wait for it: you can query and visualize the same data today through [Product Analytics](/docs/product-analytics) for trends and funnels, the [SQL editor](/docs/data-warehouse/sql) for ad-hoc HogQL, [Dashboards](/docs/product-analytics/dashboards) for at-a-glance views, and [Error Tracking](/docs/error-tracking) for `$exception` events. The events on this page won't change shape as the view matures.
-
-</CalloutBox>
+The SDK wraps your existing MCP server and emits PostHog events on every tool call, resource read, prompt fetch, and initialize handshake – no additional ingestion plumbing required.
 
 <OSButton variant="primary" asLink to="/docs/mcp-analytics/start-here">
 Get started

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -125,7 +125,7 @@ Learn about intent capture
     icon="IconLineGraph"
 >
 
-Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the preview [MCP Analytics view](/docs/mcp-analytics) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
+Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the [MCP Analytics view](/docs/mcp-analytics) (in beta – [enable the feature preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics)) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
 
 - ### <IconGraph className="text-blue w-7 -mt-1 inline-block"/> Top tools per server
   Where is your agent traffic concentrated? Which tools earn their keep?

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6328,7 +6328,7 @@ export const docsMenu = {
             icon: 'IconPlug',
             description: 'Analytics for the MCP servers you ship to AI agents',
             badge: {
-                title: 'Alpha',
+                title: 'Beta',
                 className: 'uppercase !bg-yellow/10 !text-yellow !dark:text-white !dark:bg-yellow/50',
             },
             children: [


### PR DESCRIPTION
## Problem

The MCP Analytics docs landing page (`/docs/mcp-analytics`) stacked two near-identical "flask" callouts at the top — "MCP Analytics is in beta" and "A dedicated MCP Analytics view is in preview" — repeating the same ideas (TypeScript SDK emitting `$mcp_*` events, pre-1.0, use your existing PostHog tooling). An audit surfaced three more issues:

1. **Inconsistent status word** — sidebar badge said "Alpha", docs said "beta", callout said "preview". The real early-access feature stage in PostHog is `beta`.
2. **Stale fact** — the page claimed "only TypeScript MCP servers are supported – a Python SDK is on the roadmap", but `installation.mdx` already documents a shipping Python SDK.
3. **No opt-in path** — the callout mentioned a feature flag but never linked users to enable it.

## Changes

- **Merge the two callouts into one** on `index.mdx`; remove the duplicated "use your existing PostHog tooling" sentence (it appeared 3×).
- **Fix the Python staleness** — now "Both TypeScript and Python servers are supported", linking to the Python install section.
- **Standardize status wording on "beta"** across docs copy and the `navs/index.js` sidebar badge (Alpha → Beta).
- **Add the early-access opt-in link** (`app.posthog.com/settings/user-feature-previews#mcp-analytics`) to the landing-page callout and the "Build your first dashboard" step in `start-here.mdx`, using the standard PostHog Feature Previews deep-link pattern.

The wizard install (`npx @posthog/wizard@latest mcp-analytics`) was already correctly wired — no changes needed there.

## Files

- `contents/docs/mcp-analytics/index.mdx`
- `contents/docs/mcp-analytics/start-here.mdx`
- `src/navs/index.js`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*