### PR TITLE
Add MCP Analytics Q3 2026 goals

### DIFF
--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -1,3 +1,45 @@
 ## Q3 2026 objectives
 
-_This is a new team — we're still ironing out our goals. More to come soon 🤖._
+MCP analytics is greenfield — this quarter is about making onboarding magical, launching to real customers, and betting on "self-driving" as our top engineering priority. These goals will evolve as we learn from customers.
+
+### Self-driving (top priority)
+
+**Motivation:** We shouldn't be the bottleneck for improving MCP servers. Instead of manually shipping fixes, we push signals to agents so they self-improve — closing the loop from a failing tool call to a merged PR.
+
+* Build the feedback loop: a failing tool call creates a signal and auto-generates a PR — simple changes merge automatically, complex ones go to human review
+* Ship intent clustering based on synthetic sessions (group calls within a ~1-hour gap) rather than per-tool, so we infer real user goals instead of over-indexing on generic tools like `execute_sql`
+* Standardize the SDK: migrate the internal MCP server's custom events to out-of-the-box `@posthog/mcp` functionality so feedback events feed the pipeline cleanly
+* Define a controlled release framework and validate self-driving as a 24-hour experiment against baseline
+
+**We'll know we're successful when:** a failing tool call can result in an auto-merged improvement, gated by a release framework we trust.
+
+### Magical onboarding
+
+**Motivation:** Onboarding is our funnel bottleneck (69 started, 12 completed). Getting to value should be as simple as a command, and the drop-offs are a warm outreach list.
+
+* Make wizard onboarding work magically end-to-end, validated against real-world usage ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
+* Contact onboarding drop-offs and signed-up non-activators to diagnose blockers
+* Make the docs great and publish implementation blog posts — this is how we get Claude/Codex to actually use our content
+
+**We'll know we're successful when:** wizard onboarding completion climbs and new users reach value without hand-holding.
+
+### Launch
+
+**Motivation:** "MCP analytics" is a low-competition keyword today — there's an opening to own the agent-analytics space before competitors catch up, but we need real customers and marketing behind us.
+
+* Get product marketing alignment for a launch roughly one month out
+* Land 5-10 close design-partner customers to iterate with
+* Publish blog posts on our learnings (not just docs) to capture SEO/AEO early and get indexed by Claude, ChatGPT, etc.
+* Decide pricing: separate MCP events into their own bucket (not mixed with product analytics), same rate as product analytics events but a distinct, conservative free tier — validate by modeling what PostHog would charge itself
+
+**We'll know we're successful when:** we've launched with marketing support, have a handful of active design partners, and a validated pricing model.
+
+### CLI & skills analytics (exploratory)
+
+**Motivation:** Agents don't only act through MCP — CLIs and skills are the next surfaces. We want the same instrumentation surface without building specialized SDKs for each.
+
+* CLI analytics: wrap existing CLIs with the MCP analytics SDK (Python/Go/Rust are already covered) and ship a wizard, so tool calls show up as MCP events — no separate CLI SDK
+* Skills analytics: exploratory — it depends on LLM-side hooks we don't have yet. Reach out to Anthropic (and OpenAI) about capturing skill-level data; we can likely build one for PostHog Code first
+* Treat as exploratory and start once core MCP work is stable
+
+**We'll know we're successful when:** CLI tool calls can be captured via the existing SDK, and we have a clear read on whether skills analytics is feasible.

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -1,45 +1,45 @@
 ## Q3 2026 objectives
 
-MCP analytics is greenfield — this quarter is about making onboarding magical, launching to real customers, and betting on "self-driving" as our top engineering priority. These goals will evolve as we learn from customers.
+MCP analytics is greenfield. This quarter is about making onboarding magical, launching to real customers, and betting on "self-driving" as our top engineering priority. Expect these to change as we learn from customers.
 
 ### Self-driving (top priority)
 
