### PR TITLE
docs(workflows): document wait-for-event scoping and filter limitations

### DIFF
--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -173,6 +173,15 @@ Delays help you control the timing of your messages. There are 3 types of delays
 
 You can see an example of a delay in the [email drip campaign](/docs/workflows/email-drip-campaign) tutorial.
 
+### Waiting for events
+
+A **wait until condition** step can wait for one or more events instead of (or as well as) a property condition. The step resumes when the person in the workflow run sends a matching event - events from other people never resume it. If no matching event arrives before the step's maximum wait duration, the workflow continues down the timeout branch.
+
+A couple of things to keep in mind:
+
+- **Event filters use fixed values.** Filter values are set when you save the workflow and can't reference the trigger event's properties. For example, you can wait for any `order_shipped` event from the person, but you can't wait for an `order_shipped` event whose `order_id` matches the `order_id` on the event that triggered the workflow. Template syntax like `{{event.properties.order_id}}` in a filter value is compared as a literal string, so it will never match.
+- **Each run waits independently.** If the same person triggers the workflow more than once, each run has its own wait step, and a single matching event resumes all of them. If your trigger can fire multiple times per person concurrently, design the workflow so that any matching event is a valid reason to continue.
+
 ## Audience splits
 
 Audience splits help you target your automation or messages to specific groups of users. There are 2 types of audience splits:


### PR DESCRIPTION
## Changes

Adds a "Waiting for events" subsection to the workflow builder doc's Delays section. The current doc has a single table row for "Wait until condition" and doesn't explain how event waits behave, which surfaced as a support ticket where a user tried to correlate a follow-up event to the trigger event by property.

The new subsection covers:

- Event waits resume on a matching event **from the person in the run** - they're person-scoped.
- Filter values are fixed at save time and can't reference the trigger event's properties (template syntax like `{{event.properties.order_id}}` compares as a literal string).
- Concurrent runs for the same person each resume on a single matching event.

Related: PostHog/posthog#68963 makes these steps testable in the editor test panel.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`