### PR TITLE
Update data modeling team Q3 objectives ownership

### DIFF
--- a/contents/teams/data-modeling/objectives.mdx
+++ b/contents/teams/data-modeling/objectives.mdx
@@ -1,6 +1,6 @@
 ## Q3 2026 objectives
 
-### Objective 1: Semantic layer (owner: Jovan)
+### Objective 1: Semantic layer (owner: Thiago)
 
 **Motivation:** We are increasingly hearing about inconsistency issues when an agent writes a query or an insight based on its assumptions around a definition. Same problem of "what's the source of truth?" like we humans have, but agent-amplified.
 
@@ -16,7 +16,7 @@
 - Move materialization jobs to the managed warehouse, and limit usage on CH
 - Support pricing and billing instrumentation
 
-### Objective 3: Version control (owner: New hire)
+### Objective 3: Version control (owner: Jovan)
 
 **Motivation:** While data modeling can happen inside PostHog, lack of version control makes it difficult to collaborate and safely make changes.
 
@@ -24,7 +24,7 @@
 - An easy way for agents and humans to interact with their git-based data modeling project
 - And enable a development workflow that doesn't impact the production models
 
-### Objective 4: Testing (owner: Jovan & New hire)
+### Objective 4: Testing (owner: Thiago)
 
 **Motivation:** Our agent's SQL writing has significantly improved, but we still have the verifiability gap where the users do not have a way of checking whether the models they build act as intended.
 


### PR DESCRIPTION
## Changes

Reassigned ownership on the data modeling team's Q3 2026 objectives:
- **Semantic layer** → Thiago
- **Managed warehouse** → Jovan (unchanged)
- **Version control** → Jovan
- **Testing** → Thiago

**Why:** Rebalancing objective ownership across the team now that Thiago is picking up the semantic layer and testing work.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GNDPDNEN/p1783585314625619)*