### PR TITLE
Add sampling pipeline subgoal to AI research Q3 2026 goals

### DIFF
--- a/contents/teams/ai-research/objectives.mdx
+++ b/contents/teams/ai-research/objectives.mdx
@@ -8,6 +8,7 @@
 - **DOMEncoder** - encoder for DOM state.
 - **RRWebEncoder** - encoder for rrweb replay events.
 - **Data prep** - pipelines to turn raw replays into training-ready inputs for the encoders and renderer.
+- **Sampling pipeline** - select and sample which sessions feed training, so the model learns from a representative, high-signal slice of replays.
 - **Full model training** - train the QFormer first (it starts from random weights) to compress per-event replay vectors into a compact representation, and train the language model last to avoid catastrophic forgetting.
 - **Model observability suite** - tooling (e.g. MLflow) to visualize neurons and debug problems during training.
 - **Eval dataset** - a held-out dataset to measure whether the model actually understands replays.


### PR DESCRIPTION
## Changes

Adds "sampling pipeline" as another subgoal under the AI research team's Q3 2026 "What we'll ship" list. Follow-up to #18170, which has already merged.

**Why:** The team wants selecting/sampling which sessions feed training tracked as an explicit deliverable for the replay vision / self-driving model.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ATLUQR5NX/p1783084689782609?thread_ts=1783084689.782609&cid=C0ATLUQR5NX)*