### PR TITLE
docs: add PostHog Code pricing page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,1 +1,9 @@
-{}
+{
+  "permissions": {
+    "allow": [
+      "Bash(git push *)",
+      "Bash(gh pr create --base master --head docs/posthog-code-pricing-clean --title 'docs: add PostHog Code pricing page' --body ' *)",
+      "Bash(gh run *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,1 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git push *)",
-      "Bash(gh pr create --base master --head docs/posthog-code-pricing-clean --title 'docs: add PostHog Code pricing page' --body ' *)",
-      "Bash(gh run *)"
-    ]
-  }
-}
+{}

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -87,8 +87,7 @@ The **Plan & usage** tab in the app shows your spend in real time. The in-app bi
 You’re always in control of your AI credit usage:
 
 - **Real-time tracking:** See costs as you go
-- **Default billing limit:** PostHog sets a default **$50 billing limit** so you don't accidentally rack up costs without a ceiling. You can extend this at any time.
-- **Custom billing limit:** Set your own hard caps to prevent overspending
+- **Default & custom billing limit:** PostHog sets a default **$50 billing limit** so you don't accidentally rack up costs without a ceiling. You can customize your billing limit at any time.
 - **Usage alerts:** Get notified when you hit key thresholds
 
 When you reach your billing limit, you won't be able to send messages until you raise it. Increase your billing limit to continue using PostHog Code.

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -4,31 +4,31 @@ title: PostHog Code pricing
 
 import { CalloutBox } from "components/Docs/CalloutBox";
 
-PostHog Code usage consumes **AI credits**. Each time you interact with PostHog Code, such as writing code, querying your PostHog data, or asking an ad-hoc question, credits are spent based on the resources required to complete your request.
-
-This means you only pay for what you use. There's no fixed subscription, and every organization gets a **$20 monthly free tier** to explore PostHog Code's features.
+PostHog Code usage consumes **AI credits**, with credit consumption anchored to underlying token costs. PostHog Code credits carry **no markup**: They reflect the underlying LLM provider's cost exactly, with nothing added on top.
 
 For reference, **100 AI credits = $1**.
 
-PostHog Code credits carry **no markup**: They reflect the underlying LLM provider's cost exactly, with nothing added on top.
+Each time you interact with PostHog Code, such as writing code, querying your PostHog data, or asking an ad-hoc question, credits are spent based on the resources required to complete your request.
 
-## Model pricing
+This means you only pay for what you use. There's no fixed subscription, and every organization gets a **$20 monthly free tier** to explore PostHog Code's features.
 
-For reference, the table below shows model costs **per 1M tokens**:
+## Available models & credit consumption
+
+The following table shows token costs per model and token type **per 1M tokens**:
 
 | Model | Input | Output |
 | --- | --- | --- |
-| gpt-5.6-sol | $5.00 | $30.00 |
-| gpt-5.6-terra | $2.50 | $15.00 |
-| gpt-5.6-luna | $1.00 | $6.00 |
-| gpt-5.5 | $5.00 | $30.00 |
-| gpt-5.4 | $2.50 | $15.00 |
-| Claude Sonnet 4.6 | $3.00 | $15.00 |
-| Claude Opus 4.7 | $5.00 | $25.00 |
-| Claude Opus 4.8 | $5.00 | $25.00 |
-| Claude Sonnet 5 | $2.00 | $10.00 |
-| Claude Fable 5 | $10.00 | $50.00 |
-| glm-5.2 | $1.40 | $4.40 |
+| gpt-5.6-sol | 500 credits ($5.00) | 3,000 credits ($30.00) |
+| gpt-5.6-terra | 250 credits ($2.50) | 1,500 credits ($15.00) |
+| gpt-5.6-luna | 100 credits ($1.00) | 600 credits ($6.00) |
+| gpt-5.5 | 500 credits ($5.00) | 3,000 credits ($30.00) |
+| gpt-5.4 | 250 credits ($2.50) | 1,500 credits ($15.00) |
+| Claude Sonnet 4.6 | 300 credits ($3.00) | 1,500 credits ($15.00) |
+| Claude Opus 4.7 | 500 credits ($5.00) | 2,500 credits ($25.00) |
+| Claude Opus 4.8 | 500 credits ($5.00) | 2,500 credits ($25.00) |
+| Claude Sonnet 5 | 200 credits ($2.00) | 1,000 credits ($10.00) |
+| Claude Fable 5 | 1,000 credits ($10.00) | 5,000 credits ($50.00) |
+| glm-5.2 | 140 credits ($1.40) | 440 credits ($4.40) |
 
 Prices are passed through from the underlying model providers at cost and may change as providers update their rates.
 

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -18,17 +18,17 @@ The following table shows token costs per model and token type **per 1M tokens**
 
 | Model | Input | Output |
 | --- | --- | --- |
