### PR TITLE
revert: PSAK docs until the feature flag rolls out

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -158,7 +158,7 @@ You can then just call the `"next"` URL to get the next set of results.
 PostHog partners with GitHub to automatically detect exposed API keys in public repositories. When GitHub detects a leaked key, we take immediate action:
 
 - **Personal API keys** (`phx_`): The key is automatically rolled and the user is notified via email.
-- **Project secret API keys and feature flags secure API keys** (`phs_`): Project admins and owners are notified via email so they can roll or rotate the key.
+- **Feature flags secure API keys** (`phs_`): Project admins and owners are notified via email so they can rotate the key.
 - **OAuth access tokens** (`pha_`): The key and its associated refresh token are automatically revoked and the user is notified via email.
 - **OAuth refresh tokens** (`phr_`): The key and its associated access token are automatically revoked and the user is notified via email.
 

--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-php.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-php.mdx
@@ -52,7 +52,7 @@ When the SDK fetches flag definitions from the API, it passes a JSON-compatible 
 | `onFlagDefinitionsReceived(data)` | Store definitions after a successful API fetch. | void |
 | `shutdown()` | Release locks, close connections, and clean up resources. | void |
 
-> **Note:** Provider methods may throw errors. The SDK catches and logs provider errors: failed `shouldFetchFlagDefinitions()` calls fall back to fetching from PostHog when a secret API key is configured, failed cache reads fall back to the API when no definitions are loaded and a secret API key is configured, and failed writes or shutdowns do not stop flag evaluation.
+> **Note:** Provider methods may throw errors. The SDK catches and logs provider errors: failed `shouldFetchFlagDefinitions()` calls fall back to fetching from PostHog when a feature flags secure API key is configured, failed cache reads fall back to the API when no definitions are loaded and a feature flags secure API key is configured, and failed writes or shutdowns do not stop flag evaluation.
 
 ## Using your cache provider
 
@@ -67,7 +67,7 @@ PostHog::init(
         'host' => '<ph_client_api_host>',
         'flag_definition_cache_provider' => $cache,
     ],
