### PR TITLE
Add MCP Analytics small team files

### DIFF
--- a/contents/teams/mcp-analytics/index.mdx
+++ b/contents/teams/mcp-analytics/index.mdx
@@ -1,0 +1,20 @@
+---
+title: MCP analytics
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+## What this team does
+
+We build MCP analytics — product analytics for MCP (Model Context Protocol) servers. As AI agents increasingly act through MCP tools, developers need to understand how those tools are actually being used: which tools agents call, what they're trying to accomplish, where calls fail, and what capabilities are missing.
+
+We own the `@posthog/mcp` SDK that instruments MCP servers, and the MCP analytics dashboard product that turns that data into tool-usage, latency, error, and intent insights.
+
+## Slack channel
+
+[#team-mcp-analytics](https://posthog.slack.com/messages/team-mcp-analytics)
+
+## Feature ownership
+You can find out more about the features we (and the other teams) own [here](/handbook/engineering/feature-ownership)

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -1,0 +1,3 @@
+## Q3 2026 objectives
+
+_This is a new team — we're still ironing out our goals. More to come soon 🤖._

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -442,6 +442,26 @@ const products: Product[] = [
         },
     },
     {
+        name: 'MCP analytics',
+        color: '[#8B0DC8]',
+        Icon: IconLlmAnalytics,
+        description: 'Product analytics for your MCP servers — see how agents use your tools.',
+        types: ['AI'],
+        features: [
+            { title: 'MCP tool usage and errors', Icon: IconLlmAnalytics },
+            { title: 'Agent intent clustering', Icon: IconDecisionTree },
+            { title: 'Latency and quality metrics', Icon: IconTrends },
+        ],
+        status: 'WIP',
+        badge: 'BETA',
+        pricing: {
+            cta: {
+                url: '/teams/mcp-analytics',
+                text: 'Learn more',
+            },
+        },
+    },
+    {
         name: 'Embedded analytics',
         color: '[#36C46F]',
         Icon: IconCodeInsert,

--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -249,6 +249,11 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         feature: 'Marketing analytics',
         owner: ['web-analytics'],
     },
+    'mcp-analytics': {
+        feature: 'MCP analytics',
+        owner: ['mcp-analytics'],
+        label: 'feature/mcp-analytics',
+    },
     'mcp-server': {
         feature: 'MCP server',
         owner: ['self-driving'],


### PR DESCRIPTION
## Changes

Adds the repo-side content for the new **MCP Analytics** small team. The Strapi/Squeak team record already exists at [/teams/mcp-analytics](https://posthog.com/teams/mcp-analytics) (created via the `/teams` form) — this PR adds the files the team page and site pull in at build time.

- `contents/teams/mcp-analytics/index.mdx` — "What this team does" + Slack channel + feature-ownership link (`template: team` frontmatter)
- `contents/teams/mcp-analytics/objectives.mdx` — placeholder Q3 2026 goals (real goals to be filled in)
- `src/hooks/useFeatureOwnership.tsx` — new **MCP analytics** feature-ownership entry, owned by the `mcp-analytics` team
- `src/components/Home/Board/index.tsx` — MCP analytics product tile in the homepage product board (AI column)

Follows the [Creating a new small team](https://posthog.com/handbook/engineering/posthog-com/small-teams#creating-a-new-small-team) handbook steps. The only *repo* step is creating the team directory; the feature-ownership entry (an "Other task") lives in `useFeatureOwnership.tsx`. The homepage board tile is an optional extra (precedent: the Revenue Analytics team PR).

## Notes for reviewers

- The **"What this team does" blurb** was drafted from the product concept (product analytics for MCP servers via `@posthog/mcp`) — there was no pre-existing MCP-analytics copy in the repo. Please tweak to taste.
- The **Board tile** uses `features` + CTA (no `roadmapID`, since I didn't have one). If MCP analytics has a roadmap ID, swap to `roadmapID` like the Revenue Analytics tile for a live roadmap card.
- `objectives.mdx` is a placeholder — real Q3 2026 goals to follow.

## Not in this PR (non-repo handbook "Other tasks")

Tracking, not blocking this merge: custom crest art request, GitHub team + `feature/*` labels + repo write access, Slack channel + user group, Zendesk group + `zendeskGroupID` in Strapi, Ashby team names, and finishing the CMS page (members, lead, mission, crest).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*