-| gpt-5.6-sol | 500 credits ($5.00) | 3,000 credits ($30.00) |
-| gpt-5.6-terra | 250 credits ($2.50) | 1,500 credits ($15.00) |
-| gpt-5.6-luna | 100 credits ($1.00) | 600 credits ($6.00) |
-| gpt-5.5 | 500 credits ($5.00) | 3,000 credits ($30.00) |
-| gpt-5.4 | 250 credits ($2.50) | 1,500 credits ($15.00) |
-| Claude Sonnet 4.6 | 300 credits ($3.00) | 1,500 credits ($15.00) |
+| Claude Fable 5 | 1,000 credits ($10.00) | 5,000 credits ($50.00) |
 | Claude Opus 4.7 | 500 credits ($5.00) | 2,500 credits ($25.00) |
 | Claude Opus 4.8 | 500 credits ($5.00) | 2,500 credits ($25.00) |
+| Claude Sonnet 4.6 | 300 credits ($3.00) | 1,500 credits ($15.00) |
 | Claude Sonnet 5 | 200 credits ($2.00) | 1,000 credits ($10.00) |
-| Claude Fable 5 | 1,000 credits ($10.00) | 5,000 credits ($50.00) |
 | glm-5.2 | 140 credits ($1.40) | 440 credits ($4.40) |
+| gpt-5.4 | 250 credits ($2.50) | 1,500 credits ($15.00) |
+| gpt-5.5 | 500 credits ($5.00) | 3,000 credits ($30.00) |
+| gpt-5.6-luna | 100 credits ($1.00) | 600 credits ($6.00) |
+| gpt-5.6-sol | 500 credits ($5.00) | 3,000 credits ($30.00) |
+| gpt-5.6-terra | 250 credits ($2.50) | 1,500 credits ($15.00) |
 
 Prices are passed through from the underlying model providers at cost and may change as providers update their rates.
 

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -18,17 +18,19 @@ For reference, the table below shows model costs **per 1M tokens**:
 
 | Model | Input | Output |
 | --- | --- | --- |
-| gpt-5.6-sol | — | — |
-| gpt-5.6-terra | — | — |
-| gpt-5.6-luna | — | — |
-| gpt-5.5 | — | — |
-| gpt-5.4 | — | — |
-| Claude Sonnet 4.6 | — | — |
-| Claude Opus 4.7 | — | — |
-| Claude Opus 4.8 | — | — |
-| Claude Sonnet 5 | — | — |
-| Claude Fable 5 | — | — |
-| glm-5.2 | — | — |
+| gpt-5.6-sol | $5.00 | $30.00 |
+| gpt-5.6-terra | $2.50 | $15.00 |
+| gpt-5.6-luna | $1.00 | $6.00 |
+| gpt-5.5 | $5.00 | $30.00 |
+| gpt-5.4 | $2.50 | $15.00 |
+| Claude Sonnet 4.6 | $3.00 | $15.00 |
+| Claude Opus 4.7 | $5.00 | $25.00 |
+| Claude Opus 4.8 | $5.00 | $25.00 |
+| Claude Sonnet 5 | $2.00 | $10.00 |
+| Claude Fable 5 | $10.00 | $50.00 |
+| glm-5.2 | $1.40 | $4.40 |
+
+Prices are passed through from the underlying model providers at cost and may change as providers update their rates.
 
 ## What consumes AI credits
 

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -18,17 +18,17 @@ The following table shows token costs per model and token type **per 1M tokens**
 
 | Model | Input | Output |
 | --- | --- | --- |
