### PR TITLE
docs: add Retently data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/retently.md
+++ b/contents/docs/cdp/sources/retently.md
@@ -1,0 +1,52 @@
+---
+title: Linking Retently as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Retently
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Retently connector syncs your customer feedback data – survey responses, customers, companies, campaigns, templates, sent surveys, and campaign reports – into the PostHog Data warehouse, so you can analyze NPS, CSAT, and CES results alongside your product data.
+
+## Prerequisites
+
+You need a Retently account with access to the API settings. A key with **read** permission is sufficient – this source only performs GET requests.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Retently, you'll need:
+
+- **API key** – create one under **Settings → Integrations → API** in [Retently](https://app.retently.com). PostHog sends it in the `X-Api-Key` header.
+
+## Sync modes
+
+<SyncModes />
+
+The `feedback` table supports incremental sync on the response creation date. Retently's other endpoints don't expose a reliable server-side "updated since" filter, so the remaining tables are full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Generate a new key under **Settings → Integrations → API** in Retently, then reconnect.
+- Retently rate-limits API requests to roughly 150 per minute. Syncs back off and retry automatically, but very large accounts may take a while on the first sync.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Retently data warehouse import source, implemented in [PostHog/posthog#69393](https://github.com/PostHog/posthog/pull/69393). Follows the canonical source-doc template (shared snippets, `<SourceParameters />` + `<SourceTables />`); the table catalog renders from the source's static endpoint catalog and canonical descriptions.

**Why:** the connector ships with a `docsUrl` pointing at `/docs/cdp/sources/retently`, so this page needs to exist for the source's docs link and public table catalog to resolve.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a – new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
