### PR TITLE
docs(metrics): add setup and usage guide for the Metrics alpha

### DIFF
--- a/contents/docs/metrics/architecture.mdx
+++ b/contents/docs/metrics/architecture.mdx
@@ -1,0 +1,60 @@
+---
+title: How metrics works
+---
+
+> **Note:** Metrics is in alpha. The details on this page describe current behavior and may change before general availability.
+
+This page explains what happens to a metric between your application and a chart: how ingestion works, what a series is, how aggregations are computed, and where the data lives. You don't need any of this to use metrics, but it helps when you're deciding what to instrument or debugging why a chart looks the way it does.
+
+## Ingestion
+
+Metrics arrive over the OpenTelemetry Protocol (OTLP) via HTTP at `/i/v1/metrics`, as JSON or protobuf, authenticated with your project token. PostHog accepts the standard OTLP metrics model, so anything that can export OTLP (an OpenTelemetry SDK, a Collector, or the `posthog.metrics` API in posthog-js, which speaks OTLP under the hood) can send metrics without PostHog specific packages.
+
+Each incoming data point carries a metric name, a metric type, a value (or histogram buckets), a timestamp, resource attributes describing the sender (service name, host), and data point attributes describing the measurement (route, status). Ingestion validates the payload, applies your project's quota, and writes data points to a columnar time series store.
+
+## The series model
+
+A **series** is one stream of values identified by the combination of:
+
+- the metric name
+- the metric type (`gauge`, `sum`, `histogram`, `exponential_histogram`, or `summary`)
+- the service name
+- the full set of attribute key/value pairs
+
+Record `http.requests.total` with `route=/api/checkout` and `status=200`, then again with `status=500`, and you have two series. Group a chart by `status` and each series becomes its own line.
+
+This is why attribute cardinality matters. Ten routes times five status codes is fifty series: cheap, useful, chartable. A user ID attribute with a million values is a million series: expensive, and no chart with a million lines answers a question. Keep attributes to dimensions with a bounded set of values, and reach for [logs](/docs/logs) or [traces](/docs/distributed-tracing) when you need per user or per request detail.
+
+## Metric types and temporality
+
+Counters are where most charting mistakes happen, so PostHog handles their sharp edges for you:
+
+- **Cumulative counters** (the OpenTelemetry default) report an ever growing total since process start. The absolute value is meaningless for charting; what matters is how much it grew in each time bucket. The `rate` and `increase` aggregations compute per series differences, so a counter reported by twenty processes is twenty series diffed independently and then summed.
+- **Counter resets** happen when a process restarts and its total drops back toward zero. `rate` and `increase` detect resets the same way Prometheus does, so a restart never shows up as a huge negative spike.
+- **Delta counters** report only what happened since the last export. PostHog reads the temporality that your SDK declares and sums deltas as they are, without differencing.
+- **Histograms** arrive as bucket counts with bucket boundaries. Percentile aggregations combine the buckets across the query window and interpolate the requested quantile, which is how `p95` works without storing every raw observation.
+- **Gauges** are stored as reported and aggregate naturally with `avg`, `sum`, or percentiles.
+
+If an aggregate overflows what a float can represent, the affected time bucket is returned as an explicit null gap rather than an infinity or a silently wrong number.
+
+## Querying
+
+Queries resolve over a shared time grid. PostHog picks a bucket size automatically so a chart has roughly sixty points across the selected range, from one second buckets for short windows up to daily and weekly buckets for long ones, and you can pin the interval explicitly through the API. Every series in a response shares the same grid, which is what makes cross series math line up.
+
+Filters match attribute values with equality, negation, or regular expressions, and can target resource attributes, data point attributes, or both. Group by splits the result into one series per attribute value, keeping the largest series when there are too many to chart.
+
+Through the query API you can also combine multiple metrics with a formula, for example an error ratio computed as `errors / requests`, evaluated server side on the shared grid.
+
+## Storage and SQL access
+
+Metrics are stored in a columnar time series table and exposed to SQL as `posthog.metrics`, scoped to your project like every other PostHog table. The SQL tab in the metrics viewer is a full escape hatch: anything the chart controls can't express, you can write directly, and join against the rest of your PostHog data.
+
+## What alpha means here
+
+While metrics is in alpha, ingestion details and limits may still change, and retention policy is not final. The OTLP endpoint, the series model, and the aggregation semantics described above are the stable core the product is built on.
+
+## Next steps
+
+- [Get started with metrics](/docs/metrics/start-here)
+- [Why you need metrics](/docs/metrics/basics)
+- [Set up and send metrics](/docs/metrics)

