### PR TITLE
fix: add missing pnpm security settings to satisfy semgrep

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
     - '@posthog/icons'
     - '@posthog/hedgehog-mode'
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
 
 # Hoist Gatsby's internal dependencies for webpack compatibility
 publicHoistPattern:


### PR DESCRIPTION
## Summary
- Adds `blockExoticSubdeps: true` and `trustPolicy: no-downgrade` to `pnpm-workspace.yaml`, fixing two blocking findings from the `semgrep-general` CI check.

## Test plan
- [x] `semgrep` run locally with CI's config set → 0 findings
- [x] `pnpm install --frozen-lockfile` succeeds