### PR TITLE
chore(bundle): make eager-graph check tree-shake-aware

### DIFF
--- a/gatsby/emitWebpackGraphPlugin.js
+++ b/gatsby/emitWebpackGraphPlugin.js
@@ -88,7 +88,25 @@ class EmitWebpackGraphPlugin {
                     roots.push(moduleIndex)
                 }
             }
-            entrypoints[name] = { roots }
+            // The modules webpack actually placed into this entrypoint's INITIAL
+            // (synchronously loaded) chunks — the post-tree-shaking shipped set. A module
+            // whose used exports were all eliminated is never assigned to a chunk, so it
+            // does not appear here even though it is still statically reachable in the
+            // module graph. Measuring this set instead of walking the static import graph
+            // is what makes the eager-size check tree-shake-aware: a re-export barrel only
+            // costs the sub-modules that survive into the output, not everything it names.
+            // Async chunks live in child chunk groups (from import() blocks), not in
+            // `entrypoint.chunks`, so they are correctly excluded from the eager set.
+            const eager = new Set()
+            for (const initialChunk of entrypoint.chunks) {
+                for (const module of chunkGraph.getChunkModulesIterable(initialChunk)) {
+                    const moduleIndex = indexOf.get(module)
+                    if (moduleIndex !== undefined) {
+                        eager.add(moduleIndex)
+                    }
+                }
+            }
+            entrypoints[name] = { roots, eager: [...eager] }
         }
 
         fs.mkdirSync(path.dirname(this.outputPath), { recursive: true })

--- a/scripts/bundle/__fixtures__/sample-graph.json
+++ b/scripts/bundle/__fixtures__/sample-graph.json
@@ -1,15 +1,16 @@
 {
     "entrypoints": {
-        "app": { "roots": ["a"] },
-        "polyfill": { "roots": ["p"] }
+        "app": { "roots": ["a"], "eager": ["a", "b", "c", "d"] },
+        "polyfill": { "roots": ["p"], "eager": ["p"] }
     },
     "modules": {
-        "a": { "name": "./.cache/production-app.js", "size": 100, "static": ["b", "c"], "dynamic": ["e"] },
+        "a": { "name": "./.cache/production-app.js", "size": 100, "static": ["b", "c", "g"], "dynamic": ["e"] },
         "b": { "name": "./src/components/Shell.tsx", "size": 200, "static": ["d"], "dynamic": [] },
         "c": { "name": "./src/components/Header.tsx", "size": 50, "static": [], "dynamic": [] },
         "d": { "name": "../node_modules/heavy/index.js", "size": 1000, "static": [], "dynamic": [] },
         "e": { "name": "./src/templates/lazy-page.tsx", "size": 5000, "static": ["f"], "dynamic": [] },
         "f": { "name": "../node_modules/monaco-editor/editor.js", "size": 9000, "static": [], "dynamic": [] },
+        "g": { "name": "../node_modules/tree-shaken-barrel/index.js", "size": 7000, "static": [], "dynamic": [] },
         "p": { "name": "./.cache/polyfill.js", "size": 30, "static": [], "dynamic": [] }
     }
 }

