### PR TITLE
Add rolling "Built-in tools for your agents" ticker to self-driving homepage variant

### DIFF
--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -31,6 +31,7 @@ import IntegrationPrompt from 'components/IntegrationPrompt'
 import { motion } from 'framer-motion'
 import HeroCarousel from 'components/Home/HeroCarousel'
 import { buildTabs } from 'components/Home/HeroCarousel/tabs'
+import ToolsTicker from 'components/Home/ToolsTicker'
 // NOTE: `components/PlatformInstall` (index/IconButton/schema/CopyableCommand), the new
 // `Logomark*` icons added to `components/OSIcons/Icons.tsx`, and the `canvas-confetti`
 // dependency are all VENDORED VERBATIM from the `9000` branch — kept byte-identical to that
@@ -403,7 +404,8 @@ function TestHero(): JSX.Element {
                 </div>
             </div>
 
-            <HeroCarousel tabs={buildTabs} className="mb-8" />
+            <HeroCarousel tabs={buildTabs} className="mb-4" />
+            <ToolsTicker className="mb-8" />
         </>
     )
 }

--- a/src/components/Home/ToolsTicker/README.md
+++ b/src/components/Home/ToolsTicker/README.md
@@ -25,7 +25,7 @@ Handles that don't resolve to a product with a `name` and `slug` are silently sk
 ## How the loop works
 
 - The item list is rendered **twice** inside a `flex w-max` track.
-- The `tools-ticker-marquee` keyframe (defined in `src/styles/global.css`, next to `hero-carousel-progress`) animates the track from `translateX(0)` to `translateX(-50%)` — exactly one copy's width — so the loop is seamless for any number of items.
+- The `tools-ticker-marquee` keyframe (defined in `src/styles/global.css`, next to `hero-carousel-progress`) animates the track from `translateX(0)` to `translateX(-50%)` – exactly one copy's width – so the loop is seamless for any number of items.
 - Each `<ul>` has `pr-6` matching its internal `gap-6`, so the seam between copies is invisible.
 - Duration is `items × 2.5s`, keeping the apparent speed constant when the list changes.
 
@@ -39,6 +39,6 @@ Handles that don't resolve to a product with a `name` and `slug` are silently sk
 ## Conventions
 
 - Links use `state={{ newWindow: true }}` so product pages open in a new OS-style window.
-- Icon colors use the dynamic `text-${product.color}` pattern — all colors used by the default handles are in `safelist.txt`. If you add a handle with a new color, confirm it's safelisted.
+- Icon colors use the dynamic `text-${product.color}` pattern – all colors used by the default handles are in `safelist.txt`. If you add a handle with a new color, confirm it's safelisted.
 - Layout uses container queries only (`@sm:`); the label stacks above the strip in narrow containers.
 - SSR-safe: data comes from `useProduct()` (Gatsby static query); no browser globals.

