### PR TITLE
Add The Innovator's Dilemma and Turn the Ship Around! to recommended reading

### DIFF
--- a/contents/founders/recommended-reading.md
+++ b/contents/founders/recommended-reading.md
@@ -150,7 +150,7 @@ The SaaS Playbook isn’t your normal startup how-to guide, according to Lior. I
 ## [The Innovator’s Dilemma by Clayton Christensen](https://www.goodreads.com/book/show/2615.The_Innovator_s_Dilemma)
 **Recommended by [Raquel Smith, Engineering exec](/raquel)**
 
-Raquel has done a bit of everything — customer success, marketing, [product engineering](/blog/why-product-engineering-is-so-fun) — and now looks after many of PostHog’s product teams. Her recommendation is the book that coined the term “disruptive innovation”, and it explains why market leaders keep losing to smaller companies with cheaper, simpler products.
+Raquel has done a bit of everything — customer success, growth engineering, [product engineering](/blog/why-product-engineering-is-so-fun) — and now looks after many of PostHog’s product teams. Her recommendation is the book that coined the term “disruptive innovation”, and it explains why market leaders keep losing to smaller companies with cheaper, simpler products.
 
 **Raquel's review:** “It explains why big companies with all the money and all the customers still lose to startups. Serving your best customers pulls you upmarket, and someone cheaper and simpler picks up everyone you left behind. Once you’ve read it, you’ll spot the pattern in every market — including ours.”
 

--- a/contents/founders/recommended-reading.md
+++ b/contents/founders/recommended-reading.md
@@ -148,7 +148,7 @@ The SaaS Playbook isn’t your normal startup how-to guide, according to Lior. I
 
 
 ## [The Innovator’s Dilemma by Clayton Christensen](https://www.goodreads.com/book/show/2615.The_Innovator_s_Dilemma)
-**Recommended by [Raquel Smith, Engineering](/raquel)**
+**Recommended by [Raquel Smith, Engineering exec](/raquel)**
 
 Raquel has done a bit of everything — customer success, marketing, [product engineering](/blog/why-product-engineering-is-so-fun) — and now looks after many of PostHog’s product teams. Her recommendation is the book that coined the term “disruptive innovation”, and it explains why market leaders keep losing to smaller companies with cheaper, simpler products.
 
@@ -158,11 +158,11 @@ Raquel has done a bit of everything — customer success, marketing, [product en
 
 
 ## [Turn the Ship Around! by L. David Marquet](https://www.goodreads.com/book/show/16158601-turn-the-ship-around)
-**Recommended by [Paul D'Ambra, Engineering](/paul)**
+**Recommended by [Paul D'Ambra, Engineering exec](/paul)**
 
 Paul looks after a whole fleet of PostHog’s engineering teams, which means plenty of opportunities to give orders. This book is a big part of why he tries not to. Marquet took command of the USS Santa Fe when it was the worst-performing submarine in the US Navy, and turned it into one of the best by handing control to his crew.
 
-**Paul's review:** “Marquet’s crew stopped waiting for orders and started saying ‘I intend to...’ instead, which moved decisions to the people who actually had the information. I think about that constantly. Delegated authority is most of the job — build enough clarity and competence around you that you can just say ‘very well’ and get out of the way.”
+**Paul's review:** “I became an engineer because I’m pathologically lazy. Leading others by actively giving orders wasn’t going to work for me anyway... and this book helped me see that leaning into that was more effective. Delegating authority means better decisions are made and I have more time for choosing the perfect reacji.”
 
 > **Putting it into practice:** Managers at PostHog [don’t assign tasks](/handbook/company/management) — they set context, and our [small teams](/handbook/company/small-teams) decide what to do with it.
 

--- a/contents/founders/recommended-reading.md
+++ b/contents/founders/recommended-reading.md
@@ -146,4 +146,24 @@ The SaaS Playbook isn’t your normal startup how-to guide, according to Lior. I
 
 > **Putting it into practice:** Product launches are a perpetual activity at PostHog, so our marketing team is always working in bootstrap mode — with help from [their favourite tool](/blog/posthog-marketing).
 
+
+## [The Innovator’s Dilemma by Clayton Christensen](https://www.goodreads.com/book/show/2615.The_Innovator_s_Dilemma)
+**Recommended by [Raquel Smith, Engineering](/raquel)**
+
+Raquel has done a bit of everything — customer success, marketing, [product engineering](/blog/why-product-engineering-is-so-fun) — and now looks after many of PostHog’s product teams. Her recommendation is the book that coined the term “disruptive innovation”, and it explains why market leaders keep losing to smaller companies with cheaper, simpler products.
+
+**Raquel's review:** “It explains why big companies with all the money and all the customers still lose to startups. Serving your best customers pulls you upmarket, and someone cheaper and simpler picks up everyone you left behind. Once you’ve read it, you’ll spot the pattern in every market — including ours.”
+
+> **Putting it into practice:** It’s why we aim to [get in first](/handbook/which-products) with products for early-stage teams, and why we [keep prices low](/handbook/low-prices) as we grow.
+
+
+## [Turn the Ship Around! by L. David Marquet](https://www.goodreads.com/book/show/16158601-turn-the-ship-around)
+**Recommended by [Paul D'Ambra, Engineering](/paul)**
+
+Paul looks after a whole fleet of PostHog’s engineering teams, which means plenty of opportunities to give orders. This book is a big part of why he tries not to. Marquet took command of the USS Santa Fe when it was the worst-performing submarine in the US Navy, and turned it into one of the best by handing control to his crew.
+
+**Paul's review:** “Marquet’s crew stopped waiting for orders and started saying ‘I intend to...’ instead, which moved decisions to the people who actually had the information. I think about that constantly. Delegated authority is most of the job — build enough clarity and competence around you that you can just say ‘very well’ and get out of the way.”
+
+> **Putting it into practice:** Managers at PostHog [don’t assign tasks](/handbook/company/management) — they set context, and our [small teams](/handbook/company/small-teams) decide what to do with it.
+
 <NewsletterForm />


### PR DESCRIPTION
Adds two book recommendations to [/founders/recommended-reading](https://posthog.com/founders/recommended-reading), following the article's existing entry format (Goodreads link, recommender byline, third-person intro, first-person review, and a "Putting it into practice" handbook link).

- **The Innovator's Dilemma** by Clayton Christensen — recommended by Raquel Smith
- **Turn the Ship Around!** by L. David Marquet — recommended by Paul D'Ambra

## Before marking ready for review

- [ ] **Raquel:** your review quote is a draft written for you — please approve or rewrite it in your own words
- [x] **Paul:** quote confirmed — replaced the draft with Paul's own words
- [ ] Upload the two book covers to Cloudinary and add an `![Title](url)` line above each new heading (every other entry has one)
- [x] Bylines confirmed as "Engineering exec" for both recommenders

🤖 Generated with [Claude Code](https://claude.com/claude-code)