### PR TITLE
Add PostHog Code to self-driving docs products menu

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2209,7 +2209,10 @@ export const docsMenu = {
                     name: 'CLI',
                     url: '/docs/cli',
                 },
-                // TODO: add PostHog Code (Desktop) as a surface here once it's GA.
+                {
+                    name: 'Code',
+                    url: '/code',
+                },
                 {
                     name: 'Concepts',
                 },


### PR DESCRIPTION
## Changes

Adds a **Code** entry to the Products section of the self-driving docs side menu (`/docs/self-driving`), linking to `/code`. This replaces the placeholder TODO that was waiting for this surface to be listed.

## Why

Requested so that PostHog Code shows up alongside Slack, Web app, MCP, and CLI in the self-driving products list.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1783675903279119)*