### PR TITLE
Add wizard CTA to PostHog Cloud EU blog post

### DIFF
--- a/contents/blog/posthog-cloud-eu.md
+++ b/contents/blog/posthog-cloud-eu.md
@@ -23,8 +23,6 @@ Oh, and PostHog Cloud EU also happens to be faster for users located in Europe, 
 
 PostHog Cloud EU offers everything you'd expect of PostHog – analytics, session recording, experiments and more. The only difference is that you can now choose to host in a different region, at no extra cost. 
 
-<WizardCTA />
-
 <GDPRForm />
 
 ## FAQ
@@ -50,6 +48,8 @@ For now, we're charging [the same as "regular" PostHog Cloud](../pricing). The f
 It is possible to migrate event data from another PostHog instance to EU Cloud, but it is a time-consuming process likely to take several days or weeks. There is currently no way to migrate other information, including insights, dashboards, user accounts, feature flags or API keys. 
 
 We strongly recommend that users with large volumes of data begin by setting up and connect a new EU cloud instance and only attempt to migrate data later, if needed, by following [this migration tutorial](/tutorials/migrate-eu-cloud). 
+
+<WizardCTA />
 
 ## GDPR compliance checklist
 

--- a/contents/blog/posthog-cloud-eu.md
+++ b/contents/blog/posthog-cloud-eu.md
@@ -23,6 +23,8 @@ Oh, and PostHog Cloud EU also happens to be faster for users located in Europe, 
 
 PostHog Cloud EU offers everything you'd expect of PostHog – analytics, session recording, experiments and more. The only difference is that you can now choose to host in a different region, at no extra cost. 
 
+<WizardCTA />
+
 <GDPRForm />
 
 ## FAQ


### PR DESCRIPTION
## Changes

Adds a `<WizardCTA />` to the [/blog/posthog-cloud-eu](https://posthog.com/blog/posthog-cloud-eu) post — one of our highest blog-to-signup pages. The CTA is placed after the intro, just above the existing `<GDPRForm />`.

The wizard command auto-detects the visitor's region via the `direct-to-eu-cloud` / `direct-to-us-cloud` feature flags (`useCloud()` hook), so it renders with `--region eu` for EU visitors automatically — there's no separate prop to "enable the EU flag".

**Why:** This page ranks for "PostHog EU" and is a strong signup driver, so adding the wizard CTA gives EU-intent visitors a faster path to getting started. Refs #18088.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C078QBEET1S/p1782914411558629?thread_ts=1782914411.558629&cid=C078QBEET1S)*