### PR TITLE
docs: add Kotlin Multiplatform (KMP) SDK library page

### DIFF
--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -1,0 +1,533 @@
+---
+title: Kotlin Multiplatform
+sidebarTitle: Kotlin Multiplatform
+sidebar: Docs
+showTitle: true
+github: 'https://github.com/PostHog/posthog-kmp'
+features:
+  eventCapture: true
+  userIdentification: true
+  autoCapture: true
+  sessionRecording: true
+  featureFlags: true
+  groupAnalytics: true
+  surveys: false
+  aiObservability: false
+  errorTracking: true
+  logs: false
+---
+
+The PostHog Kotlin Multiplatform (KMP) SDK lets you capture analytics from shared Kotlin code that runs on Android, iOS, and the web (JS). It's a thin wrapper that delegates to the official native PostHog SDKs on each target — [posthog-android](/docs/libraries/android) on Android, [posthog-ios](/docs/libraries/ios) on iOS, and [posthog-js](/docs/libraries/js) on the web — so you get native batching, queueing, and session replay behind a single common API.
+
+> **Early access:** This SDK is currently in a `0.x` pre-release. The API may change between minor versions until it stabilizes. We'd love your feedback on [GitHub](https://github.com/PostHog/posthog-kmp/issues).
+
+## Installation
+
+Add the dependency to your shared module's `commonMain` source set.
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+// shared/build.gradle.kts
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.posthog:posthog-kmp:<version>")
+        }
+    }
+}
+```
+
+### Version catalog
+
+```toml
+# gradle/libs.versions.toml
+[versions]
+posthog-kmp = "<version>"
+
+[libraries]
+posthog-kmp = { group = "com.posthog", name = "posthog-kmp", version.ref = "posthog-kmp" }
+```
+
+You can find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.posthog/posthog-kmp).
+
+### Configure the SDK
+
+Initialize PostHog once, early in your app's lifecycle, by calling `PostHog.setup()` with a `PostHogConfig` and a platform `PostHogContext`.
+
+```kotlin
+import com.posthog.kmp.PostHog
+import com.posthog.kmp.PostHogConfig
+import com.posthog.kmp.PostHogContext
+
+PostHog.setup(
+    config = PostHogConfig(
+        apiKey = "<ph_project_api_key>",
+        host = PostHogConfig.HOST_US, // or PostHogConfig.HOST_EU
+    ),
+    context = PostHogContext(), // platform-specific — see below
+)
+```
+
+You can find your project API key and host in [your project settings](https://us.posthog.com/settings/project).
+
+### Platform-specific setup
+
+The only platform difference is how you build `PostHogContext`. Everything else — event capture, feature flags, config — is shared code.
+
+#### Android
+
+Android requires the `Application` instance, so pass it to `PostHogContext`:
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        PostHog.setup(
+            config = PostHogConfig(apiKey = "<ph_project_api_key>"),
+            context = PostHogContext(application),
+        )
+    }
+}
+```
+
+#### iOS
+
+On iOS, use the no-argument `PostHogContext()`:
+
+```kotlin
+// MainViewController.kt
+fun MainViewController() = ComposeUIViewController {
+    LaunchedEffect(Unit) {
+        PostHog.setup(
+            config = PostHogConfig(apiKey = "<ph_project_api_key>"),
+            context = PostHogContext(),
+        )
+    }
+    App()
+}
+```
+
+#### Web (JS)
+
+On the web, use the no-argument `PostHogContext()`:
+
+```kotlin
+// main.kt
+fun main() {
+    PostHog.setup(
+        config = PostHogConfig(apiKey = "<ph_project_api_key>"),
+        context = PostHogContext(),
+    )
+}
+```
+
+## Capturing events
+
+You can send custom events using `capture`:
+
+```kotlin
+PostHog.capture("user_signed_up")
+```
+
+You can add properties to any event by passing a `properties` map:
+
+```kotlin
+PostHog.capture(
+    event = "purchase_completed",
+    properties = mapOf(
+        "product_id" to "SKU123",
+        "price" to 29.99,
+        "currency" to "USD",
+    ),
+)
+```
+
+To attach [group](/docs/product/group-analytics) context or a custom timestamp to a single event, pass `CaptureOptions`:
+
+```kotlin
+import com.posthog.kmp.CaptureOptions
+
+PostHog.capture(
+    event = "feature_used",
+    properties = mapOf("feature_name" to "export"),
+    options = CaptureOptions(groups = mapOf("company" to "acme_corp")),
+)
+```
+
+> **Note:** Properties with `null` values are dropped before the event is sent, so every platform receives the same event shape.
+
+## Identifying users
+
+> We highly recommend reading our section on [identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
+
+Use `identify` to associate events with a specific user and (optionally) set [person properties](/docs/data/user-properties):
+
+```kotlin
+PostHog.identify(
+    distinctId = "user_123",
+    userProperties = mapOf(
+        "email" to "user@example.com",
+        "plan" to "premium",
+    ),
+)
+```
+
+`userPropertiesSetOnce` works just like `userProperties`, except it only sets a property if the user doesn't already have it:
+
+```kotlin
+PostHog.identify(
+    distinctId = "user_123",
+    userPropertiesSetOnce = mapOf(
+        "first_seen" to "2025-01-01",
+        "signup_source" to "organic",
+    ),
+)
+```
+
+## Get the current user's distinct ID
+
+You may find it helpful to get the current user's distinct ID — for example, to check whether you've already called `identify` for a user. Call `getDistinctId()`, which returns either the ID automatically generated by PostHog or the one passed to `identify()`.
+
+```kotlin
+val distinctId = PostHog.getDistinctId()
+```
+
+## Alias
+
+Sometimes you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible — for example, if a distinct ID used on the frontend isn't available in your backend. Use `alias` to assign another distinct ID to the same user:
+
+```kotlin
+PostHog.alias("distinct_id")
+```
+
+We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+
+## Setting person properties
+
+Besides setting properties during `identify`, you can set person properties directly with `setPersonProperties`:
+
+```kotlin
+PostHog.setPersonProperties(
+    userProperties = mapOf("plan" to "premium"),
+    userPropertiesSetOnce = mapOf("first_seen" to "2025-01-01"),
+)
+```
+
+## Super properties
+
+Super properties are properties you set once and then send with every subsequent `capture` call. They're set with `PostHog.register`, which takes a key and value, and they persist across sessions.
+
+```kotlin
+PostHog.register("team_id", 22)
+```
+
+The call above ensures every event sent by the user includes `"team_id": 22`.
+
+> **Note:** This stores properties against the user's events, not against the user profile itself. To store properties against the person, use `identify` or `setPersonProperties`.
+
+To stop sending a super property with events, use `unregister`:
+
+```kotlin
+PostHog.unregister("team_id")
+```
+
+If you're doing this as part of a user logging out, you can instead call `PostHog.reset()`, which clears all stored super properties and more.
+
+## Feature flags
+
+PostHog's [feature flags](/docs/feature-flags) let you safely deploy and roll back new features. By default, flags are preloaded on setup (`preloadFeatureFlags = true`).
+
+Check whether a flag is enabled:
+
+```kotlin
+if (PostHog.isFeatureEnabled("new_dashboard")) {
+    showNewDashboard()
+}
+```
+
+Get the value of a [multivariate flag](/docs/feature-flags/creating-feature-flags#multivariate-feature-flags):
+
+```kotlin
+when (PostHog.getFeatureFlag("pricing_experiment")) {
+    "control" -> showOriginalPricing()
+    "variant_a" -> showNewPricing()
+    "variant_b" -> showPremiumPricing()
+}
+```
+
+Get a detailed result, including the flag's [payload](/docs/feature-flags/payloads):
+
+```kotlin
+val result = PostHog.getFeatureFlagResult("new_feature")
+if (result != null) {
+    println("Enabled: ${result.enabled}")
+    println("Variant: ${result.variant}")
+    println("Value: ${result.value}") // variant if present, otherwise enabled
+
+    // Cast the payload to an expected type
+    val payload = result.getPayloadAs<Map<String, Any>>()
+}
+```
+
+Get every evaluated flag at once as a map of `FeatureFlagResult`:
+
+```kotlin
+val allFlags = PostHog.getAllFeatureFlags()
+```
+
+Feature flags are fetched on setup and cached. If a user's properties change (for example after `identify`), reload them so they reflect the latest state:
+
+```kotlin
+PostHog.reloadFeatureFlags {
+    // flags are now up to date
+}
+```
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/start-here) use feature flags, running one is very similar to the feature flag code above:
+
+```kotlin
+if (PostHog.getFeatureFlag("experiment-feature-flag-key") == "variant-name") {
+    // do something
+}
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).
+
+## Group analytics
+
+Group analytics lets you associate a user's events with a group (e.g. a company, team, or organization). Read the [group analytics](/docs/product/group-analytics) guide for more information.
+
+> **Note:** This is a paid feature and is not available on the free plan. Learn more on the [pricing page](/pricing).
+
+Associate the current user's events with a group:
+
+```kotlin
+// "company" is the group type, "acme_corp" is the group key
+PostHog.group(type = "company", key = "acme_corp")
+```
+
+Associate with a group and update that group's properties at the same time:
+
+```kotlin
+PostHog.group(
+    type = "company",
+    key = "acme_corp",
+    groupProperties = mapOf(
+        "name" to "Acme Corporation",
+        "plan" to "enterprise",
+    ),
+)
+```
+
+The `name` is a special property used in the PostHog UI for the group's name. If you don't specify it, the group key is used instead.
+
+## Screen views
+
+Capture a [screen view](/docs/product-analytics/capture-events#screen-views) with `screen`:
+
+```kotlin
+PostHog.screen("Home")
+```
+
+You can add properties too:
+
+```kotlin
+PostHog.screen(
+    screenName = "Product Details",
+    properties = mapOf(
+        "product_id" to "SKU123",
+        "category" to "Electronics",
+    ),
+)
+```
+
+To automatically capture screen views on Android, set `captureScreenViews = true` in your config.
+
+## Error tracking
+
+Capture handled exceptions with their stack traces so they show up in [error tracking](/docs/error-tracking):
+
+```kotlin
+try {
+    riskyOperation()
+} catch (e: Exception) {
+    PostHog.captureException(
+        throwable = e,
+        additionalProperties = mapOf("context" to "checkout_flow"),
+    )
+}
+```
+
+## Session replay
+
+[Session replay](/docs/session-replay/mobile) is available on Android and iOS. To enable it, turn on "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and pass a `SessionRecordingConfig`:
+
+```kotlin
+import com.posthog.kmp.SessionRecordingConfig
+
+PostHog.setup(
+    config = PostHogConfig(
+        apiKey = "<ph_project_api_key>",
+        sessionRecording = SessionRecordingConfig(
+            enabled = true,
+            maskAllTextInputs = true, // mask sensitive text (default)
+            maskAllImages = true,     // mask images (default)
+        ),
+    ),
+    context = PostHogContext(),
+)
+```
+
+You can also enable experimental screenshot mode instead of the default wireframe recording:
+
+```kotlin
+sessionRecording = SessionRecordingConfig(
+    enabled = true,
+    screenshot = true,   // capture screenshots instead of wireframes
+    maskAllImages = true, // recommended when using screenshots
+)
+```
+
+> **Warning:** Screenshots may contain sensitive information. Make sure masking is configured appropriately before enabling screenshot mode.
+
+## Opt out of data capture
+
+You can opt users out of data capture in two ways.
+
+Opt users out by default by setting `optOut` to `true` in your config:
+
+```kotlin
+PostHog.setup(
+    config = PostHogConfig(apiKey = "<ph_project_api_key>", optOut = true),
+    context = PostHogContext(),
+)
+```
+
+Or opt a user out (and back in) at runtime:
+
+```kotlin
+PostHog.optOut()
+PostHog.optIn()
+```
+
+Check whether a user is currently opted out:
+
+```kotlin
+if (PostHog.isOptedOut()) {
+    showConsentBanner()
+}
+```
+
+## Session management
+
+Access the identifiers PostHog uses for the current session:
+
+```kotlin
+val anonymousId = PostHog.getAnonymousId() // before identification
+val sessionId = PostHog.getSessionId()
+val distinctId = PostHog.getDistinctId()
+```
+
+## Flush
+
+The SDK batches events and flushes them periodically (`flushAt` events or every `flushIntervalSeconds`). To send all queued events immediately — for example before the app shuts down — call `flush`:
+
+```kotlin
+PostHog.flush()
+```
+
+## Reset after logout
+
+To reset the user's ID and anonymous ID, call `reset`. Usually you'd do this right after the user logs out.
+
+```kotlin
+PostHog.reset()
+```
+
+## Close
+
+To flush queued events and release resources during a clean shutdown, call `close`:
+
+```kotlin
+PostHog.close()
+```
+
+## Debug mode
+
+If you're not seeing the events, feature flags, or session replay behavior you expect, enable debug mode to see verbose logs about what the SDK is doing:
+
+```kotlin
+PostHog.setup(
+    config = PostHogConfig(apiKey = "<ph_project_api_key>", debug = true),
+    context = PostHogContext(),
+)
+
+// or at runtime
+PostHog.setDebug(true)
+```
+
+## All configuration options
+
+Pass these to `PostHogConfig` when calling `setup`.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `apiKey` | `String` | **Required** | Your PostHog project API key. |
+| `host` | `String` | `HOST_US` | PostHog instance URL. Use `PostHogConfig.HOST_US` (`https://us.i.posthog.com`) or `PostHogConfig.HOST_EU` (`https://eu.i.posthog.com`). |
+| `debug` | `Boolean` | `false` | Enables verbose SDK logging. |
+| `captureApplicationLifecycleEvents` | `Boolean` | `true` | Captures app open/close lifecycle events (mobile). |
+| `captureScreenViews` | `Boolean` | `false` | Automatically captures `$screen` events (Android). |
+| `captureDeepLinks` | `Boolean` | `true` | Captures deep link opens (Android). |
+| `sendFeatureFlagEvent` | `Boolean` | `true` | Sends `$feature_flag_called` when a flag is evaluated. |
+| `preloadFeatureFlags` | `Boolean` | `true` | Fetches feature flags automatically during setup. |
+| `flushAt` | `Int` | `20` | Number of queued events that triggers a flush. |
+| `flushIntervalSeconds` | `Int` | `30` | Maximum delay before queued events are flushed. |
+| `maxQueueSize` | `Int` | `1000` | Maximum number of events kept in the queue. |
+| `maxBatchSize` | `Int` | `50` | Maximum number of events sent in one batch. |
+| `optOut` | `Boolean` | `false` | Starts with analytics opted out. |
+| `personProfiles` | `PersonProfiles` | `IDENTIFIED_ONLY` | When person profiles are created: `IDENTIFIED_ONLY`, `ALWAYS`, or `NEVER`. |
+| `sessionRecording` | `SessionRecordingConfig?` | `null` | Enables and configures session replay (Android/iOS). |
+| `autocapture` | `Boolean` | `false` | Enables automatic event capture where the native platform supports it. |
+
+### Session recording options
+
+Pass a `SessionRecordingConfig` to `PostHogConfig.sessionRecording`. Defaults match the native Android and iOS SDKs.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | `Boolean` | `true` | Enables session recording. |
+| `maskAllTextInputs` | `Boolean` | `true` | Masks all text input values. |
+| `maskAllImages` | `Boolean` | `true` | Masks all images. |
+| `captureNetworkTelemetry` | `Boolean` | `true` | Includes network requests in the recording. |
+| `captureLogs` | `Boolean` | `false` | Captures console/system logs (iOS/Web). |
+| `screenshot` | `Boolean` | `false` | Uses screenshots instead of wireframes (experimental, Android/iOS). |
+| `captureLogcat` | `Boolean` | `true` | Captures Android logcat output (Android only). |
+| `debouncerDelayMs` | `Long` | `1000` | Touch event debounce delay in milliseconds (Android only). |
+
+## Platform support
+
+| Platform | Status | Backed by |
+| --- | --- | --- |
+| Android | ✅ | [posthog-android](/docs/libraries/android) (native) |
+| iOS | ✅ | [posthog-ios](/docs/libraries/ios) (native, via a Swift bridge) |
+| Web (JS) | ✅ | [posthog-js](/docs/libraries/js) |
+
+Because the SDK delegates to the native library on each platform, feature availability and behavior follow the underlying SDK. Session replay is available on Android and iOS; the web target inherits posthog-js behavior.
+
+# FAQ
+
+## Which platforms does the KMP SDK support?
+
+Android, iOS, and web (JS). The SDK is designed for Kotlin Multiplatform projects — including Compose Multiplatform — that share business logic across these targets.
+
+## Is this different from the Android SDK?
+
+Yes. The [Android SDK](/docs/libraries/android) is for native Android apps. The KMP SDK is for shared Kotlin code targeting multiple platforms, and it wraps the native Android, iOS, and JS SDKs so you can call one common API from `commonMain`.
+
+## Why don't I see surveys or logs?
+
+The KMP wrapper currently exposes event capture, identification, feature flags, group analytics, screen tracking, session replay, and error tracking. Surveys and logs aren't wrapped yet. Follow along or request them on [GitHub](https://github.com/PostHog/posthog-kmp/issues).

--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -17,18 +17,15 @@ features:
   logs: false
 ---
 
-The PostHog Kotlin Multiplatform (KMP) SDK lets you capture analytics from shared Kotlin code that runs on Android, iOS, and the web (JS). It's a thin wrapper that delegates to the official native PostHog SDKs on each target — [posthog-android](/docs/libraries/android) on Android, [posthog-ios](/docs/libraries/ios) on iOS, and [posthog-js](/docs/libraries/js) on the web — so you get native batching, queueing, and session replay behind a single common API.
+The PostHog Kotlin Multiplatform (KMP) SDK lets you capture analytics from shared Kotlin code that runs on Android, iOS, and the web. It's a thin wrapper that delegates to the official native PostHog SDKs on each target – [Android](/docs/libraries/android), [iOS](/docs/libraries/ios), and [JavaScript](/docs/libraries/js) – so you get native batching, queueing, and session replay behind a single common API.
 
 > **Early access:** This SDK is currently in a `0.x` pre-release. The API may change between minor versions until it stabilizes. We'd love your feedback on [GitHub](https://github.com/PostHog/posthog-kmp/issues).
 
 ## Installation
 
-Add the dependency to your shared module's `commonMain` source set.
+Add the dependency to your shared module's `commonMain` source set:
 
-### Gradle (Kotlin DSL)
-
-```kotlin
-// shared/build.gradle.kts
+```kotlin file=shared/build.gradle.kts
 kotlin {
     sourceSets {
         commonMain.dependencies {
@@ -38,22 +35,11 @@ kotlin {
 }
 ```
 
-### Version catalog
-
-```toml
-# gradle/libs.versions.toml
-[versions]
-posthog-kmp = "<version>"
-
-[libraries]
-posthog-kmp = { group = "com.posthog", name = "posthog-kmp", version.ref = "posthog-kmp" }
-```
-
 You can find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.posthog/posthog-kmp).
 
 ### Configure the SDK
 
-Initialize PostHog once, early in your app's lifecycle, by calling `PostHog.setup()` with a `PostHogConfig` and a platform `PostHogContext`.
+Initialize PostHog once, early in your app's lifecycle, by calling `PostHog.setup()` with a `PostHogConfig` and a platform `PostHogContext`:
 
 ```kotlin
 import com.posthog.kmp.PostHog
@@ -62,18 +48,18 @@ import com.posthog.kmp.PostHogContext
 
 PostHog.setup(
     config = PostHogConfig(
-        apiKey = "<ph_project_api_key>",
-        host = PostHogConfig.HOST_US, // or PostHogConfig.HOST_EU
+        apiKey = "<ph_project_token>",
+        host = "<ph_client_api_host>",
     ),
-    context = PostHogContext(), // platform-specific — see below
+    context = PostHogContext(), // platform-specific, see below
 )
 ```
 
-You can find your project API key and host in [your project settings](https://us.posthog.com/settings/project).
+You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). For convenience, `PostHogConfig.HOST_US` and `PostHogConfig.HOST_EU` are provided as constants for the two PostHog Cloud hosts.
 
 ### Platform-specific setup
 
-The only platform difference is how you build `PostHogContext`. Everything else — event capture, feature flags, config — is shared code.
+The only platform difference is how you build `PostHogContext`. Everything else – event capture, feature flags, config – is shared code.
 
 #### Android
 
@@ -85,7 +71,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         PostHog.setup(
-            config = PostHogConfig(apiKey = "<ph_project_api_key>"),
+            config = PostHogConfig(apiKey = "<ph_project_token>"),
             context = PostHogContext(application),
         )
     }
@@ -101,7 +87,7 @@ On iOS, use the no-argument `PostHogContext()`:
 fun MainViewController() = ComposeUIViewController {
     LaunchedEffect(Unit) {
         PostHog.setup(
-            config = PostHogConfig(apiKey = "<ph_project_api_key>"),
+            config = PostHogConfig(apiKey = "<ph_project_token>"),
             context = PostHogContext(),
         )
     }
@@ -109,7 +95,7 @@ fun MainViewController() = ComposeUIViewController {
 }
 ```
 
-#### Web (JS)
+#### Web
 
 On the web, use the no-argument `PostHogContext()`:
 
@@ -117,7 +103,7 @@ On the web, use the no-argument `PostHogContext()`:
 // main.kt
 fun main() {
     PostHog.setup(
-        config = PostHogConfig(apiKey = "<ph_project_api_key>"),
+        config = PostHogConfig(apiKey = "<ph_project_token>"),
         context = PostHogContext(),
     )
 }
@@ -160,9 +146,11 @@ PostHog.capture(
 
 ## Identifying users
 
-> We highly recommend reading our section on [identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
+import IdentifyFrontendCallout from '../../_snippets/identify-frontend-callout.mdx'
 
-Use `identify` to associate events with a specific user and (optionally) set [person properties](/docs/data/user-properties):
+<IdentifyFrontendCallout />
+
+Use `identify` to associate events with a specific user and, optionally, set [person properties](/docs/data/user-properties):
 
 ```kotlin
 PostHog.identify(
@@ -186,9 +174,15 @@ PostHog.identify(
 )
 ```
 
+## Anonymous and identified events
+
+import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
+
+<IdentifiedVsAnonymousIntro />
+
 ## Get the current user's distinct ID
 
-You may find it helpful to get the current user's distinct ID — for example, to check whether you've already called `identify` for a user. Call `getDistinctId()`, which returns either the ID automatically generated by PostHog or the one passed to `identify()`.
+You may find it helpful to get the current user's distinct ID – for example, to check whether you've already called `identify` for a user. Call `getDistinctId()`, which returns either the ID automatically generated by PostHog or the one passed to `identify()`:
 
 ```kotlin
 val distinctId = PostHog.getDistinctId()
@@ -196,7 +190,7 @@ val distinctId = PostHog.getDistinctId()
 
 ## Alias
 
-Sometimes you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible — for example, if a distinct ID used on the frontend isn't available in your backend. Use `alias` to assign another distinct ID to the same user:
+Sometimes you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible – for example, if a distinct ID used on the frontend isn't available in your backend. Use `alias` to assign another distinct ID to the same user:
 
 ```kotlin
 PostHog.alias("distinct_id")
@@ -217,7 +211,7 @@ PostHog.setPersonProperties(
 
 ## Super properties
 
-Super properties are properties you set once and then send with every subsequent `capture` call. They're set with `PostHog.register`, which takes a key and value, and they persist across sessions.
+Super properties are properties you set once and then send with every subsequent `capture` call. They're set with `PostHog.register`, which takes a key and value, and they persist across sessions:
 
 ```kotlin
 PostHog.register("team_id", 22)
@@ -237,9 +231,11 @@ If you're doing this as part of a user logging out, you can instead call `PostHo
 
 ## Feature flags
 
-PostHog's [feature flags](/docs/feature-flags) let you safely deploy and roll back new features. By default, flags are preloaded on setup (`preloadFeatureFlags = true`).
+import FeatureFlagsLibsIntro from '../_snippets/feature-flags-libs-intro.mdx'
 
-Check whether a flag is enabled:
+<FeatureFlagsLibsIntro />
+
+By default, flags are preloaded on setup (`preloadFeatureFlags = true`). Check whether a flag is enabled:
 
 ```kotlin
 if (PostHog.isFeatureEnabled("new_dashboard")) {
@@ -277,7 +273,7 @@ Get every evaluated flag at once as a map of `FeatureFlagResult`:
 val allFlags = PostHog.getAllFeatureFlags()
 ```
 
-Feature flags are fetched on setup and cached. If a user's properties change (for example after `identify`), reload them so they reflect the latest state:
+Feature flags are fetched on setup and cached. If a user's properties change (for example, after `identify`), reload them so they reflect the latest state:
 
 ```kotlin
 PostHog.reloadFeatureFlags {
@@ -299,7 +295,7 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 ## Group analytics
 
-Group analytics lets you associate a user's events with a group (e.g. a company, team, or organization). Read the [group analytics](/docs/product/group-analytics) guide for more information.
+Group analytics lets you associate a user's events with a group (for example, a company, team, or organization). Read the [group analytics](/docs/product/group-analytics) guide for more information.
 
 > **Note:** This is a paid feature and is not available on the free plan. Learn more on the [pricing page](/pricing).
 
@@ -371,7 +367,7 @@ import com.posthog.kmp.SessionRecordingConfig
 
 PostHog.setup(
     config = PostHogConfig(
-        apiKey = "<ph_project_api_key>",
+        apiKey = "<ph_project_token>",
         sessionRecording = SessionRecordingConfig(
             enabled = true,
             maskAllTextInputs = true, // mask sensitive text (default)
@@ -402,7 +398,7 @@ Opt users out by default by setting `optOut` to `true` in your config:
 
 ```kotlin
 PostHog.setup(
-    config = PostHogConfig(apiKey = "<ph_project_api_key>", optOut = true),
+    config = PostHogConfig(apiKey = "<ph_project_token>", optOut = true),
     context = PostHogContext(),
 )
 ```
@@ -434,15 +430,25 @@ val distinctId = PostHog.getDistinctId()
 
 ## Flush
 
-The SDK batches events and flushes them periodically (`flushAt` events or every `flushIntervalSeconds`). To send all queued events immediately — for example before the app shuts down — call `flush`:
+import FlushIntro from '../_snippets/flush-intro.mdx'
+
+<FlushIntro />
+
+import FlushManual from '../_snippets/flush-manual.mdx'
+
+<FlushManual />
 
 ```kotlin
 PostHog.flush()
 ```
 
+import FlushNotes from '../_snippets/flush-notes.mdx'
+
+<FlushNotes />
+
 ## Reset after logout
 
-To reset the user's ID and anonymous ID, call `reset`. Usually you'd do this right after the user logs out.
+To reset the user's ID and anonymous ID, call `reset`. Usually you'd do this right after the user logs out:
 
 ```kotlin
 PostHog.reset()
@@ -462,7 +468,7 @@ If you're not seeing the events, feature flags, or session replay behavior you e
 
 ```kotlin
 PostHog.setup(
-    config = PostHogConfig(apiKey = "<ph_project_api_key>", debug = true),
+    config = PostHogConfig(apiKey = "<ph_project_token>", debug = true),
     context = PostHogContext(),
 )
 
@@ -476,7 +482,7 @@ Pass these to `PostHogConfig` when calling `setup`.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `apiKey` | `String` | **Required** | Your PostHog project API key. |
+| `apiKey` | `String` | **Required** | Your PostHog project token. |
 | `host` | `String` | `HOST_US` | PostHog instance URL. Use `PostHogConfig.HOST_US` (`https://us.i.posthog.com`) or `PostHogConfig.HOST_EU` (`https://eu.i.posthog.com`). |
 | `debug` | `Boolean` | `false` | Enables verbose SDK logging. |
 | `captureApplicationLifecycleEvents` | `Boolean` | `true` | Captures app open/close lifecycle events (mobile). |
@@ -490,7 +496,7 @@ Pass these to `PostHogConfig` when calling `setup`.
 | `maxBatchSize` | `Int` | `50` | Maximum number of events sent in one batch. |
 | `optOut` | `Boolean` | `false` | Starts with analytics opted out. |
 | `personProfiles` | `PersonProfiles` | `IDENTIFIED_ONLY` | When person profiles are created: `IDENTIFIED_ONLY`, `ALWAYS`, or `NEVER`. |
-| `sessionRecording` | `SessionRecordingConfig?` | `null` | Enables and configures session replay (Android/iOS). |
+| `sessionRecording` | `SessionRecordingConfig?` | `null` | Enables and configures session replay (Android and iOS). |
 | `autocapture` | `Boolean` | `false` | Enables automatic event capture where the native platform supports it. |
 
 ### Session recording options
@@ -503,8 +509,8 @@ Pass a `SessionRecordingConfig` to `PostHogConfig.sessionRecording`. Defaults ma
 | `maskAllTextInputs` | `Boolean` | `true` | Masks all text input values. |
 | `maskAllImages` | `Boolean` | `true` | Masks all images. |
 | `captureNetworkTelemetry` | `Boolean` | `true` | Includes network requests in the recording. |
-| `captureLogs` | `Boolean` | `false` | Captures console/system logs (iOS/Web). |
-| `screenshot` | `Boolean` | `false` | Uses screenshots instead of wireframes (experimental, Android/iOS). |
+| `captureLogs` | `Boolean` | `false` | Captures console and system logs (iOS and web). |
+| `screenshot` | `Boolean` | `false` | Uses screenshots instead of wireframes (experimental, Android and iOS). |
 | `captureLogcat` | `Boolean` | `true` | Captures Android logcat output (Android only). |
 | `debouncerDelayMs` | `Long` | `1000` | Touch event debounce delay in milliseconds (Android only). |
 
@@ -512,22 +518,22 @@ Pass a `SessionRecordingConfig` to `PostHogConfig.sessionRecording`. Defaults ma
 
 | Platform | Status | Backed by |
 | --- | --- | --- |
-| Android | ✅ | [posthog-android](/docs/libraries/android) (native) |
-| iOS | ✅ | [posthog-ios](/docs/libraries/ios) (native, via a Swift bridge) |
-| Web (JS) | ✅ | [posthog-js](/docs/libraries/js) |
+| Android | ✅ | [PostHog Android](/docs/libraries/android) (native) |
+| iOS | ✅ | [PostHog iOS](/docs/libraries/ios) (native, via a Swift bridge) |
+| Web | ✅ | [PostHog.js](/docs/libraries/js) |
 
-Because the SDK delegates to the native library on each platform, feature availability and behavior follow the underlying SDK. Session replay is available on Android and iOS; the web target inherits posthog-js behavior.
+Because the SDK delegates to the native library on each platform, feature availability and behavior follow the underlying SDK. Session replay is available on Android and iOS; the web target inherits PostHog.js behavior.
 
-# FAQ
+## FAQ
 
-## Which platforms does the KMP SDK support?
+### Which platforms does the KMP SDK support?
 
-Android, iOS, and web (JS). The SDK is designed for Kotlin Multiplatform projects — including Compose Multiplatform — that share business logic across these targets.
+Android, iOS, and web. The SDK is designed for Kotlin Multiplatform projects – including Compose Multiplatform – that share business logic across these targets.
 
-## Is this different from the Android SDK?
+### Is this different from the Android SDK?
 
-Yes. The [Android SDK](/docs/libraries/android) is for native Android apps. The KMP SDK is for shared Kotlin code targeting multiple platforms, and it wraps the native Android, iOS, and JS SDKs so you can call one common API from `commonMain`.
+Yes. The [Android SDK](/docs/libraries/android) is for native Android apps. The KMP SDK is for shared Kotlin code targeting multiple platforms, and it wraps the native Android, iOS, and web SDKs so you can call one common API from `commonMain`.
 
-## Why don't I see surveys or logs?
+### Why don't I see surveys or logs?
 
 The KMP wrapper currently exposes event capture, identification, feature flags, group analytics, screen tracking, session replay, and error tracking. Surveys and logs aren't wrapped yet. Follow along or request them on [GitHub](https://github.com/PostHog/posthog-kmp/issues).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2445,6 +2445,14 @@ export const docsMenu = {
                             },
                         },
                         {
+                            name: 'Kotlin Multiplatform',
+                            url: '/docs/libraries/kmp',
+                            badge: {
+                                title: 'Beta',
+                                className: '!bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50',
+                            },
+                        },
+                        {
                             name: 'Node.js',
                             url: '/docs/libraries/node',
                             children: [


### PR DESCRIPTION
## Changes

Adds a docs page for the new **Kotlin Multiplatform (KMP)** SDK ([`PostHog/posthog-kmp`](https://github.com/PostHog/posthog-kmp)) at `/docs/libraries/kmp`, and registers it in the docs libraries sidebar.

The page mirrors the structure of the existing mobile SDK docs (Android/iOS) and covers:

- Installation (Gradle Kotlin DSL + version catalog)
- Per-platform setup (Android / iOS / Web)
- Event capture, identification, super properties, person properties
- Feature flags, experiments, group analytics
- Screen views, error tracking, session replay
- Opt-out, flush, reset, close, debug mode
- Full configuration reference (core + session recording), with defaults verified against the SDK source

## Draft — waiting on first release

Kept as a **draft** intentionally. The KMP SDK hasn't published its first version to Maven Central yet, so the `implementation("com.posthog:posthog-kmp:<version>")` install snippet won't resolve until `0.0.1` ships (see [posthog-kmp#3](https://github.com/PostHog/posthog-kmp/pull/3)). Ready to mark for review as soon as that release lands.

## Follow-ups

- No `kotlin`/`kmp` platform logo exists in `src/constants/logos.ts` yet, so this page ships without a `platformLogo`. A Kotlin/KMP icon can be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)