### PR TITLE
Add Q3 2026 goals for AI research team

### DIFF
--- a/contents/teams/ai-research/objectives.mdx
+++ b/contents/teams/ai-research/objectives.mdx
@@ -2,7 +2,6 @@
 
 #### Objective 1: Ship the first version of the replay vision / self-driving model
 
-**Motivation:** Session replays contain a huge amount of objective, structured signal about what users actually do. If we can train a model that understands replays end to end, we unlock a foundation for self-driving product work — grounding agents in real user behavior instead of guesses. This quarter is about getting a first version of that model trained and evaluated, so we know the approach works.
 
 **What we'll ship:**
 - **Data labeling suite** - tooling to label replay sessions so we have high-quality supervision for training and evaluation.

--- a/contents/teams/ai-research/objectives.mdx
+++ b/contents/teams/ai-research/objectives.mdx
@@ -2,7 +2,6 @@
 
 #### Objective 1: Ship the first version of the replay vision / self-driving model
 
-
 **What we'll ship:**
 - **Data labeling suite** - tooling to label replay sessions so we have high-quality supervision for training and evaluation.
 - **Session replay text renderer** - a programmatic renderer that extracts the objective facts already present in a recording ("user clicked button X, then Y happened") into text, used to ground the model's decoder. There's precedent here in screen-reader work.

--- a/contents/teams/ai-research/objectives.mdx
+++ b/contents/teams/ai-research/objectives.mdx
@@ -13,4 +13,4 @@
 - **Eval dataset** - a held-out dataset to measure whether the model actually understands replays.
 
 **What we're not shipping:**
-- **Hand-rolled inference** - the text renderer's output isn't available at inference time in this design, so we're not building a bespoke inference path this quarter.
+- **Hand-rolled inference**

--- a/contents/teams/ai-research/objectives.mdx
+++ b/contents/teams/ai-research/objectives.mdx
@@ -1,2 +1,18 @@
-## Q2 2026 goals
+### Q3 2026 objectives
 
+#### Objective 1: Ship the first version of the replay vision / self-driving model
+
+**Motivation:** Session replays contain a huge amount of objective, structured signal about what users actually do. If we can train a model that understands replays end to end, we unlock a foundation for self-driving product work — grounding agents in real user behavior instead of guesses. This quarter is about getting a first version of that model trained and evaluated, so we know the approach works.
+
+**What we'll ship:**
+- **Data labeling suite** - tooling to label replay sessions so we have high-quality supervision for training and evaluation.
+- **Session replay text renderer** - a programmatic renderer that extracts the objective facts already present in a recording ("user clicked button X, then Y happened") into text, used to ground the model's decoder. There's precedent here in screen-reader work.
+- **DOMEncoder** - encoder for DOM state.
+- **RRWebEncoder** - encoder for rrweb replay events.
+- **Data prep** - pipelines to turn raw replays into training-ready inputs for the encoders and renderer.
+- **Full model training** - train the QFormer first (it starts from random weights) to compress per-event replay vectors into a compact representation, and train the language model last to avoid catastrophic forgetting.
+- **Model observability suite** - tooling (e.g. MLflow) to visualize neurons and debug problems during training.
+- **Eval dataset** - a held-out dataset to measure whether the model actually understands replays.
+
+**What we're not shipping:**
+- **Hand-rolled inference** - the text renderer's output isn't available at inference time in this design, so we're not building a bespoke inference path this quarter.


### PR DESCRIPTION
## Changes

Fills in the AI research team's Q3 2026 objectives, which were previously an empty heading. Formatted to match the objective / motivation / "what we'll ship" / "what we're not shipping" structure other teams (ai-observability, product-analytics) use.

The single objective is shipping the first version of the replay vision / self-driving model, with the subgoals as the "what we'll ship" list (labeling suite, text renderer, DOM + rrweb encoders, data prep, full model training, observability suite, eval dataset) and hand-rolled inference as a non-goal.

**Why:** The AI research team needed its Q3 goals written up, using the existing team-goal format as precedent.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ATLUQR5NX/p1783084689782609?thread_ts=1783084689.782609&cid=C0ATLUQR5NX)*