### PR TITLE
Update product team page: swap Query Performance for MCP Analytics under Mike Warren

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -70,8 +70,8 @@ Here is a overview that shows which of our PMs currently works with which team:
 <legend><TeamMember name="Mike Warren" photo /></legend>
 
 -   <SmallTeam slug="analytics-platform" />
+-   <SmallTeam slug="mcp-analytics" />
 -   <SmallTeam slug="product-analytics" />
--   <SmallTeam slug="query-performance" />
 -   <SmallTeam slug="web-analytics" />
 
 


### PR DESCRIPTION
## Changes

Updates the [product team page](https://posthog.com/handbook/product/product-team) so Mike Warren's small-team memberships reflect the recent team split:

- Removed the **Query Performance** team
- Added the **MCP Analytics** team

**Why:** The teams were reorganized and Mike is now supporting MCP Analytics rather than Query Performance.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1783342404559789?thread_ts=1783342404.559789&cid=C0B3E1Y576X)*