### PR TITLE
Clarify customer travel budget in spending money handbook

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -200,7 +200,7 @@ You can ask for access to team/company tools by submitted a request in Slack. Fi
 - We strongly encourage team members to try and work together in person when practical. This isn't limited to just working with people in your team, but we expect that you have a reasonable reason you need to work together. You should default to doing this in SF/London, so you'll run into other PostHog people too.
 - If you're in the same place as other team members, even if you aren't directly working together, PostHog will cover the cost of a dinner or a fun activity
 - When visiting customers (or potential customers), we should look for opportunities to connect with them over a meal. These don't need to be extravagant, but they should be appropriate to the size and expectations of the customer. If you would be comfortable justifying the spend publicly in All Hands, you're probably fine.
-  - For a normal customer visit (yourself or a couple of people, a day or less), just use your personal budget and request an increase in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) if you need more. If the visit grows into something offsite-like (the whole team, multiple days, etc.), let People & Ops know and they'll create a separate budget for it.
+  - For a normal customer visit (yourself or a couple of people), just use your personal budget and request an increase through Brex if you need more. If the visit grows into something offsite-like (the whole team, multiple days, etc.), post in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) and tag Kendal so she can create a separate budget for it.
 
 #### Hub travel budget
 

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -200,6 +200,7 @@ You can ask for access to team/company tools by submitted a request in Slack. Fi
 - We strongly encourage team members to try and work together in person when practical. This isn't limited to just working with people in your team, but we expect that you have a reasonable reason you need to work together. You should default to doing this in SF/London, so you'll run into other PostHog people too.
 - If you're in the same place as other team members, even if you aren't directly working together, PostHog will cover the cost of a dinner or a fun activity
 - When visiting customers (or potential customers), we should look for opportunities to connect with them over a meal. These don't need to be extravagant, but they should be appropriate to the size and expectations of the customer. If you would be comfortable justifying the spend publicly in All Hands, you're probably fine.
+  - For a normal customer visit (yourself or a couple of people, a day or less), just use your personal budget and request an increase in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) if you need more. If the visit grows into something offsite-like (the whole team, multiple days, etc.), let People & Ops know and they'll create a separate budget for it.
 
 #### Hub travel budget
 


### PR DESCRIPTION
## Changes

Adds a subpoint under the customer-visit travel bullet in the spending money handbook, clarifying budget handling: for a normal visit (one or two people, a day or less), use your personal budget and request an increase if needed; if it grows into an offsite-like visit (whole team, multiple days), People & Ops will create a separate budget.

**Why:** A team member asked whether a customer visit needs a separate budget or can come out of the personal budget. The guidance existed in Slack but wasn't captured in the handbook, so this writes it down where the customer-travel bullet already lives.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1783970686464519?thread_ts=1783970686.464519&cid=C017WDX3BFZ)*