### PR TITLE
docs(consent): Add guidance on using PostHog with a CMP

### DIFF
--- a/contents/docs/privacy/data-collection.mdx
+++ b/contents/docs/privacy/data-collection.mdx
@@ -12,6 +12,7 @@ You should consider the following tools to help you manage data collection:
 | Feature | Description |
 |---------|-------------|
 | [Asking for opt out](#asking-for-opt-out) | A top-level opt out of all data collection |
+| [Using a consent management platform](#using-posthog-with-a-consent-management-platform-cmp) | Integrate PostHog with a CMP like OneTrust or Cookiebot |
 | [IP data capture](#ip-data-capture) | Control whether client IP addresses are captured or discarded |
 | [Autocapture behavior](#autocapture) | Configure what elements and interactions are automatically captured |
 | [Masking sensitive information](#masking-sensitive-information) | Prevent specific sensitive data from being collected |
@@ -73,6 +74,47 @@ To opt users out by default, set `opt_out_capturing_by_default` to `true` in the
 import OptOutDefault from '../product-analytics/_snippets/multilanguage/opt-out-default.mdx'
 
 <OptOutDefault />
+
+### Using PostHog with a consent management platform (CMP)
+
+If you use a consent management platform (such as OneTrust, Cookiebot, Osano, Usercentrics, or a home-grown banner), integrate it with PostHog's opt in and out controls rather than the loader snippet.
+
+<CalloutBox type="warning" title="Don't gate the snippet behind consent">
+
+A common mistake is wrapping the PostHog snippet (or `<script>` tag) so that it only runs after consent is given. Many CMPs make this easy by letting you tag scripts as a specific cookie category and blocking them until the user accepts.
+
+The problem: if the SDK never loads, it can't count the visitors who ignore or dismiss the banner, and it can't respect a consent choice made later in the session. This is a frequent cause of sudden, large drops in event volume.
+
+**Always load posthog-js.** Control whether it captures data using the opt in and out APIs below.
+
+</CalloutBox>
+
+The recommended pattern is to load PostHog opted out by default, then opt the user in once they consent:
+
+1. Initialize PostHog with `opt_out_capturing_by_default: true` (see [opting out by default](#opting-out-by-default)) so nothing is captured until the user consents.
+2. When the user grants consent, call `posthog.opt_in_capturing()`.
+3. When the user withdraws or denies consent, call `posthog.opt_out_capturing()`.
+
+```js-web
+posthog.init('<ph_project_token>', {
+    api_host: '<ph_client_api_host>',
+    defaults: '<ph_posthog_js_defaults>',
+    opt_out_capturing_by_default: true,
+})
+
+// Wire these into your CMP's consent-change callback
+function onConsentChange(hasConsented) {
+    if (hasConsented) {
+        posthog.opt_in_capturing()
+    } else {
+        posthog.opt_out_capturing()
+    }
+}
+```
+
+Every CMP exposes some kind of callback or event that fires when consent changes (for example, OneTrust's `OptanonWrapper` / `OneTrustGroupsUpdated` event, or Cookiebot's `CookiebotOnAccept` / `CookiebotOnDecline` events). Call `opt_in_capturing()` and `opt_out_capturing()` from that callback.
+
+Alternatively, use [cookieless tracking](#cookieless-tracking) with `cookieless_mode: "on_reject"`. PostHog still loads and counts users with a privacy-preserving hash, and only starts storing cookies once the user opts in — without you needing to wire up the opt in and out calls yourself.
 
 ## IP data capture
 

--- a/contents/docs/privacy/data-collection.mdx
+++ b/contents/docs/privacy/data-collection.mdx
@@ -114,7 +114,7 @@ function onConsentChange(hasConsented) {
 
 Every CMP exposes some kind of callback or event that fires when consent changes (for example, OneTrust's `OptanonWrapper` / `OneTrustGroupsUpdated` event, or Cookiebot's `CookiebotOnAccept` / `CookiebotOnDecline` events). Call `opt_in_capturing()` and `opt_out_capturing()` from that callback.
 
-Alternatively, use [cookieless tracking](#cookieless-tracking) with `cookieless_mode: "on_reject"`. PostHog still loads and counts users with a privacy-preserving hash, and only starts storing cookies once the user opts in — without you needing to wire up the opt in and out calls yourself.
+Alternatively, use [cookieless tracking](#cookieless-tracking) with `cookieless_mode: "on_reject"`. PostHog still loads and counts users with a privacy-preserving hash, and only starts storing cookies once the user opts in – without you needing to wire up the opt in and out calls yourself.
 
 ## IP data capture
 

--- a/contents/docs/privacy/data-collection.mdx
+++ b/contents/docs/privacy/data-collection.mdx
@@ -112,7 +112,7 @@ function onConsentChange(hasConsented) {
 }
 ```
 
-Every CMP exposes some kind of callback or event that fires when consent changes (for example, OneTrust's `OptanonWrapper` / `OneTrustGroupsUpdated` event, or Cookiebot's `CookiebotOnAccept` / `CookiebotOnDecline` events). Call `opt_in_capturing()` and `opt_out_capturing()` from that callback.
+Every CMP (OneTrust, Cookiebot, and others) exposes some kind of callback or event that fires when consent changes. Call `opt_in_capturing()` and `opt_out_capturing()` from that callback, using whatever consent-change hook your CMP provides.
 
 Alternatively, use [cookieless tracking](#cookieless-tracking) with `cookieless_mode: "on_reject"`. PostHog still loads and counts users with a privacy-preserving hash, and only starts storing cookies once the user opts in – without you needing to wire up the opt in and out calls yourself.
 


### PR DESCRIPTION
## Changes

Adds a **Using PostHog with a consent management platform (CMP)** section to the [data collection docs](https://posthog.com/docs/privacy/data-collection).

- Documents the recommended load-then-opt-in pattern (`opt_out_capturing_by_default` + `opt_in_capturing()`/`opt_out_capturing()` wired into the CMP's consent-change callback).
- Adds a warning against gating the posthog-js snippet behind consent — a footgun that stops the SDK from loading for visitors who ignore the banner, so they're never counted and later consent isn't respected.
- Vendor-neutral (mentions OneTrust, Cookiebot, etc. as examples) so it covers every CMP in one place rather than per-vendor guides.
- Points to `cookieless_mode: "on_reject"` as an alternative.

## Why

A customer's event volume dropped sharply after wrapping the posthog-js script in cookie-consent gating, which stopped the SDK from loading for most visitors. We had no doc explaining the correct pattern, and don't want to maintain a guide per consent tool — this covers the general case once. Raised from a Slack thread.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C045L1VEG87/p1783966323181589?thread_ts=1783966323.181589&cid=C045L1VEG87)*