### PR TITLE
Prevent Enter key from submitting job application mid-edit

### DIFF
--- a/src/components/Job/Apply.tsx
+++ b/src/components/Job/Apply.tsx
@@ -217,6 +217,14 @@ const Form = ({
     const { setConfetti } = useApp()
     const [error, setError] = useState<string | null>(null)
     const [loading, setLoading] = useState(false)
+    // Prevent Enter in single-line inputs from submitting the whole application mid-edit.
+    // Textareas keep their native newline behavior.
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+        const target = e.target as HTMLElement
+        if (e.key === 'Enter' && target?.tagName !== 'TEXTAREA') {
+            e.preventDefault()
+        }
+    }
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
         setLoading(true)
@@ -287,7 +295,7 @@ const Form = ({
                         </p>
                     </div>
                 )}
-                <form onSubmit={handleSubmit} className="p-4">
+                <form onSubmit={handleSubmit} onKeyDown={handleKeyDown} className="p-4">
                     <div className="grid grid-cols-2 gap-3">
                         {info?.applicationFormDefinition?.sections?.map(({ fields }: { fields: any[] }) => {
                             return fields.map(


### PR DESCRIPTION
## Changes

Pressing Enter inside a single-line input on the job application form triggered the browser's native "submit the nearest form" behavior, sending off the whole application before the applicant had finished — an applicant reported accidentally submitting twice this way. This adds an `onKeyDown` guard on the form that calls `preventDefault()` on Enter unless the target is a `<textarea>`, so multi-line fields keep their native newline behavior.

**Why:** Raised by a job applicant as UX feedback — hitting Enter while editing a field submitted the application prematurely.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1783589083873889)*