--- a/scripts/bundle/build-bundle-comment.mjs
+++ b/scripts/bundle/build-bundle-comment.mjs
@@ -47,7 +47,7 @@ function eagerSection(report, baseline) {
     }
     const baseByEntry = new Map((baseline?.roots ?? []).map((r) => [r.entrypoint, r]))
     const lines = [
-        '### Eager graph (static-import closure per entrypoint)',
+        "### Eager graph (modules shipped in each entrypoint's initial chunks)",
         '',
         '| Entrypoint | Eager size | Budget | Modules |',
         '| --- | --- | --- | --- |',
@@ -122,7 +122,8 @@ function main() {
         '',
         '---',
         '_Eager-graph budgets are report-only until a baseline is established. ' +
-            'Sizes are gzip of `public/**/*.js`; eager size is webpack module source bytes._',
+            'Sizes are gzip of `public/**/*.js`; eager size is webpack module source bytes for the ' +
+            "modules actually shipped in the entrypoint's initial chunks (post-tree-shake)._",
     ].join('\n')
 
     fs.mkdirSync(reportDir, { recursive: true })

--- a/scripts/bundle/check-eager-graph.mjs
+++ b/scripts/bundle/check-eager-graph.mjs
@@ -9,24 +9,32 @@ const repoRoot = path.resolve(__dirname, '..', '..')
 const graphPath = path.join(repoRoot, 'bundle-report', 'webpack-graph.json')
 const reportPath = path.join(repoRoot, 'bundle-report', 'eager-graph-report.json')
 
-// The eager graph is everything reachable from an entrypoint through STATIC imports
-// only — the JS a browser must download and decode before that surface is interactive,
-// regardless of how the bytes are split across chunks. Total dist size can't see
-// regressions here (a fake-lazy require() moves no bytes but makes them eager), which is
-// why this check exists alongside the compressed bundle-size check.
+// The eager graph is everything an entrypoint actually SHIPS on first load — the JS a
+// browser must download and decode before that surface is interactive, regardless of how
+// the bytes are split across chunks. Total dist size can't see regressions here (a
+// fake-lazy require() moves no bytes but makes them eager), which is why this check exists
+// alongside the compressed bundle-size check.
+//
+// It is measured from the modules webpack placed into the entrypoint's INITIAL
+// (synchronously loaded) chunks — the `eager` set emitted per entrypoint by the
+// EMIT_WEBPACK_STATS plugin. That set is post-tree-shaking: a module whose used exports
+// were all eliminated is never assigned to a chunk, so a side-effect-free re-export barrel
+// only costs the sub-modules that survive into the output, not every module it statically
+// names. Walking the raw static import graph (what this check used to do) counted the whole
+// barrel and mistook reachability for shipped weight.
 //
 // posthog.com is Gatsby + webpack, page-split: every page lazily loads its own chunk.
 // What is loaded on EVERY page is the `app` entrypoint — Gatsby's runtime plus whatever
 // gatsby-browser.tsx statically pulls in (global providers, layout, global CSS-in-JS).
-// A heavy static import that creeps into that graph inflates first-load for every single
-// page on the site, so `app` is the root we budget. The measurement input is
+// A heavy import that creeps into that eager set inflates first-load for every single page
+// on the site, so `app` is the root we budget. The measurement input is
 // bundle-report/webpack-graph.json, emitted by the EMIT_WEBPACK_STATS plugin in
 // gatsby-node.ts.
 //
-// Budgets are module source bytes (webpack module.size(), pre-minification): stable
-// across builds and proportional to decoded-script cost. Ratchet policy: when a
-// splitting win lands, lower the budget to lock it in; raise one only as a conscious,
-// reviewed decision in the PR that needs it.
+// Budgets are module source bytes (webpack module.size(), pre-minification): stable across
+// builds and proportional to decoded-script cost. Ratchet policy: when a splitting win
+// lands, lower the budget to lock it in; raise one only as a conscious, reviewed decision
+// in the PR that needs it.
 const ROOTS = [
     {
         entrypoint: 'app',
@@ -79,30 +87,40 @@ export function measure(graph, roots = ROOTS) {
     const report = { roots: [], errors: [] }
     for (const { entrypoint, label, budgetBytes, forbidden } of roots) {
         const ep = graph.entrypoints?.[entrypoint]
-        if (!ep || !ep.roots?.length) {
+        if (!ep || !ep.eager?.length) {
             const known = Object.keys(graph.entrypoints ?? {}).join(', ') || '(none)'
             report.errors.push(
-                `Entrypoint '${entrypoint}' not found in webpack graph. Known entrypoints: ${known}`
+                `Entrypoint '${entrypoint}' not found in webpack graph (or has no eager modules). Known entrypoints: ${known}`
             )
             continue
         }
 
-        const { seen, parentOf } = eagerClosure(graph.modules, ep.roots)
+        // The shipped, tree-shaken set: modules webpack actually placed into this
+        // entrypoint's initial chunks. Measuring these instead of walking the static import
+        // closure means a module whose used exports were all tree-shaken away costs nothing.
+        const shipped = ep.eager
         let totalBytes = 0
-        for (const id of seen) {
+        for (const id of shipped) {
             totalBytes += graph.modules[id]?.size ?? 0
         }
-        const largest = [...seen]
+        const largest = shipped
             .map((id) => ({ file: graph.modules[id]?.name ?? id, bytes: graph.modules[id]?.size ?? 0 }))
             .sort((a, b) => b.bytes - a.bytes)
             .slice(0, 15)
 
         const overBudget = budgetBytes != null && totalBytes > budgetBytes
+
+        // A forbidden module is a violation only when it actually ships in the eager set.
+        // The import chain is a best-effort trace through the static input graph (what a
+        // human reads); it can be short if the shipped edge has no source-level counterpart.
         const forbiddenHits = []
-        for (const substr of forbidden ?? []) {
-            const hit = [...seen].find((id) => (graph.modules[id]?.name ?? '').includes(substr))
-            if (hit) {
-                forbiddenHits.push({ module: substr, chain: chainTo(parentOf, graph.modules, hit) })
+        if (forbidden?.length) {
+            const { parentOf } = eagerClosure(graph.modules, ep.roots)
+            for (const substr of forbidden) {
+                const hit = shipped.find((id) => (graph.modules[id]?.name ?? '').includes(substr))
+                if (hit != null) {
+                    forbiddenHits.push({ module: substr, chain: chainTo(parentOf, graph.modules, hit) })
+                }
             }
         }
 
@@ -110,7 +128,7 @@ export function measure(graph, roots = ROOTS) {
             entrypoint,
             label,
             bytes: totalBytes,
-            files: seen.size,
+            files: shipped.length,
             budgetBytes,
             overBudget,
             forbidden: forbidden ?? [],
@@ -136,8 +154,8 @@ function printAndEnforce(report) {
         const budget = r.budgetBytes == null ? 'unset (report-only)' : formatMiB(r.budgetBytes)
         console.info(`${status} ${r.label}`)
         console.info(`   entrypoint: ${r.entrypoint}`)
-        console.info(`   eager closure: ${r.files} modules, ${formatMiB(r.bytes)} (budget ${budget})`)
-        console.info('   largest modules in the closure:')
+        console.info(`   eager (shipped): ${r.files} modules, ${formatMiB(r.bytes)} (budget ${budget})`)
+        console.info('   largest modules shipped eagerly:')
         for (const { file, bytes } of r.largest.slice(0, 10)) {
             console.info(`   ${formatMiB(bytes).padStart(10)}  ${file}`)
         }
@@ -146,7 +164,7 @@ function printAndEnforce(report) {
         if (r.overBudget) {
             fail(
                 `Eager graph for '${r.entrypoint}' is ${formatMiB(r.bytes)}, over the ${formatMiB(r.budgetBytes)} budget.\n` +
-                    `Something newly reachable through static imports is inflating it. Largest modules:\n` +
+                    `Something newly shipped in the eager chunks is inflating it. Largest modules:\n` +
                     r.largest.map(({ file, bytes }) => `   ${formatMiB(bytes).padStart(10)}  ${file}`).join('\n') +
                     `\nMake the offending import lazy (loadable / dynamic import()), or raise the budget in ` +
                     `scripts/bundle/check-eager-graph.mjs as a conscious decision in this PR.`
@@ -154,7 +172,7 @@ function printAndEnforce(report) {
         }
         for (const hit of r.forbiddenHits) {
             fail(
-                `'${hit.module}' is statically reachable from '${r.entrypoint}' — it must stay behind a dynamic import.\n` +
+                `'${hit.module}' ships eagerly from '${r.entrypoint}' — it must stay behind a dynamic import.\n` +
                     `Import chain:\n   ${hit.chain.join('\n   -> ')}`
             )
         }

--- a/scripts/bundle/check-eager-graph.test.mjs
+++ b/scripts/bundle/check-eager-graph.test.mjs
@@ -13,24 +13,27 @@ const appRoot = (overrides = {}) => [
     { entrypoint: 'app', label: 'app', budgetBytes: null, forbidden: [], ...overrides },
 ]
 
-test('static closure excludes modules only reachable through a dynamic import', () => {
+test('eager size counts only shipped modules, not statically-reachable-but-tree-shaken ones', () => {
     const { roots } = measure(graph, appRoot())
     const r = roots[0]
-    // a -> b -> d and a -> c are static; e and f hang off a dynamic import only.
+    // app's eager set is a, b, c, d. `g` is statically imported by a but tree-shaken out of
+    // the output (absent from the eager set), and e/f hang off a dynamic import only — the
+    // old reachability metric would have counted g; the shipped metric does not.
     assert.equal(r.files, 4)
     assert.equal(r.bytes, 100 + 200 + 50 + 1000)
     const names = r.largest.map((l) => l.file)
+    assert.ok(!names.includes('../node_modules/tree-shaken-barrel/index.js'))
     assert.ok(!names.includes('./src/templates/lazy-page.tsx'))
     assert.ok(!names.includes('../node_modules/monaco-editor/editor.js'))
 })
 
-test('overBudget is true only when the closure exceeds a set budget', () => {
+test('overBudget is true only when the shipped set exceeds a set budget', () => {
     assert.equal(measure(graph, appRoot({ budgetBytes: 1000 }))['roots'][0].overBudget, true)
     assert.equal(measure(graph, appRoot({ budgetBytes: 2000 }))['roots'][0].overBudget, false)
     assert.equal(measure(graph, appRoot({ budgetBytes: null }))['roots'][0].overBudget, false)
 })
 
-test('forbidden hits fire for statically-reachable modules and not for dynamic-only ones', () => {
+test('forbidden hits fire for shipped modules and not for tree-shaken or dynamic-only ones', () => {
     const staticHit = measure(graph, appRoot({ forbidden: ['node_modules/heavy/'] }))['roots'][0]
     assert.equal(staticHit.forbiddenHits.length, 1)
     assert.deepEqual(staticHit.forbiddenHits[0].chain, [
@@ -41,6 +44,10 @@ test('forbidden hits fire for statically-reachable modules and not for dynamic-o
 
     const dynamicOnly = measure(graph, appRoot({ forbidden: ['monaco-editor'] }))['roots'][0]
     assert.equal(dynamicOnly.forbiddenHits.length, 0)
+
+    // Statically reachable but tree-shaken out of the shipped set — not an eager ship.
+    const treeShaken = measure(graph, appRoot({ forbidden: ['tree-shaken-barrel'] }))['roots'][0]
+    assert.equal(treeShaken.forbiddenHits.length, 0)
 })
 
 test('a missing entrypoint is recorded as an error, not a crash', () => {


### PR DESCRIPTION
## Changes

Makes the eager-graph budget check tree-shake-aware, porting the improvement already made to the equivalent check in the main `posthog` repo.

Previously the check walked the static import graph from each entrypoint's roots and summed the full source size of every reachable module. That over-counts: a side-effect-free re-export barrel that is statically referenced but mostly tree-shaken away was counted in full, mistaking reachability for shipped weight.

Now the measurement uses the modules webpack actually placed into the entrypoint's **initial (synchronously loaded) chunks** — the post-tree-shaking shipped set. A module whose used exports were all eliminated never lands in a chunk, so it costs nothing.

- `gatsby/emitWebpackGraphPlugin.js` now emits an `eager` module set per entrypoint (initial-chunk membership).
- `scripts/bundle/check-eager-graph.mjs` measures size/files and forbidden hits from that shipped set; the static graph is kept only to trace human-readable import chains.
- Fixture + tests updated to assert a statically-reachable-but-tree-shaken module is excluded.

**Why:** the check exists in both `posthog` and `posthog.com`; the main repo's version was improved to measure shipped weight rather than static reachability, and this brings `posthog.com` in line so its eager-graph numbers reflect what actually ships.

Webpack-specific note: rather than mirroring the main repo's esbuild output-chunk walk, this uses webpack's initial-chunk module membership, which is the natural post-tree-shake equivalent.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
