### PR TITLE
Redirect /desktop to /code

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -56,6 +56,7 @@
         { "source": "/posts/:path*", "destination": "/posts/[slug]/index.html" }
     ],
     "redirects": [
+        { "source": "/desktop", "destination": "/code" },
         { "source": "/teams/logs", "destination": "/teams/apm" },
         { "source": "/teams/query-performance", "destination": "/teams/analytics-platform" },
         {


### PR DESCRIPTION
## Changes

Adds a redirect in `vercel.json` so `/desktop` points to `/code`.

## Context

The product is still officially called **PostHog Code** — that's the current name in the nav and on the page. "Desktop" has started showing up prematurely in a few places (blog drafts, a marketing discussion), so this redirect points anyone who lands on `/desktop` to the existing Code page and flattens the inconsistency in the meantime.

Consensus from the [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1783602917119579?thread_ts=1783602917.119579&cid=C08CG24E3SR):
- Keep calling it **Code** for now — hold off on the "Desktop" term until the product is actually renamed.
- The likely plan is to get the Desktop work to beta, then do an official rename + comms to existing users explaining the vision.
- This redirect is just a stopgap for consistency; it doesn't rename anything.
- Whether the `/code` page itself needs updating is Cleo's call and not urgent.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1783602917119579?thread_ts=1783602917.119579&cid=C08CG24E3SR)*
