### PR TITLE
feat(pricing): managed data warehouse pricing (tiles, calculator, worker configurator)

### DIFF
--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -13,6 +13,7 @@ import Link from 'components/Link'
 import { IconInfo } from '@posthog/icons'
 import { formatUSD } from '../PricingSlider/pricingSliderLogic'
 import pluralizeWord from 'pluralize'
+import { COMPUTE_RAM_DIVISOR, HOURS_PER_MONTH } from '../../../constants/pricing'
 
 // Don't pluralize all-uppercase units like GB, MB, TB
 const pluralizeUnit = (unit: string, count: number): string => {
@@ -104,6 +105,41 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
         set_tiers(plans[plans.length - 1]?.tiers)
     }, [plans])
 
+    // Managed data warehouse storage arrives from the API in its real billed unit — GB-hours, with a
+    // per-GB-hour rate. Boundaries/usage stay in GB-hours, but the per-GB-hour $ is tiny, so on the
+    // STATIC table the RATE column shows the readable $/GB-month equivalent (× 744 h/mo) and the free
+    // tier is a level shown as "100 GB". The calculator breakdown (showSubtotal) deliberately keeps
+    // the raw per-GB-hour rate so each row's rate × units = its subtotal reconciles — and the footnote
+    // (rendered in BOTH, keyed on isStorageProduct) ties per-GB-hour back to the $/GB-month table.
+    const isStorageProduct = type === 'managed_data_warehouse_storage'
+    const isStorage = isStorageProduct && !showSubtotal
+    const displayTiers =
+        isStorage && tiers
+            ? tiers.map((tier) => ({
+                  ...tier,
+                  // per-GB-hour rate → readable $/GB-month; round to 4 dp to drop float noise.
+                  unit_amount_usd: (
+                      Math.round(parseFloat(tier.unit_amount_usd) * HOURS_PER_MONTH * 1e4) / 1e4
+                  ).toString(),
+              }))
+            : tiers
+    const rowUnit = unit
+    const rateUnit = isStorage ? 'GB-month' : unit
+    // GB level of the free allocation ($0 tier's GB-hour boundary ÷ 744) for the free-row label.
+    const freeAllocationGb =
+        isStorage && tiers
+            ? Math.round((tiers.find((tier) => parseFloat(tier.unit_amount_usd) === 0)?.up_to ?? 0) / HOURS_PER_MONTH)
+            : null
+    const isComputeProduct = type === 'managed_data_warehouse' || type === 'managed_data_warehouse_endpoints'
+    // MDW compute is a clean per-hour $ (e.g. $0.20), so show ≥2 decimals — it reads like money and
+    // matches the "From $X" header. Scoped to compute so other products' rate precision is untouched;
+    // only pads, never truncates a finer rate.
+    const minRateDecimals = isComputeProduct ? 2 : 0
+    const maxRateDecimals = Math.max(
+        minRateDecimals,
+        ...(displayTiers || []).map((tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0)
+    )
+
     return (
         <>
             {showSubtotal && (
@@ -114,7 +150,8 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                     <h4 className="m-0 col-span-2 text-base text-right">Subtotal</h4>
                 </Row>
             )}
-            {tiers.map(({ up_to, unit_amount_usd, eventsInThisTier, tierCost }, index) => {
+            {displayTiers.map(({ up_to, unit_amount_usd, eventsInThisTier, tierCost }, index) => {
+                const isFreeStorageTier = isStorage && parseFloat(unit_amount_usd) === 0
                 return compact && parseFloat(unit_amount_usd) <= 0 ? null : (
                     <Row
                         className={`!py-1 ${compact ? '!px-0 !space-x-0' : ''} ${
@@ -125,16 +162,27 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                         <Title
                             className={`${compact ? 'text-sm' : ''} ${showSubtotal ? 'col-span-3' : 'flex-grow'}`}
                             title={
-                                index === 0 && up_to
-                                    ? `First ${formatCompactNumber(up_to)} ${pluralizeUnit(unit, up_to)}`
+                                isFreeStorageTier
+                                    ? `Up to ${formatCompactNumber(freeAllocationGb)} GB`
+                                    : isStorage
+                                    ? // storage: anchor the GB-hours unit on every paid row (the free row
+                                      // above is shown in GB, so ranges can't inherit the unit implicitly)
+                                      up_to
+                                        ? `${formatCompactNumber(displayTiers[index - 1]?.up_to)}–${formatCompactNumber(
+                                              up_to
+                                          )} ${pluralizeUnit(rowUnit, up_to)}`
+                                        : `${formatCompactNumber(displayTiers[index - 1]?.up_to)}+ ${pluralizeUnit(
+                                              rowUnit,
+                                              2
+                                          )}`
+                                    : index === 0 && up_to
+                                    ? `First ${formatCompactNumber(up_to)} ${pluralizeUnit(rowUnit, up_to)}`
                                     : index === 0 && !up_to
-                                    ? `Unlimited ${pluralizeUnit(unit, 2)}`
+                                    ? `Unlimited ${pluralizeUnit(rowUnit, 2)}`
                                     : !up_to
-                                    ? `${formatCompactNumber(plans[plans.length - 1].tiers[index - 1]?.up_to)}+`
+                                    ? `${formatCompactNumber(displayTiers[index - 1]?.up_to)}+`
                                     : `${
-                                          formatCompactNumber(plans[plans.length - 1].tiers[index - 1]?.up_to).split(
-                                              / |k/
-                                          )[0]
+                                          formatCompactNumber(displayTiers[index - 1]?.up_to).split(/ |k/)[0]
                                       }-${formatCompactNumber(up_to)}`
                             }
                         />
@@ -148,7 +196,7 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                             <Title
                                 className={`${compact ? 'text-sm' : ''}`}
                                 title={
-                                    plans[0].free_allocation === up_to ? (
+                                    isFreeStorageTier || plans[0].free_allocation === up_to ? (
                                         <strong>Free</strong>
                                     ) : type === 'product_analytics' && index === tiers.length - 1 ? (
                                         // last row
@@ -186,17 +234,36 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                                         </div>
                                     ) : (
                                         <>
-                                            <strong>
-                                                $
-                                                {parseFloat(unit_amount_usd).toFixed(
-                                                    Math.max(
-                                                        ...plans[plans.length - 1].tiers.map(
-                                                            (tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0
+                                            <strong>${parseFloat(unit_amount_usd).toFixed(maxRateDecimals)}</strong>/
+                                            {rateUnit}
+                                            {isComputeProduct && (
+                                                <Tooltip
+                                                    content={() => {
+                                                        // Derive from the live tier rate so a price change can't
+                                                        // make the tooltip contradict the cell next to it.
+                                                        const rate = parseFloat(unit_amount_usd)
+                                                        const defaultWorkerUnits = 8 + 16 / COMPUTE_RAM_DIVISOR
+                                                        return (
+                                                            <div>
+                                                                A compute-hour is a normalized usage unit. In worker
+                                                                terms it's{' '}
+                                                                <strong>
+                                                                    ${rate.toFixed(2)}/vCPU-hour + $
+                                                                    {(rate / COMPUTE_RAM_DIVISOR).toFixed(3)}/GB-hour
+                                                                </strong>{' '}
+                                                                — so a default 8 vCPU / 16 GB worker is about{' '}
+                                                                <strong>
+                                                                    ${(rate * defaultWorkerUnits).toFixed(2)}/hour
+                                                                </strong>{' '}
+                                                                while connected.
+                                                            </div>
                                                         )
-                                                    )
-                                                )}
-                                            </strong>
-                                            /{unit}
+                                                    }}
+                                                    contentContainerClassName="max-w-xs"
+                                                >
+                                                    <IconInfo className="w-3 h-3 ml-1 opacity-50 inline-block relative -top-px" />
+                                                </Tooltip>
+                                            )}
                                         </>
                                     )
                                 }
@@ -227,6 +294,19 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                     </Row>
                 )
             })}
+            {isStorageProduct && !compact && (
+                <Row className="!py-1">
+                    <p className="m-0 text-sm opacity-70">
+                        Storage is billed per GB-hour. {HOURS_PER_MONTH} GB-hours ≈ 1 GB held for a full month
+                        {freeAllocationGb
+                            ? `, so the ${formatCompactNumber(freeAllocationGb)} GB free tier = ${(
+                                  freeAllocationGb * HOURS_PER_MONTH
+                              ).toLocaleString()} GB-hours`
+                            : ''}
+                        .
+                    </p>
+                </Row>
+            )}
         </>
     )
 }

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -135,9 +135,14 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
     // matches the "From $X" header. Scoped to compute so other products' rate precision is untouched;
     // only pads, never truncates a finer rate.
     const minRateDecimals = isComputeProduct ? 2 : 0
-    const maxRateDecimals = Math.max(
-        minRateDecimals,
-        ...(displayTiers || []).map((tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0)
+    // Cap compute at 4 dp as float-noise defense (an upstream rate like 0.20000016 must render
+    // $0.20, not all 8 decimals) — same treatment the storage rate gets above.
+    const maxRateDecimals = Math.min(
+        isComputeProduct ? 4 : Number.POSITIVE_INFINITY,
+        Math.max(
+            minRateDecimals,
+            ...(displayTiers || []).map((tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0)
+        )
     )
 
     return (
@@ -236,7 +241,7 @@ export const PricingTiers = ({ plans, unit, compact = false, type, test = false,
                                         <>
                                             <strong>${parseFloat(unit_amount_usd).toFixed(maxRateDecimals)}</strong>/
                                             {rateUnit}
-                                            {isComputeProduct && (
+                                            {isComputeProduct && parseFloat(unit_amount_usd) > 0 && (
                                                 <Tooltip
                                                     content={() => {
                                                         // Derive from the live tier rate so a price change can't

--- a/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
@@ -6,6 +6,7 @@ import { PricingTiers } from '../../Plans'
 import { NumericFormat } from 'react-number-format'
 import AutosizeInput from 'react-input-autosize'
 import pluralizeWord from 'pluralize'
+import { COMPUTE_RAM_DIVISOR, HOURS_PER_MONTH } from '../../../../constants/pricing'
 
 const TriggerEventsModal = ({ onClose, isVisible }) => {
     return (
@@ -52,6 +53,7 @@ const SliderRow = ({
     billingTiers,
     freeAllocation,
     freeAllocationText,
+    volumeAnnotation,
 }) => {
     const [currentVolume, setCurrentVolume] = useState(volume)
 
@@ -77,7 +79,7 @@ const SliderRow = ({
             <div className="col-span-6">
                 <p className="mb-2">
                     <NumericFormat
-                        inputClassName="bg-transparent text-center focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark font-code max-w-[103px] text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-0 min-w-[25px] px-1"
+                        inputClassName={numericInputClassName}
                         value={currentVolume}
                         thousandSeparator=","
                         onValueChange={({ floatValue }) => handleVolumeChange(floatValue)}
@@ -85,6 +87,11 @@ const SliderRow = ({
                     />{' '}
                     <span className="opacity-70 text-sm">{label}s/month</span>
                 </p>
+                {volumeAnnotation && (
+                    <p className="mb-2 -mt-1 text-sm text-primary/60 dark:text-primary-dark/60">
+                        {volumeAnnotation(currentVolume)}
+                    </p>
+                )}
             </div>
             <div className="col-span-2 text-right pr-3">
                 <p className="font-semibold mb-0">{formatUSD(cost)}</p>
@@ -112,6 +119,156 @@ const SliderRow = ({
                                 <em>every month!</em>
                             </>
                         )}
+                    </span>
+                </div>
+            )}
+        </div>
+    )
+}
+
+// Shared styling for the calculator's numeric inputs (slider rows + worker configurator).
+const numericInputClassName =
+    'bg-transparent text-center focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark font-code max-w-[103px] text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-0 min-w-[25px] px-1'
+
+// Fallbacks if a product config omits fields — one merge, not per-field `??`s scattered below.
+// managed_data_warehouse.tsx's computeConfigurator is the authoritative source for MDW.
+const COMPUTE_CONFIGURATOR_DEFAULTS = {
+    ramDivisor: COMPUTE_RAM_DIVISOR,
+    presets: [] as { vcpu: number; memory: number }[],
+    defaultVcpu: 8,
+    defaultMemory: 16,
+    defaultHours: 100,
+    maxVcpu: 96,
+    maxMemory: 384,
+    hoursMarks: [1, 24, 168, HOURS_PER_MONTH],
+    maxHours: HOURS_PER_MONTH,
+}
+
+// Compute isn't a single slider: cost = the worker you run (vCPU + memory) × how long. This lets you
+// pick/size a worker + hours, derives compute-hours = (vCPU + memory/ramDivisor) × hours, and prices
+// them with the same billing tiers as everything else — so the rate + free tier come from billing.
+const WorkerConfigurator = ({ config: configProp, billingTiers, setVolume, persistedState, onStateChange }) => {
+    const config = { ...COMPUTE_CONFIGURATOR_DEFAULTS, ...configProp }
+    const ramDivisor = config.ramDivisor
+    // Seed from the state persisted on the product: the calculator remounts this component on every
+    // tab switch (TabContent is keyed by product type), and without restoring the inputs the mount
+    // effect below would reset the user's worker back to the defaults.
+    const [vcpu, setVcpu] = useState(persistedState?.vcpu ?? config.defaultVcpu)
+    const [memory, setMemory] = useState(persistedState?.memory ?? config.defaultMemory)
+    const [hours, setHours] = useState(persistedState?.hours ?? config.defaultHours)
+
+    useEffect(() => {
+        onStateChange?.({ vcpu, memory, hours })
+    }, [vcpu, memory, hours])
+
+    // $/compute-hour from the live billing tiers (first paid tier) — single source of truth for the
+    // rate, so the worker $/hr and the cost can't drift from what billing charges.
+    const perUnitRate = useMemo(() => {
+        const paid = (billingTiers || []).find((t) => parseFloat(t.unit_amount_usd) > 0)
+        return paid ? parseFloat(paid.unit_amount_usd) : 0
+    }, [billingTiers])
+    const freeUnits = useMemo(() => {
+        const free = (billingTiers || []).find((t) => parseFloat(t.unit_amount_usd) === 0)
+        return free?.up_to ?? 0
+    }, [billingTiers])
+
+    const computeUnits = (vcpu || 0) + (memory || 0) / ramDivisor // compute-hours per connected hour
+    const workerRatePerHour = computeUnits * perUnitRate
+    const monthlyComputeHours = Math.round(computeUnits * (hours || 0))
+    const cost = billingTiers ? calculatePrice(monthlyComputeHours, billingTiers).total : 0
+
+    useEffect(() => {
+        if (billingTiers) {
+            setVolume(monthlyComputeHours, cost)
+        }
+    }, [monthlyComputeHours, billingTiers])
+
+    const isPreset = (p) => p.vcpu === vcpu && p.memory === memory
+
+    return (
+        <div className="mb-2">
+            <div className="flex flex-wrap gap-2 mb-3">
+                {config.presets?.map((p) => (
+                    <button
+                        key={`${p.vcpu}-${p.memory}`}
+                        onClick={() => {
+                            setVcpu(p.vcpu)
+                            setMemory(p.memory)
+                        }}
+                        className={`text-sm px-3 py-1 rounded-sm border ${
+                            isPreset(p)
+                                ? 'border-red dark:border-yellow bg-red/10 dark:bg-yellow/10 font-semibold'
+                                : 'border-light dark:border-dark hover:border-button'
+                        }`}
+                    >
+                        {p.vcpu} vCPU · {p.memory} GB
+                    </button>
+                ))}
+            </div>
+
+            <div className="grid grid-cols-8 gap-2 items-end mb-1">
+                <div className="col-span-3">
+                    <label className="text-sm opacity-70 block mb-1">vCPU</label>
+                    <NumericFormat
+                        inputClassName={numericInputClassName}
+                        value={vcpu}
+                        allowNegative={false}
+                        thousandSeparator=","
+                        onValueChange={({ floatValue }) => setVcpu(Math.min(config.maxVcpu, floatValue || 0))}
+                        customInput={AutosizeInput}
+                    />
+                </div>
+                <div className="col-span-3">
+                    <label className="text-sm opacity-70 block mb-1">Memory (GB)</label>
+                    <NumericFormat
+                        inputClassName={numericInputClassName}
+                        value={memory}
+                        allowNegative={false}
+                        thousandSeparator=","
+                        onValueChange={({ floatValue }) => setMemory(Math.min(config.maxMemory, floatValue || 0))}
+                        customInput={AutosizeInput}
+                    />
+                </div>
+                <div className="col-span-2 text-right pr-3">
+                    <p className="font-semibold mb-0">{formatUSD(cost)}</p>
+                    <p className="text-xs opacity-60 mb-0">/month</p>
+                </div>
+            </div>
+
+            <p className="mb-3 text-sm text-primary/60 dark:text-primary-dark/60">
+                Worker ≈ <strong>{formatUSD(workerRatePerHour)}/hour</strong> while connected →{' '}
+                {monthlyComputeHours.toLocaleString()} compute-hours/month
+            </p>
+
+            <div className="mb-2">
+                <p className="mb-2">
+                    <NumericFormat
+                        inputClassName={numericInputClassName}
+                        value={hours}
+                        allowNegative={false}
+                        thousandSeparator=","
+                        onValueChange={({ floatValue }) => setHours(Math.min(config.maxHours, floatValue || 0))}
+                        customInput={AutosizeInput}
+                    />{' '}
+                    <span className="opacity-70 text-sm">hours/month connected</span>
+                </p>
+                <div className="pr-1.5">
+                    <LogSlider
+                        stepsInRange={100}
+                        marks={config.hoursMarks}
+                        min={1}
+                        max={config.maxHours}
+                        onChange={(value) => setHours(Math.round(sliderCurve(value)))}
+                        value={inverseCurve(hours)}
+                    />
+                </div>
+            </div>
+
+            {freeUnits > 0 && (
+                <div className="pr-1.5 mt-10 md:mt-8 pb-4 flex gap-1 items-center">
+                    <IconLightBulb className="size-5 inline-block text-[#4f9032] dark:text-green relative -top-px" />
+                    <span className="text-sm text-[#4f9032] dark:text-green font-semibold">
+                        First {Math.round(freeUnits).toLocaleString()} compute-hours free every month.
                     </span>
                 </div>
             )}
@@ -217,17 +374,27 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                 <h4 className="mb-3 text-base font-semibold">
                     {activeProduct.productVariantName || activeProduct.name}
                 </h4>
-                <SliderRow
-                    label={activeProduct.billingData.unit}
-                    sliderConfig={activeProduct.slider}
-                    volume={mainVolume}
-                    setVolume={handleMainVolumeChange}
-                    unit={activeProduct.billingData.unit}
-                    cost={mainCost}
-                    billingTiers={mainBillingTiers}
-                    freeAllocation={activeProduct.slider.min}
-                    freeAllocationText={activeProduct.freeAllocationText}
-                />
+                {activeProduct.computeConfigurator ? (
+                    <WorkerConfigurator
+                        config={activeProduct.computeConfigurator}
+                        billingTiers={mainBillingTiers}
+                        setVolume={handleMainVolumeChange}
+                        persistedState={activeProduct.configuratorState}
+                        onStateChange={(state) => setProduct(activeProduct.handle, { configuratorState: state })}
+                    />
+                ) : (
+                    <SliderRow
+                        label={activeProduct.billingData.unit}
+                        sliderConfig={activeProduct.slider}
+                        volume={mainVolume}
+                        setVolume={handleMainVolumeChange}
+                        unit={activeProduct.billingData.unit}
+                        cost={mainCost}
+                        billingTiers={mainBillingTiers}
+                        freeAllocation={activeProduct.slider.min}
+                        freeAllocationText={activeProduct.freeAllocationText}
+                    />
+                )}
             </div>
 
             {addonBillingData.map(
@@ -247,6 +414,7 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                                     addon.freeAllocation !== undefined ? addon.freeAllocation : addon.sliderConfig.min
                                 }
                                 freeAllocationText={addon.freeAllocationText}
+                                volumeAnnotation={addon.volumeAnnotation}
                             />
                         </div>
                     )

--- a/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
@@ -288,8 +288,10 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
 
     const [addonData, setAddonData] = useState(
         () =>
-            activeProduct.addonSliders?.map((addon) => ({
-                volume: addon.volume || 0,
+            activeProduct.addonSliders?.map((addon, index) => ({
+                // Prefer the persisted volume so addon sliders (e.g. storage) survive tab
+                // switches, like the worker configurator's persisted state.
+                volume: activeProduct.addonVolumes?.[index] ?? (addon.volume || 0),
                 cost: 0,
                 costByTier: [],
             })) || []
@@ -342,9 +344,10 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                 cost: totalCost,
                 volume: mainVolume,
                 costByTier,
+                addonVolumes: addonData.map((addon) => addon.volume),
             })
         }
-    }, [totalCost, mainVolume, mainBillingTiers, activeProduct.handle, setProduct])
+    }, [totalCost, mainVolume, mainBillingTiers, activeProduct.handle, setProduct, addonData])
 
     const handleMainVolumeChange = (volume, cost) => {
         setMainVolume(volume)

--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -67,6 +67,41 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
                 size={size}
             />
             <FreeTierItem
+                name="Managed data warehouse"
+                allocation="50 compute-hours (worth $10)"
+                icon={<Icons.IconServer className={`text-purple size-5 ${size === 'large' && 'size-7'}`} />}
+                size={size}
+            />
+            <FreeTierItem
+                name="Warehouse storage"
+                allocation={
+                    <>
+                        100 GB{' '}
+                        <Tooltip
+                            content={() => (
+                                <>
+                                    Up to 100 GB of stored data, free. Storage is a held level (billed on what you keep)
+                                    — it carries over and doesn't reset monthly.
+                                </>
+                            )}
+                            placement="top"
+                        >
+                            <Icons.IconInfo
+                                className={`size-3 inline-block relative -top-px ${size === 'large' && 'size-5'}`}
+                            />
+                        </Tooltip>
+                    </>
+                }
+                icon={<Icons.IconHardDrive className={`text-purple size-5 ${size === 'large' && 'size-7'}`} />}
+                size={size}
+            />
+            <FreeTierItem
+                name="Data warehouse endpoints"
+                allocation="50 compute-hours (worth $10)"
+                icon={<Icons.IconCode className={`text-purple size-5 ${size === 'large' && 'size-7'}`} />}
+                size={size}
+            />
+            <FreeTierItem
                 name="Data pipelines"
                 allocation={
                     <>

--- a/src/constants/addons.ts
+++ b/src/constants/addons.ts
@@ -1,1 +1,6 @@
-export const EXCLUDED_ADDON_TYPES = ['mobile_replay', 'data_pipelines', 'data_warehouse_historical']
+export const EXCLUDED_ADDON_TYPES = [
+    'mobile_replay',
+    'data_pipelines',
+    'data_warehouse_historical',
+    'managed_data_warehouse_storage',
+]

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -1,0 +1,12 @@
+// Shared pricing-math constants — single source for values that would otherwise drift between the
+// pricing page, the calculator, and product data.
+
+// Hours in the longest (31-day) month. Converts MDW storage's billed GB-hours to the "N GB held all
+// month" framing (100 GB free tier = 74,400 GB-hours) and $/GB-hour rates to $/GB-month.
+export const HOURS_PER_MONTH = 744
+
+// MDW compute's RAM weighting: 1 GB of RAM counts as 1/8 of a vCPU, so
+// compute-hours = (vCPU + RAM_GB / COMPUTE_RAM_DIVISOR) × connected hours, and the single
+// $/compute-hour rate decomposes to $rate/vCPU-hour + $(rate/8)/GB-hour.
+// Must match the metering producer — if the metering ratio changes, update here too.
+export const COMPUTE_RAM_DIVISOR = 8

--- a/src/hooks/productData/managed_data_warehouse.tsx
+++ b/src/hooks/productData/managed_data_warehouse.tsx
@@ -1,4 +1,4 @@
-import { IconDatabase } from '@posthog/icons'
+import { IconServer } from '@posthog/icons'
 
 import { COMPUTE_RAM_DIVISOR, HOURS_PER_MONTH } from '../../constants/pricing'
 
@@ -10,13 +10,14 @@ import { COMPUTE_RAM_DIVISOR, HOURS_PER_MONTH } from '../../constants/pricing'
 // calculator can resolve storage's tiers (see useProducts.tsx).
 export const managedDataWarehouse = {
     name: 'Managed data warehouse',
-    Icon: IconDatabase,
+    Icon: IconServer,
     type: 'managed_data_warehouse',
     handle: 'managed_data_warehouse',
     slug: 'managed-data-warehouse',
     color: 'purple',
     colorSecondary: 'lilac',
-    category: 'data',
+    // category: not set on purpose — hides the entry from navigation and /products until a
+    // real product page exists (same convention as realtime_destinations).
     status: 'beta',
     includeAddonRates: true,
     categoryName: 'Managed data warehouse',

--- a/src/hooks/productData/managed_data_warehouse.tsx
+++ b/src/hooks/productData/managed_data_warehouse.tsx
@@ -1,0 +1,70 @@
+import { IconDatabase } from '@posthog/icons'
+
+import { COMPUTE_RAM_DIVISOR, HOURS_PER_MONTH } from '../../constants/pricing'
+
+// Managed Data Warehouse (MDW) pricing entry.
+//
+// Billed as TWO products (compute + storage) so each can have its own limit, but presented
+// as ONE product here: compute is the main slider, storage is an addon-slider. `useProducts`
+// nests the storage billing product into this product's `billingData.addons` so the
+// calculator can resolve storage's tiers (see useProducts.tsx).
+export const managedDataWarehouse = {
+    name: 'Managed data warehouse',
+    Icon: IconDatabase,
+    type: 'managed_data_warehouse',
+    handle: 'managed_data_warehouse',
+    slug: 'managed-data-warehouse',
+    color: 'purple',
+    colorSecondary: 'lilac',
+    category: 'data',
+    status: 'beta',
+    includeAddonRates: true,
+    categoryName: 'Managed data warehouse',
+    productVariantName: 'Compute', // labels the main section in the calculator
+    // Compute isn't a single dimension: cost depends on the worker size (vCPU + memory) you run and
+    // for how long. So instead of one compute-hours slider, the calculator renders a worker
+    // configurator (see StandaloneAddonsTab). It derives compute-hours from the worker + hours and
+    // prices them with the same billing tiers, so the free tier + rate stay a single source of truth.
+    //   compute-hours = (vCPU + RAM_GB / ramDivisor) × hours
+    //   ramDivisor = 8: 1 GB = ⅛ of a vCPU, so $0.20/compute-hour decomposes to
+    //   $0.20/vCPU-hour + $0.025/GB-hour.
+    computeConfigurator: {
+        ramDivisor: COMPUTE_RAM_DIVISOR,
+        presets: [
+            { vcpu: 4, memory: 8 },
+            { vcpu: 8, memory: 16 }, // default
+            { vcpu: 20, memory: 40 },
+        ],
+        defaultVcpu: 8,
+        defaultMemory: 16,
+        defaultHours: 100,
+        maxVcpu: 96,
+        maxMemory: 384,
+        hoursMarks: [1, 24, 168, HOURS_PER_MONTH], // hour · day · week · full month
+        maxHours: HOURS_PER_MONTH,
+    },
+    // Initial value only — used for the first-render cost until WorkerConfigurator mounts and
+    // recomputes from its defaults (keep consistent with computeConfigurator's defaults:
+    // (defaultVcpu + defaultMemory/ramDivisor) × defaultHours).
+    volume: 1000,
+    addonSliders: [
+        {
+            key: 'managed_data_warehouse_storage',
+            label: 'Storage',
+            // Storage is billed per GB-hour, so the slider and its tiers are in GB-hours (matching
+            // billing). Marks are the GB levels 100 / 500 / 2k / 10k / 50k held all month (× 744).
+            // The volumeAnnotation translates the current GB-hour value back into a steady GB level.
+            sliderConfig: {
+                marks: [100, 500, 2000, 10000, 50000].map((gb) => gb * HOURS_PER_MONTH),
+                min: 100 * HOURS_PER_MONTH,
+                max: 50000 * HOURS_PER_MONTH,
+            },
+            volume: 100 * HOURS_PER_MONTH,
+            unit: 'GB-hour',
+            freeAllocationText:
+                'First 74,400 GB-hours free (≈ 100 GB held all month). Storage is billed per GB-hour on what you keep — it carries over and does not reset monthly.',
+            volumeAnnotation: (volume: number) =>
+                `≈ a steady ${Math.round(volume / HOURS_PER_MONTH).toLocaleString()} GB held over a full month`,
+        },
+    ],
+}

--- a/src/hooks/productData/managed_data_warehouse_endpoints.tsx
+++ b/src/hooks/productData/managed_data_warehouse_endpoints.tsx
@@ -1,0 +1,24 @@
+import { IconDatabase } from '@posthog/icons'
+
+// Standalone pricing entry for Managed Data Warehouse endpoints (its own product card, not
+// grouped under "Managed data warehouse").
+//
+// Billed at the same rate as managed warehouse compute; compute-seconds surfaced as
+// compute-hours. Pricing joins by `type` from /api/products-v2 at build time.
+export const managedDataWarehouseEndpoints = {
+    name: 'Data warehouse endpoints',
+    Icon: IconDatabase,
+    type: 'managed_data_warehouse_endpoints',
+    handle: 'managed_data_warehouse_endpoints',
+    slug: 'managed-data-warehouse-endpoints',
+    color: 'purple',
+    colorSecondary: 'lilac',
+    category: 'data',
+    status: 'beta',
+    slider: {
+        marks: [50, 250, 1000, 5000, 20000],
+        min: 50,
+        max: 20000,
+    },
+    volume: 50,
+}

--- a/src/hooks/productData/managed_data_warehouse_endpoints.tsx
+++ b/src/hooks/productData/managed_data_warehouse_endpoints.tsx
@@ -1,4 +1,4 @@
-import { IconDatabase } from '@posthog/icons'
+import { IconCode } from '@posthog/icons'
 
 // Standalone pricing entry for Managed Data Warehouse endpoints (its own product card, not
 // grouped under "Managed data warehouse").
@@ -7,13 +7,14 @@ import { IconDatabase } from '@posthog/icons'
 // compute-hours. Pricing joins by `type` from /api/products-v2 at build time.
 export const managedDataWarehouseEndpoints = {
     name: 'Data warehouse endpoints',
-    Icon: IconDatabase,
+    Icon: IconCode,
     type: 'managed_data_warehouse_endpoints',
     handle: 'managed_data_warehouse_endpoints',
     slug: 'managed-data-warehouse-endpoints',
     color: 'purple',
     colorSecondary: 'lilac',
-    category: 'data',
+    // category: not set on purpose — hides the entry from navigation and /products until a
+    // real product page exists (same convention as realtime_destinations).
     status: 'beta',
     slider: {
         marks: [50, 250, 1000, 5000, 20000],

--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -10,6 +10,8 @@ import { sessionReplay } from './productData/session_replay'
 import { featureFlags } from './productData/feature_flags'
 import { surveys } from './productData/surveys'
 import { dataWarehouse } from './productData/data_warehouse'
+import { managedDataWarehouse } from './productData/managed_data_warehouse'
+import { managedDataWarehouseEndpoints } from './productData/managed_data_warehouse_endpoints'
 import { errorTracking } from './productData/error_tracking'
 import { cdp } from './productData/cdp'
 import { webAnalytics } from './productData/web_analytics'
@@ -28,6 +30,8 @@ const initialProducts = [
     featureFlags,
     surveys,
     dataWarehouse,
+    managedDataWarehouse,
+    managedDataWarehouseEndpoints,
     realtimeDestinations,
     errorTracking,
     cdp,
@@ -54,9 +58,19 @@ export default function useProducts() {
             // the key the billing service uses via `billingType` (e.g. AI Observability
             // is still `llm_analytics` upstream); otherwise the handle is the key.
             const billingType = (product as { billingType?: string }).billingType || product.handle
-            const billingData =
+            let billingData =
                 product.billingData ||
                 billingProducts.find((billingProduct: any) => billingProduct.type === billingType)
+
+            // Managed Data Warehouse is two billing products (compute + storage) but presented as
+            // one. Nest the storage billing product into compute's addons so the calculator's
+            // addon-slider can resolve storage's tiers.
+            if (billingType === 'managed_data_warehouse' && billingData) {
+                const storageBilling = billingProducts.find((bp: any) => bp.type === 'managed_data_warehouse_storage')
+                if (storageBilling) {
+                    billingData = { ...billingData, addons: [...(billingData.addons || []), storageBilling] }
+                }
+            }
             const paidPlan = billingData?.plans.find((plan: any) => plan.tiers)
             const startsAt = paidPlan?.tiers?.find((tier: any) => tier.unit_amount_usd !== '0')?.unit_amount_usd
             const freeLimit = paidPlan?.tiers?.find((tier: any) => tier.unit_amount_usd === '0')?.up_to


### PR DESCRIPTION
MDW on the pricing page: free-tier grid entries, GB-hour storage tiers in the calculator, and a worker-shape configurator (vCPU/RAM/hours) whose state persists across tab switches. Rates and free tiers derive from the live billing tiers.

**Do not merge before launch** — this repo deploys straight to the public site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hSheSykRTkTsD9rz1pvfv