### PR TITLE
Handbook: amortized credit payment no longer offered for new contracts

### DIFF
--- a/contents/handbook/growth/billing/customer-billing-configurations.md
+++ b/contents/handbook/growth/billing/customer-billing-configurations.md
@@ -7,7 +7,7 @@ showTitle: true
 This document outlines all possible billing configurations for customers at PostHog. The goal is to ensure the team is on the same page with the different configurations we support to ensure things move smoothly as we scale. We want to ensure they support the billing repo, dashboard, usage reports, revenue reporting, etc.
 
 
-Below are the main 5 configurations we support right now. Each outlines how the Stripe accounts are setup and billing and how we account for revenue on them. 
+Below are the main configurations. Configurations 1–4 are the ones we support for new customers going forward; configuration 5 (amortized credit payment) is **no longer offered for new contracts** and is retained here for legacy customers only. Each outlines how the Stripe accounts are setup and billing and how we account for revenue on them. 
 
 1. Free plan customers
    - We don't need to worry about these users because they aren't paying anything, even if they have a Stripe account.
@@ -46,8 +46,9 @@ Below are the main 5 configurations we support right now. Each outlines how the 
    - **Details:**
      - mrr comes from the credits payment - yearly upfront payment (we split these)
      - mrr per product comes from the actual usage in that month (minus the credit-discount-percent on the customer)
