### PR TITLE
docs: add Pabbly Subscription Billing data warehouse source doc

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -188,6 +188,7 @@ Opsgenie
 Optimizely
 OTel
 Outfunnel
+Pabbly
 Pendo
 [Pp]erplexity
 Phabricator

--- a/contents/docs/cdp/sources/pabbly-subscriptions-billing.md
+++ b/contents/docs/cdp/sources/pabbly-subscriptions-billing.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Pabbly Subscription Billing connector syncs your customers, subscriptions, products, invoices, transactions, refunds, and related billing data into the PostHog Data warehouse, so you can analyze your recurring revenue alongside your product data.
+The Pabbly Subscription Billing connector syncs your customers, subscriptions, products, invoices, transactions, refunds, and related billing data into the PostHog Data Warehouse, so you can analyze your recurring revenue alongside your product data.
 
 ## Prerequisites
 

--- a/contents/docs/cdp/sources/pabbly-subscriptions-billing.md
+++ b/contents/docs/cdp/sources/pabbly-subscriptions-billing.md
@@ -1,0 +1,52 @@
+---
+title: Linking Pabbly Subscription Billing as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: PabblySubscriptionsBilling
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Pabbly Subscription Billing connector syncs your customers, subscriptions, products, invoices, transactions, refunds, and related billing data into the PostHog Data warehouse, so you can analyze your recurring revenue alongside your product data.
+
+## Prerequisites
+
+You need a Pabbly Subscription Billing account with access to its API settings. The API key and secret key grant read access to every record in the account.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Pabbly Subscription Billing, you'll need:
+
+- **API key** and **Secret key** – generate both under **Settings → API Settings** in your [Pabbly Subscription Billing](https://payments.pabbly.com) account.
+
+## Sync modes
+
+<SyncModes />
+
+Pabbly Subscription Billing exposes no server-side change filter, so every table syncs via full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key or secret key is invalid or has been regenerated. Generate new keys under **Settings → API Settings** in Pabbly Subscription Billing, then reconnect.
+- Pabbly Subscription Billing limits accounts to 10,000 API requests per day. Very large accounts syncing many tables on a frequent schedule can hit this quota; if syncs start failing late in the day, reduce the sync frequency or the number of synced tables.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Pabbly Subscription Billing data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, alpha callout).

**Why:** the source implementation lands in [PostHog/posthog#69385](https://github.com/PostHog/posthog/pull/69385) with `docsUrl` pointing at `/docs/cdp/sources/pabbly-subscriptions-billing`, so the doc needs to exist at that slug. `audit_source_docs` passes for this source against this file.

This doc should merge alongside (or after) the source PR, since `sourceId: PabblySubscriptionsBilling` pulls its config and table list from the `public_source_configs` API.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a - new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*