### PR TITLE
docs: fix copy across product documentation

### DIFF
--- a/contents/docs/logs/basics.mdx
+++ b/contents/docs/logs/basics.mdx
@@ -32,7 +32,7 @@ With logs, you filter by that user's ID and see their request hits a cache miss,
 
 No errors fire. Your tests pass. But checkout completions drop 15% after a deploy.
 
-With logs, you see the payment gateway starts returning a new response format after their own update last night. Your code parses it without erroring, but silently drops the discount field, so users see full price and abandon cart.
+With logs, you see the payment gateway starts returning a new response format after their own update last night. Your code parses it without erroring, but silently drops the discount field, so users see full price and abandon the cart.
 
 ### Background jobs vanish into a black box
 
@@ -56,7 +56,7 @@ Logs also matter when your application *uses* AI. If you're building with LLMs, 
 
 ## What good logging looks like
 
-Most logging is bad. Not because people don't log enough, but because they log too much of the wrong things.
+Most logging is bad. Not because people don't log enough, but because they log too many of the wrong things.
 
 **Three principles that matter:**
 

--- a/contents/docs/logs/installation/javascript.mdx
+++ b/contents/docs/logs/installation/javascript.mdx
@@ -56,7 +56,7 @@ See the [web SDK config reference](/docs/libraries/js/config#configuring-logs) f
 
 <Step title="Send structured logs with posthog.logger" badge="recommended">
 
-`posthog.logger` is the declarative path. Each call produces an OTLP log record with a severity level and typed attributes you can filter and query on in the Logs product.
+`posthog.logger` is the declarative path. Each call produces an OTLP log record with a severity level and typed attributes you can filter and query in the Logs product.
 
 ```js-web
 posthog.logger.info('checkout completed', { order_id: 'ord_789', total_cents: 4200 })

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -18,7 +18,7 @@ First, check that DNS is set up properly:
 nslookup <your-hostname> 1.1.1.1
 ```
 
-Note that when using a browser there are various layers of caching and other logic that could make the resolution work (temporarily) even if its not correctly set up.
+Note that when using a browser there are various layers of caching and other logic that could make the resolution work (temporarily) even if it's not correctly set up.
 
 ## FAQ
 

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -86,7 +86,7 @@ There are three options for displaying a survey:
     classes="rounded"
 />
 
-Popover, API, and feedback button surveys are considered _in-app_ surveys, meaning they are displayed directly in your application using our SDKs. Hosted surveys are displayed via an external URLs, hosted by PostHog.
+Popover, API, and feedback button surveys are considered _in-app_ surveys, meaning they are displayed directly in your application using our SDKs. Hosted surveys are displayed via external URLs, hosted by PostHog.
 
 #### Identifying respondents on hosted surveys
 

--- a/contents/docs/surveys/destinations.mdx
+++ b/contents/docs/surveys/destinations.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-It can be useful to send survey responses to external [destinations](/docs/cdp/destinations). For example, you can receive [Slack](/tutorials/slack-surveys) notifications or trigger [Zapier zaps](/tutorials/zapier-surveys) whenever users responds to your survey.
+It can be useful to send survey responses to external [destinations](/docs/cdp/destinations). For example, you can receive [Slack](/tutorials/slack-surveys) notifications or trigger [Zapier zaps](/tutorials/zapier-surveys) whenever users respond to your survey.
 
 To do this:
 
@@ -16,7 +16,7 @@ To do this:
 
 2. Search for the destination you want and click **+ Create** (or click **Create** on **HTTP Webhook** for custom destinations).
 
-3. Follow the steps to integrate with destination.
+3. Follow the steps to integrate with the destination.
 
 4. Under **Match event and actions**, select **survey sent**.
 

--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -282,7 +282,7 @@ For more control over your surveys, you can use API surveys. When implementing a
 
 1. To get all surveys, call `getSurveys(callback, forceReload)`. This means you still need to handle display conditions yourself.
 
-2. To get surveys enabled for the current user, call `getActiveMatchingSurveys(callback, forceReload)`. This always returns an active survey if the user meets the display conditions, as long as the user (determined by their distinct ID) has not already dismissed or responded the survey.
+2. To get surveys enabled for the current user, call `getActiveMatchingSurveys(callback, forceReload)`. This always returns an active survey if the user meets the display conditions, as long as the user (determined by their distinct ID) has not already dismissed or responded to the survey.
 
 Surveys are requested on first load and then cached by default by the JavaScript SDK. If you want to force an API call to get an updated list of surveys, pass `true` to the `forceReload` parameter. You only need to do this if you want changed surveys to appear mid-session for users.
 

--- a/contents/docs/surveys/troubleshooting.mdx
+++ b/contents/docs/surveys/troubleshooting.mdx
@@ -10,7 +10,7 @@ This page covers troubleshooting for Surveys. For setup, see the [installation g
 
 ## Check Surveys feature availability
 
-**Not all surveys features are supported by every SDK.**
+**Not all Surveys features are supported by every SDK.**
 
 Please see [SDK feature support](/docs/surveys/sdk-feature-support) for the most up-to-date information on which features are available for your SDK.
 

--- a/contents/docs/web-analytics/getting-started.mdx
+++ b/contents/docs/web-analytics/getting-started.mdx
@@ -40,7 +40,7 @@ The first thing you'll see at the top of the web analytics dashboard is a graph 
 - How many people visited in the last week, month, or custom time period?
 - Is the number of visitors going up or down over a given time period?
 
-What's the difference a between a visitor and a session?
+What's the difference between a visitor and a session?
 
 - A [**session**](/docs/data/sessions) is a set of events for a single visit to your website. Sessions have a beginning, a duration, and an end.
 - A **visitor** represents a single, unique person visiting your site.
@@ -160,7 +160,7 @@ Web analytics enables you to filter by all the various UTM parameters that are a
 >
 > `https://posthog.com/fireship`
 >
-> That URL gets transformed into the following UTM paramaters:
+> That URL gets transformed into the following UTM parameters:
 >
 > `https://posthog.com/?utm_source=fireship&utm_campaign=fireship`
 >


### PR DESCRIPTION
## Changes

Fix 11 spelling, grammar, and clarity issues across eight documentation pages:

- remove an extra article and correct `parameters` in Web Analytics
- correct agreement, articles, prepositions, and product capitalization in Surveys
- clarify three awkward or incomplete phrases in Logs
- correct `its` to `it's` in the self-hosted troubleshooting guide

These changes came from a content-only docs review. 

This is a copy-only change. It does not alter code, links, page locations,
frontmatter, components, or examples.

## Validation

- `markdownlint-cli2`: 0 errors across all eight changed files
- `git diff --check`: passed
- Vale: no errors on changed lines; existing findings elsewhere in these files remain unchanged
- Source-drift check: all reviewed source blobs matched the exported review baseline

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English.
- [x] Internal links remain relative; this PR adds or changes no links.
- [x] I've checked the changed pages in the preview build.
- [x] No pages were moved, so no redirects are required.
