### PR TITLE
Align self-driving pitch page with brand story

### DIFF
--- a/contents/handbook/growth/sales/how-to-pitch-self-driving.md
+++ b/contents/handbook/growth/sales/how-to-pitch-self-driving.md
@@ -6,15 +6,15 @@ showTitle: true
 
 This is a living page for how we pitch PostHog making _your_ product self-driving. It covers the core pitch, how to run it, and a [reverse demo](#the-reverse-demo) format that lets the customer experience self-driving on their own data. We're still early, so treat this as a starting point and iterate on it as we practice the pitch and learn what lands.
 
-This pitch sits on top of our [brand story](/handbook/brand/foundations#how-we-describe-posthog), so keep it consistent with how we describe PostHog everywhere else. Two things carry through from there: **self-driving is the story** (the narrative everything sits under), and the customer's product stays the subject — we make _your_ product self-driving, PostHog isn't "a self-driving product" itself. Write it lowercase and hyphenated.
+This pitch sits on top of our [brand story](/handbook/brand/foundations#how-we-describe-posthog), so keep it consistent with how we describe PostHog everywhere else. Two things carry through from there: **self-driving is the story** (the narrative everything sits under), and the customer's product stays the subject – we make _your_ product self-driving, PostHog isn't "a self-driving product" itself. Write it lowercase and hyphenated.
 
 ### The core pitch
 
 Keep it simple. Something like this:
 
-> PostHog already has all the behavioral data about how people use your product. We turn that data into signals, feed those signals to an agent running in a sandbox, and it automatically opens PRs that improve your product. That's your product, self-driving — and the more you put into PostHog, the better the signals get.
+> PostHog already has all the behavioral data about how people use your product. We turn that data into signals, feed those signals to an agent running in a sandbox, and it automatically opens PRs that improve your product. That's your product, self-driving – and the more you put into PostHog, the better the signals get.
 
-That last line is the flywheel line. Every event, flag, and replay you capture sharpens the signals the agent works from, so more data in means better PRs out. In brand terms this is [context — the fuel](/handbook/brand/foundations#how-we-describe-posthog) for the self-driving loop, which is why "put more into PostHog" and "get better PRs out" are the same sentence.
+That last line is the flywheel line. Every event, flag, and replay you capture sharpens the signals the agent works from, so more data in means better PRs out. In brand terms this is [context – the fuel](/handbook/brand/foundations#how-we-describe-posthog) for the self-driving loop, which is why "put more into PostHog" and "get better PRs out" are the same sentence.
 
 ### Why it works
 

--- a/contents/handbook/growth/sales/how-to-pitch-self-driving.md
+++ b/contents/handbook/growth/sales/how-to-pitch-self-driving.md
@@ -4,15 +4,17 @@ sidebar: Handbook
 showTitle: true
 ---
 
-This is a living page for how we pitch PostHog as a self-driving product. It covers the core pitch, how to run it, and a [reverse demo](#the-reverse-demo) format that lets the customer experience self-driving on their own data. We're still early, so treat this as a starting point and iterate on it as we practice the pitch and learn what lands.
+This is a living page for how we pitch PostHog making _your_ product self-driving. It covers the core pitch, how to run it, and a [reverse demo](#the-reverse-demo) format that lets the customer experience self-driving on their own data. We're still early, so treat this as a starting point and iterate on it as we practice the pitch and learn what lands.
+
+This pitch sits on top of our [brand story](/handbook/brand/foundations#how-we-describe-posthog), so keep it consistent with how we describe PostHog everywhere else. Two things carry through from there: **self-driving is the story** (the narrative everything sits under), and the customer's product stays the subject — we make _your_ product self-driving, PostHog isn't "a self-driving product" itself. Write it lowercase and hyphenated.
 
 ### The core pitch
 
 Keep it simple. Something like this:
 
-> PostHog already has all the behavioral data about how people use your product. We turn that data into signals, feed those signals to an agent running in a sandbox, and it automatically opens PRs that improve your product. That's a self-driving product, and the more you put into PostHog, the better the signals get.
+> PostHog already has all the behavioral data about how people use your product. We turn that data into signals, feed those signals to an agent running in a sandbox, and it automatically opens PRs that improve your product. That's your product, self-driving — and the more you put into PostHog, the better the signals get.
 
-That last line is the flywheel line. Every event, flag, and replay you capture sharpens the signals the agent works from, so more data in means better PRs out.
+That last line is the flywheel line. Every event, flag, and replay you capture sharpens the signals the agent works from, so more data in means better PRs out. In brand terms this is [context — the fuel](/handbook/brand/foundations#how-we-describe-posthog) for the self-driving loop, which is why "put more into PostHog" and "get better PRs out" are the same sentence.
 
 ### Why it works
 


### PR DESCRIPTION
## Changes

Light-touch update to the sales handbook's [How to pitch self-driving](https://posthog.com/handbook/growth/sales/how-to-pitch-self-driving) page so it matches how we describe PostHog everywhere else.

- Keep the customer's product as the subject — the page no longer calls PostHog "a self-driving product" (in the intro and the core-pitch quote), per the brand rule that we make _your_ product self-driving.
- Link the pitch back to the [brand story](https://posthog.com/handbook/brand/foundations#how-we-describe-posthog) and pull through the two frames that carry over: "self-driving is the story" and the product-stays-the-subject rule.
- Tie the flywheel line to the brand's "context is the fuel" language.

**Why:** A sales-team member wanted the pitch page to reflect the brand foundations' "How we describe PostHog" story and link back to it, so reps stay consistent with our positioning.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0928JW20TY/p1783532350284649)*