### PR TITLE
docs(surveys): clarify surveys can be implemented headlessly

### DIFF
--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -8,7 +8,7 @@ availability:
     enterprise: full
 ---
 
-> Custom surveys is currently supported only with the [JavaScript Web SDK](/docs/libraries/js).
+> The `displaySurvey`, `renderSurvey`, `getSurveys`, and `getActiveMatchingSurveys` helper methods on this page are currently only available in the [JavaScript Web SDK](/docs/libraries/js). You don't need them to implement a custom survey, though. Because a survey is just a definition you fetch and a set of events you capture, you can run surveys **headlessly** on any platform (including a backend or other non-JavaScript environment) by [fetching the survey definition from the API](#fetching-surveys-headlessly) and [capturing responses](#capture-survey-responses) yourself.
 
 At its most basic level, a survey is a collection of response events. If you wanted to, you could capture events from anywhere, like in this example of a hardcoded Next.js feedback survey:
 
@@ -278,7 +278,7 @@ You can then style the survey by targeting the classes like `survey-box`, `surve
 
 ## Fetching surveys manually
 
-For more control over your surveys, you can use API surveys. When implementing an API survey, there are two options for fetching surveys from PostHog:
+For more control over your surveys, you can use API surveys. When implementing an API survey, the [JavaScript Web SDK](/docs/libraries/js) gives you two options for fetching surveys from PostHog:
 
 1. To get all surveys, call `getSurveys(callback, forceReload)`. This means you still need to handle display conditions yourself.
 
@@ -375,6 +375,40 @@ export default function Feedback() {
 > })
 > localStorage.setItem(`hasInteractedWithSurvey_${survey.id}`, 'true');
 > ```
