### PR TITLE
Make /self-driving workflow CTAs contextual

### DIFF
--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -434,7 +434,7 @@ const workSurfaces: {
         copy: 'A desktop app for driving parallel agents to edit your product. The same Inbox and reports live here.',
         cta: (
             <CallToAction to="/code" state={{ newWindow: true }} type="secondary" size="md">
-                Learn more
+                Get the app
             </CallToAction>
         ),
     },
@@ -449,7 +449,7 @@ const workSurfaces: {
         copy: '@PostHog brings PostHog into Slack channels. Route reports to the ones each team already watches (hedgehog mode not included).',
         cta: (
             <CallToAction to="/slack" state={{ newWindow: true }} type="secondary" size="md">
-                Learn more
+                Add to Slack
             </CallToAction>
         ),
     },
@@ -464,7 +464,7 @@ const workSurfaces: {
         copy: 'Look ma, no hands! Pull self-driving context into other tools, and pull context from your other tools into self-driving.',
         cta: (
             <CallToAction to="/mcp" state={{ newWindow: true }} type="secondary" size="md">
-                Learn more
+                Hook it up
             </CallToAction>
         ),
     },


### PR DESCRIPTION
## Changes

Follow-up to #18077. The *Works in your workflow* section on [`/self-driving`](https://posthog.com/self-driving) had three identical "Learn more" buttons. This gives each surface its own contextual CTA:

- PostHog Code → **Get the app**
- PostHog Slack app → **Add to Slack**
- PostHog MCP → **Hook it up**

(The web app already had "Sign up free".)

**Why:** feedback that three buttons reading "Learn more" was repetitive and dull.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B98FCPT3N/p1782818565161189?thread_ts=1782818565.161189&cid=C0B98FCPT3N)*
