### PR TITLE
seo: add reciprocal hreflang tags to English homepage for /ko

### DIFF
--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -545,6 +545,11 @@ export default function HomeTest() {
                 updateWindowTitle={false}
                 description="All your developer tools in one place. PostHog gives engineers everything to build, test, measure, and ship successful products faster. Get started free."
                 image="/images/og/default.png"
+                languageAlternates={[
+                    { hrefLang: 'en', href: '/' },
+                    { hrefLang: 'ko', href: '/ko' },
+                    { hrefLang: 'x-default', href: '/' },
+                ]}
             />
             <MDXEditor
                 jsxComponentDescriptors={jsxComponentDescriptors}


### PR DESCRIPTION
## Summary
- The `/ko` Korean landing page already had `hreflang` alternates pointing to the English homepage
- Google requires **both sides** to declare the relationship before it validates hreflang — without this, `/ko` is treated as unverified duplicate content rather than a canonical Korean variant, which blocks indexing
- Adds the matching `languageAlternates` prop to the English homepage SEO component (`src/components/Home/Test/index.tsx`)

After this ships, both `posthog.com` and `posthog.com/ko` will emit:
```html
<link rel="alternate" hrefLang="en" href="https://posthog.com/" />
<link rel="alternate" hrefLang="ko" href="https://posthog.com/ko" />
<link rel="alternate" hrefLang="x-default" href="https://posthog.com/" />
```

## Test plan
- [ ] After deploy, view-source `posthog.com` and confirm the three `<link rel="alternate">` tags appear in `<head>`
- [ ] Confirm `posthog.com/ko` still has the same three tags (no regression)
- [ ] Submit `posthog.com/ko` for indexing via Google Search Console URL Inspection

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*