### PR TITLE
Make beta status prominent on Slack app product page

### DIFF
--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -696,12 +696,15 @@ export default function SlackAppPage(): JSX.Element {
             <ReaderView leftSidebar={<LeftSidebarContent />} title="posthog-slack-app.md" hideTitle={true}>
                 <div className="max-w-2xl mx-auto">
                     <div className="text-center mb-4">
+                        <div className="not-prose mb-3">
+                            <Badge>Beta</Badge>
+                        </div>
                         <h1 className="text-3xl @md/reader-content-container:text-4xl font-bold m-0 mb-2">
                             Don't @ <em>me,</em> <Highlight>@PostHog</Highlight>
                         </h1>
                         <p className="text-secondary text-base @md/reader-content-container:text-lg max-w-lg mx-auto m-0">
                             PostHog now lives in Slack. Ask about your product data, debug issues, and generate PRs
-                            without leaving the thread.
+                            without leaving the thread. It's in beta, so expect rough edges as we improve it.
                         </p>
                     </div>
 


### PR DESCRIPTION
## Changes

The Slack app product page only signalled beta status via a small badge next to the "Try it" section, well below the fold. This adds a **Beta** badge to the hero (right under the title) and a short beta note in the intro copy, so it's obvious the app is in beta on first view.

**Why:** Raised in #team-slack — the beta status wasn't obvious from the product page ahead of the launch push, and we don't want to over-set expectations while onboarding is still being smoothed out.

*Screenshots to follow from the Vercel preview.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B98FCPT3N/p1783073626815319?thread_ts=1783073626.815319&cid=C0B98FCPT3N)*