-**Motivation:** We shouldn't be the bottleneck for improving MCP servers. Instead of manually shipping fixes, we push signals to agents so they self-improve — closing the loop from a failing tool call to a merged PR.
+**Motivation:** We don't want to be the bottleneck for improving MCP servers. Instead of manually shipping every fix, we push signals to agents so they improve themselves, closing the loop from a failing tool call to a merged PR.
 
-* Build the feedback loop: a failing tool call creates a signal and auto-generates a PR — simple changes merge automatically, complex ones go to human review
-* Ship intent clustering based on synthetic sessions (group calls within a ~1-hour gap) rather than per-tool, so we infer real user goals instead of over-indexing on generic tools like `execute_sql`
-* Standardize the SDK: migrate the internal MCP server's custom events to out-of-the-box `@posthog/mcp` functionality so feedback events feed the pipeline cleanly
+* Build the feedback loop: a failing tool call creates a signal and auto-generates a PR. Simple changes merge on their own, complex ones go to human review
+* Ship intent clustering based on synthetic sessions (group calls within a ~1 hour gap) instead of per-tool, so we can infer what the user actually wanted rather than over-indexing on generic tools like `execute_sql`
+* Standardize the SDK by migrating the internal MCP server's custom events to out-of-the-box `@posthog/mcp` functionality, so feedback events feed the pipeline cleanly
 * Define a controlled release framework and validate self-driving as a 24-hour experiment against baseline
 
-**We'll know we're successful when:** a failing tool call can result in an auto-merged improvement, gated by a release framework we trust.
+**We'll know it worked when** a failing tool call can turn into an auto-merged improvement, gated by a release framework we trust.
 
 ### Magical onboarding
 
-**Motivation:** Onboarding is our funnel bottleneck (69 started, 12 completed). Getting to value should be as simple as a command, and the drop-offs are a warm outreach list.
+**Motivation:** Onboarding is where we're losing people. 69 started, 12 finished. Getting to value should be as simple as running a command, and every drop-off is a warm lead.
 
-* Make wizard onboarding work magically end-to-end, validated against real-world usage ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
-* Contact onboarding drop-offs and signed-up non-activators to diagnose blockers
-* Make the docs great and publish implementation blog posts — this is how we get Claude/Codex to actually use our content
+* Make wizard onboarding work end to end, validated against real usage ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
+* Reach out to the drop-offs and the people who signed up but never activated, and figure out what blocked them
+* Make the docs genuinely good and write up what we learn as blog posts. That's how we get Claude and Codex to actually use our content
 
-**We'll know we're successful when:** wizard onboarding completion climbs and new users reach value without hand-holding.
+**We'll know it worked when** wizard completion climbs and new users reach value without us holding their hand.
 
 ### Launch
 
-**Motivation:** "MCP analytics" is a low-competition keyword today — there's an opening to own the agent-analytics space before competitors catch up, but we need real customers and marketing behind us.
+**Motivation:** Almost nobody is competing on "MCP analytics" yet, so there's a window to own agent analytics before that changes. We need real customers and marketing behind us to use it.
 
-* Get product marketing alignment for a launch roughly one month out
-* Land 5-10 close design-partner customers to iterate with
-* Publish blog posts on our learnings (not just docs) to capture SEO/AEO early and get indexed by Claude, ChatGPT, etc.
-* Decide pricing: separate MCP events into their own bucket (not mixed with product analytics), same rate as product analytics events but a distinct, conservative free tier — validate by modeling what PostHog would charge itself
+* Get product marketing on our side for a launch about a month out
+* Land 5 to 10 close customers to build with
+* Publish blog posts on what we learn, not just docs, so we get indexed by Claude, ChatGPT and the rest early
+* Settle pricing: pull MCP events into their own bucket instead of mixing them with product analytics, charge the same rate as product analytics events but with a separate, conservative free tier. Sanity-check it by asking what PostHog would pay if it were the customer
 
