### PR TITLE
docs(self-driving): expand custom scout ideas to cover all scout patterns

### DIFF
--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -55,9 +55,15 @@ You can write your own scout for anything you care about. The job is the same ea
 |---|---|
 | **Mine any Slack channel** | Sync a channel into the [data warehouse](/docs/data-warehouse) and a scout reads it like any other table – a user-feedback channel, an on-call channel, even a community Discord relay. The moment it's a table, it's fair game. |
 | **Watch any custom event** | Point a scout at any event you capture – a support event, a feedback submission, a domain-specific action – and have it turn that stream into findings. |
-| **Keep an eye on what you already care about** | Hand a scout a curated set of *your* dashboards, insights, and alerts – the metrics your team checks every morning – and have it stay quiet until one moves against its own baseline. |
+| **Keep an eye on what you already care about** | Hand a scout a curated set of *your* dashboards, insights, and alerts – the metrics your team checks every morning – and have it stay quiet until one moves against its own baseline. Tags work as the config surface too: tag the entities you want watched in PostHog, and untag to turn it off. |
 | **Own a funnel or a journey** | A scout can watch your key funnels and activation flows, flag a conversion or retention regression against the flow's own trailing baseline, and even propose the [experiment](/docs/experiments) to fix the weakest step. |
-| **Have it read your codebase** | Give a scout a repo and a job: catch docs that have drifted out of date, flag a feature shipped with no instrumentation, spot a deprecated API, or run a static-analysis tool over the last week's diffs. |
+| **Get a morning digest** | Most scouts stay quiet until something clears a bar. A digest scout inverts that: one report a day synthesizing its surface – your AI traffic, the day's merged PRs grouped into workstreams – where a quiet day gets a short "all green" and that's the product. |
+| **Turn free text into themes** | [Survey](/docs/surveys) responses, feedback submissions, support messages: instead of forwarding every item, a scout aggregates – "these six responses all describe the same checkout bug" is one actionable finding, not six noisy ones. |
+| **Triage what already pages you** | If a detector already exists – billing spike alerts, an incident pipeline, a support channel where a bot classifies every ticket – a scout can be the judgment layer on top: bundling related items into one finding, weighing who's affected, and flagging the items nobody acted on. |
+| **Guard your SLOs** | If your team has explicit success-rate targets, a scout can score against the error budget instead of a trailing baseline – catching fast burns (an incident eating the budget right now) and slow burns (a success rate quietly creeping below target). |
+| **Have it read your codebase** | Give a scout a repo and a job: catch docs that have drifted out of date, flag a feature shipped with no instrumentation, spot a third-party API your code pins that's headed for sunset, or run a static-analysis tool over the last week's diffs. |
+| **Cross-reference code with PostHog** | Some signals only exist in the overlap: a fully-rolled-out [feature flag](/docs/feature-flags) whose key still litters the codebase is cleanup work, but only a scout that reads both the flag's state *and* the repo can tell. The same shape catches insights pointing at events the code stopped emitting. |
+| **Dogfood your own product** | If your product has an API, MCP, or agent surface, a scout can use it like a real user each run – working through realistic tasks and reporting the friction it hits first-hand, before your users do. |
 | **Point a scout at your scouts** | A meta-scout that audits the rest of the fleet for miscalibration, plus a follow-up that re-checks "resolved" reports after a soak window to confirm the fix actually held. |
 
 The common thread is that a scout isn't limited to product analytics. Any source you land in PostHog – a warehouse table, a Slack relay, a third-party feed – becomes something a scout can watch.
@@ -65,6 +71,8 @@ The common thread is that a scout isn't limited to product analytics. Any source
 ## Make your own
 
 You don't write a scout by hand. In [PostHog Code](/code), open the scouts page and pick the "Make a scout" suggestion: it scans your project and proposes custom scouts grounded in your actual data. You can also ask any agent connected to the PostHog MCP to build one. Once it exists, [run it on demand](/docs/self-driving/scouts#running-a-scout-on-demand) to see what it surfaces before enabling it.
+
+Every idea above is a variation on a small set of reference shapes – anomaly watcher, watchlist, warehouse-backed source, daily digest, and so on. The [scout patterns cookbook](https://github.com/PostHog/posthog/blob/master/products/signals/skills/authoring-scouts/references/scout-patterns.md) catalogs them all, with the discriminator, memory, and gotchas for each – it's what the authoring agent reads, and it's worth a skim if you're deciding what to build.
 
 For a deep dive – two real scouts traced end to end, with a walkthrough video – read [What is a scout?](/blog/what-is-a-scout).
 

--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -36,6 +36,14 @@ Scouts run themselves on their schedule, but you can also trigger a run on deman
 
 On-demand runs count against the same daily run budget as scheduled runs, so repeatedly re-running the same scout can use up your project's daily allowance.
 
+## Every report is also an event
+
+When a scout emits a report, PostHog also captures a `$scout_report_emitted` event into your project (and a `$scout_report_edited` event when a scout later updates one). The event carries the scout's name, the report's title, summary, priority, and actionability, whether it surfaced in your inbox or was held back, and a `report_url` link straight to the report.
+
+Because it's a regular event in your stream, everything in PostHog can build on your scouts' output with nothing to wire up: query scout activity with [SQL](/docs/sql), chart it in an insight, set an [alert](/docs/alerts) on it, or point a [destination](/docs/cdp) at it – like forwarding every surfaced report to a [Slack channel](/docs/cdp/destinations/slack), templated from the event's title, summary, and link.
+
+Scout report events are captured against a synthetic per-scout ID with person processing off, so they never create person profiles or mix into your user analytics.
+
 ## Built-in and custom scouts
 
 PostHog ships with a set of scouts that watch common patterns out of the box. You can turn each on or off per project, and teams can add their own scouts for the patterns specific to their product. See [scout examples](/docs/self-driving/scout-examples) for the scouts PostHog ships with and ideas for your own.


### PR DESCRIPTION
## Changes

Syncs the [scout examples](https://posthog.com/docs/self-driving/scout-examples) page with the recently updated [scout patterns cookbook](https://github.com/PostHog/posthog/blob/master/products/signals/skills/authoring-scouts/references/scout-patterns.md) in the monorepo, so users reading the docs get ideas for every scout shape that's proven itself.

New rows in the "Ideas for custom scouts" table:

- **Get a morning digest** – the daily digest / roll-up pattern
- **Turn free text into themes** – open-text theme aggregation, now explicit
- **Triage what already pages you** – judgment layer over a pre-detected stream (existing alerts, incident pipelines, bot-classified tickets)
- **Guard your SLOs** – the error-budget variant of the anomaly watcher
- **Cross-reference code with PostHog** – state ∩ code intersection (stale flag cleanup, insights pointing at dead events)
- **Dogfood your own product** – the first-person probe pattern

Also:

- Curated-watchlist row now mentions tag-based scoping
- Codebase row picks up the third-party API deprecation variation
- "Make your own" section links directly to the patterns cookbook

And on the [scouts](https://posthog.com/docs/self-driving/scouts) page:

- New **"Every report is also an event"** section documenting the `$scout_report_emitted` / `$scout_report_edited` events scouts capture into the team's own project – so users know they can build SQL queries, insights, alerts, and CDP destinations (e.g. Slack forwards) on top of scout reports with no extra wiring.

Implementation mechanics (dedupe keys, cursors, PII handling, untrusted-content safety) intentionally stay in the cookbook – the docs link to it rather than duplicating authoring detail.