### PR TITLE
docs: note managed migration part-size pause and remedy

### DIFF
--- a/contents/docs/migrate/managed-migrations.mdx
+++ b/contents/docs/migrate/managed-migrations.mdx
@@ -187,6 +187,8 @@ If an unexpected error occurs during a migration, the job will be paused and the
 
 If the error indicates your job is attempting to import too much data (for example, exceeding export size limits), consider switching to an [S3 import](#s3-imports), which is better suited for large migrations.
 
+A job can also pause if a single part of your import is too large to process at once — for direct imports this is one date range, and for S3 imports it is one file. When this happens, the pause message will say the part is too large. To fix it, split the import into smaller date ranges (direct imports) or smaller files (S3 imports) and run them as separate jobs. Because [managed migrations do not deduplicate events](#limitations), only re-run the date ranges or files that haven't already been imported.
+
 ## Event transformations
 
 When you use direct imports, PostHog transforms events from your source (Amplitude or Mixpanel) into PostHog’s schema. Below is an overview of what changes.


### PR DESCRIPTION
## Changes

Adds a short note to the [managed migrations](https://posthog.com/docs/migrate/managed-migrations) doc, in the "Monitoring your migration" section, explaining that a job can pause when a single import part is too large to process, and how to remedy it.

- Direct imports: one date range is the "part"; S3 imports: one file is the "part".
- Remedy: split into smaller date ranges / smaller files and run as separate jobs.
- Calls out the existing no-dedup behavior so users only re-run data that was not already imported.

Deliberately describes only user-visible behavior (job pauses, message says the part is too large). No internal limit values, config, or worker mechanics, since those can change over time.

## Context

Follow-up to a reviewer request on the batch-import-worker staging disk guard (PostHog/posthog#67157) to document the limit publicly for users who may hit it. Draft until that guard ships.
