### PR TITLE
Fix marketing team page: update quarter and remove duplicate section

### DIFF
--- a/contents/teams/marketing/index.mdx
+++ b/contents/teams/marketing/index.mdx
@@ -16,22 +16,6 @@ If something needs marketing attention, there are several group handles you can 
 
 The marketing team isn't responsible for maintaining the website. For that, please refer to [the website team](/teams/website).
 
-## Product marketing ownership
-
-Product marketers (PMMs) at PostHog are centralized into the marketing team and decide which other teams need dedicated support as part of [quarterly planning](/handbook/company/goal-setting). This enables the team to allocate resources strategically.
-
-You can see which of our product marketers currently supports which team below.
-
-- Joe currently supports the <SmallTeam slug="growth" /> team. 
-
-- Cleo currently supports the <SmallTeam slug="posthog-code" /> and <SmallTeam slug="ai-observability" /> teams.
-
-- Sara currently supports the <SmallTeam slug="workflows" /> and <SmallTeam slug="apm" /> teams.
-
-- Lizzie currently supports the <SmallTeam slug="data-stack" /> team.
-
-If a team doesn't have a dedicated PMM then it doesn't mean we won't support it. You can always reach out to the product marketing team in [the #team-marketing Slack channel](https://posthog.slack.com/archives/C08CG24E3SR). We explain more about [marketing ownership](/handbook/marketing/ownership) and what product marketers do in the handbook. 
-
 ## Requesting artwork
 
 Need help with artwork, or curious about how illustrators work? Find out [how to open an art request](/handbook/brand/art-requests).

--- a/contents/teams/marketing/objectives.mdx
+++ b/contents/teams/marketing/objectives.mdx
@@ -1,4 +1,4 @@
-### Q2 2026 objectives
+### Q3 2026 objectives
 
 These are the primary goals the team is prioritizing this quarter. Goals for PMMs are meant to provide an extra level of focus or to define a specific initiative beyond the business-as-usual work that comes from covering a specific product. Supporting [the product they are assigned to](/handbook/marketing/ownership) is always the default quarterly goal. 
 


### PR DESCRIPTION
## Changes

Two fixes to the [marketing team page](https://posthog.com/teams/marketing):

- Update the objectives heading from Q2 2026 to Q3 2026.
- Remove the "Product marketing ownership" section, which duplicated the handbook — the correct [ownership page](/handbook/marketing/ownership) is already linked from the goals.

**Why:** The team requested these corrections so the page reflects the current quarter and stops duplicating handbook content.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1783455823882829?thread_ts=1783455823.882829&cid=C08CG24E3SR)*
