### PR TITLE
Updated CSM bonus structure

### DIFF
--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -37,7 +37,7 @@ CSMs are responsible for ensuring that a larger book of existing customers - bot
   - To calculate retention we use the total usage over the past quarter and annualize this, then compare it to the quarter before that.
     - For monthly customers this is the total of their 3 invoices multiplied by 4
     - For annual customers, we look at the usage-based MRR and multiply by 4
-    - For newer customers: If it's a brand new customer with less than 1 quarter of revenue, we start measuring next quarter.
+    - An account starts counting toward NRR once it has 3 paid invoices in the previous quarter (a $0 month doesn't count).
 - Bonuses are paid out quarterly, and in any case after an invoice is paid
   - Bonus payments are made at the end of January, April, July, and October - at the end of each quarter, we'll monitor how many invoices actually get paid in the first two weeks of the next quarter. Fraser will send you an email that breaks down how you did.
 - Your bonus is guaranteed at 100% for your first 3 months at PostHog - this gives you time to get up to speed, but also if you over-perform then you will get your additional bonus.

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -49,7 +49,10 @@ CSMs are responsible for ensuring that a larger book of existing customers - bot
   - In general, we compare annualized ARR over the past quarter with annualized ARR from the previous quarter.
     - For Q3 2026 bonus: Q3 ARR vs Q2 ARR
   - For customers on annual plans, we will look at their usage-based spending (instead of total contract amount / 12)
-  - If an account is removed from your book mid-quarter, they will not be included in bonus calculation. We do this extremely rarely, even if a customer shuts down. If we have to give a customer a big refund, we’ll deal with your bonus on a case by case basis depending on what happened, but usually this will still be counted. 
+  - If an account is removed from your book mid-quarter (we do this extremely rarely), it will not be included in bonus calculation.
+  - If a customer churns during the quarter, their current ARR counts as $0 and they will be removed from your book the next quarter.
+  - If a customer drops below the $20k threshold with no likelihood of growing, we don't adjust their ARR - it counts as-is, and they will be removed from your book the next quarter.
+  - If we have to give a customer a big refund, we'll deal with your bonus on a case by case basis depending on what happened, but usually this will still be counted. 
  
 **Account allocation**
 - CSMs manage approximately $2.5M in ARR.

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -55,8 +55,8 @@ CSMs are responsible for ensuring that a larger book of existing customers - bot
   - If we have to give a customer a big refund, we'll deal with your bonus on a case by case basis depending on what happened, but usually this will still be counted. 
  
 **Account allocation**
-- CSMs manage approximately $2.5M in ARR.
-- This coverage amount will grow ~10% quarterly to match our growth targets.
+- CSMs manage approximately $2.5M in ARR. Books are balanced by shape as well as total: a target number of accounts per ARR bucket, so a single large account doesn't dominate a book.
+- As of Q3 2026, a typical book is roughly 4 accounts at $20-30k, 12 at $30-60k, 5 at $60-100k, 5 at $100-250k, and 2 at $250k+. These numbers come from our [live capacity calculation](https://us.posthog.com/project/2/dashboard/1737835), and will shift as coverage grows and capacity modelling improves.
 - When rebalancing accounts (e.g., if accounts drop below the $20k threshold), we'll bring you up to the current quarter's target amount.
 
 ## Working with engineering teams

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -14,7 +14,7 @@ showTitle: true
 
 ### Customer Success Managers
 
-Each CSM is assigned customer accounts accumulating to ~$1.5m ARR to work with.  We use the CSM Managed Segment in Vitally to track this against goals and CSMs should not assign this themselves (that's up to Dana or Charles).
+Each CSM is assigned customer accounts accumulating to ~$2.5m ARR to work with.  We use the CSM Managed Segment in Vitally to track this against goals and CSMs should not assign this themselves (that's up to Dana, Phil and Simon).
 
 ## Weekly Customer Success standup
 
@@ -33,26 +33,26 @@ CSMs are responsible for ensuring that a larger book of existing customers - bot
 - Your OTE comprises an 80/20 split between base and contractual bonus.
 - Bonus is paid based on revenue retention above 100%, and is _uncapped_.
   - For example, if you have 100% revenue retention and your target is 120% revenue retention, you get 0% of bonus. For 120% retention, it's 100% bonus, and for 140% retention, it's 200% bonus. This is on a sliding scale so if you hit 110% retention you get 50% bonus.
-  - The Q4 2025 target is 120% half-yearly NRR. This may change in future depending on how things go.
-  - To calculate retention we use the total usage over the past 2 quarters and annualize this, then compare it to the 2 quarters before that.
-    - For monthly customers this is the total of their 6 invoices multiplied by 2
-    - For annual customers, we look at the usage-based MRR and multiply by 2
-    - For newer customers: if there's at least 2 quarters of revenue, we use quarter-on-quarter comparison for that specific customer. If it's a brand new customer with less than 1 quarter of revenue, we start measuring next quarter.
+  - The Q3 2026 target is 110% quarterly NRR. This may change in future depending on how things go.
+  - To calculate retention we use the total usage over the past quarter and annualize this, then compare it to the quarter before that.
+    - For monthly customers this is the total of their 3 invoices multiplied by 4
+    - For annual customers, we look at the usage-based MRR and multiply by 4
+    - For newer customers: If it's a brand new customer with less than 1 quarter of revenue, we start measuring next quarter.
 - Bonuses are paid out quarterly, and in any case after an invoice is paid
   - Bonus payments are made at the end of January, April, July, and October - at the end of each quarter, we'll monitor how many invoices actually get paid in the first two weeks of the next quarter. Fraser will send you an email that breaks down how you did.
 - Your bonus is guaranteed at 100% for your first 3 months at PostHog - this gives you time to get up to speed, but also if you over-perform then you will get your additional bonus.
 - If an account is added to your book:
   - If you inherit a new account that hasn't been managed by a PostHog human before, you have a 3 month grace period - if they drop or churn in that initial period, they won't be counted against you. We want to encourage you to right-size customers, rather than your deliberately letting them wastefully spend money due to some poor implementation.
-  - If you inherit an account from another CSM, AE, or AM, it will count toward your NRR in that quarter, even in the first 3 months.
+  - If you inherit an account from another CSM, AE, or AM, it will normally count toward your NRR in that quarter, even in the first 3 months.
+    - In exceptional circumstances we may need you to take on an account which we know isn't in a good state (ie. despite the previous owners best efforts we haven't been able to work with them).  We will note in writing on a case by case basis that any churn or downgrade in the first 3 months won't be counted against you.
 - How bonus is calculated:
-  - In general, we compare annualized ARR over the past 2 quarters with annualized ARR 2 quarters before.
-    - For Q4 2025 bonus: (Q4 + Q3 ARR) vs (Q2 + Q1 ARR)
-    - For Q1 2026 bonus: (Q1 + Q4 ARR) vs (Q3 + Q2 ARR)
+  - In general, we compare annualized ARR over the past quarter with annualized ARR from the previous quarter.
+    - For Q3 2026 bonus: Q3 ARR vs Q2 ARR
   - For customers on annual plans, we will look at their usage-based spending (instead of total contract amount / 12)
   - If an account is removed from your book mid-quarter, they will not be included in bonus calculation. We do this extremely rarely, even if a customer shuts down. If we have to give a customer a big refund, we’ll deal with your bonus on a case by case basis depending on what happened, but usually this will still be counted. 
  
 **Account allocation**
-- CSMs manage approximately $1.5M in ARR.
+- CSMs manage approximately $2.5M in ARR.
 - This coverage amount will grow ~10% quarterly to match our growth targets.
 - When rebalancing accounts (e.g., if accounts drop below the $20k threshold), we'll bring you up to the current quarter's target amount.
 

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -14,7 +14,7 @@ showTitle: true
 
 ### Customer Success Managers
 
-Each CSM is assigned customer accounts accumulating to ~$2.5m ARR to work with.  We use the CSM Managed Segment in Vitally to track this against goals and CSMs should not assign this themselves (that's up to Dana, Phil and Simon).
+Each CSM is assigned customer accounts accumulating to ~$2.5m ARR to work with.  We use the CSM Managed Segment in Vitally to track this against goals. Don't assign yourself as the CSM on an account - assigning a CSM automatically adds the account to the segment. Allocation is up to Dana, Phil and Simon.
 
 ## Weekly Customer Success standup
 

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -53,6 +53,11 @@ CSMs are responsible for ensuring that a larger book of existing customers - bot
   - If a customer churns during the quarter, their current ARR counts as $0 and they will be removed from your book the next quarter.
   - If a customer drops below the $20k threshold with no likelihood of growing, we don't adjust their ARR - it counts as-is, and they will be removed from your book the next quarter.
   - If we have to give a customer a big refund, we'll deal with your bonus on a case by case basis depending on what happened, but usually this will still be counted. 
+  - If we give a customer additional credits (goodwill, bug/incident compensation - not the credits they pre-purchase with a contract), the NRR treatment depends on why we gave them:
+    - Unintended usage spikes - a misconfiguration, SDK bug, or runaway loop inflates usage: we credit the customer and exclude the excess usage from NRR. Nobody's NRR should go up because of an accident. There are [eligibility criteria for credits](/handbook/growth/sales/refunds#eligibility-criteria) - check them before promising one.
+    - Goodwill credits - a bug hurt a paying customer's experience but their usage was real: the credit compensates them, and the usage counts as normal.
+    - Startup / YC credits - usage covered by these doesn't count toward NRR. If a customer isn't paying us real money, we don't count it. In practice the 3-paid-invoices rule above handles this.
+    - Comped usage on contract buy-outs / early renewals (e.g. comping 2 months of usage to move a customer onto a new contract early) - no blanket rule here, so flag it to your team lead and we'll handle it case by case.
  
 **Account allocation**
 - CSMs manage approximately $2.5M in ARR. Books are balanced by shape as well as total: a target number of accounts per ARR bucket, so a single large account doesn't dominate a book.


### PR DESCRIPTION
## Changes

Updated the CSM bonus structure to be measured quarterly vs. half yearly after discussions with @bendbradley and @minekansu 
110% quarterly NRR vs 120% half yearly.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