-**We'll know we're successful when:** we've launched with marketing support, have a handful of active design partners, and a validated pricing model.
+**We'll know it worked when** we've launched with marketing support, have a handful of active design partners, and a pricing model we believe in.
 
 ### CLI & skills analytics (exploratory)
 
-**Motivation:** Agents don't only act through MCP — CLIs and skills are the next surfaces. We want the same instrumentation surface without building specialized SDKs for each.
+**Motivation:** Agents don't only act through MCP. CLIs and skills are next, and we'd rather reuse what we have than build a new SDK for each surface.
 
-* CLI analytics: wrap existing CLIs with the MCP analytics SDK (Python/Go/Rust are already covered) and ship a wizard, so tool calls show up as MCP events — no separate CLI SDK
-* Skills analytics: exploratory — it depends on LLM-side hooks we don't have yet. Reach out to Anthropic (and OpenAI) about capturing skill-level data; we can likely build one for PostHog Code first
-* Treat as exploratory and start once core MCP work is stable
+* CLI analytics: wrap existing CLIs with the MCP analytics SDK (Python, Go and Rust are already covered) and ship a wizard, so tool calls just show up as MCP events. No separate CLI SDK
+* Skills analytics: this one's harder and depends on LLM-side hooks we don't have yet. Talk to Anthropic and OpenAI about capturing skill-level data. We can probably build one for PostHog Code first
+* Keep it exploratory and pick it up once the core MCP work has settled
 
-**We'll know we're successful when:** CLI tool calls can be captured via the existing SDK, and we have a clear read on whether skills analytics is feasible.
+**We'll know it worked when** CLI tool calls show up through the existing SDK, and we know whether skills analytics is actually feasible.

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -4,15 +4,14 @@ MCP analytics is greenfield. This quarter is about making onboarding magical, la
 
 ### Self-driving (top priority)
 
-**Motivation:** We don't want to be the bottleneck for improving MCP servers. Instead of shipping every fix by hand, we push signals to agents so they can improve themselves.
+**Motivation:** We don't want to be the bottleneck for improving MCP servers. Instead of fixing everything by hand, we want the system to catch problems and fix itself, with us stepping in only when it matters.
 
-* Error-driven loop: a failing tool call creates a signal that auto-generates a PR. Simple changes merge on their own, complex ones go to human review
-* Agent feedback loop: `feedback` events from MCP clients create signals that feed the same pipeline, turning what agents tell us into real fixes
-* Cluster each user's tool calls by session to figure out what they're actually trying to do, since one task usually chains several tools together. Use the proper `$session_id` where we have it, and fall back to a simple time gap (say, an hour between calls) as a stopgap until then
-* Standardize the SDK by moving the internal MCP server's custom events onto the standard `@posthog/mcp` SDK
-* Set up a safe release process and test self-driving as a 24-hour experiment against a baseline
+* When a tool call fails, it opens a PR automatically. Small fixes merge on their own, bigger ones get a human review
+* When an agent leaves feedback, it feeds into the same flow, so what agents tell us turns into real fixes
+* Group each user's tool calls by session to see what they're actually trying to do, since one task usually spans several tools. Use `$session_id` when it's there, and fall back to a simple time gap between calls until it is
+* Try the whole thing fully self-driving on our own MCP server first: let it ship improvements end to end with no human in the loop, and see how that compares to how we work today
 
-**We'll know it worked when** a failing tool call can turn into a fix on its own, with a release process we trust deciding what actually ships.
+**We'll know it worked when** a failing tool call can fix itself, and we trust the process enough to let it ship on its own.
 
 ### Magical onboarding
 

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -4,24 +4,25 @@ MCP analytics is greenfield. This quarter is about making onboarding magical, la
 
 ### Self-driving (top priority)
 
