### PR TITLE
docs(web-analytics): add Q3 2026 objectives

### DIFF
--- a/contents/teams/web-analytics/objectives.mdx
+++ b/contents/teams/web-analytics/objectives.mdx
@@ -30,11 +30,13 @@ These are the primary goals the team is prioritizing this quarter.
 </details>
 
 <details>
-<summary>Make analytics self-driving + AEO and agent analytics – <TeamMember name="Lucas Ricoy" photo /></summary>
+<summary>Make web analytics self-driving – <TeamMember name="Lucas Ricoy" photo /></summary>
 
-- Ship subscribable digests for Marketing Analytics dashboards, so insight arrives on a schedule instead of being pulled
-- Automate campaign-investment suggestions via PostHog AI ("this campaign is outperforming – shift budget to it")
-- Capture non-JS AI crawlers for AEO / agent analytics – server-side `$http_log` ingestion is the current blocker
+Web analytics shouldn't wait to be asked – it should watch, explain, and act on its own:
+
+- Insight comes to you: what changed, why, and what to do about it, before anyone opens a dashboard (think subscribable digests, anomaly-driven signals)
+- Move from reporting to acting: PostHog AI suggests the next move, like shifting budget to an outperforming campaign
+- See every visitor, human or not: AEO / agent analytics for the AI crawlers that never run JavaScript (server-side `$http_log` ingestion is the current blocker)
 
 </details>
 

--- a/contents/teams/web-analytics/objectives.mdx
+++ b/contents/teams/web-analytics/objectives.mdx
@@ -3,29 +3,31 @@
 These are the primary goals the team is prioritizing this quarter.
 
 <details>
-<summary>Take Marketing Analytics from beta to GA – <TeamMember name="Javier Bahamondes" photo /></summary>
+<summary>Take Marketing Analytics to GA – <TeamMember name="Javier Bahamondes" photo /></summary>
 
-- Close the gaps blocking GA: reliability, attribution accuracy, and channel coverage
-- Polish onboarding and source setup so marketing teams can self-serve
-- Nail pricing and packaging for GA
-
-</details>
-
-<details>
-<summary>Launch Customer Analytics – <TeamMember name="Arthur Moreira de Deus" photo /></summary>
-
-- Ship a first version with opinionated default views: who your best accounts are and what they do
-- Connect it to the rest of PostHog – one click from a customer view to the underlying events, sessions, and replays
-- Validate with early customers and iterate toward a public beta
+- Rework the product based on last quarter's feedback and PMF investigation, and ship a new onboarding so setup is self-serve
+- Ship organic insights: Google Search Console keywords next to paid channels
+- Keep pushing performance down – the dashboard p95 went from ~23s to ~15s and still has a long way to go
+- Add MCP write tools so AI can propose fixes, source setup, and budget changes instead of only reading
 
 </details>
 
 <details>
-<summary>Ship achievements and a weekly recap – <TeamMember name="Jordan Mryyan" photo /></summary>
+<summary>Replace Vitally with Customer Analytics – <TeamMember name="Arthur Moreira de Deus" photo /></summary>
 
-- Ship achievements for meaningful site milestones (traffic records, conversion streaks, launch spikes)
-- Ship a weekly recap that summarizes what happened, what changed, and what's worth celebrating
-- Make both shareable so wins travel beyond the person watching the dashboard
+- Vitally is only meaningful because we pipe PostHog data into it and sync it back – cut the middleman and build what we're missing
+- Centralize customer communications (email, Slack, meeting notes) and make account modeling flexible with custom properties
+- Enable automations on top of customer accounts via Workflows, plus MCP skills to automate repetitive CS work
+- We're done when CS, onboarding, and sales run 100% on Customer Analytics and we cancel Vitally – October at the latest
+
+</details>
+
+<details>
+<summary>Get heatmaps out of beta and make it earn its keep – <TeamMember name="Jordan Mryyan" photo /></summary>
+
+- Heatmaps is free and barely kept alive today, yet it's one of the things users keep asking for
+- Define pricing and limits (which pages we record, snapshots and comparisons over time as paid features)
+- Work with the demand gen team to make content experiments self-driving with web analytics data
 
 </details>
 
@@ -34,19 +36,34 @@ These are the primary goals the team is prioritizing this quarter.
 
 Web analytics shouldn't wait to be asked – it should watch, explain, and act on its own:
 
