### PR TITLE
docs(autocapture): Add docs documenting ignoring screen names during

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-react-native.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-react-native.mdx
@@ -59,6 +59,7 @@ export function App() {
             <PostHogProvider apiKey="<ph_project_token>" autocapture={{
               captureScreens: false, // Screen events are handled differently for v7 and higher
               captureTouches: true,
+              ignoreScreenNames: ['about'], // Ignore certain screens during autocapture.
             }}>
                 {/* Rest of app */}
             </PostHogProvider>
@@ -92,6 +93,7 @@ export const SharedPostHogProvider = (props: any) => {
     <PostHogProvider client={posthog} autocapture={{
       captureScreens: false, // Screen events are handled differently for react-native-navigation
       captureTouches: true,
+      ignoreScreenNames: ['about'], // Ignore certain screens during autocapture.
     }}>
       {props.children}
     </PostHogProvider>
@@ -122,6 +124,7 @@ Navigation.events().registerAppLaunchedListener(async () => {
       // (Optional) Tracks all passProps as properties. Defaults to undefined
       routeToProperties: (name, properties) => properties,
     },
+    ignoreScreenNames: ['about'],
     captureScreens: true,
   });
 });

--- a/contents/docs/libraries/react-native/_snippets/autocapture-config-rn.mdx
+++ b/contents/docs/libraries/react-native/_snippets/autocapture-config-rn.mdx
@@ -7,7 +7,7 @@
     maxElementsCaptured: 20,
     noCaptureProp: "ph-no-capture",
     propsToCapture: ["testID"], // Limit which props are captured. By default, identifiers and text content are captured.
-
+    ignoreScreenNames: ['about'], // Ignore certain screens during autocapture.
     navigation: {
         // By default, only the screen name is tracked but it is possible to track the
         // params or modify the name by intercepting the autocapture like so


### PR DESCRIPTION
## Changes

* Added documentation for the new `ignoreScreenNames` property under the `autocapture` options block for the React Native SDK.
* Updated React Native configuration examples to show how developers can exclude specific screens (such as modal, utility, or sensitive screens) from automatic screen capture tracking.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
```