### PR TITLE
docs(contribute): add "Answer community questions" section

### DIFF
--- a/contents/docs/contribute/index.md
+++ b/contents/docs/contribute/index.md
@@ -13,9 +13,9 @@ We have an awesome, diverse, and inclusive community. In order to maintain and g
 
 ## Answer community questions
 
-One of the most helpful ways to contribute is by answering questions from other users in [our community forum](/questions). Sharing what you've learned helps others get unblocked faster and makes PostHog better for everyone, whether it's a quick tip, a workaround, or a detailed walkthrough.
+Every month there are hundreds of new questions from other users in [our community forum](/questions). Finding solutions and sharing what you've learned helps others get unblocked faster and makes PostHog better for everyone.
 
-Not sure where to start? Our [guide to answering community questions](/handbook/community/questions) walks you through how to write helpful, accurate answers.
+If you're not sure where to start, our [guide to answering community questions](/handbook/community/questions) walks through how to write helpful, accurate answers.
 
 ## Reporting bugs or issues
 

--- a/contents/docs/contribute/index.md
+++ b/contents/docs/contribute/index.md
@@ -11,6 +11,12 @@ We love contributions to PostHog, big or small. Here's what you need to know abo
 
 We have an awesome, diverse, and inclusive community. In order to maintain and grow this, all community members must adhere to our [Code of conduct](/docs/contribute/code-of-conduct).
 
+## Answer community questions
+
+One of the most helpful ways to contribute is by answering questions from other users in [our community forum](/questions). Sharing what you've learned helps others get unblocked faster and makes PostHog better for everyone, whether it's a quick tip, a workaround, or a detailed walkthrough.
+
+Not sure where to start? Our [guide to answering community questions](/handbook/community/questions) walks you through how to write helpful, accurate answers.
+
 ## Reporting bugs or issues
 
 Bug reports help us make PostHog better for everyone. When you [report a bug](https://github.com/PostHog/posthog/issues/new/choose), the description will automatically be filled with a template that makes it very clear what we'd like you to add.


### PR DESCRIPTION
## Changes

Adds an "Answer community questions" section to the [Contribute to PostHog](https://posthog.com/docs/contribute) docs page, pointing contributors to the [community forum](/questions) and the [guide on how to answer questions](/handbook/community/questions).

## Why

Answering community questions is a valuable, low-barrier way to contribute that wasn't previously called out on the contribute overview page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AB78YBCNA/p1784018423121629)*