-- Insight comes to you: what changed, why, and what to do about it, before anyone opens a dashboard (think subscribable digests, anomaly-driven signals)
-- Move from reporting to acting: PostHog AI suggests the next move, like shifting budget to an outperforming campaign
-- See every visitor, human or not: AEO / agent analytics for the AI crawlers that never run JavaScript (server-side `$http_log` ingestion is the current blocker)
+- Figure out what a self-driving website workflow really looks like – not just "more automations"
+- Make scouts great at web fundamentals (web vitals, bounce rate, UTM tracking) and emit signals that turn into concrete code changes
+- Fully release agent analytics and grow bot analytics toward $50k MRR, including AEO correlations between bot traffic and conversions – capturing non-JS AI crawlers is blocked on server-side `$http_log` ingestion
 
 </details>
 
+<details>
+<summary>Shared: fix the performance embarrassments</summary>
+
+- Release the precomputed improvements (3–30x speedups) to everyone
+- Bring down the Marketing Analytics dashboard p95 and the 3s+ accounts list load
+
+</details>
+
+### Stretch goals
+
+- Make web analytics digest emails traceable (views, CTR) – <TeamMember name="Jordan Mryyan" photo />
+- Add AI-driven insights to the digest – <TeamMember name="Jordan Mryyan" photo />
+
 ## Q2 2026 recap
 
-- Web analytics skills shipped so PostHog AI routes questions to the right insight types
-- Agent/bot analytics segmentation launched across web analytics, product analytics, and SQL
-- Marketing Analytics expanded beyond paid ads with new channels
-- Live view improvements shipped; heatmaps reliability work ongoing
-- Activation investigation kicked off to understand the metric decline
+- Activation: reversed the decline in Web Analytics activation
+- Signals, Skills & MCP: Marketing Analytics AI and MCP integration shipped, but read-only and lightly used so far
+- Agent and bot analytics: building blocks and docs merged, working everywhere HogQL works (12 teams and ~15M events over 21 days organically) – full release pending
+- Marketing Analytics: PMF investigation nearly wrapped, performance improved (p95 ~23s to ~15s), drill-down navigation shipped (channels to sources to campaigns, UTM and ad group breakdowns)
+- Precomputed improvements ready to release to everyone (3–30x speedups)
+- Arthur joined the team to lead the Customer Analytics / Vitally replacement effort
+- Virtual HogQL properties and Google Search Console integration shipped
 
 ## Q1 2026 recap
 

--- a/contents/teams/web-analytics/objectives.mdx
+++ b/contents/teams/web-analytics/objectives.mdx
@@ -5,36 +5,36 @@ These are the primary goals the team is prioritizing this quarter.
 <details>
 <summary>Take Marketing Analytics from beta to GA – <TeamMember name="Javier Bahamondes" photo /></summary>
 
-- **Rationale:** Marketing Analytics expanded beyond paid ads last quarter and picked up real usage, but it's still rough around the edges. GA quality is what turns it from a promising beta into a product marketing teams depend on daily – and a direct revenue signal for PostHog.
-- **What we'll ship:** Close the gaps blocking GA: reliability, attribution accuracy, and channel coverage. Polish onboarding and source setup so marketing teams can self-serve. Nail pricing and packaging.
-- **We'll know we're successful when:** Marketing Analytics is GA and new users go from signup to a working ROAS view without talking to us.
+- Close the gaps blocking GA: reliability, attribution accuracy, and channel coverage
+- Polish onboarding and source setup so marketing teams can self-serve
+- Nail pricing and packaging for GA
 
 </details>
 
 <details>
 <summary>Launch Customer Analytics – <TeamMember name="Arthur Moreira de Deus" photo /></summary>
 
-- **Rationale:** Web analytics tells you what's happening on your site; customer analytics tells you who's behind it. Customers keep rebuilding the same dashboards to answer "who are my best accounts and what do they do?" We should answer that natively, with the same 80/20 opinionated approach that works for web analytics.
-- **What we'll ship:** A first version of Customer Analytics with opinionated default views, connected to the rest of PostHog so a customer view is one click away from the underlying events, sessions, and replays. Validate with early customers and iterate toward a public beta.
-- **We'll know we're successful when:** early-access users answer their customer questions in Customer Analytics instead of building custom dashboards.
+- Ship a first version with opinionated default views: who your best accounts are and what they do
+- Connect it to the rest of PostHog – one click from a customer view to the underlying events, sessions, and replays
+- Validate with early customers and iterate toward a public beta
 
 </details>
 
 <details>
 <summary>Ship achievements and a weekly recap – <TeamMember name="Jordan Mryyan" photo /></summary>
 
