### PR TITLE
docs: deprecate trial evals

### DIFF
--- a/contents/docs/ai-evals/index.mdx
+++ b/contents/docs/ai-evals/index.mdx
@@ -13,7 +13,7 @@ Evaluations automatically assess the quality of your LLM [generations](/docs/ai-
 - **Monitor output quality at scale** – Automatically check if generations are helpful, relevant, or safe without manual review.
 - **Detect problematic content** – Catch hallucinations, toxicity, or jailbreak attempts before they reach users.
 - **Track quality trends** – See pass rates across models, prompts, or user segments over time.
-- **Debug with reasoning** – Each evaluation provides an explanation for its decision, making it easy to understand failures.
+- **Debug with reasoning** – Each evaluation provides an explanation for its decision, so you can see why a generation failed.
 
 ## Choosing an evaluation type
 
@@ -23,7 +23,7 @@ Evaluations automatically assess the quality of your LLM [generations](/docs/ai-
 | **Cost**        | LLM API call per evaluation                                  | Free                                                       | Free                                                     |
 | **Speed**       | Seconds                                                      | Milliseconds                                               | Milliseconds                                             |
 | **Output**      | Pass/fail with reasoning                                     | Pass/fail with reasoning                                   | Positive, neutral, or negative with a confidence score   |
-| **Setup**       | Write a prompt                                               | Write Hog code                                             | Pick the type — no prompt or code required               |
+| **Setup**       | Write a prompt                                               | Write Hog code                                             | Pick the type – no prompt or code required               |
 
 ## LLM-as-a-judge evaluations
 
@@ -181,7 +181,7 @@ Your Hog code has access to these variables:
 
 ### Writing Hog evaluation code
 
-Your code must return a boolean: `true` for pass, `false` for fail. Use `print()` statements to provide reasoning — the output is captured and stored alongside the result.
+Your code must return a boolean: `true` for pass, `false` for fail. Use `print()` statements to provide reasoning – the output is captured and stored alongside the result.
 
 > **Hog tip:** Use single quotes for strings (`'hello'`), `length()` instead of `len()`, and wrap property access with `ifNull()` to avoid null comparison errors.
 
@@ -263,7 +263,7 @@ Before saving, use the **Test on sample** button to run your code against recent
 - Any `print()` output (reasoning)
 - Any errors in your code
 
-Testing does not create evaluation events or affect your data — it runs entirely in preview mode.
+Testing does not create evaluation events or affect your data – it runs entirely in preview mode.
 
 ### Using AI to generate evaluations
 
@@ -275,13 +275,13 @@ Click **Generate with AI** in the code editor to open Max, PostHog's AI assistan
 
 ## Sentiment analysis evaluations
 
-Sentiment evaluations classify the sentiment of the user messages in each generation as **positive**, **neutral**, or **negative**. They're ideal for monitoring how users feel during conversations with your AI features — spotting frustrated users, tracking satisfaction trends, and prioritizing the conversations that matter most.
+Sentiment evaluations classify the sentiment of the user messages in each generation as **positive**, **neutral**, or **negative**. They're ideal for monitoring how users feel during conversations with your AI features – spotting frustrated users, tracking satisfaction trends, and prioritizing the conversations that matter most.
 
 ### How they work
 
 When a [generation](/docs/ai-observability/generations) is sampled, PostHog runs a local open-source ML model ([cardiffnlp/twitter-roberta-base-sentiment-latest](https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest)) against the user messages in that generation. Each message is classified as positive, neutral, or negative with a confidence score, and the result is stored and linked to the original generation.
 
-The model only processes user messages (the `$ai_input` property) — it does not process LLM outputs. Sentiment runs entirely within PostHog's infrastructure, so **no data is sent to any third-party AI provider**, and there's no LLM cost.
+The model only processes user messages (the `$ai_input` property) – it does not process LLM outputs. Sentiment runs entirely within PostHog's infrastructure, so **no data is sent to any third-party AI provider**, and there's no LLM cost.
 
 Sentiment evaluations share the same sampling rate and property filter options as the other evaluation types, so you can scope them to production traffic, specific models, or particular user segments.
 
@@ -335,7 +335,7 @@ The auto-created report uses these defaults:
 | --------------------- | ------------- | ------------------------------------------------------------ |
 | **Frequency**         | Count-based   | Generates a report after a set number of evaluation runs     |
 | **Trigger threshold** | 100           | A report is generated every 100 new evaluation results       |
-| **Cooldown**          | 1 hour        | Minimum hours between count-triggered reports (1–24 hours)   |
+| **Cooldown**          | 1 hour        | Minimum hours between count-triggered reports (1 – 24 hours) |
 | **Daily run cap**     | 10            | Maximum report runs per day                                  |
 | **Enabled**           | Yes           | Reports start generating immediately                         |
 | **Delivery targets**  | None          | Reports are viewable in the UI but no notifications are sent |
@@ -347,7 +347,7 @@ Reports are viewable directly in the evaluation's **Reports** tab without config
 You can adjust the report configuration after creating an evaluation:
 
 - Change the trigger threshold to generate reports more or less frequently
-- Adjust the minimum hours between reports (1–24) to control how often count-triggered reports can fire
+- Adjust the minimum hours between reports (1 – 24) to control how often count-triggered reports can fire
 - Add email or Slack delivery targets to receive notifications when reports are generated
 - Disable the report if you don't need automated summaries
 
@@ -391,8 +391,8 @@ Each evaluation run counts as one AI Observability event toward your quota.
 
 If a provider API key is missing or deleted, PostHog automatically disables the affected evaluations and shows an error status. See [Evaluation status and errors](#evaluation-status-and-errors) for details on error states and how to resolve them.
 
-**Code-based evaluations** have no LLM cost — they run your Hog code directly with no external API calls.
+**Code-based evaluations** have no LLM cost – they run your Hog code directly with no external API calls.
 
-**Sentiment evaluations** have no LLM cost — they run a local ML model with no external API calls.
+**Sentiment evaluations** have no LLM cost – they run a local ML model with no external API calls.
 
 Use sampling rates strategically to balance coverage and cost – 5-10% sampling often provides sufficient signal for quality monitoring.

--- a/contents/docs/ai-evals/index.mdx
+++ b/contents/docs/ai-evals/index.mdx
@@ -363,11 +363,10 @@ Each evaluation has a status that indicates whether it's running:
 
 PostHog automatically disables evaluations and sets them to error status when:
 
-| Error reason             | Cause                                                     | How to resolve                                                                                                                                   |
-| ------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Trial limit reached**  | The 100 free trial evaluation runs have been exhausted.   | Add your own API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok).       |
-| **Model not allowed**    | The selected model isn't available on the trial plan.     | Switch to a trial-allowed model, or add your own provider API key.                                                                               |
-| **Provider key deleted** | The provider API key used by this evaluation was removed. | Add a new provider API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok). |
+| Error reason                        | Cause                                                     | How to resolve                                                                                                                                   |
+| ----------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **No provider API key configured**  | The evaluation has no provider API key to run with.       | Add a provider API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok).     |
+| **Provider key deleted**            | The provider API key used by this evaluation was removed. | Add a new provider API key in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok). |
 
 ### Identifying errored evaluations
 