-**Motivation:** We don't want to be the bottleneck for improving MCP servers. Instead of manually shipping every fix, we push signals to agents so they improve themselves, closing the loop from a failing tool call to a merged PR.
+**Motivation:** We don't want to be the bottleneck for improving MCP servers. Instead of shipping every fix by hand, we push signals to agents so they can improve themselves.
 
-* Build the feedback loop: a failing tool call creates a signal and auto-generates a PR. Simple changes merge on their own, complex ones go to human review
-* Ship intent clustering based on synthetic sessions (group calls within a ~1 hour gap) instead of per-tool, so we can infer what the user actually wanted rather than over-indexing on generic tools like `execute_sql`
-* Standardize the SDK by migrating the internal MCP server's custom events to out-of-the-box `@posthog/mcp` functionality, so feedback events feed the pipeline cleanly
-* Define a controlled release framework and validate self-driving as a 24-hour experiment against baseline
+* Error-driven loop: a failing tool call creates a signal that auto-generates a PR. Simple changes merge on their own, complex ones go to human review
+* Agent feedback loop: `feedback` events from MCP clients create signals that feed the same pipeline, turning what agents tell us into real fixes
+* Cluster each user's tool calls by session to figure out what they're actually trying to do, since one task usually chains several tools together. Use the proper `$session_id` where we have it, and fall back to a simple time gap (say, an hour between calls) as a stopgap until then
+* Standardize the SDK by moving the internal MCP server's custom events onto the standard `@posthog/mcp` SDK
+* Set up a safe release process and test self-driving as a 24-hour experiment against a baseline
 
-**We'll know it worked when** a failing tool call can turn into an auto-merged improvement, gated by a release framework we trust.
+**We'll know it worked when** a failing tool call can turn into a fix on its own, with a release process we trust deciding what actually ships.
 
 ### Magical onboarding
 
-**Motivation:** Onboarding is where we're losing people. Most who start the wizard don't finish. Getting to value should be as simple as running a command, and every drop-off is a warm lead.
+**Motivation:** Onboarding is where we're losing people. Most who start the wizard don't finish. Getting started should be as simple as running a command, and every drop-off is someone we can learn from.
 
-* Make wizard onboarding work end to end, validated against real usage ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
-* Reach out to the drop-offs and the people who signed up but never activated, and figure out what blocked them
+* Make wizard onboarding work end to end, and make sure it works for real users ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
+* Reach out to the people who dropped off or signed up but never got going, and find out what got in the way
 * Make the docs genuinely good and write up what we learn as blog posts. That's how we get Claude and Codex to actually use our content
 
-**We'll know it worked when** wizard completion climbs and new users reach value without us holding their hand.
+**We'll know it worked when** more people finish the wizard and get to value without us walking them through it.
 
 ### Launch
 
@@ -29,17 +30,17 @@ MCP analytics is greenfield. This quarter is about making onboarding magical, la
 
 * Get product marketing on our side for a launch about a month out
 * Land 5 to 10 close customers to build with
-* Publish blog posts on what we learn, not just docs, so we get indexed by Claude, ChatGPT and the rest early
-* Settle pricing: pull MCP events into their own bucket instead of mixing them with product analytics, charge the same rate as product analytics events but with a separate, conservative free tier. Sanity-check it by asking what PostHog would pay if it were the customer
+* Publish blog posts on what we learn, not just docs, so Claude, ChatGPT and the rest pick us up early
+* Settle pricing: give MCP events their own bucket instead of mixing them with Product Analytics, charge the same rate as Product Analytics events but with a separate, smaller free tier to start. Sanity-check it by asking what PostHog would pay if it were the customer
 
-**We'll know it worked when** we've launched with marketing support, have a handful of active design partners, and a pricing model we believe in.
+**We'll know it worked when** we've launched with marketing support, have a handful of customers building with us, and a pricing model we believe in.
 
 ### CLI & skills analytics (exploratory)
 
