### PR TITLE
Cloud Platform team page: "Q3 goals" heading

### DIFF
--- a/contents/teams/cloud-platform/objectives.mdx
+++ b/contents/teams/cloud-platform/objectives.mdx
@@ -1,3 +1,7 @@
+---
+goalsTitle: Q3 goals
+---
+
 ### 🚀 Deployments – make them a real product – Driver: <TeamMember name="Stephen Schmidt" />
 > Treat Deployments like a real product. Make it easy to deploy apps, know the status of deployments, integrate with agents, and actually make the deployment process a first-class citizen.
 

--- a/src/pages/teams/[slug].tsx
+++ b/src/pages/teams/[slug].tsx
@@ -182,6 +182,9 @@ export default function TeamPage(props: TeamPageProps) {
                     fields {
                         slug
                     }
+                    frontmatter {
+                        goalsTitle
+                    }
                     body
                 }
             }
@@ -268,9 +271,11 @@ export default function TeamPage(props: TeamPageProps) {
     `)
 
     const body = data?.allTeams?.nodes?.find((node: any) => node?.fields?.slug === `/teams/${slug}`)?.body
-    const objectives = data?.allObjectives?.nodes?.find(
+    const objectivesNode = data?.allObjectives?.nodes?.find(
         (node: any) => node?.fields?.slug === `/teams/${slug}/objectives`
-    )?.body
+    )
+    const objectives = objectivesNode?.body
+    const objectivesTitle = objectivesNode?.frontmatter?.goalsTitle || 'Goals'
     const teamData = data?.allSqueakTeam?.nodes?.find((node: any) => node?.slug === slug)
     const { totalCount: totalSlackEmojis } = data?.allSlackEmoji || {}
     const allTeams = data?.allTeamsData || { nodes: [] }
@@ -875,7 +880,7 @@ export default function TeamPage(props: TeamPageProps) {
 
                 {objectives && (
                     <>
-                        <h2>Goals</h2>
+                        <h2>{objectivesTitle}</h2>
                         <MDXProvider components={{ TeamMember: TeamMemberComponent, FutureTeamMember, SmallTeam }}>
                             <MDXRenderer>{objectives}</MDXRenderer>
                         </MDXProvider>


### PR DESCRIPTION
## Changes

The team page goals heading was hardcoded to "Goals" for every team. This adds an optional `goalsTitle` frontmatter field on a team's `objectives.mdx` that overrides the heading (defaulting to "Goals" when unset), and sets it to "Q3 goals" for the Cloud Platform team only.

**Why:** The Cloud Platform team wants their goals section labelled with the quarter rather than a generic "Goals".

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B0XG26C2G/p1783934855187009)*