### PR TITLE
Handbook: Brand in practice page edits

### DIFF
--- a/contents/handbook/brand/in-practice.md
+++ b/contents/handbook/brand/in-practice.md
@@ -106,7 +106,7 @@ Print requires additional consideration because you can't iterate after it's shi
 
 ### Approval:
 
-All print materials should be reviewed by in `#design-review` before going to print. Mistakes in print are expensive. [Submit a request](/handbook/brand/art-requests) early.
+All print materials should be reviewed in `#design-review` before going to print. Mistakes in print are expensive. [Submit a request](/handbook/brand/art-requests) early.
 
 ## Merch & swag
 


### PR DESCRIPTION
## Changes

Small grammar fix on the [Brand in practice handbook page](https://posthog.com/handbook/brand/in-practice): "reviewed by in `#design-review`" -> "reviewed in `#design-review`".

This PR is opened as a base for further edits to this page, which will be added directly in GitHub.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1783029342611419)*