### PR TITLE
Revert "Handbook: edits to LinkedIn, content, brand & product announcements pages (#18144)"

### DIFF
--- a/contents/handbook/brand/in-practice.md
+++ b/contents/handbook/brand/in-practice.md
@@ -106,7 +106,7 @@ Print requires additional consideration because you can't iterate after it's shi
 
 ### Approval:
 
-All print materials should be reviewed in `#design-review` before going to print. Mistakes in print are expensive. [Submit a request](/handbook/brand/art-requests) early.
+All print materials should be reviewed by in `#design-review` before going to print. Mistakes in print are expensive. [Submit a request](/handbook/brand/art-requests) early.
 
 ## Merch & swag
 

--- a/contents/handbook/brand/tone.md
+++ b/contents/handbook/brand/tone.md
@@ -18,7 +18,6 @@ That means:
 - **Honest.** Including about limitations. Developers trust honesty more than polish.
 - **Conversational.** Contractions are fine. Starting a sentence with "But" or "And" is fine.
 - **No jargon for jargon's sake.** Technical precision when it helps. No buzzwords.
-- **No emojis.** Emojis can make a brand seem try-hard and cringe. Avoid them.
 
 If there's an industry-standard phrase, question if it's actually the best way to describe something – or if somebody came up with it once and then everyone else followed suit. Maybe it makes sense to stick with it, but we also have the unique opportunity to coin a new term if the juice is worth the squeeze.
 
@@ -40,7 +39,7 @@ These make copy feel weak and corporate. Cut them:
 | "best-in-class"         | show, don't claim                            |
 | "holistic"              | comprehensive, or just describe the parts    |
 | "seamless"              | describe *why* it's easy                     |
-| "synergy"               | C'mon, really...                             |
+| "synergy"               | C'mon, really... |
 
 ### Passive voice
 
@@ -95,12 +94,3 @@ On that last one: PostHog makes _your_ product self-driving. Keep the customer's
 | ✅ Do                                              | ❌ Don't                                                      |
 | ------------------------------------------------- | ------------------------------------------------------------ |
 | "You've been quiet for a bit. Here's what's new." | "We noticed you haven't engaged with our platform recently and wanted to reach out." |
-
-### Social Media  
-
-| ✅ Do | ❌ Don't |
-| --- | --- |
-| We have a million products and never talk about most of them, so here's a full list | PostHog has more than two dozen varied products for your needs. They are: |
-| Introducing PostHog Code, the product editor that:<br/>• Understands your product<br/>• Identifies usage patterns<br/>• Triages bugs and errors for you<br/>• Creates PRs to fix them<br/>• Continuously monitors and improves your product | Introducing PostHog Code, the product editor that: understands your product, identifies usage patterns, triages bugs and errors for you, creates PRs to fix them, and continuously monitors and improves your product. |
-| Fable 5's in PostHog Code (again) | We're proud to announce that Fable 5 is now available in PostHog Code. Happy coding! |
-| (reply) this is incredible | (reply) Nice work! We love it! 😁|

