### PR TITLE
fix: move desktop icons into the trash instead of hiding behind it

### DIFF
--- a/src/components/Desktop/DraggableDesktopIcon.tsx
+++ b/src/components/Desktop/DraggableDesktopIcon.tsx
@@ -4,18 +4,56 @@ import { AppLink, AppItem } from 'components/OSIcons/AppIcon'
 import ZoomHover from 'components/ZoomHover'
 import { useApp } from '../../context/App'
 
+type Box = { left: number; top: number; right: number; bottom: number }
+
+const toBox = (r: DOMRect | null): Box | null =>
+    r ? { left: r.left, top: r.top, right: r.right, bottom: r.bottom } : null
+
+const rectsIntersect = (a: Box, b: Box, pad = 0): boolean =>
+    a.left < b.right + pad && a.right > b.left - pad && a.top < b.bottom + pad && a.bottom > b.top - pad
+
+// How much slack to give the trash rect so dropping "near enough" still counts.
+const DROP_PAD = 12
+
 interface DraggableDesktopIconProps {
     app: AppItem
     initialPosition: { x: number; y: number }
     onPositionChange: (position: { x: number; y: number }) => void
+    // This icon is the Trash: it's the drop target and can never be trashed itself.
+    isTrash?: boolean
+    // Trash-only: an icon is currently hovering over me → render the drop highlight.
+    isDropActive?: boolean
+    // The Desktop attaches its trashRef here so it can read the live trash rect.
+    innerRef?: React.Ref<HTMLLIElement>
+    // Non-trash icons: read the live trash rect for hit-testing.
+    getTrashRect?: () => DOMRect | null
+    // Non-trash icons: report when the dragged icon starts/stops overlapping the trash.
+    onTrashHoverChange?: (isOver: boolean) => void
+    // Non-trash icons: report a drop onto the trash.
+    onDropOnTrash?: (app: AppItem) => void
 }
 
