### PR TITLE
Document the #panel=max deep-link format for PostHog AI

### DIFF
--- a/contents/handbook/wizard-and-docs/mdx-and-components.mdx
+++ b/contents/handbook/wizard-and-docs/mdx-and-components.mdx
@@ -295,6 +295,24 @@ Use `<AskAIInput>` for troubleshooting sections:
 <AskAIInput placeholder="Ask about error tracking..." />
 ```
 
+#### Linking to PostHog AI in the app
+
+The `<MaxCTA>` component renders a callout that sends readers into the PostHog app with a question for PostHog AI:
+
+```jsx
+<MaxCTA question="What changed across my product this week?" />
+```
+
+Under the hood it builds a URL using the `#panel=max:` hash format, which you can also use directly in any link. The question must be URL-encoded (`encodeURIComponent`), and an optional prefix before the question controls what happens when the panel opens:
+
+| URL | Behavior |
+|-----|----------|
+| `https://app.posthog.com/#panel=max:What%20changed%3F` | Opens the PostHog AI side panel with "What changed?" pre-loaded, so the user can edit it before sending |
+| `https://app.posthog.com/#panel=max:?What%20changed%3F` | Same as above - `?` is the explicit pre-load modifier |
+| `https://app.posthog.com/#panel=max:!What%20changed%3F` | Auto-runs "What changed?" immediately, without waiting for the user to press enter |
+
+Use the pre-load form when the reader should review or adapt the question first, and the auto-run (`!`) form for CTAs where the question is fully self-contained, like `<MaxCTA>` does. The prefix parsing lives in `parseCommandString` in [`maxLogic`](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/max/maxLogic.tsx) in the app repo.
+
 ## Platform logos
 
 All platform logos are centralized in `src/constants/logos.ts`. To add a new platform:

--- a/contents/handbook/wizard-and-docs/mdx-and-components.mdx
+++ b/contents/handbook/wizard-and-docs/mdx-and-components.mdx
@@ -308,7 +308,6 @@ Under the hood it builds a URL using the `#panel=max:` hash format, which you ca
 | URL | Behavior |
 |-----|----------|
 | `https://app.posthog.com/#panel=max:What%20changed%3F` | Opens the PostHog AI side panel with "What changed?" pre-loaded, so the user can edit it before sending |
-| `https://app.posthog.com/#panel=max:?What%20changed%3F` | Same as above - `?` is the explicit pre-load modifier |
 | `https://app.posthog.com/#panel=max:!What%20changed%3F` | Auto-runs "What changed?" immediately, without waiting for the user to press enter |
 
 Use the pre-load form when the reader should review or adapt the question first, and the auto-run (`!`) form for CTAs where the question is fully self-contained, like `<MaxCTA>` does. The prefix parsing lives in `parseCommandString` in [`maxLogic`](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/max/maxLogic.tsx) in the app repo.


### PR DESCRIPTION
## Changes

Documents the `#panel=max:` URL hash format for linking into PostHog AI in the app, in the "PostHog AI components" section of the MDX and components handbook page:

- `#panel=max:<question>` or `#panel=max:?<question>` pre-loads the question into the composer
- `#panel=max:!<question>` auto-runs it
- Notes that `<MaxCTA>` builds these URLs, and links to the parser in the app repo

**Why:** these links recently broke for users on the new PostHog AI side panel and the format was only documented in tribal knowledge. The app-side fixes are [PostHog/posthog#69246](https://github.com/PostHog/posthog/pull/69246) (restores prompt handling in the new panel) and [PostHog/posthog#69634](https://github.com/PostHog/posthog/pull/69634) (makes the `?` pre-load modifier explicit). Best merged once those land.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