--- a/contents/handbook/content/index.md
+++ b/contents/handbook/content/index.md
@@ -41,7 +41,7 @@ It should be the same as [who we are building for](/handbook/who-we-are-building
 
 ## What kind of content do we produce?
 
-1. **Opinionated advice:** Articles where we offer a strong point of view on a topic that impacts our audience. Examples include [The Product-Market Fit Game](/founders/product-market-fit-game), [Burning money on paid ads for a dev tool](/founders/dev-marketing-paid-ads), and [How to design your company for speed](https://newsletter.posthog.com/p/how-to-design-your-company-for-speed)
+1. **Opinionated advice:** Articles where we offer a strong point of view on a topic that impacts our audience. Examples include [The Product-Market Fit Game](/founders/product-market-fit-game), [Burning money on paid ads for a dev tool](/founders/dev-marketing-paid-ads), and [How to design your company for speed](https://newsletter.posthog.com/p/how-to-design-your-company-for-speed) 
 
 2. **High intent SEO comparisons:** Articles for people actively considering PostHog, or searching for a product like ours. Examples include comparisons between [PostHog and competing products](/blog/tags/comparisons), guides on the [best alternatives to popular tools](/blog/best-heap-alternatives), and guides to [most popular tools in our segments](/blog/best-open-source-ab-testing-tools).
 
@@ -80,11 +80,13 @@ Follow our [SEO best practices guide](/handbook/content/seo-guide) for more on s
 
 ### 2. LinkedIn
 
-Share a post using either your own account or the company account, but note that the company account will have dramatically less reach than your personal one. If you feel something needs to go out on the company account, (tag <TeamMember name="Liam Graham" />) in `#team-editorial`.
+Share a post using either your own account or the company account, but note that the company account will have dramatically less reach than your personal one. To post using the company account, use [Buffer](https://buffer.com/) (ask <TeamMember name="Andy Vandervell" /> to add you to it if you don't have access).
 
 See our [LinkedIn posting advice](/handbook/content/linkedin) for more.
 
 ### 3. Twitter / X
+
+Again, use Buffer to post from the company account.
 
 Tips for writing a good post:
 
@@ -96,7 +98,7 @@ Tips for writing a good post:
 
 ### 4. Share internally
 
-Internal teams, especially sales, CS, and the relevant product team, can often make use of the content you write if they know about it. They can share it with customers and use the ideas and examples in their conversations.
+Internal teams, especially sales, CS, and the relevant product team, can often make use of the content you write if they know about it. They can share it with customers and use the ideas and examples in their conversations. 
 
 It's worth sharing in their Slack channels directly as they don't see everything we publish. Asking them to smash the like button, subscribe, and share with their friends and family is a good tactic too.
 

--- a/contents/handbook/content/linkedin.md
+++ b/contents/handbook/content/linkedin.md
@@ -4,9 +4,9 @@ sidebar: Handbook
 showTitle: true
 ---
 
-LinkedIn is the OG slop center, but it’s a popular channel with our ICP, important for recruiting, and our posts often do well there. Here's a few best practices to have your posts seen more on the platform.
+Yes, I realize LinkedIn has a bad reputation, but it’s a popular channel with our ICP, important for recruiting, and our posts often do well there. We're posting more there, so here's what we've learned about doing it well so far.
 
-## Advice on LinkedIn posting
+## Advice on LinkedInposting
 
 - The hook is everything. Get people to click “show more.” What works:
   - **Money** - “We spend $X and here are the best things we learned”
@@ -15,7 +15,7 @@ LinkedIn is the OG slop center, but it’s a popular channel with our ICP, impor
   - **Transformation stories, before and after** - “This product helped us go from X to Y”
   - **Data reveals** - “PostHog has seen an ~8x increase in traffic from ChatGPT in the last year”
   - **Resource lists** - “Here are the 10 best posts on X”
-  - **Takeaways** - “After weeks of researching X, I’ve published Y deepdive. Here are Z interesting things I learned along the way.”
+  - **Takeaways** - “After weeks of researching X, I’ve published Y deepdive. Here are Z interesting things I learned a long the way.”
   - **Work** - “I wrote a 2000-word long article on how AI impacts performance of software and systems.”
 - Use lists and numbers.
 
@@ -33,13 +33,11 @@ LinkedIn is the OG slop center, but it’s a popular channel with our ICP, impor
 
 - Commenting on popular posts works, comments can get 30k+ impressions.
 
-- Posting time doesn’t matter to going viral, however it's good practice to post between Monday-Thursday and within 1 hour of standard working hours wherever most of your connections are based.
+- Posting time doesn’t matter to going viral.
 
 - Posting daily beats 1-2x/week “perfect” posts. A lot won’t hit, but this will more than pay off for the ones that do.
 
 - If you are posting a changelog update, you can create nice images when clicking **Add entry** in the [changelog](/changelog). It's under the **Social sharing** header.
-
-- Once you've posted, throw a link into `#shitposters-unite`, and your fellow PostHog employees will shower your post with reactions, giving you a dopamine boost and helping it reach a wider audience.
 
 > Thank you to <TeamMember name="Lucas Faria" photo /> for many of these tips.
 

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -4,16 +4,16 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> **Have something you want to announce?** Let the Marketing team know! If it's an iterative update, you can also demo it in the all-hands, or post in the #tell-posthog-anything Slack channel.
+> **Have something you want to announce?** Let the Marketing team know! If it's an iterative update, you can also demo it in the all-hands, or post in the #tell-posthog-anything Slack channel. 
 
-Product marketers take responsibility for coordinating and publicizing news about PostHog, including product announcements. We also help with [incident](/handbook/engineering/operations/incidents) and [maintenance announcements](/handbook/marketing/product-announcements#announcing-scheduled-maintenance), if needed.
+Product marketers take responsibility for coordinating and publicizing news about PostHog, including product announcements. We also help with [incident](/handbook/engineering/operations/incidents) and [maintenance announcements](/handbook/marketing/product-announcements#announcing-scheduled-maintenance), if needed. 
 
 ## Types of announcement
 
 We classify announcements using the general guidelines below, with full discretion for doing something different.
 
 ### Minor announcements
-Minor announcements involve changes which have no noticeable impact on the experience of most users. They can involve small visual changes, such as UI tweaks, but are more often small bug fixes or back-end changes. They do not require action from users and pose no known risk.
+Minor announcements involve changes which have no noticeable impact on the experience of most users. They can involve small visual changes, such as UI tweaks, but are more often small bug fixes or back-end changes. They do not require action from users and pose no known risk. 
 
 We may typically support minor announcements by:
 
@@ -41,7 +41,7 @@ We might do anything and everything for a major announcement.
 Examples of major announcements include [the surveys beta](/changelog?id=1945) or [the analytics pricing change](/changelog?id=1907).
 
 ### New product announcements
-New product launches are major announcements. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/meta/issues/new/choose). Product marketers should always create a launch plan for new product announcements.
+New product launches are major announcements. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/meta/issues/new/choose). Product marketers should always create a launch plan for new product announcements. 
 
 For new product announcements we generally apply the following best practices:
 
@@ -60,30 +60,30 @@ Comms should also be aware of [the engineering best practices for product launch
 If the product is moving from free beta to paid general availability (GA) you might also want to choose a reward for beta users. Examples of this include giving PostHog AI beta users 30 extra days of unlimited free usage, or giving Workflows beta users a discount code for merch.
 
 ### PR announcements
-We do not typically do public relations for anything other than company-level news. We have separate [processes and guides for managing press announcements](/handbook/marketing/press).
+We do not typically do public relations for anything other than company-level news. We have separate [processes and guides for managing press announcements](/handbook/marketing/press). 
 
 ## Maintenance communications
 
-Occasionally, we have to conduct scheduled maintenance. When this happens, it's important that we tell users about it in advance if they would experience any disruption.
+Occasionally, we have to conduct scheduled maintenance. When this happens, it's important that we tell users about it in advance if they would experience any disruption. 
 
-> If you're aware of any upcoming maintenance which would cause disruption, please inform the Support, Marketing, and Customer Success teams as soon as possible. Marketing will ensure that users are notified as the work is planned and completed. Customer Success may wish to inform specific users at the time.
+> If you're aware of any upcoming maintenance which would cause disruption, please inform the Support, Marketing, and Customer Success teams as soon as possible. Marketing will ensure that users are notified as the work is planned and completed. Customer Success may wish to inform specific users at the time. 
 
-Typically, Product Marketers take responsibility for informing users about maintenance work beforehand by telling users who will be impacted through email and other channels.
+Typically, Product Marketers take responsibility for informing users about maintenance work beforehand by telling users who will be impacted through email and other channels. 
 
 When informing users about maintenance, it is important to answer all of the following points:
 
 - When will the maintenance occur?
 - How long will it take?
-- Who will be impacted?
+- Who will be impacted? 
 - Will any data be lost?
 - Do users need to take any sort of action?
 - How will feature flags and experiments be impacted?
 - What will the impact be? Will insights, etc., still function?
 - Why is the maintenance being done, and what benefit will there be for users?
 
-We typically notify users of upcoming maintenance by email, so the Marketing team will need a way to target the correct users before they can update them. For smaller maintenance updates which will not cause any user updates, engineering teams can also update our status page.
+We typically notify users of upcoming maintenance by email, so the Marketing team will need a way to target the correct users before they can update them. For smaller maintenance updates which will not cause any user updates, engineering teams can also update our status page. 
 
 ## Incidents communications
 
-When an [incident is declared](/handbook/engineering/operations/incidents) the Brand team should join the incident channel as observers, and monitor to make sure that customer comms are handled correctly.
+When an [incident is declared](/handbook/engineering/operations/incidents) the Brand team should join the incident channel as observers, and monitor to make sure that customer comms are handled correctly. 
 


### PR DESCRIPTION
Reverts #18144.

This restores the handbook LinkedIn, content, brand (in-practice & tone), and product announcements pages to their state before that PR was merged.

Reverted commit: f147e2882d4f5527489233f02dbcd2174bef53df

🤖 Generated with [Claude Code](https://claude.com/claude-code)