### PR TITLE
Update quarterly account plan template to opp-focused format

### DIFF
--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -30,7 +30,7 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 Add the plan as an account note in PostHog customer analytics on the account's profile. For each account, work through these six questions:
 
-1. **What type of opportunities (opps) are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
+1. **What type of opportunities (opps) are there this quarter?** Name each one — conversion (moving a pay-as-you-go plan onto a discounted credit plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
 2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
 3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
 4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -20,7 +20,7 @@ Risk mitigation is about building habits that surface problems before they becom
 
 ### Quarterly account planning
 
-Every AM Managed account should have an Account Plan note created in Vitally once per quarter. You should also review this regularly with your manager and updated it as needed.  This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
+Every AM Managed account should have an Account Plan note created in PostHog customer analytics, on the account's profile, once per quarter. You should also review this regularly with your manager and update it as needed. This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
 
 The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
@@ -28,9 +28,9 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 **Title format:** `Q[X] Account Plan - [Company Name]`
 
-Use the Account Plan template in Vitally, which auto-populates key fields from the account record. For each account, work through these six questions:
+Add the plan as an account note in PostHog customer analytics on the account's profile. For each account, work through these six questions:
 
-1. **What type of oops are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
+1. **What type of opps are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
 2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
 3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
 4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.
@@ -212,7 +212,7 @@ Not every at-risk account can be saved. When a customer churns, write a retro an
 
 | Activity | Cadence |
 |----------|---------|
-| Account Plan note in Vitally | Quarterly |
+| Account Plan note in PostHog customer analytics | Quarterly |
 | Implementation health check | At onboarding + annually |
 | Early warning signal monitoring | Ongoing |
 | Behavioral product adoption push | Ongoing (especially for warehouse-heavy accounts) |

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -28,14 +28,15 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 **Title format:** `Q[X] Account Plan - [Company Name]`
 
-Add the plan as an account note in PostHog Customer Analytics on the account's profile. For each account, work through these six questions:
+Add the plan as an account note in PostHog Customer Analytics on the account's profile. For each account, work through these seven questions:
 
 1. **What type of opportunities (opps) are there this quarter?** Name each one – conversion (moving a pay-as-you-go plan onto a discounted credit plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) – so you're clear on what you're actually driving toward.
-2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, Error Tracking adopted) so success is measurable rather than vague.
-3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
-4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.
-5. **Link to the SFDC opp.** Drop in the Salesforce opportunity link so anyone reviewing can jump straight to the deal.
-6. **Who are the key players?** List the stakeholders – champions, budget holders, technical evaluators, and end-users – and where you stand with each.
+2. **What are the customer's business objectives?** Capture what they're trying to achieve with PostHog and how it connects to their broader goals so it's clear what they are – and if you don't know, say so, so the gap is visible.
+3. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, Error Tracking adopted) so success is measurable rather than vague.
+4. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
+5. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.
+6. **Link to the SFDC opp.** Drop in the Salesforce opportunity link so anyone reviewing can jump straight to the deal.
+7. **Who are the key players?** List the stakeholders – champions, budget holders, technical evaluators, and end-users – and where you stand with each.
 
 #### Ongoing updates
 1. What did you do with them last week.

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -20,7 +20,7 @@ Risk mitigation is about building habits that surface problems before they becom
 
 ### Quarterly account planning
 
-Every AM Managed account should have an Account Plan note created in PostHog customer analytics, on the account's profile, once per quarter. You should also review this regularly with your manager and update it as needed. This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
+Every managed account should have an Account Plan note created in PostHog customer analytics, on the account's profile, once per quarter. You should also review this regularly with your manager and update it as needed. This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
 
 The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
@@ -30,7 +30,7 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 Add the plan as an account note in PostHog customer analytics on the account's profile. For each account, work through these six questions:
 
-1. **What type of oops are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
+1. **What type of opportunities (opps) are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
 2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
 3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
 4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -30,7 +30,7 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 Use the Account Plan template in Vitally, which auto-populates key fields from the account record. For each account, work through these six questions:
 
-1. **What type of opps are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
+1. **What type of oops are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
 2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
 3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
 4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -22,35 +22,20 @@ Risk mitigation is about building habits that surface problems before they becom
 
 Every AM Managed account should have an Account Plan note created in Vitally once per quarter. You should also review this regularly with your manager and updated it as needed.  This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
 
-The plan can be broken into two parts. Initial writeup and ongoing updates.
+The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
-#### Initial Writeup
-This happens when you first onboard an account and will change less frequently (every 1 - 3 quarters) and can largely remain stable.
+#### Quarterly plan
 
 **Title format:** `Q[X] Account Plan - [Company Name]`
 
-Use the Account Plan template in Vitally, which auto-populates key fields from the account record. The template covers:
+Use the Account Plan template in Vitally, which auto-populates key fields from the account record. For each account, work through these six questions:
 
