### PR TITLE
docs(self-driving): point setup module to the combined wizard

### DIFF
--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -57,7 +57,7 @@ A general-purpose coding agent has your code, but not your context. PostHog ties
 
 <QuestLogItem title="Set up PostHog" subtitle="Wire in your data" icon="IconRocket">
 
-Self-driving is only as good as the data feeding it. First, [install PostHog](/docs/getting-started/install) with the setup wizard so it's capturing events. Then run our self-driving wizard to turn on your signal sources and set up your scouts. Add the [Slack app](/docs/slack) to bring your whole team in.
+Self-driving is only as good as the data feeding it. Run our self-driving wizard to get set up in one command. It installs PostHog if you haven't already, then turns on your signal sources and sets up your scouts. Add the [Slack app](/docs/slack) to bring your whole team in.
 
 Once data is flowing, PostHog will continuously monitor your product and reports begin landing in your inbox. Most teams are set up in a few minutes.
 


### PR DESCRIPTION
## Problem

The self-driving overview page (`/docs/self-driving`) still described the old two-step setup flow: install PostHog first, *then* run the self-driving wizard. That contradicts the setup page (`/docs/self-driving/setup`), which now correctly explains the wizards are combined — the self-driving wizard installs PostHog if needed and sets up self-driving in a single command.

## Change

Updates the "Set up PostHog" module copy in `contents/docs/self-driving/index.mdx` to describe the single-command flow. The inline "install PostHog" link is removed (the wizard handles install now); the existing "Set up self-driving" CTA button remains the link to `/docs/self-driving/setup`.

One paragraph changed, no URLs moved, no redirects needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*