--- a/src/components/Home/ToolsTicker/README.md
+++ b/src/components/Home/ToolsTicker/README.md
@@ -1,0 +1,44 @@
+# ToolsTicker
+
+A one-line, infinitely rolling marquee of PostHog products: a static label ("Built-in tools for your agents:") followed by a horizontally scrolling strip of product icons + names, each linking to its product page.
+
+Currently rendered in `TestHero` (`src/components/Home/Test/index.tsx`), directly under the tabbed `HeroCarousel`, so it only appears in the `test` variant of the `self-driving-mode-test` homepage experiment.
+
+## Usage
+
+```tsx
+import ToolsTicker from 'components/Home/ToolsTicker'
+
+<ToolsTicker className="mb-8" />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `handles` | `string[]` | Core products + notable betas (18 handles) | Product handles resolved via `useProduct()` |
+| `label` | `string` | `"Built-in tools for your agents:"` | Static prefix shown before the scrolling strip |
+| `className` | `string` | `''` | Extra classes on the root element |
+
+Handles that don't resolve to a product with a `name` and `slug` are silently skipped. `SLUG_OVERRIDES` in the component maps handles whose product data has no `slug` (currently `inbox` → `docs/self-driving/inbox`).
+
+## How the loop works
+
+- The item list is rendered **twice** inside a `flex w-max` track.
+- The `tools-ticker-marquee` keyframe (defined in `src/styles/global.css`, next to `hero-carousel-progress`) animates the track from `translateX(0)` to `translateX(-50%)` — exactly one copy's width — so the loop is seamless for any number of items.
+- Each `<ul>` has `pr-6` matching its internal `gap-6`, so the seam between copies is invisible.
+- Duration is `items × 2.5s`, keeping the apparent speed constant when the list changes.
+
+## Behavior
+
+- **Pause on hover/focus**: `animationPlayState` toggles via mouse enter/leave and focus/blur (focus events bubble from the links), same pattern as `HeroCarousel`'s progress bar.
+- **Reduced motion**: with `prefers-reduced-motion: reduce`, the animation is disabled and the strip becomes a manually scrollable `overflow-x-auto` row.
+- **Accessibility**: the duplicate copy is `aria-hidden` and its links have `tabIndex={-1}`, so screen readers and keyboard users encounter each product exactly once.
+- **Edge fade**: CSS `mask-image` gradients fade both ends of the strip (same arbitrary-value pattern as `PlatformInstall/CopyableCommand`).
+
+## Conventions
+
+- Links use `state={{ newWindow: true }}` so product pages open in a new OS-style window.
+- Icon colors use the dynamic `text-${product.color}` pattern — all colors used by the default handles are in `safelist.txt`. If you add a handle with a new color, confirm it's safelisted.
+- Layout uses container queries only (`@sm:`); the label stacks above the strip in narrow containers.
+- SSR-safe: data comes from `useProduct()` (Gatsby static query); no browser globals.

--- a/src/components/Home/ToolsTicker/ToolsTickerStrip.tsx
+++ b/src/components/Home/ToolsTicker/ToolsTickerStrip.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Link from 'components/Link'
+
+export interface ToolsTickerProduct {
+    handle: string
+    name: string
+    slug: string
+    color?: string
+    Icon?: React.ComponentType<{ className?: string }>
+}
+
+interface ToolsTickerStripProps {
+    products: ToolsTickerProduct[]
+    ariaHidden?: boolean
+}
+
+export default function ToolsTickerStrip({ products, ariaHidden = false }: ToolsTickerStripProps): JSX.Element {
+    return (
+        <ul aria-hidden={ariaHidden || undefined} className="flex items-center gap-6 pr-6 m-0 p-0 list-none shrink-0">
+            {products.map((product) => (
+                <li key={product.handle} className="flex items-center gap-1.5 whitespace-nowrap">
+                    {product.Icon && <product.Icon className={`size-4 shrink-0 text-${product.color}`} />}
+                    <Link
+                        to={`/${product.slug}`}
+                        state={{ newWindow: true }}
+                        tabIndex={ariaHidden ? -1 : undefined}
+                        className="text-sm font-semibold"
+                    >
+                        {product.name}
+                    </Link>
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/src/components/Home/ToolsTicker/index.tsx
+++ b/src/components/Home/ToolsTicker/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import Link from 'components/Link'
 import useProduct from 'hooks/useProduct'
+import ToolsTickerStrip from './ToolsTickerStrip'
 
 // Seconds each item takes to cross one loop; total duration scales with item count
 // so the apparent speed stays constant when handles are added or removed.
@@ -59,26 +59,6 @@ export default function ToolsTicker({
         return null
     }
 
-    // The list is rendered twice so the translateX(-50%) loop is seamless; the
-    // duplicate is hidden from screen readers and its links removed from tab order.
-    const strip = (ariaHidden: boolean) => (
-        <ul aria-hidden={ariaHidden || undefined} className="flex items-center gap-6 pr-6 m-0 p-0 list-none shrink-0">
-            {products.map((product: any) => (
-                <li key={product.handle} className="flex items-center gap-1.5 whitespace-nowrap">
-                    {product.Icon && <product.Icon className={`size-4 shrink-0 text-${product.color}`} />}
-                    <Link
-                        to={`/${product.slug}`}
-                        state={{ newWindow: true }}
-                        tabIndex={ariaHidden ? -1 : undefined}
-                        className="text-sm font-semibold"
-                    >
-                        {product.name}
-                    </Link>
-                </li>
-            ))}
-        </ul>
-    )
-
     return (
         <div className={`@container not-prose ${className}`}>
             <div className="flex flex-col @sm:flex-row @sm:items-center gap-1 @sm:gap-3">
@@ -97,8 +77,9 @@ export default function ToolsTicker({
                             animationPlayState: isPaused ? 'paused' : 'running',
                         }}
                     >
-                        {strip(false)}
-                        {strip(true)}
+                        {/* Rendered twice so translateX(-50%) loops seamlessly; duplicate is aria-hidden. */}
+                        <ToolsTickerStrip products={products} />
+                        <ToolsTickerStrip products={products} ariaHidden />
                     </div>
                 </div>
             </div>

--- a/src/components/Home/ToolsTicker/index.tsx
+++ b/src/components/Home/ToolsTicker/index.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react'
+import Link from 'components/Link'
+import useProduct from 'hooks/useProduct'
+
+// Seconds each item takes to cross one loop; total duration scales with item count
+// so the apparent speed stays constant when handles are added or removed.
+const SECONDS_PER_ITEM = 2.5
+
+// Core products plus notable betas, in the order they scroll.
+const DEFAULT_HANDLES = [
+    'product_analytics',
+    'web_analytics',
+    'session_replay',
+    'feature_flags',
+    'experiments',
+    'surveys',
+    'error_tracking',
+    'data_warehouse',
+    'cdp',
+    'workflows_emails',
+    'logs',
+    'ai_observability',
+    'endpoints',
+    'inbox',
+    'traces',
+    'heatmaps',
+    'replay_vision',
+    'no_code_ab_testing',
+]
+
+// Inbox intentionally has no slug in its product data (it isn't in product/app
+// navigation yet), so link it to its docs page instead.
+const SLUG_OVERRIDES: Record<string, string> = {
+    inbox: 'docs/self-driving/inbox',
+}
+
+interface ToolsTickerProps {
+    handles?: string[]
+    label?: string
+    className?: string
+}
+
+export default function ToolsTicker({
+    handles = DEFAULT_HANDLES,
+    label = 'Built-in tools for your agents:',
+    className = '',
+}: ToolsTickerProps): JSX.Element | null {
+    const allProducts = useProduct()
+    const [isPaused, setIsPaused] = useState(false)
+
+    const products = handles
+        .map((handle) =>
+            Array.isArray(allProducts) ? allProducts.find((product: any) => product.handle === handle) : undefined
+        )
+        .map((product: any) => (product ? { ...product, slug: SLUG_OVERRIDES[product.handle] ?? product.slug } : null))
+        .filter((product: any) => product?.name && product?.slug)
+
+    if (!products.length) {
+        return null
+    }
+
+    // The list is rendered twice so the translateX(-50%) loop is seamless; the
+    // duplicate is hidden from screen readers and its links removed from tab order.
+    const strip = (ariaHidden: boolean) => (
+        <ul aria-hidden={ariaHidden || undefined} className="flex items-center gap-6 pr-6 m-0 p-0 list-none shrink-0">
+            {products.map((product: any) => (
+                <li key={product.handle} className="flex items-center gap-1.5 whitespace-nowrap">
+                    {product.Icon && <product.Icon className={`size-4 shrink-0 text-${product.color}`} />}
+                    <Link
+                        to={`/${product.slug}`}
+                        state={{ newWindow: true }}
+                        tabIndex={ariaHidden ? -1 : undefined}
+                        className="text-sm font-semibold"
+                    >
+                        {product.name}
+                    </Link>
+                </li>
+            ))}
+        </ul>
+    )
+
+    return (
+        <div className={`@container not-prose ${className}`}>
+            <div className="flex flex-col @sm:flex-row @sm:items-center gap-1 @sm:gap-3">
+                <span className="shrink-0 text-sm text-secondary">{label}</span>
+                <div
+                    className="relative flex-1 min-w-0 overflow-hidden motion-reduce:overflow-x-auto [mask-image:linear-gradient(to_right,transparent,#000_1.5rem,#000_calc(100%-1.5rem),transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,#000_1.5rem,#000_calc(100%-1.5rem),transparent)]"
+                    onMouseEnter={() => setIsPaused(true)}
+                    onMouseLeave={() => setIsPaused(false)}
+                    onFocus={() => setIsPaused(true)}
+                    onBlur={() => setIsPaused(false)}
+                >
+                    <div
+                        className="flex w-max motion-reduce:[animation:none!important]"
+                        style={{
+                            animation: `tools-ticker-marquee ${products.length * SECONDS_PER_ITEM}s linear infinite`,
+                            animationPlayState: isPaused ? 'paused' : 'running',
+                        }}
+                    >
+                        {strip(false)}
+                        {strip(true)}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2720,6 +2720,15 @@ div[data-radix-popper-content-wrapper] {
     }
 }
 
+@keyframes tools-ticker-marquee {
+    from {
+        transform: translateX(0);
+    }
+    to {
+        transform: translateX(-50%);
+    }
+}
+
 @keyframes hero-carousel-fade-in {
     from {
         opacity: 0;


### PR DESCRIPTION
## Changes

Adds a small, one-line rolling marquee — **"Built-in tools for your agents:"** followed by scrolling product icons + names — that permanently sits directly under the tabbed hero carousel in the `test` variant of the `self-driving-mode-test` homepage experiment ([flag 732599](https://us.posthog.com/project/2/feature_flags/732599)). It lists the core product lineup plus notable betas (18 tools), each linking to its product page.

**Why:** make it immediately clear to homepage visitors that PostHog has all of these tools built in, ready to be used by agents or manually — reinforcing the self-driving positioning the experiment is testing.

- New `ToolsTicker` component (`src/components/Home/ToolsTicker/`, with README): seamless infinite loop (content rendered twice, `translateX(-50%)` keyframe), pauses on hover/focus, honors `prefers-reduced-motion` (becomes a manually scrollable row), edge-fade masks, duplicate copy hidden from screen readers and tab order.
- Rendered at the end of `TestHero` in `src/components/Home/Test/index.tsx`, so it's automatically variant-gated and client-only.
- One new keyframe in `src/styles/global.css`.

Verified in a headless browser against the dev server: control variant unaffected; test variant renders all 18 items with correct icons, colors, and links; hover/focus pause, reduced-motion fallback, dark mode, and narrow-container stacking all confirmed with zero console errors.

To see it in the Vercel preview, force the variant in the browser console: `posthog.featureFlags.overrideFeatureFlags({flags:{'self-driving-mode-test':'test'}})` and reload — the ticker only renders when the flag resolves to `test`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
