### PR TITLE
docs(workflows): document email link click-tracking opt-out

### DIFF
--- a/contents/docs/workflows/library.mdx
+++ b/contents/docs/workflows/library.mdx
@@ -106,6 +106,20 @@ You can type Liquid syntax directly into your email template. We also provide a 
 
 If you type Liquid syntax directly and the Liquid doesn't compile correctly, the email won't be sent. Always verify your Liquid syntax is valid before starting a workflow.
 
+### Link click tracking
+
+PostHog automatically rewrites every link in an email to route through a click-tracking redirect. This is what powers the `$workflows_email_link_clicked` [engagement event](/docs/workflows/engagement-events).
+
+On some mobile mail clients this redirect breaks links that are meant to open a native app (iOS universal links or Android app links), because the operating system only hands the link off to the app when it points directly at the app's own domain. Routing through the tracking redirect sends the recipient to a browser instead.
+
+To keep a specific link untracked so it reaches its destination exactly as written, add an HTML block and mark the anchor with either `clicktracking="off"` or `data-ph-no-track`:
+
+```html
+<a href="https://yourapp.com/deep/link" data-ph-no-track>Open in app</a>
+```
+
+The attribute must be on the `<a>` tag itself, not a child element. Links marked this way won't produce click events.
+
 ### Testing templates
 
 It's best practice to test a message in a workflow before starting the workflow. This helps ensure your template displays correctly with real user data and that all Liquid variables resolve properly.

--- a/contents/docs/workflows/library.mdx
+++ b/contents/docs/workflows/library.mdx
@@ -106,16 +106,14 @@ You can type Liquid syntax directly into your email template. We also provide a 
 
 If you type Liquid syntax directly and the Liquid doesn't compile correctly, the email won't be sent. Always verify your Liquid syntax is valid before starting a workflow.
 
-### Link click tracking
+### Disabling link click tracking
 
-PostHog automatically rewrites every link in an email to route through a click-tracking redirect. This is what powers the `$workflows_email_link_clicked` [engagement event](/docs/workflows/engagement-events).
+PostHog automatically rewrites every link in an email to route through a click-tracking redirect, which powers the `$workflows_email_link_clicked` [engagement event](/docs/workflows/engagement-events).
 
-On some mobile mail clients this redirect breaks links that are meant to open a native app (iOS universal links or Android app links), because the operating system only hands the link off to the app when it points directly at the app's own domain. Routing through the tracking redirect sends the recipient to a browser instead.
-
-To keep a specific link untracked so it reaches its destination exactly as written, add an HTML block and mark the anchor with either `clicktracking="off"` or `data-ph-no-track`:
+If you need a link to reach its destination exactly as written, add an HTML block and mark the anchor with either `clicktracking="off"` or `data-ph-no-track`:
 
 ```html
-<a href="https://yourapp.com/deep/link" data-ph-no-track>Open in app</a>
+<a href="https://example.com/your-link" data-ph-no-track>Open link</a>
 ```
 
 The attribute must be on the `<a>` tag itself, not a child element. Links marked this way won't produce click events.


### PR DESCRIPTION
## Changes

Documents how workflow email links are click-tracked and how to opt a link out.

Adds a **Link click tracking** section to the email templates library doc (`contents/docs/workflows/library.mdx`). It explains:

- Every email link is automatically rewritten through a click-tracking redirect, which powers the `$workflows_email_link_clicked` engagement event.
- Why that redirect breaks mobile deeplinks: iOS universal links and Android app links only open the app when the href points directly at the app's own domain, so routing through the redirect drops the recipient into a browser instead.
- The opt-out: mark the anchor with `clicktracking="off"` or `data-ph-no-track` (on the `<a>` tag itself, via an HTML block) to keep a link untracked so it reaches its destination unchanged.

This came out of a support request where a personalised deeplink CTA worked as plain auto-linked text but failed on mobile inside a button. Companion code change (the actual opt-out support) is in PostHog/posthog#67308.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