@@ -379,8 +378,7 @@ On the evaluation detail page, the header shows a red **Error** tag and a banner
 
 You must resolve the underlying issue before re-enabling an errored evaluation:
 
-- **Trial limit reached** – Add your own provider API key.
-- **Model not allowed** – Switch to a trial-allowed model, or add your own provider API key.
+- **No provider API key configured** – Add a provider API key.
 - **Provider key deleted** – Add a new provider API key.
 
 Once the issue is resolved, open the evaluation and toggle it back on.
@@ -389,9 +387,9 @@ Once the issue is resolved, open the evaluation and toggle it back on.
 
 Each evaluation run counts as one AI Observability event toward your quota.
 
-**LLM judge evaluations** use an LLM to score your generations. Your first 100 evaluation runs are on us so you can try the feature right away. After that, add your own API key from OpenAI, Azure OpenAI, Google Gemini, Anthropic, OpenRouter, Fireworks, or Together AI in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok) to keep running evaluations.
+**LLM judge evaluations** use an LLM to score your generations. Add your own API key from OpenAI, Azure OpenAI, Google Gemini, Anthropic, OpenRouter, Fireworks, or Together AI in [**Settings** > **AI Observability**](https://app.posthog.com/settings/environment-ai-observability#ai-observability-byok) to run evaluations.
 
-If a provider API key is deleted or an evaluation hits trial limits, PostHog automatically disables the affected evaluations and shows an error status. See [Evaluation status and errors](#evaluation-status-and-errors) for details on error states and how to resolve them.
+If a provider API key is missing or deleted, PostHog automatically disables the affected evaluations and shows an error status. See [Evaluation status and errors](#evaluation-status-and-errors) for details on error states and how to resolve them.
 
 **Code-based evaluations** have no LLM cost — they run your Hog code directly with no external API calls.
 


### PR DESCRIPTION
## Changes

We are [removing trial evals](https://github.com/PostHog/posthog/pull/68234), we should remove references to them from the docs too.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
