### PR TITLE
docs: clarify CIMD redirect_uris can be cross-domain

### DIFF
--- a/contents/docs/api/oauth.mdx
+++ b/contents/docs/api/oauth.mdx
@@ -43,7 +43,9 @@ The JSON document you host at your `client_id` URL should include at least:
 
 - `client_name` (required) – The human-readable name of your application, shown to users on the authorization screen.
 - `logo_uri` (optional) – A URL to a logo image that will be shown alongside the name on the authorization screen.
-- `redirect_uris` (required) – The URLs PostHog is allowed to redirect users to after authorization.
+- `redirect_uris` (required) – The URLs PostHog is allowed to redirect users to after authorization. These may be on a different domain than your `client_id` – they only need to be listed here. At authorization time, the requested `redirect_uri` must match one of these entries exactly (scheme, host, port, and path), and must use `https` unless it's a loopback address (`localhost` or `127.0.0.1`).
+
+PostHog caches your metadata document according to the `Cache-Control: max-age` header you return. If you add a new redirect URI after your client has already been used, the previously cached document stays in effect until its TTL elapses. Return a shorter `max-age` to have changes picked up sooner.
 
 See the [OAuth Client ID Metadata Document draft](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) for the full specification.
 

--- a/contents/docs/api/oauth.mdx
+++ b/contents/docs/api/oauth.mdx
@@ -45,6 +45,8 @@ The JSON document you host at your `client_id` URL should include at least:
 - `logo_uri` (optional) – A URL to a logo image that will be shown alongside the name on the authorization screen.
 - `redirect_uris` (required) – The URLs PostHog is allowed to redirect users to after authorization. These may be on a different domain than your `client_id` – they only need to be listed here. At authorization time, the requested `redirect_uri` must match one of these entries exactly (scheme, host, port, and path), and must use `https` unless it's a loopback address (`localhost` or `127.0.0.1`).
 
+For native apps that grab a dynamically assigned local port at runtime (per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3)), register a loopback redirect URI *without* a port – for example `http://localhost/callback` or `http://127.0.0.1/callback` – and a request on any port, like `http://localhost:54321/callback`, will match. If you register a `localhost` URI *with* a port, the request must use that exact port. `127.0.0.1` and `::1` allow any port regardless of what you register.
+
 PostHog caches your metadata document according to the `Cache-Control: max-age` header you return. If you add a new redirect URI after your client has already been used, the previously cached document stays in effect until its TTL elapses. Return a shorter `max-age` to have changes picked up sooner.
 
 See the [OAuth Client ID Metadata Document draft](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) for the full specification.


### PR DESCRIPTION
## Changes

Clarifies the OAuth CIMD docs (`/docs/api/oauth`) on two points that came up in a partner support ticket:

- `redirect_uris` **may be on a different domain than your `client_id`** – they only need to be listed in the metadata document. The old example used the same domain for both, which led a partner to assume same-domain was required. It isn't – PostHog does an exact-match check against the listed URIs, with no origin comparison against the `client_id`.
- Added a note that PostHog **caches the metadata document per your `Cache-Control: max-age`**, so a newly added redirect URI won't take effect until the cached copy's TTL elapses. This was the actual root cause of the partner's "redirect URI mismatch" (they added the cross-domain URI after their client was first cached).

Both statements were verified against the implementation in the `posthog` monorepo (CIMD validation stores `redirect_uris` verbatim with no domain check; the authorize flow uses django-oauth-toolkit's exact-match `redirect_uri_allowed`; `https` is required except for loopback).

## Checklist

- [x] I've read the docs style guide
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a – no move)

🤖 Generated with [Claude Code](https://claude.com/claude-code)