### PR TITLE
Fix Langfuse MCP server for prompts in comparison data

### DIFF
--- a/src/hooks/competitorData/langfuse.tsx
+++ b/src/hooks/competitorData/langfuse.tsx
@@ -52,7 +52,7 @@ prompt_management: {
         prompt_labels: true,
         prompt_playground: true,
         composable_prompts: true,
-        mcp_server_for_prompts: false,
+        mcp_server_for_prompts: true,
         ab_test_prompt_versions: false,
     },
 },


### PR DESCRIPTION
## TL;DR

The PostHog vs Langfuse comparison table marks "MCP server for prompts" as unsupported for Langfuse, but Langfuse ships one. This flips `mcp_server_for_prompts` to `true` in `src/hooks/competitorData/langfuse.tsx`.

## Details

Langfuse has a built-in MCP server at `/api/public/mcp` (streamable HTTP, no external setup) that lets AI agents create prompts, create new versions, and manage labels — matching the feature definition ("Manage prompts via AI coding agents"). It's generally available, not beta.

Source: https://langfuse.com/docs/prompt-management/features/mcp-server

Affects the prompt management table in `/blog/posthog-vs-langfuse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)