### PR TITLE
docs: Python backend identify callout with the correct code

### DIFF
--- a/contents/docs/_snippets/identify-backend-callout-python.mdx
+++ b/contents/docs/_snippets/identify-backend-callout-python.mdx
@@ -1,18 +1,14 @@
-<CalloutBox icon="IconInfo" title="Identifying users is required">
-
-Backend events need a `distinct_id` to associate events with the correct user.
-
-In Python, you can do this through a context. All event captures in the same context will be tagged automatically with the correct `distinct_id`. Typically, you would set a fresh context and identify at the top of each route.
-
-```python
-from posthog import new_context, identify_context, capture
-
-@app.get("/foo")
-def foo(current_user: User = Depends(get_current_user)):
-    with new_context(): # Set context at the top of a route
-        identify_context(current_user.id)
-        capture("foo_viewed")
-    return {"status": "ok"}
-```
-
-</CalloutBox>
+> **Identifying users is required.** Backend events need a `distinct_id` to associate events with the correct user.
+>
+> In Python, you can do this through a context. All event captures in the same context will be tagged automatically with the correct `distinct_id`. Typically, you would set a fresh context and identify at the top of each route.
+>
+> ```python
+> from posthog import new_context, identify_context, capture
+>
+> @app.get("/foo")
+> def foo(current_user: User = Depends(get_current_user)):
+>     with new_context(): # Set context at the top of a route
+>         identify_context(current_user.id)
+>         capture("foo_viewed")
+>     return {"status": "ok"}
+> ```

--- a/contents/docs/_snippets/identify-backend-callout-python.mdx
+++ b/contents/docs/_snippets/identify-backend-callout-python.mdx
@@ -1,15 +1,18 @@
 <CalloutBox icon="IconInfo" title="Identifying users is required">
 
-Backend events need a `distinct_id` that matches the ID your frontend sets when calling `posthog.identify()`. The Python SDK has no top-level `identify()` method — associate the user inside a [context](/docs/libraries/python#contexts) with `identify_context()`:
+Backend events need a `distinct_id` to associate events with the correct user.
+
+In Python, you can do this through a context. All event captures in the same context will be tagged automatically with the correct `distinct_id`. Typically, you would set a fresh context and identify at the top of each route.
 
 ```python
-from posthog import new_context, identify_context
+from posthog import new_context, identify_context, capture
 
-with new_context():
-    identify_context(user_id)
-    posthog.capture("event_name")
+@app.get("/foo")
+def foo(current_user: User = Depends(get_current_user)):
+    with new_context(): # Set context at the top of a route
+        identify_context(current_user.id)
+        capture("foo_viewed")
+    return {"status": "ok"}
 ```
-
-Without a matching `distinct_id`, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking). See our guide on [identifying users](/docs/getting-started/identify-users) for more.
 
 </CalloutBox>

--- a/contents/docs/_snippets/identify-backend-callout-python.mdx
+++ b/contents/docs/_snippets/identify-backend-callout-python.mdx
@@ -1,0 +1,15 @@
+<CalloutBox icon="IconInfo" title="Identifying users is required">
+
+Backend events need a `distinct_id` that matches the ID your frontend sets when calling `posthog.identify()`. The Python SDK has no top-level `identify()` method — associate the user inside a [context](/docs/libraries/python#contexts) with `identify_context()`:
+
+```python
+from posthog import new_context, identify_context
+
+with new_context():
+    identify_context(user_id)
+    posthog.capture("event_name")
+```
+
+Without a matching `distinct_id`, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking). See our guide on [identifying users](/docs/getting-started/identify-users) for more.
+
+</CalloutBox>

--- a/contents/docs/_snippets/identify-backend-callout-python.mdx
+++ b/contents/docs/_snippets/identify-backend-callout-python.mdx
@@ -1,3 +1,0 @@
-> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. In Python, set it with `identify_context()` inside a `new_context()` block — the server SDK has no top-level `identify()` method. Without a matching `distinct_id`, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking).
->
-> See our guide on [identifying users](/docs/getting-started/identify-users) for how to set this up.

--- a/contents/docs/_snippets/identify-backend-callout-python.mdx
+++ b/contents/docs/_snippets/identify-backend-callout-python.mdx
@@ -1,0 +1,3 @@
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. In Python, set it with `identify_context()` inside a `new_context()` block — the server SDK has no top-level `identify()` method. Without a matching `distinct_id`, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking).
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users) for how to set this up.

--- a/contents/docs/_snippets/identify-backend-callout.mdx
+++ b/contents/docs/_snippets/identify-backend-callout.mdx
@@ -1,3 +1,3 @@
-> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking).
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the one your frontend sets by calling `posthog.identify()` — associate it on the backend with this SDK's own identify method. Without a matching `distinct_id`, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking).
 >
 > See our guide on [identifying users](/docs/getting-started/identify-users) for how to set this up.

