### PR TITLE
docs: filtering autocaptured screens via before_send (mobile SDKs)

### DIFF
--- a/contents/docs/libraries/_snippets/filter-screen-events-beforesend.mdx
+++ b/contents/docs/libraries/_snippets/filter-screen-events-beforesend.mdx
@@ -1,1 +1,3 @@
 You can stop specific screens from being autocaptured by filtering them in your before-send hook. Return `null` for any `$screen` event whose `$screen_name` matches a screen you don't want to track, and it's dropped before being sent – keeping unwanted screen views out of your event log.
+
+This works as either an **ignorelist** (drop the screens you name) or an **allowlist** (invert the check to capture only the screens you name).

--- a/contents/docs/libraries/_snippets/filter-screen-events-beforesend.mdx
+++ b/contents/docs/libraries/_snippets/filter-screen-events-beforesend.mdx
@@ -1,0 +1,1 @@
+You can stop specific screens from being autocaptured by filtering them in your before-send hook. Return `null` for any `$screen` event whose `$screen_name` matches a screen you don't want to track, and it's dropped before being sent – keeping unwanted screen views out of your event log.

--- a/contents/docs/libraries/_snippets/filter-screen-events-beforesend.mdx
+++ b/contents/docs/libraries/_snippets/filter-screen-events-beforesend.mdx
@@ -1,3 +1,3 @@
 You can stop specific screens from being autocaptured by filtering them in your before-send hook. Return `null` for any `$screen` event whose `$screen_name` matches a screen you don't want to track, and it's dropped before being sent – keeping unwanted screen views out of your event log.
 
