### PR TITLE
Add customer complexity rubric

### DIFF
--- a/contents/handbook/cs-and-onboarding/customer-complexity.md
+++ b/contents/handbook/cs-and-onboarding/customer-complexity.md
@@ -1,0 +1,29 @@
+# Customer Complexity
+
+Where Customer health measures the risk of churn and the strength of an organization's relationship with the customer, customer complexity helps to track and plan for the amount of lift required to maintain and support an account. Customer Complexity, in general terms, accounts for any given account's implementation choices, organizational structure, and product adoption habits.
+
+Though complexity is critical in helping to determine customer priority, it should be used in tandem with customer health when planning proactive engagement and allocating engineering bandwidth.
+
+## Complexity Factors
+
+## Complexity factors
+
+| Factor | Low | Medium | High |
+| --- | --- | --- | --- |
+| **PostHog products** | 1–2 products | 3–4 products | 5+ products |
+| **Implementation** | Single SDK | Multiple SDKs | Multiple SDKs, potentially with custom integrations |
+| **Instrumentation** | Primarily autocapture and pageviews | Blend of automatic and custom events | Finely-tuned custom event model |
+| **Stakeholders** | Single team and/or primary contact | Multiple stakeholders | Cross-functional teams with executive sponsors, and/or Post-acquisition organization with autonomous business units |
+| **Integrations** | Few to none | Several | Multiple business-critical integrations |
+| **Event volume** | Low | Moderate | High or rapidly escalating |
+| **Internal adoption** | Single-team adoption of PostHog | Multiple team adoption of PostHog | Organization-wide adoption across Product, Engineering, Marketing, and Leadership |
+
+### Interpreting complexity
+
+| Complexity | Typical characteristics | Customer Success focus |
+| --- | --- | --- |
+| **Low** | Simple implementation, limited stakeholders, few integrations | Product adoption, education, quick wins |
+| **Medium** | Growing implementation, multiple teams, regular experimentation | Best practices, cross-team enablement, regular business reviews |
+| **High** | Enterprise-scale implementation, multiple PostHog products, complex integrations, executive stakeholders | Strategic partnership, executive alignment, roadmap planning, cost optimization |
+
+Complexity can present itself in a range of ways, so please treat this as an example of what each level *might* look like


### PR DESCRIPTION
## PR summary

This PR adds a customer complexity assessment.

While reading through the handbook and working on the SuperDay exercise, I realized I tend to think about customer health and customer complexity as two separate factors. Health tells us which customers may need intervention to prevent churn, but it doesn't always give us much info about how much lift an account will require to enable and help grow. This rubric is one I have adapted from past use cases to try and account for complexity as a factor to consider in day-to-day work. If 

### Why I have made this change

I thought this could be a useful complement to the existing health guidance.

For example, two customers might the same/similar health scores but need very different engagement strategies. A customer using one product with a single stakeholder is a very different account from one using multiple PostHog products across several teams, even if both are considered "healthy."

### Changes
- Added a Customer complexity section to health-tracking.md
- Added a table describing common complexity factors
- Added guidance for interpreting low, medium, and high complexity accounts
- Clarified that complexity complements health scoring rather than replacing it


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