-    personalAPIKey: 'your secret API key'
+    personalAPIKey: 'your feature flags secure API key'
 );
 ```
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -58,15 +58,15 @@ Local evaluation is also more cost-effective: with remote evaluation, every flag
 
 There are 3 steps to enable local evaluation:
 
-## Step 1: Get a secret API key
+## Step 1: Find your feature flags secure API key
 
 import ObtainFeatureFlagsSecureAPIKey from "../../integrate/_snippets/obtain-flags-secure-key.mdx";
 
 <ObtainFeatureFlagsSecureAPIKey />
 
-## Step 2: Initialize PostHog with your secret API key
+## Step 2: Initialize PostHog with your feature flags secure API key
 
-When you initialize PostHog with your secret API key, PostHog will use the key to automatically fetch feature flag definitions. These definitions are then used to evaluate feature flags locally.
+When you initialize PostHog with your feature flags secure API key, PostHog will use the key to automatically fetch feature flag definitions. These definitions are then used to evaluate feature flags locally.
 
 By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in the Go SDK). However, you can change this frequency by specifying a different value in the polling interval argument.
 
@@ -284,7 +284,7 @@ let flag = flags.get_flag("flag-key");
 
 ## Reloading flags
 
-As mentioned in [step 2](#step-2-initialize-posthog-with-your-secret-api-key), PostHog periodically fetches feature flag definitions. However, you can also force a reload by calling `reloadFeatureFlags()`:
+As mentioned in [step 2](#step-2-initialize-posthog-with-your-feature-flags-secure-api-key), PostHog periodically fetches feature flag definitions. However, you can also force a reload by calling `reloadFeatureFlags()`:
 
 <MultiLanguage>
 

--- a/contents/docs/feature-flags/project-wide-settings.mdx
+++ b/contents/docs/feature-flags/project-wide-settings.mdx
@@ -64,22 +64,19 @@ Key behaviors:
 
 ## Feature flags secure API key
 
-> **Deprecated:** The feature flags secure API key is deprecated. Use a [project secret API key](https://us.posthog.com/settings/environment-secret-api-keys) with the `feature_flag:read` scope instead — it works as a drop-in replacement for [local evaluation](/docs/feature-flags/local-evaluation) and [remote config settings](/docs/feature-flags/remote-config), no SDK code changes needed. Existing feature flags secure API keys continue to work until you switch.
-
-Secure API keys retrieve feature flag definitions for [local evaluation](/docs/feature-flags/local-evaluation) or [remote config settings](/docs/feature-flags/remote-config).
+Use secure API keys to retrieve feature flag definitions for [local evaluation](/docs/feature-flags/local-evaluation) or [remote config settings](/docs/feature-flags/remote-config). These keys replace personal API keys for flag-related operations.
 
 ### Key management
-
-If you still use a feature flags secure API key, you can manage it from the Feature flags tab of your project settings:
 
 - **Primary key**: The currently active key used for API requests
 - **Backup key**: Created when you rotate keys to support safe migration
 - **Key rotation**: Generate new keys while keeping the old one temporarily active
 
-Rotation without downtime works by maintaining both primary and backup keys during the transition period. Delete the backup key once all your systems use the new one.
+### Best practices
 
-### Migrating to a project secret API key
+1. **Keep keys private**: Never expose these keys in client-side code
+2. **Rotate regularly**: Generate new keys periodically for security
+3. **Clean up backups**: Delete backup keys once you've migrated all systems
+4. **Use project-specific keys**: Each PostHog project should use its own secure API key
 
-1. Create a [project secret API key](https://us.posthog.com/settings/environment-secret-api-keys) with the **Local feature flag evaluation** preset (the `feature_flag:read` scope).
-2. Replace the key in your SDK configuration. Both key types use the same `phs_` prefix and the same configuration option, so nothing else changes.
-3. Once all your deployments use the new key, delete the legacy feature flags secure API key.
+The secure API key system enables you to safely rotate keys without downtime by maintaining both primary and backup keys during the transition period.

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -14,19 +14,19 @@ Remote config flags enable you to configure a simple flag that always returns th
 
 There are 3 steps to start using remote config flags:
 
-## Step 1: Get a secret API key
+## Step 1: Find your feature flags secure API key
 
 import ObtainFeatureFlagsSecureAPIKey from "../integrate/_snippets/obtain-flags-secure-key.mdx"
 
 <ObtainFeatureFlagsSecureAPIKey />
 
-## Step 2: Initialize PostHog with your secret API key in options
+## Step 2: Initialize PostHog with your feature flags secure API key in options
 
 import ConfigureFlagsSecureKey from "../integrate/_snippets/configure-flags-secure-key.mdx"
 
 <ConfigureFlagsSecureKey />
 
-> **Note:** By default, initializing PostHog with your secret API key enables local evaluation, but this can be disabled in `posthog-node` by setting `enableLocalEvaluation: false` in your config.
+> **Note:** By default, initializing PostHog with your feature flags secure API key enables local evaluation, but this can be disabled in `posthog-node` by setting `enableLocalEvaluation: false` in your config.
 
 
 ## Step 3: Use remote config flags

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -5,7 +5,7 @@ const client = new PostHog(
     '<ph_project_token>',
     { 
         host: '<ph_client_api_host>',
-        personalApiKey: 'your secret API key from step 1',
+        personalApiKey: 'your feature flags secure API key from step 1',
         featureFlagsPollingInterval: 30000 // Optional. Measured in milliseconds. Defaults to 30000 (30 seconds)
     }
 ) 
@@ -15,7 +15,7 @@ const client = new PostHog(
 posthog = PostHog::Client.new({
   api_key: "<ph_project_token>",
   host: "<ph_client_api_host>",
-  personal_api_key: 'your secret API key from step 1',
+  personal_api_key: 'your feature flags secure API key from step 1',
   feature_flags_polling_interval: 30 # Optional. Measured in seconds. Defaults to 30.
 })
 ```
