### PR TITLE
Declare "hedgelord" as the official term for a PostHog employee

### DIFF
--- a/contents/handbook/company/lore.md
+++ b/contents/handbook/company/lore.md
@@ -6,6 +6,8 @@ showTitle: true
 
 A beginner's guide to some of our custom Slack emojis and various anecdotes you'll see and hear about.
 
+* A PostHog employee is officially known as a **hedgelord**. Collectively, a group of them – or the company as a whole – is an **array**, which is fitting given that a group of hedgehogs is technically called an array (and it's also how you store a bunch of things in code). This was settled by emoji consensus in a suitably chaotic Slack thread, after strong showings from "hogginhos" and "employees".
+
 * <Emoji name="bad-internet" src="/images/emojis/bad-internet.png" /> Yakko always had bad internet when demoing. <em>Always.</em>
 
 * <TeamMember name="James Greenhill" photo /> wore a skin tight green all-body suit for months to improve his Zoom background game without us realizing.

--- a/contents/handbook/company/lore.md
+++ b/contents/handbook/company/lore.md
@@ -6,7 +6,7 @@ showTitle: true
 
 A beginner's guide to some of our custom Slack emojis and various anecdotes you'll see and hear about.
 
-* A PostHog employee is officially known as a **hedgelord**. Collectively, a group of them – or the company as a whole – is an **array**, which is fitting given that a group of hedgehogs is technically called an array (and it's also how you store a bunch of things in code). This was settled by emoji consensus in a suitably chaotic Slack thread, after strong showings from "hogginhos" and "employees".
+* A PostHog employee is officially known as a **hedgelord**. Collectively, a group of them (or the company as a whole) is an **array**, which is fitting given that a group of hedgehogs is technically called an array (and it's also how you store a bunch of things in code). This was settled by emoji consensus in a suitably chaotic Slack thread, after strong showings from "hogginhos" and "employees".
 
 * <Emoji name="bad-internet" src="/images/emojis/bad-internet.png" /> Yakko always had bad internet when demoing. <em>Always.</em>
 


### PR DESCRIPTION
Formally establishes in the handbook lore that a PostHog employee is a **hedgelord**, and a group of them (or the company as a whole) is an **array**.

**Why:** A company Slack thread pointed out that after six years we still had no official collective noun for PostHog people. Emoji consensus landed on "hedgelord" (with "array" as the pre-existing group term), so it is now committed to handbook form.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1783018813224549?thread_ts=1783018813.224549&cid=C02E3BKC78F)*