-**Motivation:** Agents don't only act through MCP. CLIs and skills are next, and we'd rather reuse what we have than build a new SDK for each surface.
+**Motivation:** Agents don't only act through MCP. CLIs and skills are next, and we'd rather reuse what we have than build a new SDK for each one.
 
 * CLI analytics: wrap existing CLIs with the MCP analytics SDK (Python, Go and Rust are already covered) and ship a wizard, so tool calls just show up as MCP events. No separate CLI SDK
-* Skills analytics: this one's harder and depends on LLM-side hooks we don't have yet. Talk to Anthropic and OpenAI about capturing skill-level data. We can probably build one for PostHog Code first
+* Skills analytics: harder, and it needs hooks on the LLM side that we don't have yet. Talk to Anthropic and OpenAI about capturing skill-level data. We can probably build one for PostHog Code first
 * Keep it exploratory and pick it up once the core MCP work has settled
 
-**We'll know it worked when** CLI tool calls show up through the existing SDK, and we know whether skills analytics is actually feasible.
+**We'll know it worked when** CLI tool calls show up through the existing SDK, and we know whether skills analytics is actually doable.

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -15,9 +15,9 @@ MCP analytics is greenfield. This quarter is about making onboarding magical, la
 
 ### Magical onboarding
 
-**Motivation:** Onboarding is where we're losing people. 69 started, 12 finished. Getting to value should be as simple as running a command, and every drop-off is a warm lead.
+**Motivation:** Onboarding is where we're losing people. Most who start the wizard don't finish. Getting to value should be as simple as running a command, and every drop-off is a warm lead.
 
-* Make wizard onboarding work end to end, validated against real usage ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
+* Make wizard onboarding work end to end, validated against real usage
 * Reach out to the drop-offs and the people who signed up but never activated, and figure out what blocked them
 * Make the docs genuinely good and write up what we learn as blog posts. That's how we get Claude and Codex to actually use our content
 

--- a/contents/teams/mcp-analytics/objectives.mdx
+++ b/contents/teams/mcp-analytics/objectives.mdx
@@ -17,7 +17,7 @@ MCP analytics is greenfield. This quarter is about making onboarding magical, la
 
 **Motivation:** Onboarding is where we're losing people. Most who start the wizard don't finish. Getting to value should be as simple as running a command, and every drop-off is a warm lead.
 
-* Make wizard onboarding work end to end, validated against real usage
+* Make wizard onboarding work end to end, validated against real usage ([wizard stats](https://us.posthog.com/project/2/dashboard/1781611))
 * Reach out to the drop-offs and the people who signed up but never activated, and figure out what blocked them
 * Make the docs genuinely good and write up what we learn as blog posts. That's how we get Claude and Codex to actually use our content
 


### PR DESCRIPTION
## Changes

Replaces the placeholder in `contents/teams/mcp-analytics/objectives.mdx` with the team's Q3 2026 goals, synthesized from the planning call and follow-ups.

Four goals, following the house style (motivation → what we'll ship → success criteria):

1. **Self-driving** (flagged as the top engineering priority) — failing tool call → signal → auto-generated PR, synthetic-session intent clustering, SDK event standardization, and a controlled release framework validated via a 24h experiment.
2. **Magical onboarding** — fix the wizard funnel (69 started / 12 completed), contact drop-offs, great docs + implementation blog posts.
3. **Launch** — marketing alignment, 5-10 design-partner customers, SEO/AEO content, and a pricing decision (MCP events in their own bucket, PA rate, distinct free tier).
4. **CLI & skills analytics** (exploratory) — wrap existing CLIs with the SDK, explore skill-level hooks with Anthropic/OpenAI.

## Notes for reviewers

- These are intentionally a starting guideline for the quarter and will evolve as we learn from customers.
- I left out per-goal **drivers/owners** (`<TeamMember>` tags) since I wasn't sure of the final roster — easy to add if you want them, like the error-tracking / web-analytics team pages do.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*