### PR TITLE
Credit rollover: one source of truth + underuse exception

### DIFF
--- a/contents/docs/billing/pre-paid-plans.md
+++ b/contents/docs/billing/pre-paid-plans.md
@@ -19,6 +19,7 @@ With a pre-paid plan you'll:
 * We'll ask you to sign an order form which captures the credit amount, term, discount percentage and payment terms (Net 30 by default). We use PandaDoc for e-signatures here.
 * The order form will also specify that you can buy additional credit at the same discount level in the first 6 months, meaning that you aren't penalised for underestimating your usage across the term.
 * If you don't use all of your credits by the end of the contract term, you can roll over half of your remaining credits to the new contract, provided that you sign a renewal contract of equal or higher spend than the original contract.
+* If a significant part of your unused credits is due to circumstances outside your control (for example a PostHog-side incident or a data issue on our side), talk to your account contact at renewal. We can roll over more than half, up to your full remaining balance, or extend the window to use your existing credits. We decide this case by case based on what happened at the time, so flag it early.
 * You can then subscribe to any of our [pay-as-you-go plans](/pricing) and track your credit usage on the [billing page](https://app.posthog.com/organization/billing)
 * We'll also monitor your usage in the first few months and proactively reach out so that you can take advantage of the pre-agreed discount if it looks like you might go over your credit allocation by the end of the contract term.
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -254,7 +254,11 @@ For any of the above scenarios you should use our [discounting principles](contr
 
 ### When they will end the contract term with credit remaining
 
-We can roll up to half the amount of credit from the original order form to a new contract term, provided that the customer signs a renewal contract of equal or higher annual spend than the original contract.
+If a customer ends a term with unused credits and signs a renewal of equal or higher spend, we roll over part of their _remaining_ (unused) credits into the new term. The [pre-paid plans doc](/docs/billing/pre-paid-plans) is the source of truth for the exact amount and the customer-facing wording, so keep the mechanic there and link to it rather than restating it here (this is where these two pages had drifted).
+
+We scale the rollover to _remaining_ credits rather than the original order form amount. For a customer who underused and renews at equal spend, rolling a share of the original on top of the renewal stacks up more credits than they were ever going to use, which rewards a mis-sized deal with a bigger pile and makes the account harder to expand later. Scaling to what they actually didn't use keeps the balance proportionate.
+
+Where the underuse was outside the customer's control (a PostHog-side incident, a data issue on our side, or a documented disruption on theirs), we can roll over more than the standard amount, up to the full remaining balance, or extend the window to use existing credits. We handle these case by case based on what was logged at the time, so flag it early.
 
 ### When a customer doesn't renew their credit purchase
 When a customer chooses not to renew a prepaid credit contract we automatically remove any remaining credits on the expiry date. Their account will then roll onto our standard monthly plan and they'll be charged for usage. It's the customer's responsibility to stop sending us events or cancel their subscription and downgrade to the free tier if they don't want to keep paying.


### PR DESCRIPTION
## Why

Leo flagged in #sales that the handbook and the pre-paid plans doc describe the credit rollover rule differently:

- Handbook: "roll up to half the amount of credit from **the original order form**"
- Docs: "roll over half of **your remaining credits**"

Half of **remaining** is the intended rule. Original-order-form basis inflates balances for customers who underused and renew at equal spend, rewarding a mis-sized deal with a bigger credit pile and making the account harder to expand later.

## What changed

1. **Docs (`pre-paid-plans.md`) is now the single source of truth** for the customer-facing mechanic. Wording unchanged (already correct), plus a new bullet.
2. **Handbook (`contract-rules.md`)** stops restating the number (that restating is what drifted) and links to the doc instead. Keeps the rationale for why we use remaining credits.
3. **New exception, public on both pages:** where the underuse was outside the customer's control (a PostHog-side incident, a data issue on our side, or a documented disruption on theirs), we can roll over more than the standard amount, up to the full remaining balance, or extend the window to use existing credits. Handled case by case based on what was logged at the time.

The exception answers the structural concern that a strict remaining-basis plus the equal-or-higher renewal floor is a double hit on a customer who underused through no fault of their own (e.g. an incident during ramp), without loosening the default for everyone.

cc @leo