### PR TITLE
Update YouTube team goals to Q3 2026

### DIFF
--- a/contents/teams/youtube/objectives.mdx
+++ b/contents/teams/youtube/objectives.mdx
@@ -23,7 +23,7 @@
 
 - **Owner:** <TeamMember name="Alex van Leeuwen" photo /> and <TeamMember name="Charles Cook" photo />
 - **Motivation:** We want to ship an entire Super Bowl-style campaign promoting PostHog self-driving.
-- **What we'll ship:** Concept and plan to shoot ads in Q4 with a view to shipping in Q1
+- **What we'll ship:** Concept and timeline for shooting and shipping ads
 - **We'll know we're successful when:** Internal excitement around the plan for ads
 
 </details>

--- a/contents/teams/youtube/objectives.mdx
+++ b/contents/teams/youtube/objectives.mdx
@@ -14,7 +14,7 @@
 - **Owner:** <TeamMember name="Alex van Leeuwen" photo />
 - **Motivation:** Wrapping up the Q2 goal
 - **What we'll ship:** Two ads for PostHog Code / Self-Driving and AI Observability.
-- **We'll know we're successful when:** Ads have shipped and we're seeing positive feedback about how weird and awesome they are.
+- **We'll know we're successful when:** We're seeing positive feedback about how weird and awesome they are.
 
 </details>
 
@@ -47,9 +47,9 @@
 <summary>Reusable assets and brand guide</summary>
 
 - **Owner:** <TeamMember name="Jordo Dibb" photo />
-- **Motivation:** We need to have a centralised bank of reusable assets we can broadly drag & drop into a variety of films moving forward.
-- **What we'll ship:** Reusable assets, most with a Resolve and Premiere version, and clear instructions for how to use them.
-- **We'll know we're successful when:** We're shipping video efficiently with limited debates about how visual assets in each video look and feel.
+- **Motivation:** We need a centralised bank of reusable assets we can drag & drop into a variety of films
+- **What we'll ship:** Reusable assets, most with a Resolve and Premiere version, and clear instructions for how to use them
+- **We'll know we're successful when:** We're shipping video efficiently and making relatively few new assets
 
 </details>
 

--- a/contents/teams/youtube/objectives.mdx
+++ b/contents/teams/youtube/objectives.mdx
@@ -6,45 +6,59 @@
 
 3. **We are a benchmark.** People love what we do. They want to copy what we do. We are proud of our work. People cite our video as an example of how to do video right.
 
-## Q2 2026 Goals
+## Q3 2026 Goals
 
-### Unblock production obstructions
-- **Owner:** Alex 
-- **Motivation:** We need work smarter to ship high-quality video predictably.
-- **What we'll ship:** Identify the obstructions (self-serve templates, animation assets, design processes etc.), and a plan to fix them that we execute.
-- **We'll know we're successful when:** 
-	- Video production feels reliable and predictable
-	- Videos have a polished, consistent style that's easy to produce
-	- We can turnaround good quality videos at short notice when necessary
+<details>
+<summary>Ship the weird and awesome ads</summary>
 
-### Weird and awesome video ads
-- **Owner:** Alex
-- **Motivation:** We want to increase awareness of new and existing products and, just like billboards, we can use weird and awesome video ads to do so. 
-- **What we'll ship:** 
-	- Work with marketing and demand gen teams to ideate and ship video ads (YouTube pre-roll, social feed ads, etc) for products that we promote through paid. 
-	- Focus on PostHog Code (general availability), AI Observability, Observability Stack (Replay, Error Tracking, Logs) first before covering other products.
-- **We'll know we're successful when:** We've shipped ads people love and they've worked well enough that we want make more ads promoting other PostHog products.
+- **Owner:** <TeamMember name="Alex van Leeuwen" photo />
+- **Motivation:** Wrapping up the Q2 goal
+- **What we'll ship:** Two ads for PostHog Code / Self-Driving and AI Observability.
+- **We'll know we're successful when:** Ads have shipped and we're seeing positive feedback about how weird and awesome they are.
 
-### Feature trailers that pop
-- **Owner:** Jordo
-- **Motivation:** Changelog was the right idea, but the wrong execution. They took too long and weren't well optimized for social and ads. We want to showcase PostHog products with video in a format that's evocative and fast to produce.
-- **What we'll ship:** A new format for showcasing PostHog products and features:
-	- 30 to 45 seconds per video
-	- Little to no scripting needed
-	- Consistent style and execution
-	- Feels closer to the brand and identifiably PostHog
-	- Easy to produce at short notice (e.g. ~5-day turnaround)
-	- A simple rubric for when we choose to do them (no fixed schedule)
-- **We'll know we're successful when:** We have a format that we like that pops on social and can be produced as quickly as our product moves.
+</details>
 
