### PR TITLE
Add workflow surface CTAs and spacing on /self-driving

### DIFF
--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -447,6 +447,11 @@ const workSurfaces: {
             </Link>
         ),
         copy: '@PostHog brings PostHog into Slack channels. Route reports to the ones each team already watches (hedgehog mode not included).',
+        cta: (
+            <CallToAction to="/slack" state={{ newWindow: true }} type="secondary" size="md">
+                Learn more
+            </CallToAction>
+        ),
     },
     {
         icon: IconMCP,
@@ -457,6 +462,11 @@ const workSurfaces: {
             </Link>
         ),
         copy: 'Look ma, no hands! Pull self-driving context into other tools, and pull context from your other tools into self-driving.',
+        cta: (
+            <CallToAction to="/mcp" state={{ newWindow: true }} type="secondary" size="md">
+                Learn more
+            </CallToAction>
+        ),
     },
 ]
 
@@ -850,7 +860,7 @@ export default function SelfDrivingPage(): JSX.Element {
                         <p>
                             The same Inbox and agents show up across four surfaces (everywhere you go, there's PostHog).
                         </p>
-                        <div className="not-prose grid @md/reader-content:grid-cols-2 gap-x-6 gap-y-4 my-6">
+                        <div className="not-prose grid @md/reader-content:grid-cols-2 gap-x-6 gap-y-8 mt-6 mb-12">
                             {workSurfaces.map(({ icon: Icon, iconColor, label, copy, cta }, index) => (
                                 <div key={index}>
                                     <p className="m-0 inline-flex items-center gap-2 font-bold text-base">


### PR DESCRIPTION
## Changes

Tweaks to the *Works in your workflow* section on [`/self-driving`](https://posthog.com/self-driving):

- Added "Learn more" CTAs to the **Slack app** (`/slack`) and **MCP** (`/mcp`) entries, so all four surfaces have a way to try them. Both open in a new window like the existing PostHog Code CTA.
- More vertical space between the four options (`gap-y-4` → `gap-y-8`).
- More margin below the section to separate the options from the Slack screenshot.

**Why:** feedback that the bottom two surfaces (Slack + MCP) were missing calls to action, and the section felt cramped against the screenshot below it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B98FCPT3N/p1782818565161189?thread_ts=1782818565.161189&cid=C0B98FCPT3N)*
