### PR TITLE
docs(self-driving): document scout report channel, on-demand runs, and new scouts

### DIFF
--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -27,13 +27,16 @@ PostHog ships a fleet of canonical scouts out of the box, each watching a common
 | [CSP violations](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-csp-violations/SKILL.md) | Content Security Policy violation clusters, per-directive bursts, and suspicious third-party domains |
 | [Customer analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-customer-analytics/SKILL.md) | Churn-risk shapes on named accounts – engagement cliffs, dormancy, single-threaded champions |
 | [Data pipelines](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-data-pipelines/SKILL.md) | Delivery failures across CDP destinations, batch exports, and workflows, where config and reality disagree |
+| [Data warehouse](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-data-warehouse/SKILL.md) | Imports that quietly stop keeping their promise – failed source connections, stuck or silently stale syncs, row-volume cliffs, and failed materialized views |
 | [Error tracking](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-error-tracking/SKILL.md) | Error spikes, stuck loops, and fingerprint clusters, triaged by how many users they hit |
 | [Experiments](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-experiments/SKILL.md) | Validity threats like sample-ratio mismatch, plus zombie experiments running past their useful life |
 | [Feature flags](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-feature-flags/SKILL.md) | Evaluation cliffs, ghost flags (keys no longer in code), and flag debt |
 | [General](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-general/SKILL.md) | Cross-product correlations and any surface no specialist covers |
 | [Health checks](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-health-checks/SKILL.md) | Setup health issues – no live events, outdated SDKs, missing reverse proxy, failing warehouse models |
 | [Inbox validation](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-inbox-validation/SKILL.md) | Whether a merged fix actually held, re-measured after a deployment soak window |
+| [Insight alerts](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-insight-alerts/SKILL.md) | Alert firings a human likely missed, especially ones the normal notification path stayed silent on |
 | [Logs](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-logs/SKILL.md) | Volume bursts, severity-distribution shifts, service silence, and new error message patterns |
+| [MCP tool calls](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-mcp-tool-calls/SKILL.md) | MCP tools that need improvement – broad failure rates, retry hammering, and slow or context-bloating responses |
 | [Observability gaps](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-observability-gaps/SKILL.md) | Coverage gaps – high-volume events with no insight, dashboard, or alert |
 | [Product analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-product-analytics/SKILL.md) | Regressions in your funnels, retention, lifecycle, stickiness, and paths |
 | [Replay Vision](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-replay-vision/SKILL.md) | Whether Replay Vision scanners are still observing, and what their observations surface |
@@ -61,7 +64,7 @@ The common thread is that a scout isn't limited to product analytics. Any source
 
 ## Make your own
 
-You don't write a scout by hand. In [PostHog Code](/code), open the scouts page and pick the "Make a scout" suggestion: it scans your project and proposes custom scouts grounded in your actual data. You can also ask any agent connected to the PostHog MCP to build one.
+You don't write a scout by hand. In [PostHog Code](/code), open the scouts page and pick the "Make a scout" suggestion: it scans your project and proposes custom scouts grounded in your actual data. You can also ask any agent connected to the PostHog MCP to build one. Once it exists, [run it on demand](/docs/self-driving/scouts#running-a-scout-on-demand) to see what it surfaces before enabling it.
 
 For a deep dive – two real scouts traced end to end, with a walkthrough video – read [What is a scout?](/blog/what-is-a-scout).
 

--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -13,17 +13,28 @@ Self-driving is currently in open beta.
 
 </CalloutBox>
 
-A scout is a scheduled agent that explores your PostHog data and raises a hand when it finds something worth knowing. Scouts are one of the things that start the [self-improving loop](/docs/self-driving/self-improving-loop): they turn raw product data into [signals](/docs/self-driving/signals) the rest of the loop can act on.
+A scout is a scheduled agent that explores your PostHog data and raises a hand when it finds something worth knowing. Scouts are one of the things that start the [self-improving loop](/docs/self-driving/self-improving-loop): they turn raw product data into [signals](/docs/self-driving/signals) and [reports](/docs/self-driving/reports) the rest of the loop can act on.
 
 ## How a scout works
 
