### PR TITLE
docs: flag Postgres/Supabase CDC sync as alpha

### DIFF
--- a/contents/docs/cdp/sources/postgres.mdx
+++ b/contents/docs/cdp/sources/postgres.mdx
@@ -79,6 +79,12 @@ PostgreSQL sources created after February 18, 2026 require SSL/TLS encryption fo
 
 Postgres tables support full table, incremental, append-only, and CDC sync methods.
 
+<CalloutBox icon="IconFlask" title="CDC sync is in alpha" type="action">
+
+CDC sync is currently in **alpha**. It works end to end, but you may still hit rough edges, and the interface and behavior may change. [Let us know](https://us.posthog.com/#panel=support%3Asupport%3Adata_warehouse%3A%3Atrue) if you run into issues.
+
+</CalloutBox>
+
 Use CDC when you need PostHog to stay close to your source database and you care about deletes. It is especially useful when:
 
 - Your table has inserts, updates, and deletes.

--- a/contents/docs/cdp/sources/postgres.mdx
+++ b/contents/docs/cdp/sources/postgres.mdx
@@ -81,9 +81,7 @@ Postgres tables support full table, incremental, append-only, and CDC sync metho
 
 <CalloutBox icon="IconFlask" title="CDC sync is in alpha" type="action">
 
-CDC sync is currently in **alpha**.
-
-We'd love to [hear your feedback](https://app.posthog.com/home#panel=support%3Afeedback%3A%3Alow%3Atrue).
+CDC sync is currently in **alpha**. We'd love to [hear your feedback](https://app.posthog.com/home#panel=support%3Afeedback%3A%3Alow%3Atrue).
 
 </CalloutBox>
 

--- a/contents/docs/cdp/sources/postgres.mdx
+++ b/contents/docs/cdp/sources/postgres.mdx
@@ -81,7 +81,9 @@ Postgres tables support full table, incremental, append-only, and CDC sync metho
 
 <CalloutBox icon="IconFlask" title="CDC sync is in alpha" type="action">
 
-CDC sync is currently in **alpha**. It works end to end, but you may still hit rough edges, and the interface and behavior may change. [Let us know](https://us.posthog.com/#panel=support%3Asupport%3Adata_warehouse%3A%3Atrue) if you run into issues.
+CDC sync is currently in **alpha**.
+
+We'd love to [hear your feedback](https://app.posthog.com/home#panel=support%3Afeedback%3A%3Alow%3Atrue).
 
 </CalloutBox>
 

--- a/contents/docs/cdp/sources/supabase.mdx
+++ b/contents/docs/cdp/sources/supabase.mdx
@@ -11,6 +11,12 @@ sourceId: Supabase
 
 The Supabase connector can link your Supabase database tables to PostHog. Supabase is built on top of Postgres, so this connector uses the same underlying integration as the [Postgres source](/docs/cdp/sources/postgres).
 
+<CalloutBox icon="IconFlask" title="CDC sync is in alpha" type="action">
+
+Because Supabase uses the Postgres integration, you can also enable change data capture (CDC) sync. CDC sync is currently in **alpha**. It works end to end, but you may still hit rough edges, and the interface and behavior may change. See the [Postgres source documentation](/docs/cdp/sources/postgres#sync-methods) for details, and [let us know](https://us.posthog.com/#panel=support%3Asupport%3Adata_warehouse%3A%3Atrue) if you run into issues.
+
+</CalloutBox>
+
 To link Supabase:
 
 1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog

--- a/contents/docs/cdp/sources/supabase.mdx
+++ b/contents/docs/cdp/sources/supabase.mdx
@@ -13,7 +13,9 @@ The Supabase connector can link your Supabase database tables to PostHog. Supaba
 
 <CalloutBox icon="IconFlask" title="CDC sync is in alpha" type="action">
 
-Because Supabase uses the Postgres integration, you can also enable change data capture (CDC) sync. CDC sync is currently in **alpha**. It works end to end, but you may still hit rough edges, and the interface and behavior may change. See the [Postgres source documentation](/docs/cdp/sources/postgres#sync-methods) for details, and [let us know](https://us.posthog.com/#panel=support%3Asupport%3Adata_warehouse%3A%3Atrue) if you run into issues.
+Because Supabase uses the Postgres integration, you can also enable change data capture (CDC) sync. See the [Postgres source documentation](/docs/cdp/sources/postgres#sync-methods) for details. CDC sync is currently in **alpha**.
+
+We'd love to [hear your feedback](https://app.posthog.com/home#panel=support%3Afeedback%3A%3Alow%3Atrue).
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

The Postgres and Supabase source docs describe CDC (change data capture) sync but never note that it's still in alpha, even though the app UI labels it as alpha. This adds a flask-icon alpha callout:

- **Postgres** — added to the "Sync methods" section where CDC is introduced.
- **Supabase** — added near the intro (the Supabase doc doesn't document sync methods itself, so it links to the Postgres CDC details).

Wording borrowed from the existing alpha/beta release snippets in `contents/docs/cdp/_snippets/`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BFJR6M28M/p1783419090985429?thread_ts=1783419090.985429&cid=C0BFJR6M28M)*