### PR TITLE
docs: route static sites to the JS snippet from the wizard docs

### DIFF
--- a/contents/docs/getting-started/_snippets/wizard.mdx
+++ b/contents/docs/getting-started/_snippets/wizard.mdx
@@ -151,6 +151,9 @@ We've got more on the way.
 
 Check out the wizard's [GitHub repo](https://github.com/PostHog/wizard) for more details.
 
+If your site is plain HTML (a static site, a GitHub Pages portfolio), you don't need the wizard at all: use the [JS snippet](/docs/getting-started/install?tab=snippet) instead. It's a single copy-paste into your <head>.
+
+
 <DetailSetUpReverseProxy />
 
 <DetailGroupProductsInOneProject />


### PR DESCRIPTION

## Changes

I installed PostHog for the first time this week on a static GitHub Pages site. The docs routed me to the wizard, which has no option for plain HTML sites — my correct path was the JS snippet one tab over, but nothing said so, and I only worked it out by digging through the docs afterwards. This adds a short note after the frameworks list so static-site users get pointed at the snippet at the exact moment they've scanned the list and found nothing.

Related feedback filed at PostHog/wizard#869 and PostHog/wizard#870.

## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [X] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [X] If I moved a page, I added a redirect in `vercel.json`
