### PR TITLE
Fix circular source maps link in CLI docs and add repo link

### DIFF
--- a/contents/docs/cli.mdx
+++ b/contents/docs/cli.mdx
@@ -9,9 +9,11 @@ import PlatformInstall, { cliInstallSchema } from "components/PlatformInstall"
 The PostHog CLI lets you use PostHog from your terminal, your coding agents, local scripts, and CI/CD pipelines.
 
 - **API**: Use `posthog-cli api` to access PostHog's API and MCP tool catalog from shell-friendly commands, including running SQL queries against your data
-- **Source maps**: [Inject and upload source maps](/docs/cli) for PostHog error tracking
+- **Source maps**: [Inject and upload source maps](/docs/error-tracking/upload-source-maps/cli) for PostHog error tracking
 - **Schema management**: Download and check schema definitions for product analytics workflows
 - **Tasks:** List, create, update, and delete PostHog tasks
+
+The CLI is open source. You can find the code in the [`cli` directory of the PostHog repo](https://github.com/PostHog/posthog/tree/master/cli).
 
 ## Installation
 


### PR DESCRIPTION
## Changes

- The "Inject and upload source maps" bullet on /docs/cli linked back to `/docs/cli` itself (introduced in #18354). It now points to the CLI-specific source map upload guide at `/docs/error-tracking/upload-source-maps/cli`.
- Adds a link to the CLI source code, which lives in the [`cli` directory of the PostHog monorepo](https://github.com/PostHog/posthog/tree/master/cli).