### PR TITLE
Add project secret API keys to feature ownership table

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import { PrivateLink } from '../components/PrivateLink'
+import TeamMember from '../components/TeamMember'
 
 export interface Feature {
     slug: string
@@ -340,6 +341,16 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         feature: 'Project homepage',
         owner: ['platform-ux'],
         label: 'feature/home',
+    },
+    'project-secret-api-keys': {
+        feature: 'Project secret API keys',
+        owner: ['platform-features'],
+        notes: (
+            <>
+                <TeamMember name="Jovan Sakovic" /> is the point owner.
+            </>
+        ),
+        label: false,
     },
     'property-filters': {
         feature: 'Property filters',


### PR DESCRIPTION
## Changes

Adds a **Project secret API keys** entry to the [feature ownership table](https://posthog.com/handbook/engineering/feature-ownership), owned by the Platform Features team with Jovan Sakovic as the point owner.

**Why:** These keys had no listed owner in the handbook; this makes ownership clear now that the feature is starting to roll out.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1783073896666469?thread_ts=1783073896.666469&cid=C02E3BKC78F)*
