### PR TITLE
docs: add shippo data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/shippo.md
+++ b/contents/docs/cdp/sources/shippo.md
@@ -1,0 +1,52 @@
+---
+title: Linking Shippo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Shippo
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Shippo connector syncs your shipping data – shipments, purchased labels, orders, addresses, parcels, refunds, customs data, and carrier accounts – into the PostHog Data warehouse, so you can analyze fulfillment and delivery alongside your product data.
+
+## Prerequisites
+
+You need a Shippo account with access to its API settings. Shippo issues separate live (`shippo_live_...`) and test (`shippo_test_...`) API tokens – use the live token to sync your production shipping data.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Shippo, you'll need:
+
+- **API token** – find or generate one under **Settings → API** in the [Shippo dashboard](https://apps.goshippo.com/settings/api). The token grants read access to all of your account's shipping data.
+
+## Sync modes
+
+<SyncModes />
+
+The `shipments` table supports incremental syncs on its creation time. Note that the Shippo API doesn't return shipments older than 390 days, which bounds how far back the initial sync can reach. The other tables are synced with a full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API token is invalid or has been revoked. Generate a new token under **Settings → API** in the Shippo dashboard, then reconnect.
+- Test mode tokens have much lower API rate limits than live tokens, so a large sync using a `shippo_test_` token can take noticeably longer.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Shippo data warehouse source, implemented in [PostHog/posthog#69392](https://github.com/PostHog/posthog/pull/69392). Follows the canonical source-doc template: shared snippets, `<SourceParameters />` and `<SourceTables />` (the source sets `lists_tables_without_credentials`, so the table catalog renders), plus Shippo-specific notes on the 390-day shipment history limit and test-token rate limits.

`sourceId: Shippo` matches the `ExternalDataSourceType` value and the filename matches the source's `docsUrl` (`/docs/cdp/sources/shippo`); `audit_source_docs` passes for this source.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a – new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
