### PR TITLE
docs(data-warehouse): add elevenlabs source doc

### DIFF
--- a/contents/docs/cdp/sources/elevenlabs.md
+++ b/contents/docs/cdp/sources/elevenlabs.md
@@ -1,0 +1,51 @@
+---
+title: Linking ElevenLabs as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ElevenLabs
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The ElevenLabs connector syncs your AI audio data into the PostHog Data warehouse: speech generation history, conversational AI conversations and agents, voices, and models. Use it to analyze generation volume, character costs, and agent call outcomes alongside your product data.
+
+## Prerequisites
+
+You need an ElevenLabs account with an API key. API keys are available on every plan.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking ElevenLabs, you'll need:
+
+- **API key** – create one in your ElevenLabs account under [Profile → API keys](https://elevenlabs.io/app/settings/api-keys). If you restrict the key's permissions, grant read access to the endpoints you want to sync: **History**, **Conversational AI**, **Voices**, **Models**, and **User** (used to verify the key).
+
+## Sync modes
+
+<SyncModes />
+
+The `history` and `conversations` tables support incremental sync using their creation timestamps. The `agents`, `voices`, and `models` tables are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your ElevenLabs API key may be invalid, revoked, or missing a permission for one of the synced endpoints. Check the key's permissions under Profile → API keys in ElevenLabs, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new ElevenLabs data warehouse source, implemented in [PostHog/posthog#69624](https://github.com/PostHog/posthog/pull/69624). Follows the canonical source-doc template (alpha callout, shared snippets, `<SourceParameters />` + `<SourceTables />`); the table catalog and connection fields render from the `public_source_configs` API once the source PR lands.

This should merge after PostHog/posthog#69624 (the doc's `sourceId: ElevenLabs` has no API data until then). `python manage.py audit_source_docs` passes for this source against the implementation branch.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*