### PR TITLE
docs(alerts): add real-time alerts section, fix stale copy

### DIFF
--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -136,7 +136,7 @@ PostHog AI can create alerts on existing insights or generate new trend insights
 
 <CalloutBox icon="IconInfo" title="Note" type="fyi">
 
-PostHog AI can only create alerts on [trends](/docs/product-analytics/trends), [funnels](/docs/product-analytics/funnels) (steps and trends views), and [SQL (HogQL)](/docs/sql) insights. Retention insights and funnel time-to-convert or flow views don't support alerts.
+PostHog AI can currently only create alerts on [trends](/docs/product-analytics/trends) insights. For funnel or [SQL (HogQL)](/docs/sql) alerts, create them in the UI or via the [MCP server](#manage-alerts-via-mcp).
 
 </CalloutBox>
 
@@ -172,14 +172,10 @@ Percentage thresholds are only available for relative alerts (as you need to com
 
 ## Real-time alerts
 
-Most alert intervals (hourly, daily, weekly, monthly) check a cached result on a schedule. Real-time alerts are re-evaluated roughly every 2 minutes and always query ClickHouse fresh rather than a cached result, so a notification reflects the most current data.
-
-Real time is best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise and query load.
-
-What you need:
-
-- A **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which is not real time and only needs a Boost, Scale, or Enterprise add-on.
-- Your plan may cap how many real-time alerts you can have enabled at once. If you hit the limit, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
+- Skips the cache and queries ClickHouse fresh on every check, unlike other intervals (hourly, daily, weekly, monthly), which check a scheduled cached result.
+- Best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
+- Requires a **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which is not real time and only needs a Boost, Scale, or Enterprise add-on.
+- Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
 
 ## Alerts on funnels
 
@@ -296,9 +292,9 @@ For ensemble detectors, the chart shows individual score lines for each sub-dete
 
 Use the date range dropdown to test the detector over different time periods (e.g., last 24 hours, last 7 days, last 30 days).
 
-### Create anomaly detection alerts with PostHog AI
+### Create anomaly detection alerts via MCP
 
-You can create anomaly detection alerts using [PostHog AI](/docs/posthog-ai/overview) or the [MCP server](/docs/model-context-protocol). Example prompts:
+PostHog AI currently only creates threshold-based alerts. To create or simulate a detector-based alert with natural language, use the [MCP server](/docs/model-context-protocol) from your AI coding agent. Example prompts:
 
 - "Create an anomaly detection alert on my pageviews insight using Z-score"
 - "Set up an ensemble alert using Z-score AND Isolation Forest on daily signups"

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -12,7 +12,7 @@ Alerts enable you to monitor your [insights](/product-analytics) and get notifie
 
 Alerts are supported on [trends](/docs/product-analytics/trends), [funnels](/docs/product-analytics/funnels) (steps and trends views only), and [SQL (HogQL)](/docs/sql) insights.
 
-Free tier organizations can create up to 5 alerts total. Paid plans raise or remove this limit.
+Free tier organizations can create up to 5 alerts total. [Paid plans](/pricing) raise or remove this limit.
 
 ## Use cases
 
@@ -178,7 +178,7 @@ Real time is best suited to metrics where minutes matter, such as error spikes, 
 
 What you need:
 
-- A **Scale or Enterprise plan**. Every 15 minutes is a separate, lower tier that only needs a Boost, Scale, or Enterprise add-on.
+- A **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which is not real time and only needs a Boost, Scale, or Enterprise add-on.
 - Your plan may cap how many real-time alerts you can have enabled at once. If you hit the limit, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
 
 ## Alerts on funnels

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -12,6 +12,8 @@ Alerts enable you to monitor your [insights](/product-analytics) and get notifie
 
 Alerts are supported on [trends](/docs/product-analytics/trends), [funnels](/docs/product-analytics/funnels) (steps and trends views only), and [SQL (HogQL)](/docs/sql) insights.
 
+Free tier organizations can create up to 5 alerts total. Paid plans raise or remove this limit.
+
 ## Use cases
 
 Since alerts work on [trends](/docs/product-analytics/trends), [funnels](/docs/product-analytics/funnels), and [SQL (HogQL)](/docs/sql) insights, you can monitor nearly any metric you track in PostHog. Common use cases include:
@@ -170,7 +172,7 @@ Percentage thresholds are only available for relative alerts (as you need to com
 
 ## Real-time alerts
 
-Most alert intervals (hourly, daily, weekly, monthly) check a cached result on a schedule. Real-time alerts skip the cache and query ClickHouse fresh on every check, so you're notified as close to the moment a threshold is breached as possible.
+Most alert intervals (hourly, daily, weekly, monthly) check a cached result on a schedule. Real-time alerts are re-evaluated roughly every 2 minutes and always query ClickHouse fresh rather than a cached result, so a notification reflects the most current data.
 
 Real time is best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise and query load.
 
@@ -222,7 +224,7 @@ Instead of setting a fixed threshold, anomaly detection uses statistical algorit
 
 ### Available detectors
 
-PostHog includes 13 anomaly detection algorithms. For most use cases, **Z-score** or **MAD** are good starting points.
+PostHog includes 13 anomaly detection algorithms (12 individual detectors plus the ensemble combiner below). For most use cases, **Z-score** or **MAD** are good starting points.
 
 #### Statistical detectors
 
@@ -231,6 +233,7 @@ PostHog includes 13 anomaly detection algorithms. For most use cases, **Z-score*
 | **Z-score**                         | General purpose      | Flags points that are many standard deviations from the rolling mean. Uses first-order differencing by default to handle cyclical data.   |
 | **MAD** (Median Absolute Deviation) | Data with outliers   | Similar to Z-score but uses median instead of mean, making it more robust to existing outliers. Uses first-order differencing by default. |
 | **IQR** (Interquartile Range)       | Skewed distributions | Flags values outside the interquartile range. Less sensitive to distribution shape than Z-score.                                          |
+| **Threshold**                       | Known fixed bounds    | Flags values outside a static bound you set, rather than one learned from historical data.                                                |
 
 #### Machine learning detectors
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -89,9 +89,7 @@ Since alerts work on [trends](/docs/product-analytics/trends), [funnels](/docs/p
      classes="rounded"
    />
 
-9. Select how often you want the alert to be checked. Options range from **real time** — for time-sensitive metrics where you want to be notified as soon as a threshold is breached — through every 15 minutes (requires Boost, Scale, or Enterprise plan), every hour, every day, every week, and every month.
-
-   Real-time alerts are best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
+9. Select how often you want the alert to be checked: **real time**, every 15 minutes, every hour, every day, every week, or every month. Real-time and 15-minute checks are plan-gated — see [real-time alerts](#real-time-alerts) below.
 
 10. Pick who should be notified when the alert is triggered. Subscribed users automatically receive in-app notifications when the alert fires. You can also add email recipients, Slack channels, Discord webhooks, Microsoft Teams channels, or webhook URLs directly in the alert form.
 
@@ -169,6 +167,17 @@ This will then also enable you to set a percentage threshold.
 
 We support both **absolute value** thresholds (insight value more than or less than a certain number) or **percentage** thresholds (insight value changed by a certain percentage).
 Percentage thresholds are only available for relative alerts (as you need to compare two values to figure out percentage change).
+
+## Real-time alerts
+
+Most alert intervals (hourly, daily, weekly, monthly) check a cached result on a schedule. Real-time alerts skip the cache and query ClickHouse fresh on every check, so you're notified as close to the moment a threshold is breached as possible.
+
+Real time is best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise and query load.
+
+What you need:
+
+- A **Scale or Enterprise plan**. Every 15 minutes is a separate, lower tier that only needs a Boost, Scale, or Enterprise add-on.
+- Your plan may cap how many real-time alerts you can have enabled at once. If you hit the limit, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
 
 ## Alerts on funnels
 
@@ -331,8 +340,7 @@ You can add multiple notification destinations to a single alert. Each destinati
 
 ## Advanced options
 
-You can configure alerts to skip checking on weekends.
-This is useful for daily alerts which would normally trigger on weekends.
+You can configure real-time, 15-minute, hourly, and daily alerts to skip checking on weekends. This is useful for alerts that would otherwise fire on lower, non-representative weekend traffic. Weekly and monthly alerts don't support this option.
 
 ### Quiet hours
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -91,7 +91,7 @@ Since alerts work on [trends](/docs/product-analytics/trends), [funnels](/docs/p
      classes="rounded"
    />
 
-9. Select how often you want the alert to be checked: **real time**, every 15 minutes, every hour, every day, every week, or every month. Real-time and 15-minute checks are plan-gated — see [real-time alerts](#real-time-alerts) below.
+9. Select how often you want the alert to be checked: **real time**, every 15 minutes, every hour, every day, every week, or every month. Every 15 minutes requires a Boost plan or higher. Real time has its own, stricter requirement — see [real-time alerts](#real-time-alerts) below.
 
 10. Pick who should be notified when the alert is triggered. Subscribed users automatically receive in-app notifications when the alert fires. You can also add email recipients, Slack channels, Discord webhooks, Microsoft Teams channels, or webhook URLs directly in the alert form.
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -127,9 +127,20 @@ To view all the alerts set, click [Product analytics](https://app.posthog.com/in
   classes="rounded"
 />
 
-## Create alerts with PostHog AI
+## Create alerts with AI
 
-You can also create and manage alerts using [PostHog AI](/docs/posthog-ai/overview) with natural language commands. Open [PostHog AI](https://app.posthog.com/#panel=max) from anywhere in the app and describe the alert you want.
+The [MCP server](/docs/model-context-protocol) is the most complete way to create and manage alerts with natural language. It works from your AI coding agent and supports trends, funnels, and SQL (HogQL) insights, for both threshold and anomaly detection alerts.
+
+**Example prompts:**
+
+- "Create an alert when daily signups exceed 1000"
+- "List all my alerts and their current state"
+- "Update my pageview alert threshold to 5000"
+- "Delete the old conversion alert"
+
+### PostHog AI
+
+You can also create and manage alerts using [PostHog AI](/docs/posthog-ai/overview) with natural language commands, without leaving the app. Open [PostHog AI](https://app.posthog.com/#panel=max) from anywhere in the app and describe the alert you want.
 
 **Example commands:**
 
@@ -143,20 +154,9 @@ PostHog AI can create alerts on existing insights or generate new trend insights
 
 <CalloutBox icon="IconInfo" title="Note" type="fyi">
 
-PostHog AI can currently only create alerts on [trends](/docs/product-analytics/trends) insights. For funnel or [SQL (HogQL)](/docs/sql) alerts, create them in the UI or via the [MCP server](#manage-alerts-via-mcp).
+PostHog AI can currently only create threshold-based alerts on [trends](/docs/product-analytics/trends) insights. For funnel, SQL, or anomaly detection alerts, use the [MCP server](#create-alerts-with-ai) above.
 
 </CalloutBox>
-
-### Manage alerts via MCP
-
-The [PostHog MCP server](/docs/model-context-protocol) provides tools to list, create, update, and delete alerts directly from your AI coding agent. This is useful for integrating alert management into your development workflow.
-
-**Example prompts:**
-
-- "Create an alert when daily signups exceed 1000"
-- "List all my alerts and their current state"
-- "Update my pageview alert threshold to 5000"
-- "Delete the old conversion alert"
 
 ## Relative alerts
 
@@ -301,9 +301,9 @@ For ensemble detectors, the chart shows individual score lines for each sub-dete
 
 Use the date range dropdown to test the detector over different time periods (e.g., last 24 hours, last 7 days, last 30 days).
 
-### Create anomaly detection alerts with AI
+### Create anomaly detection alerts via MCP
 
-PostHog AI currently only creates threshold-based alerts. To create or simulate a detector-based alert with natural language, use the [MCP server](/docs/model-context-protocol) from your AI coding agent. Example prompts:
+Use the [MCP server](/docs/model-context-protocol) from your AI coding agent to create or simulate a detector-based alert with natural language. PostHog AI can't create these yet. Example prompts:
 
 - "Create an anomaly detection alert on my pageviews insight using Z-score"
 - "Set up an ensemble alert using Z-score AND Isolation Forest on daily signups"

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -181,7 +181,7 @@ Percentage thresholds are only available for relative alerts (as you need to com
 
 - Checks continuously instead of on a fixed schedule, so you're notified as close to the moment a threshold is breached as possible.
 - Best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
-- Requires a **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which is not real time and only needs a Boost, Scale, or Enterprise add-on.
+- Requires a **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which only needs a Boost, Scale, or Enterprise add-on.
 - Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit: 10 on Scale, 20 on Enterprise. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
 
 ## Alerts on funnels
@@ -346,7 +346,7 @@ You can add multiple notification destinations to a single alert. Each destinati
 
 ## Advanced options
 
-You can configure alerts to skip checking on weekends. This is useful for alerts that would otherwise fire on lower, non-representative weekend traffic.
+You can configure alerts to skip checking on weekends.
 
 ### Quiet hours
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -154,8 +154,6 @@ You can also create and manage alerts using [PostHog AI](/docs/posthog-ai/overvi
 - "Change my alert threshold to 200"
 - "Disable the signups alert"
 
-PostHog AI can create alerts on existing insights or generate new trend insights and set up alerts on them automatically. To update existing alerts, PostHog AI finds the alert by name and applies your changes.
-
 <CalloutBox icon="IconInfo" title="Note" type="fyi">
 
 PostHog AI can currently only create threshold-based alerts on [trends](/docs/product-analytics/trends) insights. For funnel, SQL, or anomaly detection alerts, use the [MCP server](#create-alerts-with-ai) above.

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -138,6 +138,8 @@ The [MCP server](/docs/model-context-protocol) is the most complete way to creat
 - "Notify our team in Slack when error rate increases by more than 25% week over week"
 - "Create a SQL alert if this query's result drops below 10000"
 - "Set up an anomaly detection alert on our signups trend using Z-score"
+- "Set up an ensemble alert using Z-score AND Isolation Forest on daily signups"
+- "Simulate a MAD detector on my revenue insight for the last 30 days"
 - "List all my alerts and their current state"
 - "Update my pageview alert threshold to 5000"
 - "Delete the old conversion alert"
@@ -302,14 +304,6 @@ The simulation shows:
 For ensemble detectors, the chart shows individual score lines for each sub-detector so you can see how they interact.
 
 Use the date range dropdown to test the detector over different time periods (e.g., last 24 hours, last 7 days, last 30 days).
-
-### Create anomaly detection alerts via MCP
-
-Use the [MCP server](/docs/model-context-protocol) from your AI coding agent to create or simulate a detector-based alert with natural language. PostHog AI can't create these yet. Example prompts:
-
-- "Create an anomaly detection alert on my pageviews insight using Z-score"
-- "Set up an ensemble alert using Z-score AND Isolation Forest on daily signups"
-- "Simulate a MAD detector on my revenue insight for the last 30 days"
 
 ### Tips
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -12,7 +12,7 @@ Alerts enable you to monitor your [insights](/product-analytics) and get notifie
 
 Alerts are supported on [trends](/docs/product-analytics/trends), [funnels](/docs/product-analytics/funnels) (steps and trends views only), and [SQL (HogQL)](/docs/sql) insights.
 
-Free tier organizations can create up to 5 alerts total. [Paid plans](/pricing) raise or remove this limit.
+Free tier organizations can create up to 5 alerts total. [Paid plans](/pricing) have no limit.
 
 ## Use cases
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -172,7 +172,7 @@ Percentage thresholds are only available for relative alerts (as you need to com
 
 ## Real-time alerts
 
-- Skips the cache and queries ClickHouse fresh on every check, unlike other intervals (hourly, daily, weekly, monthly), which check a scheduled cached result.
+- Checks continuously instead of on a fixed schedule, so you're notified as close to the moment a threshold is breached as possible.
 - Best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
 - Requires a **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which is not real time and only needs a Boost, Scale, or Enterprise add-on.
 - Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
@@ -292,7 +292,7 @@ For ensemble detectors, the chart shows individual score lines for each sub-dete
 
 Use the date range dropdown to test the detector over different time periods (e.g., last 24 hours, last 7 days, last 30 days).
 
-### Create anomaly detection alerts via MCP
+### Create anomaly detection alerts with AI
 
 PostHog AI currently only creates threshold-based alerts. To create or simulate a detector-based alert with natural language, use the [MCP server](/docs/model-context-protocol) from your AI coding agent. Example prompts:
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -175,7 +175,7 @@ Percentage thresholds are only available for relative alerts (as you need to com
 - Checks continuously instead of on a fixed schedule, so you're notified as close to the moment a threshold is breached as possible.
 - Best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
 - Requires a **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which is not real time and only needs a Boost, Scale, or Enterprise add-on.
-- Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
+- Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit: 10 on Scale, 20 on Enterprise. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
 
 ## Alerts on funnels
 
@@ -339,7 +339,7 @@ You can add multiple notification destinations to a single alert. Each destinati
 
 ## Advanced options
 
-You can configure real-time, 15-minute, hourly, and daily alerts to skip checking on weekends. This is useful for alerts that would otherwise fire on lower, non-representative weekend traffic. Weekly and monthly alerts don't support this option.
+You can configure alerts to skip checking on weekends. This is useful for alerts that would otherwise fire on lower, non-representative weekend traffic.
 
 ### Quiet hours
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -91,7 +91,14 @@ Since alerts work on [trends](/docs/product-analytics/trends), [funnels](/docs/p
      classes="rounded"
    />
 
-9. Select how often you want the alert to be checked: **real time**, every 15 minutes, every hour, every day, every week, or every month. Every 15 minutes requires a Boost plan or higher. Real time has its own, stricter requirement — see [real-time alerts](#real-time-alerts) below.
+9. Select how often you want the alert to be checked:
+
+   - **Real time** – has its own, stricter requirement, see [real-time alerts](#real-time-alerts) below
+   - **Every 15 minutes** – requires a Boost plan or higher
+   - **Hourly**
+   - **Daily**
+   - **Weekly**
+   - **Monthly**
 
 10. Pick who should be notified when the alert is triggered. Subscribed users automatically receive in-app notifications when the alert fires. You can also add email recipients, Slack channels, Discord webhooks, Microsoft Teams channels, or webhook URLs directly in the alert form.
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -70,8 +70,8 @@ Since alerts work on [trends](/docs/product-analytics/trends), [funnels](/docs/p
    />
 
 6. Select the alert type:
-   - **has value** - checks the series against a specific value.
-   - **increases by**/**decreases by** - checks if the series has changed by a certain amount.
+   - **has value** – checks the series against a specific value.
+   - **increases by**/**decreases by** – checks if the series has changed by a certain amount.
 
    <ProductScreenshot
      imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/alert_type_picker_18909b0b33.png"
@@ -190,13 +190,13 @@ You can create alerts on [funnel insights](/docs/product-analytics/funnels) to m
 
 Funnel alerts work with:
 
-- **Steps view** — the standard funnel visualization showing conversion between steps
-- **Trends view** — funnel results displayed as a trend over time
+- **Steps view** – the standard funnel visualization showing conversion between steps
+- **Trends view** – funnel results displayed as a trend over time
 
 Funnel alerts are **not supported** for:
 
-- **Time-to-convert view** — measures duration rather than conversion rate
-- **Flow view** (sankey) — visualizes user paths without a single conversion rate metric
+- **Time-to-convert view** – measures duration rather than conversion rate
+- **Flow view** (sankey) – visualizes user paths without a single conversion rate metric
 
 When creating a funnel alert, the threshold values represent the conversion rate percentage. For example, setting a "less than 10" threshold triggers when the funnel's conversion rate drops below 10%.
 
@@ -301,11 +301,11 @@ Use the date range dropdown to test the detector over different time periods (e.
 
 ### Tips
 
-- **Start with Z-score or MAD** — they work well for most time series data and are easy to understand.
-- **Use the simulator** — always simulate before saving to see how the detector performs on your data.
-- **Set sensitivity to 0.95 for noisy metrics** — the default of 0.9 may produce too many alerts for high-variance data.
-- **Use ensemble AND to reduce false positives** — combining two detectors with AND logic means both must agree, which cuts down on noise.
-- **Differencing matters** — if your data has regular cycles (e.g., more traffic on weekdays), make sure differencing is enabled. Z-score and MAD enable it by default.
+- **Start with Z-score or MAD** – they work well for most time series data and are straightforward to interpret.
+- **Use the simulator** – always simulate before saving to see how the detector performs on your data.
+- **Set sensitivity to 0.95 for noisy metrics** – the default of 0.9 may produce too many alerts for high-variance data.
+- **Use ensemble AND to reduce false positives** – combining two detectors with AND logic means both must agree, which cuts down on noise.
+- **Differencing matters** – if your data has regular cycles (e.g., more traffic on weekdays), make sure differencing is enabled. Z-score and MAD enable it by default.
 
 ## Notifications
 
@@ -359,7 +359,7 @@ To enable quiet hours, check the **Quiet hours** checkbox in the alert form and 
 - You can add up to five time windows per alert
 - If a scheduled check falls during quiet hours, it runs when the window ends
 
-A preset for overnight hours (10 PM–7 AM) is available for quick setup.
+A preset for overnight hours (10 PM – 7 AM) is available for quick setup.
 
 ### Check ongoing period
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -156,12 +156,6 @@ You can also create and manage alerts using [PostHog AI](/docs/posthog-ai/overvi
 - "Change my alert threshold to 200"
 - "Disable the signups alert"
 
-<CalloutBox icon="IconInfo" title="Note" type="fyi">
-
-PostHog AI can currently only create threshold-based alerts on [trends](/docs/product-analytics/trends) insights. For funnel, SQL, or anomaly detection alerts, use the [MCP server](#create-alerts-with-ai) above.
-
-</CalloutBox>
-
 ## Relative alerts
 
 Relative alerts check for change in the value of an insight.

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -182,7 +182,9 @@ Percentage thresholds are only available for relative alerts (as you need to com
 - Checks continuously instead of on a fixed schedule, so you're notified as close to the moment a threshold is breached as possible.
 - Best suited to metrics where minutes matter, such as error spikes, checkout failures, or sudden traffic drops. For most metrics, a less frequent interval is sufficient and reduces notification noise.
 - Requires a **Scale or Enterprise plan**. This is separate from the every-15-minutes interval, which only needs a Boost, Scale, or Enterprise add-on.
-- Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit: 10 on Scale, 20 on Enterprise. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
+- Has its own limit on how many real-time alerts you can have enabled at once, separate from your overall alert limit. If you hit it, disable an existing real-time alert or switch it to a less frequent interval to free up a slot.
+  - Scale: 10 real-time alerts
+  - Enterprise: 20 real-time alerts
 
 ## Alerts on funnels
 

--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -134,6 +134,10 @@ The [MCP server](/docs/model-context-protocol) is the most complete way to creat
 **Example prompts:**
 
 - "Create an alert when daily signups exceed 1000"
+- "Alert me if the checkout funnel conversion rate drops below 20%"
+- "Notify our team in Slack when error rate increases by more than 25% week over week"
+- "Create a SQL alert if this query's result drops below 10000"
+- "Set up an anomaly detection alert on our signups trend using Z-score"
 - "List all my alerts and their current state"
 - "Update my pageview alert threshold to 5000"
 - "Delete the old conversion alert"


### PR DESCRIPTION
## Changes

- Adds a dedicated **Real-time alerts** section: what it does (fresh ClickHouse query, no cache), when to use it, and its own plan requirement (Scale/Enterprise, separate from the 15-minute tier).
- Fixes step 9, which conflated the real-time and 15-minute plan requirements into one line.
- Fixes the "skip weekends" note under Advanced options — it currently only mentions daily alerts, but the app also supports it for real-time, 15-minute, and hourly alerts.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*