### PR TITLE
docs: add Bland AI data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/bland-ai.md
+++ b/contents/docs/cdp/sources/bland-ai.md
@@ -1,0 +1,53 @@
+---
+title: Linking Bland AI as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: BlandAI
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Bland AI connector syncs your AI phone call data – calls, per-call transcripts, and conversational pathways – into the PostHog Data warehouse, so you can analyze your voice agents' performance alongside your product data.
+
+## Prerequisites
+
+You need a Bland AI account with access to an API key. The key grants read access to all calls, transcripts, and pathways in your account.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Bland AI, you'll need:
+
+- **API key** – find it in the [Bland dashboard](https://app.bland.ai/) under **Settings → API keys**.
+
+## Sync modes
+
+<SyncModes />
+
+The `call_transcripts` table fetches each call's transcript individually (Bland excludes transcripts from its call list API for size reasons), so it makes one extra API request per call and is disabled by default. Enable it only if you need utterance-level transcript data.
+
+Incremental syncs on the call tables track the call creation time. Post-call analysis added to older calls after a sync won't be picked up incrementally – run a full refresh if you need to re-sync updated analysis fields.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key in the Bland dashboard, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new `bland_ai` Data warehouse import source, implemented in [PostHog/posthog#69625](https://github.com/PostHog/posthog/pull/69625) (scaffolded in [PostHog/posthog#69517](https://github.com/PostHog/posthog/pull/69517)).

Follows the canonical source-doc template: alpha callout, prerequisites, shared setup/sync-mode/troubleshooting snippets, and `<SourceParameters />` + `<SourceTables />` rendered from the source registry (`sourceId: BlandAI`). Includes source-specific notes on the opt-in `call_transcripts` table (one API request per call) and the created-time-based incremental cursor.

`python manage.py audit_source_docs` in the posthog repo passes for this doc.

> [!NOTE]
> Should merge after PostHog/posthog#69625 lands, so `sourceId: BlandAI` resolves against the deployed source registry.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