-A scout runs on a schedule. Each run, it looks at one slice of your data, decides whether anything is worth surfacing, and if so emits a [signal](/docs/self-driving/signals): a structured finding with the evidence behind it and a suggested action.
+A scout runs on a schedule. Each run, it looks at one slice of your data, decides whether anything is worth surfacing, and if so files what it found. A scout has two ways to do that:
+
+- **File a report directly.** When a scout finishes its research with a complete, well-formed finding, it authors a [report](/docs/self-driving/reports) straight into your [inbox](/docs/self-driving/inbox) – a title, a summary, the evidence behind it, and a call on how actionable it is. Most of the built-in scouts work this way, and a scout-authored report shows the scout's name in the inbox so you know where it came from.
+- **Emit a signal.** When a finding is a weaker or partial observation – the kind that only becomes meaningful next to other findings – the scout emits a [signal](/docs/self-driving/signals) instead and lets the pipeline deduplicate it and group it with related signals into a report.
+
+Either way, the bar is the same: a structured finding with the evidence behind it and a suggested action. The difference is whether the scout has already done enough research to stand behind the finding as a single inbox item, or whether the pipeline should consolidate it with others first.
 
 A scout reads your data through the same [PostHog MCP](/docs/model-context-protocol) you can connect to Claude Code or Cursor, so it can see anything in PostHog out of the box – events, [data warehouse](/docs/data-warehouse) tables, insights, dashboards – with nothing to wire up per scout. Because any source you land in PostHog becomes queryable, a scout isn't limited to product analytics: a Slack channel, a billing system, or a support inbox synced to your warehouse is fair game too.
 
 A scout also keeps a durable memory between runs. Each run, it reads back what earlier runs learned and recorded – what's normal, what it's already surfaced, what it decided to hold – so it dedupes against itself and gets sharper over time instead of starting cold. That memory is what makes a scout a long-running agent rather than a one-shot check.
 
 Because scouts run on a schedule, the loop keeps noticing problems and opportunities on its own, instead of waiting for someone to file a ticket.
+
+## Running a scout on demand
+
+Scouts run themselves on their schedule, but you can also trigger a run on demand – useful to test a scout right after authoring it, or to refresh its findings without waiting for the next scheduled run. A scout that's still disabled can be run this way too, so you can see what it would surface before turning it on.
+
+On-demand runs count against the same daily run budget as scheduled runs, so repeatedly re-running the same scout can use up your project's daily allowance.
 
 ## Built-in and custom scouts
 
@@ -37,7 +48,7 @@ The difference is how they look. A signal source watches a single stream in real
 
 ## Next step
 
-A scout's output is a signal. See what's in one.
+Whether a scout files a report directly or lets the pipeline do the grouping, every finding is built on signals. See what's in one.
 
 <CallToAction type="primary" to="/docs/self-driving/signals">
   Signals

--- a/contents/docs/self-driving/signals.mdx
+++ b/contents/docs/self-driving/signals.mdx
@@ -32,7 +32,7 @@ Signals come from two kinds of source, which you can turn on independently:
 - **Signal sources** are built-in pipelines that watch one stream continuously: error tracking, session replay, and health checks inside PostHog, plus external tools like Zendesk, GitHub Issues, and Linear.
 - **[Scouts](/docs/self-driving/scouts)** are agents that run on a schedule and look across your product data more holistically.
 
-Both feed signals into the same pipeline. A single problem usually shows up as several signals from several sources, so the loop deduplicates and groups them, and you act on the problem, not the noise.
+Both feed signals into the same pipeline. A single problem usually shows up as several signals from several sources, so the loop deduplicates and groups them, and you act on the problem, not the noise. (A scout that finishes its research with a complete finding can also skip the grouping step and file a [report](/docs/self-driving/reports) directly – its evidence still lands as signals backing the report.)
 
 ## From signals to reports
 


### PR DESCRIPTION
Updates the self-driving scouts docs to catch up with recent changes in the [PostHog monorepo](https://github.com/PostHog/posthog) (landed June 26 – July 1):

## Scouts (`/docs/self-driving/scouts`)

- **Report channel**: most canonical scouts now author reports directly into the inbox instead of only emitting signals for the pipeline to cluster ([#66131](https://github.com/PostHog/posthog/pull/66131), [#66132](https://github.com/PostHog/posthog/pull/66132), and the fleet-wide porting PRs). Rewrote "How a scout works" to describe both output channels and when a scout uses each.
- **Scout attribution**: scout-authored reports show the scout's name in the inbox ([#67471](https://github.com/PostHog/posthog/pull/67471)).
- **On-demand runs**: new section covering the run-now capability ([#66996](https://github.com/PostHog/posthog/pull/66996)) — testing right after authoring, running disabled scouts, and the note that manual runs consume the same daily run budget as scheduled runs ([#67338](https://github.com/PostHog/posthog/pull/67338)).

## Scout examples (`/docs/self-driving/scout-examples`)

Added three new canonical scouts to the catalog table:

- **Data warehouse** — import integrity: failed sources, stale syncs, failed materialized views ([#66975](https://github.com/PostHog/posthog/pull/66975))
- **Insight alerts** — alert firings a human likely missed ([#66966](https://github.com/PostHog/posthog/pull/66966))
- **MCP tool calls** — MCP tools that need improvement ([#67504](https://github.com/PostHog/posthog/pull/67504))

Also added a pointer to on-demand runs in the "Make your own" section.

## Signals (`/docs/self-driving/signals`)

One-sentence consistency tweak noting a scout with a complete finding can file a report directly, with its evidence still landing as signals backing the report.