### PR TITLE
feat(docs): add Hugging Face warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/hugging-face.md
+++ b/contents/docs/cdp/sources/hugging-face.md
@@ -1,0 +1,49 @@
+---
+title: Linking Hugging Face as a source
+sidebar: Docs
+showTitle: true
+availability: { free: full, selfServe: full, enterprise: full }
+sourceId: HuggingFace
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Hugging Face connector syncs the repositories owned by a Hub namespace – models, datasets, and Spaces – into PostHog, so you can analyze your Hub activity alongside your product data.
+
+## Prerequisites
+
+You need a [Hugging Face](https://huggingface.co) account and a User Access Token. A read token is enough for public repositories. To include private repositories, the token needs read access to the namespace's repository contents, plus `read-org` if you are syncing an organization.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+You need two things to connect Hugging Face:
+
+- **Access token** – create one in your [Hugging Face access token settings](https://huggingface.co/settings/tokens). It starts with `hf_`.
+- **Username or organization** – the namespace whose models, datasets, and Spaces you want to sync (for example your username, or an organization you belong to).
+
+## Sync modes
+
+<SyncModes />
+
+The Hugging Face Hub has no server-side timestamp filter on its list endpoints, so every table is synced as a full refresh. Each sync walks the namespace's repositories newest-last and merges them on their repository id.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If the connection fails with an authentication error, confirm the access token is still valid in your Hugging Face settings and that it grants read access to the namespace you entered. Regenerate the token and reconnect if it has been revoked.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## What

Adds the user-facing docs page for the Hugging Face data warehouse source at `contents/docs/cdp/sources/hugging-face.md`, matching the source's `docsUrl` (`https://posthog.com/docs/cdp/sources/hugging-face`).

The Hugging Face source is implemented in the main [posthog/posthog](https://github.com/posthog/posthog) repo (models, datasets, and Spaces streams, full-refresh, tracked HTTP transport) but had no docs page, so its `docsUrl` pointed at a missing file. This fills that gap.

## Notes

- Follows the canonical warehouse-source doc template: intro, Prerequisites, Adding a data source, Sync modes, Configuration, Supported tables, Troubleshooting.
- `<SourceParameters />` and `<SourceTables />` render from the `public_source_configs` API, so connection fields and the table list are not hand-written. The source sets `lists_tables_without_credentials = True`, so the supported-tables section is populated.
- `sourceId: HuggingFace` matches the `ExternalDataSourceType` value.
- Opened as a **draft** because the source is currently shipped with `unreleasedSource=True` (alpha, hidden from the wizard). Ready to mark for review once the source is released to users.

Authored by Claude (Claude Code) following the `documenting-warehouse-sources` skill.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