-### YouTube channel momentum
-- **Owner:** Dennis
-- **Motivation:** Our long-term goal is to build an organic audience on YouTube
-- **What we'll ship:** 
-	- A new video every week
-	- 2-3 different styles of video we can test
-	- Consistent theme and creation flow for thumbnail design
-	- Find a style and rhythm for video animations and visuals
+<details>
+<summary>Start scoping out self-driving ad campaign</summary>
+
+- **Owner:** <TeamMember name="Alex van Leeuwen" photo /> and <TeamMember name="Charles Cook" photo />
+- **Motivation:** We want to ship an entire Super Bowl-style campaign promoting PostHog self-driving.
+- **What we'll ship:** Concept and plan to shoot ads in Q4 with a view to shipping in Q1
+- **We'll know we're successful when:** Internal excitement around the plan for ads
+
+</details>
+
+<details>
+<summary>Feature trailers</summary>
+
+- **Owner:** <TeamMember name="Jordo Dibb" photo /> & <TeamMember name="Andy Vandervell" photo />
+- **Motivation:** Video massively amplifies announcements.
+- **What we'll ship:**
+	- 30s-1m videos that showcase a new products, features, and use cases
+	- Flexible formats (e.g. one format that can shipped in less than a week)
 - **We'll know we're successful when:**
-	- We're publishing videos predictably every week
-	- We're seeing momentum in terms of consistent views and engagement
+	- Marketing know how to brief videos
+	- We can ship videos to predictable timelines
+	- Consistent impact from videos we produce
+
+</details>
+
+<details>
+<summary>Reusable assets and brand guide</summary>
+
+- **Owner:** <TeamMember name="Jordo Dibb" photo />
+- **Motivation:** We need to have a centralised bank of reusable assets we can broadly drag & drop into a variety of films moving forward.
+- **What we'll ship:** Reusable assets, most with a Resolve and Premiere version, and clear instructions for how to use them.
+- **We'll know we're successful when:** We're shipping video efficiently with limited debates about how visual assets in each video look and feel.
+
+</details>
+
+<details>
+<summary>Keep building YouTube momentum</summary>
+
+- **Owner:** <TeamMember name="Dennis Ivy" photo />
+- **Motivation:** We're starting to see green shoots of growth from the channel. We want to keep that going.
+- **What we'll ship:** Weekly main channel videos and shorts and robust testing of thumbnails and titles.
+- **We'll know we're successful when:** Views, subscribers and watch time are growing Month-on-Month.
+
+</details>

--- a/contents/teams/youtube/objectives.mdx
+++ b/contents/teams/youtube/objectives.mdx
@@ -19,7 +19,7 @@
 </details>
 
 <details>
-<summary>Start scoping out self-driving ad campaign</summary>
+<summary>Self-driving ad campaign plan</summary>
 
 - **Owner:** <TeamMember name="Alex van Leeuwen" photo /> and <TeamMember name="Charles Cook" photo />
 - **Motivation:** We want to ship an entire Super Bowl-style campaign promoting PostHog self-driving.

--- a/contents/teams/youtube/objectives.mdx
+++ b/contents/teams/youtube/objectives.mdx
@@ -13,7 +13,7 @@
 
 - **Owner:** <TeamMember name="Alex van Leeuwen" photo />
 - **Motivation:** Wrapping up the Q2 goal
-- **What we'll ship:** Two ads for PostHog Code / Self-Driving and AI Observability.
+- **What we'll ship:** Two ads for Self-Driving and AI Observability.
 - **We'll know we're successful when:** We're seeing positive feedback about how weird and awesome they are.
 
 </details>


### PR DESCRIPTION
Updates the YouTube team's goals page (`contents/teams/youtube/objectives.mdx`).

## What changed
- Removed the completed **Q2 2026** goals
- Added the **Q3 2026** goals:
  - Ship the weird and awesome ads
  - Start scoping out self-driving ad campaign
  - Feature trailers
  - Reusable assets and brand guide
  - Keep building YouTube momentum
- Wrapped each goal in a collapsible `<details>` expand for neatness
- Each field is its own bullet, and owners now use the `<TeamMember />` component so they link to community profiles

The `# Mission for 2026` section is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*