### PR TITLE
docs: point provisioning scopes at the OAuth metadata source of truth

### DIFF
--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -446,26 +446,15 @@ Each refresh token is single-use. The response includes a new refresh token for 
 
 ### Available scopes
 
-The `scopes` field in the account request controls what permissions the access token receives. If omitted, a default set of scopes is granted. The default set does not include every scope below, so explicitly request the scopes your integration needs. Available scopes:
+The `scopes` field in the account request controls what permissions the access token receives. If omitted, a default set of scopes is granted – it does not include every available scope, so explicitly request the ones your integration needs.
 
-| Scope | Description |
-|---|---|
-| `customer_journey:read` | Read customer journey data |
-| `query:read` | Execute read-only queries |
-| `session_recording:read` | Read session recordings |
-| `conversation:read` | Read PostHog AI conversations |
-| `conversation:write` | Create and update PostHog AI conversations |
-| `experiment:read` | Read experiments |
-| `feature_flag:read` | Read feature flags |
-| `insight:read` | Read insights |
-| `organization:read` | Read organization details |
-| `person:read` | Read person data |
-| `project:read` | Read project settings |
-| `ticket:read` | Read tickets |
-| `ticket:write` | Create and update tickets |
-| `user:read` | Read user information |
-| `hog_flow:read` | Read Hog flows |
-| `hog_flow:write` | Create and update Hog flows |
+The full, always-current list of grantable scopes is published in the `scopes_supported` field of PostHog's [OAuth server metadata](/docs/api/oauth#supported-scopes), so you can read it straight from the source rather than a list that can fall out of date:
+
+```bash
+curl https://us.posthog.com/.well-known/oauth-authorization-server | jq '.scopes_supported'
+```
+
+Use `eu.posthog.com` for the EU region. These mirror the scopes available for [personal API keys](/docs/api/personal-api-keys); any scope PostHog reserves for internal use is not grantable. Common choices for a provisioning integration include `query:read`, `endpoint:read` and `endpoint:write` (read analytics back through [endpoints](/docs/endpoints)), `insight:read`, `person:read`, `project:read`, `project:write`, `session_recording:read`, and `sharing_configuration:write`.
 
 ## What the user gets
 


### PR DESCRIPTION
## Changes

The **Available scopes** table in the provisioning docs (`contents/docs/integrate/provisioning.mdx`) listed 16 scopes in the page source. That list no longer matched the backend. It omitted `endpoint:read`, `endpoint:write`, `project:write`, and `sharing_configuration:write`.

The OAuth server metadata advertises all four of those scopes in `scopes_supported`, which holds 189 scopes. PostHog can grant all four to a self-registered CIMD client. A developer who reads the table concludes that those scopes do not exist.

This PR replaces the table with a pointer to `scopes_supported` in the OAuth metadata document, and adds a `curl … | jq` example. [`docs/api/oauth.mdx`](https://posthog.com/docs/api/oauth#supported-scopes) already documents scopes this way. The `### Available scopes` heading stays, so existing `#available-scopes` links still resolve. The page now reads the list from the backend, so the two cannot hold different values.

I checked this against `us.posthog.com`. All four missing scopes appear in `scopes_supported`. The API also enforces `endpoint:write`: a create call returns 201 with that scope, and returns 403 with the message `missing required scope 'endpoint:write'` without it. I found this while I built an integration on the provisioning API with these scopes.

[blog: how to build a PostHog integration with the provisioning API](https://github.com/PostHog/posthog.com/pull/17911) is the blog post that uses these scopes.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable, no page moved)

Skills invoked: `/unambiguous-agent-text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
