### PR TITLE
chore: correct provisioning blog post date to publish day

### DIFF
--- a/contents/blog/embedded-analytics-provisioning-api.md
+++ b/contents/blog/embedded-analytics-provisioning-api.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-07-06"
+date: "2026-07-07"
 title: "How to build a PostHog integration with the provisioning API"
 featuredImage: https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/posthog-engineering-blog.png
 featuredImageType: full


### PR DESCRIPTION
## Changes

One-line follow-up to [blog: how to build a PostHog integration with the provisioning API](https://github.com/PostHog/posthog.com/pull/17911): the post merged on July 7 but the frontmatter still said `2026-07-06`. Bumps `date` to the actual publish day so the post displays and sorts correctly in the blog feed.

## Checklist

- [x] Words are spelled using American English (n/a)
- [x] Use relative URLs for internal links (n/a)
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)
