### PR TITLE
Replace Product OS nav menu with new Products menu

### DIFF
--- a/src/components/TaskBarMenu/README.md
+++ b/src/components/TaskBarMenu/README.md
@@ -37,9 +37,9 @@ Add to any menu item to control mobile behavior:
 ```
 
 **Values:**
-- `string` - URL to link to on mobile (converts submenu to simple link)
-- `false` - Completely omit this item from mobile menu
-- `undefined` - Use default mobile processing
+- `string` – URL to link to on mobile (converts submenu to simple link)
+- `false` – Completely omit this item from mobile menu
+- `undefined` – Use default mobile processing
 
 ### 2. mobileLink Property
 
@@ -138,9 +138,9 @@ Submenus are automatically converted to simple links on mobile:
 
 ## File Structure
 
-- `menuData.tsx` - Menu data and mobile processing logic
-- `index.tsx` - TaskBar component that renders the menu
-- `../RadixUI/MenuBar.tsx` - Base menu component with mobile support
+- `menuData.tsx` – Menu data and mobile processing logic
+- `index.tsx` – TaskBar component that renders the menu
+- `../RadixUI/MenuBar.tsx` – Base menu component with mobile support
 
 ## Testing Mobile Menu
 

--- a/src/components/TaskBarMenu/README.md
+++ b/src/components/TaskBarMenu/README.md
@@ -16,7 +16,7 @@ The TaskBar menu system provides a desktop-style navigation experience that adap
 On mobile, the main navigation items are moved from the top-level menu bar into the logo menu dropdown. This consolidates navigation into a single menu button to save space.
 
 ```
