### PR TITLE
Point PostHog Web to /products; rename Product OS to Products

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -42,7 +42,7 @@ export const useProductLinks = () => {
             source: 'desktop',
         },
         {
-            label: 'Product OS',
+            label: 'Products',
             Icon: <AppIcon name="notebook" />,
             url: '/products',
             source: 'desktop',

--- a/src/components/Products/ProductsTest.tsx
+++ b/src/components/Products/ProductsTest.tsx
@@ -302,7 +302,7 @@ export default function ProductsTest(): JSX.Element {
     return (
         <>
             <SEO
-                title="Product OS – PostHog"
+                title="Products – PostHog"
                 description="PostHog is the cracked technical co-founder that handles all the stuff you used to worry about."
                 image="/images/og/default.png"
             />

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -236,7 +236,7 @@ const buildProductsMenuItems = (allProducts: any[]) => {
         {
             type: 'item',
             label: 'PostHog Web',
-            link: '/self-driving',
+            link: '/products',
             icon: <Icons.IconBolt className="size-4 text-red" />,
         },
         {

--- a/src/components/TreeMenu/index.tsx
+++ b/src/components/TreeMenu/index.tsx
@@ -12,7 +12,16 @@ interface MenuItem {
     url?: string
     children?: MenuItem[]
     icon?: React.ReactNode
+    badge?: {
+        title: string
+        className?: string
+    }
 }
+
+const badgeClasses = 'bg-accent text-secondary text-xs font-medium rounded-sm px-1 py-0.5 inline-block leading-none'
+
+const Badge = ({ badge }: { badge?: MenuItem['badge'] }) =>
+    badge?.title ? <span className={`${badgeClasses} ${badge.className || ''}`}>{badge.title}</span> : null
 
 interface TreeMenuProps {
     items: MenuItem[]
@@ -47,10 +56,18 @@ const TreeLink = ({
             onClick={() => onClick(menuItem)}
             icon={typeof menuItem.icon !== 'string' && menuItem.icon}
         >
-            {menuItem.name}
+            <span className={`inline-flex items-center gap-1.5${menuItem.badge?.title ? ' pr-1' : ''}`}>
+                <span>{menuItem.name}</span>
+                <Badge badge={menuItem.badge} />
+            </span>
         </OSButton>
     ) : (
-        <div className={`text-muted text-sm py-0.5 !mt-2 ml-${2 + index} pl-${index * 4}`}>{menuItem.name}</div>
+        <div className={`text-muted text-sm py-0.5 !mt-2 ml-${2 + index} pl-${index * 4}`}>
+            <span className="inline-flex items-center gap-1.5">
+                <span>{menuItem.name}</span>
+                <Badge badge={menuItem.badge} />
+            </span>
+        </div>
     )
 }
 
@@ -164,7 +181,10 @@ function TreeMenuItem({
                             <IconChevronRight className="size-4" />
                         </motion.div>
                     )}
-                    <span className={`${open ? 'font-semibold' : ''}`}>{item.name}</span>
+                    <span className={`inline-flex items-center gap-1.5 ${open ? 'font-semibold' : ''}`}>
+                        <span>{item.name}</span>
+                        <Badge badge={item.badge} />
+                    </span>
                 </OSButton>
             </Collapsible.Trigger>
 

--- a/src/hooks/useProductOSNavigation.tsx
+++ b/src/hooks/useProductOSNavigation.tsx
@@ -97,8 +97,16 @@ export const productOSNav = {
         // { name: 'Utilities & add-ons' },
         // { name: 'Overview', url: '/products?category=product_os' },
         { name: 'Self-driving products' },
-        { name: 'What is self-driving?', url: '/self-driving' },
-        { name: 'Use PostHog in Slack', url: '/slack' },
+        {
+            name: 'What is self-driving?',
+            url: '/self-driving',
+            badge: { title: 'Beta', className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50' },
+        },
+        {
+            name: 'Use PostHog in Slack',
+            url: '/slack',
+            badge: { title: 'Beta', className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50' },
+        },
         { name: 'Platform tools' },
         { name: 'User activity', url: '/activity' },
         { name: 'User profiles', url: '/profiles' },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2159,11 +2159,19 @@ export const docsMenu = {
             color: 'red',
             url: '/docs/self-driving',
             description: 'Understand PostHog and get set up',
+            badge: {
+                title: 'Beta',
+                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+            },
             children: [
                 {
                     name: 'Overview',
                     url: '/docs/self-driving',
                     icon: 'IconHome',
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
                 },
                 {
                     name: 'Get started',
@@ -6947,6 +6955,10 @@ export const docsMenu = {
             color: 'purple',
             url: '/docs/slack',
             description: 'Run PostHog from any Slack channel — agent tasks, analytics, and notifications.',
+            badge: {
+                title: 'Beta',
+                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+            },
             children: [
                 {
                     name: 'Slack app',
@@ -6956,6 +6968,10 @@ export const docsMenu = {
                     url: '/docs/slack',
                     icon: 'IconHome',
                     color: 'seagreen',
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
                 },
                 {
                     name: 'Setup',


### PR DESCRIPTION
## Changes

Follow-up to #18206 / #18213, adjusting the new **Products** nav and naming:

- **PostHog Web** in the Products dropdown now links to `/products` (was `/self-driving`). The self-driving page is currently narrow, while `/products` covers PostHog's web tooling more broadly.
- The home-page desktop icon is renamed from **Product OS** to **Products**.
- The `/products` page title (SEO + OS window title, via `components/seo.tsx`) is now **Products – PostHog** instead of *Product OS – PostHog*.

**Why:** Requested in the thread — "Product OS" is being retired as a user-facing name, and PostHog Web is a lot more than just self-driving, so it should point at the broader products page for now (WIP, to be rationalized later).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1783411297578439?thread_ts=1783411297.578439&cid=C01V9AT7DK4)*
