### PR TITLE
Clarify the onboarding buddy role in the handbook

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -42,8 +42,8 @@ Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner w
 -   You will remain the new joiner's main point of contact for the first few weeks, so please continue to check in with them at least once a week for the first month or so.
 -   As onboarding buddy, you are responsible for making sure the onboarding is fun and effective, so you should make sure there's a clear plan for work _and_ social time. Great in-person onboarding is crucial for getting someone started at PostHog.
     -   The plan doesn't need to be minute-by-minute, but do have a rough shape for the days you're together so the new joiner isn't left wondering what's next once the initial intro conversations are done. A little structure goes a long way, and still leaves plenty of room to explore and learn by doing.
--   Point the new joiner to the [handbook](/handbook) early and talk through why it matters — it's how we default to sharing context at PostHog, and knowing their way around it is one of the most useful things they can pick up in week one.
--   **Not run an onboarding before?** That's completely fine — ask the People & Ops team or your team lead to pair you with someone who's done it before to support _you_. It's much easier to give someone a great start when you're not figuring out what "great" looks like at the same time.
+-   Point the new joiner to the [handbook](/handbook) early and talk through why it matters – it's how we default to sharing context at PostHog, and knowing their way around it is one of the most useful things they can pick up in week one.
+-   **Not run an onboarding before?** That's completely fine – ask the People & Ops team or your team lead to pair you with someone who's done it before to support _you_. It's much easier to give someone a great start when you're not figuring out what "great" looks like at the same time.
 
 ## In-person onboarding
 

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -41,6 +41,9 @@ Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner w
     -   Make sure to add the details of the in-person onboarding to the [In-person Onboarding Calendar](https://calendar.google.com/calendar/u/0?cid=Y19lMzdjNjE0NzM0NDAyOGJlY2ZkMTc0Y2MxZjUxZjY5ZTkxMzY0NzVlNTFjMTE3MjA4OGM2NWQwNjE1YTczNmRlQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) so that other PostHog team members can join, if possible. Simply create an event in your calendar and then invite the in-person onboarding calendar as a guest.
 -   You will remain the new joiner's main point of contact for the first few weeks, so please continue to check in with them at least once a week for the first month or so.
 -   As onboarding buddy, you are responsible for making sure the onboarding is fun and effective, so you should make sure there's a clear plan for work _and_ social time. Great in-person onboarding is crucial for getting someone started at PostHog.
+    -   The plan doesn't need to be minute-by-minute, but do have a rough shape for the days you're together so the new joiner isn't left wondering what's next once the initial intro conversations are done. A little structure goes a long way, and still leaves plenty of room to explore and learn by doing.
+-   Point the new joiner to the [handbook](/handbook) early and talk through why it matters — it's how we default to sharing context at PostHog, and knowing their way around it is one of the most useful things they can pick up in week one.
+-   **Not run an onboarding before?** That's completely fine — ask the People & Ops team or your team lead to pair you with someone who's done it before to support _you_. It's much easier to give someone a great start when you're not figuring out what "great" looks like at the same time.
 
 ## In-person onboarding
 


### PR DESCRIPTION
## Changes

Expands the "Guidance for onboarding buddies" section of the onboarding handbook page:

- Sets the expectation of a rough plan for the in-person days, so the new joiner isn't left wondering what's next after intro conversations (while still leaving room to learn by doing).
- Adds a nudge to introduce the new joiner to the handbook early and explain why it matters.
- Adds a note that first-time onboarders can ask People & Ops or their team lead to pair them with someone experienced to support *them*.

**Why:** Feedback from a recent onboarding surfaced that buddies — especially first-time ones — would benefit from clearer guidance on planning and their role. Discussed in [this Slack thread](https://posthog.slack.com/archives/C0BBEA0Q49X/p1783088091367499?thread_ts=1783088091.367499&cid=C0BBEA0Q49X).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BBEA0Q49X/p1783088091367499?thread_ts=1783088091.367499&cid=C0BBEA0Q49X)*
