### PR TITLE
docs: add langfuse data warehouse source doc

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -144,6 +144,7 @@ Knative
 [Kk]oala
 Kubernetes
 Kudosity
+Langfuse
 LaunchDarkly
 [Ll]aunchpad
 Lightdash

--- a/contents/docs/cdp/sources/langfuse.md
+++ b/contents/docs/cdp/sources/langfuse.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Langfuse connector syncs your LLM observability data — traces, observations, evaluation scores, sessions, prompts, models, and datasets — into PostHog, so you can analyze your AI application's behavior, cost, and quality alongside your product data.
+The Langfuse connector syncs your LLM observability data – traces, observations, evaluation scores, sessions, prompts, models, and datasets – into PostHog, so you can analyze your AI application's behavior, cost, and quality alongside your product data.
 It works with Langfuse Cloud (all regions) and self-hosted Langfuse instances.
 
 ## Prerequisites
@@ -51,7 +51,7 @@ Each incremental run re-reads a trailing one-hour window to pick up late-arrivin
 
 ## Troubleshooting
 
-- If you see an invalid key error, confirm the public/secret key pair in **Project settings > API keys** and make sure the host matches your project's region — keys only work against the region they were created in.
+- If you see an invalid key error, confirm the public/secret key pair in **Project settings > API keys** and make sure the host matches your project's region – keys only work against the region they were created in.
 - Langfuse rate limits its read APIs by plan (as low as 15 requests/minute on the Hobby plan). The connector backs off and retries automatically, but large first syncs on lower plans can take a while.
 - If the host is not allowed, use a publicly reachable host.
 

--- a/contents/docs/cdp/sources/langfuse.md
+++ b/contents/docs/cdp/sources/langfuse.md
@@ -1,0 +1,58 @@
+---
+title: Linking Langfuse as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Langfuse
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Langfuse connector syncs your LLM observability data — traces, observations, evaluation scores, sessions, prompts, models, and datasets — into PostHog, so you can analyze your AI application's behavior, cost, and quality alongside your product data.
+It works with Langfuse Cloud (all regions) and self-hosted Langfuse instances.
+
+## Prerequisites
+
+You need a Langfuse project and its API key pair.
+API keys are project-scoped and available on all Langfuse plans.
+Self-hosted users also need a publicly reachable Langfuse host.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Langfuse, you'll need:
+
+- **Public key** and **Secret key** – find both in the Langfuse dashboard under **Project settings > API keys**.
+- **Host** – set it to your Langfuse region: `https://cloud.langfuse.com` (EU, the default), `https://us.cloud.langfuse.com` (US), `https://jp.cloud.langfuse.com` (JP), or `https://hipaa.cloud.langfuse.com` (HIPAA). Self-hosted users should set it to their own Langfuse host. Leave it blank to use Langfuse Cloud EU.
+
+## Sync modes
+
+<SyncModes />
+
+Traces, observations, scores, and sessions support incremental sync using Langfuse's creation/start-time filters.
+Each incremental run re-reads a trailing one-hour window to pick up late-arriving updates, such as traces whose aggregated metrics change as observations arrive.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an invalid key error, confirm the public/secret key pair in **Project settings > API keys** and make sure the host matches your project's region — keys only work against the region they were created in.
+- Langfuse rate limits its read APIs by plan (as low as 15 requests/minute on the Hobby plan). The connector backs off and retries automatically, but large first syncs on lower plans can take a while.
+- If the host is not allowed, use a publicly reachable host.
+
+<TroubleshootingLink />


### PR DESCRIPTION
Adds the user-facing doc for the new Langfuse data warehouse import source, implemented in [PostHog/posthog#69613](https://github.com/PostHog/posthog/pull/69613).

**Why:** the source's `docsUrl` points at `/docs/cdp/sources/langfuse`, so this doc needs to exist to avoid a 404 once the source ships.

Follows the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, `sourceId: Langfuse`) and passes `audit_source_docs`. Kept as a draft until the source PR merges and the source is released, since the rendered components pull from the `public_source_configs` API.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
