### PR TITLE
docs: add pipeliner data warehouse source doc

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -59,6 +59,7 @@ Cloudflare
 Cloudwatch
 Codecov
 CodeSandbox
+Coevera
 Cognito
 [Cc]ohere
 Coinbase
@@ -193,6 +194,7 @@ Pendo
 Phabricator
 Pinterest
 Pipedrive
+Pipeliner
 Pixar
 PlanetScale
 PlayerZero

--- a/contents/docs/cdp/sources/pipeliner.md
+++ b/contents/docs/cdp/sources/pipeliner.md
@@ -1,0 +1,60 @@
+---
+title: Linking Pipeliner as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Pipeliner
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Pipeliner connector syncs your Pipeliner CRM (Coevera) accounts, contacts, leads, opportunities, activities, and product catalog into the PostHog Data warehouse, so you can analyze your sales pipeline alongside your product data.
+
+## Prerequisites
+
+You need administrator access to your Pipeliner team space to create an API application. The API credentials it issues are scoped to that team space.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Pipeliner, you'll need the API access details of an API application:
+
+1. Sign in to Pipeliner and open the administration area of your team space.
+2. Go to **Unit, Users & Roles → Applications** and create a new application.
+3. Click **Show API Access** to reveal the connection details.
+
+From those details, enter:
+
+- **Service URL** – the regional API host your space is served from, for example `us-east.api.pipelinersales.com`.
+- **Space ID** – the identifier of your team space.
+- **API username** and **API password** – the generated API key pair. These are shown only once, so store them safely.
+
+## Sync modes
+
+<SyncModes />
+
+Every table supports incremental syncs on the `modified` timestamp. Note that records deleted in Pipeliner are only removed from PostHog by a full refresh sync.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API credentials are invalid or have been revoked. Create a new API application in your team space's administration area, then reconnect.
+- If you see a permissions error, the API application is missing the access needed to sync this data. Check the application's permissions, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Pipeliner CRM (Coevera) data warehouse source, shipped in [PostHog/posthog#69381](https://github.com/PostHog/posthog/pull/69381). Follows the canonical source-doc template: shared snippets, `<SourceParameters />` and `<SourceTables />` rendered from the `public_source_configs` API, and the alpha-release callout. `python manage.py audit_source_docs` in the posthog repo passes for this source with the doc in place.

**Why:** the connector's `docsUrl` points at `/docs/cdp/sources/pipeliner`, so the doc needs to exist before the source is released.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
