### PR TITLE
Update onboarding team goals to Q3 2026

### DIFF
--- a/contents/teams/onboarding/objectives.mdx
+++ b/contents/teams/onboarding/objectives.mdx
@@ -4,7 +4,7 @@
 
   - Hit Onboarding Specialist Logo Retention of 90% (Team)
   - Refine Onboarding segmentation and update our process to match customer potential, segment volume, and the right level of human touch. (Magda)
-  - Ship a shared skill and work on an AI tool that drafts (or sends) personalized outreach and call prep for every new onboarding account, so the team can shift focus to high-potential accounts. (Dan)
+  - Ship a shared skill and work on an AI tool that drafts (or sends) personalized outreach and call prep for every new onboarding account, so the team can shift focus to high-potential accounts. (Daniel)
 
 
 

--- a/contents/teams/onboarding/objectives.mdx
+++ b/contents/teams/onboarding/objectives.mdx
@@ -1,16 +1,10 @@
 **Objective**: Build an awesome Onboarding team and create a great onboarding experience for our users
 
-## Q2 2026 Goals
+## Q3 2026 Goals
 
   - Hit Onboarding Specialist Logo Retention of 90% (Team)
-  - Implement the onboarding conversations playbook in our workflow to promote more user engagement, and provide more value to our high-spend customers (Team)
-
-#### Boosted User Experience
-  - Develop an “onboarding template” dashboard that can be used on customer accounts during calls and help teach customers to fix their own issues over time (Daniel)
-
-#### Research & Process
-  - Drive the increase and maturity of internal onboarding metrics to better understand and communicate our team’s impact (Magda)
-  - Analyze a set of customer onboarding journeys to develop the onboarding program further through improved messaging and other necessary process adjustments (Magda)
+  - Refine Onboarding segmentation and update our process to match customer potential, segment volume, and the right level of human touch. (Magda)
+  - Ship a shared skill and work on an AI tool that drafts (or sends) personalized outreach and call prep for every new onboarding account, so the team can shift focus to high-potential accounts. (Dan)
 
 
 


### PR DESCRIPTION
## Changes

Replaces the Onboarding team's Q2 2026 Goals section on `/teams/onboarding` with the new Q3 2026 Goals.

**Why:** The quarter has rolled over and the team's objectives page needed to reflect the current Q3 goals.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BE0AVBDRR/p1782975629611599)*
