### PR TITLE
Fix group type deletion instructions in group analytics docs

### DIFF
--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -388,7 +388,7 @@ if (flags.isEnabled('new-groups-feature')) {
 
 ### Rename group types
 
-Change how group types display in PostHog in [Settings > Customer Analytics](https://app.posthog.com/settings/project-customer-analytics#group-analytics).
+Change how group types display in PostHog in [Settings > Product analytics](https://app.posthog.com/settings/project-product-analytics#group-analytics).
 
 <ProductScreenshot
     imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/project_Setting_Light_ff8617214d.png"
@@ -399,10 +399,9 @@ Change how group types display in PostHog in [Settings > Customer Analytics](htt
 
 ### Delete group types
 
-To delete a group type:
+To delete a group type, go to [Settings > Product analytics](https://app.posthog.com/settings/project-product-analytics#group-analytics) and click the delete icon next to the group type you want to remove.
 
-1. Go to the [people tab](https://app.posthog.com/persons) in the PostHog app.
-2. Select **Menu options** > **Delete group type**.
+You can also delete a group type from the navigation: under **People > Groups**, open the group type's menu options and select **Delete group type**.
 
 <ProductScreenshot
     imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/delete_Group_Type_Light_8f08fae9f8.png"


### PR DESCRIPTION
## Changes

- Corrected the **Delete group types** section. Deletion is self-serve via **Settings > Product analytics > Group analytics** (delete icon) or the **People > Groups** navigation menu — the section previously pointed to the people tab and a "Menu options" step that no longer matches the current UI.
- Aligned the **Rename group types** link to the same **Product analytics** settings page, since rename and delete live in the same Group analytics settings section.

**Why:** Group type deletion has been self-serve for a while, but the docs still described an outdated location. That can lead users to conclude deletion isn't possible and contact support unnecessarily. This makes the self-serve path discoverable.

Note on the settings URL: I used `project-product-analytics#group-analytics`, the default location where the section appears for projects without the Customer Analytics preview. If Customer Analytics is meant to be the canonical home, both the rename and delete links can flip to `project-customer-analytics`.

Refs #2518

## Checklist

- [x] I've read the docs style guide
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links (only PostHog app deep links here, matching the existing convention in this section)
- [ ] I've checked the pages added or changed in the Vercel preview build (not verified in this environment — worth a reviewer check)
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
