### PR TITLE
Docs: More CLI

### DIFF
--- a/contents/blog/ai-is-killing-no-code-experiments.md
+++ b/contents/blog/ai-is-killing-no-code-experiments.md
@@ -23,7 +23,7 @@ AI is changing all this, and in doing so, is making no-code experiments extinct.
 
 AI code generation is fulfilling the promise of no-code experiments: it actually lets you run experiments without relying on engineers. Writing code is [becoming less of a bottleneck](/newsletter/hidden-danger-of-shipping-fast). Now the hard part is moving where it should have been all along: figuring out what experiments to run.
 
-You still need to describe your test in plain language and learn how to set up experiments correctly, but the coding can now be done with the combination of your favorite coding agent and [PostHog MCP](/docs/model-context-protocol). When you combine these, you just describe your test and the agent generates:
+You still need to describe your test in plain language and learn how to set up experiments correctly, but the coding can now be done with the combination of your favorite coding agent and [PostHog MCP](/docs/model-context-protocol) (or [CLI](/docs/cli)). When you combine these, you just describe your test and the agent generates:
 
 - The actual code change implementing your variant
 - An [experiment](/docs/experiments) in PostHog with your success metric

--- a/contents/blog/ai-observability-for-mvps.mdx
+++ b/contents/blog/ai-observability-for-mvps.mdx
@@ -214,7 +214,7 @@ A quick pitch, since this is our blog after all:
 - **[Prompt management](/docs/prompt-management)** with versioning, fetch-at-runtime, and rollback
 - **[Connected product analytics](/product-analytics)** – the same user IDs flow through, so you can correlate AI usage with retention, conversion, and churn
 - **[Session replay](/docs/ai-observability/link-session-replay)** alongside traces, so you can see exactly what the user was doing when the model misbehaved
-- **An [MCP server](/docs/model-context-protocol)** that lets you query traces, costs, and evals directly from Claude Code or Cursor while you're iterating
+- **An [MCP server](/docs/model-context-protocol)** and [CLI](/docs/cli) that let you query traces, costs, and evals directly from Claude Code or Cursor while you're iterating
 
 If you want to take it for a spin, [you can start free](/blog/cheapest-ai-observability-tools) – no credit card needed.
 

--- a/contents/blog/best-ai-observability-tools.mdx
+++ b/contents/blog/best-ai-observability-tools.mdx
@@ -63,7 +63,7 @@ PostHog is free to start: 100k AI observability events per month, no credit card
 
 #### Strengths
 
-- Query traces and ship fixes [from Slack](/slack), your editor ([via MCP](/mcp)), [PostHog Code](/code), or [PostHog AI](/ai) in the app.
+- Query traces and ship fixes [from Slack](/slack), your editor ([via MCP](/mcp) or [CLI](/cli)), [PostHog Code](/code), or [PostHog AI](/ai) in the app.
 - Tie a bad generation to the exact session replay, funnel, or experiment it affected.
 - Run SQL directly on your trace data and join it against product, user, and revenue data in the same query.
 - Usage-based pricing with no per-seat fees, so adding teammates doesn't inflate the bill.

--- a/contents/blog/best-growthbook-alternatives.mdx
+++ b/contents/blog/best-growthbook-alternatives.mdx
@@ -744,7 +744,7 @@ PostHog uses usage-based pricing with a [generous free tier](/pricing): 1 millio
 
 Yes. GrowthBook has added AI capabilities including natural language SQL generation, experiment hypothesis checking, experiment summaries, and an MCP server for integration with AI coding tools.
 
-PostHog offers [session replay summaries](/docs/session-replay/session-summaries), an [MCP server](/docs/model-context-protocol) for AI coding tools like Cursor and Claude Code, and [PostHog AI](/ai) for generating insights and querying your data in natural language.
+PostHog offers [session replay summaries](/docs/session-replay/session-summaries), an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for AI coding tools like Cursor and Claude Code, and [PostHog AI](/ai) for generating insights and querying your data in natural language.
 
 </details>
 

