### PR TITLE
docs: document platform view masking for Flutter session replay

### DIFF
--- a/contents/docs/session-replay/_snippets/flutter-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-privacy.mdx
@@ -23,4 +23,36 @@ config.sessionReplayConfig.maskAllImages = false;
 ...
 ```
 
+### Masking platform views
+
+Platform views (such as `WebView`, Google Maps, or other natively-rendered widgets) are composited outside the Flutter layer tree. To avoid accidentally recording sensitive content, PostHog **masks every platform view with a black box by default**.
+
+To reveal all platform views globally, set `maskAllPlatformViews` to `false`:
+
+```dart
+final config = PostHogConfig('<ph_project_token>');
+config.sessionReplay = true;
+/// Mask all platform views (WebView, Maps, etc.) in session replay.
+/// Default: true.
+config.sessionReplayConfig.maskAllPlatformViews = false;
+```
+
+For per-view control, wrap an individual platform view with the `PostHogPlatformView` widget. This overrides the global `maskAllPlatformViews` setting for that view (and every platform view in its subtree):
+
+```dart
+// Reveal this view even when maskAllPlatformViews is true
+PostHogPlatformView(
+  privacy: PostHogPlatformViewPrivacy.capture,
+  child: WebViewWidget(controller: _controller),
+)
+
+// Mask this view even when maskAllPlatformViews is false
+PostHogPlatformView(
+  privacy: PostHogPlatformViewPrivacy.mask,
+  child: WebViewWidget(controller: _controller),
+)
+```
+
+> **Platform support:** On iOS, only `WKWebView`-backed platform views (for example `webview_flutter` in its default mode) are captured. Other platform view types — Google Maps, ARKit, camera previews, and so on — are always masked, because the iOS compositor cannot safely snapshot arbitrary native views without risking leaking unmasked content. Capture is not supported on macOS, where all platform views are always masked.
+
 <SensitiveThirdPartyScreens />

--- a/contents/docs/session-replay/_snippets/flutter-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-privacy.mdx
@@ -37,7 +37,7 @@ config.sessionReplay = true;
 config.sessionReplayConfig.maskAllPlatformViews = false;
 ```
 
-For per-view control, wrap an individual platform view with the `PostHogPlatformView` widget. This overrides the global `maskAllPlatformViews` setting for that view (and every platform view in its subtree):
+For per-view control, wrap an individual platform view with the `PostHogPlatformView` widget. This overrides the global `maskAllPlatformViews` setting for that view (and every platform view nested inside it):
 
 ```dart
 // Reveal this view even when maskAllPlatformViews is true
@@ -53,6 +53,6 @@ PostHogPlatformView(
 )
 ```
 
-> **Platform support:** On iOS, only `WKWebView`-backed platform views (for example `webview_flutter` in its default mode) are captured. Other platform view types — Google Maps, ARKit, camera previews, and so on — are always masked, because the iOS compositor cannot safely snapshot arbitrary native views without risking leaking unmasked content. Capture is not supported on macOS, where all platform views are always masked.
+> **Platform support:** On iOS, only `WKWebView`-backed platform views (for example `webview_flutter` in its default mode) are captured. Other platform view types (Google Maps, camera previews, and so on) are always masked, because the iOS compositor cannot safely snapshot arbitrary native views without risking leaking unmasked content. Capture is not supported on macOS, where all platform views are always masked.
 
 <SensitiveThirdPartyScreens />

--- a/contents/docs/session-replay/_snippets/flutter-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-privacy.mdx
@@ -53,6 +53,6 @@ PostHogPlatformView(
 )
 ```
 
-> **Platform support:** On iOS, only `WKWebView`-backed platform views (for example `webview_flutter` in its default mode) are captured. Other platform view types (Google Maps, camera previews, and so on) are always masked, because the iOS compositor cannot safely snapshot arbitrary native views without risking leaking unmasked content. Capture is not supported on macOS, where all platform views are always masked.
+> **Platform support:** On iOS, only `WKWebView`-backed platform views (for example `webview_flutter` in its default mode) are captured. Other platform view types (Google Maps, camera previews, and so on) are always masked, because the iOS compositor cannot safely snapshot arbitrary native views without risking leaking unmasked content.
 
 <SensitiveThirdPartyScreens />


### PR DESCRIPTION
## Changes

Documents platform view masking for Flutter session replay, shipped in [posthog-flutter#453](https://github.com/PostHog/posthog-flutter/pull/453).

Adds a **Masking platform views** section to the Flutter privacy snippet covering:

- Platform views (WebView, Maps, etc.) are masked with a black box **by default**.
- Global opt-out via `config.sessionReplayConfig.maskAllPlatformViews = false`.
- Per-view control with the `PostHogPlatformView` widget (`PostHogPlatformViewPrivacy.capture` / `.mask`).
- Platform caveats: iOS only captures `WKWebView`-backed views; macOS never captures.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`