### PR TITLE
Handbook: Voice & tone page edits

### DIFF
--- a/contents/handbook/brand/tone.md
+++ b/contents/handbook/brand/tone.md
@@ -39,7 +39,7 @@ These make copy feel weak and corporate. Cut them:
 | "best-in-class"         | show, don't claim                            |
 | "holistic"              | comprehensive, or just describe the parts    |
 | "seamless"              | describe *why* it's easy                     |
-| "synergy"               | C'mon, really... |
+| "synergy"               | C'mon, really...                             |
 
 ### Passive voice
 


### PR DESCRIPTION
## Changes

Minor source-formatting fix on the [Voice & tone handbook page](https://posthog.com/handbook/brand/tone): aligned the misaligned "synergy" row in the hedge-words table so the columns line up.

This PR is opened as a base for further edits to this page, which will be added directly in GitHub.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1783029342611419)*