### PR TITLE
docs: add CLI to docs sidebar and rename Surfaces to Products

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2181,7 +2181,7 @@ export const docsMenu = {
                     url: '/docs/self-driving/setup',
                 },
                 {
-                    name: 'Surfaces',
+                    name: 'Products',
                 },
                 {
                     name: 'Slack',
@@ -2194,6 +2194,10 @@ export const docsMenu = {
                 {
                     name: 'MCP',
                     url: '/docs/model-context-protocol',
+                },
+                {
+                    name: 'CLI',
+                    url: '/docs/cli',
                 },
                 // TODO: add PostHog Code (Desktop) as a surface here once it's GA.
                 {


### PR DESCRIPTION
## Changes

Adds the **CLI** page (`/docs/cli`) to the docs left sidebar under the self-driving section — it wasn't listed before. Also renames the **Surfaces** sub-section header to **Products** to match our brand guidelines.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1783526898667479)*
