### PR TITLE
chore(handbook): add email fallback goal for Yasen

### DIFF
--- a/contents/teams/platform-features/objectives.mdx
+++ b/contents/teams/platform-features/objectives.mdx
@@ -8,6 +8,7 @@
     - Access control scope expansion
     - Fix the broken US/EU redirects
     - Support Grow plan launch
+    - Build a fallback mechanism for emails (c.io -> smtp)
 
 - Reece
     - Multi-domain SAML/SCIM support


### PR DESCRIPTION
## Changes

Adds a new Q3 2026 objective for Yasen on the Platform features team:

> Build a fallback mechanism for emails (c.io -> smtp)

Provides SMTP as a fallback delivery path when Customer.io is unavailable, for the team's Emails / notifications area.