--- a/contents/blog/best-logrocket-alternatives.mdx
+++ b/contents/blog/best-logrocket-alternatives.mdx
@@ -55,7 +55,7 @@ PostHog [ships new features constantly](/changelog) and is built to keep up with
 
 - **Error tracking:** Capture exceptions with full stack traces and source maps, linked directly to the session replay of what the user was doing when the error happened.
 
-- **PostHog AI:** Natural language querying and an [MCP server](/docs/mcp) for using PostHog from Claude, Cursor, and other AI coding tools.
+- **PostHog AI:** Natural language querying as well as an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for using PostHog from Claude, Cursor, and other AI coding tools.
 
 ### How does PostHog compare to LogRocket?
 

--- a/contents/blog/best-open-source-business-intelligence-tools.mdx
+++ b/contents/blog/best-open-source-business-intelligence-tools.mdx
@@ -92,7 +92,7 @@ PostHog has the flexibility of a business intelligence tool, while including a f
 
 For example, not only can you analyze [A/B tests from warehouse data](/docs/experiments/data-warehouse) in PostHog, but you can actually set up and run them natively using our experimentation and feature flag products. You don't need to set up four different products, just PostHog.
 
-[PostHog AI](/ai) can also generate and fix SQL queries, answer questions about your data, and more. The [MCP server](/docs/model-context-protocol) enables your [AI agents](/newsletter/building-ai-agents) and tools to directly interact with PostHog's products.
+[PostHog AI](/ai) can also generate and fix SQL queries, answer questions about your data, and more. The [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) enable your [AI agents](/newsletter/building-ai-agents) and tools to directly interact with PostHog's products.
 
 PostHog comes with 1 million events and 1 million rows synced for free every month, and has [transparent and usage-based pricing](/pricing).
 

--- a/contents/blog/best-product-analytics-tools-for-startups.mdx
+++ b/contents/blog/best-product-analytics-tools-for-startups.mdx
@@ -161,7 +161,7 @@ Every product has its own generous free tier, so you pay nothing until you have 
 
 ### Key features
 
-- [AI-powered analytics](/ai) with natural language queries, SQL generation, session replay summaries, and an [MCP server](/docs/model-context-protocol) for AI workflows
+- [AI-powered analytics](/ai) with natural language queries, SQL generation, session replay summaries, an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for AI workflows
 - [Funnels](/docs/product-analytics/funnels), [retention](/docs/product-analytics/retention), [paths](/docs/product-analytics/paths), [cohorts](/docs/data/cohorts), [lifecycle analysis](/docs/product-analytics/lifecycle) – all included in free tier
 - [Session replay](/session-replay) with console logs, network requests, and performance data
 - [Experimentation](/experiments) with statistical significance built on [feature flags](/feature-flags)
@@ -206,7 +206,7 @@ Use the [pricing calculator](/pricing) to estimate costs based on your actual vo
 
 - You just launched your MVP and wants to get analytics up and running quickly
 - You're a technical founder or product engineer who'd rather install one tool than manage five
-- You want [AI-powered analytics](/ai) with natural language queries, and an [MCP server](/docs/model-context-protocol) to integrate your analytics data into your AI workflows
+- You want [AI-powered analytics](/ai) with natural language queries, and an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) to integrate your analytics data into your AI workflows
 - You need EU hosting for privacy and compliance
 - You want to [hit the ground running](/wizard), start free, and only start paying when you have momentum
 
@@ -583,7 +583,7 @@ Some tools give you the full product at low volume. Others gate core features be
 - **Mixpanel** if your team includes non-technical PMs who need a polished, visual query builder
 
 **For engineering-heavy teams**
-- **PostHog** if you want SQL access, an [MCP server](/docs/model-context-protocol), open source, and everything in one data model
+- **PostHog** if you want SQL access, an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli), open source, and everything in one data model
 - **Amplitude** if you need type-safe tracking (Ampli CLI) and governance tooling as your data team grows
 - **Mixpanel** if you have a data warehouse and want strong warehouse connectors with experiments built in
 

