### PR TITLE
Fix Wizard & Docs team name in newsletter

### DIFF
--- a/contents/newsletter/context-engineering.md
+++ b/contents/newsletter/context-engineering.md
@@ -52,7 +52,7 @@ The agent routinely got these details wrong because it was operating in a contex
 
 <Caption>The wizard is <a href="https://github.com/PostHog/wizard">open source</a>. You should steal it!</Caption>
 
-Our Docs team of technical writers became a [Docs & Wizard team](/teams/docs-wizard) of context engineers – same people, different mission. Their job became building a library of context for agents, and a delivery system that made it accessible.
+Our Docs team of technical writers became a [Wizard & Docs team](/teams/wizard-and-docs) of context engineers – same people, different mission. Their job became building a library of context for agents, and a delivery system that made it accessible.
 
 The result was a company-wide context layer that could pull from everything we maintained: docs, source code, SDK references, example apps, anything that could widen the scope of what the agent could handle.
 
@@ -181,7 +181,7 @@ Here's how it changed our onboarding:
 
 Building a context layer is high-leverage for any company shipping agents, but it takes real investment and a shift in how you think about the work.
 
-We created a whole [new team](/teams/docs-wizard) for it. It's a kind of work that didn't exist a year ago, and it's only going to get bigger as more of what companies ship runs on agents.
+We created a whole [new team](/teams/wizard-and-docs) for it. It's a kind of work that didn't exist a year ago, and it's only going to get bigger as more of what companies ship runs on agents.
 
 The job is context.
 


### PR DESCRIPTION
## Changes

Fix a couple of team name links and references in the 24 June context engineering newsletter, re: Posthog/posthog.com#18018

## Checklist

- [✅] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [✅] Words are spelled using American English
- [✅] Use relative URLs for internal links
- [✅] I've checked the pages added or changed in the Vercel preview build 
- [N/A] If I moved a page, I added a redirect in `vercel.json`