-- **Rationale:** Analytics should celebrate wins, not just report numbers. A weekly recap gives users a reason to come back every week, and achievements make hitting milestones (traffic records, conversion streaks, launch spikes) feel as good as they should. It's the live view dopamine flywheel, extended over time.
-- **What we'll ship:** Achievements for meaningful site milestones and a weekly recap that summarizes what happened, what changed, and what's worth celebrating. Both shareable, so wins travel beyond the person watching the dashboard.
-- **We'll know we're successful when:** users open the weekly recap without being prompted and achievements show up in their Slack channels.
+- Ship achievements for meaningful site milestones (traffic records, conversion streaks, launch spikes)
+- Ship a weekly recap that summarizes what happened, what changed, and what's worth celebrating
+- Make both shareable so wins travel beyond the person watching the dashboard
 
 </details>
 
 <details>
 <summary>Make analytics self-driving + AEO and agent analytics – <TeamMember name="Lucas Ricoy" photo /></summary>
 
-- **Rationale:** Analytics today waits to be asked. The next step is analytics that comes to you: what changed, why, and what to do about it, without anyone opening a dashboard. Meanwhile AI agents keep growing as web users, and most of them never execute JavaScript – so today we can't see them at all.
-- **What we'll ship:** Subscribable digests for Marketing Analytics dashboards, so insight arrives on a schedule instead of being pulled. Automated campaign-investment suggestions via PostHog AI (e.g. "this campaign is outperforming – shift budget to it"). Non-JS AI crawler capture for AEO and agent analytics – server-side `$http_log` ingestion is the current blocker, so unblocking that pipeline is part of the goal.
-- **We'll know we're successful when:** customers get actionable insight from Web and Marketing Analytics without asking for it, and AI crawler traffic shows up in agent analytics even when no JavaScript runs.
+- Ship subscribable digests for Marketing Analytics dashboards, so insight arrives on a schedule instead of being pulled
+- Automate campaign-investment suggestions via PostHog AI ("this campaign is outperforming – shift budget to it")
+- Capture non-JS AI crawlers for AEO / agent analytics – server-side `$http_log` ingestion is the current blocker
 
 </details>
 

--- a/contents/teams/web-analytics/objectives.mdx
+++ b/contents/teams/web-analytics/objectives.mdx
@@ -1,87 +1,66 @@
-## Q2 2026 objectives
+## Q3 2026 objectives
 
-### Signals, Skills & MCP
+These are the primary goals the team is prioritizing this quarter.
 
-The whole team will contribute to making Web Analytics a first-class citizen in PostHog's AI and automation ecosystem.
+<details>
+<summary>Take Marketing Analytics from beta to GA – <TeamMember name="Javier Bahamondes" photo /></summary>
 
-**Motivation:** PostHog is going all-in on AI agents and MCP. Web Analytics needs to ensure questions are routed to the right insight types, signals are comprehensive, and the team is dogfooding MCP daily.
+- **Rationale:** Marketing Analytics expanded beyond paid ads last quarter and picked up real usage, but it's still rough around the edges. GA quality is what turns it from a promising beta into a product marketing teams depend on daily – and a direct revenue signal for PostHog.
+- **What we'll ship:** Close the gaps blocking GA: reliability, attribution accuracy, and channel coverage. Polish onboarding and source setup so marketing teams can self-serve. Nail pricing and packaging.
+- **We'll know we're successful when:** Marketing Analytics is GA and new users go from signup to a working ROAS view without talking to us.
 
-* Route questions to web analytics insight types and queries natively via skills
-* Double down on having all web analytics signals (web vitals, heatmaps, bot activity, anomalies)
-* Have an MCP hero on the team who uses it daily and dogfoods the integration
-* Ship Marketing Analytics skills so PostHog AI can answer marketing questions natively
+</details>
 
-**We'll know we're successful when:** PostHog AI reliably answers web analytics questions, and the team is using MCP in daily workflows.
+<details>
+<summary>Launch Customer Analytics – <TeamMember name="Arthur Moreira de Deus" photo /></summary>
 
-### Agent & Bot Analytics + AEO
+- **Rationale:** Web analytics tells you what's happening on your site; customer analytics tells you who's behind it. Customers keep rebuilding the same dashboards to answer "who are my best accounts and what do they do?" We should answer that natively, with the same 80/20 opinionated approach that works for web analytics.
+- **What we'll ship:** A first version of Customer Analytics with opinionated default views, connected to the rest of PostHog so a customer view is one click away from the underlying events, sessions, and replays. Validate with early customers and iterate toward a public beta.
+- **We'll know we're successful when:** early-access users answer their customer questions in Customer Analytics instead of building custom dashboards.
 