--- a/contents/docs/_snippets/identify-backend-callout.mdx
+++ b/contents/docs/_snippets/identify-backend-callout.mdx
@@ -1,3 +1,3 @@
-> **Identifying users is required.** Backend events need a `distinct_id` that matches the one your frontend sets by calling `posthog.identify()` — associate it on the backend with this SDK's own identify method. Without a matching `distinct_id`, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking).
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay), [LLM traces](/docs/ai-engineering), or [error tracking](/docs/error-tracking).
 >
 > See our guide on [identifying users](/docs/getting-started/identify-users) for how to set this up.

--- a/contents/docs/libraries/django.mdx
+++ b/contents/docs/libraries/django.mdx
@@ -62,9 +62,9 @@ Events captured without a context or explicit `distinct_id` are sent as [anonymo
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../_snippets/identify-backend-callout-python.mdx'
+import IdentifyBackendCalloutPython from '../_snippets/identify-backend-callout-python.mdx'
 
-<IdentifyBackendCallout />
+<IdentifyBackendCalloutPython />
 
 ## Django contexts middleware
 

--- a/contents/docs/libraries/django.mdx
+++ b/contents/docs/libraries/django.mdx
@@ -62,7 +62,7 @@ Events captured without a context or explicit `distinct_id` are sent as [anonymo
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../_snippets/identify-backend-callout-python.mdx'
+import IdentifyBackendCallout from '../_snippets/identify-backend-callout.mdx'
 
 <IdentifyBackendCallout />
 

--- a/contents/docs/libraries/django.mdx
+++ b/contents/docs/libraries/django.mdx
@@ -62,7 +62,7 @@ Events captured without a context or explicit `distinct_id` are sent as [anonymo
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../_snippets/identify-backend-callout.mdx'
+import IdentifyBackendCallout from '../_snippets/identify-backend-callout-python.mdx'
 
 <IdentifyBackendCallout />
 

--- a/contents/docs/libraries/flask.mdx
+++ b/contents/docs/libraries/flask.mdx
@@ -39,9 +39,9 @@ You can find your project token and instance address in [your project settings](
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../_snippets/identify-backend-callout-python.mdx'
+import IdentifyBackendCalloutPython from '../_snippets/identify-backend-callout-python.mdx'
 
-<IdentifyBackendCallout />
+<IdentifyBackendCalloutPython />
 
 ## Request contexts
 

--- a/contents/docs/libraries/flask.mdx
+++ b/contents/docs/libraries/flask.mdx
@@ -39,7 +39,7 @@ You can find your project token and instance address in [your project settings](
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../_snippets/identify-backend-callout.mdx'
+import IdentifyBackendCallout from '../_snippets/identify-backend-callout-python.mdx'
 
 <IdentifyBackendCallout />
 

--- a/contents/docs/libraries/flask.mdx
+++ b/contents/docs/libraries/flask.mdx
@@ -39,7 +39,7 @@ You can find your project token and instance address in [your project settings](
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../_snippets/identify-backend-callout-python.mdx'
+import IdentifyBackendCallout from '../_snippets/identify-backend-callout.mdx'
 
 <IdentifyBackendCallout />
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -32,7 +32,7 @@ import PythonInstall from '../../integrate/_snippets/install-python.mdx'
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../../_snippets/identify-backend-callout-python.mdx'
+import IdentifyBackendCallout from '../../_snippets/identify-backend-callout.mdx'
 
 <IdentifyBackendCallout />
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -32,9 +32,9 @@ import PythonInstall from '../../integrate/_snippets/install-python.mdx'
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../../_snippets/identify-backend-callout-python.mdx'
+import IdentifyBackendCalloutPython from '../../_snippets/identify-backend-callout-python.mdx'
 
-<IdentifyBackendCallout />
+<IdentifyBackendCalloutPython />
 
 ## Capturing events
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -32,7 +32,7 @@ import PythonInstall from '../../integrate/_snippets/install-python.mdx'
 
 ## Identifying users
 
-import IdentifyBackendCallout from '../../_snippets/identify-backend-callout.mdx'
+import IdentifyBackendCallout from '../../_snippets/identify-backend-callout-python.mdx'
 
 <IdentifyBackendCallout />
 


### PR DESCRIPTION
Adds a Python-SDK variant of the backend identify callout that shows the actual `identify_context()`/`new_context()` code (the Python SDK has no top-level `identify()`), shared across the python, django, and flask docs; the generic callout is untouched for the other backend SDKs.