+
+### Fetching surveys headlessly
+
+The methods above are convenience wrappers around PostHog's public surveys endpoint. Because fetching a survey is just an HTTP request, you don't need the JavaScript Web SDK (or even a browser) to do it. This is what lets you implement surveys **headlessly** from a backend, a mobile app, or any environment that can make HTTP requests and capture events.
+
+To fetch your survey definitions directly, make a `GET` request to the `/api/surveys` endpoint with your [project token](https://app.posthog.com/project/settings):
+
+```bash
+curl "<ph_client_api_host>/api/surveys/?token=<ph_project_token>"
+```
+
+The response contains the same survey objects shown above, nested under a `surveys` key:
+
+```json
+{
+  "surveys": [
+    {
+      "id": "your_survey_id",
+      "name": "Your survey name",
+      "type": "api",
+      // ...plus the other survey fields shown above
+      "questions": [
+        {
+          "type": "open_text",
+          "question": "What can we do to improve our product?",
+          "id": "cbeee176-54e0-4757-befd-f4e8fb33b9a9"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Because nothing is rendered for you in a headless setup, display conditions and targeting aren't evaluated automatically. You decide which survey to show and when, then [capture the `survey shown`, `survey sent`, and `survey dismissed` events](#capture-survey-lifecycle-events) using whichever [PostHog SDK](/docs/libraries) or the [capture API](/docs/api/capture) fits your platform.
 
 ## Capture survey responses
 

--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -8,7 +8,7 @@ availability:
     enterprise: full
 ---
 
-> Custom surveys are currently supported only with the [JavaScript Web SDK](/docs/libraries/js). You're not limited to PostHog's rendered surveys, though: because a survey is just a definition you fetch and a set of events you capture, you can [fetch surveys](#fetching-surveys-manually) and [capture responses](#capture-survey-responses) yourself to run one **headlessly** with your own UI.
+> Custom surveys are currently supported only with the [JavaScript Web SDK](/docs/libraries/js). You aren't limited to the surveys PostHog renders for you, though. Because a survey is just a set of questions you fetch and responses you capture, you can [fetch your surveys](#fetching-surveys-manually) and [capture responses](#capture-survey-responses) yourself and show them with your own UI.
 
 At its most basic level, a survey is a collection of response events. If you wanted to, you could capture events from anywhere, like in this example of a hardcoded Next.js feedback survey:
 
@@ -278,7 +278,7 @@ You can then style the survey by targeting the classes like `survey-box`, `surve
 
 ## Fetching surveys manually
 
-For more control over your surveys, you can use API surveys. Fetching the survey definition and [capturing its responses](#capture-survey-responses) yourself is all it takes to render a survey with your own UI, with no PostHog-rendered popover. There are two options for fetching surveys from PostHog:
+For more control over your surveys, you can use API surveys. Fetching a survey and capturing its responses yourself is all you need to show it with your own UI, without PostHog's built-in popover. This approach is sometimes called a headless survey. There are two options for fetching surveys from PostHog:
 
 1. To get all surveys, call `getSurveys(callback, forceReload)`. This means you still need to handle display conditions yourself.
 

--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -8,7 +8,7 @@ availability:
     enterprise: full
 ---
 
-> The `displaySurvey`, `renderSurvey`, `getSurveys`, and `getActiveMatchingSurveys` helper methods on this page are currently only available in the [JavaScript Web SDK](/docs/libraries/js). You don't need them to implement a custom survey, though. Because a survey is just a definition you fetch and a set of events you capture, you can run surveys **headlessly** on any platform (including a backend or other non-JavaScript environment) by [fetching the survey definition from the API](#fetching-surveys-headlessly) and [capturing responses](#capture-survey-responses) yourself.
+> Custom surveys are currently supported only with the [JavaScript Web SDK](/docs/libraries/js). You're not limited to PostHog's rendered surveys, though: because a survey is just a definition you fetch and a set of events you capture, you can [fetch surveys](#fetching-surveys-manually) and [capture responses](#capture-survey-responses) yourself to run one **headlessly** with your own UI.
 
 At its most basic level, a survey is a collection of response events. If you wanted to, you could capture events from anywhere, like in this example of a hardcoded Next.js feedback survey:
 
@@ -278,7 +278,7 @@ You can then style the survey by targeting the classes like `survey-box`, `surve
 
 ## Fetching surveys manually
 
-For more control over your surveys, you can use API surveys. When implementing an API survey, the [JavaScript Web SDK](/docs/libraries/js) gives you two options for fetching surveys from PostHog:
+For more control over your surveys, you can use API surveys. Fetching the survey definition and [capturing its responses](#capture-survey-responses) yourself is all it takes to render a survey with your own UI, with no PostHog-rendered popover. There are two options for fetching surveys from PostHog:
 
 1. To get all surveys, call `getSurveys(callback, forceReload)`. This means you still need to handle display conditions yourself.
 
@@ -375,40 +375,6 @@ export default function Feedback() {
 > })
 > localStorage.setItem(`hasInteractedWithSurvey_${survey.id}`, 'true');
 > ```
-
-### Fetching surveys headlessly
-
-The methods above are convenience wrappers around PostHog's public surveys endpoint. Because fetching a survey is just an HTTP request, you don't need the JavaScript Web SDK (or even a browser) to do it. This is what lets you implement surveys **headlessly** from a backend, a mobile app, or any environment that can make HTTP requests and capture events.
-
-To fetch your survey definitions directly, make a `GET` request to the `/api/surveys` endpoint with your [project token](https://app.posthog.com/project/settings):
-
-```bash
-curl "<ph_client_api_host>/api/surveys/?token=<ph_project_token>"
-```
-
-The response contains the same survey objects shown above, nested under a `surveys` key:
-
-```json
-{
-  "surveys": [
-    {
-      "id": "your_survey_id",
-      "name": "Your survey name",
-      "type": "api",
-      // ...plus the other survey fields shown above
-      "questions": [
-        {
-          "type": "open_text",
-          "question": "What can we do to improve our product?",
-          "id": "cbeee176-54e0-4757-befd-f4e8fb33b9a9"
-        }
-      ]
-    }
-  ]
-}
-```
-
-Because nothing is rendered for you in a headless setup, display conditions and targeting aren't evaluated automatically. You decide which survey to show and when, then [capture the `survey shown`, `survey sent`, and `survey dismissed` events](#capture-survey-lifecycle-events) using whichever [PostHog SDK](/docs/libraries) or the [capture API](/docs/api/capture) fits your platform.
 
 ## Capture survey responses
 


### PR DESCRIPTION
## Changes

The [custom surveys doc](https://posthog.com/docs/surveys/implementing-custom-surveys) opened by saying custom surveys are "supported only with the JavaScript Web SDK," which read as though you were stuck with PostHog's rendered surveys. In reality, the SDK's fetch-and-capture flow already lets you build a fully custom survey with your own UI. This just makes that headless path explicit.

- Clarified that you're not limited to PostHog's rendered surveys: you can fetch surveys and capture responses yourself to run one **headlessly** with your own UI.
- Framed the "Fetching surveys manually" section as that headless path, using the existing `getSurveys` / `getActiveMatchingSurveys` SDK methods. No new API surface is introduced.

**Why:** Raised in [this Slack thread](https://posthog.slack.com/archives/C093VB2F9U5/p1783608783573229) — the docs didn't reflect that surveys can be implemented headlessly, only the SDK-rendered path.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
