### PR TITLE
feat(data-warehouse): add onepagecrm source doc

### DIFF
--- a/contents/docs/cdp/sources/onepagecrm.md
+++ b/contents/docs/cdp/sources/onepagecrm.md
@@ -1,0 +1,53 @@
+---
+title: Linking OnePageCRM as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Onepagecrm
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The OnePageCRM connector syncs your CRM data – contacts, companies, deals, actions, notes, calls, meetings, users, statuses, and lead sources – into the PostHog Data warehouse, so you can analyze your sales pipeline alongside your product data.
+
+## Prerequisites
+
+You need a OnePageCRM account with API access. The API key grants read access to every record your user can see.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking OnePageCRM, you'll need:
+
+- **User ID** – find it in [OnePageCRM](https://app.onepagecrm.com) under **Apps & Integrations → API**.
+- **API key** – shown in the same place as your User ID.
+
+## Sync modes
+
+<SyncModes />
+
+Contacts, deals, actions, notes, calls, and meetings support incremental sync on the `modified_at` field. Companies, users, statuses, and lead sources are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your User ID or API key is invalid or has been revoked. Check both under **Apps & Integrations → API** in OnePageCRM, then reconnect.
+- If you see a permissions error, the key is missing the access needed to sync this data. Check your OnePageCRM user's account permissions, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new OnePageCRM data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, alpha callout).

The source implementation lands in PostHog/posthog#69370 – it ships as unreleased/alpha, so this doc should merge once that source is released. `sourceId: Onepagecrm` matches the `ExternalDataSourceType` value, and `audit_source_docs` in the posthog repo passes for this source against this file.

**Why:** the warehouse-source workflow requires every finished source to ship with a consistent posthog.com doc, and the source's `docsUrl` already points at `/docs/cdp/sources/onepagecrm`.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
