### PR TITLE
docs(prompt-management): fix SDK examples to use the PromptResult shape

### DIFF
--- a/contents/docs/prompt-management/index.mdx
+++ b/contents/docs/prompt-management/index.mdx
@@ -144,21 +144,23 @@ prompts = Prompts(
 )
 
 # Fetch the latest version of a prompt
-template = prompts.get(
+result = prompts.get(
     'support-system-prompt',
+    with_metadata=True,  # Returns a PromptResult with prompt, name, version, and source
     cache_ttl_seconds=600,  # Override default 5-minute cache
     fallback='You are a helpful assistant.'  # Used if fetch fails
 )
 
 # Or fetch a specific version
-template = prompts.get(
+result = prompts.get(
     'support-system-prompt',
+    with_metadata=True,
     version=2,
     fallback='You are a helpful assistant.'
 )
 
 # Compile with variables
-system_prompt = prompts.compile(template, {
+system_prompt = prompts.compile(result.prompt, {
     'company': 'Acme Corp',
     'tier': 'premium',
     'user_name': 'Alice'
@@ -190,19 +192,20 @@ const prompts = new Prompts({
 })
 
 // Fetch the latest version of a prompt
-const template = await prompts.get('support-system-prompt', {
+// Returns a PromptResult with prompt, name, version, and source
+const result = await prompts.get('support-system-prompt', {
   cacheTtlSeconds: 600,
   fallback: 'You are a helpful assistant.'
 })
 
 // Or fetch a specific version
-const template = await prompts.get('support-system-prompt', {
+const result = await prompts.get('support-system-prompt', {
   version: 2,
   fallback: 'You are a helpful assistant.'
 })
 
 // Compile with variables
-const systemPrompt = prompts.compile(template, {
+const systemPrompt = prompts.compile(result.prompt, {
   company: 'Acme Corp',
   tier: 'premium',
   userName: 'Alice'


### PR DESCRIPTION
## Problem

The JS example passes the return value of `prompts.get()` directly into `prompts.compile()`, but `get()` returns a `PromptResult` object (`{ prompt, name, version, source }`), not a string — the example is a type error as written. The Python example relies on the plain-string return, which the SDK marks deprecated ("will be removed in a future major version").

## Changes

Both examples now use the result shape: Python passes `with_metadata=True` and both compile `result.prompt`. Verified against the installed Python SDK signatures and the published `@posthog/ai` type declarations.

The in-app snippets on the prompt Usage tab use the same corrected shape (PostHog/posthog#69600).