-<TeamMember name="Lucas Ricoy" photo /> will be focusing on launching agent analytics and building some AEO (Answer Engine Optimization) and SEO tooling.
+</details>
 
-**Motivation:** Users want to distinguish and understand what bot/agent traffic is driving on their sites. Some because they need to prevent unwanted bots from scraping site content, others want to ensure their pages are seen by the right bots. 
+<details>
+<summary>Ship achievements and a weekly recap – <TeamMember name="Jordan Mryyan" photo /></summary>
 
-* Launch agent/bot analytics with full segmentation across web analytics, product analytics, SQL/HogQL and MCP.
-* Build AEO tooling that works for founders
-* Ship activity signals: anomaly detection for drops/spikes on tracked pages (bots or not)
+- **Rationale:** Analytics should celebrate wins, not just report numbers. A weekly recap gives users a reason to come back every week, and achievements make hitting milestones (traffic records, conversion streaks, launch spikes) feel as good as they should. It's the live view dopamine flywheel, extended over time.
+- **What we'll ship:** Achievements for meaningful site milestones and a weekly recap that summarizes what happened, what changed, and what's worth celebrating. Both shareable, so wins travel beyond the person watching the dashboard.
+- **We'll know we're successful when:** users open the weekly recap without being prompted and achievements show up in their Slack channels.
 
-**We'll know we're successful when:** customers can segment agent vs human traffic end-to-end, and the AEO dashboard is adopted by early-access users.
+</details>
 
-### Marketing Analytics
+<details>
+<summary>Make analytics self-driving + AEO and agent analytics – <TeamMember name="Lucas Ricoy" photo /></summary>
 
-<TeamMember name="Javier Bahamondes" photo /> will be focusing on finding Marketing Analytics' product-market fit and expanding beyond paid ads.
+- **Rationale:** Analytics today waits to be asked. The next step is analytics that comes to you: what changed, why, and what to do about it, without anyone opening a dashboard. Meanwhile AI agents keep growing as web users, and most of them never execute JavaScript – so today we can't see them at all.
+- **What we'll ship:** Subscribable digests for Marketing Analytics dashboards, so insight arrives on a schedule instead of being pulled. Automated campaign-investment suggestions via PostHog AI (e.g. "this campaign is outperforming – shift budget to it"). Non-JS AI crawler capture for AEO and agent analytics – server-side `$http_log` ingestion is the current blocker, so unblocking that pipeline is part of the goal.
+- **We'll know we're successful when:** customers get actionable insight from Web and Marketing Analytics without asking for it, and AI crawler traffic shows up in agent analytics even when no JavaScript runs.
 
-**Motivation:** We're getting many feature requests for Marketing Analytics: a direct revenue signal. Expanding beyond paid ads to social, SEO, and other channels makes PostHog more central to how technical marketing teams work. Adding actionability (pausing campaigns, changing budgets) turns MA into a control surface, not just a BI tool. Integrating with Workflows for campaign management increases stickiness and daily usage.
+</details>
 
-* Expand channel support beyond paid ads: organic, social, referral, email
-* Explore workflow actions for closing the loop (campaign actions, budget controls, Workflows integration)
-* Run competitor research and customer interviews to define the MA differentiator
+## Q2 2026 recap
 
-**We'll know we're successful when:** Marketing Analytics supports the top organic/social channels and we have a clear, validated positioning for what makes MA different from competitors.
-
-### Live View & Heatmaps
-
-<TeamMember name="Jordan Mryyan" photo /> will be focusing on making live view a compelling real-time experience and improving heatmaps.
-
-**Motivation:** Live view can become a flywheel for PostHog: connecting it to experiments, error tracking, and session replays gives users reasons to come more often. Not to mention that the dopamine hit is so good. 
-
-* Improve live view and ship stable and feature complete real-time dashboard with use cases in mind (campaign launches, AB test tracking, milestone celebrations)
-* Cross-product integration: connect live view to experiments, error tracking, and session replay
-* Integrate real time capabilities into heatmaps
-* (Strecth) Fix heatmaps reliability and UX issues, define pricing strategy for premium features (comparisons, time snapshots)
-
-**We'll know we're successful when:** live view is stable and integrated with other PostHog products, and heatmaps reliability issues are resolved.
-
-### Activation
-
-The whole team will contribute on reversing the decline in Web Analytics activation.
-
-**Motivation:** Web Analytics activation has been declining and we don't fully understand why. Reversing this trend is critical to growth since users who don't activate never retain.
-
-* Investigate activation metric decline and identify what drives retention
-* Ship improved onboarding flows to get new users to value faster
-
-**We'll know we're successful when:** we've identified the root causes of activation decline and shipped onboarding changes that stabilize or reverse the trend.
-
-### Stretch
-
-* Synthetic monitoring: revive the hackathon project for uptime and performance monitoring
-* Globe visualization: ship the beta globe view as a polished live view feature
-* Comparison date ranges: period vs period and YoY picker across web analytics
+- Web analytics skills shipped so PostHog AI routes questions to the right insight types
+- Agent/bot analytics segmentation launched across web analytics, product analytics, and SQL
+- Marketing Analytics expanded beyond paid ads with new channels
+- Live view improvements shipped; heatmaps reliability work ongoing
+- Activation investigation kicked off to understand the metric decline
 
 ## Q1 2026 recap
 