-**Account overview**
-
-- ARR, business description, website, HQ location
-- Business type (B2B SaaS, E-commerce, Marketplace, Developer Tools, Fintech, Healthcare, etc.)
-- Key metrics relevant to their business model
-- Business stage and funding
-
-**Business objectives**
-
-- What they're trying to achieve with PostHog (specific goals, not vague "analytics")
-- How PostHog connects to their larger business objectives
-- Whether value aligns with their expectations
-- Obstacles they're facing, both in using PostHog and in their broader goals
-- Upcoming constraints (budget freezes, code freezes, migrations, seasonality)
-- Future needs over 6-18 months
-
-**Stakeholders and users**
-
-- Key contacts with their priorities, goals, and preferred communication
-- Multithreading status: do we have two-way dialogue with technical stakeholders, budget holders, and end-users?
+1. **What type of opps are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
+2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
+3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
+4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.
+5. **Link to the SFDC opp.** Drop in the Salesforce opportunity link so anyone reviewing can jump straight to the deal.
+6. **Who are the key players?** List the stakeholders — champions, budget holders, technical evaluators, and end-users — and where you stand with each.
 
 #### Ongoing updates
 1. What did you do with them last week.

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -30,7 +30,7 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 Add the plan as an account note in PostHog customer analytics on the account's profile. For each account, work through these six questions:
 
-1. **What type of opps are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
+1. **What type of oops are there this quarter?** Name each one — conversion (moving a free or trialing account onto a paid plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
 2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
 3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
 4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.

--- a/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
+++ b/contents/handbook/growth/sales/risk-mitigation-and-churn-prevention.md
@@ -20,7 +20,7 @@ Risk mitigation is about building habits that surface problems before they becom
 
 ### Quarterly account planning
 
-Every managed account should have an Account Plan note created in PostHog customer analytics, on the account's profile, once per quarter. You should also review this regularly with your manager and update it as needed. This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
+Every managed account should have an Account Plan note created in PostHog Customer Analytics, on the account's profile, once per quarter. You should also review this regularly with your manager and update it as needed. This forces you to step back and evaluate the account holistically rather than just reacting to whatever's in front of you.
 
 The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
@@ -28,14 +28,14 @@ The plan can be broken into two parts: the quarterly plan and ongoing updates.
 
 **Title format:** `Q[X] Account Plan - [Company Name]`
 
-Add the plan as an account note in PostHog customer analytics on the account's profile. For each account, work through these six questions:
+Add the plan as an account note in PostHog Customer Analytics on the account's profile. For each account, work through these six questions:
 
-1. **What type of opportunities (opps) are there this quarter?** Name each one — conversion (moving a pay-as-you-go plan onto a discounted credit plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) — so you're clear on what you're actually driving toward.
-2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, error tracking adopted) so success is measurable rather than vague.
+1. **What type of opportunities (opps) are there this quarter?** Name each one – conversion (moving a pay-as-you-go plan onto a discounted credit plan), renewal (securing an existing contract for another term), or cross-sell (getting them onto a product they aren't using yet) – so you're clear on what you're actually driving toward.
+2. **What's the desired outcome for the account by the end of the quarter?** State the concrete result you want (renewal signed, in with a new team, Error Tracking adopted) so success is measurable rather than vague.
 3. **Does the customer know about this plan?** Note whether you've aligned with them, because a plan they haven't bought into is just a guess.
 4. **Is it blocked on anything right now, and are there any other risks?** Call out current blockers and any other risks so you can get ahead of them before they derail the outcome.
 5. **Link to the SFDC opp.** Drop in the Salesforce opportunity link so anyone reviewing can jump straight to the deal.
-6. **Who are the key players?** List the stakeholders — champions, budget holders, technical evaluators, and end-users — and where you stand with each.
+6. **Who are the key players?** List the stakeholders – champions, budget holders, technical evaluators, and end-users – and where you stand with each.
 
 #### Ongoing updates
 1. What did you do with them last week.
@@ -212,7 +212,7 @@ Not every at-risk account can be saved. When a customer churns, write a retro an
 
 | Activity | Cadence |
 |----------|---------|
-| Account Plan note in PostHog customer analytics | Quarterly |
+| Account Plan note in PostHog Customer Analytics | Quarterly |
 | Implementation health check | At onboarding + annually |
 | Early warning signal monitoring | Ongoing |
 | Behavioral product adoption push | Ongoing (especially for warehouse-heavy accounts) |


### PR DESCRIPTION
## Changes

Updates the recommended quarterly account plan template on the [risk mitigation & churn prevention](https://posthog.com/handbook/growth/sales/risk-mitigation-and-churn-prevention#quarterly-account-planning) handbook page. Swaps the account-overview / business-objectives / stakeholders writeup for a leaner, opportunity-focused set of six questions, each with a one-line explanation of what it is and why it matters:

1. What type of opps are there this quarter? (conversion / renewal / cross-sell)
2. What's the desired outcome by end of quarter?
3. Does the customer know about this plan?
4. Is it blocked on anything, and any other risks?
5. Link to the SFDC opp
6. Who are the key players?

The "Ongoing updates" weekly log is unchanged.

**Why:** An AM found this six-question format more useful than the existing template and asked to make it the recommended one.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0928JW20TY/p1783621433796279)*