--- a/contents/blog/best-split-alternatives.mdx
+++ b/contents/blog/best-split-alternatives.mdx
@@ -46,7 +46,7 @@ This means it's not only an alternative to Split but also tools like [Mixpanel](
 
 - **Error tracking:** Automatically capture exceptions and link them directly to session replays, feature flags, and user profiles for faster debugging.
 
-- **PostHog AI:** PostHog's AI assistant (and MCP) can create and manage feature flags and experiments using natural language – roll out flags, configure targeting rules, audit stale flags, summarize experiment results, and more.
+- **PostHog AI:** PostHog's AI assistant, [MCP](/docs/model-context-protocol), and [CLI](/docs/cli) can create and manage feature flags and experiments using natural language – roll out flags, configure targeting rules, audit stale flags, summarize experiment results, and more.
 
 ### How does PostHog compare to Split?
 

--- a/contents/blog/cheapest-ai-observability-tools.mdx
+++ b/contents/blog/cheapest-ai-observability-tools.mdx
@@ -57,7 +57,7 @@ Since LLM data is stored as [regular events](/docs/data/events), you can connect
 
 PostHog's [AI Evals](/docs/ai-evals/evaluations) score outputs with LLM-as-judge or your own code, and run automatically after a prompt or model change to catch the quality regressions that error rates miss.
 