-This works as either an **ignorelist** (drop the screens you name) or an **allowlist** (invert the check to capture only the screens you name).
+Because it's just a function, you can filter however you like – an **ignorelist** (drop the screens you name), an **allowlist** (invert the check to capture only the screens you name), or any custom rule such as a name prefix, a regex, or a check against the event's properties.

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -454,8 +454,8 @@ import FilterScreenEvents from '../_snippets/filter-screen-events-beforesend.mdx
 val ignoredScreens = setOf("Splash", "Debug")
 
 config.addBeforeSend { event ->
-    val screenName = event.properties?.get("\$screen_name") as? String
-    if (event.event == "\$screen" && screenName in ignoredScreens) {
+    val screenName = event.properties?.get("$screen_name") as? String
+    if (event.event == "$screen" && screenName in ignoredScreens) {
         null
     } else {
         event

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -444,6 +444,25 @@ config.addBeforeSend { event ->
 }
 ```
 
+#### Filtering autocaptured screens
+
+import FilterScreenEvents from '../_snippets/filter-screen-events-beforesend.mdx'
+
+<FilterScreenEvents />
+
+```kotlin
+val ignoredScreens = setOf("Splash", "Debug")
+
+config.addBeforeSend { event ->
+    val screenName = event.properties?.get("\$screen_name") as? String
+    if (event.event == "\$screen" && screenName in ignoredScreens) {
+        null
+    } else {
+        event
+    }
+}
+```
+
 # FAQ
 
 ## What Android API level is required?

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -270,6 +270,26 @@ config.beforeSend = [
 ];
 ```
 
+### Filtering autocaptured screens
+
+import FilterScreenEvents from '../_snippets/filter-screen-events-beforesend.mdx'
+
+<FilterScreenEvents />
+
+```dart
+const ignoredScreens = {'Splash', 'Debug'};
+
+config.beforeSend = [
+  (event) {
+    final screenName = event.properties?['\$screen_name'];
+    if (event.event == '\$screen' && ignoredScreens.contains(screenName)) {
+      return null;
+    }
+    return event;
+  },
+];
+```
+
 ### Limitations
 
 The `beforeSend` callbacks only apply to events captured via Dart APIs:

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -281,8 +281,8 @@ const ignoredScreens = {'Splash', 'Debug'};
 
 config.beforeSend = [
   (event) {
-    final screenName = event.properties?['\$screen_name'];
-    if (event.event == '\$screen' && ignoredScreens.contains(screenName)) {
+    final screenName = event.properties?['$screen_name'];
+    if (event.event == '$screen' && ignoredScreens.contains(screenName)) {
       return null;
     }
     return event;

--- a/contents/docs/libraries/ios/configuration.mdx
+++ b/contents/docs/libraries/ios/configuration.mdx
@@ -129,6 +129,30 @@ config.setBeforeSend { event in
 
 </details>
 
+import FilterScreenEvents from '../_snippets/filter-screen-events-beforesend.mdx'
+
+<details>
+<summary>Filter autocaptured screen views</summary>
+
+<FilterScreenEvents />
+
+```swift
+let config = PostHogConfig(projectToken: "<ph_project_token>", host: "<ph_api_client_host>")
+
+let ignoredScreens: Set<String> = ["Splash", "Debug"]
+
+config.setBeforeSend { event in
+    if event.event == "$screen",
+       let screenName = event.properties["$screen_name"] as? String,
+       ignoredScreens.contains(screenName) {
+        return nil
+    }
+    return event
+}
+```
+
+</details>
+
 ### Sampling events
 
 Sampling lets you choose to send only a percentage of events to PostHog. It is a good way to control your costs without having to completely turn off features of the SDK.

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -132,6 +132,49 @@ If there are elements you don't want to be captured, you can add the `ph-no-capt
 <View ph-no-capture>Sensitive view here</View>
 ```
 
+### Capturing screen views
+
+With `captureScreens: true` (the default in `PostHogProvider`), PostHog captures a `$screen` event automatically when the user navigates, provided you're using `@react-navigation/native` (v6 or lower) or `react-native-navigation`.
+
+To manually send a screen capture event, use the `screen` method:
+
+```react-native
+posthog.screen('Dashboard', { fromIcon: 'bottom' })
+```
+
+> **React Navigation v7 users:** automatic screen tracking may throw errors if PostHog is initialized outside a screen context. For v7, disable automatic screen capture (`captureScreens: false`) and call `posthog.screen()` manually inside each screen component.
+
+#### Filtering autocaptured screens
+
+import FilterScreenEvents from '../_snippets/filter-screen-events-beforesend.mdx'
+
+<FilterScreenEvents />
+
+`before_send` is a client option, so pass it via the provider's `options` prop (or to `new PostHog(...)` if you create the client yourself):
+
+```react-native
+const IGNORED_SCREENS = new Set(['Splash', 'Debug'])
+
+<PostHogProvider
+    apiKey="<ph_project_token>"
+    autocapture={{ captureScreens: true }}
+    options={{
+        host: '<ph_client_api_host>',
+        before_send: (event) => {
+            if (event?.event === '$screen') {
+                const screenName = event.properties?.['$screen_name']
+                return IGNORED_SCREENS.has(screenName) ? null : event
+            }
+            return event
+        },
+    }}
+>
+    {/* app */}
+</PostHogProvider>
+```
+
+Swap the check for an allowlist (`return TRACKED_SCREENS.has(screenName) ? event : null`) if you'd rather capture only a specific set of screens.
+
 ## Identifying users
 
 > We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -179,13 +179,13 @@ Swap the check for an allowlist (`return TRACKED_SCREENS.has(screenName) ? event
 
 `before_send` accepts a single function or an array of functions that run in order, so you can compose several small hooks. Filtering screens is one use – here are a few others.
 
-**Sample a noisy event.** Send only a percentage of a high-volume event to control costs:
+**Drop a specific event.** Stop an internal or debug event from ever being sent:
 
 ```react-native
 const posthog = new PostHog('<ph_project_token>', {
     before_send: (event) => {
-        if (event?.event === 'high_volume_event' && Math.random() > 0.1) {
-            return null // keep roughly 10%
+        if (event?.event === 'debug_only_event') {
+            return null // never send this event
         }
         return event
     },

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -175,6 +175,49 @@ const IGNORED_SCREENS = new Set(['Splash', 'Debug'])
 
 Swap the check for an allowlist (`return TRACKED_SCREENS.has(screenName) ? event : null`) if you'd rather capture only a specific set of screens.
 
+## Common `before_send` patterns
+
+`before_send` accepts a single function or an array of functions that run in order, so you can compose several small hooks. Filtering screens is one use – here are a few others.
+
+**Sample a noisy event.** Send only a percentage of a high-volume event to control costs:
+
+```react-native
+const posthog = new PostHog('<ph_project_token>', {
+    before_send: (event) => {
+        if (event?.event === 'high_volume_event' && Math.random() > 0.1) {
+            return null // keep roughly 10%
+        }
+        return event
+    },
+})
+```
+
+**Log events instead of sending them.** Handy while debugging what would be captured:
+
+```react-native
+const posthog = new PostHog('<ph_project_token>', {
+    before_send: (event) => {
+        console.log('[PostHog] would send', event?.event, event?.properties)
+        return null // drop everything
+    },
+})
+```
+
+**Redact sensitive properties.** Strip a value before it leaves the device:
+
+```react-native
+const posthog = new PostHog('<ph_project_token>', {
+    before_send: (event) => {
+        if (event?.properties?.email) {
+            event.properties.email = '***'
+        }
+        return event
+    },
+})
+```
+
+For more examples, see the [JavaScript Web SDK docs](/docs/libraries/js/usage#amending-or-sampling-events).
+
 ## Identifying users
 
 > We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.


### PR DESCRIPTION
## Changes

Documents how to filter autocaptured `$screen` events using the before-send hook across the mobile SDKs, so users can keep unwanted screen views (splash screens, debug/tab containers, etc.) out of their event logs without extra SDK config.

- **New shared snippet** `_snippets/filter-screen-events-beforesend.mdx` — the language-agnostic mechanism, imported by each SDK.
- **React Native** — adds a "Capturing screen views" section (manual `posthog.screen()` + `before_send` filtering example). This also **fixes the previously broken `#capturing-screen-views` anchor**, which was linked from two places but had no matching heading.
- **iOS** — adds a "Filter autocaptured screen views" example alongside the existing amend/drop examples.
- **Android** — adds a screen-filter example to the `beforeSend` section.
- **Flutter** — adds a screen-filter example to the drop-events section.

Each page shows the SDK's own before-send API (`before_send` / `setBeforeSend` / `addBeforeSend` / `beforeSend`) returning `null` for `$screen` events whose `$screen_name` matches a screen to skip.
