### PR TITLE
skill(suggest-links): recommend running with Opus or higher

### DIFF
--- a/.claude/commands/suggest-links.md
+++ b/.claude/commands/suggest-links.md
@@ -4,6 +4,8 @@ description: Suggest internal links for a blog post, newsletter, or other conten
 
 # Suggest Internal Links
 
+> **Model:** Run this with Opus or higher. Matching a candidate sentence's topic to a new post's section (and judging whether an anchor phrase reads naturally) requires more nuanced language understanding than this skill's mechanical steps suggest — weaker models tend to force keyword matches that don't actually fit. If you're on Sonnet or below, tell the user to switch models before running this skill.
+
 Analyze a piece of content and suggest specific internal links based on PostHog's internal linking resource. The user will provide a file path: $ARGUMENTS
 
 ## Core constraint: link existing text only


### PR DESCRIPTION
## Changes

Backlink suggestions from `/suggest-links` need real judgment about whether a candidate sentence's topic genuinely fits a new post's section — not just keyword overlap. On a recent newsletter post, weaker-model runs produced two backlinks that were technically topical but conceptually forced (linking AI observability sentences to a "verify by observation" section that's actually about reviewing agent-written code). Re-running the same skill on Opus caught and fixed this.

- Adds a note at the top of `.claude/commands/suggest-links.md` recommending Opus or higher, with the reasoning spelled out so the model (or a human) understands why.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*