--- a/contents/docs/metrics/basics.mdx
+++ b/contents/docs/metrics/basics.mdx
@@ -1,0 +1,51 @@
+---
+title: Why you need metrics
+---
+
+Metrics are numbers about your system measured over time: how many requests you served, how long they took, how deep the job queue is, how much memory a process is using. Where [logs](/docs/logs) record individual events and [traces](/docs/distributed-tracing) follow individual requests, metrics summarize everything. They answer "how is the system doing?" at a glance, cheaply, all the time.
+
+## What is a metric?
+
+A metric is a named time series. You pick a name like `http.server.duration`, record values against it, and PostHog turns those values into points on a chart. Three shapes cover almost everything:
+
+- A **counter** counts things that only accumulate: requests handled, jobs completed, errors raised. You never care about a counter's absolute value, only how fast it grows. That's why counters are charted as a `rate` (per second) or an `increase` (per time bucket).
+- A **gauge** is a value that goes up and down: queue depth, open connections, temperature, memory. The current value is the interesting part, so gauges are charted with `avg` or the latest reading.
+- A **histogram** records a distribution: every request duration, every payload size. Histograms let you ask for percentiles, so instead of an average that hides your slowest users, you see the `p95` or `p99` they actually experience.
+
+Attributes add dimensions to a metric. Record `http.server.duration` with a `route` and `status` attribute and you can later split one chart into a line per route, or filter to only the 5xx responses.
+
+## What metrics show you that nothing else does
+
+Logs and traces are records of individual things that happened. They're the right tool when you need to know what happened to one request. But they're expensive to keep at full volume and slow to aggregate across millions of events.
+
+Metrics are pre-aggregated by design. A burst of a million requests becomes a handful of data points per series, which means you can afford to measure everything, keep it always on, and chart a month of history instantly. That makes metrics the right tool for:
+
+- **Trends**: is latency creeping up week over week? Is the queue draining slower than it fills?
+- **Capacity**: how close to saturation are your workers, connections, and disks?
+- **Health at a glance**: one dashboard that tells you in five seconds whether production is fine.
+- **Alerting ground truth**: the numbers you page on need to be cheap, fast, and reliable to compute.
+
+## When metrics save you
+
+A queue that grows by 2% an hour never shows up in logs. Every individual job is processed fine, every trace looks healthy, and three weeks later the backlog takes the system down. A gauge on queue depth makes that failure visible on day one as a line that isn't flat.
+
+The same goes for error budgets and latency. A `rate` on an error counter divided by a rate on a request counter is your error ratio, and a `p95` on a duration histogram is what your slowest users feel. Watching those two numbers per service catches most production regressions before your customers report them.
+
+## What good metrics look like
+
+- **Stable names.** Pick a convention and keep it. OpenTelemetry style dotted names like `http.server.duration` and Prometheus style names like `jobs_processed_total` both work; mixing conventions inside one system makes metrics hard to find.
+- **The right type.** Counting things? Counter. Measuring a level? Gauge. Measuring durations or sizes? Histogram.
+- **Low cardinality attributes.** Attach dimensions with a bounded set of values (route, status, plan). Never attach user IDs or request IDs; each unique value becomes its own series.
+- **Units in the name or metadata.** `duration_ms` or a `unit` field saves everyone from guessing.
+
+## How PostHog makes metrics useful
+
+Most teams keep metrics in a separate system from everything else, so answering "did that latency spike affect signups?" means tab switching and timestamp matching. In PostHog, metrics live alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), product analytics, and session replays, in the same project with the same query language.
+
+Everything is queryable as SQL through the `posthog.metrics` table, and the [PostHog MCP server](/docs/model-context-protocol) exposes metrics to AI agents, so your tools can chart, compare, and investigate metrics for you.
+
+## Next steps
+
+- [Get started with metrics](/docs/metrics/start-here)
+- [Set up and send metrics](/docs/metrics)
+- [How metrics works under the hood](/docs/metrics/architecture)

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -4,16 +4,16 @@ title: Metrics
 
 > **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
 
-PostHog Metrics lets you send application and infrastructure metrics – request counts, latencies, queue depths, resource usage – to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
+PostHog Metrics lets you send application and infrastructure metrics (request counts, latencies, queue depths, resource usage) to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
 
 There are two ways to send metrics:
 
