### PR TITLE
Add docs for Grafana's PostHog analytics integration

### DIFF
--- a/contents/docs/libraries/grafana.md
+++ b/contents/docs/libraries/grafana.md
@@ -3,12 +3,6 @@ title: Grafana
 platformLogo: grafana
 ---
 
-## Objective
-
-Forwarding Grafana usage analytics to PostHog using Grafana's built-in PostHog analytics backend.
-
-## Why is this useful?
-
 [Grafana](https://grafana.com/) is an open source observability platform for visualizing metrics, logs, and traces. Grafana's echo service captures frontend usage events from your Grafana instance, and as of Grafana v13.1 it can forward them to PostHog. With this integration, you can:
 
 - Track how your team uses Grafana, including pageviews and UI interactions
@@ -16,33 +10,23 @@ Forwarding Grafana usage analytics to PostHog using Grafana's built-in PostHog a
 - Capture frontend performance metrics and JavaScript errors from your Grafana instance
 - Analyze Grafana usage alongside the rest of your product data in PostHog
 
-This is particularly useful for platform and observability teams who want to understand how their internal Grafana deployment is used.
-
 ## Prerequisites
 
-To follow this tutorial, you should:
-
-1. Have a [PostHog account](https://us.posthog.com/signup) (Cloud or self-hosted)
+1. Have a [PostHog account](https://app.posthog.com/signup)
 2. Run a self-managed [Grafana instance](https://grafana.com/docs/grafana/latest/setup-grafana/) on version 13.1 or later
 
-## Step-by-step instructions
+## Configuring Grafana
 
-### Getting your PostHog project token
-
-1. In PostHog, go to [your project settings](https://app.posthog.com/settings/project).
-2. Copy your project token.
-
-### Configuring Grafana
-
-1. Open your Grafana configuration file (`grafana.ini`, or `custom.ini` on Windows).
-2. Add your project token to the `[analytics]` section. The integration is disabled unless a token is set.
+1. In PostHog, copy your project token from [your project settings](https://app.posthog.com/settings/project).
+2. Open your Grafana configuration file (`grafana.ini`, or `custom.ini` on Windows).
+3. Add your project token to the `[analytics]` section. The integration is disabled unless a token is set.
 
    ```ini
    [analytics]
    posthog_token = <ph_project_token>
    ```
 
-3. If you use PostHog Cloud EU or a self-hosted PostHog instance, also set `posthog_host`. It defaults to `https://us.i.posthog.com` if not set.
+4. If you use PostHog Cloud EU, also set `posthog_host`. It defaults to `https://us.i.posthog.com` if not set.
 
    ```ini
    [analytics]
@@ -50,7 +34,7 @@ To follow this tutorial, you should:
    posthog_host = https://eu.i.posthog.com
    ```
 
-4. Restart Grafana for the changes to take effect.
+5. Restart Grafana for the changes to take effect.
 
 If you run Grafana in Docker or Kubernetes, you can use Grafana's standard environment variable overrides instead of editing the configuration file:
 
@@ -59,7 +43,7 @@ GF_ANALYTICS_POSTHOG_TOKEN=<ph_project_token>
 GF_ANALYTICS_POSTHOG_HOST=https://eu.i.posthog.com
 ```
 
-### Verifying the integration
+## Verifying the integration
 
 1. Open your Grafana instance and click around a few dashboards.
 2. Check that events appear in your [PostHog activity tab](https://app.posthog.com/activity/explore).
@@ -88,10 +72,6 @@ See Grafana's [configuration documentation](https://grafana.com/docs/grafana/lat
 ### Who maintains this integration?
 
 This integration is part of Grafana core and was contributed by PostHog. If you have issues with the integration not functioning as intended, [let us know in-app](http://app.posthog.com/home#supportModal).
-
-### Can I use this with a self-hosted PostHog instance?
-
-Yes! Set `posthog_host` to your self-hosted instance URL in the `[analytics]` section of your Grafana configuration.
 
 ### What if my question isn't answered above?
 

--- a/contents/docs/libraries/grafana.md
+++ b/contents/docs/libraries/grafana.md
@@ -1,0 +1,97 @@
+---
+title: Grafana
+---
+
+## Objective
+
+Forwarding Grafana usage analytics to PostHog using Grafana's built-in PostHog analytics backend.
+
+## Why is this useful?
+
+[Grafana](https://grafana.com/) is an open source observability platform for visualizing metrics, logs, and traces. Grafana's echo service captures frontend usage events from your Grafana instance, and as of Grafana v13.1 it can forward them to PostHog. With this integration, you can:
+
+- Track how your team uses Grafana, including pageviews and UI interactions
+- See which dashboards and features get the most use
+- Capture frontend performance metrics and JavaScript errors from your Grafana instance
+- Analyze Grafana usage alongside the rest of your product data in PostHog
+
+This is particularly useful for platform and observability teams who want to understand how their internal Grafana deployment is used.
+
+## Prerequisites
+
+To follow this tutorial, you should:
+
+1. Have a [PostHog account](https://us.posthog.com/signup) (Cloud or self-hosted)
+2. Run a self-managed [Grafana instance](https://grafana.com/docs/grafana/latest/setup-grafana/) on version 13.1 or later
+
+## Step-by-step instructions
+
+### Getting your PostHog project API key
+
+1. In PostHog, go to [your project settings](https://us.posthog.com/settings/project).
+2. Copy your project API key.
+
+### Configuring Grafana
+
+1. Open your Grafana configuration file (`grafana.ini`, or `custom.ini` on Windows).
+2. Add your project API key to the `[analytics]` section. The integration is disabled unless a token is set.
+
+   ```ini
+   [analytics]
+   posthog_token = <ph_project_api_key>
+   ```
+
+3. If you use PostHog Cloud EU or a self-hosted PostHog instance, also set `posthog_host`. It defaults to `https://us.i.posthog.com` if not set.
+
+   ```ini
+   [analytics]
+   posthog_token = <ph_project_api_key>
+   posthog_host = https://eu.i.posthog.com
+   ```
+
+4. Restart Grafana for the changes to take effect.
+
+If you run Grafana in Docker or Kubernetes, you can use Grafana's standard environment variable overrides instead of editing the configuration file:
+
+```shell
+GF_ANALYTICS_POSTHOG_TOKEN=<ph_project_api_key>
+GF_ANALYTICS_POSTHOG_HOST=https://eu.i.posthog.com
+```
+
+### Verifying the integration
+
+1. Open your Grafana instance and click around a few dashboards.
+2. Check that events appear in your [PostHog activity tab](https://us.posthog.com/activity/explore).
+
+## What data is sent?
+
+Grafana forwards all of its echo event types to PostHog:
+
+| Grafana event | PostHog event |
+|---------------|---------------|
+| Pageview | `$pageview`, with the page path |
+| Interaction | Captured under the interaction name, with its properties |
+| Experiment view | `experiment_viewed`, with `experiment_id`, `experiment_group`, and `experiment_variant` |
+| Meta analytics | Captured under the meta analytics event name |
+| Performance | `performance_metric`, with `metric_name` and `metric_value` |
+| Grafana JavaScript agent | `grafana_javascript_agent_event` |
+
+If the signed-in Grafana user has an analytics identifier, Grafana also identifies them in PostHog with their `email`, `name`, `orgId`, `orgName`, and `orgRole` as person properties.
+
+## FAQ
+
+### Where can I find out more?
+
+See Grafana's [configuration documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#posthog_token) for more information on the `posthog_token` and `posthog_host` settings.
+
+### Who maintains this integration?
+
+This integration is part of Grafana core and was contributed by PostHog. If you have issues with the integration not functioning as intended, [let us know in-app](http://us.posthog.com/home#supportModal).
+
+### Can I use this with a self-hosted PostHog instance?
+
+Yes! Set `posthog_host` to your self-hosted instance URL in the `[analytics]` section of your Grafana configuration.
+
+### What if my question isn't answered above?
+
+We love answering questions. Ask us anything via [our community forum](/questions), or [drop us a message](http://app.posthog.com/home#supportModal).

--- a/contents/docs/libraries/grafana.md
+++ b/contents/docs/libraries/grafana.md
@@ -3,7 +3,7 @@ title: Grafana
 platformLogo: grafana
 ---
 
-[Grafana](https://grafana.com/) is an open source observability platform for visualizing metrics, logs, and traces. Grafana's echo service captures frontend usage events from your Grafana instance, and as of Grafana v13.1 it can forward them to PostHog. With this integration, you can:
+[Grafana](https://grafana.com/) is an open source observability and data visualization platform. Grafana's echo service captures frontend usage events from your Grafana instance, and as of Grafana v13.1 it can forward them to PostHog. With this integration, you can:
 
 - Track how your team uses Grafana, including pageviews and UI interactions
 - See which dashboards and features get the most use
@@ -63,7 +63,7 @@ Grafana forwards all of its echo event types to PostHog:
 
 If the signed-in Grafana user has an analytics identifier, Grafana also identifies them in PostHog with their `email`, `name`, `orgId`, `orgName`, and `orgRole` as person properties.
 
-## FAQ
+## Frequently asked questions
 
 ### Where can I find out more?
 

--- a/contents/docs/libraries/grafana.md
+++ b/contents/docs/libraries/grafana.md
@@ -1,5 +1,6 @@
 ---
 title: Grafana
+platformLogo: grafana
 ---
 
 ## Objective
@@ -26,26 +27,26 @@ To follow this tutorial, you should:
 
 ## Step-by-step instructions
 
-### Getting your PostHog project API key
+### Getting your PostHog project token
 
-1. In PostHog, go to [your project settings](https://us.posthog.com/settings/project).
-2. Copy your project API key.
+1. In PostHog, go to [your project settings](https://app.posthog.com/settings/project).
+2. Copy your project token.
 
 ### Configuring Grafana
 
 1. Open your Grafana configuration file (`grafana.ini`, or `custom.ini` on Windows).
-2. Add your project API key to the `[analytics]` section. The integration is disabled unless a token is set.
+2. Add your project token to the `[analytics]` section. The integration is disabled unless a token is set.
 
    ```ini
    [analytics]
-   posthog_token = <ph_project_api_key>
+   posthog_token = <ph_project_token>
    ```
 
 3. If you use PostHog Cloud EU or a self-hosted PostHog instance, also set `posthog_host`. It defaults to `https://us.i.posthog.com` if not set.
 
    ```ini
    [analytics]
-   posthog_token = <ph_project_api_key>
+   posthog_token = <ph_project_token>
    posthog_host = https://eu.i.posthog.com
    ```
 
@@ -54,14 +55,14 @@ To follow this tutorial, you should:
 If you run Grafana in Docker or Kubernetes, you can use Grafana's standard environment variable overrides instead of editing the configuration file:
 
 ```shell
-GF_ANALYTICS_POSTHOG_TOKEN=<ph_project_api_key>
+GF_ANALYTICS_POSTHOG_TOKEN=<ph_project_token>
 GF_ANALYTICS_POSTHOG_HOST=https://eu.i.posthog.com
 ```
 
 ### Verifying the integration
 
 1. Open your Grafana instance and click around a few dashboards.
-2. Check that events appear in your [PostHog activity tab](https://us.posthog.com/activity/explore).
+2. Check that events appear in your [PostHog activity tab](https://app.posthog.com/activity/explore).
 
 ## What data is sent?
 
@@ -86,7 +87,7 @@ See Grafana's [configuration documentation](https://grafana.com/docs/grafana/lat
 
 ### Who maintains this integration?
 
-This integration is part of Grafana core and was contributed by PostHog. If you have issues with the integration not functioning as intended, [let us know in-app](http://us.posthog.com/home#supportModal).
+This integration is part of Grafana core and was contributed by PostHog. If you have issues with the integration not functioning as intended, [let us know in-app](http://app.posthog.com/home#supportModal).
 
 ### Can I use this with a self-hosted PostHog instance?
 

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -49,6 +49,7 @@ export const LOGOS = {
     gatsby: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/gatsby.svg',
     github: 'https://res.cloudinary.com/dmukukwp6/image/upload/github_mark_903e35d471.svg',
     go: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/go.svg',
+    grafana: 'https://res.cloudinary.com/dmukukwp6/image/upload/Grafana_logo_b2df48fb94.svg',
     granola: 'https://www.google.com/s2/favicons?domain=granola.ai&sz=64',
     googleAds: 'https://res.cloudinary.com/dmukukwp6/image/upload/Google_Ads_logo_b59e784792.svg',
     groq: 'https://res.cloudinary.com/dmukukwp6/image/upload/groq_a0ed539e47.png',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2634,6 +2634,10 @@ export const docsMenu = {
                             url: '/docs/libraries/google-tag-manager',
                         },
                         {
+                            name: 'Grafana',
+                            url: '/docs/libraries/grafana',
+                        },
+                        {
                             name: 'MoEngage',
                             url: '/docs/libraries/moengage',
                         },


### PR DESCRIPTION
## Changes

Grafana 13.1 added PostHog as an analytics destination for its echo service ([grafana/grafana#122263](https://github.com/grafana/grafana/pull/122263), contributed by @rafaeelaudibert). Setting `posthog_token` (and optionally `posthog_host`) in the `[analytics]` section of `grafana.ini` forwards all of Grafana's frontend usage events — pageviews, UI interactions, experiment views, performance metrics, and frontend errors — to PostHog.

This PR documents the integration:

- **New page** `contents/docs/libraries/grafana.md` (→ `/docs/libraries/grafana`), structured as reference material per the `/docs/libraries` convention: intro, prerequisites (Grafana v13.1+), `grafana.ini` and env-var configuration, verification steps, a table mapping Grafana echo event types to PostHog events, `identify` behavior, and FAQs.
- **Nav entry** in `src/navs/index.js` under SDKs → Services, in alphabetical order.
- **Grafana logo** added to `src/constants/logos.ts` and wired up via `platformLogo` frontmatter.

## Review feedback addressed

- Links use `app.posthog.com` instead of hardcoded `us.posthog.com` (@rafaeelaudibert)
- Grafana logo uploaded to Cloudinary and wired up (@rafaeelaudibert)
- Restructured from tutorial-style to reference-style; removed Objective/"Why is this useful?" boilerplate and the self-hosted PostHog FAQ entry (@gewenyu99)
- Vale warnings cleared, except the flag on the lowercase `grafana` in the `https://grafana.com/` link URL, which can't be capitalized

## Notes

- New page, so no redirects needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)