### PR TITLE
Document posthog-node v5 requirements and the V4 to V5 upgrade

### DIFF
--- a/contents/docs/integrate/_snippets/install-node.mdx
+++ b/contents/docs/integrate/_snippets/install-node.mdx
@@ -4,6 +4,8 @@ import InstallNodePackageManagers from "./install-node-package-managers.mdx"
 
 <InstallNodePackageManagers />
 
+> **Note:** `posthog-node` version 5 and above requires Node 20+, as it uses the runtime's native `fetch`. On older Node versions, either upgrade your runtime or pin the SDK to version 4 (`posthog-node@^4`).
+
 In your app, set your project token **before** making any calls.
 
 ```node

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -511,6 +511,18 @@ You can capture LLM usage and performance data by combining the `posthog-node` a
 
 You can capture errors using the `posthog-node` library. This enables you to see stack traces, source code, and watch associated session recordings to improve your application stability. Learn more in our [error tracking docs](/docs/error-tracking/installation/node).
 
+## Upgrading from V4 to V5
+
+The `capture()` method signature is **unchanged** between V4 and V5. It still takes a single object, `capture({ distinctId, event, properties })`, so you do not need to rewrite your capture calls, and a capture that stops producing events after upgrading is not caused by an API change. If events go missing after moving to V5, check your Node version and your flushing (see [short-lived processes](#short-lived-processes-like-serverless-environments)) before changing any code.
+
+With that said, V5 does include some breaking changes:
+
+1. **Node 20+ is required.** V5 uses the runtime's native `fetch`. On older Node versions, either upgrade your runtime or pin the SDK to V4 (`posthog-node@^4`).
+2. `capture()` and `captureImmediate()` no longer send locally-evaluated feature flags with events by default. Set `sendFeatureFlags` explicitly on the call if you want flag values attached.
+3. Messages are compressed with GZip before being sent when the runtime supports it.
+4. The deprecated `captureMode`, the `is_simple_flag` field, and the deprecated `personProperties` and `groupProperties` options were removed. Use `setPersonPropertiesForFlags` and `setGroupPropertiesForFlags` instead.
+5. For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js/blob/main/packages/node/CHANGELOG.md).
+
 ## Upgrading from V1 to V2
 
 V2.x.x of the Node.js library is completely rewritten in Typescript and is based on a new JS core shared with other JavaScript based libraries with the goal of ensuring new features and fixes reach the different libraries at the same pace.


### PR DESCRIPTION
Adds a Node 20+ install callout and a V4-to-V5 upgrade section that leads with capture() being unchanged so failing events are not misdiagnosed as an API break.