-1. **Already have PostHog installed?** Record metrics directly with the [`posthog.metrics` API](#already-have-posthog-installed-use-posthogmetrics) built into the PostHog SDK – no extra packages.
-2. **Using OpenTelemetry?** Point any standard OpenTelemetry library or Collector at [PostHog's OTLP endpoint](#set-up-metrics-with-opentelemetry) – no PostHog-specific packages.
+1. **Already have PostHog installed?** Record metrics directly with the [`posthog.metrics` API](#already-have-posthog-installed-use-posthogmetrics) built into the PostHog SDK, with no extra packages.
+2. **Using OpenTelemetry?** Point any standard OpenTelemetry library or Collector at [PostHog's OTLP endpoint](#set-up-metrics-with-opentelemetry), with no PostHog-specific packages.
 
 ## Already have PostHog installed? Use posthog.metrics
 
-If [posthog-js](/docs/libraries/js) is already running on your site, you can record metrics immediately – no OpenTelemetry setup, no new dependencies, and no extra authentication beyond the project API key you already configured:
+If [posthog-js](/docs/libraries/js) is already running on your site, you can record metrics immediately: no OpenTelemetry setup, no new dependencies, and no extra authentication beyond the project API key you already configured:
 
 ```js
 // A counter for things that only go up
@@ -44,11 +44,11 @@ posthog.metrics.histogram('api.request.duration', 187, {
 })
 ```
 
-Metrics are safe to record from hot paths. Samples are aggregated in memory and sent as one data point per series every 10 seconds – a burst of 10,000 `count()` calls costs one data point on the wire. Pending metrics are flushed automatically when the page is hidden or closed, and you can force a flush with `posthog.metrics.flush()`.
+Metrics are safe to record from hot paths. Samples are aggregated in memory and sent as one data point per series every 10 seconds, so a burst of 10,000 `count()` calls costs one data point on the wire. Pending metrics are flushed automatically when the page is hidden or closed, and you can force a flush with `posthog.metrics.flush()`.
 
 The `metrics` config also accepts `flushIntervalMs`, `maxSeriesPerFlush` (a cardinality guardrail, default 1000 series per window), `resourceAttributes`, and a `beforeSend` hook to filter or modify metrics before they're aggregated.
 
-Metrics deliberately carry no user or session context: every distinct attribute value creates a new series, so attach low-cardinality dimensions like plan, route, or status – not user IDs.
+Metrics deliberately carry no user or session context: every distinct attribute value creates a new series, so attach low-cardinality dimensions like plan, route, or status. Never attach user IDs.
 
 > **Note:** `posthog.metrics` is currently available in posthog-js (web). Support in posthog-node and other SDKs is coming. If you're on another SDK, or not using PostHog SDKs at all, use the OpenTelemetry setup below.
 
@@ -144,11 +144,11 @@ const queueDepth = meter.createGauge('queue.depth')
 queueDepth.record(17, { queue: 'emails' })
 ```
 
-> **Note:** If your language isn't listed, any OpenTelemetry SDK works – check the [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/) for your language and point its OTLP metrics exporter at PostHog.
+> **Note:** If your language isn't listed, any OpenTelemetry SDK works. Check the [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/) for your language and point its OTLP metrics exporter at PostHog.
 
 ### Already running an OpenTelemetry Collector?
 
-If your services already ship metrics to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), add PostHog as an exporter – no application changes needed:
+If your services already ship metrics to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), add PostHog as an exporter, with no application changes needed:
 
 ```yaml
 exporters:
@@ -176,20 +176,20 @@ PostHog ingests all OTLP metric types:
 | **Exponential histogram** | Distributions with automatic bucketing | Same as histogram, with better resolution across wide ranges |
 | **Summary** | Pre-computed quantiles | Latency percentiles from legacy clients |
 
-A metric's identity is its **name, type, and attributes** together. `http.requests` with `{route: "/home"}` and `http.requests` with `{route: "/checkout"}` are separate series, so keep attribute values low-cardinality – attach things like route, status, or plan, not user IDs or request IDs.
+A metric's identity is its **name, type, and attributes** together. `http.requests` with `{route: "/home"}` and `http.requests` with `{route: "/checkout"}` are separate series, so keep attribute values low-cardinality. Attach things like route, status, or plan, not user IDs or request IDs.
 
 ### Naming and units
 
-Give metrics descriptive, dot-separated names like `checkout.failed`, `email.sent`, or `queue.depth` – not vague ones like `metric1` or `counter`. Set an explicit unit on histograms (`ms`, `bytes`) so charts are unambiguous. Use one name per metric type: recording `queue.depth` as both a gauge and a counter blends both series in charts.
+Give metrics descriptive, dot-separated names like `checkout.failed`, `email.sent`, or `queue.depth`, not vague ones like `metric1` or `counter`. Set an explicit unit on histograms (`ms`, `bytes`) so charts are unambiguous. Use one name per metric type: recording `queue.depth` as both a gauge and a counter blends both series in charts.
 
 ### What to instrument
 
 Good starting points:
 
-- **Critical operations** – count successes and failures of the flows that matter: checkouts, signups, imports
-- **Service boundaries** – time external API calls and database queries with histograms
-- **Business events** – counters for orders, upgrades, or invites, sliced by plan or region
-- **Resource usage** – gauge queue depths, connection pools, and cache sizes
+- **Critical operations**: count successes and failures of the flows that matter: checkouts, signups, imports
+- **Service boundaries**: time external API calls and database queries with histograms
+- **Business events**: counters for orders, upgrades, or invites, sliced by plan or region
+- **Resource usage**: gauge queue depths, connection pools, and cache sizes
 
 ## Use your metrics
 
@@ -200,7 +200,7 @@ Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in Pos
 The **Viewer** tab lets you explore metrics without writing any queries:
 
 - **Pick a metric** by name to chart it over time
-- **Choose an aggregation** – sum, average, count, p95, rate, or increase. The viewer recommends one based on the metric's type: increase for counters, average for gauges, p95 for histograms
+- **Choose an aggregation**: sum, average, count, p95, rate, or increase. The viewer recommends one based on the metric's type: increase for counters, average for gauges, p95 for histograms
 - **Group by attributes** to break a metric down into one line per value, like per route or per status code
 - **Filter** to the series you care about, and adjust the date range
 
@@ -212,19 +212,19 @@ The **SQL** tab gives you direct access to your metrics with [SQL](/docs/sql):
 SELECT * FROM posthog.metrics LIMIT 10
 ```
 
-Use it for anything the viewer doesn't cover – joining metrics against each other, custom math, or ad-hoc exploration of raw data points.
+Use it for anything the viewer doesn't cover, joining metrics against each other, custom math, or ad-hoc exploration of raw data points.
 
 ## Troubleshooting
 
 **No metrics showing up?**
 
 1. Check you're using your **project token** (`phc_...`), not a personal API key (`phx_...`)
-2. Check the endpoint path is exactly `/i/v1/metrics` – requests without a token return `401 Unauthorized`
-3. OTLP SDKs export on an interval (60 seconds by default) – lower `export_interval_millis` while testing, and in short-lived scripts flush before exit (`meterProvider.forceFlush()` / `shutdown()`), or your metrics may never be sent
-4. Using `posthog.metrics`? The SDK flushes every 10 seconds – call `posthog.metrics.flush()` to send immediately while testing, and check you're not opted out of capturing
+2. Check the endpoint path is exactly `/i/v1/metrics`, requests without a token return `401 Unauthorized`
+3. OTLP SDKs export on an interval (60 seconds by default), lower `export_interval_millis` while testing, and in short-lived scripts flush before exit (`meterProvider.forceFlush()` / `shutdown()`), or your metrics may never be sent
+4. Using `posthog.metrics`? The SDK flushes every 10 seconds, call `posthog.metrics.flush()` to send immediately while testing, and check you're not opted out of capturing
 
 ## Next steps
 
-- **[Logs](/docs/logs)** – capture what happened at each point, using the same OpenTelemetry setup
-- **[Distributed tracing](/docs/distributed-tracing)** – follow requests across your services
-- **[Error tracking](/docs/error-tracking)** – turn failures into issues you can assign and resolve
+- **[Logs](/docs/logs)**: capture what happened at each point, using the same OpenTelemetry setup
+- **[Distributed tracing](/docs/distributed-tracing)**: follow requests across your services
+- **[Error tracking](/docs/error-tracking)**: turn failures into issues you can assign and resolve

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -1,0 +1,172 @@
+---
+title: Metrics
+---
+
+> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+
+PostHog Metrics lets you send application and infrastructure metrics – request counts, latencies, queue depths, resource usage – to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
+
+Metrics works with any OpenTelemetry-compatible client. You don't need any PostHog-specific packages – use standard OpenTelemetry libraries or an OpenTelemetry Collector and point them at PostHog's OTLP endpoint.
+
+## Set up metrics
+
+### 1. Get your project token
+
+You'll need your PostHog project token to authenticate metric requests. This is the same token you use for capturing events with the PostHog SDK.
+
+> **Important:** Use your **project token**, which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project token in [Project Settings](https://app.posthog.com/settings).
+
+### 2. Point your OTLP metrics exporter at PostHog
+
+Metrics are ingested over the OpenTelemetry Protocol (OTLP) via HTTP. Configure your OpenTelemetry SDK with these environment variables:
+
+```bash
+OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="<ph_client_api_host>/i/v1/metrics"
+OTEL_EXPORTER_OTLP_METRICS_HEADERS="Authorization=Bearer <ph_project_token>"
+OTEL_SERVICE_NAME="my-app"
+```
+
+Alternatively, you can pass the token as a query parameter instead of a header:
+
+```bash
+OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="<ph_client_api_host>/i/v1/metrics?token=<ph_project_token>"
+```
+
+### 3. Record metrics from your code
+
+If you'd rather configure the exporter in code, here's a complete setup.
+
+#### Python
+
+```bash
+pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
+```
+
+```python
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+exporter = OTLPMetricExporter(
+    endpoint="<ph_client_api_host>/i/v1/metrics",
+    headers={"Authorization": "Bearer <ph_project_token>"},
+)
+reader = PeriodicExportingMetricReader(exporter, export_interval_millis=15000)
+metrics.set_meter_provider(MeterProvider(metric_readers=[reader]))
+
+meter = metrics.get_meter("my-app")
+
+# A counter for things that only go up
+checkouts = meter.create_counter("checkouts", description="Completed checkouts")
+checkouts.add(1, {"plan": "pro"})
+
+# A histogram for distributions like durations
+request_duration = meter.create_histogram("http.request.duration", unit="ms")
+request_duration.record(42.5, {"route": "/api/checkout", "status": "200"})
+```
+
+#### Node.js
+
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-metrics @opentelemetry/exporter-metrics-otlp-http
+```
+
+```typescript
+import { metrics } from '@opentelemetry/api'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
+
+const exporter = new OTLPMetricExporter({
+    url: '<ph_client_api_host>/i/v1/metrics',
+    headers: { Authorization: 'Bearer <ph_project_token>' },
+})
+
+const meterProvider = new MeterProvider({
+    readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 15000 })],
+})
+metrics.setGlobalMeterProvider(meterProvider)
+
+const meter = metrics.getMeter('my-app')
+
+// A counter for things that only go up
+const checkouts = meter.createCounter('checkouts', { description: 'Completed checkouts' })
+checkouts.add(1, { plan: 'pro' })
+
+// A gauge for values that go up and down
+const queueDepth = meter.createGauge('queue.depth')
+queueDepth.record(17, { queue: 'emails' })
+```
+
+> **Note:** If your language isn't listed, any OpenTelemetry SDK works – check the [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/) for your language and point its OTLP metrics exporter at PostHog.
+
+### Already running an OpenTelemetry Collector?
+
+If your services already ship metrics to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), add PostHog as an exporter – no application changes needed:
+
+```yaml
+exporters:
+  otlphttp/posthog:
+    metrics_endpoint: "<ph_client_api_host>/i/v1/metrics"
+    headers:
+      Authorization: "Bearer <ph_project_token>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp/posthog]
+```
+
+## Supported metric types
+
+PostHog ingests all OTLP metric types:
+
+| Type | What it's for | Example |
+|------|---------------|---------|
+| **Counter (sum)** | Values that only go up | Requests served, checkouts completed |
+| **Gauge** | Values that go up and down | Queue depth, memory in use, active connections |
+| **Histogram** | Distributions | Request duration, payload size |
+| **Exponential histogram** | Distributions with automatic bucketing | Same as histogram, with better resolution across wide ranges |
+| **Summary** | Pre-computed quantiles | Latency percentiles from legacy clients |
+
+A metric's identity is its **name, type, and attributes** together. `http.requests` with `{route: "/home"}` and `http.requests` with `{route: "/checkout"}` are separate series, so keep attribute values low-cardinality – attach things like route, status, or plan, not user IDs or request IDs.
+
+## Use your metrics
+
+Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog.
+
+### Chart metrics in the viewer
+
+The **Viewer** tab lets you explore metrics without writing any queries:
+
+- **Pick a metric** by name to chart it over time
+- **Choose an aggregation** – sum, average, count, p95, rate, or increase. The viewer recommends one based on the metric's type: increase for counters, average for gauges, p95 for histograms
+- **Group by attributes** to break a metric down into one line per value, like per route or per status code
+- **Filter** to the series you care about, and adjust the date range
+
+### Query metrics with SQL
+
+The **SQL** tab gives you direct access to your metrics with [SQL](/docs/sql):
+
+```sql
+SELECT * FROM posthog.metrics LIMIT 10
+```
+
+Use it for anything the viewer doesn't cover – joining metrics against each other, custom math, or ad-hoc exploration of raw data points.
+
+## Troubleshooting
+
+**No metrics showing up?**
+
+1. Check you're using your **project token** (`phc_...`), not a personal API key (`phx_...`)
+2. Check the endpoint path is exactly `/i/v1/metrics` – requests without a token return `401 Unauthorized`
+3. OTLP SDKs export on an interval (60 seconds by default) – lower `export_interval_millis` while testing, and in short-lived scripts flush before exit (`meterProvider.forceFlush()` / `shutdown()`), or your metrics may never be sent
+
+## Next steps
+
+- **[Logs](/docs/logs)** – capture what happened at each point, using the same OpenTelemetry setup
+- **[Distributed tracing](/docs/distributed-tracing)** – follow requests across your services
+- **[Error tracking](/docs/error-tracking)** – turn failures into issues you can assign and resolve

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -6,9 +6,53 @@ title: Metrics
 
 PostHog Metrics lets you send application and infrastructure metrics – request counts, latencies, queue depths, resource usage – to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
 
-Metrics works with any OpenTelemetry-compatible client. You don't need any PostHog-specific packages – use standard OpenTelemetry libraries or an OpenTelemetry Collector and point them at PostHog's OTLP endpoint.
+There are two ways to send metrics:
 
-## Set up metrics
+1. **Already have PostHog installed?** Record metrics directly with the [`posthog.metrics` API](#already-have-posthog-installed-use-posthogmetrics) built into the PostHog SDK – no extra packages.
+2. **Using OpenTelemetry?** Point any standard OpenTelemetry library or Collector at [PostHog's OTLP endpoint](#set-up-metrics-with-opentelemetry) – no PostHog-specific packages.
+
+## Already have PostHog installed? Use posthog.metrics
+
+If [posthog-js](/docs/libraries/js) is already running on your site, you can record metrics immediately – no OpenTelemetry setup, no new dependencies, and no extra authentication beyond the project API key you already configured:
+
+```js
+// A counter for things that only go up
+posthog.metrics.count('checkout.completed')
+
+// A gauge for values that go up and down
+posthog.metrics.gauge('cart.items', 3)
+
+// A histogram for distributions like durations
+posthog.metrics.histogram('api.request.duration', 187, { unit: 'ms' })
+```
+
+Add attributes to slice a metric by dimension, and set a service name so your metrics are easy to find and filter:
+
+```js
+posthog.init('<ph_project_api_key>', {
+    api_host: '<ph_client_api_host>',
+    metrics: {
+        serviceName: 'storefront-web',
+        environment: 'production',
+    },
+})
+
+posthog.metrics.count('checkout.completed', 1, { attributes: { plan: 'pro' } })
+posthog.metrics.histogram('api.request.duration', 187, {
+    unit: 'ms',
+    attributes: { route: '/api/checkout', status: '200' },
+})
+```
+
+Metrics are safe to record from hot paths. Samples are aggregated in memory and sent as one data point per series every 10 seconds – a burst of 10,000 `count()` calls costs one data point on the wire. Pending metrics are flushed automatically when the page is hidden or closed, and you can force a flush with `posthog.metrics.flush()`.
+
+The `metrics` config also accepts `flushIntervalMs`, `maxSeriesPerFlush` (a cardinality guardrail, default 1000 series per window), `resourceAttributes`, and a `beforeSend` hook to filter or modify metrics before they're aggregated.
+
+Metrics deliberately carry no user or session context: every distinct attribute value creates a new series, so attach low-cardinality dimensions like plan, route, or status – not user IDs.
+
+> **Note:** `posthog.metrics` is currently available in posthog-js (web). Support in posthog-node and other SDKs is coming. If you're on another SDK, or not using PostHog SDKs at all, use the OpenTelemetry setup below.
+
+## Set up metrics with OpenTelemetry
 
 ### 1. Get your project token
 
@@ -134,6 +178,19 @@ PostHog ingests all OTLP metric types:
 
 A metric's identity is its **name, type, and attributes** together. `http.requests` with `{route: "/home"}` and `http.requests` with `{route: "/checkout"}` are separate series, so keep attribute values low-cardinality – attach things like route, status, or plan, not user IDs or request IDs.
 
+### Naming and units
+
+Give metrics descriptive, dot-separated names like `checkout.failed`, `email.sent`, or `queue.depth` – not vague ones like `metric1` or `counter`. Set an explicit unit on histograms (`ms`, `bytes`) so charts are unambiguous. Use one name per metric type: recording `queue.depth` as both a gauge and a counter blends both series in charts.
+
+### What to instrument
+
+Good starting points:
+
+- **Critical operations** – count successes and failures of the flows that matter: checkouts, signups, imports
+- **Service boundaries** – time external API calls and database queries with histograms
+- **Business events** – counters for orders, upgrades, or invites, sliced by plan or region
+- **Resource usage** – gauge queue depths, connection pools, and cache sizes
+
 ## Use your metrics
 
 Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog.
@@ -164,6 +221,7 @@ Use it for anything the viewer doesn't cover – joining metrics against each ot
 1. Check you're using your **project token** (`phc_...`), not a personal API key (`phx_...`)
 2. Check the endpoint path is exactly `/i/v1/metrics` – requests without a token return `401 Unauthorized`
 3. OTLP SDKs export on an interval (60 seconds by default) – lower `export_interval_millis` while testing, and in short-lived scripts flush before exit (`meterProvider.forceFlush()` / `shutdown()`), or your metrics may never be sent
+4. Using `posthog.metrics`? The SDK flushes every 10 seconds – call `posthog.metrics.flush()` to send immediately while testing, and check you're not opted out of capturing
 
 ## Next steps
 

--- a/contents/docs/metrics/start-here.mdx
+++ b/contents/docs/metrics/start-here.mdx
@@ -1,0 +1,112 @@
+---
+title: Getting started with metrics
+hideRightSidebar: true
+contentMaxWidthClass: max-w-5xl
+---
+
+import { QuestLog, QuestLogItem } from "components/Docs/QuestLog";
+
+> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+
+<QuestLog firstSpeechBubble="Let's set up metrics!" lastSpeechBubble="Time to chart your metrics!">
+
+<QuestLogItem
+    title="Send your first metrics"
+    subtitle="Required"
+    icon="IconCode"
+>
+
+There are two ways to get metrics into PostHog, and both take a few minutes.
+
+If [posthog-js](/docs/libraries/js) is already running on your site, record metrics directly with the `posthog.metrics` API. No new packages, no extra authentication:
+
+```js
+posthog.metrics.count('checkout.completed')
+posthog.metrics.gauge('cart.items', 3)
+posthog.metrics.histogram('api.request.duration', 187, { unit: 'ms' })
+```
+
+If you use OpenTelemetry anywhere else (backend services, infrastructure, an existing Collector), point your OTLP metrics exporter at PostHog. No PostHog packages are required:
+
+```bash
+OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="<ph_client_api_host>/i/v1/metrics"
+OTEL_EXPORTER_OTLP_METRICS_HEADERS="Authorization=Bearer <ph_project_token>"
+OTEL_SERVICE_NAME="my-app"
+```
+
+`<ph_client_api_host>` and `<ph_project_token>` are filled in with your project's values when you're logged in. Use your **project token** (the same one you use for capturing events), not a [personal API key](/docs/api#authentication).
+
+For full setup details, including Python and Node.js code samples and Collector configuration, see the [metrics overview](/docs/metrics).
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Pick the right metric type"
+    subtitle="Required"
+    icon="IconStack"
+>
+
+Metrics come in three shapes, and picking the right one determines which aggregations make sense later:
+
+- **Counters** only go up: requests handled, jobs processed, errors raised. Chart them with `rate` or `increase`.
+- **Gauges** go up and down: queue depth, active connections, memory in use. Chart them with `avg`.
+- **Histograms** record distributions: request durations, payload sizes. Chart them with percentiles like `p95`.
+
+Give each metric a stable, descriptive name (`http.server.duration`, `jobs.processed.total`) and set a service name so metrics from different systems stay easy to tell apart.
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Add attributes, carefully"
+    subtitle="Required"
+    icon="IconListTree"
+>
+
+Attributes let you slice a metric by dimension: route, status code, plan, region. Every unique combination of attribute values creates a new series, so attach dimensions with a small, bounded set of values.
+
+Good attributes: `route`, `status`, `plan`, `queue`. Bad attributes: user IDs, session IDs, request IDs, timestamps. Each of those would create a series per user or per request, which makes charts unreadable and ingestion expensive.
+
+If you need to know what happened for one specific user or request, that's a job for [logs](/docs/logs) or [traces](/docs/distributed-tracing), not metrics.
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Verify metrics are arriving"
+    subtitle="Required"
+    icon="IconSearch"
+>
+
+Open **Metrics** in the PostHog sidebar. Pick your metric from the name picker and you should see data points within a minute of sending. The viewer recommends an aggregation based on the metric's type, so a counter defaults to `increase` and a gauge to `avg`.
+
+If nothing shows up, check that the endpoint ends in `/i/v1/metrics`, that the token starts with `phc_`, and see the [troubleshooting section](/docs/metrics#troubleshooting).
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Chart what matters"
+    subtitle="Recommended"
+    icon="IconTrends"
+>
+
+Once data flows, build the views you'll actually watch:
+
+- **Group by** an attribute to get one line per value, for example request rate per route or queue depth per worker.
+- **Filter** with `key=value` chips to focus on one service, environment, or status.
+- Switch to **stat mode** for a single headline number with an automatic comparison against the baseline.
+- Turn on **live** to refresh the chart every few seconds while you watch a deploy or an incident.
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Query with SQL or ask AI"
+    subtitle="Optional"
+    icon="IconDatabase"
+>
+
+Every metric lands in the `posthog.metrics` table, so the SQL tab in the metrics viewer gives you full query access for anything the chart controls don't cover.
+
+If you use the [PostHog MCP server](/docs/model-context-protocol), your AI tools can query metrics directly: ask your agent to chart a metric, compare error rates between services, or characterize an anomaly, all without leaving your editor.
+
+</QuestLogItem>
+
+</QuestLog>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7257,6 +7257,24 @@ export const docsMenu = {
             ],
         },
         {
+            name: 'Metrics',
+            icon: 'IconTrends',
+            color: 'green',
+            url: '/docs/metrics',
+            description: 'Send OpenTelemetry metrics to PostHog and analyze them.',
+            children: [
+                {
+                    name: 'Metrics',
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/metrics',
+                    icon: 'IconHome',
+                    color: 'seagreen',
+                },
+            ],
+        },
+        {
             name: 'Distributed tracing',
             icon: 'IconListTree',
             color: 'purple',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7272,6 +7272,28 @@ export const docsMenu = {
                     icon: 'IconHome',
                     color: 'seagreen',
                 },
+                {
+                    name: 'Getting started',
+                },
+                {
+                    name: 'Start here',
+                    url: '/docs/metrics/start-here',
+                    icon: 'IconListCheck',
+                    color: 'orange',
+                    featured: true,
+                },
+                {
+                    name: 'Why you need metrics',
+                    url: '/docs/metrics/basics',
+                    icon: 'IconBook',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'How metrics works',
+                    url: '/docs/metrics/architecture',
+                    icon: 'IconDatabase',
+                    color: 'purple',
+                },
             ],
         },
         {


### PR DESCRIPTION
## Changes

Adds the how-to guide for the new **Metrics** product (alpha) at `/docs/metrics`, sitting in the APM/observability docs adjacent to [Logs](https://posthog.com/docs/logs) and [Distributed tracing](https://posthog.com/docs/distributed-tracing).

The in-app Metrics scene already links to `https://posthog.com/docs/metrics` from its setup banner and empty state, so this page fills that URL.

The guide covers:

- **Setup**: pointing any OTLP metrics exporter at `<ph_client_api_host>/i/v1/metrics` with the project token (Bearer header or `?token=` query param), env-var quickstart, Python and Node.js SDK examples, and an OpenTelemetry Collector exporter config for teams that already run one
- **Supported metric types**: counter/sum, gauge, histogram, exponential histogram, summary, plus a note on series identity and attribute cardinality
- **Usage**: the Viewer tab (metric picker, per-type recommended aggregations, group-by, filters) and the SQL tab (`SELECT * FROM posthog.metrics`)
- **Troubleshooting**: token type, endpoint path, and the export-interval/flush gotcha for short-lived processes

Also adds a Metrics section to the docs nav between Logs and Distributed tracing.

Details verified against the current implementation in the main repo: OTLP routes and auth in `rust/capture-logs`, metric types in `metric_record.rs`, and the viewer/SQL behavior in `products/metrics/frontend`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

## Update: three more pages, mirroring the Logs and Distributed tracing doc sets

- **Getting started with metrics** (`/docs/metrics/start-here`): a QuestLog checklist that walks from first metric to a chart worth watching, covering both the `posthog.metrics` path and the OTLP path, metric type selection, attribute cardinality, verification, and charting.
- **Why you need metrics** (`/docs/metrics/basics`): the conceptual page. What counters, gauges, and histograms are, what metrics show that logs and traces can't, and what good instrumentation looks like.
- **How metrics works** (`/docs/metrics/architecture`): ingestion flow, the series identity model, counter temporality and reset handling, the shared query grid, and SQL access. Written against current merged behavior only.

Also registers the pages in the docs nav and sweeps dash punctuation from the overview page.
