### PR TITLE
docs: add surveysparrow data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/surveysparrow.md
+++ b/contents/docs/cdp/sources/surveysparrow.md
@@ -1,0 +1,65 @@
+---
+title: Linking SurveySparrow as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: SurveySparrow
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The SurveySparrow connector syncs your survey and feedback data into the PostHog Data warehouse, so you can analyze surveys, responses, questions, and contacts alongside your product data.
+
+## Prerequisites
+
+You need a SurveySparrow account that can create a private app, which is how SurveySparrow issues API access tokens.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking SurveySparrow, you'll need:
+
+- **Access token** – create a private app under **Settings → Apps & Integrations** in SurveySparrow and generate an access token. The token is displayed only once, so copy it when it's created.
+- **Data center** – the region your SurveySparrow account is hosted in. Tokens are only valid against their own region's API host:
+
+| Region       | API host                       |
+| ------------ | ------------------------------ |
+| US           | `api.surveysparrow.com`        |
+| EU           | `eu-api.surveysparrow.com`     |
+| Asia-Pacific | `ap-api.surveysparrow.com`     |
+| Middle East  | `me-api.surveysparrow.com`     |
+| UK           | `eu-ln-api.surveysparrow.com`  |
+| Sydney       | `ap-sy-app.surveysparrow.com`  |
+| Canada       | `ca-api.surveysparrow.com`     |
+
+If you're unsure which data center your account uses, check your SurveySparrow account settings or contact SurveySparrow support.
+
+## Sync modes
+
+<SyncModes />
+
+The `responses` table supports incremental sync on `completed_time`, using SurveySparrow's server-side submission date filter. Only completed responses are synced — partial (in-progress) submissions are not imported. All other tables are full refresh only, since their API endpoints expose no reliable incremental cursor.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your access token is invalid or revoked, or it's being sent to the wrong region. Check the data center matches your account, or generate a new token under **Settings → Apps & Integrations**, then reconnect.
+- If you get a permission error, your access token is missing scopes for the resources you're syncing. Grant read access for those resources when creating the private app, then reconnect.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/surveysparrow.md
+++ b/contents/docs/cdp/sources/surveysparrow.md
@@ -47,7 +47,7 @@ If you're unsure which data center your account uses, check your SurveySparrow a
 
 <SyncModes />
 
-The `responses` table supports incremental sync on `completed_time`, using SurveySparrow's server-side submission date filter. Only completed responses are synced — partial (in-progress) submissions are not imported. All other tables are full refresh only, since their API endpoints expose no reliable incremental cursor.
+The `responses` table supports incremental sync on `completed_time`, using SurveySparrow's server-side submission date filter. Only completed responses are synced – partial (in-progress) submissions are not imported. All other tables are full refresh only, since their API endpoints expose no reliable incremental cursor.
 
 ## Configuration
 


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new SurveySparrow data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, alpha callout).

**Why:** companion to the source implementation in [PostHog/posthog#69380](https://github.com/PostHog/posthog/pull/69380), whose `docsUrl` points at `/docs/cdp/sources/surveysparrow`. The source ships unreleased/alpha, so this can land alongside or after that PR.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