@@ -34,7 +34,7 @@ func main() {
 		os.Getenv("POSTHOG_API_KEY"),
 		posthog.Config{
 			Endpoint:       "<ph_client_api_host>",
-			PersonalApiKey: "your secret API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
+			PersonalApiKey: "your feature flags secure API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
             DefaultFeatureFlagsPollingInterval: time.Minute * 5, // time.Duration // Optional. Defaults to 5 minutes.
             // NextFeatureFlagsPollingTick: func() time.Duration {} // Optional. Use this to sync polling intervals between instances. For an example see: https://github.com/PostHog/posthog-go/pull/36#issuecomment-1991734125
 		},
@@ -48,7 +48,7 @@ func main() {
 PostHog::init(
     '<ph_project_token>',
     ['host' => '<ph_client_api_host>'],
-    personalAPIKey: 'your secret API key from step 1'
+    personalAPIKey: 'your feature flags secure API key from step 1'
 );
 // NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialize the posthog client
 ```
@@ -59,7 +59,7 @@ from posthog import Posthog
 posthog = Posthog('<ph_project_token>', 
     host='<ph_client_api_host>',
     poll_interval=30, # Optional. Measured in seconds. Defaults to 30.
-    personal_api_key='your secret API key from step 1'
+    personal_api_key='your feature flags secure API key from step 1'
 )
 ```
 
@@ -70,7 +70,7 @@ posthog = Posthog('<ph_project_token>',
 var client = new PostHogClient(
     new PostHogOptions {
         ProjectToken = "<ph_project_token>",
-        PersonalApiKey = "your secret API key from step 1"
+        PersonalApiKey = "your feature flags secure API key from step 1"
     });
 ```
 
@@ -81,7 +81,7 @@ import com.posthog.server.PostHogInterface;
 
 PostHogConfig config = PostHogConfig.builder("<ph_project_token>")
     .host("<ph_client_api_host>")
-    .personalApiKey("your secret API key from step 1")
+    .personalApiKey("your feature flags secure API key from step 1")
     .pollIntervalSeconds(30)  // Optional. Measured in seconds. Defaults to 30.
     .build();
 
@@ -93,7 +93,7 @@ use posthog_rs::ClientOptionsBuilder;
 
 let options = ClientOptionsBuilder::default()
     .api_key("<ph_project_token>")
-    .personal_api_key("your secret API key from step 1")
+    .personal_api_key("your feature flags secure API key from step 1")
     .enable_local_evaluation(true)
     .poll_interval_seconds(30) // Optional. Measured in seconds. Defaults to 30.
     .build()

--- a/contents/docs/integrate/_snippets/obtain-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/obtain-flags-secure-key.mdx
@@ -1,15 +1,13 @@
-Local evaluation requires a secret API key that gives the SDK access to the feature flag definitions for your project. This key needs to be kept secret, and should not be used in the frontend or exposed to users.
+The feature flags secure API key is a secret project specific token listed in the [Feature Flags tab of your project settings](https://us.posthog.com/settings/environment-feature-flags) in the "Feature Flags Secure API Key" section. It provides the SDKs with access to the feature flag definitions for your project so they can evaluate flags locally.
 
-We recommend using a **project secret API key** with the `feature_flag:read` scope. Project secret API keys are hashed at rest, scoped to only what they need, and you can create up to 50 per project, so you can issue and roll keys per deployment without affecting the others.
+This key needs to be kept secret, and should not be used in the frontend or exposed to users.
 
-> **Note:** Existing feature flags secure API keys and personal API keys continue to work for local evaluation, but both are deprecated. We recommend switching to a project secret API key.
+> **Note:** Existing personal API keys will continue to work for local evaluation, but we recommend switching to the feature flags secure API key for local evaluation moving forward. We will be deprecating personal API keys for local evaluation in the future.
 
-#### How to create a project secret API key
+#### How to obtain a feature flags secure API key
 
-1. Go to the [project secret API keys section of your project settings](https://us.posthog.com/settings/environment-secret-api-keys)
+1. Go to the [Feature Flags tab of your project settings](https://us.posthog.com/settings/environment-feature-flags)
 
-2. Create a new key with the **Local feature flag evaluation** preset (the `feature_flag:read` scope) and give it a label.
+2. The key should be displayed in the "Feature Flags Secure API Key" section.
 
-3. Copy the key. It's only displayed once, so store it somewhere safe, like a secrets manager.
-
-4. Use it to initialize the PostHog client.
+3. Copy the key and use it to initialize the PostHog client.

--- a/contents/docs/libraries/convex.mdx
+++ b/contents/docs/libraries/convex.mdx
@@ -99,7 +99,7 @@ Environment variables:
 | --- | --- | --- |
 | `POSTHOG_PROJECT_TOKEN` | Yes | Your project token (`phc_`). Sends events and evaluates flags remotely. |
 | `POSTHOG_HOST` | No | Defaults to `https://us.i.posthog.com`. Use `https://eu.i.posthog.com` for EU Cloud or your self-hosted URL. |
-| `POSTHOG_PERSONAL_API_KEY` | No | A [secret API key](/docs/feature-flags/local-evaluation#step-1-get-a-secret-api-key) (`phs_`, recommended) or personal API key (`phx_`). Setting it enables local flag evaluation. |
+| `POSTHOG_PERSONAL_API_KEY` | No | A [feature flags secure API key](/docs/feature-flags/local-evaluation#step-1-find-your-feature-flags-secure-api-key) (`phs_`, recommended) or personal API key (`phx_`). Setting it enables local flag evaluation. |
 | `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` | No | Cron interval for refreshing flag definitions. Defaults to `60`. Raise it on free-tier dev deployments to cut function-call usage. |
 
 ### 2. Set your PostHog credentials
@@ -109,10 +109,10 @@ npx convex env set POSTHOG_PROJECT_TOKEN <ph_project_token>
 npx convex env set POSTHOG_HOST <ph_client_api_host>
 ```
 
-For local feature flag evaluation (covered in step 5), also set a [secret API key](/docs/feature-flags/local-evaluation#step-1-get-a-secret-api-key):
+For local feature flag evaluation (covered in step 5), also set a [feature flags secure API key](/docs/feature-flags/local-evaluation#step-1-find-your-feature-flags-secure-api-key):
 
 ```sh
-npx convex env set POSTHOG_PERSONAL_API_KEY phs_your_secret_api_key
+npx convex env set POSTHOG_PERSONAL_API_KEY phs_your_feature_flags_secure_api_key
 ```
 
 Local evaluation kicks in on the next cron tick — no redeploy needed.

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -324,7 +324,7 @@ import NodeFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/f
 
 <NodeFeatureFlagsCode />
 
-> **Note:** For remote config flags, see the [remote config documentation](/docs/feature-flags/remote-config). Remote config requires the [secret API key](/docs/feature-flags/remote-config#step-1-get-a-secret-api-key) passed as the `personalApiKey` option.
+> **Note:** For remote config flags, see the [remote config documentation](/docs/feature-flags/remote-config). Remote config requires the [Feature Flags secure API key](/docs/feature-flags/remote-config#step-1-find-your-feature-flags-secure-api-key) passed as the `personalApiKey` option.
 
 import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-intro.mdx"
 

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -111,13 +111,13 @@ import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-
 
 <LocalEvaluationIntro />
 
-To load feature flag definitions for local evaluation, initialize the SDK with your secret API key as `personalAPIKey`:
+To load feature flag definitions for local evaluation, initialize the SDK with your feature flags secure API key as `personalAPIKey`:
 
 ```php
 PostHog::init(
     '<ph_project_token>',
     ['host' => '<ph_client_api_host>'],
-    personalAPIKey: 'your secret API key'
+    personalAPIKey: 'your feature flags secure API key'
 );
 ```
 

--- a/contents/handbook/cs-and-onboarding/health-checks.md
+++ b/contents/handbook/cs-and-onboarding/health-checks.md
@@ -125,4 +125,4 @@ It is important that hitting the flags endpoint does not block an application fr
 ### Server side local evaluation
 Implementing [Server-side local evaluation](/docs/feature-flags/local-evaluation) will ensure that flags continue to return values regardless of the network status of the flags endpoint. By default, PostHog will attempt to evaluate the flag locally using definitions it loads on initialization and at the `poll interval`. If this fails, PostHog then makes a server request to fetch the flag value.
 
-As a note, server side local evaluation is [billed differently](/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-secret-api-key) than other flag requests.
+As a note, server side local evaluation is [billed differently](/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-feature-flags-secure-api-key) than other flag requests.


### PR DESCRIPTION
## Changes

Reverts #18177.

Those docs point users at creating a project secret API key in project settings, but that settings section is gated behind the `project-secret-api-keys` feature flag, which is currently only rolled out internally. Anyone following the local evaluation or remote config guides right now gets sent to a settings page they can't see.

Reverting until the flag rolls out to customers, then the docs can be re-landed as-is (`git revert` of this PR). Part of the migration tracked in PostHog/posthog#63111.
