### PR TITLE
skill(suggest-links): stop suggesting new sentences to force backlinks

### DIFF
--- a/.claude/commands/suggest-links.md
+++ b/.claude/commands/suggest-links.md
@@ -53,9 +53,7 @@ Find at least 3 existing posts in `contents/` that would naturally link to the n
 
 - **Find the most relevant existing posts** by searching for content that discusses the same concepts as the new post's sections. Use `grep` or `Bash` if needed.
 - **Match section to section.** Don't just link to the new post's root — link to the specific `#anchor` that matches the concept being discussed in the existing post. Derive the anchor from the heading text (lowercase, spaces → hyphens, punctuation removed).
-- **Keep it natural.** The backlink should either:
-  - Fit within an existing sentence (preferred), or
-  - Be a brief new sentence that flows naturally from the surrounding paragraph.
+- **Do NOT add new sentences or content.** The backlink must fit within an existing sentence — never invent new prose to host a link. If there's no existing sentence a link fits into, skip that candidate.
 - **Don't add a standalone "further reading" line** unless the existing post already has a "Further reading" section — in that case, a bullet there is fine.
 - **Don't use the new article's title as anchor text.** Describe the concept, not the article.
 


### PR DESCRIPTION
## Changes

Ian flagged this in review of #18012 (`agent-first-product-engineering.md` line 132): the `/suggest-links` skill was writing new sentences just to create a place to drop a backlink, diluting a sentence that already made its point on its own.

This removes the "brief new sentence that flows naturally" fallback from the backlink rules — backlinks must now wrap existing text only. If there's no existing sentence a link naturally fits into, the skill should skip that candidate instead of inventing prose.

Note: this overlaps with @ivanagas's open #18064, which makes a similar (more thorough) change plus other edits to this file. Worth reconciling the two before merging both.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`