-And because [PostHog AI](/ai) and the [MCP server](/docs/model-context-protocol) can read your trace data, you can ask questions in plain English such as "what were my most expensive calls yesterday?" directly from your code editor.
+And because [PostHog AI](/ai), the [MCP server](/docs/model-context-protocol), and [CLI](/docs/cli) can read your trace data, you can ask questions in plain English such as "what were my most expensive calls yesterday?" directly from your code editor.
 
 **Free tier:** [PostHog's free plan](/pricing) includes 100K LLM events per month, unlimited seats, and 30 day retention.
 

--- a/contents/blog/ga4-alternatives.mdx
+++ b/contents/blog/ga4-alternatives.mdx
@@ -733,7 +733,7 @@ See our guide to [GDPR-compliant analytics tools](/blog/best-gdpr-compliant-anal
 <details>
 <summary>What's the best GA4 alternative for developers?</summary>
 
-**PostHog** is built for developers – SQL access, MCP server for AI coding tools, open-source codebase, extensively documented APIs, and SDKs for every major platform. **TelemetryDeck** is a good lightweight option for app developers who prioritize privacy.
+**PostHog** is built for developers – SQL access, MCP server and [CLI](/docs/cli) for AI coding tools, open-source codebase, extensively documented APIs, and SDKs for every major platform. **TelemetryDeck** is a good lightweight option for app developers who prioritize privacy.
 
 </details>
 

--- a/contents/blog/posthog-alternatives.mdx
+++ b/contents/blog/posthog-alternatives.mdx
@@ -52,7 +52,7 @@ PostHog is a product development platform that includes:
  
 It's priced per product with a [generous free tier](/pricing) – 90% of companies use PostHog for free!
 
-PostHog is built by engineers, for engineers. Everything is open source, and the [MCP server](/docs/model-context-protocol) means your AI coding assistant can query your product data without leaving your editor.
+PostHog is built by engineers, for engineers. Everything is open source, and the [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) means your AI coding assistant can query your product data without leaving your editor.
  
 </details>
  

--- a/contents/blog/posthog-vs-growthbook.mdx
+++ b/contents/blog/posthog-vs-growthbook.mdx
@@ -41,7 +41,7 @@ Having all these dev tools together enables you to do better analysis of shipped
 
 PostHog is built for high-growth startups. This means it is simple for founders and engineers to implement themselves. 
 
-There are many [SDKs](/docs/libraries), [tutorials](/tutorials), and [docs](/docs) to help you get started quickly with any type of app – plus an [MCP server](/docs/model-context-protocol) for AI coding tools.
+There are many [SDKs](/docs/libraries), [tutorials](/tutorials), and [docs](/docs) to help you get started quickly with any type of app – plus an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for AI coding tools.
 
 As startups scale, PostHog also provides the more advanced tools they need to succeed. These include advanced product analytics, [SQL querying](/docs/product-analytics/sql), [CDPs](/docs/cdp), and [data warehousing](/docs/data-warehouse).
 
@@ -299,7 +299,7 @@ Both PostHog and GrowthBook enable companies to remain secure and compliant with
 ### Recommendations by team type
 
 **For engineering-led product teams**
-- **PostHog** – All-in-one platform with analytics, replay, error tracking, and experiments tightly integrated. No SQL required to set up goals or analyze results. [MCP server](/docs/model-context-protocol) for AI coding tools.
+- **PostHog** – All-in-one platform with analytics, replay, error tracking, and experiments tightly integrated. No SQL required to set up goals or analyze results. [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for AI coding tools.
 
 **For data teams with existing warehouse infrastructure**
 - **GrowthBook** – Warehouse-native architecture queries your existing data directly. Advanced stats engine with Bayesian, Frequentist, CUPED, and post-stratification. 23 SDKs across client, server, mobile, and edge.

--- a/contents/blog/posthog-vs-launchdarkly.mdx
+++ b/contents/blog/posthog-vs-launchdarkly.mdx
@@ -47,7 +47,7 @@ Our [pricing](/pricing) is transparent, too – no opaque add-ons or surprise ex
 
 ### 3. Built for startups and engineers
 
-PostHog is built for high-growth startups. It's simple to implement – we have many [SDKs](/docs/libraries), [tutorials](/tutorials), an [MCP server](/docs/model-context-protocol) for AI workflows, and docs to help you get started quickly with any type of app – and will grow with you as you scale. 
+PostHog is built for high-growth startups. It's simple to implement – we have many [SDKs](/docs/libraries), [tutorials](/tutorials), an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for AI workflows, and docs to help you get started quickly with any type of app – and will grow with you as you scale. 
 
 When you need more – [a CDP](/cdp), [data warehouse](/data-stack), or advanced analytics – you can just turn those features on. LaunchDarkly is built for enterprise teams and DevOps, with a focus on governance, compliance, and integrations that are often gated behind expensive enterprise contracts.
 

--- a/contents/blog/posthog-vs-logrocket.mdx
+++ b/contents/blog/posthog-vs-logrocket.mdx
@@ -33,7 +33,7 @@ Want to know how PostHog and LogRocket compare? If you remember nothing else, re
 
 ### 2. PostHog is for engineers, technical users, _builders_
 
-PostHog is designed from the ground up to meet the needs of developers, and product-focused engineers. Session replay includes advanced tools for debugging errors and performance issues, while feature flags make it easy to test, and roll out, new features at scale. You get [SQL access](/docs/product-analytics/sql), an [MCP server](/docs/model-context-protocol), a fully documented [API](/docs/api), and [SDKs](/docs/libraries) for every major platform.
+PostHog is designed from the ground up to meet the needs of developers, and product-focused engineers. Session replay includes advanced tools for debugging errors and performance issues, while feature flags make it easy to test, and roll out, new features at scale. You get [SQL access](/docs/product-analytics/sql), an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli), a fully documented [API](/docs/api), and [SDKs](/docs/libraries) for every major platform.
 
 ### 3. Transparent pricing, generous free tiers 
 
@@ -248,7 +248,7 @@ Both PostHog and LogRocket are SOC 2 certified and GDPR-ready. PostHog adds HIPA
 ### Recommendations by team type
 
 **For engineering-led product teams**
-- **PostHog** – SQL access, open-source code, an [MCP server](/docs/model-context-protocol) for AI coding tools, feature flags, error tracking, and session replay connected to your full analytics. Everything lives in one platform with a shared data model.
+- **PostHog** – SQL access, open-source code, an [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for AI coding tools, feature flags, error tracking, and session replay connected to your full analytics. Everything lives in one platform with a shared data model.
 
 **For frontend engineers debugging production issues**
 - **LogRocket** – Galileo AI proactive issue surfacing and session replay paired with console logs and network monitoring are purpose-built for front-end debugging workflows. PostHog's replay is strong but doesn't match LogRocket here.

--- a/contents/blog/what-is-ai-observability.mdx
+++ b/contents/blog/what-is-ai-observability.mdx
@@ -170,7 +170,7 @@ The free tier covers 100K LLM events/mo. EU hosting available. SDKs for OpenAI, 
 - [Evals](/docs/ai-evals) with deterministic checks and LLM-as-a-judge
 - [Prompt management](/docs/prompt-management) with versioning and fetch-at-runtime
 - [Prompt experiments](/docs/prompt-management/prompt-experiments) (beta) for A/B testing prompts with built-in cost, latency, and eval pass rate metrics
-- [MCP server](/docs/model-context-protocol) for querying observability data from Claude Code or Cursor
+- [MCP server](/docs/model-context-protocol) and [CLI](/docs/cli) for querying observability data from Claude Code or Cursor
 - Connected to [product analytics](/docs/product-analytics), [session replay](/docs/session-replay), and [error tracking](/docs/error-tracking) so you can debug AI failures with full user context
 
 **Best for:** Teams that want everything in one place. Especially valuable for engineers focused on correlating model behavior with what users actually do and debugging AI features with user context.

--- a/contents/docs/ai-engineering/index.mdx
+++ b/contents/docs/ai-engineering/index.mdx
@@ -28,6 +28,7 @@ Here are the AI products, tools, and resources we offer so far:
 | [PostHog AI](/docs/posthog-ai) | Ask our in-app AI agent anything about your product data and PostHog. PostHog AI can write SQL, create dashboards, find session replays, and more. | 🤖 | <Link to="https://github.com/PostHog/posthog/tree/master/ee/hogai" external>Code</Link> |
 | [AI wizard](/docs/ai-engineering/ai-wizard) | Magically add PostHog to your codebase with a single CLI command using AI. | 🧙 | <Link to="https://github.com/PostHog/wizard" external>Code</Link> |
 | [PostHog MCP](/docs/model-context-protocol) | Enable your AI agents to interact with PostHog – create feature flags, run experiments, and query data using HogQL.  | 🧰 | <Link to="https://github.com/PostHog/posthog/tree/master/services/mcp" external>Code</Link> |
+| [PostHog CLI](/docs/cli) | Use PostHog from your terminal and coding agents – access the MCP tool catalog, query data, and more. | ⌨️ | <Link to="https://github.com/PostHog/posthog/tree/master/cli" external>Code</Link> |
 | [AI Observability](/docs/ai-observability) | Track and analyze the usage of LLMs in your applications, including token usage, latency, and cost. | 📊 | <Link to="https://github.com/PostHog/posthog/tree/master/products/ai_observability" external>Code</Link> |
 | [Markdown and llms.txt](/docs/ai-engineering/markdown-llms-txt) | Feed your AI agents more context. All of our docs pages are available in raw Markdown. | 📚 | <Link to="https://posthog.com/llms.txt" external>Code</Link> |
 

--- a/contents/docs/cli.mdx
+++ b/contents/docs/cli.mdx
@@ -4,21 +4,20 @@ sidebar: Docs
 showTitle: true
 ---
 
+import PlatformInstall, { cliInstallSchema } from "components/PlatformInstall"
+
 The PostHog CLI lets you use PostHog from your terminal, your coding agents, local scripts, and CI/CD pipelines.
 
-- **API**: Use `posthog-cli api` to access PostHog's API and MCP tool catalog from shell-friendly commands
-- **Querying data**: Run SQL queries against data in PostHog
-- **Source maps**: Inject and upload source maps for PostHog error tracking
+- **API**: Use `posthog-cli api` to access PostHog's API and MCP tool catalog from shell-friendly commands, including running SQL queries against your data
+- **Source maps**: [Inject and upload source maps](/docs/cli) for PostHog error tracking
 - **Schema management**: Download and check schema definitions for product analytics workflows
 - **Tasks:** List, create, update, and delete PostHog tasks
 
 ## Installation
 
-Install the PostHog CLI with our wizard by running this command:
+Install the PostHog CLI with our wizard:
 
-```bash
-npx -y @posthog/wizard@latest cli add
-```
+<PlatformInstall schema={cliInstallSchema} />
 
 If you'd rather not use our wizard, you can install the CLI by running:
 
@@ -26,7 +25,7 @@ If you'd rather not use our wizard, you can install the CLI by running:
 npm install -g @posthog/cli@latest
 ```
 
-Note: if you are installing the CLI for use with a coding agent, you should follow our [setup for agents](#setup-for-agents) instructions.
+> **Using Claude Code, Codex, or another coding agent?**: You should follow our [CLI setup for agents](#setup-for-agents) instructions.
 
 ### Authentication
 
@@ -62,6 +61,19 @@ For broad agent workflows, create a [personal API key](https://app.posthog.com/s
 | `posthog-cli exp` | Run experimental commands |
 | `posthog-cli help` | Print CLI help or help for a subcommand |
 
+## Global options
+
+These options apply to any command and go before the subcommand (for example, `posthog-cli --dry-run hermes upload ...`).
+
+| Option | Description |
+| --- | --- |
+| `--host <HOST>` | PostHog host to connect to. Defaults to `https://us.posthog.com`. |
+| `--no-fail` | Disable non-zero exit codes on errors. Use with caution. |
+| `--skip-ssl-verification` | Skip SSL certificate verification when talking to the PostHog API. Use only with self-signed certificates. |
+| `--rate-limit <RATE_LIMIT>` | Set the number of requests per minute for the PostHog API client. Also settable via `POSTHOG_CLIENT_RATE_LIMIT`. |
+| `--dotenv-file <PATH>` | Load PostHog credentials from a dotenv-style file when not present in the process environment. |
+| `--dry-run` | Skip artifact processing and upload (sourcemap, dSYM, hermes, proguard) without contacting PostHog or requiring credentials. Intended for CI gates, not release builds. Also settable via `POSTHOG_CLI_DRY_RUN`. |
+
 ## Using the CLI with a coding agent
 
 PostHog supports both CLI and [MCP](/docs/model-context-protocol) interfaces for agent workflows. You usually only need one, and which one you choose depends on how you want the agent to interact with PostHog.
@@ -80,7 +92,9 @@ MCP is also preferred when you want a native tool-calling experience, you need t
 
 Agents don't automatically know that a CLI tool exists or is available, so we need to tell them. The PostHog wizard installation path inserts agent instructions into the instructions file your agent reads, such as `AGENTS.md` or `CLAUDE.md`.
 
-`npx -y @posthog/wizard@latest cli add`
+```bash
+npx -y @posthog/wizard@latest cli add
+```
 
 If you wish to install the CLI directly, you should add a snippet in your agent's instructions or tell it directly to use the `posthog-cli` for PostHog tasks. You can manually install the snippet with `posthog-cli api agents-md install [--path AGENTS.md]`.
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -65,6 +65,7 @@ There's a lot more – analytics queries, feature flag and experiment management
 
 ## Next steps
 
+- [PostHog CLI](/docs/cli): Use PostHog from your terminal, coding agents, scripts, and CI/CD pipelines
 - [PostHog AI plugin](https://github.com/PostHog/ai-plugin): Install PostHog as a plugin for Claude Code, Codex, Cursor, and Gemini CLI
 - [Lovable integration](/docs/integrations/lovable): Set up PostHog in your Lovable project
 - [Replit integration](/docs/integrations/replit): Set up PostHog with Replit Agent

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -99,7 +99,7 @@ The full [PostHog app](https://app.posthog.com), in your browser. Explore your d
 
 ### <IconMagic className="text-purple w-7 -mt-1 inline-block" /> MCP
 
-Bring PostHog's data and tools into Claude Code, Cursor, and other AI tools, so your own agent works with product context, not only code. See the [MCP docs](/docs/model-context-protocol).
+Bring PostHog's data and tools into Claude Code, Cursor, and other AI tools, so your own agent works with product context, not only code. See the [MCP docs](/docs/model-context-protocol) or [CLI docs](/docs/cli).
 
 </QuestLogItem>
 

--- a/contents/docs/self-driving/web.mdx
+++ b/contents/docs/self-driving/web.mdx
@@ -10,7 +10,7 @@ import { AppsList } from 'components/Docs/AppsList'
 
 [PostHog Web](https://app.posthog.com) is the PostHog you already know, now a surface for self-driving. It's the full product in your browser, and it ties the whole loop together: your data lives here, your tools run here, and the inbox where you review the work agents do lives here too.
 
-It's one of the products you use, alongside [Slack](/docs/slack) and [MCP](/docs/model-context-protocol). Slack is for summoning agents in the flow of your day. The web app is for going deep: exploring your data, reviewing proposed work, and steering what self-driving does.
+It's one of the products you use, alongside [Slack](/docs/slack), [MCP](/docs/model-context-protocol), and [CLI](/docs/cli). Slack is for summoning agents in the flow of your day. The web app is for going deep: exploring your data, reviewing proposed work, and steering what self-driving does.
 
 ## Your inbox
 

--- a/contents/docs/slack/index.mdx
+++ b/contents/docs/slack/index.mdx
@@ -74,7 +74,7 @@ The bot reacts to your `@PostHog` message as it works through your request, so y
 
 ## Link unfurling
 
-When you paste a PostHog insight or dashboard URL in a channel the bot is invited to, Slack shows a rich preview with the title, type, and description. Unfurling respects PostHog access permissions. Only teammates with at least viewer access on the item will see the preview. See [Slack link unfurling](/docs/libraries/slack #link-unfurling) for details.
+When you paste a PostHog insight or dashboard URL in a channel the bot is invited to, Slack shows a rich preview with the title, type, and description. Unfurling respects PostHog access permissions. Only teammates with at least viewer access on the item will see the preview. See [Slack link unfurling](/docs/libraries/slack#link-unfurling) for details.
 
 ## Related
 

--- a/src/components/PlatformInstall/index.tsx
+++ b/src/components/PlatformInstall/index.tsx
@@ -10,6 +10,7 @@ import { CopyableCommand } from './CopyableCommand'
 import { InlineCommand } from './InlineCommand'
 import { buildWizardCommand, buildSchemaCommand } from './buildCommand'
 import {
+    cliInstallSchema,
     mcpInstallSchema,
     wizardInstallSchema,
     type InstallMethod,
@@ -312,5 +313,5 @@ export default function PlatformInstall({
 }
 
 export { CopyableCommand } from './CopyableCommand'
-export { mcpInstallSchema, wizardInstallSchema }
+export { cliInstallSchema, mcpInstallSchema, wizardInstallSchema }
 export type { InstallSchema, Platform, PlatformOption, InstallMethod } from './schema'

--- a/src/components/PlatformInstall/schema.tsx
+++ b/src/components/PlatformInstall/schema.tsx
@@ -493,6 +493,21 @@ export const mcpInstallSchema: InstallSchema = {
     platforms: installPlatforms,
 }
 
+// Display shows a clean command; the copy pins `-y` (auto-confirm) and `@latest` (freshness).
+const { displayCommand: cliWizardCommand, copyCommand: cliWizardCommandCopy } = buildWizardCommand({
+    subcommand: 'cli add',
+})
+
+export const cliInstallSchema: InstallSchema = {
+    title: 'Install the PostHog CLI',
+    defaultCommand: cliWizardCommand,
+    defaultCopyCommand: cliWizardCommandCopy,
+    supports: <>Installs the CLI and adds instructions to your coding agent</>,
+    // No per-client picker: CLI install is the same global binary everywhere. The manual
+    // npm fallback and per-agent setup live in the surrounding docs.
+    platforms: [],
+}
+
 export const wizardInstallSchema: InstallSchema = {
     title: 'Get started',
     titleTooltip: (


### PR DESCRIPTION
## Changes

- Add CLI links in lots of places
- Update CLI doc page
- Use cool wizard component (lets see if this works)

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
