### PR TITLE
Replaced Pylon with SupportHog

### DIFF
--- a/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
+++ b/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
@@ -162,7 +162,7 @@ Prioritize potential churn risks, low engagement, and accounts where something i
 A lot of valuable context lives in past conversations:
 
 - **BuildBetter** — recordings of customer success, sales, and onboarding calls. Use <PrivateLink url="https://app.buildbetter.app/people">People</PrivateLink> to search companies or contacts and see call history, or use direct search / AI chat.
-- **Pylon** — Slack channel history. The <PrivateLink url="https://app.usepylon.com/accounts">account</PrivateLink> page is linked to Salesforce accounts that have a Slack channel. Filter by Owner (mapped to the account owner in Salesforce) to view all Slack/Teams interactions for your accounts.
+- **[SupportHog](/handbook/growth/sales/slack-channels)** — Slack channel history. Our own tool links [shared Slack (and MS Teams) channels](/handbook/growth/sales/slack-channels) to Salesforce accounts so you can view Slack/Teams interactions for your accounts.
 - **Vitally** — Zendesk and email conversations under <PrivateLink url="https://posthog.vitally-eu.io/conversations/active/">Active Conversations</PrivateLink>. See who the key contacts have been, who's supported them in the past, and how frequently they raise tickets.
 
 ### Product usage analysis

