### PR TITLE
Add Social media handbook page, fold LinkedIn beneath it

### DIFF
--- a/contents/handbook/content/social-media.md
+++ b/contents/handbook/content/social-media.md
@@ -6,7 +6,7 @@ showTitle: true
 
 ## Where we post
 
-PostHog has a presence on the following platforms: X, LinkedIn, YouTube, Instagram, Threads, and Bluesky. Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
+PostHog has a presence on the following platforms: [X](https://x.com/posthog), [LinkedIn](https://www.linkedin.com/company/posthog), [YouTube](https://www.youtube.com/@posthog), [Instagram](https://www.instagram.com/teamposthog), [Threads](https://www.threads.com/@teamposthog), and [Bluesky](https://bsky.app/profile/posthog.com). Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
 
 Our 'primary' platforms are X, LinkedIn, and YouTube. These are those which we optimize for. Content is posted on secondary platforms, but it's not worth the resources needed to tailor content for them.
 

--- a/contents/handbook/content/social-media.md
+++ b/contents/handbook/content/social-media.md
@@ -6,13 +6,13 @@ showTitle: true
 
 ## Where we post
 
-PostHog has a presence on the following platforms: X, LinkedIn, YouTube, Instagram, Threads, and BlueSky.
+PostHog has a presence on the following platforms: X, LinkedIn, YouTube, Instagram, Threads, and BlueSky. Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
 
 Our 'primary' platforms are X, LinkedIn, and YouTube. These are those which we optimize for. Content is posted on secondary platforms, but it's not worth the resources needed to tailor content for them.
 
 ## What we post
 
-We post content that shows off our product, provides delight, and informs our audience as outlined [here](/handbook/content).
+We post content that shows off our product, provides delight, and informs our [audience](/handbook/content).
 
 When creating, evaluating, and putting out each post, we have to always ask the question "does this look like something another company would put out?"
 
@@ -66,7 +66,7 @@ The audience which sees our posts on LinkedIn is less interested in technical co
 
 Articles or posts are shared with a 4x5 graphic or photo and with the outbound link included at the foot of each post, only if required. This is an inexact science, as traditional advice is to never include outbound links or to bury it in the comments. However, LinkedIn-native articles have not performed especially well for us, so this is the logical best practice.
 
-For specific LinkedIn posting advice on personal channels, see the [LinkedIn posting page here](/handbook/content/linkedin).
+For specific LinkedIn posting advice on personal channels, see the [LinkedIn posting page](/handbook/content/linkedin).
 
 ### Posting on YouTube
 

--- a/contents/handbook/content/social-media.md
+++ b/contents/handbook/content/social-media.md
@@ -6,7 +6,7 @@ showTitle: true
 
 ## Where we post
 
-PostHog has a presence on the following platforms: X, LinkedIn, YouTube, Instagram, Threads, and BlueSky. Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
+PostHog has a presence on the following platforms: X, LinkedIn, YouTube, Instagram, Threads, and Bluesky. Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
 
 Our 'primary' platforms are X, LinkedIn, and YouTube. These are those which we optimize for. Content is posted on secondary platforms, but it's not worth the resources needed to tailor content for them.
 
@@ -72,7 +72,7 @@ For specific LinkedIn posting advice on personal channels, see the [LinkedIn pos
 
 See the [video](/handbook/marketing/video) page.
 
-### Posting on Threads, BlueSky
+### Posting on Threads & Bluesky
 
 Yeah, we're on 'em.
 
@@ -84,4 +84,4 @@ Because our offering is thinner on these two platforms, we can take more liberti
 
 Instagram's a platform we are actively trying to mature on. Our goal is to set a cadence of posting articles in carousel format, and our [first carousel](https://instagram.com/p/DZ_dGYGgQZK) has already gone out.
 
-Like Threads and BlueSky, we can take more liberties with the mentions and interactions we have, especially if someone tags us in an IG story when they're at a conference or event.
+Like Threads and Bluesky, we can take more liberties with the mentions and interactions we have, especially if someone tags us in an IG story when they're at a conference or event.

--- a/contents/handbook/content/social-media.md
+++ b/contents/handbook/content/social-media.md
@@ -1,0 +1,87 @@
+---
+title: Social media
+sidebar: Handbook
+showTitle: true
+---
+
+## Where we post
+
+PostHog has a presence on the following platforms: X, LinkedIn, YouTube, Instagram, Threads, and BlueSky.
+
+Our 'primary' platforms are X, LinkedIn, and YouTube. These are those which we optimize for. Content is posted on secondary platforms, but it's not worth the resources needed to tailor content for them.
+
+## What we post
+
+We post content that shows off our product, provides delight, and informs our audience as outlined [here](/handbook/content).
+
+When creating, evaluating, and putting out each post, we have to always ask the question "does this look like something another company would put out?"
+
+If the answer is "yes", we have to go back to the drawing board, either in terms of the content itself or the copy that accompanies it.
+
+The order of effectiveness for assets is video > graphics/photos > text only, and we prioritize what's posted accordingly.
+
+Unless otherwise stated, we optimize for a mobile viewing experience, as that's where approximately 80% of our impressions on social media come from. That means photos in 4x5, and video in 9x16.
+
+We are not overly-concerned with everything PostHog-related needing to come from the PostHog brand accounts. On some platforms, LinkedIn especially, this is actually a hindrance: content performs much better and is perceived more earnestly when it comes from an individual.
+
+Posts from the brand account follow our [style guide](/handbook/content/posthog-style-guide), except if it's a reply.
+
+Replies should be done in lowercase. This humanizes the brand slightly as it underscores that a human would have written it, and is in the same style that [James](https://x.com/james406) uses on social media. More details on this can be found on the [voice & tone handbook page](/handbook/brand/tone).
+
+## What metrics we look at
+
+Not a lot. We are of the belief that [all social media metrics are bad](/blog/social-media-metrics-are-all-bad). That's not to mean that they are meaningless or are not worth drawing insights from. However, social media metrics can be very easily misconstrued to draw false conclusions, and often the performance of certain posts is to do with factors beyond the platform that they're on.
+
+Because of this, we take a more holistic view at social media performance: we prioritize creating content our ICP would like, and look at metrics at a high level. Have we seen that a few videos edited a certain way have got way more engagements than normal? That's good insight, and we will use that learning going forward. Have we seen one video perform well in isolation? That's not good insight: we need more information and context before changing anything.
+
+## How to run social media for PostHog
+
+There are two places to check a few times a day for opportunities to interact and repost: one is via each app's notifications. The other is the `#brand-mentions` Slack channel, where Octolens pulls in brand mentions from across several platforms. This channel is especially useful as it picks up mentions where we are not explicitly tagged.
+
+On weekends at 11am PT, `#weekend-brand-mentions` has a summary of the 10 most relevant mentions we've received in the past 24 hours posted by a friendly bot.
+
+To schedule posts in advance where we can, we use [Typefully](https://typefully.com). Ask <TeamMember name="Liam Graham" photo /> for a link to the team account.
+
+### Posting on X
+
+We can think of content we put out on X in two silos: one is articles, and one is everything else.
+
+X articles have performed very well for us on the platform, unlike on LinkedIn, so any time a blog post or newsletter goes out, we are default yes on whether or not we should cross-post it to X. When sharing X articles:
+
+- Use aggressive header styling (the largest subheaders in a blog post should be H1 in X's article composer).
+- Make sure all images are included (ask <TeamMember name="Liam Graham" photo /> for a Claude skill that can do this automatically).
+- Take advantage of the tools X's article composer has, namely the ability to create tables and insert code and quote blocks.
+- For the banner image, create a 2000x800 frame in Figma, and adjust your artwork in it. Include an author icon inside the design.
+- Feel free to re-write headlines and any snippets of an article to be more appealing for the platform.
+
+For "everything else", we follow the guidance above to optimize for mobile. Informative posts with a design or graphic will almost always outperform posts that do not have one. Copy should always be slightly unhinged.
+
+We "like" all posts which are complimentary of PostHog to reinforce that behavior from users. We rarely retweet or quote tweet: only doing so for examples of helpful use cases that users share.
+
+### Posting on LinkedIn
+
+LinkedIn is a platform that rewards individual contributions over amplifying company pages. As a result, we lean heavily on reposting content that employees and users tag us in, as it will achieve more reach.
+
+The audience which sees our posts on LinkedIn is less interested in technical content than X, so what we share reflects that. Insight into the business of PostHog and testimonies of building from PostHog employees are what performs well.
+
+Articles or posts are shared with a 4x5 graphic or photo and with the outbound link included at the foot of each post, only if required. This is an inexact science, as traditional advice is to never include outbound links or to bury it in the comments. However, LinkedIn-native articles have not performed especially well for us, so this is the logical best practice.
+
+For specific LinkedIn posting advice on personal channels, see the [LinkedIn posting page here](/handbook/content/linkedin).
+
+### Posting on YouTube
+
+See the [video](/handbook/marketing/video) page.
+
+### Posting on Threads, BlueSky
+
+Yeah, we're on 'em.
+
+On these Twitter clones, our content consists of X posts, duplicated. In the case of articles, we duplicate our LinkedIn posts (4x5 image, short summary, link at bottom if necessary).
+
+Because our offering is thinner on these two platforms, we can take more liberties with reposting use cases or mentions. Have fun with it.
+
+### Posting on Instagram
+
+Instagram's a platform we are actively trying to mature on. Our goal is to set a cadence of posting articles in carousel format, and our [first carousel](https://instagram.com/p/DZ_dGYGgQZK) has already gone out.
+
+Like Threads and BlueSky, we can take more liberties with the mentions and interactions we have, especially if someone tags us in an IG story when they're at a conference or event.

--- a/contents/handbook/content/social-media.md
+++ b/contents/handbook/content/social-media.md
@@ -6,9 +6,9 @@ showTitle: true
 
 ## Where we post
 
-PostHog has a presence on the following platforms: [X](https://x.com/posthog), [LinkedIn](https://www.linkedin.com/company/posthog), [YouTube](https://www.youtube.com/@posthog), [Instagram](https://www.instagram.com/teamposthog), [Threads](https://www.threads.com/@teamposthog), and [Bluesky](https://bsky.app/profile/posthog.com). Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
+PostHog has a presence on [X](https://x.com/posthog), [LinkedIn](https://www.linkedin.com/company/posthog), [YouTube](https://www.youtube.com/@posthog), [Instagram](https://www.instagram.com/teamposthog), [Threads](https://www.threads.com/@teamposthog), and [Bluesky](https://bsky.app/profile/posthog.com). Day to day, this is managed by <TeamMember name="Liam Graham" photo />.
 
-Our 'primary' platforms are X, LinkedIn, and YouTube. These are those which we optimize for. Content is posted on secondary platforms, but it's not worth the resources needed to tailor content for them.
+Our primary platforms are X, LinkedIn, and YouTube. We optimize for them. Content is posted on secondary platforms, but it's not worth the resources needed to tailor content for them.
 
 ## What we post
 
@@ -30,7 +30,7 @@ Replies should be done in lowercase. This humanizes the brand slightly as it und
 
 ## What metrics we look at
 
-Not a lot. We are of the belief that [all social media metrics are bad](/blog/social-media-metrics-are-all-bad). That's not to mean that they are meaningless or are not worth drawing insights from. However, social media metrics can be very easily misconstrued to draw false conclusions, and often the performance of certain posts is to do with factors beyond the platform that they're on.
+Not a lot. We believe [all social media metrics are bad](/blog/social-media-metrics-are-all-bad). They aren't meaningless or not worth drawing insights from, but can be easily misconstrued to draw false conclusions. The performance of certain posts is to do with factors beyond the platform that they're on.
 
 Because of this, we take a more holistic view at social media performance: we prioritize creating content our ICP would like, and look at metrics at a high level. Have we seen that a few videos edited a certain way have got way more engagements than normal? That's good insight, and we will use that learning going forward. Have we seen one video perform well in isolation? That's not good insight: we need more information and context before changing anything.
 
@@ -48,7 +48,7 @@ We can think of content we put out on X in two silos: one is articles, and one i
 
 X articles have performed very well for us on the platform, unlike on LinkedIn, so any time a blog post or newsletter goes out, we are default yes on whether or not we should cross-post it to X. When sharing X articles:
 
-- Use aggressive header styling (the largest subheaders in a blog post should be H1 in X's article composer).
+- Use aggressive header styling (H2s in blog posts should be "Titles" in X's article composer).
 - Make sure all images are included (ask <TeamMember name="Liam Graham" photo /> for a Claude skill that can do this automatically).
 - Take advantage of the tools X's article composer has, namely the ability to create tables and insert code and quote blocks.
 - For the banner image, create a 2000x800 frame in Figma, and adjust your artwork in it. Include an author icon inside the design.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -626,8 +626,18 @@ export const handbookSidebar = [
                 url: '/handbook/content/metadata',
             },
             {
-                name: 'LinkedIn',
-                url: '/handbook/content/linkedin',
+                name: 'Social media',
+                url: '/handbook/content/social-media',
+                children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/content/social-media',
+                    },
+                    {
+                        name: 'LinkedIn',
+                        url: '/handbook/content/linkedin',
+                    },
+                ],
             },
         ],
     },


### PR DESCRIPTION
## Changes

Adds a new **Social media** handbook page under Content (`/handbook/content/social-media`) covering where we post, what we post, which metrics we look at, and per-platform guidance for X, LinkedIn, YouTube, Threads, BlueSky, and Instagram.

Also nests the existing **LinkedIn** page beneath the new Social media entry in the handbook nav, mirroring how **YouTube** sits under **Video**.

**Why:** Consolidates our social media guidance into a single top-level handbook page, with the existing LinkedIn-specific advice folded underneath it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1783719082664639)*