### PR TITLE
docs(data-warehouse): add docs for 74 alpha warehouse sources

### DIFF
--- a/contents/docs/cdp/sources/agilecrm.md
+++ b/contents/docs/cdp/sources/agilecrm.md
@@ -1,0 +1,54 @@
+---
+title: Linking AgileCRM as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: AgileCRM
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The AgileCRM connector syncs your CRM data into the PostHog Data warehouse, so you can analyze your contacts, deals, and sales activity alongside your product data.
+
+## Prerequisites
+
+You need an Agile CRM account with API access so you can generate an API key. You authenticate with the email address you log in with and that key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking AgileCRM, you'll need:
+
+- **Domain** – the subdomain of your Agile CRM URL. For `https://acme.agilecrm.com` the domain is `acme`.
+- **Email** – the email address you use to log in to Agile CRM.
+- **API key** – find it under **Admin Settings → Developers & API** in your Agile CRM account.
+
+## Sync modes
+
+<SyncModes />
+
+All AgileCRM tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your Agile CRM email or API key is invalid. Generate a new API key under **Admin Settings → Developers & API**, then reconnect.
+- If you get a permission error, your Agile CRM account does not have access to this data. Check your API access settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/aha.md
+++ b/contents/docs/cdp/sources/aha.md
@@ -1,0 +1,51 @@
+---
+title: Linking Aha! as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Aha
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Aha! connector syncs your product roadmap data into the PostHog Data warehouse, so you can analyze your planning and delivery workflows alongside your product data.
+
+## Prerequisites
+
+You need an Aha! account with permission to create an API key. The key inherits your account permissions, so it can read every record you can see.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Aha!, you'll need:
+
+- **Account domain** – the first part of your Aha! account host. For `yourcompany.aha.io`, enter `yourcompany`.
+- **API key** – create one under **Settings → Personal → Developer → API keys** in your Aha! account.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key in your Aha! account settings, then reconnect.
+- If you see a permissions error, the key is missing the access needed to sync this data. Check the key's account permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/algolia.md
+++ b/contents/docs/cdp/sources/algolia.md
@@ -1,0 +1,54 @@
+---
+title: Linking Algolia as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Algolia
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Algolia connector syncs your Algolia search data – index records, synonyms, query rules, and indices – into PostHog, so you can analyze your search configuration alongside your product data.
+
+## Prerequisites
+
+You need an Algolia account with access to your Application ID and the ability to create an API key with the ACLs for the data you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Algolia, you'll need:
+
+- **Application ID** – found in your [Algolia dashboard](https://dashboard.algolia.com/account/api-keys/all) under your account API keys.
+- **API key** – create one in the same [Algolia dashboard](https://dashboard.algolia.com/account/api-keys/all). Grant the ACLs for the data you want to sync: `browse` for index records, `settings` for synonyms and query rules, and `listIndexes` for the list of indices.
+- **Index name** – the name of the Algolia index you want to sync.
+
+## Sync modes
+
+<SyncModes />
+
+Algolia endpoints do not expose a server-side updated-since filter, so this source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, check that your Application ID and API key are correct in the Algolia dashboard.
+- If a table fails to sync, make sure your API key has the ACL required for it: `browse` for records, `settings` for synonyms and query rules, and `listIndexes` for indices.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/apify-dataset.md
+++ b/contents/docs/cdp/sources/apify-dataset.md
@@ -1,0 +1,54 @@
+---
+title: Linking Apify Dataset as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ApifyDataset
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Apify Dataset connector syncs the rows of an Apify dataset into PostHog, so you can analyze the output of your Apify Actors and web scrapers alongside your product data.
+
+## Prerequisites
+
+You need an Apify account with an API token that has read access to the dataset's storage, and the ID of the dataset you want to import.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Apify Dataset, you'll need:
+
+- **API token** – create one in your [Apify account settings](https://console.apify.com/settings/integrations). The token needs read access to the dataset's storage.
+- **Dataset ID** – find it in the [Apify Console](https://console.apify.com/storage/datasets), or use the `username~dataset-name` shorthand.
+
+## Sync modes
+
+<SyncModes />
+
+Apify datasets are full refresh only. The whole dataset is re-imported on every sync.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API token is invalid or has expired, create a new token in your Apify account settings, then reconnect.
+- If your token cannot access the dataset, use a token with read access to the dataset's storage, then reconnect.
+- If the dataset could not be found, check that the dataset ID is correct and the token can access it.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/appfigures.md
+++ b/contents/docs/cdp/sources/appfigures.md
@@ -1,0 +1,50 @@
+---
+title: Linking Appfigures as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Appfigures
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Appfigures connector syncs your app-store analytics – products, reviews, and sales and revenue reports – into PostHog, so you can analyze your mobile app performance alongside your product data.
+
+## Prerequisites
+
+You need an Appfigures account with access to the developer portal so you can create an API client and Personal Access Token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Appfigures, you'll need:
+
+- **Personal access token** – create an API client and Personal Access Token at [appfigures.com/developers/keys](https://appfigures.com/developers/keys). When creating the client, grant the data sets you want to sync: `products:read` for products, `public:read` for reviews, and `private:read` for sales and revenue reports.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid or expired token error, create a new Personal Access Token in your Appfigures developer settings, then reconnect.
+- If a table fails with a missing scope error, grant the required data sets to your API client, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/assemblyai.md
+++ b/contents/docs/cdp/sources/assemblyai.md
@@ -1,0 +1,52 @@
+---
+title: Linking AssemblyAI as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: AssemblyAI
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The AssemblyAI connector syncs your speech-to-text transcripts into the PostHog Data warehouse, so you can analyze your transcription data alongside your product data. AssemblyAI retains only the last 90 days of transcripts, so only those are available to sync.
+
+## Prerequisites
+
+You need an AssemblyAI account with API access so you can create an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking AssemblyAI, you'll need:
+
+- **API key** – find your key in the [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys).
+- **Region** – choose the region that matches your account, either US (`api.assemblyai.com`) or EU (`api.eu.assemblyai.com`).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your AssemblyAI API key may be invalid or revoked. Create a new key in the AssemblyAI dashboard, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/aviationstack.md
+++ b/contents/docs/cdp/sources/aviationstack.md
@@ -1,0 +1,53 @@
+---
+title: Linking Aviationstack as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Aviationstack
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The aviationstack connector syncs real-time, scheduled, and historical flight data along with aviation reference tables into PostHog, so you can analyze flight and aviation data alongside your product data.
+
+## Prerequisites
+
+You need an aviationstack account with an active access key. Some tables, such as historical flights and certain filters, require a paid plan.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Aviationstack, you'll need:
+
+- **Access key** – find it in your [aviationstack dashboard](https://aviationstack.com/dashboard). Note that aviationstack pricing is a monthly request quota tied to your plan.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only. Every table is re-synced on each run because aviationstack has no server-side updated-at cursor.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your access key is invalid or has been deactivated, generate a new key in your aviationstack dashboard, then reconnect.
+- If your plan does not grant access to a table, upgrade your aviationstack plan or deselect the restricted tables, then reconnect.
+- If you hit your monthly request quota, upgrade your plan or wait for the quota to reset, then resync.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/beamer.md
+++ b/contents/docs/cdp/sources/beamer.md
@@ -1,0 +1,50 @@
+---
+title: Linking Beamer as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Beamer
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Beamer connector syncs your changelog posts, feature requests, comments, votes, reactions, and NPS responses into the PostHog Data warehouse, so you can analyze product engagement and feedback alongside your product data.
+
+## Prerequisites
+
+You need a Beamer account with access to your API key. Some tables have additional requirements: the Users table needs a Beamer Scale plan, and some post queries need the key's "Read posts (ignore filters)" permission.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Beamer, you'll need:
+
+- **API key** – find it in your [Beamer account settings](https://app.getbeamer.com/settings#api). Beamer sends it in the `Beamer-Api-Key` header.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Generate a new key in your Beamer account settings, then reconnect.
+- If a table fails with a permission error, your key may be missing the plan or permission needed to sync it. The Users table needs a Scale plan, and some post queries need the "Read posts (ignore filters)" permission. Adjust the key in your Beamer account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/bigmailer.md
+++ b/contents/docs/cdp/sources/bigmailer.md
@@ -1,0 +1,51 @@
+---
+title: Linking BigMailer as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: BigMailer
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The BigMailer connector syncs your email marketing data into the PostHog Data warehouse, so you can analyze your campaigns and contacts alongside your product data.
+
+## Prerequisites
+
+You need a BigMailer account with API access so you can create an API key. The key has account-wide access, so no extra scopes need to be granted.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking BigMailer, you'll need:
+
+- **API key** – create one in your BigMailer console under **Account Settings → API Keys**.
+
+## Sync modes
+
+<SyncModes />
+
+All BigMailer tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If the connection fails, your BigMailer API key is invalid or lacks the required permissions. Create a new key in your BigMailer console, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/blogger.md
+++ b/contents/docs/cdp/sources/blogger.md
@@ -1,0 +1,51 @@
+---
+title: Linking Blogger as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Blogger
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Blogger connector syncs your publicly visible Blogger content – posts, pages, and comments – into the PostHog Data warehouse, so you can analyze your published content alongside your product data.
+
+## Prerequisites
+
+You need a Google account with a project in the [Google Cloud console](https://console.cloud.google.com/apis/credentials) where you can create an API key and enable the Blogger API v3. The API key reads publicly visible content only. Drafts and admin-only data require OAuth, which isn't supported yet.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Blogger, you'll need:
+
+- **API key** – create one in the [Google Cloud console](https://console.cloud.google.com/apis/credentials) and enable the **Blogger API v3** for the project.
+- **Blog ID** – shown in the Blogger dashboard URL (`blogger.com/blog/posts/<blogId>`).
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key in the Google Cloud console with the Blogger API enabled, then reconnect.
+- If you see a permissions error, the key cannot access this blog. Enable the Blogger API for your Google Cloud project and confirm the blog is publicly visible, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/bluetally.md
+++ b/contents/docs/cdp/sources/bluetally.md
@@ -1,0 +1,53 @@
+---
+title: Linking BlueTally as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Bluetally
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The BlueTally connector syncs your IT asset management data into PostHog, so you can analyze your assets alongside your product data.
+
+## Prerequisites
+
+You need a BlueTally account with access to create an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking BlueTally, you'll need:
+
+- **API key** – create one in BlueTally under **Settings → API Keys**, then paste it here.
+- **Tenant ID** – optional. If your account has multi-tenancy enabled, enter the tenant ID the key should act on.
+
+## Sync modes
+
+<SyncModes />
+
+BlueTally exposes no server-side timestamp filter, so this source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or expired. Create a new key under **Settings → API Keys** in BlueTally, then reconnect.
+- If you see a permission error, check that the key has permission to read the data you want to sync.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/boldsign.md
+++ b/contents/docs/cdp/sources/boldsign.md
@@ -1,0 +1,53 @@
+---
+title: Linking BoldSign as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: BoldSign
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The BoldSign connector syncs your eSignature data – documents, templates, and contacts – into PostHog, so you can analyze your signing workflows alongside your product data.
+
+## Prerequisites
+
+You need a BoldSign account with access to its account settings so you can create an API key, and you need to know which region your account is hosted in.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking BoldSign, you'll need:
+
+- **API key** – create one in your [BoldSign account settings](https://app.boldsign.com/settings) under **API** → **API Key**. API keys carry all scopes by default.
+- **Region** – pick the region your BoldSign account lives in. Accounts are hosted on either the US (`api.boldsign.com`) or EU (`api-eu.boldsign.com`) host.
+
+## Sync modes
+
+<SyncModes />
+
+BoldSign tables are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid or has been revoked, create a new key in your BoldSign account settings, then reconnect.
+- If your API key does not have permission to access the data, check the key's permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/breezometer.md
+++ b/contents/docs/cdp/sources/breezometer.md
@@ -1,0 +1,54 @@
+---
+title: Linking BreezoMeter as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Breezometer
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The BreezoMeter connector syncs air-quality and pollen data for the locations you track into PostHog, so you can analyze environmental data alongside your product data. BreezoMeter is now part of Google Maps Platform, and this source uses its Air Quality API and Pollen API.
+
+## Prerequisites
+
+You need a Google Cloud project with an API key, and both the Air Quality API and the Pollen API enabled for that project.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking BreezoMeter, you'll need:
+
+- **API key** – create an API key in the [Google Cloud console](https://console.cloud.google.com/apis/credentials) and enable both the [Air Quality API](https://developers.google.com/maps/documentation/air-quality) and the [Pollen API](https://developers.google.com/maps/documentation/pollen) for your project.
+- **Locations** – there is no list endpoint, so enter one location per line as `lat,lon` (an optional label is allowed: `lat,lon,label`), for example `51.5074,-0.1278,London`.
+
+## Sync modes
+
+<SyncModes />
+
+Each sync polls every location once per table. To accumulate a history of point-in-time snapshots, pick the append sync method on the table.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If the Air Quality API returns an error, check that your API key is valid and that the Air Quality API is enabled for your Google Cloud project, then reconnect.
+- If the Pollen API returns an error, check that your API key is valid and that the Pollen API is enabled for your Google Cloud project, then reconnect.
+- If access is denied, check any restrictions on your API key, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/bugsnag.md
+++ b/contents/docs/cdp/sources/bugsnag.md
@@ -1,0 +1,52 @@
+---
+title: Linking Bugsnag as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Bugsnag
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The BugSnag connector pulls your error-monitoring data into the PostHog Data warehouse, so you can analyze your errors, events, and releases alongside your product data.
+
+## Prerequisites
+
+You need a BugSnag account so you can generate a personal auth token. The token inherits your account's access, so it can read every organization and project you can see.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Bugsnag, you'll need:
+
+- **Auth token** – generate a personal auth token in the **My Account** section of your [BugSnag account settings](https://app.bugsnag.com/settings/my-account/).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your BugSnag auth token may be invalid or revoked. Generate a new personal auth token in your BugSnag account settings, then reconnect.
+- If you see a permission error, the token does not have access to the requested data. Check the token's account permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/bunny.md
+++ b/contents/docs/cdp/sources/bunny.md
@@ -1,0 +1,52 @@
+---
+title: Linking Bunny.net as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Bunny
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The bunny.net connector syncs your bunny.net data – pull zones, storage zones, DNS zones, and Stream video libraries – into PostHog, so you can analyze your content delivery and streaming data alongside your product data.
+
+## Prerequisites
+
+You need a bunny.net account with access to your account API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Bunny.net, you'll need:
+
+- **Account API key** – find it under **Account Settings → API** in the [bunny.net dashboard](https://dash.bunny.net/account/settings). This single key grants read access to the Core API.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only. Every table is re-synced on each run because bunny.net's list endpoints expose no server-side timestamp filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your account API key is invalid or has been revoked, generate a new key under Account Settings → API, then reconnect.
+- If your key does not have access to some data, check the key's permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/buzzsprout.md
+++ b/contents/docs/cdp/sources/buzzsprout.md
@@ -1,0 +1,53 @@
+---
+title: Linking Buzzsprout as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Buzzsprout
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Buzzsprout connector syncs your podcast data into the PostHog Data warehouse, so you can analyze your podcast performance alongside your product data.
+
+## Prerequisites
+
+You need a Buzzsprout account with access to its API settings so you can obtain an API token and your podcast ID.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Buzzsprout, you'll need:
+
+- **API token** – find it in your [Buzzsprout API settings](https://www.buzzsprout.com/my/profile/api).
+- **Podcast ID** – shown alongside your API token in the same [Buzzsprout API settings](https://www.buzzsprout.com/my/profile/api) page.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only. Each sync pulls the complete dataset and merges on the primary key, so mutable fields such as total plays stay up to date.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API token may be invalid or revoked. Create a new token in your Buzzsprout account settings, then reconnect.
+- If you see a forbidden error, your token may not have access to this podcast. Check the token and podcast ID, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/callrail.md
+++ b/contents/docs/cdp/sources/callrail.md
@@ -1,0 +1,51 @@
+---
+title: Linking CallRail as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CallRail
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The CallRail connector syncs your call-tracking data into the PostHog Data warehouse, so you can analyze your calls and attribution alongside your product data.
+
+## Prerequisites
+
+You need a CallRail account with API access so you can create an API key. API keys are scoped to the creating user, so the key only sees data that user can access.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking CallRail, you'll need:
+
+- **API key** – create one under **Account settings → Integrations → API Keys** in CallRail.
+- **Account ID** – optional. Leave it blank to use the first account your key can access, or set it to sync a specific account.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your CallRail API key is invalid or has been revoked. Create a new key under **Account settings → Integrations → API Keys**, then reconnect.
+- If you get a permission error, your API key does not have access to this data. The key only sees what its creating user can access, so check the user's permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/campayn.md
+++ b/contents/docs/cdp/sources/campayn.md
@@ -1,0 +1,53 @@
+---
+title: Linking Campayn as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Campayn
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Campayn connector syncs your email marketing data into the PostHog Data warehouse, so you can analyze your campaigns and contacts alongside your product data.
+
+## Prerequisites
+
+You need a Campayn account with access to your account settings, where you can find and regenerate your API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Campayn, you'll need:
+
+- **Subdomain** – the first part of your account host. For `acme.campayn.com`, enter `acme`.
+- **API key** – find and regenerate it in your Campayn account settings.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full-refresh only. Campayn's API exposes no pagination, cursors, or timestamp filters, so every table is fully re-synced on each run.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been regenerated. Create a new key in your Campayn account settings, then reconnect.
+- If you see a permissions error, the key is not authorized for this data. Check the key's permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/canny.md
+++ b/contents/docs/cdp/sources/canny.md
@@ -1,0 +1,51 @@
+---
+title: Linking Canny as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Canny
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Canny connector syncs your Canny feedback, posts, and roadmap data into PostHog, so you can analyze customer feedback alongside your product data.
+
+## Prerequisites
+
+You need a Canny account with access to its secret API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Canny, you'll need:
+
+- **API key** – find your secret API key under **Settings → API** in your Canny dashboard.
+
+## Sync modes
+
+<SyncModes />
+
+Canny list endpoints do not expose a server-side updated-since filter, so this source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Find your secret API key under **Settings → API** in your Canny dashboard, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/capsule-crm.md
+++ b/contents/docs/cdp/sources/capsule-crm.md
@@ -1,0 +1,50 @@
+---
+title: Linking Capsule CRM as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CapsuleCRM
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Capsule CRM connector syncs your CRM data – parties, opportunities, projects, and tasks – into PostHog, so you can analyze your sales pipeline alongside your product data.
+
+## Prerequisites
+
+You need a Capsule CRM account with permission to see the records you want to sync, so you can create a Personal Access Token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Capsule CRM, you'll need:
+
+- **Personal Access Token** – create one under **My Preferences → API Authentication Tokens** in your Capsule account. The token inherits your user's permissions, so make sure your user can see the records you want to sync (parties, opportunities, projects, tasks).
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your Personal Access Token is invalid or has been revoked, create a new token in your Capsule account settings, then reconnect.
+- If your user does not have permission to read the data, check the user's permissions in Capsule, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/care-quality-commission.md
+++ b/contents/docs/cdp/sources/care-quality-commission.md
@@ -1,0 +1,53 @@
+---
+title: Linking Care Quality Commission as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CareQualityCommission
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Care Quality Commission connector syncs UK health and social care provider and location data into PostHog, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need an account on the CQC developer portal so you can subscribe to the Syndication API and obtain a subscription key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Care Quality Commission, you'll need:
+
+- **Subscription key** – create a subscription key from the [CQC developer portal](https://api-portal.service.cqc.org.uk). Subscribe to the Syndication API product and copy its primary key.
+- **Partner code** – optional but recommended. Requests sent with a partner code are allowed up to 2000 requests/minute, while requests without one are throttled harder. Request a partner code from CQC if you don't have one.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid subscription key error, create a new key from the CQC developer portal, then reconnect.
+- If access is not authorized, subscribe to the Syndication API product in the CQC developer portal, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/chameleon.md
+++ b/contents/docs/cdp/sources/chameleon.md
@@ -1,0 +1,51 @@
+---
+title: Linking Chameleon as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Chameleon
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Chameleon connector syncs your in-product onboarding and adoption data, such as tours and Microsurvey responses, into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a Chameleon account so you can generate an account-specific API secret.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Chameleon, you'll need:
+
+- **Account secret** – generate an account-specific API secret in your [Chameleon account settings](https://app.chameleon.io/settings/tokens). The secret is only shown once, so copy it when you create it.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see a permission error, your Chameleon account secret may be invalid or revoked. Generate a new secret in your Chameleon account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/chargedesk.md
+++ b/contents/docs/cdp/sources/chargedesk.md
@@ -1,0 +1,50 @@
+---
+title: Linking Chargedesk as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Chargedesk
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The ChargeDesk connector syncs your billing and payments data into PostHog, so you can analyze charges, customers, and subscriptions alongside your product data.
+
+## Prerequisites
+
+You need a ChargeDesk account with API access enabled for the company you want to sync. Each company has its own secret key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Chargedesk, you'll need:
+
+- **Secret API key** – create one in your ChargeDesk account under **Setup → API / Webhooks → Issue New Key**, and make sure API access is enabled for the company.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your secret API key is invalid or has been revoked, issue a new key in your ChargeDesk account (Setup → API / Webhooks), then reconnect.
+- If your key does not have API access enabled, enable API access for the company in your ChargeDesk account, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/churnkey.md
+++ b/contents/docs/cdp/sources/churnkey.md
@@ -1,0 +1,54 @@
+---
+title: Linking Churnkey as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Churnkey
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Churnkey connector pulls your cancel-flow session data into the PostHog Data warehouse, so you can analyze churn, retention, and cancellation behavior alongside your product data.
+
+## Prerequisites
+
+You need a Churnkey account and a Data API key. The Data API key is distinct from your Cancel Flow API key and is requested from Churnkey support at support@churnkey.co.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Churnkey, you'll need:
+
+- **Data API key** – request one from [support@churnkey.co](mailto:support@churnkey.co). This is distinct from your Cancel Flow API key. Once issued, it is shown in Churnkey under **Settings → Account**.
+- **App ID** – shown in Churnkey under **Settings → Account**.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, check your Data API key and App ID under **Settings → Account**, then reconnect.
+- If you see a forbidden error, confirm you are using a Data API key and not a Cancel Flow key, then reconnect.
+- If your App ID is not recognized, check the App ID under **Settings → Account**, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/cimis.md
+++ b/contents/docs/cdp/sources/cimis.md
@@ -1,0 +1,52 @@
+---
+title: Linking CIMIS as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Cimis
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The CIMIS connector pulls California weather and reference evapotranspiration (ETo) data from the [California Irrigation Management Information System (CIMIS)](https://cimis.water.ca.gov/) into the PostHog Data warehouse, so you can analyze weather data alongside your product data.
+
+## Prerequisites
+
+CIMIS is a free service. You need a CIMIS account so you can create a web-services appKey.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking CIMIS, you'll need:
+
+- **App key** – register for a free account and create a web-services appKey in your [CIMIS account](https://et.water.ca.gov/Account/Login).
+- **Targets (station numbers)** – optional. To sync the daily and hourly weather tables, set this to a comma-separated list of CIMIS station numbers (e.g. `2,8,127`). You can look up station numbers in the `stations` table or on the [CIMIS station map](https://cimis.water.ca.gov/Stations.aspx). The station and zip-code metadata tables sync without targets.
+- **Unit of measure** – optional. Choose English (°F, inches) or Metric (°C, mm). Defaults to English.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your CIMIS appKey is invalid or has expired. Create a new appKey in your CIMIS account, then reconnect.
+- If your appKey is rejected, it may not have been activated yet. Check the key in your CIMIS account, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/clockify.md
+++ b/contents/docs/cdp/sources/clockify.md
@@ -1,0 +1,50 @@
+---
+title: Linking Clockify as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Clockify
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Clockify connector syncs your time-tracking data into the PostHog Data warehouse, so you can analyze projects, clients, and time entries alongside your product data.
+
+## Prerequisites
+
+You need a Clockify account. The API key is user-scoped, so use an admin or owner key to sync workspace-wide data such as projects, clients, and every member's time entries.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Clockify, you'll need:
+
+- **API key** – generate one on your [Clockify profile settings](https://app.clockify.me/user/settings) page.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Generate a new key in your Clockify profile settings, then reconnect.
+- If you see a permissions error, the key lacks the access needed to sync this data. Use an admin or owner key, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/clockodo.md
+++ b/contents/docs/cdp/sources/clockodo.md
@@ -1,0 +1,53 @@
+---
+title: Linking Clockodo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Clockodo
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Clockodo connector syncs your Clockodo time-tracking data into PostHog, so you can analyze time and project data alongside your product data.
+
+## Prerequisites
+
+You need a Clockodo account with access to your personal API key. Credentials are scoped to that co-worker's permissions, so connect a user that can see the data you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Clockodo, you'll need:
+
+- **Email** – the email address of the Clockodo user whose API key you're using.
+- **API key** – find your personal API key under **Personal data** in your Clockodo account.
+
+## Sync modes
+
+<SyncModes />
+
+Clockodo exposes no server-side modified-since filter, so this source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, check that your email and API key are correct. Find your API key under **Personal data** in Clockodo, then reconnect.
+- If you see a permission error, Clockodo credentials are scoped per co-worker. Check the user's permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/codefresh.md
+++ b/contents/docs/cdp/sources/codefresh.md
@@ -1,0 +1,52 @@
+---
+title: Linking Codefresh as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Codefresh
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Codefresh connector syncs your CI/CD data – projects, pipelines, builds, images, and more – into PostHog, so you can analyze your delivery pipeline alongside your product data.
+
+## Prerequisites
+
+You need a Codefresh account on the US SaaS host (`g.codefresh.io`) so you can create an API key. EU and self-hosted or on-prem installations are not yet supported.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Codefresh, you'll need:
+
+- **API key** – create one in your [Codefresh user settings](https://g.codefresh.io/user/settings). Codefresh API keys are scoped per resource, so grant read access for the resources you want to sync, for example Project (projects), Pipeline (pipelines, triggers), Build (builds, images), and Step Type (step types).
+
+## Sync modes
+
+<SyncModes />
+
+Codefresh tables are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid or has been revoked, create a new key in your Codefresh user settings, then reconnect.
+- If your API key is missing the access scope needed to sync some data, grant the required resource scopes to the key in your Codefresh user settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/coin-api.md
+++ b/contents/docs/cdp/sources/coin-api.md
@@ -1,0 +1,52 @@
+---
+title: Linking CoinAPI as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CoinApi
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The CoinAPI connector syncs cryptocurrency market data – assets, exchanges, symbols, exchange rates, and OHLCV and trade history – into PostHog, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a CoinAPI account so you can create an API key. CoinAPI uses a credit/quota-based (pay-as-you-go) model with a daily credit limit, so large time-series tables can consume significant credits.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking CoinAPI, you'll need:
+
+- **API key** – create a key in the [CoinAPI customer portal](https://customer.coinapi.io/).
+
+The reference tables (assets, exchanges, symbols) and exchange rates sync with just an API key. The OHLCV and trades history tables are scoped to a single market, so set the Symbol ID field (and, for OHLCV, the Period ID) to enable them.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid or incorrectly formatted key error, create a new key in the CoinAPI customer portal, then reconnect.
+- If access is denied, check that your CoinAPI subscription covers the data you're trying to sync, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/coingecko.md
+++ b/contents/docs/cdp/sources/coingecko.md
@@ -1,0 +1,53 @@
+---
+title: Linking CoinGecko as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CoinGecko
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The CoinGecko connector pulls cryptocurrency market data into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a CoinGecko account so you can create an API key, either a free Demo key or a paid Pro key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking CoinGecko, you'll need:
+
+- **Plan** – choose the plan that matches your key. Demo (free) keys use the `x-cg-demo-api-key` header and Pro (paid) keys use the `x-cg-pro-api-key` header, and they use different hosts.
+- **API key** – create a key in your [CoinGecko developer dashboard](https://www.coingecko.com/en/developers/dashboard).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your CoinGecko API key may be invalid or revoked. Create a new key of the matching plan in your CoinGecko dashboard, then reconnect.
+- CoinGecko enforces tight per-minute rate limits and monthly credit caps, especially on the Demo plan, so large tables may take a while to sync.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/coinmarketcap.md
+++ b/contents/docs/cdp/sources/coinmarketcap.md
@@ -1,0 +1,49 @@
+---
+title: Linking CoinMarketCap as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CoinMarketCap
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The CoinMarketCap connector syncs cryptocurrency and market data into PostHog, so you can analyze crypto and market data alongside your product data.
+
+## Prerequisites
+
+You need a CoinMarketCap account with a Pro API key. Some endpoints, such as exchanges, require a higher plan tier.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking CoinMarketCap, you'll need:
+
+- **API key** – create one from your [CoinMarketCap developer dashboard](https://pro.coinmarketcap.com/account). The key grants read access to every endpoint.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid or has been revoked, create a new key in your CoinMarketCap developer dashboard, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/concord.md
+++ b/contents/docs/cdp/sources/concord.md
@@ -1,0 +1,52 @@
+---
+title: Linking Concord as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Concord
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Concord connector pulls your contract lifecycle data into the PostHog Data warehouse, so you can analyze your contracts alongside your product data.
+
+## Prerequisites
+
+You need a Concord account on a paid plan so you can generate an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Concord, you'll need:
+
+- **API key** – generate one in your Concord account settings (API key generation requires a paid plan). Concord sends it as an `X-API-KEY` header.
+- **Environment** – choose Production or Sandbox to match the Concord environment your API key belongs to.
+- **Organization ID** – optional. Leave it blank to use the first organization your API key can access.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Generate a new key in your Concord account settings, then reconnect.
+- If a table fails with a permission error, your key may be missing the required access. The events log requires the Administrator role. Adjust the key's access, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/ding-connect.md
+++ b/contents/docs/cdp/sources/ding-connect.md
@@ -1,0 +1,52 @@
+---
+title: Linking DingConnect as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: DingConnect
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The DingConnect connector syncs your DingConnect data into the PostHog Data warehouse, so you can analyze your top-up transactions and account balances alongside your product data.
+
+## Prerequisites
+
+You need a DingConnect account with API access so you can generate an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking DingConnect, you'll need:
+
+- **API key** – generate one under the **Developer** tab of your [DingConnect account settings](https://www.dingconnect.com/Account/Settings).
+
+## Sync modes
+
+<SyncModes />
+
+All DingConnect tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your DingConnect API key is invalid or has been revoked. Generate a new key under the **Developer** tab of your account settings, then reconnect.
+- If you get a permission error, your API key does not have access to this data. Check the key's permissions in your DingConnect account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/docuseal.md
+++ b/contents/docs/cdp/sources/docuseal.md
@@ -1,0 +1,53 @@
+---
+title: Linking DocuSeal as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Docuseal
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The DocuSeal connector syncs your document signing data – templates, submissions, and submitters – into the PostHog Data warehouse, so you can analyze your signing workflows alongside your product data.
+
+## Prerequisites
+
+You need a DocuSeal account with access to create an API key. The key has full account access, as DocuSeal does not offer per-resource scopes. Self-hosted deployments are not supported yet.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking DocuSeal, you'll need:
+
+- **API key** – create one under **Settings → API** in your [DocuSeal console](https://console.docuseal.com/api).
+- **Region** – pick the region your DocuSeal account is hosted in, either Global (`api.docuseal.com`) or EU (`api.docuseal.eu`).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full-refresh only. DocuSeal has no server-side timestamp filter, and its records mutate as submission statuses change, so every table is fully re-synced on each run.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key in your DocuSeal account settings, then reconnect.
+- If you see a permissions error, the key does not have access to this data. Check the key in your DocuSeal account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/dropbox-sign.md
+++ b/contents/docs/cdp/sources/dropbox-sign.md
@@ -1,0 +1,52 @@
+---
+title: Linking Dropbox Sign as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: DropboxSign
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Dropbox Sign connector syncs your Dropbox Sign e-signature data into PostHog, so you can analyze your signature requests and documents alongside your product data.
+
+## Prerequisites
+
+You need a Dropbox Sign account with access to create an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Dropbox Sign, you'll need:
+
+- **API key** – create one in your [Dropbox Sign API settings](https://app.hellosign.com/home/myAccount#api). The key is used with HTTP Basic authentication (the key as the username, with a blank password).
+
+## Sync modes
+
+<SyncModes />
+
+Dropbox Sign exposes no server-side timestamp cursor, so this source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Create a new API key in your Dropbox Sign API settings, then reconnect.
+- If you see a permission error, check the key's permissions and your plan, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/e-conomic.md
+++ b/contents/docs/cdp/sources/e-conomic.md
@@ -1,0 +1,53 @@
+---
+title: Linking e-conomic as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: EConomic
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The e-conomic connector syncs your Visma e-conomic accounting data into PostHog, so you can analyze your financials alongside your product data.
+
+## Prerequisites
+
+You need a Visma e-conomic agreement and an app registered in the e-conomic Developer portal, so you can obtain both authentication tokens.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking e-conomic, you'll need:
+
+- **App secret token** – your app's secret, from the [e-conomic Developer portal](https://www.e-conomic.com/developer).
+- **Agreement grant token** – issued when an e-conomic user grants your app access to their agreement.
+
+Both tokens grant read access to the whole agreement. e-conomic has no per-resource scopes.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your tokens are invalid or have been revoked, check your app secret token and agreement grant token, then reconnect.
+- If your tokens do not have access to some data, re-grant the app access to the agreement, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/easypost.md
+++ b/contents/docs/cdp/sources/easypost.md
@@ -1,0 +1,50 @@
+---
+title: Linking EasyPost as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Easypost
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The EasyPost connector syncs your shipping data into PostHog, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need an EasyPost account with access to your API keys.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking EasyPost, you'll need:
+
+- **API key** – find your API keys in your [EasyPost account settings](https://www.easypost.com/account/api-keys). Use a production key to sync production data, or a test key to sync test-mode data.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid or revoked key error, create a new key in your EasyPost account settings, then reconnect.
+- If the key is inactive or not authorized, activate it (or create a new one) in your EasyPost account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/easypromos.md
+++ b/contents/docs/cdp/sources/easypromos.md
@@ -1,0 +1,52 @@
+---
+title: Linking Easypromos as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Easypromos
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Easypromos connector syncs your promotions data, such as contests and giveaways, into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need an Easypromos account on a **White Label** or **Corporate** plan, since the REST API is only available on those plans. The API does not export data from Basic or Premium promotions.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Easypromos, you'll need:
+
+- **Access token** – get the token from the **Utilities** menu of your Easypromos account.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your Easypromos access token may be invalid or revoked. Generate a new token from the Utilities menu of your Easypromos account, then reconnect.
+- If you see a permission error, your Easypromos plan may not have access to the REST API (which requires White Label or Corporate), or the token lacks access to this resource.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/elasticemail.md
+++ b/contents/docs/cdp/sources/elasticemail.md
@@ -1,0 +1,49 @@
+---
+title: Linking Elastic Email as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Elasticemail
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Elastic Email connector syncs your email marketing data – contacts, campaigns, templates, reports, and more – into PostHog, so you can analyze your email data alongside your product data.
+
+## Prerequisites
+
+You need an Elastic Email account with an API key that has read access to the data you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Elastic Email, you'll need:
+
+- **API key** – create one in your [Elastic Email account settings](https://app.elasticemail.com/marketing/settings/new/manage-api). Grant the key read access to the data you want to sync, such as Contacts, Campaigns, Templates, and Reports.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid, expired, or missing the required read permissions, create a new key in your Elastic Email account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/emailoctopus.md
+++ b/contents/docs/cdp/sources/emailoctopus.md
@@ -1,0 +1,50 @@
+---
+title: Linking EmailOctopus as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: EmailOctopus
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The EmailOctopus connector syncs your email marketing data into the PostHog Data warehouse, so you can analyze your lists and campaigns alongside your product data.
+
+## Prerequisites
+
+You need an EmailOctopus account with access to its API so you can create an API key. The key grants account-wide read access.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking EmailOctopus, you'll need:
+
+- **API key** – create one in your [EmailOctopus account settings](https://emailoctopus.com/api-documentation). The key grants account-wide read access.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Create a new API key in your EmailOctopus account settings, then reconnect.
+- If you see a forbidden error, your key may not have permission to access this data. Check the key in your EmailOctopus account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/eventee.md
+++ b/contents/docs/cdp/sources/eventee.md
@@ -1,0 +1,52 @@
+---
+title: Linking Eventee as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Eventee
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Eventee connector syncs your event's content into the PostHog Data warehouse, so you can analyze your event program alongside your product data.
+
+## Prerequisites
+
+You need an Eventee account with admin access so you can generate an API token. The token is scoped to a single event, so connect one source per event you want to import.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Eventee, you'll need:
+
+- **API token** – generate one in your Eventee admin dashboard under **Settings → Features**. The token is scoped to a single event.
+
+## Sync modes
+
+<SyncModes />
+
+All Eventee tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your Eventee API token is invalid or has expired. Generate a new token in your Eventee admin dashboard (**Settings → Features**), then reconnect.
+- If you get a permission error, your token does not have access to this event's data. Check the token in your Eventee admin dashboard, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/everhour.md
+++ b/contents/docs/cdp/sources/everhour.md
@@ -1,0 +1,50 @@
+---
+title: Linking Everhour as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Everhour
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Everhour connector syncs your time-tracking data into the PostHog Data warehouse, so you can analyze your time entries and projects alongside your product data.
+
+## Prerequisites
+
+You need a paid Everhour plan, as API access is not available on the free tier.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Everhour, you'll need:
+
+- **API key** – find it in your [Everhour profile settings](https://app.everhour.com/#/account/profile) under the API section.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Generate a new key in your Everhour profile settings, then reconnect.
+- If you see a permissions error, the key does not have access to this data. Check the key's permissions in Everhour, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/exchange-rates-api.md
+++ b/contents/docs/cdp/sources/exchange-rates-api.md
@@ -1,0 +1,52 @@
+---
+title: Linking Exchange Rates API as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ExchangeRatesApi
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Exchange Rates API connector syncs foreign-exchange reference rates into PostHog, so you can analyze currency data alongside your product data.
+
+## Prerequisites
+
+You need an exchangeratesapi.io account with an access key. The free plan is restricted to the `EUR` base currency, and the `timeseries` table may not be available on every plan – a custom base currency requires a paid plan.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Exchange Rates API, you'll need:
+
+- **Access key** – create one in your [exchangeratesapi.io dashboard](https://exchangeratesapi.io/dashboard).
+- **Base currency** – optional. Defaults to `EUR`. A custom base currency requires a paid plan.
+- **Start date** – optional. The start date for the `timeseries` backfill, in `YYYY-MM-DD` format. The `timeseries` table is capped at a 365-day range per request and backfills are chunked automatically.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your access key may be invalid or revoked. Create a new key in your exchangeratesapi.io dashboard, then reconnect.
+- If you see a permission error, your plan may not allow the request (for example a non-EUR base currency or the timeseries endpoint on the free plan). Upgrade your plan or adjust the source settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/ezofficeinventory.md
+++ b/contents/docs/cdp/sources/ezofficeinventory.md
@@ -1,0 +1,53 @@
+---
+title: Linking EZOfficeInventory as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: EZOfficeInventory
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The EZOfficeInventory connector syncs your asset and inventory management data into PostHog, so you can analyze your equipment and stock alongside your product data.
+
+## Prerequisites
+
+You need an EZOfficeInventory account with API access enabled under **Settings → Integrations → API Integration**, so you can generate an access token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking EZOfficeInventory, you'll need:
+
+- **Subdomain** – the `<subdomain>` part of your `<subdomain>.ezofficeinventory.com` account URL.
+- **Access token** – enable API access in **Settings → Integrations → API Integration** and generate a token there.
+
+## Sync modes
+
+<SyncModes />
+
+All EZOfficeInventory tables sync via full refresh. The API exposes no general server-side `updated_after` cursor.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your access token is invalid or expired, generate a new token and reconnect.
+- If your access token does not have the required permissions, or API access is disabled for the account, check the token's permissions and confirm API access is enabled in Settings.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/factorial.md
+++ b/contents/docs/cdp/sources/factorial.md
@@ -1,0 +1,52 @@
+---
+title: Linking Factorial as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Factorial
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Factorial connector syncs your HR, time-off, attendance, payroll, and recruiting data into PostHog, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a Factorial account with access to create an API key that has read access to your company's data.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Factorial, you'll need:
+
+- **API key** – create an API key in your Factorial account under **Settings > API keys** (or **Integrations > Public API**). The key grants read access to your company's data across every supported table.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid or revoked key error, create a new key in your Factorial account settings, then reconnect.
+- If access is denied, check the key's permissions, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/finage.md
+++ b/contents/docs/cdp/sources/finage.md
@@ -1,0 +1,54 @@
+---
+title: Linking Finage as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Finage
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Finage connector pulls US stock market data, such as quotes, trades, and historical OHLCV bars, into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a Finage account with a paid plan that includes access to the **US stocks** endpoints so you can create an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Finage, you'll need:
+
+- **API key** – find your key in the [Finage dashboard](https://finage.co.uk/dashboard) after subscribing to a plan. The key needs access to the US stocks endpoints.
+- **Symbols** – a comma-separated list of US stock symbols to sync, for example `AAPL,MSFT,TSLA`.
+- **Backfill start date** – optional. The earliest date (`YYYY-MM-DD`) to pull historical aggregate bars from. Defaults to the connector's built-in start date.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your Finage API key may be invalid or revoked. Generate a new key in your Finage dashboard, then reconnect.
+- If you see a permission error, your Finage plan does not include access to this data. Upgrade your Finage subscription or remove the affected tables, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/financial-modelling.md
+++ b/contents/docs/cdp/sources/financial-modelling.md
@@ -1,0 +1,51 @@
+---
+title: Linking Financial Modeling Prep as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: FinancialModelling
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Financial Modeling Prep connector syncs market and company financial data – company profiles, financial statements, and historical prices – into PostHog, so you can analyze financial data alongside your product data.
+
+## Prerequisites
+
+You need a Financial Modeling Prep account with an API key. Free-tier keys are heavily rate-limited, so keep your list of symbols focused.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Financial Modeling Prep, you'll need:
+
+- **API key** – find it in your [Financial Modeling Prep dashboard](https://site.financialmodelingprep.com/developer/docs/dashboard).
+- **Symbols** – a comma-separated list of tickers to sync, for example `AAPL, MSFT, GOOGL`. The symbol-keyed tables are fetched once per ticker you list, so keep the list focused.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid or has been revoked, generate a new key in your Financial Modeling Prep dashboard, then reconnect.
+- If your plan does not grant access to a table, upgrade your plan or deselect the affected tables, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/finnhub.md
+++ b/contents/docs/cdp/sources/finnhub.md
@@ -1,0 +1,52 @@
+---
+title: Linking Finnhub as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Finnhub
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Finnhub connector pulls market and company financial data into the PostHog Data warehouse, so you can analyze financial metrics alongside your product data.
+
+## Prerequisites
+
+You need a Finnhub account so you can create an API key. A free key works, though the free tier is rate limited to 60 requests per minute and some endpoints require a paid plan.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Finnhub, you'll need:
+
+- **API key** – create a free API key in your [Finnhub dashboard](https://finnhub.io/dashboard).
+- **Symbols** – optional, comma-separated. Per-company tables (company profile, quote, company news, basic financials, recommendation trends, and earnings surprises) are synced for each ticker you list here, for example `AAPL, MSFT, GOOGL`. Market-wide tables sync without any symbols.
+- **Exchange** – optional. Used for the stock symbols table, for example `US`.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Create a new key in your Finnhub dashboard, then reconnect.
+- If a table fails with a forbidden error, your plan may not include access to that data. Upgrade your plan or deselect the affected tables, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/finnworlds.md
+++ b/contents/docs/cdp/sources/finnworlds.md
@@ -1,0 +1,52 @@
+---
+title: Linking Finnworlds as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Finnworlds
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Finnworlds connector pulls financial market data into the PostHog Data warehouse, so you can analyze fundamentals, prices, dividends, ratings, and more alongside your product data.
+
+## Prerequisites
+
+You need a Finnworlds account with API access so you can obtain an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Finnworlds, you'll need:
+
+- **API key** – find it in your [Finnworlds dashboard](https://finnworlds.com/dashboard/).
+- **Tickers** – the stock tickers you want to sync (e.g. `AAPL, MSFT, GOOGL`). Most datasets (fundamentals, prices, dividends, ratings) return data for one company per request, so the connector fetches each dataset for every ticker. Bond yields are global and ignore the ticker list.
+
+## Sync modes
+
+<SyncModes />
+
+All Finnworlds tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If the connection fails, your Finnworlds API key is invalid or expired, or it lacks access to this dataset. Generate a new key and reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/firehydrant.md
+++ b/contents/docs/cdp/sources/firehydrant.md
@@ -1,0 +1,53 @@
+---
+title: Linking FireHydrant as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: FireHydrant
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The FireHydrant connector syncs your incident management data into the PostHog Data warehouse, so you can analyze your incidents and response workflows alongside your product data.
+
+## Prerequisites
+
+You need a FireHydrant account with permission to create an API key. Bot tokens are recommended for automation that isn't tied to a specific user.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking FireHydrant, you'll need:
+
+- **API key** – create a bot token or personal API key in your [FireHydrant API keys settings](https://app.firehydrant.io/organizations/api_keys).
+- **Region** – pick the region your FireHydrant account is hosted in, either US (`api.firehydrant.io`) or EU (`api.eu.firehydrant.io`).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full-refresh only. FireHydrant has no uniform server-side incremental cursor, so every table is fully re-synced on each run.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new API key in your FireHydrant settings, then reconnect.
+- If you see a permissions error, the key is missing the permissions needed to sync this data. Grant the required permissions in your FireHydrant settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/fleetio.md
+++ b/contents/docs/cdp/sources/fleetio.md
@@ -1,0 +1,51 @@
+---
+title: Linking Fleetio as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Fleetio
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Fleetio connector syncs your Fleetio fleet management data into PostHog, so you can analyze your vehicles, maintenance, and fleet operations alongside your product data.
+
+## Prerequisites
+
+You need a Fleetio account with access to create an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Fleetio, you'll need:
+
+- **API key** – create one under **Account Menu → Account Settings → API Keys** in Fleetio.
+- **Account token** – shown on the same page as the API key. It identifies your Fleetio account.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key or account token may be invalid or revoked. Generate a new API key in your Fleetio account settings, then reconnect.
+- If you see a permission error, check the key's permissions in your Fleetio account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/jotform.md
+++ b/contents/docs/cdp/sources/jotform.md
@@ -1,0 +1,52 @@
+---
+title: Linking Jotform as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Jotform
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Jotform connector syncs your forms and submissions into PostHog, so you can analyze your form responses alongside your product data.
+
+## Prerequisites
+
+You need a Jotform account so you can create an API key. A read-only key is enough.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Jotform, you'll need:
+
+- **API key** – create one in your [Jotform API settings](https://www.jotform.com/myaccount/api). A read-only key is enough.
+- **Region** – pick the region that matches where your Jotform account is hosted (US, EU, or HIPAA).
+- **Enterprise domain (optional)** – for Jotform Enterprise, leave the region as US and enter your Enterprise domain here instead.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid or has been revoked, create a new key in your Jotform API settings, then reconnect.
+- If your API key does not have permission to read some data, grant it read access in your Jotform API settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/lago.md
+++ b/contents/docs/cdp/sources/lago.md
@@ -1,0 +1,52 @@
+---
+title: Linking Lago as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Lago
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Lago connector syncs your billing data into PostHog, so you can analyze it alongside your product data. It works with both Lago Cloud and self-hosted Lago instances.
+
+## Prerequisites
+
+You need a Lago account with access to create an API key. Self-hosted users also need a publicly reachable Lago host.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Lago, you'll need:
+
+- **API key** – create an API key in the Lago dashboard under **Developers > API keys**.
+- **API URL** – self-hosted only. Set it to your own Lago host (for example `https://billing.example.com`). Leave it blank to use Lago Cloud.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid key error, generate a new key in the Lago dashboard, then reconnect.
+- If your key lacks the required permissions, check the key and try again.
+- If the API URL is not allowed, use a publicly reachable host.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/lemlist.md
+++ b/contents/docs/cdp/sources/lemlist.md
@@ -1,0 +1,50 @@
+---
+title: Linking Lemlist as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Lemlist
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The lemlist connector syncs your sales outreach data into the PostHog Data warehouse, so you can analyze your campaigns alongside your product data.
+
+## Prerequisites
+
+You need a lemlist account so you can generate an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Lemlist, you'll need:
+
+- **API key** – generate an API key in your lemlist **Settings > Integrations** page.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your lemlist API key may be invalid or revoked. Generate a new key in lemlist Settings > Integrations, then reconnect.
+- If you see a permission error, your lemlist account may be blocked from API access. Check your lemlist account status, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/mailersend.md
+++ b/contents/docs/cdp/sources/mailersend.md
@@ -1,0 +1,50 @@
+---
+title: Linking MailerSend as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: MailerSend
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The MailerSend connector syncs your transactional email data – activity events, domains, recipients, and templates – into PostHog, so you can analyze your email data alongside your product data.
+
+## Prerequisites
+
+You need a MailerSend account with an API token that has read access to the data you want to sync. MailerSend retains email activity for 1-30 days depending on your plan, so the activity table only backfills as far as that retention window on its first sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking MailerSend, you'll need:
+
+- **API token** – create one in your [MailerSend domain settings](https://app.mailersend.com/api-tokens). Grant the token read access to the data you want to sync, such as Email (for activity events), Domains, Recipients, and Templates.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API token is invalid or has been revoked, create a new token in your MailerSend domain settings, then reconnect.
+- If your token is missing the read permissions needed to sync some data, grant the required read scopes in your MailerSend domain settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/metabase.md
+++ b/contents/docs/cdp/sources/metabase.md
@@ -1,0 +1,56 @@
+---
+title: Linking Metabase as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Metabase
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Metabase connector pulls your Metabase data into the PostHog Data warehouse, so you can analyze your Metabase content and metadata alongside your product data.
+
+## Prerequisites
+
+You need a Metabase instance and credentials with read access to the data you want to sync. To use an API key, your instance must be Metabase v0.47 or newer; older instances can authenticate with a username and password instead.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Metabase, you'll need:
+
+- **Instance URL** – your Metabase instance's public URL, for example `https://your-company.metabaseapp.com`.
+- **Authentication method** – choose one of the following:
+  - **API key** – create one in Metabase under **Admin settings > Authentication > API keys** (Metabase v0.47+). The key needs read access to the data you want to sync.
+  - **Username & password** – the email and password of a Metabase user with read access to the data you want to sync.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your credentials may be invalid or expired. Update them and reconnect.
+- If you see a permissions error, grant the API key or user read access to the data you want to sync, then reconnect.
+- If the host is rejected, use your instance's public URL.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/mux.md
+++ b/contents/docs/cdp/sources/mux.md
@@ -1,0 +1,53 @@
+---
+title: Linking Mux as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Mux
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Mux connector syncs your Mux Video data into the PostHog Data warehouse, so you can analyze your assets, live streams, and uploads alongside your product data.
+
+## Prerequisites
+
+You need a Mux account with admin access so you can create an access token. Tokens are scoped to a single Mux environment.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Mux, you'll need:
+
+- **Access Token ID** – create an access token under [Settings → Access Tokens](https://dashboard.mux.com/settings/access-tokens) in your Mux dashboard.
+- **Secret Key** – shown alongside the Access Token ID when you create the token. Grant Mux Video (read) for assets, live streams, uploads, playback restrictions, and transcription vocabularies, and Mux System (read) for signing keys.
+
+## Sync modes
+
+<SyncModes />
+
+All Mux tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your Mux access token is invalid or has been revoked. Create a new access token in your Mux dashboard, then reconnect.
+- If you get a permission error, your access token is missing the read permissions needed to sync this data. Grant Mux Video and Mux System read access, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/orb.md
+++ b/contents/docs/cdp/sources/orb.md
@@ -1,0 +1,50 @@
+---
+title: Linking Orb as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Orb
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Orb connector syncs your billing data into the PostHog Data warehouse, so you can analyze your usage-based billing alongside your product data.
+
+## Prerequisites
+
+You need an Orb account with permission to create an API key. A read-only key is sufficient.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Orb, you'll need:
+
+- **API key** – create one in your [Orb account settings](https://app.withorb.com/settings). A read-only key is sufficient.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new API key in your Orb account settings, then reconnect.
+- If you see a permissions error, the key does not have permission to read this data. Check the key's permissions in your Orb account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/oura.md
+++ b/contents/docs/cdp/sources/oura.md
@@ -1,0 +1,50 @@
+---
+title: Linking Oura as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Oura
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Oura connector syncs your Oura Ring health data into PostHog, so you can analyze your health and activity metrics alongside your product data.
+
+## Prerequisites
+
+You need an Oura account with access to create a personal access token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Oura, you'll need:
+
+- **Personal access token** – create one in the [Oura developer portal](https://cloud.ouraring.com/personal-access-tokens). Grant the scopes needed for the data you want to sync.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your access token may be invalid or revoked. Create a new personal access token in the Oura developer portal, then reconnect.
+- If you see a permission error, your token may be missing the scopes needed to sync this data. Grant the required scopes, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/paystack.md
+++ b/contents/docs/cdp/sources/paystack.md
@@ -1,0 +1,52 @@
+---
+title: Linking Paystack as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Paystack
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Paystack connector syncs your payments and billing data into PostHog, so you can analyze your transactions and revenue alongside your product data.
+
+## Prerequisites
+
+You need a Paystack account with access to its dashboard so you can retrieve your secret API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Paystack, you'll need:
+
+- **Secret API key** – find it (it starts with `sk_live_` or `sk_test_`) under **Settings → API Keys & Webhooks** in your [Paystack dashboard](https://dashboard.paystack.com/#/settings/developers). The key has read access to your integration's data.
+
+## Sync modes
+
+<SyncModes />
+
+Paystack tables are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If authentication fails, check that your secret API key is valid.
+- If access is denied, check that your secret API key has the required permissions.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/plausible.md
+++ b/contents/docs/cdp/sources/plausible.md
@@ -1,0 +1,52 @@
+---
+title: Linking Plausible as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Plausible
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Plausible connector syncs your web analytics into PostHog, so you can analyze it alongside your product data. It works with both Plausible Cloud and self-hosted instances.
+
+## Prerequisites
+
+You need a Plausible account with access to create an API key, and the domain of the site you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Plausible, you'll need:
+
+- **API key** – create an API key under **Account settings → API keys** with the `stats read` scope.
+- **Site domain** – enter your site's domain (for example `example.com`).
+- **Host** – self-hosted only. Set it to your instance URL (for example `https://plausible.example.com`). Leave it blank for Plausible Cloud.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid or revoked key error, create a new key in your Plausible account settings, then reconnect.
+- If a table fails with a missing scope error, grant the `stats read` scope in your Plausible account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/pylon.md
+++ b/contents/docs/cdp/sources/pylon.md
@@ -1,0 +1,50 @@
+---
+title: Linking Pylon as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Pylon
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Pylon connector pulls your customer support data into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a Pylon account with admin access so you can create an API token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Pylon, you'll need:
+
+- **API token** – create an API token from your Pylon dashboard under **Settings > API tokens** (admin only).
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your Pylon API token may be invalid or revoked. Create a new token in Settings > API tokens, then reconnect.
+- If you see a permission error, your Pylon API token is missing the permissions needed to sync this data. Recreate the token with the required access, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/rootly.md
+++ b/contents/docs/cdp/sources/rootly.md
@@ -1,0 +1,50 @@
+---
+title: Linking Rootly as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Rootly
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Rootly connector syncs your incident-management data into PostHog, so you can analyze incidents and reliability data alongside your product data.
+
+## Prerequisites
+
+You need a Rootly account with an API key. A Global-scope key can read every resource; Team- and User-scope keys only see the resources they are granted.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Rootly, you'll need:
+
+- **API key** – create one in your [Rootly account settings](https://rootly.com/account/api_keys). Use a Global-scope key to read every resource, or grant a narrower-scoped key access to the resources you want to sync.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key is invalid or has been revoked, create a new API key in your Rootly account settings, then reconnect.
+- If your key is missing access to a resource, grant the key access in your Rootly account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/segment.md
+++ b/contents/docs/cdp/sources/segment.md
@@ -1,0 +1,54 @@
+---
+title: Linking Segment as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Segment
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Segment connector pulls your Twilio Segment workspace configuration, admin, and metadata into the PostHog Data warehouse via the Segment Public API. It does not connect to the event or Profile data plane.
+
+## Prerequisites
+
+You need a Twilio Segment workspace and a workspace-scoped Public API token, along with the region your workspace lives in.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Segment, you'll need:
+
+- **Region** – choose the region your Segment workspace lives in, US (`api.segmentapis.com`) or EU (`eu1.api.segmentapis.com`).
+- **Public API token** – create one in your Segment workspace under **Settings → Access Management → Tokens**.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your Public API token may be missing or invalid. Create a new Public API token in your Segment workspace settings, then reconnect.
+- If you see a forbidden error, your token may be revoked or missing the permissions needed to sync this data. Create a new token with the required access, then reconnect.
+- If the connection fails, confirm you selected the region that matches your workspace.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/sparkpost.md
+++ b/contents/docs/cdp/sources/sparkpost.md
@@ -1,0 +1,53 @@
+---
+title: Linking SparkPost as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: SparkPost
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The SparkPost connector syncs your email data into the PostHog Data warehouse, including message events, suppression lists, recipient lists, templates, sending domains, subaccounts, and webhooks, so you can analyze your email program alongside your product data.
+
+## Prerequisites
+
+You need a SparkPost account with API access so you can create an API key. SparkPost runs independent US and EU stacks that do not share data, so you'll need to know which region your account is on.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking SparkPost, you'll need:
+
+- **Region** – pick the region your account is on: US (api.sparkpost.com) or EU (api.eu.sparkpost.com).
+- **API key** – create one in your [SparkPost account settings](https://app.sparkpost.com/account/api-keys) (or the EU console at app.eu.sparkpost.com). Grant the read permissions for the data you want to sync, for example `Events: Read-only`, `Suppression Lists: Read-only`, `Recipient Lists: Read-only`, `Templates: Read-only`, `Sending Domains: Read-only`, `Subaccounts: Read-only`, and `Webhooks: Read-only`.
+
+## Sync modes
+
+<SyncModes />
+
+Message events are retained for 10 days, so the initial sync of events can only reach back that far.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your SparkPost API key is invalid. Generate a valid key and reconnect.
+- If you get a permission error, your API key is missing the read permissions for this data. Grant the required permissions and reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/squarespace.md
+++ b/contents/docs/cdp/sources/squarespace.md
@@ -1,0 +1,50 @@
+---
+title: Linking Squarespace as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Squarespace
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Squarespace connector syncs your Commerce data – orders, transactions, products, inventory, store pages, and profiles – into the PostHog Data warehouse, so you can analyze your store alongside your product data.
+
+## Prerequisites
+
+You need a Squarespace site where you can create a Developer API key. The Commerce APIs (orders, inventory) require the merchant to be on a Commerce plan.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Squarespace, you'll need:
+
+- **API key** – create one in your Squarespace site under **Settings → Advanced → Developer API Keys**, granting read access to the data you want to sync: Orders (orders, transactions), Products (products, inventory, store pages), and Profiles (profiles).
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new API key in your Squarespace developer settings, then reconnect.
+- If you see a permissions error, the key or the site's plan is missing access needed to sync this data. Grant the relevant permission, and ensure the site is on a Commerce plan for orders and inventory, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/teamwork.md
+++ b/contents/docs/cdp/sources/teamwork.md
@@ -1,0 +1,51 @@
+---
+title: Linking Teamwork as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Teamwork
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Teamwork connector syncs your Teamwork.com projects data into PostHog, so you can analyze your projects and team workflow alongside your product data.
+
+## Prerequisites
+
+You need a Teamwork.com account with access to your API key. The key inherits your own permissions, so it can only sync data you can see.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Teamwork, you'll need:
+
+- **Site** – your Teamwork.com site, for example `yoursite.teamwork.com`.
+- **API key** – find your key under **Profile → Edit my details → API & Mobile** in Teamwork.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Generate a new key in your Teamwork profile settings, then reconnect.
+- If you see a permission error, check the key's permissions, then reconnect. The key can only access data your own account can see.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/thinkific.md
+++ b/contents/docs/cdp/sources/thinkific.md
@@ -1,0 +1,51 @@
+---
+title: Linking Thinkific as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Thinkific
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Thinkific connector syncs your course, enrollment, and order data into PostHog, so you can analyze your online learning business alongside your product data.
+
+## Prerequisites
+
+You need a Thinkific account with admin access so you can create an API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Thinkific, you'll need:
+
+- **API key** – create one under **Settings → Code & analytics → API** in your Thinkific admin.
+- **Subdomain** – the `<subdomain>` part of your `<subdomain>.thinkific.com` admin URL.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API key or subdomain is invalid, create a new API key in your Thinkific admin (Settings → Code & analytics → API) and confirm the subdomain, then reconnect.
+- If your API key does not have permission to access some data, check the key in your Thinkific admin, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/tmdb.md
+++ b/contents/docs/cdp/sources/tmdb.md
@@ -1,0 +1,51 @@
+---
+title: Linking TMDb as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: TMDb
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The TMDb connector syncs movie, TV, and people catalog data into PostHog, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a TMDB account so you can create a free API key. Commercial use requires a separate license from TMDB.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking TMDb, you'll need:
+
+- **API key** – create a free API key (v3 auth) in your [TMDB account settings](https://www.themoviedb.org/settings/api).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid or revoked key error, create a new key in your TMDB account settings, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/todoist.md
+++ b/contents/docs/cdp/sources/todoist.md
@@ -1,0 +1,52 @@
+---
+title: Linking Todoist as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Todoist
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Todoist connector syncs your task and project data into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need a Todoist account so you can find your personal API token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Todoist, you'll need:
+
+- **API token** – find your personal API token in [Todoist's integration settings](https://app.todoist.com/app/settings/integrations/developer).
+
+## Sync modes
+
+<SyncModes />
+
+This source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your Todoist API token may be invalid or revoked. Generate a new token in your Todoist integration settings, then reconnect.
+- If you see a permission error, your Todoist API token is missing the permissions needed to sync this data. Reconnect with a token that has the required access.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/vercel.md
+++ b/contents/docs/cdp/sources/vercel.md
@@ -1,0 +1,51 @@
+---
+title: Linking Vercel as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Vercel
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Vercel connector syncs your deployments, projects, teams, domains, and aliases into PostHog, so you can analyze your Vercel data alongside your product data.
+
+## Prerequisites
+
+You need a Vercel account with an access token. A read-only token is sufficient. To sync resources owned by a team, you also need the team's ID.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Vercel, you'll need:
+
+- **Access token** – create one in your [Vercel account settings](https://vercel.com/account/tokens). A read-only token is sufficient.
+- **Team ID (optional)** – to sync resources owned by a team, enter the team's ID, found under **Team Settings**. Leave it blank to sync resources owned by the token's user.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your access token is invalid or has been revoked, create a new token in your Vercel account settings, then reconnect.
+- If your token is not authorized for a resource, check the token's scope and team access, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/wordpress.md
+++ b/contents/docs/cdp/sources/wordpress.md
@@ -1,0 +1,53 @@
+---
+title: Linking WordPress as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Wordpress
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The WordPress connector syncs posts, pages, comments, media, categories, tags, and users from a self-hosted WordPress site into the PostHog Data warehouse via the core REST API (`/wp-json/wp/v2`).
+
+## Prerequisites
+
+You need a self-hosted WordPress site with the core REST API available. Public, published content syncs without credentials. To sync private content or authenticate, you need WordPress 5.6+ on an HTTPS site so you can create an application password.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking WordPress, you'll need:
+
+- **Site URL** – your WordPress site URL, for example `https://example.com`.
+- **Username** – optional. Required only to authenticate or sync private content.
+- **Application password** – optional. Create one under **Users > Profile > Application Passwords** ([application password docs](https://wordpress.org/documentation/article/application-passwords/)). Required only to authenticate or sync private content, and requires WordPress 5.6+ on an HTTPS site.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your username or application password may be invalid. Create a new application password and reconnect.
+- If you see a permissions error, check the user's role has permission to read this data, then try again.
+- If the site URL is rejected, use a publicly reachable URL, and make sure it uses HTTPS when you provide credentials.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/workable.md
+++ b/contents/docs/cdp/sources/workable.md
@@ -1,0 +1,52 @@
+---
+title: Linking Workable as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Workable
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Workable connector syncs your recruiting data into the PostHog Data warehouse, so you can analyze your jobs and candidates alongside your product data.
+
+## Prerequisites
+
+You need a Workable account with admin access so you can create an access token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Workable, you'll need:
+
+- **Account subdomain** – the subdomain from `https://<subdomain>.workable.com`.
+- **API access token** – create one in your Workable account under **Settings > Integrations > Access Tokens** (admins only). Grant the `r_jobs` and `r_candidates` read scopes.
+
+## Sync modes
+
+<SyncModes />
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your Workable access token is invalid or has expired. Create a new token in your Workable account settings, then reconnect.
+- If you get a permission error, your access token is missing the read scopes needed to sync this data (e.g. `r_jobs`, `r_candidates`). Grant them in your Workable account settings, then reconnect.
+- If your subdomain is rejected, use just the account subdomain from `https://<subdomain>.workable.com`.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/zendesk-sell.md
+++ b/contents/docs/cdp/sources/zendesk-sell.md
@@ -1,0 +1,52 @@
+---
+title: Linking Zendesk Sell as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ZendeskSell
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Zendesk Sell connector syncs your Sell (formerly Base CRM) data into the PostHog Data warehouse, so you can analyze your sales pipeline alongside your product data.
+
+## Prerequisites
+
+You need a Zendesk Sell account with permission to create a personal access token. A read-only token is sufficient.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Zendesk Sell, you'll need:
+
+- **Access token** – create a personal access token under **Settings > Integrations > OAuth > Access Tokens** in Zendesk Sell.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full-refresh only. The Zendesk Sell Core API has no server-side timestamp filter, so every table is fully re-synced on each run.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your access token is invalid or has expired. Create a new access token in your Zendesk Sell settings, then reconnect.
+- If you see a permissions error, the token is missing the permissions needed to sync this data. Grant read access and reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds user-facing source docs for 74 Data warehouse import sources that were missing them. Every one is a currently-alpha, bulk-scaffolded connector whose `docsUrl` in the source registry pointed at a `contents/docs/cdp/sources/<slug>.md` file that didn't exist, so `manage.py audit_source_docs` was failing for all of them.

Each doc follows the standard source template (same shape as `ashby.md` / `active-campaign.md`):

- Alpha status callout, standard frontmatter with the exact `sourceId` from the registry.
- Intro, Prerequisites, Adding a data source, Sync modes, Configuration, Supported tables, Troubleshooting.
- Connection fields and the supported-tables list are rendered by `<SourceParameters />` and `<SourceTables />` from the `public_source_configs` API. I did not hand-write either, so they stay in sync with the source code.
- Credential instructions, prerequisites, and troubleshooting are grounded in each source's `caption`, required `fields`, and `get_non_retryable_errors` in its `source.py`. No dashboard paths or URLs were invented. Where every schema is full-refresh only, a one-line sync-modes note says so.

Sources covered: agilecrm, aha, algolia, apify-dataset, appfigures, assemblyai, aviationstack, beamer, bigmailer, blogger, bluetally, boldsign, breezometer, bugsnag, bunny, buzzsprout, callrail, campayn, canny, capsule-crm, care-quality-commission, chameleon, chargedesk, churnkey, cimis, clockify, clockodo, codefresh, coin-api, coingecko, coinmarketcap, concord, ding-connect, docuseal, dropbox-sign, e-conomic, easypost, easypromos, elasticemail, emailoctopus, eventee, everhour, exchange-rates-api, ezofficeinventory, factorial, finage, financial-modelling, finnhub, finnworlds, firehydrant, fleetio, jotform, lago, lemlist, mailersend, metabase, mux, orb, oura, paystack, plausible, pylon, rootly, segment, sparkpost, squarespace, teamwork, thinkific, tmdb, todoist, vercel, wordpress, workable, zendesk-sell.

`manage.py audit_source_docs` now passes (236 source docs consistent with the registry).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a - all new pages)
