### PR TITLE
Add Growth TAM benchmark to compensation calculator

### DIFF
--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -18,6 +18,7 @@ export const sfBenchmark: Record<string, number> = {
     'Forward Deployed Engineer': 230000,
     'Full Stack Engineer': 285000,
     'Graphic Designer': 147530,
+    'Growth TAM (OTE)': 180000,
     'Legal & Compliance': 209600,
     'Mobile Engineer': 285000,
     'Onboarding Specialist': 211000,


### PR DESCRIPTION
## Changes

Adds a `Growth TAM (OTE)` role to the SF compensation benchmark data with a $180k OTE benchmark, so it shows up in the compensation calculator.

**Why:** We're opening a Growth TAM role and need it available in the comp calculator. Starting at a lower band than the standard TAM benchmark to test the market and adjust as we learn.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06SQGM58N9/p1782849751375719?thread_ts=1782849751.375719&cid=C06SQGM58N9)*