### PR TITLE
Add Together AI data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/together-ai.md
+++ b/contents/docs/cdp/sources/together-ai.md
@@ -1,0 +1,52 @@
+---
+title: Linking Together AI as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: TogetherAI
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Together AI connector syncs your fine-tuning jobs, batch inference jobs, uploaded files, dedicated endpoints, evaluations, and the model catalog into the PostHog Data warehouse, so you can analyze your AI training and inference operations alongside your product data.
+
+## Prerequisites
+
+You need a Together AI account with an API key. Together AI requires a payment method on file before API keys can make requests.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Together AI, you'll need:
+
+- **API key** – find or create one under [Settings → API keys](https://api.together.xyz/settings/api-keys) in your Together AI account.
+
+## Sync modes
+
+<SyncModes />
+
+Together AI's list endpoints don't support timestamp filtering, so all tables sync with full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key in your Together AI settings, then reconnect.
+- Usage and billing data isn't available through Together AI's public API, so it can't be synced. It's only visible in the Together AI dashboard.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Together AI data warehouse source, implemented in [PostHog/posthog#69608](https://github.com/PostHog/posthog/pull/69608). Follows the canonical source-doc template: alpha callout, prerequisites, shared setup/sync-mode/troubleshooting snippets, and `<SourceParameters />` / `<SourceTables />` (both rendered from the source's API config once #69608 lands).

The filename, the source's `docsUrl`, and the `sourceId: TogetherAI` frontmatter all agree; `python manage.py audit_source_docs` in the posthog repo reports no issues for this doc.

> [!NOTE]
> This should merge after PostHog/posthog#69608 (and its base scaffold PR PostHog/posthog#69517), since `<SourceParameters />` and `<SourceTables />` have no data until the source is registered.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
