### PR TITLE
docs(cdp): align Cloudflare API token permissions table with dashboard

### DIFF
--- a/contents/docs/cdp/sources/cloudflare.md
+++ b/contents/docs/cdp/sources/cloudflare.md
@@ -34,9 +34,8 @@ Before linking Cloudflare, create an API token with the required permissions:
    | Zone              | DNS              | Read   |
 
 6. Under **Account Resources**, select the accounts you want to sync.
-7. Under **Zone Resources**, select the zones you want to sync. Choose **All zones** to sync DNS records from every zone.
-8. Click **Continue to summary**, then **Create Token**.
-9. Copy the token – you won't be able to see it again.
+7. Click **Continue to summary**, then **Create Token**.
+8. Copy the token – you won't be able to see it again.
 
 ## Linking Cloudflare
 

--- a/contents/docs/cdp/sources/cloudflare.md
+++ b/contents/docs/cdp/sources/cloudflare.md
@@ -27,11 +27,11 @@ Before linking Cloudflare, create an API token with the required permissions:
 4. Give your token a descriptive name (e.g. "PostHog Data Warehouse").
 5. Under **Permissions**, add the following with **Read** access:
 
-| Permissions Group | Permission       | Access |
-| ----------------- | ---------------- | ------ |
-| Account           | Account Settings | Read   |
-| Zone              | Zone             | Read   |
-| Zone              | DNS              | Read   |
+   | Permissions Group | Permission       | Access |
+   | ----------------- | ---------------- | ------ |
+   | Account           | Account Settings | Read   |
+   | Zone              | Zone             | Read   |
+   | Zone              | DNS              | Read   |
 
 6. Under **Account Resources**, select the accounts you want to sync.
 7. Under **Zone Resources**, select the zones you want to sync. Choose **All zones** to sync DNS records from every zone.

--- a/contents/docs/cdp/sources/cloudflare.md
+++ b/contents/docs/cdp/sources/cloudflare.md
@@ -23,15 +23,15 @@ Before linking Cloudflare, create an API token with the required permissions:
 
 1. Go to the [Cloudflare dashboard API tokens page](https://dash.cloudflare.com/profile/api-tokens).
 2. Click **Create Token**.
-3. Click **Create Custom Token** > **Get started**.
+3. Click **Get started** in the **Custom token** section.
 4. Give your token a descriptive name (e.g. "PostHog Data Warehouse").
 5. Under **Permissions**, add the following with **Read** access:
 
-| Resource         | Permission |
-| ---------------- | ---------- |
-| Account Settings | Read       |
-| Zone             | Read       |
-| DNS              | Read       |
+| Permissions Group | Permission       | Access |
+| ----------------- | ---------------- | ------ |
+| Account           | Account Settings | Read   |
+| Zone              | Zone             | Read   |
+| Zone              | DNS              | Read   |
 
 6. Under **Account Resources**, select the accounts you want to sync.
 7. Under **Zone Resources**, select the zones you want to sync. Choose **All zones** to sync DNS records from every zone.


### PR DESCRIPTION
## Changes

Updates the Cloudflare source setup steps to match Cloudflare's actual **Create Custom Token** dashboard flow.

- Replaced the table headings to match Cloudflare's layout and terminology (verified against [Cloudflare's token creation docs](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/) and their [permissions reference](https://developers.cloudflare.com/fundamentals/api/reference/permissions/#zone-permissions)).
- Updated step 3 to reflect the **Custom token** section
   - <details><summary>screenshot</summary>
      <img width="686" height="428" alt="2026-07-13_00-56-56" src="https://github.com/user-attachments/assets/ef3cac31-d095-4180-8ab3-0cc03b784ecb" />
      </details>
- Fixed the nested table's markdown so that it doesn't break the ordered list

### Screenshot

<img width="1131" height="566" alt="2026-07-13_01-38-07" src="https://github.com/user-attachments/assets/3b0ead70-ff06-41be-ac47-808e8dc2cb10" />*Before | After*

### Why

The permissions table's `Resource | Permission` headings don't match what readers see in Cloudflare's UI:

<img width="795" height="368" alt="2026-07-13_00-48-49" src="https://github.com/user-attachments/assets/f489001c-0b72-48bc-be5a-5ed199d33974" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`