### PR TITLE
Make self-driving docs bolder and more actionable

### DIFF
--- a/contents/docs/self-driving/anatomy-of-a-pr.mdx
+++ b/contents/docs/self-driving/anatomy-of-a-pr.mdx
@@ -13,7 +13,7 @@ Self-driving is in open beta. It's improving quickly – expect rough edges, and
 
 </CalloutBox>
 
-The rest of these docs describe the [self-improving loop](/docs/self-driving/self-improving-loop) in the abstract. This page follows one bug all the way through it, from the first signal to the measured fix. The product is a composite example, but every step is exactly what self-driving does.
+The concepts docs describe the [self-improving loop](/docs/self-driving/self-improving-loop) in the abstract. This page follows one bug all the way through it, from the first signal to the measured fix. The product is a composite example, but every step is exactly what self-driving does.
 
 ## 1. The signals arrive
 
@@ -52,7 +52,7 @@ An agent picks up the report and digs into both sides of the story:
 - **Your PostHog data** – when the error started, which release it correlates with, how many users and how much revenue sit behind it.
 - **Your codebase** – it pairs the stack trace with the code and finds the root cause: `applyDiscount()` returns `undefined` for carts using a legacy coupon format, and the confirm step reads `.total` off the result without checking.
 
-The verdict: the problem is real, the fix is concrete, and the report is **actionable**. If it had needed a product decision instead – say, two valid ways to handle legacy coupons – it would surface in your inbox marked **needs input** and wait for you, for free.
+The verdict: the problem is real, the fix is concrete, and the report is marked **actionable**. If it had needed a product decision instead – say, two valid ways to handle legacy coupons – it would surface in your inbox marked **needs input** and wait for you, for free.
 
 ## 4. The pull request
 