-| Claude Fable 5 | 1,000 credits ($10.00) | 5,000 credits ($50.00) |
-| Claude Opus 4.7 | 500 credits ($5.00) | 2,500 credits ($25.00) |
-| Claude Opus 4.8 | 500 credits ($5.00) | 2,500 credits ($25.00) |
-| Claude Sonnet 4.6 | 300 credits ($3.00) | 1,500 credits ($15.00) |
-| Claude Sonnet 5 | 200 credits ($2.00) | 1,000 credits ($10.00) |
-| glm-5.2 | 140 credits ($1.40) | 440 credits ($4.40) |
-| gpt-5.4 | 250 credits ($2.50) | 1,500 credits ($15.00) |
-| gpt-5.5 | 500 credits ($5.00) | 3,000 credits ($30.00) |
-| gpt-5.6-luna | 100 credits ($1.00) | 600 credits ($6.00) |
-| gpt-5.6-sol | 500 credits ($5.00) | 3,000 credits ($30.00) |
-| gpt-5.6-terra | 250 credits ($2.50) | 1,500 credits ($15.00) |
+| Claude Fable 5 | 1,000 credits | 5,000 credits |
+| Claude Opus 4.7 | 500 credits | 2,500 credits |
+| Claude Opus 4.8 | 500 credits | 2,500 credits |
+| Claude Sonnet 4.6 | 300 credits | 1,500 credits |
+| Claude Sonnet 5 | 200 credits | 1,000 credits |
+| glm-5.2 | 140 credits | 440 credits |
+| gpt-5.4 | 250 credits | 1,500 credits |
+| gpt-5.5 | 500 credits | 3,000 credits |
+| gpt-5.6-luna | 100 credits | 600 credits |
+| gpt-5.6-sol | 500 credits | 3,000 credits |
+| gpt-5.6-terra | 250 credits | 1,500 credits |
 
 Prices are passed through from the underlying model providers at cost and may change as providers update their rates.
 

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -61,8 +61,8 @@ Stay on top of your AI credit spend in real time:
 2. Check the [billing overview](https://app.posthog.com/organization/billing/overview) and [billing usage](https://app.posthog.com/organization/billing/usage) pages to view your total monthly consumption
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-over-time-light.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-over-time-dark.png"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/code_cost_over_time_light_d6c7d839e6.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/code_cost_over_time_dark_7483f921bc.png"
     alt="PostHog Code spend over time, broken down by day"
     classes="rounded"
 />
@@ -70,8 +70,8 @@ Stay on top of your AI credit spend in real time:
 <Caption>Track your PostHog Code spend over time in the Plan &amp; usage tab</Caption>
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-by-model-light.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-by-model-dark.png"
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/code_cost_by_model_light_4b7f1ed6ad.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/code_cost_by_model_dark_d3d95f7976.png"
     alt="PostHog Code spend broken down by model"
     classes="rounded"
 />

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -1,0 +1,94 @@
+---
+title: PostHog Code pricing
+---
+
+import { CalloutBox } from "components/Docs/CalloutBox";
+
+PostHog Code usage consumes **AI credits**. Each time you interact with PostHog Code, such as writing code, querying your PostHog data, or asking an ad-hoc question, credits are spent based on the resources required to complete your request.
+
+This means you only pay for what you use. There's no fixed subscription, and every organization gets a **$20 monthly free tier** to explore PostHog Code's features.
+
+For reference, **100 AI credits = $1**.
+
+PostHog Code credits carry **no markup**: They reflect the underlying LLM provider's cost exactly, with nothing added on top.
+
+## Model pricing
+
+For reference, the table below shows model costs **per 1M tokens**:
+
+| Model | Input | Output |
+| --- | --- | --- |
+| gpt-5.6-sol | — | — |
+| gpt-5.6-terra | — | — |
+| gpt-5.6-luna | — | — |
+| gpt-5.5 | — | — |
+| gpt-5.4 | — | — |
+| Claude Sonnet 4.6 | — | — |
+| Claude Opus 4.7 | — | — |
+| Claude Opus 4.8 | — | — |
+| Claude Sonnet 5 | — | — |
+| Claude Fable 5 | — | — |
+| glm-5.2 | — | — |
+
+## What consumes AI credits
+
+Every interaction with PostHog Code consumes AI credits. This includes:
+
+- Writing or editing code
+- Querying your PostHog data
+- Any ad-hoc question you ask
+
+All usage is charged as credits, after your $20 monthly free tier.
+
+## How AI credit usage works
+
+AI credits are based on the **underlying token costs**, which reflect the effort required to complete your request.
+
+- Simple, short tasks use very few tokens, and therefore very few credits.
+- More complex tasks that span many files or multiple iterations use more tokens and consume more credits.
+- Because we charge no markup, your credits reflect exactly what the underlying model costs.
+- You can pick [any model and any harness](/docs/posthog-code/use-any-model-and-harness), so you're free to choose a cheaper model for simpler tasks.
+
+While exact usage varies, credit consumption usually scales with complexity. You’ll always see **real-time cost information** while using PostHog Code.
+
+## Track your AI credit usage
+
+Stay on top of your AI credit spend in real time:
+
+1. Open the **Plan & usage** tab in the PostHog Code app to see your real-time spend, broken down by day and by model
+2. Check the [billing overview](https://app.posthog.com/organization/billing/overview) and [billing usage](https://app.posthog.com/organization/billing/usage) pages to view your total monthly consumption
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-over-time-light.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-over-time-dark.png"
+    alt="PostHog Code spend over time, broken down by day"
+    classes="rounded"
+/>
+
+<Caption>Track your PostHog Code spend over time in the Plan &amp; usage tab</Caption>
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-by-model-light.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/code-cost-by-model-dark.png"
+    alt="PostHog Code spend broken down by model"
+    classes="rounded"
+/>
+
+<Caption>See which models are driving your spend</Caption>
+
+<CalloutBox icon="IconInfo" title="Important" type="fyi">
+
+The **Plan & usage** tab in the app shows your spend in real time. The in-app billing overview and billing usage pages can be delayed by up to 24 hours, so use the Plan & usage tab for the most up-to-date view.
+
+</CalloutBox>
+
+## Control your AI credit spend
+
+You’re always in control of your AI credit usage:
+
+- **Real-time tracking:** See costs as you go
+- **Default billing limit:** PostHog sets a default **$50 billing limit** so you don't accidentally rack up costs without a ceiling. You can extend this at any time.
+- **Custom billing limit:** Set your own hard caps to prevent overspending
+- **Usage alerts:** Get notified when you hit key thresholds
+
+When you reach your billing limit, you won't be able to send messages until you raise it. Increase your billing limit to continue using PostHog Code.

--- a/contents/docs/posthog-code/pricing.mdx
+++ b/contents/docs/posthog-code/pricing.mdx
@@ -90,6 +90,6 @@ You’re always in control of your AI credit usage:
 
 - **Real-time tracking:** See costs as you go
 - **Default & custom billing limit:** PostHog sets a default **$50 billing limit** so you don't accidentally rack up costs without a ceiling. You can customize your billing limit at any time.
-- **Usage alerts:** Get notified when you hit key thresholds
+- **Usage alerts:** Get notified when you hit key thresholds through automated billing emails
 
 When you reach your billing limit, you won't be able to send messages until you raise it. Increase your billing limit to continue using PostHog Code.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6995,6 +6995,12 @@ export const docsMenu = {
                     name: 'Resources',
                 },
                 {
+                    name: 'Pricing',
+                    url: '/docs/posthog-code/pricing',
+                    icon: 'IconPiggyBank',
+                    color: 'green',
+                },
+                {
                     name: 'Open source',
                     url: '/docs/posthog-code/open-source',
                     icon: 'IconGithub',


### PR DESCRIPTION
## Changes

Adds a **PostHog Code pricing** page at `/docs/posthog-code/pricing`, modeled on the [PostHog AI pricing page](https://posthog.com/docs/posthog-ai/pricing), plus a "Pricing" nav entry under the PostHog Code docs section.

### What the page covers

- **Billing model** — usage-based AI credits, 100 credits = $1, **no markup** (unlike PostHog AI)
- **$20 monthly free tier**
- **Model pricing table** — input/output cost per 1M tokens, in **AI credits**, for all currently available models
- **What consumes credits** — every interaction (writing code, querying PostHog data, ad-hoc questions)
- **How usage works** — token-based, pick any model/harness
- **Tracking** — in-app **Plan & usage** tab (real-time, by day and model) with screenshots, plus billing pages (24h delay)
- **Controls** — $50 default billing limit (extendable), custom limits, usage alerts, behavior when the limit is hit

### Model prices

The per-1M-token prices are filled in and shown **in AI credits** (100 credits = $1), consistent with how usage is billed. The values are the **pass-through provider rates the LLM gateway bills against** — `MODEL_COST_OVERRIDES` in `services/llm-gateway` plus LiteLLM's live cost map (and the Cloudflare resold rate for `glm-5.2`) — so they match what customers are actually charged. Since these track the underlying providers, they may drift over time and should be re-checked against the gateway if provider rates change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
