### PR TITLE
Add Q3 goals for Graphics team

### DIFF
--- a/contents/teams/graphics/objectives.mdx
+++ b/contents/teams/graphics/objectives.mdx
@@ -1,0 +1,59 @@
+## Heidi Berton
+
+<TeamMember name="Heidi Berton" photo />
+
+### Updating old assets
+
+**Motivation:** We're relaunching the website already, so let's make sure there's no artifacts of our out of date design to muddy the future.
+
+**What we'll ship:** New illustrations anywhere there are old ones, plus add them to the library as single hogs.
+
+**We'll know we're successful when:** Our brand is cohesive and nothing on our website feels out of place.
+
+### Merch update and continued push (sidequest)
+
+**Motivation:** Last quarter we succeeded in elevating our merch with subtle, straightforward designs. Now it's time to give people more opportunities to rep PostHog loudly.
+
+**What we'll ship:** Wacky merch that still feels elevated and cool.
+
+**We'll know we're successful when:** Every type of PostHog fan can find merch that speaks to them.
+
+## Lottie Coxon
+
+<TeamMember name="Lottie Coxon" photo />
+
+### Locking down new brand design-system library
+
+**Motivation:** Working towards our unified team goal of building brand consistency.
+
+**What we'll ship:** The new brand look and feel across the company, where every part of the brand feels related to the core PostHog brand. Working with Daniel to compile these brand elements in a single source of truth Figma file and on the website.
+
+**We'll know we're successful when:** Every part of the brand feels unified and related, with strong updated branding.
+
+### Do more weird (sidequest)
+
+**Motivation:** Making sure some "do more weird" projects get shipped.
+
+**What we'll ship:** Some "do more weird" projects.
+
+**We'll know we're successful when:** "Do more weird" projects have been shipped.
+
+## Daniel Hawkins
+
+<TeamMember name="Daniel Hawkins" photo />
+
+### Self-serve campaigns via Weave
+
+**Motivation:** We don't want to be blockers for other teams shipping quickly.
+
+**What we'll ship:** Weave apps available for other teams to use.
+
+**We'll know we're successful when:** Teams are able to ship things without assistance, and we are happy with what ships.
+
+### Turning new styles into design system/library (sidequest)
+
+**Motivation:** Everyone who is creating content needs to be able to pull from the same styles and assets.
+
+**What we'll ship:** Removing the "WIP" from the Brand Book.
+
+**We'll know we're successful when:** Other teams are able to find what they need easily.


### PR DESCRIPTION
Adds a quarterly goals (objectives) page for the Graphics team, rendered under the "Goals" section on `/teams/graphics`.

## What's included

Creates `contents/teams/graphics/objectives.mdx`, following the same format as other team objective files. Goals are grouped by team member, each with their main goal and a sidequest:

- **Heidi Berton** — Updating old assets; Merch update and continued push (sidequest)
- **Lottie Coxon** — Locking down new brand design-system library; Do more weird (sidequest)
- **Daniel Hawkins** — Self-serve campaigns via Weave; Turning new styles into design system/library (sidequest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)