### PR TITLE
Add MCP Analytics team page (split from Product Analytics)

### DIFF
--- a/contents/teams/mcp-analytics/index.mdx
+++ b/contents/teams/mcp-analytics/index.mdx
@@ -1,0 +1,23 @@
+---
+title: MCP Analytics
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+MCP Analytics makes PostHog's analytics work for AI agents. We own the MCP (Model Context Protocol) surface for analytics — the tools, queries, and skills that let agents like Claude, Cursor, and PostHog's own assistant retrieve data, build insights, and investigate metrics without a human driving the UI.
+
+We split out of <SmallTeam slug="product-analytics" /> to focus on this full time: as agents become a primary way people interact with their data, the analytics MCP needs to be a complete, reliable alternative to the UI rather than a partial mirror of it.
+
+## Slack channel
+
+[#team-mcp-analytics](https://posthog.slack.com/messages/team-mcp-analytics)
+
+## Working with other teams
+
+We work closely with <SmallTeam slug="product-analytics" /> (the insights and queries we expose) and <SmallTeam slug="agents" /> on the agent surfaces that consume our tools.
+
+## Feature ownership
+
+You can find out more about the [features we own](/handbook/engineering/feature-ownership).

--- a/contents/teams/mcp-analytics/mission.mdx
+++ b/contents/teams/mcp-analytics/mission.mdx
@@ -1,0 +1,1 @@
+Any AI agent can retrieve, build, and investigate PostHog analytics through MCP as capably as a person can in the UI.

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -1,0 +1,14 @@
+### Q3 2026 objectives
+
+MCP Analytics is newly split out of <SmallTeam slug="product-analytics" />. Our focus is making the analytics MCP a complete alternative to the UI: full data-retrieval coverage, reliable query generation, and skills that let agents do real analysis on their own.
+
+### What we'll ship
+
+#### <TeamMember name="Georgis Andonis" />
+
+- Inline events adoption in retention, stickiness, and lifecycle
+  - Desired outcome: Establish a mature inline events feature across all insight types, enabling us to replace Actions and eliminate the back-and-forth associated with them. Support all common actions (rename, duplicate, in a separate popover menu)
+- Add missing MCP data retrieval queries: paths, lifecycle, stickiness, actors queriers, enterprise queriers
+  - Desired outcome: We want to enable other AI agents to interact with the above queries
+- Implement "Investigate metric" skill
+  - Desired outcome: Allow agents to analyze a metric and find the root cause behind it

--- a/contents/teams/product-analytics/objectives.mdx
+++ b/contents/teams/product-analytics/objectives.mdx
@@ -25,15 +25,6 @@
 - Period over period comparison in funnels (#3)
   - Desired outcome: Adopted by customers
 
-#### <TeamMember name="Georgis Andonis" />
-
-- Inline events adoption in retention, stickiness, and lifecycle (#3)
-  - Desired outcome: Establish a mature inline events feature across all insight types, enabling us to replace Actions and eliminate the back-and-forth associated with them. Support all common actions (rename, duplicate, in a separate popover menu)
-- Add missing MCP data retrieval queries: paths, lifecycle, stickiness, actors queriers, enterprise queriers (#1)
-  - Desired outcome: We want to enable other AI agents to interact with the above queries
-- Implement "Investigate metric" skill (#1)
-  - Desired outcome: Allow agents to analyze a metric and find the root cause behind it
-
 #### <TeamMember name="Sam Pennington" />
 
 - Create analytics components (charts, tooltips, etc.) in the UI library and use them (#2)


### PR DESCRIPTION
## Changes

Adds the new **MCP Analytics** small team, split out of Product Analytics.

- New handbook pages at `contents/teams/mcp-analytics/` — `index.mdx`, `mission.mdx`, `objectives.mdx`.
- Moves Georgis's objectives out of `product-analytics/objectives.mdx` into the new team.

**Why:** MCP Analytics is being spun up as its own team so the analytics MCP surface gets dedicated focus as agents become a primary way people work with their data.

> [!NOTE]
> Team membership and leads (Georgis + Lucas moving over, Mike as PM) are managed in the posthog.com team admin (Strapi/Squeak CMS), not this repo. **Those roster moves still need to be done there** — and the CMS team needs the slug `mcp-analytics` for these pages to render its roster.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1782893480376419)*
