### PR TITLE
Add "Q3 2026 Goals" header to Cloud Foundations team page

### DIFF
--- a/contents/teams/cloud-foundations/objectives.mdx
+++ b/contents/teams/cloud-foundations/objectives.mdx
@@ -1,3 +1,5 @@
+## Q3 2026 Goals
+
 ### 🧱 Nail baseline infra creation - Driver: <TeamMember name="Michael Kutsch" />
 > Terraform is our foundation but keeps growing without standards. Opinionated, versioned modules that can't go wrong, with our standards built in and integrated with the golden chart and The Application™. We will also evaluate if there are any other tools that can help us here.
 

--- a/contents/teams/cloud-platform/objectives.mdx
+++ b/contents/teams/cloud-platform/objectives.mdx
@@ -1,3 +1,5 @@
+## Q3 2026 Goals
+
 ### 🚀 Deployments – make them a real product – Driver: <TeamMember name="Stephen Schmidt" />
 > Treat Deployments like a real product. Make it easy to deploy apps, know the status of deployments, integrate with agents, and actually make the deployment process a first-class citizen.
 


### PR DESCRIPTION
## Changes

Added a `## Q3 2026 Goals` header to the top of the Cloud Foundations team's objectives so the goals section is clearly labeled, matching the convention already used by other team pages (customer-success, blitzscale, etc.). Previously the page jumped straight into individual goals without a "Q3 goals" heading.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01MM7VT7MG/p1783933072813529?thread_ts=1783933072.813529&cid=C01MM7VT7MG)*
