### PR TITLE
Add ShopWired data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/shopwired.md
+++ b/contents/docs/cdp/sources/shopwired.md
@@ -1,0 +1,52 @@
+---
+title: Linking ShopWired as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ShopWired
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The ShopWired connector syncs your e-commerce store data into the PostHog Data warehouse, so you can analyze your products, customers, and orders alongside your product analytics data.
+
+## Prerequisites
+
+You need a ShopWired account with access to API keys. API credentials inherit full access to your store's data.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking ShopWired, you'll need:
+
+- **API key** and **API secret** – create these under **Account > API keys** in your [ShopWired](https://www.shopwired.co.uk) account.
+
+## Sync modes
+
+<SyncModes />
+
+Orders support incremental sync using their creation date. ShopWired doesn't expose a modified-date filter, so incremental syncs only pick up newly created orders — changes to existing records are only captured by a full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key or secret is invalid or has been revoked. Generate new credentials under **Account > API keys** in ShopWired, then reconnect.
+- Syncs of very large stores can be slowed by ShopWired's API rate limit (2 requests per second sustained). The connector backs off and retries automatically, so this shows up as a longer sync, not a failure.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new ShopWired data warehouse connector, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, alpha callout).

The connector itself lands in the main repo with `docsUrl` pointing at `/docs/cdp/sources/shopwired`, matching this filename. Companion PR link will be in the connector PR description.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
