### PR TITLE
docs: per-screen session replay control for React Native

### DIFF
--- a/contents/docs/session-replay/_snippets/android-manual-replay-control.mdx
+++ b/contents/docs/session-replay/_snippets/android-manual-replay-control.mdx
@@ -11,3 +11,31 @@ You can manually control when to start and stop session recordings using the fol
   - Stops/pauses the current session recording.
 
 > **Note:** Calling these methods will have no effect if session recordings are disabled in your PostHog [Project Settings](https://app.posthog.com/project/settings).
+
+#### Record or ignore specific screens
+
+You can combine these methods with your navigation to record only certain screens, or to pause recording on sensitive ones. For example, registering `ActivityLifecycleCallbacks`, stop recording when a sensitive activity resumes and resume otherwise:
+
+```kotlin
+val ignoredScreens = setOf("PaymentActivity", "SettingsActivity")
+
+application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+    override fun onActivityResumed(activity: Activity) {
+        if (activity::class.simpleName in ignoredScreens) {
+            PostHog.stopSessionReplay()
+        } else {
+            PostHog.startSessionReplay()
+        }
+    }
+
+    // Other lifecycle callbacks can be left empty
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+})
+```
+
+Invert the check (`startSessionReplay` only for screens in an allowlist, `stopSessionReplay` otherwise) if you'd rather record just a specific set of screens.

--- a/contents/docs/session-replay/_snippets/flutter-manual-replay-control.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-manual-replay-control.mdx
@@ -11,3 +11,33 @@ You can manually control when to start and stop session recordings using the fol
   - Stops/pauses the current session recording.
 
 > **Note:** Calling these methods will have no effect if session recordings are disabled in your PostHog [Project Settings](https://app.posthog.com/project/settings). Manual starts still respect project ingestion controls, including sampling and event triggers.
+
+#### Record or ignore specific screens
+
+You can combine these methods with your navigation to record only certain screens, or to pause recording on sensitive ones. For example, using a `NavigatorObserver`, stop recording on a sensitive route and resume otherwise:
+
+```dart
+const ignoredScreens = {'Payment', 'Settings'};
+
+class RecordingByScreenObserver extends NavigatorObserver {
+  void _update(Route<dynamic>? route) {
+    final screenName = route?.settings.name;
+    if (screenName != null && ignoredScreens.contains(screenName)) {
+      Posthog().stopSessionRecording();
+    } else {
+      Posthog().startSessionRecording();
+    }
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) => _update(route);
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) => _update(previousRoute);
+}
+
+// Then register it on your MaterialApp:
+// navigatorObservers: [RecordingByScreenObserver()]
+```
+
+Invert the check (`startSessionRecording` only for screens in an allowlist, `stopSessionRecording` otherwise) if you'd rather record just a specific set of screens.

--- a/contents/docs/session-replay/_snippets/ios-manual-replay-control.mdx
+++ b/contents/docs/session-replay/_snippets/ios-manual-replay-control.mdx
@@ -11,3 +11,26 @@ You can manually control when to start and stop session recordings using the fol
   - Stops/pauses the current session recording.
 
 > **Note:** Calling these methods will have no effect if session recordings are disabled in your PostHog [Project Settings](https://app.posthog.com/project/settings). Manual starts still respect project ingestion controls, including sampling and event triggers.
+
+#### Record or ignore specific screens
+
+You can combine these methods with your navigation to record only certain screens, or to pause recording on sensitive ones. For example, using a `UINavigationControllerDelegate`, stop recording when a sensitive screen appears and resume otherwise:
+
+```swift
+let ignoredScreens: Set<String> = ["PaymentViewController", "SettingsViewController"]
+
+func navigationController(
+    _ navigationController: UINavigationController,
+    didShow viewController: UIViewController,
+    animated: Bool
+) {
+    let screenName = String(describing: type(of: viewController))
+    if ignoredScreens.contains(screenName) {
+        PostHogSDK.shared.stopSessionRecording()
+    } else {
+        PostHogSDK.shared.startSessionRecording()
+    }
+}
+```
+
+Invert the check (`startSessionRecording` only for screens in an allowlist, `stopSessionRecording` otherwise) if you'd rather record just a specific set of screens.

--- a/contents/docs/session-replay/_snippets/react-native-manual-replay-control.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-manual-replay-control.mdx
@@ -22,3 +22,31 @@ await posthog.stopSessionRecording()
 ```
 
 > **Note:** Calling these methods will have no effect if session recordings are disabled in your PostHog [Project Settings](https://app.posthog.com/project/settings).
+
+#### Record or ignore specific screens
+
+You can combine these methods with your navigation to record only certain screens, or to pause recording on sensitive ones. For example, using `@react-navigation/native`, stop recording when a sensitive screen is focused and resume when the user leaves:
+
+```typescript
+import { useNavigationContainerRef } from '@react-navigation/native'
+import { usePostHog } from 'posthog-react-native'
+
+const IGNORED_SCREENS = ['Payment', 'Settings']
+
+function useRecordingByScreen(navigationRef: ReturnType<typeof useNavigationContainerRef>) {
+    const posthog = usePostHog()
+
+    useEffect(() => {
+        return navigationRef.addListener('state', () => {
+            const routeName = navigationRef.getCurrentRoute()?.name
+            if (routeName && IGNORED_SCREENS.includes(routeName)) {
+                void posthog.stopSessionRecording()
+            } else {
+                void posthog.startSessionRecording()
+            }
+        })
+    }, [navigationRef, posthog])
+}
+```
+
+Invert the check (`startSessionRecording` only for screens in an allowlist, `stopSessionRecording` otherwise) if you'd rather record just a specific set of screens.


### PR DESCRIPTION
## Changes

Adds a **"Record or ignore specific screens"** recipe to the manual session replay control docs for **all four mobile SDKs** (React Native, iOS, Android, Flutter).

The manual `startSessionRecording` / `stopSessionRecording` methods (Android: `startSessionReplay` / `stopSessionReplay`) are already documented, but there was no guidance on the common ask: *"only record certain screens"* / *"pause recording on sensitive screens."* Each recipe wires those methods to the SDK's native navigation hook (React Navigation listener, `UINavigationControllerDelegate`, `ActivityLifecycleCallbacks`, `NavigatorObserver`) so recording follows an ignore-list — with a note on inverting it for an allowlist.

Related to the "Screen by screen basis recording" issue set:

- https://github.com/PostHog/posthog-js/issues/3806 (React Native)
- https://github.com/PostHog/posthog-ios/issues/160 (iOS)
- https://github.com/PostHog/posthog-android/issues/558 (Android)
- https://github.com/PostHog/posthog-flutter/issues/415 (Flutter)

This documents the **manual approach that works today**
