### PR TITLE
fix(docs): correct outdated subscriptions doc claims

### DIFF
--- a/contents/docs/product-analytics/subscriptions.mdx
+++ b/contents/docs/product-analytics/subscriptions.mdx
@@ -125,6 +125,14 @@ You can then select any channel the app has access to and set a frequency. **Pri
   alt="Slack channel selection"
 />
 
+## Asking @PostHog about subscription reports
+
+When you receive a Slack subscription, you can reply in the message thread and mention [`@PostHog`](/docs/slack) to ask follow-up questions about the delivered report. If the [PostHog Slack app](/docs/slack) is fully configured with the required scopes, a hint appears at the bottom of each subscription message encouraging you to do this.
+
+If the hint links to setup docs instead, your Slack integration needs to be reconnected with updated scopes. See the [PostHog Slack app setup guide](/docs/slack/setup) for instructions.
+
+This feature requires your organization to have AI data processing consent enabled in your organization settings.
+
 ## Scheduling options
 
 Subscriptions support three frequency options: **daily**, **weekly**, and **monthly**. You can also set a custom interval (e.g. every 2 weeks) and choose the time of day for delivery.

--- a/contents/docs/product-analytics/subscriptions.mdx
+++ b/contents/docs/product-analytics/subscriptions.mdx
@@ -74,7 +74,7 @@ When creating a subscription for a dashboard, you can select which specific insi
 
 You can give each subscription a custom name to help distinguish between them. This is especially useful when you have multiple subscriptions to the same dashboard or insight – for example, different reports for different teams or frequencies.
 
-For Slack subscriptions, the custom name appears in the message header. For example, a subscription named "Weekly KPI Report" for a dashboard called "Main Dashboard" displays as **Weekly KPI Report** (dashboard: Main Dashboard) in the Slack message. Without a custom name, the message references the dashboard or insight name directly.
+For Slack subscriptions, the custom name is used as the message title in place of the dashboard or insight name.
 
 ## Email subscriptions
 
@@ -124,14 +124,6 @@ You can then select any channel the app has access to and set a frequency. **Pri
   classes="rounded"
   alt="Slack channel selection"
 />
-
-## Asking @PostHog about subscription reports
-
-When you receive a Slack subscription, you can reply in the message thread and mention [`@PostHog`](/docs/slack) to ask follow-up questions about the delivered report. If the [PostHog Slack app](/docs/slack) is fully configured with the required scopes, a hint appears at the bottom of each subscription message encouraging you to do this.
-
-If the hint links to setup docs instead, your Slack integration needs to be reconnected with updated scopes. See the [PostHog Slack app setup guide](/docs/slack/setup) for instructions.
-
-This feature requires your organization to have AI data processing consent enabled in your organization settings.
 
 ## Scheduling options
 
@@ -261,4 +253,4 @@ To re-enable a disabled subscription:
 
 PostHog validates that the issue is resolved before allowing re-enable. If the prerequisite is still broken (e.g., Slack is still disconnected or the bot isn't in the channel), re-enabling is rejected with an error message.
 
-When you successfully re-enable a subscription, PostHog immediately sends a confirmation delivery and sets the next scheduled delivery date.
+Once re-enabled, the subscription resumes delivering on its regular schedule.


### PR DESCRIPTION
## Changes

Audited the [Subscriptions docs page](contents/docs/product-analytics/subscriptions.mdx) against the current `posthog/posthog` implementation and fixed three claims that no longer match the code:

- Removed the "Asking @PostHog about subscription reports" section, describing a Slack thread Q&A feature that isn't implemented (only the invitation hint text ships, not the follow-up-answering capability)
- Fixed the custom-name-in-Slack-message example, which described a `(dashboard: X)` suffix pattern that doesn't exist in the delivery code
- Softened the re-enable claim about an automatic confirmation delivery, which isn't backed by code

Everything else in the doc (subscriptions page, insight limits of 6/10, email/Slack setup, scheduling options, AI summaries, prompt subscriptions, test delivery, auto-disable reasons) was verified accurate against the codebase.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*