### PR TITLE
Update product assignments and add new products

### DIFF
--- a/contents/handbook/marketing/ownership.md
+++ b/contents/handbook/marketing/ownership.md
@@ -12,17 +12,16 @@ If you need help with the website, go to `#posthogdotcom`.
 
 We generally only have product marketers on teams that _already_ have a product manager. Products without a product manager a) are usually too early for marketing to get involved, and b) distract engineers as they need to spend time briefing the product marketer, vs. shipping more stuff. [Product managers](/handbook/product/product-manager-role) help teams figure out what to build and how much to charge for it, product marketers then help you get as many users as possible. 
 
-| Product | PM | PMM | Blitzscale |
-|---|---|---|---|
-| *Context warehouse* | Anna | Lizzie | Raquel |
-| *PostHog Code* | Annika | Cleo | James H |
-| *PostHog Slack* | Annika | Cleo | James H |
-| *Inbox* | Annika | Sara | James H |
-| *PostHog AI* | Annika | Joe | James H |
-| *MCP* | n/a | Joe | James |
-| *AI Gateway* | Marco | n/a | Ben W |
-| *Agents* | n/a | Danilo | Ben W |
-
+| Product             | PM     | PMM    | Blitzscale |
+| ------------------- | ------ | ------ | ---------- |
+| *Context warehouse* | Anna   | Lizzie | Raquel     |
+| *PostHog Desktop*   | Annika | Cleo   | James H    |
+| *PostHog Slack*     | Annika | Cleo   | James H    |
+| *PostHog Web*       | Annika | Sara   | James H    |
+| *PostHog Research*  | n/a    | Joe    | James H    |
+| *PostHog MCP*       | n/a    | Joe    | James      |
+| *AI Gateway*        | Marco  | n/a    | Ben W      |
+| *Agents*            | n/a    | Danilo | Ben W      |
 
 <details>
 <summary>I need a product marketer, but my team hasn't been assigned one</summary>


### PR DESCRIPTION
Clarifying some of the PMM ownership. 

PostHog Code as a product is likely to grow and include more in the future (Bluebird, for example).

PostHog Inbox and PostHog AI, meanwhile, were unclear. There's an Inbox in the Web app and Code, for example. And PostHog AI is like a whole big thing. 

Finally, we want to start being more bullish on the cool AI research stuff, which currently nobody owns. 

SO. 

PostHog Code is now PostHog Desktop (Cleo). 
Inbox is now PostHog Web (Sara). 
PostHog Research now exists (Joe). 

This should help clarify more of what we're already discussing: that PMMs own products (or surface areas) and should have total autonomy for marketing within each product, with no overlap.

This shouldn't change any of the work anyone is doing right now in the short term, with the exception of the PostHog AI launch I was planning and which I've discussed with Sara separately.


## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