--- a/contents/handbook/cs-and-onboarding/handling-customer-issues.md
+++ b/contents/handbook/cs-and-onboarding/handling-customer-issues.md
@@ -16,13 +16,12 @@ We use [Zendesk Support](https://posthoghelp.zendesk.com/agent) as our internal 
 
 ### Tickets from Slack
 
-Customers can [create tickets from Slack](/handbook/engineering/support-hero#pylon-to-create-zendesk-tickets-from-slack-posts) by adding the 🎫 emoji reaction. This means they can get help even when you're asleep or on holiday. Let your customer know about this, and remind them now and then.
+Customers can [create tickets from Slack](/handbook/engineering/support-hero#creating-zendesk-tickets-from-slack-posts) by adding the 🎫 emoji reaction (or mentioning `@SupportHog`). This means they can get help even when you're asleep or on holiday. Let your customer know about this, and remind them now and then.
 
-If it isn't working, check that you've [invited Pylon to the channel](/handbook/growth/sales/slack-channels). Fill out the [automated message asking for `Group` and `Severity`](/handbook/engineering/support-hero#pylon-to-create-zendesk-tickets-from-slack-posts) so the ticket goes to the right team — customers often forget, so fill it for them. Check [feature ownership](/handbook/engineering/feature-ownership) if you're not sure who owns a product area.
 
-If you're working on a ticket the customer raised in Slack, let support know to avoid duplicate effort. Leave an internal note in Zendesk.
+If you're working on a ticket the customer raised in Slack, let support know to avoid duplicate effort. Leave an internal note in PostHog.
 
-> Tip: Customer messages from Pylon channels also go to [#support-customer-success](https://posthog.slack.com/archives/C05MUMZLC13). Find the ticket there and reply in the thread — that also creates an internal note in Zendesk.
+> Tip: Customer messages from SupportHog channels also go to [#support-managed-customers](https://posthog.slack.com/archives/C05MUMZLC13). Find the ticket there and follow the link to see the ticket in PostHog.
 
 ## Investigating issues
 
@@ -30,7 +29,7 @@ Ask for specifics: links to the insight, feature flag, or dashboard; a screensho
 
 If it helps, log in as the customer. Clicking a link from their PostHog instance will sometimes offer a "log in as" option. Otherwise, go to <PrivateLink url="https://us.posthog.com/admin/">US admin</PrivateLink> (<PrivateLink url="https://eu.posthog.com/admin/">EU admin</PrivateLink>), search for the org or user, and click "Log in as user". If you don't see that option, ask <TeamMember name="Dana Zou" photo /> to add you as a staff member in admin.
 
-Use our [docs](/docs), [troubleshooting tips](/handbook/support/troubleshooting-tips), and search Slack, Zendesk, GitHub, and Pylon for similar issues. If you've just joined, spend 30 mins to an hour investigating yourself before asking for help — onboarding is when you learn the products best. Use common sense based on urgency.
+Use our [docs](/docs), [troubleshooting tips](/handbook/support/troubleshooting-tips), and search Slack, Zendesk, and GitHub for similar issues. If you've just joined, spend 30 mins to an hour investigating yourself before asking for help — onboarding is when you learn the products best. Use common sense based on urgency.
 
 Keep the customer in the loop while you investigate — progress, blockers, next steps.
 

--- a/contents/handbook/cs-and-onboarding/handling-customer-issues.md
+++ b/contents/handbook/cs-and-onboarding/handling-customer-issues.md
@@ -19,7 +19,7 @@ We use [Zendesk Support](https://posthoghelp.zendesk.com/agent) as our internal 
 Customers can [create tickets from Slack](/handbook/engineering/support-hero#creating-zendesk-tickets-from-slack-posts) by adding the 🎫 emoji reaction (or mentioning `@SupportHog`). This means they can get help even when you're asleep or on holiday. Let your customer know about this, and remind them now and then.
 
 
-If you're working on a ticket the customer raised in Slack, let support know to avoid duplicate effort. Leave an internal note in PostHog.
+If you're working on a ticket the customer raised in Slack, assign yourself as the owner in PostHog Support, and then either resolve it or assign it to Team Support if you need to escalate it.
 
 > Tip: Customer messages from SupportHog channels also go to [#support-managed-customers](https://posthog.slack.com/archives/C05MUMZLC13). Find the ticket there and follow the link to see the ticket in PostHog.
 

--- a/contents/handbook/cs-and-onboarding/handling-customer-issues.md
+++ b/contents/handbook/cs-and-onboarding/handling-customer-issues.md
@@ -29,7 +29,7 @@ Ask for specifics: links to the insight, feature flag, or dashboard; a screensho
 
 If it helps, log in as the customer. Clicking a link from their PostHog instance will sometimes offer a "log in as" option. Otherwise, go to <PrivateLink url="https://us.posthog.com/admin/">US admin</PrivateLink> (<PrivateLink url="https://eu.posthog.com/admin/">EU admin</PrivateLink>), search for the org or user, and click "Log in as user". If you don't see that option, ask <TeamMember name="Dana Zou" photo /> to add you as a staff member in admin.
 
-Use our [docs](/docs), [troubleshooting tips](/handbook/support/troubleshooting-tips), and search Slack, Zendesk, and GitHub for similar issues. If you've just joined, spend 30 mins to an hour investigating yourself before asking for help — onboarding is when you learn the products best. Use common sense based on urgency.
+Use our [docs](/docs), [troubleshooting tips](/handbook/support/troubleshooting-tips), and search Slack, PostHog Support, Zendesk, and GitHub for similar issues. If you've just joined, spend 30 mins to an hour investigating yourself before asking for help — onboarding is when you learn the products best. Use common sense based on urgency.
 
 Keep the customer in the loop while you investigate — progress, blockers, next steps.
 

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -82,19 +82,9 @@ You will run into questions that you don't know the answer to from time to time 
 
 Most of our customers use Slack, and it's a great way for us to be responsive to them. Everyone has the permission in Slack to create a Connect channel with a customer, and you should do this as early as possible in your relationship with them.
 
-When you've created the channel you should also add Pylon, which is used to sync Slack conversations with Zendesk so that our Support and Engineering teams can work on customer issues in a familiar context.
+When you've created the channel you should also add SupportHog, our own tool that syncs Slack conversations with PostHog so that our Support and Engineering teams can work on customer issues in a familiar context. Follow the [shared Slack channel setup steps](/handbook/growth/sales/slack-channels#setting-up-a-shared-slack-channel-via-slack-connect) to invite SupportHog and configure the channel.
 
-To add Pylon to your customer channel:
-
-1. In the Slack desktop app, click the channel name.
-2. On the Settings tab, click Add apps.
-3. Type Pylon and click Add.
-4. In the popup that appears in the Slack channel, select Customer Channel.
-5. Add yourself as the Account Owner.
-6. Click Enable.
-7. Add Tim, Charles, and Abigail to the channel.
-
-Once enabled, you can add the :ticket: emoji to a Slack thread to create a new Ticket in Zendesk.  Customers can also do this.  Make sure that a Group and Severity are selected or the ticket won't be routed properly.
+Once it's in the channel, you can add the :ticket: emoji to a Slack thread — or mention `@SupportHog` — to create a new ticket in Zendesk.  Customers can also do this.
 
 > It's your job to ensure your customer issues are resolved, make sure you follow up with Support and Engineering if you feel like the issue isn't getting the right level of attention.
 

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -45,7 +45,7 @@ In-person onboarding typically happens this week (3-4 days led by your team lead
 - Walking through your book of business with your team lead - prioritisation, where to start, who to reach out to first.
 - Digging into individual customers - what they're using, where they are in the lifecycle, any open issues, recent conversations.
 - Demo practice and feedback.
-- Seeing how the systems we use (Vitally, PostHog data, Zendesk) come together day-to-day.
+- Seeing how the systems we use (Vitally, PostHog data, PostHog Support, Zendesk) come together day-to-day.
 - A no-stupid-questions session - bring everything you've been wondering about from Week 1.
 - First look at signals - what Vitally tags and alerts are, how the team uses them. You won't be confidently responding to them yet, but that comes over the rest of the month.
 

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -45,7 +45,7 @@ In-person onboarding typically happens this week (3-4 days led by your team lead
 - Walking through your book of business with your team lead - prioritisation, where to start, who to reach out to first.
 - Digging into individual customers - what they're using, where they are in the lifecycle, any open issues, recent conversations.
 - Demo practice and feedback.
-- Seeing how the systems we use (Vitally, PostHog data, Pylon, Zendesk) come together day-to-day.
+- Seeing how the systems we use (Vitally, PostHog data, Zendesk) come together day-to-day.
 - A no-stupid-questions session - bring everything you've been wondering about from Week 1.
 - First look at signals - what Vitally tags and alerts are, how the team uses them. You won't be confidently responding to them yet, but that comes over the rest of the month.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -340,7 +340,7 @@ If you do discover any potentially offensive content in a customer account then 
 
 ### Creating Zendesk tickets from Slack posts
 
-We use [SupportHog](/handbook/growth/sales/slack-channels), our own tool, to create PostHog Support tickets from Slack posts. To do so, add the `:ticket:` (🎫) emoji reaction to the post that you want to create a Zendesk ticket from, or mention `@SupportHog` in the thread.
+We use [SupportHog](/handbook/growth/sales/slack-channels), our own tool, to create PostHog Support tickets from Slack posts. To do so, add the `:ticket:` (🎫) emoji reaction to the post that you want to create a PostHog Support ticket from, or mention `@SupportHog` in the thread.
 
 Zendesk tickets created this way will normally be marked as high priority tickets. You can respond to them either in Zendesk or Slack, as there is a two-way sync.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -204,8 +204,6 @@ As a business we need to ensure we are focusing support on our paying customers,
 
 \* Try to be especially responsive to any customers marked as `Sales/CS Top 20`. This set of customers is regularly reviewed by the sales team, and this priority is applied to those customers we'd like to have an especially fantastic support experience.
 
-\*\* Due to the way we're using Pylon, "new" tickets from high prio customer Slack channels only appear as `New` in Zendesk for a few seconds, then a webhook updates the ticket and quickly changes it to `Open`.
-
 ### What if I need to confirm priority by checking a customer's MRR?
 
 You've got a couple of options. By order of quickness:
@@ -267,7 +265,7 @@ We use [Zendesk Support](https://posthoghelp.zendesk.com) as our internal platfo
 
 Zendesk allows us to manage all our customer conversations in one place and reply through Slack or email.
 
-Zendesk is populated with new tickets when issues are sent via the in-app [Support panel](https://us.posthog.com/home#panel=support) (the `Help` tab in the righthand sidebar), from people outside the PostHog GitHub organization adding issues to the `posthog` and `posthog.com` repos, and new [community questions](/questions). High priority customers also have Slack channels they can post support questions in. We can [create Zendesk tickets from Slack questions via Pylon.](#pylon-to-create-zendesk-tickets-from-slack-posts)
+Zendesk is populated with new tickets when issues are sent via the in-app [Support panel](https://us.posthog.com/home#panel=support) (the `Help` tab in the righthand sidebar), from people outside the PostHog GitHub organization adding issues to the `posthog` and `posthog.com` repos, and new [community questions](/questions). High priority customers also have Slack channels they can post support questions in. We can [create Zendesk tickets from Slack questions via SupportHog.](#creating-zendesk-tickets-from-slack-posts)
 
 The Zendesk tickets will include links to the GitHub issue, Slack thread, or the community question so we can answer in the appropriate platform. After replying to a community question, make an `internal note` on the Zendesk ticket confirming that you've replied outside of Zendesk, and set the [ticket status](#ticket-status) accordingly when submitting the internal note.
 
@@ -340,11 +338,9 @@ This looks at the Content Warning field on the Zendesk Organization, and adds th
 
 If you do discover any potentially offensive content in a customer account then please update this field on the Zendesk Organization so that other team members are aware of the content.
 
-### Pylon to create Zendesk tickets from Slack posts
+### Creating Zendesk tickets from Slack posts
 
-We use [Pylon](https://usepylon.com/) to create Zendesk tickets from Slack posts. To do so, add the `:ticket:` (🎫) emoji reaction to the post that you want to create a Zendesk ticket from.
-
-Adding the `:ticket:` emoji reaction will cause Pylon to add a couple of replies in a thread under the post. The last of those replies includes options for the Zendesk ticket you're creating: Use the `Group` menu to send the ticket to the appropriate team, and the `Severity` menu to set the severity flag on the Zendesk ticket, then hit the `Submit` button.
+We use [SupportHog](/handbook/growth/sales/slack-channels), our own tool, to create PostHog Support tickets from Slack posts. To do so, add the `:ticket:` (🎫) emoji reaction to the post that you want to create a Zendesk ticket from, or mention `@SupportHog` in the thread.
 
 Zendesk tickets created this way will normally be marked as high priority tickets. You can respond to them either in Zendesk or Slack, as there is a two-way sync.
 

--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -34,7 +34,7 @@ Reach out before customers ask, even if it’s just to say, “We’re aware and
 
 | Level | Description | Examples | Channels | Cadence |
 | ----- | ----- | ----- | ----- | ----- |
-| **SEV 0 – Emergency** | Existential service failure; all or most customers impacted with no workaround. CMOC sends immediately via broadcast. Account owners do **not** gate comms. | Full platform outage, data loss, security breach with active customer impact. | Pylon broadcast → Email → DM/SMS | Immediate broadcast, then every 15–30 min; postmortem within 24h |
+| **SEV 0 – Emergency** | Existential service failure; all or most customers impacted with no workaround. CMOC sends immediately via broadcast. Account owners do **not** gate comms. | Full platform outage, data loss, security breach with active customer impact. | Slack broadcast → Email → DM/SMS | Immediate broadcast, then every 15–30 min; postmortem within 24h |
 | **SEV 1 – Critical** | Major outage or data loss; widespread impact. | API unavailable, ingestion halted, login failures. | Slack → Email → (DM or SMS if needed) | Every 30–60 min; postmortem within 48h |
 | **SEV 2 – Major** | Partial degradation or downtime; workaround available. | Replay or query delays \>30 min, flag evaluation slow. | Slack or Email | Every 1–2 hrs |
 | **SEV 3 – Minor** | Limited impact or slow recovery. | Billing sync delays, isolated org issues. | Slack | Start and close |
@@ -44,9 +44,9 @@ Reach out before customers ask, even if it’s just to say, “We’re aware and
 
 ### **Emergency (SEV 0)**
 
-> **This overrides the standard workflow.** CMOC sends directly to all affected customer channels via Pylon broadcast without waiting for account owners. Account owners follow up individually once online.
+> **This overrides the standard workflow.** CMOC sends directly to all affected customer channels via Slack broadcast without waiting for account owners. Account owners follow up individually once online.
 
-**Initial broadcast (Pylon):**
+**Initial broadcast (SupportHog):**
 
 We're investigating a major incident affecting [feature/service]. [Symptom — e.g., "Event ingestion is fully stopped" or "The PostHog app is unreachable."]
 
@@ -143,7 +143,7 @@ Heads up — maintenance on \[system\] from \[time window\]. No downtime expecte
 
 ### **Workflow**
 
-> **SEV 0 override:** For SEV 0 incidents, the CMOC skips steps 4–5 and sends the initial message directly via [Pylon broadcast](#using-pylon-for-broadcasts) to all affected customer channels. Account owners are notified in [#group-cs-sales-support](https://posthog.slack.com/archives/C090RCG671C) simultaneously, and take over individual follow-up threads once online. The CMOC continues to own broadcast updates until the incident is resolved or downgraded.
+> **SEV 0 override:** For SEV 0 incidents, the CMOC skips steps 4–5 and sends the initial message directly via Slack broadcast to all affected customer channels. Account owners are notified in [#group-cs-sales-support](https://posthog.slack.com/archives/C090RCG671C) simultaneously, and take over individual follow-up threads once online. The CMOC continues to own broadcast updates until the incident is resolved or downgraded.
 1. **Incident declared** (Engineering).
 2. **CMOC activated**, notified of impact.
 3. **Assess customer impact**, this <PrivateLink url="https://us.posthog.com/project/2/insights/EBiXOD91">insight</PrivateLink> (or this <PrivateLink url="https://docs.google.com/spreadsheets/d/1EyV55L0vWTfD4W02j5A3Vx3YZYPUODmQQC1toFPcKXU/edit?gid=1396499197#gid=1396499197">Google Sheet</PrivateLink> as a backup) will help you understand which customers are using which components in which cloud environment.
@@ -163,20 +163,3 @@ Heads up — maintenance on \[system\] from \[time window\]. No downtime expecte
 4. **Account Owner sends the message** to their customers. Example outbound: “We’re investigating an outage affecting event ingestion. Updates every 30 minutes.”
 5. **During:** “Root cause identified (Redis queue saturation). Fix in progress.”
 6. **Resolution:** “Resolved at 11:42 UTC. Write-up soon.”
-
-## Using Pylon for broadcasts
-
-It's best that communications are shared directly from the account owner; however, if speed is of the essence, i.e. for a SEV 1 or security issue, and some folks are not yet working or on PTO, the CMOC can use Pylon to send a broadcast to all customer Slack channels en masse:
-
-1. Log into app.usepylon.com with your PostHog Slack account.
-2. Go to the _Broadcasts_ link on the left-hand side of the navigation.
-3. Click _Create Broadcast_ in the top right-hand corner of the UI.
-4. Enter the message you want to send, ensuring the formatting looks correct in the preview on the right-hand side.
-5. Ensure the Send as option is set to PostHog, not your own user (unless you want to handle 450+ potential separate threads)
-6. Click _Next_ in the top right-hand corner of the UI.
-7. Select your audience. You can use the filters to select all channels not owned by specific people, e.g., those who are currently online and communicating 1:1 with customers.
-8. Make sure you click _Add to Audience_ to add the selected channels to the broadcast.
-9. Click _Next_ in the top right-hand corner of the UI.
-10. Set the engagement notification channel to be [#support-customer-success](https://posthog.slack.com/archives/C05MUMZLC13)
-11. Check that you're happy with the message and audience and click _Send Now_ in the top right of the UI.
-12. Ask everyone online to monitor [#support-customer-success](https://posthog.slack.com/archives/C05MUMZLC13) for replies and respond where necessary.

--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -44,7 +44,7 @@ Reach out before customers ask, even if it’s just to say, “We’re aware and
 
 ### **Emergency (SEV 0)**
 
-> **This overrides the standard workflow.** CMOC sends directly to all affected customer channels via Slack broadcast without waiting for account owners. Account owners follow up individually once online.
+> **This overrides the standard workflow.** CMOC sends directly to all affected Slack customer channels without waiting for account owners. Account owners follow up individually once online.
 
 **Initial broadcast (SupportHog):**
 

--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -46,7 +46,7 @@ Reach out before customers ask, even if it’s just to say, “We’re aware and
 
 > **This overrides the standard workflow.** CMOC sends directly to all affected Slack customer channels without waiting for account owners. Account owners follow up individually once online.
 
-**Initial broadcast (SupportHog):**
+**Initial message (Slack):**
 
 We're investigating a major incident affecting [feature/service]. [Symptom — e.g., "Event ingestion is fully stopped" or "The PostHog app is unreachable."]
 

--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -143,7 +143,7 @@ Heads up — maintenance on \[system\] from \[time window\]. No downtime expecte
 
 ### **Workflow**
 
-> **SEV 0 override:** For SEV 0 incidents, the CMOC skips steps 4–5 and sends the initial message directly via Slack broadcast to all affected customer channels. Account owners are notified in [#group-cs-sales-support](https://posthog.slack.com/archives/C090RCG671C) simultaneously, and take over individual follow-up threads once online. The CMOC continues to own broadcast updates until the incident is resolved or downgraded.
+> **SEV 0 override:** For SEV 0 incidents, the CMOC skips steps 4–5 and sends the initial message directly via Slack to all affected customer channels. Account owners are notified in [#group-cs-sales-support](https://posthog.slack.com/archives/C090RCG671C) simultaneously, and take over individual follow-up threads once online. The CMOC continues to own broadcast updates until the incident is resolved or downgraded.
 1. **Incident declared** (Engineering).
 2. **CMOC activated**, notified of impact.
 3. **Assess customer impact**, this <PrivateLink url="https://us.posthog.com/project/2/insights/EBiXOD91">insight</PrivateLink> (or this <PrivateLink url="https://docs.google.com/spreadsheets/d/1EyV55L0vWTfD4W02j5A3Vx3YZYPUODmQQC1toFPcKXU/edit?gid=1396499197#gid=1396499197">Google Sheet</PrivateLink> as a backup) will help you understand which customers are using which components in which cloud environment.

--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -34,7 +34,7 @@ Reach out before customers ask, even if it’s just to say, “We’re aware and
 
 | Level | Description | Examples | Channels | Cadence |
 | ----- | ----- | ----- | ----- | ----- |
-| **SEV 0 – Emergency** | Existential service failure; all or most customers impacted with no workaround. CMOC sends immediately via broadcast. Account owners do **not** gate comms. | Full platform outage, data loss, security breach with active customer impact. | Slack broadcast → Email → DM/SMS | Immediate broadcast, then every 15–30 min; postmortem within 24h |
+| **SEV 0 – Emergency** | Existential service failure; all or most customers impacted with no workaround. CMOC sends immediately via broadcast. Account owners do **not** gate comms. | Full platform outage, data loss, security breach with active customer impact. | Slack message → Email → DM/SMS | Immediate broadcast, then every 15–30 min; postmortem within 24h |
 | **SEV 1 – Critical** | Major outage or data loss; widespread impact. | API unavailable, ingestion halted, login failures. | Slack → Email → (DM or SMS if needed) | Every 30–60 min; postmortem within 48h |
 | **SEV 2 – Major** | Partial degradation or downtime; workaround available. | Replay or query delays \>30 min, flag evaluation slow. | Slack or Email | Every 1–2 hrs |
 | **SEV 3 – Minor** | Limited impact or slow recovery. | Billing sync delays, isolated org issues. | Slack | Start and close |

--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -15,7 +15,7 @@ As a general principle, we try to make sure as much customer communication as po
 
 For existing customers, you'll sometimes send emails directly from <PrivateLink url="https://posthog.vitally-eu.io/">Vitally</PrivateLink>. To ensure these also make it to Salesforce, first look up your _Email to Salesforce Address_ from the [personal settings page](https://posthog.lightning.force.com/lightning/settings/personal/EmailToSalesforceUserSetup/home) in Salesforce, and then add it to your <PrivateLink url="https://posthog.vitally-eu.io/settings/profile/gmail">Vitally gmail settings</PrivateLink>.
 
-All Slack messages sync up with the corresponding account in Salesforce. We use [Pylon](https://app.usepylon.com) for this sync, so make sure Pylon is added to the customer Slack channel integrations and the channel is [linked to the Salesforce account](https://app.usepylon.com/integrations/salesforce?tab=account-mapping) properly for the sync to work smoothly.
+All Slack messages sync up with the corresponding account in Salesforce. We use [SupportHog](/handbook/growth/sales/slack-channels) for this sync, so make sure SupportHog is [added to the customer Slack channel](/handbook/growth/sales/slack-channels) and the channel's name is recorded on the relevant Salesforce account record for the sync to work smoothly.
 
 You are most likely to use the following regularly:
 

--- a/contents/handbook/growth/sales/customer-onboarding.md
+++ b/contents/handbook/growth/sales/customer-onboarding.md
@@ -40,8 +40,8 @@ We'll need them to be able to demo their product to us, as well as attend two or
 
 Ideally we will also have them in Slack Connect channel so that we can provide responsive support and expose them to the wider PostHog team.
 
-Some customers may wish to use MS Teams rather than Slack - we can sync our Slack with Teams via Pylon to do this. First you will need an MS Teams licence - ask Simon for one. Then, follow the instructions on [the link here](https://docs.usepylon.com/bridges/microsoft-teams/setup) to get set up.
-Before adding the customer into the channel, remember to test it on both sides to ensure the integration is working correctly.
+Some customers may wish to use MS Teams rather than Slack - SupportHog works in Teams too. See [Using MS Teams](/handbook/growth/sales/slack-channels#using-ms-teams) on the shared channels page for how to get set up.
+Before adding the customer into the channel, remember to test it to ensure ticket creation is working correctly.
 
 ## Day 0 - Session: Kick off
 

--- a/contents/handbook/growth/sales/new-sales.md
+++ b/contents/handbook/growth/sales/new-sales.md
@@ -256,9 +256,9 @@ By the end of either the 1st or 2nd call with a customer, you should have a defi
 
 ### 5. Product evaluation
 
-Once qualified, and if you think they are a good prospect for our sales-led process, your first priority is to try and get them into trial of PostHog with [a shared Slack channel](/handbook/growth/sales/slack-channels) as quickly as possible. If you close them, a shared Slack channel will also be their primary channel for support. Add the Pylon app to the channel and it will automate the support bot and channel description. React with a 🎫 to customer messages or tag `@support` to create a ticket in a thread. Generally it's better to seek forgiveness than ask permission for adding people to a Slack channel - use your judgement. 
+Once qualified, and if you think they are a good prospect for our sales-led process, your first priority is to try and get them into trial of PostHog with [a shared Slack channel](/handbook/growth/sales/slack-channels) as quickly as possible. If you close them, a shared Slack channel will also be their primary channel for support. [Invite SupportHog to the channel](/handbook/growth/sales/slack-channels) so tickets can be created from Slack. React with a 🎫 to customer messages or mention `@SupportHog` to create a ticket in a thread. Generally it's better to seek forgiveness than ask permission for adding people to a Slack channel - use your judgement. 
 
-Some customers may wish to use MS Teams rather than Slack - we can sync our Slack with Teams via Pylon to do this. First you will need an MS Teams licence - ask Simon for one. Then, set up [a Slack channel](/handbook/growth/sales/slack-channels). Then, [follow the instructions here](https://docs.usepylon.com/pylon-docs/integrations/chat/microsoft-teams) to get set up. Before adding the customer into the channel, remember to test it on both sides to ensure the integration is working correctly.
+Some customers may wish to use MS Teams rather than Slack - SupportHog works in Teams too. See [Using MS Teams](/handbook/growth/sales/slack-channels#using-ms-teams) on the shared Slack channels page for how to get set up. Before adding the customer into the channel, remember to test it to ensure ticket creation is working correctly.
 
 You should then follow up with a standard email/Slack message that:
 

--- a/contents/handbook/growth/sales/outbound-sales.md
+++ b/contents/handbook/growth/sales/outbound-sales.md
@@ -321,7 +321,6 @@ graph TD
     SF --> VITALLY[Vitally]
     CIO[Customer.io] --> VITALLY
     ZENDESK[Zendesk] --> VITALLY
-    PYLON[Pylon] --> VITALLY
     GMAIL[Gmail] --> VITALLY
     STRIPE[Stripe] --> VITALLY
 ```

--- a/contents/handbook/growth/sales/sales-and-cs-tools.md
+++ b/contents/handbook/growth/sales/sales-and-cs-tools.md
@@ -33,7 +33,6 @@ The three tools layer on top of each other: Zoom hosts the call, Gong records it
 - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/)
 - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances. Login to both as this is needed for admin access
   - [PostHog App + Website](https://us.posthog.com/project/2) reference within PostHog US instance
-- [Pylon](https://usepylon.com/) - use Slack SSO
 - [QuoteHog](https://quote.posthog.net/)
 - [Salesforce](https://posthog.lightning.force.com/)
 - [Vitally](https://posthog.vitally-eu.io/) - once you've logged in once with Google ask your Team Lead to upgrade your role to Team Member

--- a/contents/handbook/marketing/slack-messaging.md
+++ b/contents/handbook/marketing/slack-messaging.md
@@ -4,9 +4,9 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> This page isn't accurate - we are figuring out how to replace previous broadcast capability
+> This page isn't accurate - we have deprecated Pylon and don't have a comparable broadcast capability in SupportHog or elsewhere.  In the meantime if you want to get a Slack message out to customers ask account owners to do it on your behalf in [#group-cs-sales-support](https://posthog.slack.com/archives/C090RCG671C)
 
-We share [Slack channels with many of our customers and partners](/handbook/growth/sales/slack-channels) via Slack Connect, managed through [SupportHog](/handbook/growth/sales/slack-channels), our own tool. These channels are normally used for support and relationship building, but SupportHog's **broadcast** functionality also lets us send a single message to every customer or partner Slack channel at once.
+We share [Slack channels with many of our customers and partners](/handbook/growth/sales/slack-channels) via Slack Connect, managed through [Pylon](/handbook/growth/sales/slack-channels), our own tool. These channels are normally used for support and relationship building, but Pylon's **broadcast** functionality also lets us send a single message to every customer or partner Slack channel at once.
 
 This is a powerful way to amplify [product announcements](/handbook/marketing/product-announcements) and other comms directly to the people building on PostHog, alongside our usual [email](/handbook/marketing/email-comms) and [in-app](/handbook/marketing/in-app) channels.
 
@@ -32,21 +32,21 @@ Broadcasts reach live customer and partner channels, and Sales or the TAMs may k
 3. **Ping more than once.** A single message is easy to miss. Follow up a couple of times, and give a final heads-up with the scheduled send time (e.g. "this is going out at X") so people have a last chance to flag anything.
 4. If no feedback is received within that window, go ahead and send - you don't need to wait for explicit sign-off or be blocked.
 
-SupportHog broadcasts should be treated like email messages and added to the Marketing Messaging calendar as standard.
+Pylon broadcasts should be treated like email messages and added to the Marketing Messaging calendar as standard.
 This step is required, but it keeps PMMs unblocked while giving the people closest to our customers a simple way to catch anything sensitive.
 
 ### Excluding channels before you send
 
 Beyond accounts that sales or CS flags, scan the audience yourself for channels that shouldn't receive the message:
 
-- **Drop legacy and archived channels.** SupportHog's audience often includes old or inactive channels. They're usually obvious from the name – exclude them so the message only lands in live channels.
+- **Drop legacy and archived channels.** Pylon's audience often includes old or inactive channels. They're usually obvious from the name – exclude them so the message only lands in live channels.
 - **Check for recent negative sentiment.** It's worth quickly asking an LLM to scan the `#posthog-*` channels and surface any negative sentiment from the last two weeks. This usually turns up a handful worth excluding.
 - **Consider excluding people already using the feature.** If the broadcast is nudging people towards something, exclude accounts that already use it – or word the message so it still works for them (e.g. framing it as "in case you missed these features" rather than assuming they haven't seen them).
 
-## How to send a broadcast in SupportHog
+## How to send a broadcast in Pylon
 
-1. Log into SupportHog using SSO with your PostHog email address.
-2. Find the broadcasts feature in SupportHog and create a new broadcast.
+1. Log into Pylon using SSO with your PostHog email address.
+2. Find the broadcasts feature in Pylon and create a new broadcast.
 3. Select the audience – typically all customer and/or partner Slack channels. Double-check the audience before sending, as the message goes to live customer channels.
 4. Write your message. Keep it short, friendly, and link out to the [changelog](/changelog), blog post, or docs for the full detail.
 5. **Send the message as yourself, not as PostHog.** Pylon lets you choose the sender - sending from a real person feels more personal and gets a better response than a faceless company message.

--- a/contents/handbook/marketing/slack-messaging.md
+++ b/contents/handbook/marketing/slack-messaging.md
@@ -4,7 +4,9 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We share [Slack channels with many of our customers and partners](/handbook/growth/sales/slack-channels) via Slack Connect, managed through [Pylon](https://app.usepylon.com/). These channels are normally used for support and relationship building, but Pylon's **broadcast** functionality also lets us send a single message to every customer or partner Slack channel at once.
+> This page isn't accurate - we are figuring out how to replace previous broadcast capability
+
+We share [Slack channels with many of our customers and partners](/handbook/growth/sales/slack-channels) via Slack Connect, managed through [SupportHog](/handbook/growth/sales/slack-channels), our own tool. These channels are normally used for support and relationship building, but SupportHog's **broadcast** functionality also lets us send a single message to every customer or partner Slack channel at once.
 
 This is a powerful way to amplify [product announcements](/handbook/marketing/product-announcements) and other comms directly to the people building on PostHog, alongside our usual [email](/handbook/marketing/email-comms) and [in-app](/handbook/marketing/in-app) channels.
 
@@ -30,21 +32,21 @@ Broadcasts reach live customer and partner channels, and Sales or the TAMs may k
 3. **Ping more than once.** A single message is easy to miss. Follow up a couple of times, and give a final heads-up with the scheduled send time (e.g. "this is going out at X") so people have a last chance to flag anything.
 4. If no feedback is received within that window, go ahead and send - you don't need to wait for explicit sign-off or be blocked.
 
-Pylon broadcasts should be treated like email messages and added to the Marketing Messaging calendar as standard.
+SupportHog broadcasts should be treated like email messages and added to the Marketing Messaging calendar as standard.
 This step is required, but it keeps PMMs unblocked while giving the people closest to our customers a simple way to catch anything sensitive.
 
 ### Excluding channels before you send
 
 Beyond accounts that sales or CS flags, scan the audience yourself for channels that shouldn't receive the message:
 
-- **Drop legacy and archived channels.** Pylon's audience often includes old or inactive channels. They're usually obvious from the name – exclude them so the message only lands in live channels.
+- **Drop legacy and archived channels.** SupportHog's audience often includes old or inactive channels. They're usually obvious from the name – exclude them so the message only lands in live channels.
 - **Check for recent negative sentiment.** It's worth quickly asking an LLM to scan the `#posthog-*` channels and surface any negative sentiment from the last two weeks. This usually turns up a handful worth excluding.
 - **Consider excluding people already using the feature.** If the broadcast is nudging people towards something, exclude accounts that already use it – or word the message so it still works for them (e.g. framing it as "in case you missed these features" rather than assuming they haven't seen them).
 
-## How to send a broadcast in Pylon
+## How to send a broadcast in SupportHog
 
-1. Log into the [Pylon admin](https://app.usepylon.com/) using SSO with your PostHog email address.
-2. Find the broadcasts feature in the Pylon UI and create a new broadcast.
+1. Log into SupportHog using SSO with your PostHog email address.
+2. Find the broadcasts feature in SupportHog and create a new broadcast.
 3. Select the audience – typically all customer and/or partner Slack channels. Double-check the audience before sending, as the message goes to live customer channels.
 4. Write your message. Keep it short, friendly, and link out to the [changelog](/changelog), blog post, or docs for the full detail.
 5. **Send the message as yourself, not as PostHog.** Pylon lets you choose the sender - sending from a real person feels more personal and gets a better response than a faceless company message.

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -199,7 +199,7 @@ In this call the support engineer will be able to answer any questions, as well 
 
 -   [ ] [What the role of a support hero is](/handbook/support/customer-support#support-is-done-by-actual-engineers) and how they can expect to receive tickets/escalations
 -   [ ] [An overview of where tickets come from](/handbook/support/customer-support#its-easy-for-customers-to-reach-us) and how to differentiate between paying/free users
--   [ ] [How to create tickets from Slack threads](/handbook/engineering/support-hero#pylon-to-create-zendesk-tickets-from-slack-posts) and [reassign tickets to other teams](https://support.zendesk.com/hc/en-us/articles/4408887127450-Manually-assigning-a-ticket)
+-   [ ] [How to create tickets from Slack threads](/handbook/engineering/support-hero#creating-zendesk-tickets-from-slack-posts) and [reassign tickets to other teams](https://support.zendesk.com/hc/en-us/articles/4408887127450-Manually-assigning-a-ticket)
 -   [ ] [Advice on how to communicate with customers](/handbook/engineering/support-hero#how-do-i-communicate) and [prioritize tickets](/handbook/engineering/support-hero#how-do-i-prioritize)
 -   [ ] [How and when to mark tickets as 'On Hold' or 'Pending'](/handbook/engineering/support-hero#ticket-status)
 -   [ ] [What our SLAs](/handbook/support/customer-support#response-targets) are and [what ticket severity indicates](/docs/support-options#severity-levels)


### PR DESCRIPTION
## Changes

I've replaced all references to Pylon in the handbook, cleaning up instructions where needed.

- @tjcran I need you to keep me honest on how conversations are synced to Salesforce / Vitally now as I'm not super clear.
- We also need to figure out and document how to do broadcasts

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
