### PR TITLE
chore(workflows): update team objectives for Q3 2026

### DIFF
--- a/contents/teams/workflows/objectives.mdx
+++ b/contents/teams/workflows/objectives.mdx
@@ -1,24 +1,33 @@
-### Q2 2026 Objectives
+### Q3 2026 Objectives
 
-- **Fit into product autonomy** (Champion: Dan)
-  - Solve the blockers for autonomous workflows by ensuring compatibility with LLM agents.
-  - What we’ll ship:
-    - PostHog AI can reliably create and iterate on workflows and email designs via multi-turn agent threads
-    - Integration with PostHog Signals
-    - LLM workflow node with bring-your-own credentials
-- **Workflows engine scaling** (Champion: Myke)
-  - Strengthen our infrastructure so we can maintain high product velocity going forward.
-  - What we’ll ship:
-    - A job queue we feel confident iterating on
-    - Reduced data throughput to support continued scaling
-    - Product guardrails to protect reliability
-    - Dead letter queue and invocation outcomes store
-    - Message sending rate throttling (follow-up to cron/batch workflows)
-- **Messaging feature depth** (Champion: Haven)
-  - Fill the remaining gaps in our messaging capabilities and polish the end-to-end experience.
-  - What we’ll ship:
-    1. Realtime "wait for event" listeners (wait until event performed, exit early on conversion)
-    2. Behavioral cohort triggers (batch workflows for entire cohorts, trigger on membership changes)
-    3. Additional native channels (push notifications, SMTP relay)
-    4. UX improvements for large workflows (goto/early exit nodes, full-screen mode, general papercuts)
-    5. Iteration on table-stakes features (message previewing, email editor)
+- **Become a 2030 Workflows Product** (Champion: Harley)
+  - Motivation: Agents are far better at building context and making modifications than users.
+  - What we'll ship:
+    - Fully AI native & agentic workflow product
+    - Chat interface for rapid iteration
+    - Move to read-only UI for workflows / email templates / messaging
+    - Removal of hefty existing UI if new experience & user testing is superior
+    - Revisions
+    - Reshape APIs to be agentic-friendly for rapid turnaround
+- **Fit into self-driving products** (Champion: Dan)
+  - Motivation: A single person can drive 1000 workflows.
+  - What we'll ship:
+    - Get our data right so 'self-driving' can first suggest changes
+    - Integrate with 'self-driving' to propose the change (using revisions and APIs)
+    - Test revisions of actions against each other for improvements (still human in the loop)
+    - Self-driving applying the outcomes of the A/B tests
+- **Reliability & Trust** (Champion: Myke)
+  - Motivation: Customers trust us fully with their workflows.
+  - What we'll ship:
+    - Harden our systems to never drop data
+    - Finalise the re-run system so we can replay failed invocations
+    - Full visibility into every messaging channel
+- **Nail Messaging** (Champions: Dan & Myke)
+  - Motivation: Feature parity on table-stakes features with our competitors.
+  - What we'll ship:
+    - Behavioural cohorts (no backfilling)
+    - Push notifications
+    - A/B testing
+    - Email events
+    - Messaging metrics
+    - Email with multiple links / more detailed metrics

--- a/contents/teams/workflows/objectives.mdx
+++ b/contents/teams/workflows/objectives.mdx
@@ -6,7 +6,7 @@
     - Fully AI native & agentic workflow product
       - Chat interface for rapid iteration
       - Move to read-only UI for workflows / email templates / messaging
-      - Removal of hefty existing UI if new experience & user testing is superior
+    - Removal of hefty existing UI if new experience & user testing is superior
     - Revisions
     - Reshape APIs to be agentic-friendly for rapid turnaround
 - **Fit into self-driving products** (Champion: Dan)

--- a/contents/teams/workflows/objectives.mdx
+++ b/contents/teams/workflows/objectives.mdx
@@ -4,9 +4,9 @@
   - Motivation: Agents are far better at building context and making modifications than users.
   - What we'll ship:
     - Fully AI native & agentic workflow product
-    - Chat interface for rapid iteration
-    - Move to read-only UI for workflows / email templates / messaging
-    - Removal of hefty existing UI if new experience & user testing is superior
+      - Chat interface for rapid iteration
+      - Move to read-only UI for workflows / email templates / messaging
+      - Removal of hefty existing UI if new experience & user testing is superior
     - Revisions
     - Reshape APIs to be agentic-friendly for rapid turnaround
 - **Fit into self-driving products** (Champion: Dan)

--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -523,8 +523,9 @@ export default function Team({
         }
     }
 
-    const hasUnderConsideration = underConsideration?.length > 0
-    const hasInProgress = inProgress?.length > 0
+    const hideRoadmap = slug === 'workflows'
+    const hasUnderConsideration = !hideRoadmap && underConsideration?.length > 0
+    const hasInProgress = !hideRoadmap && inProgress?.length > 0
     const hasBody = !!body
     const heightToHedgehogs =
         profiles?.data?.reduce((acc, curr) => acc + (curr?.attributes?.height || 0), 0) / hedgehogLengthInches || 0
@@ -749,7 +750,7 @@ export default function Team({
                 </div>
             </Fieldset>
 
-            {(hasInProgress || hasUnderConsideration || recentlyShipped) && (
+            {!hideRoadmap && (hasInProgress || hasUnderConsideration || recentlyShipped) && (
                 <>
                     <h2 id="roadmap">Roadmap</h2>
 


### PR DESCRIPTION
## Changes

Refresh the Workflows team objectives page with Q3 2026 objectives. Full replacement of the Q2 content, matching the shape of the existing file.

Q3 2026 objectives:

- **Become a 2030 Workflows Product** (Champion: Harley) — go AI-native / agentic-first
- **Fit into self-driving products** (Champion: Dan) — plug into the self-driving stack via revisions + APIs
- **Reliability & Trust** (Champion: Myke) — never drop data, finish re-run, full channel visibility
- **Nail Messaging** (Champions: Dan & Myke) — behavioural cohorts, push, A/B testing, richer email metrics

Companion megaissue: PostHog/posthog#67408

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`