-* Pre-aggregated tables shipped to 50% of teams
-* Session explorer performance improvements
-* Filters and UX revamp across Web Analytics
-* Heatmaps inherited and stabilized with many fixes
-* Marketing Analytics: improved ROAS, added new sources, ongoing support post-GA
-* Agent/bot basic segmentation shipped, browser detection deferred to Q2
-* Installation Health v2 partially shipped
+- Pre-aggregated tables shipped to 50% of teams
+- Session explorer performance improvements
+- Filters and UX revamp across Web Analytics
+- Heatmaps inherited and stabilized with many fixes
+- Marketing Analytics: improved ROAS, added new sources, ongoing support post-GA
+- Agent/bot basic segmentation shipped, browser detection deferred to Q2
+- Installation Health v2 partially shipped
 
 ## Q4 2025 recap
 
-* Marketing Analytics launched as GA with strong user feedback
-* Web Analytics integrated with Posthog AI
-* Shipped Web Analytics components as insights
-* Pre-aggregated tables made available for selected teams
-* Query concurrency and performance improved
-* Many bug fixes and UX improvements across Web Analytics
+- Marketing Analytics launched as GA with strong user feedback
+- Web Analytics integrated with PostHog AI
+- Shipped Web Analytics components as insights
+- Pre-aggregated tables made available for selected teams
+- Query concurrency and performance improved
+- Many bug fixes and UX improvements across Web Analytics

--- a/contents/teams/web-analytics/objectives.mdx
+++ b/contents/teams/web-analytics/objectives.mdx
@@ -9,6 +9,7 @@ These are the primary goals the team is prioritizing this quarter.
 - Ship organic insights: Google Search Console keywords next to paid channels
 - Keep pushing performance down – the dashboard p95 went from ~23s to ~15s and still has a long way to go
 - Add MCP write tools so AI can propose fixes, source setup, and budget changes instead of only reading
+- Run the pricing review – GA means deciding how Marketing Analytics is packaged and billed
 
 </details>
 
@@ -54,6 +55,17 @@ Web analytics shouldn't wait to be asked – it should watch, explain, and act o
 
 - Make web analytics digest emails traceable (views, CTR) – <TeamMember name="Jordan Mryyan" photo />
 - Add AI-driven insights to the digest – <TeamMember name="Jordan Mryyan" photo />
+
+## Next quarters
+
+Non-exhaustive list of things we want to work on eventually:
+
+- Group analytics – unloved but useful, and it should be better
+- Cross-domain identification that "just works", including marketing site to app sign-up
+- More advanced marketing analytics: attribution modeling, incrementality experiments, tighter ties to Experiments
+- Cookieless tracking, together with Session Replay and Error Tracking
+- Data warehouse-based conversions in web analytics
+- Wizard-driven setup: detect the site type, define conversions, spot existing pixels and ad platforms
 
 ## Q2 2026 recap
 


### PR DESCRIPTION
Updates the Web Analytics team objectives for Q3 2026, based on the team's Q3 planning doc and using the same `<details>` format the Growth and Support teams used for their Q3 goals.

**Q3 objectives:**
- Take Marketing Analytics to GA (including the pricing review) – Javier
- Replace Vitally with Customer Analytics – Arthur
- Get heatmaps out of beta and make it earn its keep – Jordan
- Make web analytics self-driving – Lucas
- Shared: fix the performance embarrassments (precompute rollout, MA dashboard p95, accounts list load)

Also adds Jordan's stretch goals (digest traceability, AI-driven digest insights), a "Next quarters" backlog section, and a Q2 2026 recap taken from the planning doc's reflection section.

See the first comment for per-person rationale (what made it in from HOGS, what was deliberately left out) and open questions for the team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)