### PR TITLE
fix(authors): correct Rohit Rajpal author details

### DIFF
--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -685,11 +685,11 @@
     },
     {
         "handle": "rohit-rajpal",
-        "name": "Rohit Rajpal ",
+        "name": "Rohit Rajpal",
         "role": "Freelance Technical Writer",
         "link_type": "github",
-        "link_url": "https://github.com/ioannisj",
-        "profile_id": 31730
+        "link_url": "https://github.com/rajpalrohit04",
+        "profile_id": 46025
     },
     {
         "handle": "nyior-clement",


### PR DESCRIPTION
Fixes the author byline on [posthog.com/blog/best-langfuse-alternatives](https://posthog.com/blog/best-langfuse-alternatives), which was crediting Ioannis Josephides instead of Rohit Rajpal.

The `rohit-rajpal` entry in `authors.json` had been created by copying Ioannis's entry and only changing the handle/name/role — it still carried Ioannis's `profile_id` (`31730`) and GitHub URL. Since the blog template resolves the byline from `profile_id`, it rendered Ioannis's name and avatar and linked the byline to his community profile.

This points the entry at Rohit's own community profile and GitHub, and trims a stray trailing space in the name.

**Why:** Reported in Slack — Ioannis was showing up as an author and clicking "Rohit" redirected to Ioannis's profile.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9AKT9NTY/p1783545452689099)*