--- a/contents/docs/self-driving/anatomy-of-a-pr.mdx
+++ b/contents/docs/self-driving/anatomy-of-a-pr.mdx
@@ -1,0 +1,92 @@
+---
+title: Anatomy of a pull request
+sidebarTitle: Anatomy of a PR
+sidebar: Docs
+showTitle: true
+---
+
+import { CallToAction } from 'components/CallToAction'
+
+<CalloutBox icon="IconFlask" title="Open beta" type="action">
+
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
+
+</CalloutBox>
+
+The rest of these docs describe the [self-improving loop](/docs/self-driving/self-improving-loop) in the abstract. This page follows one bug all the way through it, from the first signal to the measured fix. The product is a composite example, but every step is exactly what self-driving does.
+
+## 1. The signals arrive
+
+Tuesday, 09:14. A deploy goes out. Within minutes, three different sources notice something, independently:
+
+- **[Error tracking](/docs/error-tracking)** catches a new exception: `TypeError: Cannot read properties of undefined (reading 'total')` in `checkout/confirm.ts`, already hit by dozens of users.
+- **[Session replay](/docs/session-replay)** picks up a rage-click cluster: users hammering the **Confirm order** button, then leaving.
+- **Zendesk** files two fresh tickets the next morning, both variations of "I can't complete my order."
+
+Each source turns what it saw into a [signal](/docs/self-driving/signals): not a bare alert, but a structured finding.
+
+```text
+Finding:          New exception in checkout/confirm.ts, first seen 09:14,
+                  affecting users whose cart contains a discounted item.
+Evidence:         Stack trace, 47 affected sessions, error rate by release.
+Suggested action: Investigate the discount path in the confirm step.
+```
+
+No one wrote a ticket. No one was paged. The loop just started.
+
+## 2. The pipeline groups them into a report
+
+One problem rarely shows up as one clean signal, so the pipeline deduplicates the stream and clusters the signals pointing at the same underlying issue into a single [report](/docs/self-driving/reports):
+
+- **Title:** Checkout confirm fails when the cart contains a discounted item
+- **Grouped signals:** the exception, the rage-click cluster, and both support tickets
+- **Priority:** P1 – it's in a hot path (checkout), it's breaking the product for affected users, and the affected users include paying customers
+- **State:** to be determined by investigation
+
+Instead of a dozen alerts across three tools, your [inbox](/docs/self-driving/inbox) gets one framed problem with the evidence attached.
+
+## 3. An agent investigates
+
+An agent picks up the report and digs into both sides of the story:
+
+- **Your PostHog data** – when the error started, which release it correlates with, how many users and how much revenue sit behind it.
+- **Your codebase** – it pairs the stack trace with the code and finds the root cause: `applyDiscount()` returns `undefined` for carts using a legacy coupon format, and the confirm step reads `.total` off the result without checking.
+
+The verdict: the problem is real, the fix is concrete, and the report is **actionable**. If it had needed a product decision instead – say, two valid ways to handle legacy coupons – it would surface in your inbox marked **needs input** and wait for you, for free.
+
+## 4. The pull request
+
+Because the report is actionable, an implementation agent builds the fix in a sandbox:
+
+1. It clones your repo and creates a branch like `ai-fix/checkout-discount-null`.
+2. It writes the change: handle the legacy coupon format and add the missing guard, plus a regression test that reproduces the original failure.
+3. It opens a pull request with a written description of the problem, the root cause, and the reasoning, and links back to the report and its evidence.
+4. It suggests a reviewer from git blame, and babysits CI until the checks are green.
+
+The PR reads like it came from a teammate who did the investigation properly, because that's what happened.
+
+## 5. You review and merge
+
+The PR lands in your inbox ranked with everything else. You review it the way you'd review anyone's code: read the diff, check the test, ask for changes if something's off. The agent responds to review feedback and updates the branch.
+
+Nothing ships without you. This is also the moment you're billed: a flat $15 for the pull request, and [if it wasn't worth paying for, we refund it](/docs/self-driving/pricing#refunds).
+
+## 6. PostHog measures the result
+
+After the fix ships, the loop closes:
+
+- Checkout conversion recovers to its baseline, and the exception stops firing.
+- After a soak window, a validation scout re-checks that the fix actually held, instead of assuming the merge was the end of the story.
+- The outcome feeds back in as new signals, so the next pass works from better data than the last.
+
+## The whole loop, on one bug
+
+From first exception to merged, verified fix: about a day. Along the way, nobody filed a ticket, triaged an alert channel, or reconstructed the bug from a support thread. That's the difference between monitoring, which tells you something broke, and self-driving, which hands you the fix.
+
+## Next step
+
+Get this running on your own product. Setup is one command and takes a few minutes.
+
+<CallToAction type="primary" to="/docs/self-driving/setup">
+  Set up self-driving
+</CallToAction>

--- a/contents/docs/self-driving/anatomy-of-a-pr.mdx
+++ b/contents/docs/self-driving/anatomy-of-a-pr.mdx
@@ -81,7 +81,7 @@ After the fix ships, the loop closes:
 
 ## The whole loop, on one bug
 
-From first exception to merged, verified fix: about a day. Along the way, nobody filed a ticket, triaged an alert channel, or reconstructed the bug from a support thread. That's the difference between monitoring, which tells you something broke, and self-driving, which hands you the fix.
+From first exception to merged, verified fix: about a day. The support tickets still arrived – but they became evidence in a report that was already moving, instead of a queue for someone to triage. Nobody chased an alert channel or reconstructed the bug from a thread. That's the difference between monitoring, which tells you something broke, and self-driving, which hands you the fix.
 
 ## Next step
 

--- a/contents/docs/self-driving/context.mdx
+++ b/contents/docs/self-driving/context.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -19,7 +19,7 @@ Context helps your agents do their best work.
 
 ## What is context?
 
-Context is every piece of knowledge an agent needs to understand your product and act on it. It's more than the data stored in a warehouse, and it comes from two places.
+Context is every piece of knowledge an agent needs to understand your product and act on it. It's more than the data stored in a warehouse, and it comes from three places.
 
 ### Product usage data
 
@@ -40,6 +40,14 @@ Tied together, these give an agent the full picture of your product and business
 Self-driving can't be reproduced by pointing a general-purpose coding agent at your repo. That agent has your code, but not your context. The signals that drive the loop live in your product data, and PostHog is where that data, and the meaning around it, already lives.
 
 The richer your context, the better self-driving performs. Every product you turn on and every source you connect gives your agents more to work with.
+
+Not sure where your gaps are? Paste this into any agent connected to the [PostHog MCP](/docs/model-context-protocol):
+
+```text
+Audit my PostHog instrumentation. What events, signal sources, and warehouse
+tables does my project have, which key flows aren't instrumented, and what
+missing context would most improve agent-written pull requests?
+```
 
 ## Next step
 

--- a/contents/docs/self-driving/context.mdx
+++ b/contents/docs/self-driving/context.mdx
@@ -41,7 +41,7 @@ Self-driving can't be reproduced by pointing a general-purpose coding agent at y
 
 The richer your context, the better self-driving performs. Every product you turn on and every source you connect gives your agents more to work with.
 
-Not sure where your gaps are? Paste this prompt into any agent connected to the [PostHog MCP](/docs/model-context-protocol):
+Not sure where your gaps are? Paste this prompt into [PostHog AI](/docs/posthog-ai) or any agent connected to the [PostHog MCP](/docs/model-context-protocol):
 
 ```text
 Audit my PostHog instrumentation. What events, signal sources, and warehouse

--- a/contents/docs/self-driving/context.mdx
+++ b/contents/docs/self-driving/context.mdx
@@ -41,7 +41,7 @@ Self-driving can't be reproduced by pointing a general-purpose coding agent at y
 
 The richer your context, the better self-driving performs. Every product you turn on and every source you connect gives your agents more to work with.
 
-Not sure where your gaps are? Paste this into any agent connected to the [PostHog MCP](/docs/model-context-protocol):
+Not sure where your gaps are? Paste this prompt into any agent connected to the [PostHog MCP](/docs/model-context-protocol):
 
 ```text
 Audit my PostHog instrumentation. What events, signal sources, and warehouse

--- a/contents/docs/self-driving/faq.mdx
+++ b/contents/docs/self-driving/faq.mdx
@@ -1,0 +1,80 @@
+---
+title: Self-driving FAQ
+sidebarTitle: FAQ
+sidebar: Docs
+showTitle: true
+---
+
+import WizardCommand from 'components/WizardCommand'
+
+<CalloutBox icon="IconFlask" title="Open beta" type="action">
+
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
+
+</CalloutBox>
+
+Skeptical questions, answered straight. If yours isn't here, ask us via [in-app support](https://app.posthog.com/home#supportModal) or the [community](/questions).
+
+## Won't this fill my repo with AI slop?
+
+That's the failure mode, and the whole system is built to avoid it. Three things stand between a signal and your main branch:
+
+1. **Reports are investigated before anything is written.** An agent has to confirm the problem is real in your data and your code before a PR exists at all. Reports that don't clear the bar never become code.
+2. **Every change is a pull request a human reviews.** It arrives with your CI and review rules attached, and nothing merges itself.
+3. **You pay per PR, and [we refund PRs that miss the bar](/docs/self-driving/pricing#refunds).** A business model that charges for slop dies quickly. Ours only works if the PRs are worth merging.
+
+Self-driving also stays in its lane: maintenance, fixes, and optimization. It doesn't attempt speculative rewrites of your architecture.
+
+## Why can't I just point Claude Code or Cursor at my repo?
+
+You can, and you should – they're great at the coding half. But a coding agent starts from a prompt or a ticket and sees only your repo. It can't originate work from "users are rage-clicking the confirm button and revenue dipped," because those signals don't live in your code. They live in your product data, and that's what PostHog has.
+
+That's the honest difference: general-purpose agents are cruise control, keeping you moving in the lane you already picked. Self-driving finds the road. And if you want your own agent to have that context too, connect it via the [PostHog MCP](/docs/model-context-protocol).
+
+## What can the agents actually touch?
+
+Less than a contractor with repo access:
+
+- Work happens in an **isolated sandbox** in the cloud, on a clone of your repo, never on your machines or infrastructure.
+- Agents work on a **branch** and open a pull request. They follow your branch protections, CI, and review rules, and they can't merge.
+- Every action is **logged**. Open the agent log on any report to see exactly which files it read, which queries it ran, and how it reached its conclusion.
+
+Nothing reaches production without a human clicking merge.
+
+## Do you use this on PostHog itself?
+
+Yes, heavily. A troop of 35 scouts watches the PostHog app, and reports about posthog.com become pull requests on [the public repo that builds this site](https://github.com/PostHog/posthog.com/pulls), where you can read them. We're the first customer of every part of the loop, and the first to feel it when something's off.
+
+## What happens when it gets something wrong?
+
+It will sometimes; it's in open beta and we say so on every page. The system is designed so that being wrong is cheap:
+
+- A wrong report costs you nothing. Reports are free, and you can decline or snooze them.
+- A wrong PR costs you a review, and then nothing: [we refund PRs](/docs/self-driving/pricing#refunds) that misdiagnose the problem or don't fix what they claim to.
+- A wrong merged change gets caught by the loop itself. PostHog measures whether the targeted metric actually moved, and a validation scout re-checks fixes after a soak window.
+
+## Is my code or data used to train models?
+
+Your private repos stay private and your data stays in PostHog. We do [train our own models](/blog/training-ai-models), but not on your code. Self-driving relies on AI, so your organization needs [AI data processing turned on](/docs/posthog-ai/allow-access) – the setup wizard checks this for you.
+
+The scouts themselves aren't a black box either: every canonical scout is a readable skill [published in the PostHog repo](https://github.com/PostHog/posthog/tree/master/products/signals/skills).
+
+## How is this different from alerts and monitoring?
+
+Monitoring tells you something broke, then the work begins: triage the alert, reproduce the bug, find the owner, write the fix. Self-driving does that pipeline for you. A signal is investigated, grouped with related evidence, root-caused against your code, and handed to you as a reviewed-and-ready pull request. The [anatomy of a pull request](/docs/self-driving/anatomy-of-a-pr) walks through the difference on a single bug.
+
+## How do I control what it watches, and what it costs?
+
+Everything is a toggle, and every dollar has a ceiling:
+
+- Turn individual [signal sources](/docs/self-driving/inbox/sources) and [scouts](/docs/self-driving/scouts) on or off per project.
+- You pay a flat $15 per pull request. Reports are free, and your first three PRs each month are free.
+- A default $150 billing limit is set for you, and you can lower it. When you hit the limit, PR generation pauses until the next billing period.
+
+See [pricing](/docs/self-driving/pricing) for the full picture.
+
+## Convinced, or at least curious?
+
+Setup is one command, and most teams are done in a few minutes:
+
+<WizardCommand command="self-driving" />

--- a/contents/docs/self-driving/inbox/implementation.mdx
+++ b/contents/docs/self-driving/inbox/implementation.mdx
@@ -34,7 +34,7 @@ The agent pushes the branch to your remote and opens a pull request:
 
 Your job is to review the code the same way you would any other pull request, then click **Merge** when you're happy with it. If something needs tweaking, you can chat with the implementation agent directly and it'll make the changes you ask for.
 
-Nothing ships without you – the agent opens the PR, but merging is always your call.
+Nothing ships without you. The inbox is where you stay in control of what self-driving does.
 
 ## Next step
 

--- a/contents/docs/self-driving/inbox/implementation.mdx
+++ b/contents/docs/self-driving/inbox/implementation.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -34,7 +34,7 @@ The agent pushes the branch to your remote and opens a pull request:
 
 Your job is to review the code the same way you would any other pull request, then click **Merge** when you're happy with it. If something needs tweaking, you can chat with the implementation agent directly and it'll make the changes you ask for.
 
-Nothing ships without you — the agent opens the PR, but merging is always your call.
+Nothing ships without you – the agent opens the PR, but merging is always your call.
 
 ## Next step
 

--- a/contents/docs/self-driving/inbox/index.mdx
+++ b/contents/docs/self-driving/inbox/index.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -36,7 +36,7 @@ Nothing ships without you. The inbox is where you stay in control of what self-d
 
 ## Where to find it
 
-The inbox is available across surfaces — the [web app](/docs/self-driving/web), [PostHog Code](/docs/posthog-code), and Slack — so you can review and act on work wherever you are. It's the same inbox everywhere; only the way you open it changes.
+The inbox is available across surfaces – the [web app](/docs/self-driving/web), [PostHog Code](/docs/posthog-code), and Slack – so you can review and act on work wherever you are. It's the same inbox everywhere; only the way you open it changes.
 
 Self-driving is one shared setup, not a separate one per surface. Your [signal sources](/docs/self-driving/inbox/sources), [scouts](/docs/self-driving/scouts), [reports](/docs/self-driving/reports), and inbox state are the same whether you open PostHog Code or the web app – connect a source or tune a scout in one place and it takes effect everywhere.
 

--- a/contents/docs/self-driving/inbox/research.mdx
+++ b/contents/docs/self-driving/inbox/research.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 

--- a/contents/docs/self-driving/inbox/research.mdx
+++ b/contents/docs/self-driving/inbox/research.mdx
@@ -18,7 +18,7 @@ When a [signal](/docs/self-driving/signals) arrives – an [error tracking](/doc
 The result is a [report](/docs/self-driving/reports) rated on two axes:
 
 - **Actionability** – marked **Actionable** when the problem can be solved with code.
-- **Priority (P0–P4)** – how urgent the work is, so the most important reports rise to the top.
+- **Priority (P0 to P4)** – how urgent the work is, so the most important reports rise to the top.
 
 You can audit the research agent's logs at any point to see exactly how it navigated your repo and reached its conclusions.
 

--- a/contents/docs/self-driving/inbox/sources.mdx
+++ b/contents/docs/self-driving/inbox/sources.mdx
@@ -18,7 +18,7 @@ Signal sources are what fill your inbox. A [signal](/docs/self-driving/signals) 
 
 ## Configure sources
 
-From the inbox, open settings and configure your sources. Toggle the ones you want to enable, then follow the authentication prompts for any external services. The inbox is available across surfaces – the [web app](/docs/self-driving/web), [PostHog Code](/docs/posthog-code), and Slack – and your sources stay the same wherever you open it.
+From the inbox, open **settings** and configure your sources. Toggle the ones you want to enable, then follow the authentication prompts for any external services. The inbox is available across surfaces – the [web app](/docs/self-driving/web), [PostHog Code](/docs/posthog-code), and Slack – and your sources stay the same wherever you open it.
 
 <CalloutBox icon="IconInfo" title="MCP is handled for you" type="fyi">
 

--- a/contents/docs/self-driving/inbox/sources.mdx
+++ b/contents/docs/self-driving/inbox/sources.mdx
@@ -10,7 +10,7 @@ import List from 'components/List'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -18,7 +18,7 @@ Signal sources are what fill your inbox. A [signal](/docs/self-driving/signals) 
 
 ## Configure sources
 
-From the inbox, open settings and configure your sources. Toggle the ones you want to enable, then follow the authentication prompts for any external services. The inbox is available across surfaces — the [web app](/docs/self-driving/web), [PostHog Code](/docs/posthog-code), and Slack — and your sources stay the same wherever you open it.
+From the inbox, open settings and configure your sources. Toggle the ones you want to enable, then follow the authentication prompts for any external services. The inbox is available across surfaces – the [web app](/docs/self-driving/web), [PostHog Code](/docs/posthog-code), and Slack – and your sources stay the same wherever you open it.
 
 <CalloutBox icon="IconInfo" title="MCP is handled for you" type="fyi">
 

--- a/contents/docs/self-driving/inbox/troubleshooting.mdx
+++ b/contents/docs/self-driving/inbox/troubleshooting.mdx
@@ -5,9 +5,11 @@ sidebar: Docs
 showTitle: true
 ---
 
+import { CallToAction } from 'components/CallToAction'
+
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -34,3 +36,11 @@ Every action the agent takes is logged. Open the **Agent log** in the inbox to s
 - How it arrived at the final implementation logic
 
 Use the log to check what the agent saw, which decisions it made, and where to step in if the result looks wrong.
+
+## Next step
+
+Still stuck, or still skeptical? The FAQ answers the hard questions straight.
+
+<CallToAction type="primary" to="/docs/self-driving/faq">
+  Self-driving FAQ
+</CallToAction>

--- a/contents/docs/self-driving/inbox/troubleshooting.mdx
+++ b/contents/docs/self-driving/inbox/troubleshooting.mdx
@@ -39,7 +39,7 @@ Use the log to check what the agent saw, which decisions it made, and where to s
 
 ## Next step
 
-Still stuck, or still skeptical? The FAQ answers the hard questions straight.
+Still stuck, or just skeptical? The FAQ answers the hard questions straight.
 
 <CallToAction type="primary" to="/docs/self-driving/faq">
   Self-driving FAQ

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -10,7 +10,7 @@ contentMaxWidthClass: max-w-5xl
 import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 import OSButton from 'components/OSButton'
 import WizardCommand from 'components/WizardCommand'
-import { IconMessage, IconLaptop, IconMagic } from '@posthog/icons'
+import { IconMessage, IconLaptop, IconMagic, IconCode, IconTerminal } from '@posthog/icons'
 
 PostHog makes your product self-driving. It watches how people actually use your product, finds what's worth fixing, opens a pull request, and measures whether the change worked. You review and merge. Turning it on takes one command:
 
@@ -94,7 +94,7 @@ Put together, that's the self-improving loop: scouts and sources emit signals, s
 
 </QuestLogItem>
 
-<QuestLogItem title="Use PostHog from anywhere" subtitle="Slack, Web, and MCP" icon="IconLaptop">
+<QuestLogItem title="Use PostHog from anywhere" subtitle="Slack, Web, Code, MCP, and CLI" icon="IconLaptop">
 
 Self-driving meets you where you already work. Pick the surface that fits how you want to work.
 
@@ -106,9 +106,17 @@ Mention `@PostHog` in any channel to ask about your data or put an agent to work
 
 The full [PostHog app](https://app.posthog.com), in your browser. Explore your data, watch the signals feeding the loop, and review the work agents propose.
 
+### <IconCode className="text-green w-7 -mt-1 inline-block" /> Code
+
+[PostHog Code](/docs/posthog-code) is a desktop app for driving parallel agents that edit your product. The same inbox, reports, and scouts live there too.
+
 ### <IconMagic className="text-purple w-7 -mt-1 inline-block" /> MCP
 
-Bring PostHog's data and tools into Claude Code, Cursor, and other AI tools, so your own agent works with product context, not only code. See the [MCP docs](/docs/model-context-protocol) or [CLI docs](/docs/cli).
+Bring PostHog's data and tools into Claude Code, Cursor, and other AI tools, so your own agent works with product context, not only code. See the [MCP docs](/docs/model-context-protocol).
+
+### <IconTerminal className="text-orange w-7 -mt-1 inline-block" /> CLI
+
+PostHog from your terminal. See the [CLI docs](/docs/cli) to install it and see what it can do.
 
 </QuestLogItem>
 

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -9,9 +9,14 @@ contentMaxWidthClass: max-w-5xl
 
 import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 import OSButton from 'components/OSButton'
+import WizardCommand from 'components/WizardCommand'
 import { IconMessage, IconLaptop, IconMagic } from '@posthog/icons'
 
-New to PostHog? Let's get you on the fast track to using it well: understand how it works, get set up, and start shipping.
+PostHog makes your product self-driving. It watches how people actually use your product, finds what's worth fixing, opens a pull request, and measures whether the change worked. You review and merge. Turning it on takes one command:
+
+<WizardCommand command="self-driving" />
+
+Here's the big idea, how to get set up, and what to expect once it's running.
 
 <QuestLog firstSpeechBubble="Vroom vroom!" lastSpeechBubble="Happy shipping!">
 
@@ -21,7 +26,7 @@ A self-driving product can prompt itself. PostHog turns your product data into s
 
 Instead of waiting for someone to notice a bug, file a ticket, and assign it, PostHog spots the pattern in your data, drafts a fix, and opens a pull request for you to review.
 
-It runs as a loop. Scouts and signal sources emit signals, signals group into reports, and an agent investigates each report. 
+It runs as a loop. Scouts and signal sources emit signals, signals group into reports, and an agent investigates each report.
 
 When a report is actionable, PostHog opens a pull request for you to review and merge; when it needs your input, it surfaces the report in your inbox instead. PostHog then checks whether the change worked and feeds the result back into the next pass.
 
@@ -49,9 +54,13 @@ flowchart LR
     class G outcome
 ```
 
-Self-driving works because the signals that drive the loop live in your product data, and that's exactly what PostHog has. 
+Self-driving works because the signals that drive the loop live in your product data, and that's exactly what PostHog has.
 
 A general-purpose coding agent has your code, but not your context. PostHog ties everything together into a [context warehouse](/docs/self-driving/context): your product usage data, your data warehouse, and the context your agents need, in one place. That's what helps your agents do their best work.
+
+We don't just sell this loop, we run it. A troop of 35 scouts watches the PostHog app, and reports about posthog.com become pull requests on [the public repo that builds it](https://github.com/PostHog/posthog.com/pulls). If self-driving ever stops being worth it, we'll be the first to know.
+
+To see the loop play out on a single bug, from first signal to measured fix, read the [anatomy of a pull request](/docs/self-driving/anatomy-of-a-pr).
 
 </QuestLogItem>
 
@@ -59,7 +68,7 @@ A general-purpose coding agent has your code, but not your context. PostHog ties
 
 Self-driving is only as good as the data feeding it. Run our self-driving wizard to get set up in one command. It installs PostHog if you haven't already, then turns on your signal sources and sets up your scouts. Add the [Slack app](/docs/slack) to bring your whole team in.
 
-Once data is flowing, PostHog will continuously monitor your product and reports begin landing in your inbox. Most teams are set up in a few minutes.
+Once data is flowing, PostHog continuously monitors your product and reports begin landing in your inbox. Most teams are set up in a few minutes.
 
 <OSButton variant="primary" asLink to="/docs/self-driving/setup">
     Set up self-driving
@@ -105,14 +114,28 @@ Bring PostHog's data and tools into Claude Code, Cursor, and other AI tools, so 
 
 <QuestLogItem title="See it work" subtitle="Your day-to-day" icon="IconFlag">
 
-Once self-driving is running, you don't have to prompt it. Scouts keep watching your product, reports become pull requests, and they land in your [inbox](/docs/self-driving/inbox) ranked by priority. 
+Once self-driving is running, you don't have to prompt it. Scouts keep watching your product, reports become pull requests, and they land in your [inbox](/docs/self-driving/inbox) ranked by priority.
 
-The day-to-day is simple: open your inbox, review what's waiting, and merge the changes you're happy with, the same as any other pull request. 
+The day-to-day is simple: open your inbox, review what's waiting, and merge the changes you're happy with, the same as any other pull request.
 
 PostHog then checks whether each change moved the metric and feeds the result into the next pass.
 
 <OSButton variant="primary" asLink to="/docs/self-driving/inbox">
   Explore your inbox
+</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem title="Know what it's good at (and what it isn't)" subtitle="Honest limits" icon="IconTarget">
+
+Self-driving is at its best in maintenance mode: bug fixes, broken flows, instrumentation gaps, and the steady optimization work that never makes it to the top of a sprint. Robots do the maintenance so humans can do the creative work.
+
+It won't invent your product vision. Deciding what to build next, designing a new feature, or making a judgment call between two valid futures is your job. Reports that need that kind of judgment land in your inbox marked **needs input** instead of becoming a pull request.
+
+We hold it to a simple standard: you pay a flat **$15 per pull request**, your first three each month are free, reports are always free, and [if a PR wasn't worth paying for, we refund it](/docs/self-driving/pricing#refunds). Work priced per outcome has to be worth the outcome.
+
+<OSButton variant="primary" asLink to="/docs/self-driving/pricing">
+  How pricing works
 </OSButton>
 
 </QuestLogItem>

--- a/contents/docs/self-driving/pricing.mdx
+++ b/contents/docs/self-driving/pricing.mdx
@@ -9,7 +9,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta, and pricing is subject to change.
+Self-driving is in open beta and pricing is subject to change. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -75,7 +75,7 @@ When you hit your billing limit, report and PR generation is paused until your u
 
 ## Refunds
 
-Self-driving is currently in open beta, and we don't get it right every time yet.
+Self-driving is in open beta, and we don't get it right every time yet.
 
 You're charged per PR, so a PR should be worth paying for. We hold every PR to two standards:
 

--- a/contents/docs/self-driving/reports.mdx
+++ b/contents/docs/self-driving/reports.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -17,7 +17,7 @@ A report groups related [signals](/docs/self-driving/signals) into one item of w
 
 ## Why reports, not raw signals
 
-A real problem rarely shows up as one clean signal. "Checkout is broken" might surface as a spike in error tracking, a cluster of rage-clicks in session replay, and a handful of support tickets, all at once. A report ties those together so you see one problem instead of a dozen alerts.
+A real problem rarely shows up as one clean signal. "Checkout is broken" might surface as a spike in error tracking, a cluster of rage-clicks in session replay, and a handful of support tickets, all at once. A report ties those together so you see one problem instead of a dozen alerts. ([Anatomy of a pull request](/docs/self-driving/anatomy-of-a-pr) follows exactly this example through the whole loop.)
 
 ## What's in a report
 

--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -70,7 +70,15 @@ The common thread is that a scout isn't limited to product analytics. Any source
 
 ## Make your own
 
-You don't write a scout by hand. In [PostHog Code](/code), open the scouts page and pick the "Make a scout" suggestion: it scans your project and proposes custom scouts grounded in your actual data. You can also ask any agent connected to the PostHog MCP to build one. Once it exists, [run it on demand](/docs/self-driving/scouts#running-a-scout-on-demand) to see what it surfaces before enabling it.
+You don't write a scout by hand. In [PostHog Code](/code), open the scouts page and pick the "Make a scout" suggestion: it scans your project and proposes custom scouts grounded in your actual data. You can also ask any agent connected to the [PostHog MCP](/docs/model-context-protocol) to build one – a prompt like this works:
+
+```text
+Read my PostHog project and propose three custom scouts grounded in my actual
+data. For each one: a name, the slice of data it watches, what "worth my
+attention" means for it, and how often it should run. Then build the one I pick.
+```
+
+Once a scout exists, [run it on demand](/docs/self-driving/scouts#running-a-scout-on-demand) to see what it surfaces before enabling it.
 
 Every idea above is a variation on a small set of reference shapes – anomaly watcher, watchlist, warehouse-backed source, daily digest, and so on. The [scout patterns cookbook](https://github.com/PostHog/posthog/blob/master/products/signals/skills/authoring-scouts/references/scout-patterns.md) catalogs them all, with the discriminator, memory, and gotchas for each – it's what the authoring agent reads, and it's worth a skim if you're deciding what to build.
 

--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -13,7 +13,7 @@ Self-driving is in open beta. It's improving quickly – expect rough edges, and
 
 </CalloutBox>
 
-A [scout](/docs/self-driving/scouts) can watch almost anything you land in PostHog. There are two kinds: the **canonical** scouts PostHog ships with, and **custom** scouts you write for the patterns specific to your product. This page is a catalog of both, to spark ideas for what to point a scout at.
+A [scout](/docs/self-driving/scouts) can watch almost anything you land in PostHog. There are two kinds: the **canonical** scouts PostHog ships with, and **custom** scouts you create for the patterns specific to your product. This page is a catalog of both, to spark ideas for what to point a scout at.
 
 ## Canonical scouts
 
@@ -49,7 +49,7 @@ Most are specialists that watch one surface in depth; the [general](https://gith
 
 ## Ideas for custom scouts
 
-You can write your own scout for anything you care about. The job is the same each time: pick a surface you wish someone was watching, write down what "worth my attention" means for it in plain English, and let the scout hold that bar for you. Some directions to steal:
+You can create your own scout for anything you care about. The job is the same each time: pick a surface you wish someone was watching, write down what "worth my attention" means for it in plain English, and let the scout hold that bar for you. Some directions to steal:
 
 | Use case | What it does |
 |---|---|

--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
@@ -42,6 +42,16 @@ When a scout emits a report, PostHog also captures a `$scout_report_emitted` eve
 
 Because it's a regular event in your stream, everything in PostHog can build on your scouts' output with nothing to wire up: query scout activity with [SQL](/docs/sql), chart it in an insight, set an [alert](/docs/alerts) on it, or point a [destination](/docs/cdp) at it – like forwarding every surfaced report to a [Slack channel](/docs/cdp/destinations/slack), templated from the event's title, summary, and link.
 
+Try it: this query lists your fleet's most recent findings.
+
+```sql
+SELECT properties.skill_name AS scout, properties.title, properties.priority, properties.report_url
+FROM events
+WHERE event = '$scout_report_emitted'
+ORDER BY timestamp DESC
+LIMIT 20
+```
+
 Scout report events are captured against a synthetic per-scout ID with person processing off, so they never create person profiles or mix into your user analytics.
 
 ## Built-in and custom scouts
@@ -56,8 +66,8 @@ The difference is how they look. A signal source watches a single stream in real
 
 ## Next step
 
-Whether a scout files a report directly or lets the pipeline do the grouping, every finding is built on signals. See what's in one.
+Meet the scouts PostHog ships with, and steal ideas for your own.
 
-<CallToAction type="primary" to="/docs/self-driving/signals">
-  Signals
+<CallToAction type="primary" to="/docs/self-driving/scout-examples">
+  Scout examples
 </CallToAction>

--- a/contents/docs/self-driving/self-improving-loop.mdx
+++ b/contents/docs/self-driving/self-improving-loop.mdx
@@ -9,11 +9,11 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 
-The self-improving loop is how PostHog turns product data into shipped changes, then checks whether they worked. The [overview](/docs/self-driving) has the loop at a glance. This page is how it works under the hood, stage by stage.
+The self-improving loop is how PostHog turns product data into shipped changes, then checks whether they worked. The [overview](/docs/self-driving) has the loop at a glance. This page is how it works under the hood, stage by stage. Prefer it concrete? [Anatomy of a pull request](/docs/self-driving/anatomy-of-a-pr) follows one bug through every stage below.
 
 ```mermaid
 %%{init: {'themeVariables': {'fontSize': '18px'}}}%%
@@ -70,8 +70,8 @@ Once a change ships, PostHog checks whether the metric it targeted actually move
 
 ## Next step
 
-Scouts are one of the two ways the loop picks up signals. See how they work.
+The loop is only as sharp as the context it runs on. See what feeds it.
 
-<CallToAction type="primary" to="/docs/self-driving/scouts">
-  Scouts
+<CallToAction type="primary" to="/docs/self-driving/context">
+  Context
 </CallToAction>

--- a/contents/docs/self-driving/setup.mdx
+++ b/contents/docs/self-driving/setup.mdx
@@ -10,7 +10,7 @@ import WizardCommand from 'components/WizardCommand'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 

--- a/contents/docs/self-driving/signals.mdx
+++ b/contents/docs/self-driving/signals.mdx
@@ -9,7 +9,7 @@ import { CallToAction } from 'components/CallToAction'
 
 <CalloutBox icon="IconFlask" title="Open beta" type="action">
 
-Self-driving is currently in open beta.
+Self-driving is in open beta. It's improving quickly – expect rough edges, and expect them to disappear fast.
 
 </CalloutBox>
 

--- a/contents/docs/self-driving/web.mdx
+++ b/contents/docs/self-driving/web.mdx
@@ -20,7 +20,7 @@ See the [inbox docs](/docs/self-driving/inbox) for how it works.
 
 ## Your tools
 
-Every PostHog tool — product analytics, session replay, feature flags, and the rest — is something you use in PostHog Web:
+Every PostHog tool – product analytics, session replay, feature flags, and the rest – is something you use in PostHog Web:
 
 <AppsList className="my-4" />
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2221,6 +2221,10 @@ export const docsMenu = {
                     url: '/docs/self-driving/self-improving-loop',
                 },
                 {
+                    name: 'Anatomy of a pull request',
+                    url: '/docs/self-driving/anatomy-of-a-pr',
+                },
+                {
                     name: 'Context',
                     url: '/docs/self-driving/context',
                 },
@@ -2278,6 +2282,10 @@ export const docsMenu = {
                 {
                     name: 'Pricing',
                     url: '/docs/self-driving/pricing',
+                },
+                {
+                    name: 'FAQ',
+                    url: '/docs/self-driving/faq',
                 },
             ],
         },

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -532,35 +532,6 @@ const humanRoles: { heading: string; copy: string; image: string; alt: string }[
     },
 ]
 
-// The self-driving manifesto – what we believe about where software is going.
-// Keep these aligned with the brand messaging framework in /handbook/brand/foundations.
-const manifesto: { title: string; copy: string }[] = [
-    {
-        title: "Data shouldn't sit in dashboards.",
-        copy: 'A dashboard is a to-do list nobody was assigned. If your product data knows something is broken, something should happen.',
-    },
-    {
-        title: 'A product should prompt itself.',
-        copy: 'The signals were always there – errors, replays, tickets. Waiting for a human to notice them was the bottleneck, not the intelligence.',
-    },
-    {
-        title: 'Robots do maintenance. Humans do creative work.',
-        copy: 'Bots are great at fixing bugs and tuning what exists. People are best at deciding what should exist. Self-driving frees you up for build mode.',
-    },
-    {
-        title: 'Nothing ships without you.',
-        copy: "Self-driving means autonomy from instruction, not from the engineer. Agents don't wait to be told every step – and they never touch the merge button.",
-    },
-    {
-        title: 'Pay for outcomes, not effort.',
-        copy: "No seats, no tokens, no metering anxiety. A flat price per pull request, and a refund if it wasn't worth paying for.",
-    },
-    {
-        title: 'No black boxes.',
-        copy: 'The scouts that watch your product are skills you can read, fork, and rewrite. Trust is easier when you can view source.',
-    },
-]
-
 const faqItems = [
     {
         trigger: 'What is a self-driving product?',
@@ -1000,31 +971,6 @@ export default function SelfDrivingPage(): JSX.Element {
                                             className="w-full !block"
                                             imgClassName="w-full !block"
                                         />
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-
-                        {/* The self-driving manifesto */}
-                        <h3>
-                            The self-driving <Highlight>manifesto</Highlight>
-                        </h3>
-                        <p>
-                            Six things we believe about where software is going. We built PostHog around them, and{' '}
-                            <Link to="/docs/self-driving" state={{ newWindow: true }}>
-                                the docs
-                            </Link>{' '}
-                            hold us to them.
-                        </p>
-                        <div className="not-prose my-6 grid grid-cols-1 gap-3 @md/reader-content:grid-cols-2">
-                            {manifesto.map(({ title, copy }, index) => (
-                                <div key={title} className="flex gap-3 rounded-md border border-primary bg-primary p-4">
-                                    <span className="text-2xl font-bold leading-none text-red dark:text-yellow">
-                                        {String(index + 1).padStart(2, '0')}
-                                    </span>
-                                    <div>
-                                        <p className="m-0 text-base font-bold text-primary">{title}</p>
-                                        <p className="m-0 mt-1 text-sm text-secondary">{copy}</p>
                                     </div>
                                 </div>
                             ))}

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -532,6 +532,35 @@ const humanRoles: { heading: string; copy: string; image: string; alt: string }[
     },
 ]
 
+// The self-driving manifesto – what we believe about where software is going.
+// Keep these aligned with the brand messaging framework in /handbook/brand/foundations.
+const manifesto: { title: string; copy: string }[] = [
+    {
+        title: "Data shouldn't sit in dashboards.",
+        copy: 'A dashboard is a to-do list nobody was assigned. If your product data knows something is broken, something should happen.',
+    },
+    {
+        title: 'A product should prompt itself.',
+        copy: 'The signals were always there – errors, replays, tickets. Waiting for a human to notice them was the bottleneck, not the intelligence.',
+    },
+    {
+        title: 'Robots do maintenance. Humans do creative work.',
+        copy: 'Bots are great at fixing bugs and tuning what exists. People are best at deciding what should exist. Self-driving frees you up for build mode.',
+    },
+    {
+        title: 'Nothing ships without you.',
+        copy: "Self-driving means autonomy from instruction, not from the engineer. Agents don't wait to be told every step – and they never touch the merge button.",
+    },
+    {
+        title: 'Pay for outcomes, not effort.',
+        copy: "No seats, no tokens, no metering anxiety. A flat price per pull request, and a refund if it wasn't worth paying for.",
+    },
+    {
+        title: 'No black boxes.',
+        copy: 'The scouts that watch your product are skills you can read, fork, and rewrite. Trust is easier when you can view source.',
+    },
+]
+
 const faqItems = [
     {
         trigger: 'What is a self-driving product?',
@@ -971,6 +1000,31 @@ export default function SelfDrivingPage(): JSX.Element {
                                             className="w-full !block"
                                             imgClassName="w-full !block"
                                         />
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* The self-driving manifesto */}
+                        <h3>
+                            The self-driving <Highlight>manifesto</Highlight>
+                        </h3>
+                        <p>
+                            Six things we believe about where software is going. We built PostHog around them, and{' '}
+                            <Link to="/docs/self-driving" state={{ newWindow: true }}>
+                                the docs
+                            </Link>{' '}
+                            hold us to them.
+                        </p>
+                        <div className="not-prose my-6 grid grid-cols-1 gap-3 @md/reader-content:grid-cols-2">
+                            {manifesto.map(({ title, copy }, index) => (
+                                <div key={title} className="flex gap-3 rounded-md border border-primary bg-primary p-4">
+                                    <span className="text-2xl font-bold leading-none text-red dark:text-yellow">
+                                        {String(index + 1).padStart(2, '0')}
+                                    </span>
+                                    <div>
+                                        <p className="m-0 text-base font-bold text-primary">{title}</p>
+                                        <p className="m-0 mt-1 text-sm text-secondary">{copy}</p>
                                     </div>
                                 </div>
                             ))}


### PR DESCRIPTION
## Changes

Makes /docs/self-driving bolder, more actionable, and more honest, per the [brand messaging framework](https://posthog.com/handbook/brand/foundations):

- **Voice pass across all 15 pages** – confident open-beta callouts, tightened copy, en-dash and terminology consistency, and a fixed "three places" heading count on the context page.
- **A coherent reading path** – the next-step buttons now follow one spine: loop → context → scouts → examples → signals → reports → inbox → … → FAQ.
- **New page: [Anatomy of a pull request](https://posthog.com/docs/self-driving/anatomy-of-a-pr)** – one bug followed end to end, from first signal to measured fix.
- **New page: [Self-driving FAQ](https://posthog.com/docs/self-driving/faq)** – straight answers to skeptical questions (slop, sandboxing, "why not just Cursor?", model training, refunds).
- **Overview** – wizard command as the hero, a dogfooding proof point, and a new "what it's good at (and what it isn't)" section carrying the outcome-pricing and refund stance.
- **Executable docs** – copy-paste MCP prompts (instrumentation audit, custom scout builder) and a real SQL example for querying scout report events.
- Nav entries for the two new pages in `src/navs/index.js`.

*Vale note: the vale binary isn't available in this environment; group-M prose conventions (spaced en dashes, sentence case, American English) were applied manually.*

## Why

The self-driving docs explained the product well but modestly; the boldest facts (outcome pricing, refunds, dogfooding, the honest limits) were buried or internal-only. This surfaces them and aligns the section with the handbook's positioning and pitch framing.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