-Desktop: [Logo Menu] [Product OS] [Pricing] [Docs] [Library] [Company]
+Desktop: [Logo Menu] [Products] [Pricing] [Docs] [Library] [Company]
 Mobile:  [Logo Menu ▼] (contains all navigation items)
 ```
 
@@ -47,8 +47,8 @@ Add to top-level menus to convert the menu trigger itself into a direct link on 
 
 ```typescript
 {
-    trigger: 'Product OS',
-    items: buildProductOSMenuItems(allProducts),
+    trigger: 'Products',
+    items: buildProductsMenuItems(allProducts),
     mobileLink: '/products', // Entire menu becomes a link on mobile
 }
 ```
@@ -118,9 +118,9 @@ Submenus are automatically converted to simple links on mobile:
 
 ```typescript
 {
-    trigger: 'Product OS',
-    items: buildProductOSMenuItems(allProducts),
-    mobileLink: '/products', // "Product OS" becomes a link to /products on mobile
+    trigger: 'Products',
+    items: buildProductsMenuItems(allProducts),
+    mobileLink: '/products', // "Products" becomes a link to /products on mobile
 }
 ```
 

--- a/src/components/TaskBarMenu/SearchableProductMenu.tsx
+++ b/src/components/TaskBarMenu/SearchableProductMenu.tsx
@@ -82,7 +82,7 @@ const SearchableProductMenu: React.FC<SearchableProductMenuProps> = ({ products 
                 <input
                     ref={inputRef}
                     type="text"
-                    placeholder="Search apps..."
+                    placeholder="Search tools..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                     className="w-full !pl-8 pr-3 py-2 text-sm bg-accent border border-input rounded text-primary placeholder-muted focus:outline-none focus:ring-1 focus:ring-blue"
@@ -137,12 +137,12 @@ const SearchableProductMenu: React.FC<SearchableProductMenuProps> = ({ products 
                                 className="flex items-center gap-2 px-2 py-1.5 text-sm rounded hover:bg-accent-2 text-primary no-underline font-medium"
                             >
                                 <Icons.IconApps className="size-4 text-red" />
-                                Browse all apps ({APP_COUNT})
+                                Browse all tools ({APP_COUNT})
                             </Link>
                         </div>
                     </>
                 ) : (
-                    <div className="text-center py-4 text-muted text-sm">No apps found for "{searchTerm}"</div>
+                    <div className="text-center py-4 text-muted text-sm">No tools found for "{searchTerm}"</div>
                 )}
             </div>
         </div>

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -6,15 +6,6 @@ import { useSmallTeamsMenuItems } from './SmallTeamsMenuItems'
 import Logo from 'components/Logo'
 import { APP_COUNT } from '../../constants'
 import SearchableProductMenu from './SearchableProductMenu'
-import {
-    categoryOrder,
-    categoryDisplayNames,
-    categoryIcons,
-    buildCategoryMenuItems,
-    buildProductMenuItems,
-    popularProducts,
-    newestProducts,
-} from '../../constants/productNavigation'
 import useProduct from '../../hooks/useProduct'
 import {
     IconXNotTwitter,
@@ -239,98 +230,58 @@ const processHandbookSidebar = (items: any[], isRoot = true): any[] => {
         })
 }
 
-// Build Product OS menu items with categories
-const buildProductOSMenuItems = (allProducts: any[]) => {
+// Build Products menu items
+const buildProductsMenuItems = (allProducts: any[]) => {
     const items: any[] = [
         {
             type: 'item',
-            label: `Browse all apps (${APP_COUNT})`,
+            label: 'PostHog Code',
+            link: '/code',
+            icon: <Icons.IconCoffee className="size-4 text-brown" />,
+        },
+        {
+            type: 'item',
+            label: 'PostHog Web',
+            link: '/self-driving',
+            icon: <Icons.IconBolt className="size-4 text-red" />,
+        },
+        {
+            type: 'item',
+            label: 'PostHog Slack',
+            link: '/slack',
+            icon: <Icons.IconAtSign className="size-4 text-sky-blue" />,
+        },
+        {
+            type: 'item',
+            label: 'PostHog MCP',
+            link: '/mcp',
+            icon: <Icons.IconPlug className="size-4 text-gray" />,
+        },
+        {
+            type: 'item',
+            label: 'Context Warehouse',
+            link: '/data-stack',
+            icon: <Icons.IconDatabase className="size-4 text-blue" />,
+        },
+        {
+            type: 'separator',
+        },
+        {
+            type: 'item',
+            label: `Browse all tools (${APP_COUNT})`,
             link: '/products',
             icon: <Icons.IconApps className="size-4 text-red" />,
             mobileDestination: '/products',
         },
         {
-            type: 'separator',
-        },
-        {
             type: 'submenu' as const,
-            label: 'Search apps',
+            label: 'Search tools',
             link: '/products',
             items: <SearchableProductMenu products={allProducts} />,
             icon: <Icons.IconSearch className="size-4 text-gray" />,
             mobileDestination: '/products',
         },
-        {
-            type: 'submenu',
-            label: 'Popular products',
-            items: buildProductMenuItems(popularProducts, allProducts),
-            icon: <Icons.IconTrending className="size-4 text-green" />,
-            mobileDestination: '/products',
-        },
-        {
-            type: 'submenu',
-            label: 'New products',
-            items: buildProductMenuItems(newestProducts, allProducts),
-            icon: <Icons.IconPresent className="size-4 text-blue" />,
-            mobileDestination: '/products',
-        },
-        {
-            type: 'separator',
-        },
-        {
-            type: 'item',
-            label: 'Categories',
-            disabled: true,
-        },
     ]
-
-    // Add category submenus
-    categoryOrder.forEach((category) => {
-        const categoryProducts = allProducts.filter((product: any) => product.category === category)
-        if (categoryProducts.length === 0) return
-
-        const categoryItems = buildCategoryMenuItems(category, allProducts)
-        if (categoryItems.length > 0) {
-            // Get the icon for this category
-            let iconElement = null
-            const iconConfig = categoryIcons[category]
-            if (iconConfig) {
-                const IconComponent = Icons[iconConfig.icon as keyof typeof Icons]
-                if (IconComponent) {
-                    iconElement = React.createElement(IconComponent, {
-                        className: `size-4 text-${iconConfig.color}`,
-                    })
-                }
-            }
-
-            // Prepend MCP as the first item in 'Utilities, add-ons, & packages'
-            if (category === 'product_os') {
-                categoryItems.unshift({
-                    type: 'item' as const,
-                    label: 'MCP',
-                    link: '/mcp',
-                    icon: React.createElement(Icons.IconPlug, { className: 'size-4 text-gray' }),
-                })
-            }
-
-            // Lead the Automation section with Self-driving
-            if (category === 'automation') {
-                categoryItems.unshift({
-                    type: 'item' as const,
-                    label: 'Self-driving',
-                    link: '/self-driving',
-                    icon: React.createElement(Icons.IconBolt, { className: 'size-4 text-red' }),
-                })
-            }
-
-            items.push({
-                type: 'submenu',
-                label: categoryDisplayNames[category] || category,
-                icon: iconElement,
-                items: categoryItems,
-            })
-        }
-    })
 
     return items
 }
@@ -354,8 +305,8 @@ export function useMenuData(): MenuType[] {
     // Define main navigation items (excluding logo menu)
     const mainNavItems: MenuType[] = [
         {
-            trigger: 'Product OS',
-            items: buildProductOSMenuItems(allProducts),
+            trigger: 'Products',
+            items: buildProductsMenuItems(allProducts),
             mobileLink: '/products', // Direct link on mobile
         },
         {


### PR DESCRIPTION
## Changes

Renames the **Product OS** taskbar menu to **Products** and replaces its contents with:

- PostHog Code → `/code`
- PostHog Web → `/self-driving`
- PostHog Slack → `/slack`
- PostHog MCP → `/mcp`
- Context Warehouse → `/data-stack`
- ---
- Browse all tools → `/products` (renamed from "Browse all apps", keeps the app count)
- Search tools (renamed from "Search apps", same searchable product submenu)

The old Popular products, New products, and category submenus are removed along with their now-unused imports. Icons are reused from existing menu items/product data (coffee for Code, bolt for Web, @-sign for Slack, plug for MCP, database for Context Warehouse).

Also updates the TaskBarMenu `README.md` examples to match.

## Notes

- On mobile the menu still collapses to a direct `/products` link (unchanged).
- The Korean taskbar menu (`src/components/Korean/KoreanTaskBarMenu/`) has its own separate copy and is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)