### PR TITLE
Fix typo in actions.mdx from 'analzying' to 'analyzing'

### DIFF
--- a/contents/docs/data/actions.mdx
+++ b/contents/docs/data/actions.mdx
@@ -24,7 +24,7 @@ You can also use actions to "rename" events by creating an action based on a sin
 
 ## How are actions useful?
 
-Actions are great for analzying related events as if they were one.
+Actions are great for analyzing related events as if they were one.
 
 At PostHog, for example, we track custom events like `insight created`, `insight analyzed`, and `dashboard created`. These are all different ways to interacting with product analytics.
 


### PR DESCRIPTION
## Changes

Simple typo fix

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
