### PR TITLE
Document real-time alert check interval

### DIFF
--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -75,7 +75,9 @@ Alerts are supported on [trends](/docs/product-analytics/trends) and [SQL (HogQL
      classes="rounded"
    />
 
-9. Select how often you want the alert to be checked. Options include every 15 minutes (requires Boost, Scale, or Enterprise plan), every hour, every day, every week, and every month.
+9. Select how often you want the alert to be checked. Options range from **real time** — for time-sensitive metrics where you want to be notified as soon as a threshold is breached — through every 15 minutes (requires Boost, Scale, or Enterprise plan), every hour, every day, every week, and every month.
+
+   Real-time alerts are best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
 
 10. Pick who should be notified when the alert is triggered. Subscribed users automatically receive in-app notifications when the alert fires. You can also add email recipients, Slack channels, Discord webhooks, Microsoft Teams channels, or webhook URLs directly in the alert form.
 


### PR DESCRIPTION
## Changes

Adds **real time** to the list of alert check frequencies on the [Alerts docs page](https://posthog.com/docs/alerts), with a short note on when it's the right choice (time-sensitive metrics like error spikes, checkout failures, or traffic drops) versus when a less frequent interval is a better fit.

**Why:** Real-time alerts are now available, but the docs only listed intervals down to every 15 minutes, so the new option was undocumented. Refs [#42382](https://github.com/PostHog/posthog/issues/42382).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B70P3KWLW/p1783433902580489)*