-5. Enterprise customers (amortized credit payment)
-   - Similar to above, where an enterprise customer is paying for credits. This is the case where they commit but pay monthly.
+5. Enterprise customers (amortized credit payment) — **legacy, not offered for new contracts**
+   - > **We no longer offer this configuration for new contracts.** Per our [contract rules](/handbook/growth/sales/contract-rules#discounts), we require upfront payment for all discounted contracts — quarterly, monthly, or otherwise split payment terms are not available, irrespective of commitment length. If a customer needs payment flexibility, adjust the credit amount and discount to fit their budget while keeping payment upfront. The details below are retained only to document existing legacy customers still on this setup.
+   - Similar to above, where an enterprise customer is paying for credits. This is the case where they commit but pay on a recurring cadence (e.g. monthly) rather than upfront.
    - That means they need two customers in Stripe - one for the credits and one for the usage.
    - Currently, this also means they have two customers in billing. See more below on "unsupported configurations" for how this will change. 
    - The credits are charged on a recurring cadence and tracked as MRR - cadence could be monthly, quarterly, semi-annually, during the fourth phase of the moon on the second sunday of the festival of Saturnalia, etc.

--- a/contents/handbook/growth/billing/customer-billing-configurations.md
+++ b/contents/handbook/growth/billing/customer-billing-configurations.md
@@ -7,7 +7,7 @@ showTitle: true
 This document outlines all possible billing configurations for customers at PostHog. The goal is to ensure the team is on the same page with the different configurations we support to ensure things move smoothly as we scale. We want to ensure they support the billing repo, dashboard, usage reports, revenue reporting, etc.
 
 
-Below are the main configurations. Configurations 1–4 are the ones we support for new customers going forward; configuration 5 (amortized credit payment) is **no longer offered for new contracts** and is retained here for legacy customers only. Each outlines how the Stripe accounts are setup and billing and how we account for revenue on them. 
+Below are the main configurations. Each outlines how the Stripe accounts are setup and billing and how we account for revenue on them. 
 
 1. Free plan customers
    - We don't need to worry about these users because they aren't paying anything, even if they have a Stripe account.
@@ -34,34 +34,15 @@ Below are the main configurations. Configurations 1–4 are the ones we support 
    - **Details**
      - mrr = 0 while on credits
      - mrr per product = 0 while on credits
-4. Enterprise customers (yearly credit purchase)
+4. Enterprise customers
    - Enterprise customers pay an invoice for credits (before the subscription is created).
-   - Once the invoice is paid, the subscription is created by CS.
+   - Once the invoice is paid, the subscription is created by revops.
    - Much of this is done via Zapier. See the [docs](https://posthog.com/handbook/growth/sales/billing) for more info.
-   - Credits apply to their usage (including the Teams package - up to the discretion of the CS team is that's charged for).
+   - Credits apply to their usage.
    - Credits reduce product charges on invoices.
-   - Can be with or without tax.
    - Should be using default products/prices.
-   - Should only have 1 stripe account and 1 subscription.
    - **Details:**
-     - mrr comes from the credits payment - yearly upfront payment (we split these)
-     - mrr per product comes from the actual usage in that month (minus the credit-discount-percent on the customer)
-5. Enterprise customers (amortized credit payment) — **legacy, not offered for new contracts**
-   - > **We no longer offer this configuration for new contracts.** Per our [contract rules](/handbook/growth/sales/contract-rules#discounts), we require upfront payment for all discounted contracts — quarterly, monthly, or otherwise split payment terms are not available, irrespective of commitment length. If a customer needs payment flexibility, adjust the credit amount and discount to fit their budget while keeping payment upfront. The details below are retained only to document existing legacy customers still on this setup.
-   - Similar to above, where an enterprise customer is paying for credits. This is the case where they commit but pay on a recurring cadence (e.g. monthly) rather than upfront.
-   - That means they need two customers in Stripe - one for the credits and one for the usage.
-   - Currently, this also means they have two customers in billing. See more below on "unsupported configurations" for how this will change. 
-   - The credits are charged on a recurring cadence and tracked as MRR - cadence could be monthly, quarterly, semi-annually, during the fourth phase of the moon on the second sunday of the festival of Saturnalia, etc.
-   - The usage is tracked by another stripe customer with its own subscription - where credit is used against invoices.
-   - Can be with or without tax.
-   - **Details:**
-     - the customer will have two Stripe customers, each with a subscriptions
-     - the mrr comes from the credits subscription on one customer
-     - the mrr per product comes from the usage subscription (paid by the credits) on the other customer (minus the credit-discount-percent on the customer)
+     - mrr comes comes from the actual usage in that month (minus the credit-discount-percent on the customer)
 
 #### Legacy configuration
 Note: this above list is focused about the creation of new customers going forward - there are many existing configurations not covered directly in this document.
-
-#### Unsupported configurations
-While we don't currently fully support these, we would like to soon:
-- 2 Stripe Customers, each with 1 Subscription [There is another RFC](https://github.com/PostHog/product-internal/pull/604) outlining the current limitations in the works.

--- a/contents/handbook/growth/billing/customer-billing-configurations.md
+++ b/contents/handbook/growth/billing/customer-billing-configurations.md
@@ -42,7 +42,7 @@ Below are the main configurations. Each outlines how the Stripe accounts are set
    - Credits reduce product charges on invoices.
    - Should be using default products/prices.
    - **Details:**
-     - mrr comes comes from the actual usage in that month (minus the credit-discount-percent on the customer)
+     - mrr comes from the actual usage in that month (minus the credit-discount-percent on the customer)
 
 #### Legacy configuration
-Note: this above list is focused about the creation of new customers going forward - there are many existing configurations not covered directly in this document.
+Note: this above list is focused about the creation of new customers going forward – there are many existing configurations not covered directly in this document.


### PR DESCRIPTION
## Changes

Updates the **Customer billing configurations** handbook page so it no longer presents amortized (recurring-cadence) credit payment as a supported setup for new customers.

Configuration 5 ("Enterprise customers (amortized credit payment)") is now marked **legacy, not offered for new contracts**, with a callout pointing to the [contract rules](https://posthog.com/handbook/growth/sales/contract-rules#discounts). The billing/revenue accounting details are kept in place to document existing legacy customers still on this setup.

**Why:** The billing-configurations page contradicted the sales contract rules, which require upfront payment for all discounted contracts and state that quarterly/monthly split payment terms are not available irrespective of commitment length. This surfaced when a prospect asked to sign an annual commitment but pay monthly — the page read as though we still offer this, but we don't.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07TQR0V16U/p1783662921010299?thread_ts=1783662921.010299&cid=C07TQR0V16U)*