-export default function DraggableDesktopIcon({ app, initialPosition, onPositionChange }: DraggableDesktopIconProps) {
+export default function DraggableDesktopIcon({
+    app,
+    initialPosition,
+    onPositionChange,
+    isTrash = false,
+    isDropActive = false,
+    innerRef,
+    getTrashRect,
+    onTrashHoverChange,
+    onDropOnTrash,
+}: DraggableDesktopIconProps) {
     const [position, setPosition] = useState(initialPosition)
     const [isDragging, setIsDragging] = useState(false)
     const [hasDragged, setHasDragged] = useState(false)
     const controls = useDragControls()
     const { constraintsRef, isMobile } = useApp()
+
+    const localRef = useRef<HTMLLIElement>(null)
+    const startRectRef = useRef<Box | null>(null)
+    const trashRectRef = useRef<Box | null>(null)
+    const overTrashRef = useRef(false)
 
     useEffect(() => {
         setPosition(initialPosition)
@@ -24,6 +62,14 @@ export default function DraggableDesktopIcon({ app, initialPosition, onPositionC
     const handleDragStart = () => {
         setIsDragging(true)
         setHasDragged(false)
+        overTrashRef.current = false
+        // Cache both rects once at drag start: reconstructing the moved rect from
+        // info.offset avoids per-frame reflows and stays correct despite whileDrag
+        // scale/rotate. The trash can't move while another icon is being dragged.
+        if (!isTrash && !isMobile) {
+            startRectRef.current = toBox(localRef.current?.getBoundingClientRect() ?? null)
+            trashRectRef.current = toBox(getTrashRect?.() ?? null)
+        }
     }
 
     const handleDrag = (_event: any, info: any) => {
@@ -32,10 +78,44 @@ export default function DraggableDesktopIcon({ app, initialPosition, onPositionC
         if (Math.abs(info.offset.x) > 5 || Math.abs(info.offset.y) > 5) {
             setHasDragged(true)
         }
+
+        if (isTrash || isMobile) return
+        const start = startRectRef.current
+        const trash = trashRectRef.current
+        if (!start || !trash) return
+
+        const moved: Box = {
+            left: start.left + info.offset.x,
+            top: start.top + info.offset.y,
+            right: start.right + info.offset.x,
+            bottom: start.bottom + info.offset.y,
+        }
+        const over = rectsIntersect(moved, trash, DROP_PAD)
+        // Only fire on a flip — this ref-guard is the "throttle" that avoids a
+        // parent re-render on every pointer move.
+        if (over !== overTrashRef.current) {
+            overTrashRef.current = over
+            onTrashHoverChange?.(over)
+        }
     }
 
     const handleDragEnd = (_event: any, info: any) => {
         setIsDragging(false)
+
+        // Dropped onto the trash: hand off to the Desktop and skip the position
+        // update — the icon is about to unmount, so there's no settle animation
+        // that could leave it hiding behind the bin (the original bug).
+        if (!isTrash && overTrashRef.current) {
+            overTrashRef.current = false
+            onTrashHoverChange?.(false)
+            onDropOnTrash?.(app)
+            // Keep the click-vs-drag guard behavior consistent.
+            setTimeout(() => {
+                setHasDragged(false)
+            }, 100)
+            return
+        }
+
         if (!constraintsRef.current) return
 
         const bounds = constraintsRef.current.getBoundingClientRect()
@@ -70,6 +150,7 @@ export default function DraggableDesktopIcon({ app, initialPosition, onPositionC
 
     return (
         <motion.li
+            ref={isTrash ? innerRef : localRef}
             className={`absolute w-28 flex justify-center items-center ${isDragging ? 'z-50' : 'z-10'}`}
             animate={{
                 x: position.x,
@@ -77,6 +158,7 @@ export default function DraggableDesktopIcon({ app, initialPosition, onPositionC
                 scale: 1,
                 opacity: 1,
             }}
+            exit={{ scale: 0, opacity: 0 }}
             drag={!isMobile}
             dragControls={!isMobile ? controls : undefined}
             dragListener={false}
@@ -91,7 +173,7 @@ export default function DraggableDesktopIcon({ app, initialPosition, onPositionC
             transition={{ duration: 0.3, ease: 'easeOut' }}
         >
             <div
-                className="relative cursor-move"
+                className={`relative cursor-move transition-transform duration-150 ${isDropActive ? 'scale-110' : ''}`}
                 onPointerDown={(e) => {
                     e.preventDefault()
                     e.stopPropagation()

--- a/src/components/Desktop/appList.tsx
+++ b/src/components/Desktop/appList.tsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import Link from 'components/Link'
+import { IconDemoThumb, AppIcon } from 'components/OSIcons'
+import { AppItem } from 'components/OSIcons/AppIcon'
+import { useApp } from '../../context/App'
+import { useToast } from '../../context/Toast'
+import usePostHog from '../../hooks/usePostHog'
+
+// Desktop icon definitions. Extracted into their own light module so consumers
+// (e.g. the /trash page, which reconstructs trashed icons by label) can import
+// the lists without pulling the entire Desktop chunk (ReactConfetti, Hedgehog
+// mode, Screensaver, …) into their bundle. Re-exported from `./index` for
+// backwards compatibility.
+
+export const useProductLinks = () => {
+    const { posthogInstance, openNewChat, siteSettings, updateSiteSettings } = useApp()
+    const { addToast } = useToast()
+    const posthog = usePostHog()
+
+    return [
+        {
+            label: 'home.mdx',
+            Icon: <AppIcon name="doc" />,
+            url: '/',
+            source: 'desktop',
+        },
+        {
+            label: 'Products',
+            Icon: <AppIcon name="notebook" />,
+            url: '/products',
+            source: 'desktop',
+        },
+        {
+            label: 'Pricing',
+            Icon: <AppIcon name="pricing" />,
+            url: '/pricing',
+            source: 'desktop',
+        },
+        {
+            label: 'customers.mdx',
+            Icon: <AppIcon name="spreadsheet" />,
+            url: '/customers',
+            source: 'desktop',
+        },
+        {
+            label: 'demo.mov',
+            Icon: IconDemoThumb,
+            url: '/demo',
+            className: 'size-14 -my-1',
+            source: 'desktop',
+        },
+        {
+            label: 'Docs',
+            Icon: <AppIcon name="notebook" />,
+            url: '/docs',
+            source: 'desktop',
+        },
+        {
+            label: 'Talk to a human',
+            Icon: <AppIcon name="envelope" />,
+            url: '/talk-to-a-human',
+            source: 'desktop',
+        },
+        {
+            label: 'Ask a question',
+            Icon: <AppIcon name="forums" />,
+            onClick: () => openNewChat({ path: `ask-max` }),
+            source: 'desktop',
+        },
+        ...(posthogInstance
+            ? [
+                  {
+                      label: 'Open app ↗',
+                      Icon: <AppIcon name="computerCoffee" />,
+                      url: 'https://app.posthog.com',
+                      external: true,
+                      source: 'desktop',
+                  },
+              ]
+            : [
+                  {
+                      label: 'Sign up ↗',
+                      Icon: <AppIcon name="compass" />,
+                      url: 'https://app.posthog.com/signup',
+                      external: true,
+                      source: 'desktop',
+                  },
+              ]),
+        {
+            label: 'Switch to website mode',
+            Icon: <AppIcon name="switch" />,
+            onClick: () => {
+                updateSiteSettings({ ...siteSettings, experience: 'boring' })
+                posthog?.capture('switched site mode', {
+                    value: 'website',
+                    source: 'desktop',
+                })
+                addToast({
+                    title: 'Switched to website mode',
+                    description: 'Hover the logo to return to OS mode.',
+                    duration: 5000,
+                    onUndo: () => {
+                        updateSiteSettings({ ...siteSettings, experience: 'posthog' })
+                    },
+                })
+            },
+            source: 'desktop',
+        },
+    ]
+}
+
+export const apps: AppItem[] = [
+    {
+        label: 'Why PostHog?',
+        Icon: <AppIcon name="posthog" />,
+        url: '/about',
+        source: 'desktop',
+    },
+    {
+        label: 'Changelog',
+        Icon: <AppIcon name="invite" />,
+        url: '/changelog',
+        source: 'desktop',
+    },
+    // {
+    //     label: 'Cool tech events',
+    //     Icon: <AppIcon name="invite" />,
+    //     url: '/events',
+    //     source: 'desktop',
+    // },
+    {
+        label: 'Company handbook',
+        Icon: <AppIcon name="handbook" />,
+        url: '/handbook',
+        source: 'desktop',
+    },
+    {
+        label: 'Store',
+        Icon: <AppIcon name="shoppingBag" />,
+        url: '/merch',
+        source: 'desktop',
+    },
+    {
+        label: 'Work here',
+        Icon: <AppIcon name="typewriter" />,
+        url: '/careers',
+        source: 'desktop',
+    },
+    {
+        label: 'Trash',
+        Icon: <AppIcon name="trash" />,
+        url: '/trash',
+        source: 'desktop',
+    },
+]

--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -1,20 +1,21 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'components/Link'
 import { useApp } from '../../context/App'
-import { IconDemoThumb, AppIcon } from 'components/OSIcons'
 import { AppItem } from 'components/OSIcons/AppIcon'
 import ContextMenu from 'components/RadixUI/ContextMenu'
 import CloudinaryImage from 'components/CloudinaryImage'
 import DraggableDesktopIcon from './DraggableDesktopIcon'
+import { useProductLinks, apps } from './appList'
 import { Screensaver } from '../Screensaver'
 import { useInactivityDetection } from '../../hooks/useInactivityDetection'
 import NotificationsPanel from 'components/NotificationsPanel'
 import useTheme from '../../hooks/useTheme'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import HedgeHogModeEmbed from 'components/HedgehogMode'
 import ReactConfetti from 'react-confetti'
 import { useToast } from '../../context/Toast'
 import usePostHog from '../../hooks/usePostHog'
+import { useTrashedIcons } from '../../hooks/useTrashedIcons'
 
 declare global {
     interface Window {
@@ -29,147 +30,10 @@ interface Product {
     color?: string
 }
 
-export const useProductLinks = () => {
-    const { posthogInstance, openNewChat, siteSettings, updateSiteSettings } = useApp()
-    const { addToast } = useToast()
-    const posthog = usePostHog()
-
-    return [
-        {
-            label: 'home.mdx',
-            Icon: <AppIcon name="doc" />,
-            url: '/',
-            source: 'desktop',
-        },
-        {
-            label: 'Products',
-            Icon: <AppIcon name="notebook" />,
-            url: '/products',
-            source: 'desktop',
-        },
-        {
-            label: 'Pricing',
-            Icon: <AppIcon name="pricing" />,
-            url: '/pricing',
-            source: 'desktop',
-        },
-        {
-            label: 'customers.mdx',
-            Icon: <AppIcon name="spreadsheet" />,
-            url: '/customers',
-            source: 'desktop',
-        },
-        {
-            label: 'demo.mov',
-            Icon: IconDemoThumb,
-            url: '/demo',
-            className: 'size-14 -my-1',
-            source: 'desktop',
-        },
-        {
-            label: 'Docs',
-            Icon: <AppIcon name="notebook" />,
-            url: '/docs',
-            source: 'desktop',
-        },
-        {
-            label: 'Talk to a human',
-            Icon: <AppIcon name="envelope" />,
-            url: '/talk-to-a-human',
-            source: 'desktop',
-        },
-        {
-            label: 'Ask a question',
-            Icon: <AppIcon name="forums" />,
-            onClick: () => openNewChat({ path: `ask-max` }),
-            source: 'desktop',
-        },
-        ...(posthogInstance
-            ? [
-                  {
-                      label: 'Open app ↗',
-                      Icon: <AppIcon name="computerCoffee" />,
-                      url: 'https://app.posthog.com',
-                      external: true,
-                      source: 'desktop',
-                  },
-              ]
-            : [
-                  {
-                      label: 'Sign up ↗',
-                      Icon: <AppIcon name="compass" />,
-                      url: 'https://app.posthog.com/signup',
-                      external: true,
-                      source: 'desktop',
-                  },
-              ]),
-        {
-            label: 'Switch to website mode',
-            Icon: <AppIcon name="switch" />,
-            onClick: () => {
-                updateSiteSettings({ ...siteSettings, experience: 'boring' })
-                posthog?.capture('switched site mode', {
-                    value: 'website',
-                    source: 'desktop',
-                })
-                addToast({
-                    title: 'Switched to website mode',
-                    description: 'Hover the logo to return to OS mode.',
-                    duration: 5000,
-                    onUndo: () => {
-                        updateSiteSettings({ ...siteSettings, experience: 'posthog' })
-                    },
-                })
-            },
-            source: 'desktop',
-        },
-    ]
-}
-
-export const apps: AppItem[] = [
-    {
-        label: 'Why PostHog?',
-        Icon: <AppIcon name="posthog" />,
-        url: '/about',
-        source: 'desktop',
-    },
-    {
-        label: 'Changelog',
-        Icon: <AppIcon name="invite" />,
-        url: '/changelog',
-        source: 'desktop',
-    },
-    // {
-    //     label: 'Cool tech events',
-    //     Icon: <AppIcon name="invite" />,
-    //     url: '/events',
-    //     source: 'desktop',
-    // },
-    {
-        label: 'Company handbook',
-        Icon: <AppIcon name="handbook" />,
-        url: '/handbook',
-        source: 'desktop',
-    },
-    {
-        label: 'Store',
-        Icon: <AppIcon name="shoppingBag" />,
-        url: '/merch',
-        source: 'desktop',
-    },
-    {
-        label: 'Work here',
-        Icon: <AppIcon name="typewriter" />,
-        url: '/careers',
-        source: 'desktop',
-    },
-    {
-        label: 'Trash',
-        Icon: <AppIcon name="trash" />,
-        url: '/trash',
-        source: 'desktop',
-    },
-]
+// Icon lists live in `./appList` so lightweight consumers (e.g. the /trash page)
+// can import them without pulling the whole Desktop chunk into their bundle.
+// Re-exported here for backwards compatibility.
+export { useProductLinks, apps }
 
 interface IconPosition {
     x: number
@@ -241,6 +105,25 @@ export default function Desktop() {
     const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
     const { getWallpaperClasses } = useTheme()
     const { addToast } = useToast()
+    const posthog = usePostHog()
+    const { trashedItems, trashItem, restoreItem, emptyTrash } = useTrashedIcons()
+    const trashRef = useRef<HTMLLIElement>(null)
+    const [isTrashHot, setIsTrashHot] = useState(false)
+
+    const getTrashRect = useCallback(() => trashRef.current?.getBoundingClientRect() ?? null, [])
+
+    const handleDropOnTrash = (app: AppItem) => {
+        setIsTrashHot(false)
+        trashItem(app.label)
+        posthog?.capture('desktop icon trashed', { label: app.label, source: 'desktop' })
+        addToast({
+            title: 'Moved to Trash',
+            description: `"${app.label}" was moved to the Trash.`,
+            duration: 5000,
+            onUndo: () => restoreItem(app.label),
+        })
+    }
+
     function generateInitialPositions(columns = 2): IconPositions {
         const positions: IconPositions = {}
 
@@ -382,6 +265,10 @@ export default function Desktop() {
 
     const allApps = [...productLinks, ...apps]
 
+    // Hide trashed icons, but never hide the Trash itself (even if storage is corrupted).
+    // Positions are intentionally kept intact so restoring returns an icon to its exact spot.
+    const visibleApps = allApps.filter((app) => app.label === 'Trash' || !trashedItems.includes(app.label))
+
     const handleScreensaverDismiss = () => {
         addToast({
             title: 'Screensaver dismissed',
@@ -453,6 +340,7 @@ export default function Desktop() {
                                 onClick={() => {
                                     localStorage.removeItem(STORAGE_KEY)
                                     setIconPositions(generateInitialPositions())
+                                    emptyTrash()
                                 }}
                             >
                                 Reset icons
@@ -645,20 +533,29 @@ export default function Desktop() {
                                 animate={{ opacity: rendered ? 1 : 0 }}
                                 className="list-none m-0 -mt-2 md:mt-0 p-0 grid sm:grid-cols-4 grid-cols-3 gap-2"
                             >
-                                {allApps.map((app) => {
-                                    const position = iconPositions[app.label] || { x: 0, y: 0 }
+                                <AnimatePresence>
+                                    {visibleApps.map((app) => {
+                                        const position = iconPositions[app.label] || { x: 0, y: 0 }
+                                        const isTrash = app.label === 'Trash'
 
-                                    return (
-                                        <DraggableDesktopIcon
-                                            key={app.label}
-                                            app={app}
-                                            initialPosition={position}
-                                            onPositionChange={(newPosition) =>
-                                                handlePositionChange(app.label, newPosition)
-                                            }
-                                        />
-                                    )
-                                })}
+                                        return (
+                                            <DraggableDesktopIcon
+                                                key={app.label}
+                                                app={app}
+                                                initialPosition={position}
+                                                onPositionChange={(newPosition) =>
+                                                    handlePositionChange(app.label, newPosition)
+                                                }
+                                                isTrash={isTrash}
+                                                innerRef={isTrash ? trashRef : undefined}
+                                                isDropActive={isTrash && isTrashHot}
+                                                getTrashRect={isTrash ? undefined : getTrashRect}
+                                                onTrashHoverChange={isTrash ? undefined : setIsTrashHot}
+                                                onDropOnTrash={isTrash ? undefined : handleDropOnTrash}
+                                            />
+                                        )
+                                    })}
+                                </AnimatePresence>
                             </motion.ul>
                         </nav>
                     )}

--- a/src/components/OSIcons/AppIcon.tsx
+++ b/src/components/OSIcons/AppIcon.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { BaseIcon, type IconProps } from './Icons'
 import Link from 'components/Link'
+import { ContextMenuItemProps } from 'components/RadixUI/ContextMenu'
 import { useRef } from 'react'
 import useTheme from '../../hooks/useTheme'
 import { useApp } from '../../context/App'
@@ -295,6 +296,7 @@ export interface AppItem {
     orientation?: 'row' | 'column'
     source?: string
     external?: boolean
+    customMenuItems?: ContextMenuItemProps[]
 }
 
 export const AppLink = ({
@@ -312,6 +314,7 @@ export const AppLink = ({
     orientation = 'column',
     source,
     external,
+    customMenuItems,
 }: AppItem) => {
     const posthog = usePostHog()
     const { posthogInstance } = useApp()
@@ -451,6 +454,7 @@ export const AppLink = ({
                     to={url}
                     {...(external ? { externalNoIcon: true } : { state: { newWindow: true } })}
                     className={`${commonClassName} ${orientationClassName}`}
+                    customMenuItems={customMenuItems}
                     onClick={(e) => {
                         if (hasDragged) {
                             e.preventDefault()

--- a/src/hooks/useTrashedIcons.ts
+++ b/src/hooks/useTrashedIcons.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from 'react'
+
+// Single source of truth for which desktop icons have been dragged into the Trash.
+// Icons are identified by their `label` (the same key used for render keys and
+// `desktop-icon-positions`). We store labels only because an `AppItem` isn't
+// serializable (its `Icon` is a React element and some carry `onClick` closures);
+// the visuals are reconstructed from the exported app lists when needed.
+const STORAGE_KEY = 'desktop-trashed-icons'
+
+// Same-document sync channel. The `/trash` window renders in the SAME document as
+// the desktop (not an iframe), and the native `storage` event only fires in OTHER
+// tabs — so this CustomEvent is the load-bearing sync between the two windows.
+const CHANGE_EVENT = 'desktop-trashed-change'
+
+// Labels that must never be trashed (the Trash can't throw itself away).
+const NEVER_TRASH = new Set<string>(['Trash'])
+
+const readTrashed = (): string[] => {
+    if (typeof window === 'undefined') return []
+    try {
+        const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '[]')
+        return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : []
+    } catch (error) {
+        // localStorage might not be available (SSR, private browsing, etc.)
+        console.warn('Failed to read trashed icons from localStorage:', error)
+        return []
+    }
+}
+
+export function useTrashedIcons() {
+    // Empty on the server and first client paint → no hydration mismatch.
+    const [trashedItems, setTrashedItems] = useState<string[]>([])
+
+    useEffect(() => {
+        const sync = () => setTrashedItems(readTrashed())
+        sync()
+
+        const onStorage = (e: StorageEvent) => {
+            if (e.key === STORAGE_KEY) sync()
+        }
+
+        // Same-document windows (desktop <-> /trash) sync via CustomEvent;
+        // other browser tabs sync via the native `storage` event (bonus).
+        window.addEventListener(CHANGE_EVENT, sync)
+        window.addEventListener('storage', onStorage)
+        return () => {
+            window.removeEventListener(CHANGE_EVENT, sync)
+            window.removeEventListener('storage', onStorage)
+        }
+    }, [])
+
+    const persist = useCallback((next: string[]) => {
+        setTrashedItems(next)
+        if (typeof window === 'undefined') return
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+        } catch (error) {
+            console.warn('Failed to save trashed icons to localStorage:', error)
+        }
+        window.dispatchEvent(new CustomEvent(CHANGE_EVENT))
+    }, [])
+
+    // Mutations read fresh from storage as their base so concurrent hook
+    // instances (desktop + /trash open at once) stay consistent.
+    const trashItem = useCallback(
+        (label: string) => {
+            if (NEVER_TRASH.has(label)) return
+            persist(Array.from(new Set([...readTrashed(), label])))
+        },
+        [persist]
+    )
+
+    const restoreItem = useCallback(
+        (label: string) => {
+            persist(readTrashed().filter((l) => l !== label))
+        },
+        [persist]
+    )
+
+    const emptyTrash = useCallback(() => persist([]), [persist])
+
+    return { trashedItems, trashItem, restoreItem, emptyTrash }
+}

--- a/src/pages/trash/index.tsx
+++ b/src/pages/trash/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Explorer from 'components/Explorer'
 import SEO from 'components/seo'
-import { AppIcon, AppIconName, AppLink } from 'components/OSIcons/AppIcon'
+import { AppIcon, AppIconName, AppLink, AppItem } from 'components/OSIcons/AppIcon'
 import { Accordion } from 'components/RadixUI/Accordion'
 import ZoomHover from 'components/ZoomHover'
 import { explorerGridColumns } from '../../constants'
@@ -9,10 +9,26 @@ import { explorerLayoutOptions } from '../../constants/explorerLayoutOptions'
 import { ToggleGroup } from 'components/RadixUI/ToggleGroup'
 import { useExplorerLayout } from '../../hooks/useExplorerLayout'
 import { useMenuSelectOptions } from 'components/TaskBarMenu/menuData'
+import { useProductLinks, apps } from 'components/Desktop/appList'
+import { useTrashedIcons } from '../../hooks/useTrashedIcons'
 
 export default function Trash(): JSX.Element {
     const { isListLayout, setLayoutValue, currentLayout } = useExplorerLayout('grid')
     const selectOptions = useMenuSelectOptions()
+    const productLinks = useProductLinks()
+    const { trashedItems, restoreItem } = useTrashedIcons()
+
+    // Reconstruct trashed desktop icons from the canonical lists by label
+    // (labels are the identity; an AppItem itself isn't serializable). Stale
+    // labels resolve to nothing and are dropped.
+    const appsByLabel = React.useMemo(() => {
+        const map = new Map<string, AppItem>()
+        ;[...productLinks, ...apps].forEach((app) => map.set(app.label, app as AppItem))
+        return map
+    }, [productLinks])
+    const desktopItems = trashedItems
+        .map((label) => appsByLabel.get(label))
+        .filter((app): app is AppItem => Boolean(app))
 
     return (
         <>
@@ -151,6 +167,59 @@ export default function Trash(): JSX.Element {
 
                     return (
                         <div className="@container not-prose space-y-2">
+                            {desktopItems.length > 0 && (
+                                <Accordion
+                                    skin={false}
+                                    triggerClassName="flex-row-reverse [&>svg]:!-rotate-90 [&[data-state=open]>svg]:!rotate-0 [&>span]:relative [&>span]:after:absolute [&>span]:after:right-0 [&>span]:after:top-1/2 [&>span]:after:h-px [&>span]:after:w-full [&>span]:after:bg-border [&>span]:after:content-['']"
+                                    defaultValue="from_desktop"
+                                    items={[
+                                        {
+                                            value: 'from_desktop',
+                                            trigger: (
+                                                <span className="bg-primary pr-2 relative z-10">
+                                                    From your desktop ({desktopItems.length})
+                                                </span>
+                                            ),
+                                            content: (
+                                                <div
+                                                    className={`@md:pl-4 grid ${
+                                                        isListLayout
+                                                            ? '@lg:grid-cols-2 @3xl:grid-cols-3 gap-y-4'
+                                                            : explorerGridColumns +
+                                                              ' gap-y-4 items-start justify-items-center'
+                                                    } gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
+                                                >
+                                                    {desktopItems.map((item) => (
+                                                        <ZoomHover
+                                                            key={item.label}
+                                                            className={
+                                                                isListLayout
+                                                                    ? 'w-full justify-start'
+                                                                    : 'w-28 justify-center'
+                                                            }
+                                                        >
+                                                            {/* Click opens the item (its real url/onClick); right-click
+                                                                offers "Put back" alongside the standard link menu. */}
+                                                            <AppLink
+                                                                {...item}
+                                                                background="bg-primary"
+                                                                orientation={isListLayout ? 'row' : 'column'}
+                                                                customMenuItems={[
+                                                                    {
+                                                                        type: 'item',
+                                                                        label: 'Put back',
+                                                                        onClick: () => restoreItem(item.label),
+                                                                    },
+                                                                ]}
+                                                            />
+                                                        </ZoomHover>
+                                                    ))}
+                                                </div>
+                                            ),
+                                        },
+                                    ]}
+                                />
+                            )}
                             {categoryOrder.map((category) => {
                                 const items = trashData[category as keyof typeof trashData]
                                 if (!items || items.length === 0) return null
@@ -174,11 +243,12 @@ export default function Trash(): JSX.Element {
                                                 ),
                                                 content: (
                                                     <div
-                                                        className={`@md:pl-4 grid ${isListLayout
+                                                        className={`@md:pl-4 grid ${
+                                                            isListLayout
                                                                 ? '@lg:grid-cols-2 @3xl:grid-cols-3 gap-y-4'
                                                                 : explorerGridColumns +
-                                                                ' gap-y-4 items-start justify-items-center'
-                                                            } gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
+                                                                  ' gap-y-4 items-start justify-items-center'
+                                                        } gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
                                                     >
                                                         {items.map((item) => {
                                                             const appLink = (


### PR DESCRIPTION
## Changes

Fixes #12777 — dragging a desktop icon onto the trash bin now moves it into the trash instead of leaving it hidden behind the bin.

- On drop, `DraggableDesktopIcon` hit-tests against the live trash rect and skips the settle animation that was leaving the icon behind the bin.
- Trashed icons are hidden from the desktop and persisted by label via a new `useTrashedIcons` hook (localStorage + same-document CustomEvent sync).
- `/trash` gains a "From your desktop" section, each icon with a right-click "Put back" to restore. Toast + Undo on trash; "Reset icons" empties it too.
- Refactor: desktop icon lists moved to `Desktop/appList.tsx` (re-exported from `./index` for back-compat) so `/trash` imports them without the Desktop chunk.


https://github.com/user-attachments/assets/b2a82de3-148c-4536-95b1-06b70f6eaded



## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` — N/A, no pages moved
