### PR TITLE
Capture a 'squeak question created' event for new questions

### DIFF
--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -283,6 +283,7 @@ export const QuestionForm = ({
     ...other
 }: QuestionFormProps) => {
     const { user, getJwt, logout } = useUser()
+    const posthog = usePostHog()
     const [formValues, setFormValues] = useState<QuestionFormValues | null>(null)
     const [view, setView] = useState<string | null>(initialView || null)
     const [loading, setLoading] = useState(false)
@@ -349,6 +350,18 @@ export const QuestionForm = ({
                 data,
             }),
         }).then((res) => res.json())
+
+        // Fires only for new questions (replies use a separate `reply()` path), and only
+        // after the API confirms creation — a reliable count of new questions asked.
+        if (questionData?.id) {
+            posthog?.capture('squeak question created', {
+                questionId: questionData.id,
+                topicId: topicID,
+                slug,
+                subject,
+            })
+        }
+
         return questionData
     }
 


### PR DESCRIPTION
## Problem

We want reliable data on **how many new questions are asked** on `/questions`, but there's no clean event for it today:

- The existing `squeak reply` event fires for **replies only** — new questions have **no dedicated event**.
- As a result, new-question counts have been proxied off first-pageviews, which is unreliable.

## Change

Adds a single client-side capture in `createQuestion()` (`src/components/Squeak/components/QuestionForm.tsx`):

```ts
posthog?.capture('squeak question created', {
    questionId: questionData.id,
    topicId: topicID,
    slug,
    subject,
})
```

- Fires **only for new questions** — replies go through a separate `reply()` path (`useQuestion.tsx`, which POSTs to `/api/replies`), so this can never fire on a reply.
- Fires **after the API confirms creation** (guarded on `questionData?.id`), matching the existing `squeak reply` pattern — a reliable count of real questions.
- Covers all entry points (docs/topic pages and the `/questions` forum modal) since both funnel through `createQuestion()`.

## Properties

`questionId`, `topicId`, `slug`, `subject` — so new questions can be broken down by topic and origin page in a dashboard.

## Squeak backend

No change needed. The archived `PostHog/squeak` repo is legacy, and `PostHog/squeak-strapi` (the datastore/API) has no analytics `capture` calls — the whole squeak analytics pattern is client-side here.

## Verification

- Typechecks clean (`tsc --noEmit`) and passes Prettier.
- After deploy: confirm `squeak question created` events arrive in PostHog (project 2), then build a trends insight counting them over time.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*