### PR TITLE
Document multi-year credit allocation in sales contracts handbook

### DIFF
--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -10,12 +10,10 @@ For customers who want to sign up for an annual (or longer) plan there is some a
 
 ### Multi-year deals and credit allocation
 
-For a multi-year deal, the credit term matches the length of the contract (e.g. 24 months for a two-year deal), not 12 months.
+The credit term only extends beyond 12 months (e.g. to 24 months for a two-year deal) if the customer pays the full amount for the entire term upfront (e.g. the full two-year amount paid upfront). How the credits are allocated depends on how the customer pays:
 
-How the credits are allocated depends on how the customer pays:
-
--   **Paying per year (or in tranches):** credits are granted in tranches allocated on each renewal date. For example, a two-year deal split evenly grants half the credits in the first year and half in the second.
--   **Paying all upfront:** the customer gets the full credit amount added in bulk at the start, with an expiry set to the full length of the term (e.g. a two-year expiry for a two-year deal).
+-   **Paying all upfront for the full term:** the customer gets the full credit amount added in bulk at the start, with an expiry set to the full length of the term (e.g. a two-year expiry for a two-year deal paid upfront).
+-   **Paying per year (or in tranches):** the extended term does not apply. Credits are granted in tranches allocated on each renewal date, each with a 12-month term. For example, a two-year deal split evenly grants half the credits in the first year and half on the renewal date at the start of the second.
 
 ### What about monthly customers?
 

--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -8,6 +8,15 @@ showTitle: true
 
 For customers who want to sign up for an annual (or longer) plan there is some additional paperwork needed to capture their contractual commitment to a minimum term, and likely custom pricing as well. At a minimum, they should sign an Order Form which references our standard [terms](/terms) and [privacy notice](/privacy). In addition, they may want a custom Master Services Agreement (MSA) or Data Processing Agreement (DPA).
 
+### Multi-year deals and credit allocation
+
+For a multi-year deal, the credit term matches the length of the contract (e.g. 24 months for a two-year deal), not 12 months.
+
+How the credits are allocated depends on how the customer pays:
+
+-   **Paying per year (or in tranches):** credits are granted in tranches allocated on each renewal date. For example, a two-year deal split evenly grants half the credits in the first year and half in the second.
+-   **Paying all upfront:** the customer gets the full credit amount added in bulk at the start, with an expiry set to the full length of the term (e.g. a two-year expiry for a two-year deal).
+
 ### What about monthly customers?
 
 Anyone on a monthly plan simply agrees to our [terms](/terms) and [privacy policy](/privacy) when they sign up.


### PR DESCRIPTION
## Changes

Added a "Multi-year deals and credit allocation" subsection to the [sales contracts handbook page](https://posthog.com/handbook/growth/sales/contracts#creating-and-managing-contracts), clarifying two things that came up in support:

- The credit term for a multi-year deal matches the contract length (e.g. 24 months for a two-year deal), not 12 months.
- How credits are allocated depends on payment: tranches on each renewal date when paying per year, vs. the full amount granted in bulk with a term-length expiry when paying all upfront.

**Why:** A sales rep hit this question for a customer exploring a two-year upfront deal and the answer wasn't documented anywhere, so it needed a confirmation from the team each time.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C093XHYMGBE/p1783412725126519?thread_ts=1783412725.126519&cid=C093XHYMGBE)*