### PR TITLE
Fixed typos in developing-the-website.md

### DIFF
--- a/contents/handbook/engineering/posthog-com/developing-the-website.md
+++ b/contents/handbook/engineering/posthog-com/developing-the-website.md
@@ -68,14 +68,14 @@ Use the built-in Git tab in VS Code to commit and push your changes.
 
     ![Publish changes](https://res.cloudinary.com/dmukukwp6/image/upload/codespaces_publish_81f21426e4.png)
 
-> **Note:** After finish changes on your branch, be sure to switch back to `master` so you don't inadvertently make future changes to your current branch.
+> **Note:** After finishing changes on your branch, be sure to switch back to `master` so you don't inadvertently make future changes to your current branch.
 >
 > ![Checkout to master](https://res.cloudinary.com/dmukukwp6/image/upload/codespaces_checkout_master_4821478b5e.png) > ![Switch to master](https://res.cloudinary.com/dmukukwp6/image/upload/codespaces_select_branch_58c9512cee.png)
 
 ### Stopping the server
 
 1. Place your cursor into Terminal and type `Cmd+C` to stop the server.
-1. In the bottom left corner of the window, click **Codspaces: [your codespace name]**, then **Stop current codespace.**
+1. In the bottom left corner of the window, click **Codespaces: [your codespace name]**, then **Stop current codespace.**
 
 ### Notes
 
@@ -331,7 +331,7 @@ tags: ['filters', 'settings']
 
 -   `date`: the date the tutorial was posted
 -   `title`: the title that appears at the top of the tutorial and on the tutorial listing page
--   `author`: the author(s) of the tutorial. Ccrrelates to your handle located in /src/data/authors.json
+-   `author`: the author(s) of the tutorial. Correlates to your handle located in /src/data/authors.json
 -   `featuredTutorial`: determines if tutorial should be featured on the homepage
 -   `featuredVideo`: the iframe src of the video that appears at the top of the tutorial
 -   `featuredImage`: the Cloudinary URL of the image that appears at the top of the tutorial and on the tutorial listing page
@@ -576,7 +576,7 @@ If you are pushing to an existing branch, navigate to the [posthog.com repo](htt
 
 Then, open the **Contribute** dropdown and click the **Open pull request** button.
 
-Make the pull request title descriptive name and complete the detail requested in the body.
+Make the pull request title a descriptive name and complete the detail requested in the body.
 
 If you know who you would like to review the pull request, select them in the **Reviewers** dropdown.
 


### PR DESCRIPTION
## Changes

* Fixed four typos and grammatical errors in `developing-the-website.md`:

  * Changed “After finish changes” to “After finishing changes.”
  * Corrected “Codspaces” to “Codespaces.”
  * Corrected “Ccrrelates” to “Correlates.”
  * Added the missing article in “Make the pull request title a descriptive name.”
* No visual or UI changes.

## Checklist

* [x] I've read the [[docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide)](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [[content](https://posthog.com/handbook/content/posthog-style-guide)](https://posthog.com/handbook/content/posthog-style-guide) style guides.
* [x] Words are spelled using American English
* [x] Use relative URLs for internal links
* [ ] I've checked the pages added or changed in the Vercel preview build
* [ ] If I moved a page, I added a redirect in `vercel.json` — Not applicable; no pages were moved.