### PR TITLE
docs: add Split (Harness FME) data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/split-io.md
+++ b/contents/docs/cdp/sources/split-io.md
@@ -1,0 +1,61 @@
+---
+title: Linking Split as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: SplitIo
+---
+
+<CalloutBox icon="IconFlask" title="Alpha release" type="action">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+Enter your Split (Harness FME) Admin API key to pull your workspaces, environments, feature flags, segments, and change requests into the PostHog data warehouse.
+
+## Prerequisites
+
+You need an **Admin API key** for your Split organization. Client-side and server-side SDK keys won't work. Creating Admin API keys requires administrator access in Split.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Split.io.
+3. In Split, go to **Admin settings** → **API keys** and create a new API key with the **Admin** type. Copy the key.
+4. Back in PostHog, enter the Admin API key and click **Next**.
+5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+Once the syncs are complete, you can start using Split data in PostHog.
+
+## Available tables
+
+| Table | Description | Sync method |
+| ----- | ----------- | ----------- |
+| `workspaces` | Workspaces in your Split organization | Full refresh |
+| `environments` | Environments, fetched per workspace | Full refresh |
+| `traffic_types` | Traffic types, fetched per workspace | Full refresh |
+| `feature_flags` | Feature flags (splits), fetched per workspace | Full refresh |
+| `segments` | Segments, fetched per workspace | Full refresh |
+| `rollout_statuses` | Rollout statuses, fetched per workspace | Full refresh |
+| `flag_sets` | Flag sets, fetched per workspace | Full refresh |
+| `groups` | Groups in your organization | Full refresh |
+| `users` | Active members of your organization | Full refresh |
+| `change_requests` | Change requests awaiting or past approval | Full refresh |
+
+Tables fetched per workspace carry an injected `_workspace_id` column identifying the workspace each row came from.
+
+## Sync limitations
+
+Split's Admin API exposes no server-side timestamp filter on these resources, so every table is full refresh only and reloads all records on each sync.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new `split_io` data warehouse source, implemented in [PostHog/posthog#69365](https://github.com/PostHog/posthog/pull/69365).

**Why:** a finished warehouse source ships with a matching posthog.com doc; the source's `docsUrl` points at `/docs/cdp/sources/split-io`, so without this page it 404s.

- Follows the canonical source-doc template (frontmatter `sourceId: SplitIo`, alpha callout, prerequisites, setup steps, `<SourceParameters />`, `<SourceTables />`).
- Slug `split-io` matches the source's `docsUrl`; `audit_source_docs` passes for this source against the posthog repo branch.
- Should merge after (or together with) the source PR so `SourceParameters`/`SourceTables` have data to render.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
