### PR TITLE
fix(vibe-check): make logo readable in dark mode

### DIFF
--- a/src/pages/vibe-check/index.tsx
+++ b/src/pages/vibe-check/index.tsx
@@ -10,6 +10,7 @@ import OSButton from 'components/OSButton'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
 
 import SuggestedLinksBlock from 'components/SuggestedLinksBlock'
+import { useApp } from '../../context/App'
 
 const FinalSlide = () => (
     <div className="flex-1 px-4">
@@ -58,6 +59,7 @@ function Slide({ card, slideIndex }: { card: any; slideIndex: number }) {
 
 export default function Ick() {
     const [slideIndex, setSlideIndex] = useState(0)
+    const { siteSettings } = useApp()
 
     const cards = HomepageCards
     const totalSlides = cards.length + 1 // +1 for the final custom slide
@@ -102,7 +104,12 @@ export default function Ick() {
                     {!isFinalSlide && (
                         <header className="pb-4">
                             <h1 className="text-2xl flex items-center justify-center gap-2">
-                                You'll hate <Logo className="relative -top-px" /> if...
+                                You'll hate{' '}
+                                <Logo
+                                    className="relative -top-px"
+                                    fill={siteSettings.theme === 'dark' ? 'white' : undefined}
+                                />{' '}
+                                if...
                             </h1>
                         </header>
                     )}


### PR DESCRIPTION
## Changes

Fixes #17952

In dark mode on `/vibe-check`, the PostHog logo in the "You'll hate PostHog if..." heading was nearly invisible: the Logo SVG letters use hardcoded black path fills that don't adapt to the theme.

This applies the same theme-conditional fill already used for the Logo across the site (`About/v2/Letterhead.tsx`, `Home/Control`, `Home/Test`, `ko/_KoreanHome.tsx`):

`fill={siteSettings.theme === 'dark' ? 'white' : undefined}`

- In dark mode the **whole logo (letters + glyph) renders monochrome white** — intentional, matching the site's established dark-mode logo treatment (see screenshots).
- In light mode `undefined` falls back to the component default — unchanged behavior.

**Note:** open PR #17950 fixes the *text* contrast on this same page (#17926). This PR only touches the Logo fill — semantically independent, but both edit adjacent lines of the same `<h1>`, so whichever lands second needs a trivial rebase. Happy to rebase if #17950 merges first.

**Screenshots** *(dark before → dark after → light unchanged)*

Dark before:
<img width="775" height="604" alt="Screenshot 2026-07-03 132520" src="https://github.com/user-attachments/assets/79152635-75f8-46fe-9f67-6bd00939b2fd" />

Dark after:
<img width="770" height="597" alt="Screenshot 2026-07-03 132538" src="https://github.com/user-attachments/assets/38bc8ac6-9b13-47c8-8138-ab367577b5b5" />

Light unchanged:
<img width="770" height="593" alt="Screenshot 2026-07-03 133053" src="https://github.com/user-attachments/assets/1b764013-44f1-446f-9984-1f82b15021a7" />


## Checklist

- [x] I've read the docs/content style guides
- [x] Words are spelled using American English
- [x] Relative URLs for internal links (n/a — none added)
- [ ] Vercel preview build checked *(will verify once the preview builds)*
- [x] No page moved (n/a)

## 🤖 Agent context

> Claude-written: implemented with Claude Code under my direction.

- **Tools:** Claude Code (single session). **Approach:** located the root cause in `components/Logo` (hardcoded path fills), searched the repo for existing dark-mode Logo treatments and applied the established pattern rather than inventing one.
- **Verification:** ran the site locally (Gatsby dev), visually verified both themes on `/vibe-check`; Prettier/ESLint via the repo's commit hooks.
- **Human review:** I reviewed the diff and can explain it.