### PR TITLE
docs(error-tracking): skipping conflicting iOS dSYM uploads

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/ios.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/ios.mdx
@@ -117,6 +117,26 @@ POSTHOG_INCLUDE_SOURCE=1 ${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh
 
 </Step>
 
+<Step title="Optional: Skip conflicting uploads" badge="optional">
+
+If PostHog already has a dSYM with the same UUID but different content, the upload fails with `content_hash_mismatch` and stops your build. To skip these conflicting uploads and keep the existing symbols instead, set the `POSTHOG_SKIP_ON_CONFLICT` environment variable when calling the upload script:
+
+<MultiLanguage>
+
+```bash file=Swift Package Manager
+POSTHOG_SKIP_ON_CONFLICT=1 ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/posthog-ios/build-tools/upload-symbols.sh
+```
+
+```bash file=CocoaPods
+POSTHOG_SKIP_ON_CONFLICT=1 ${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh
+```
+
+</MultiLanguage>
+
+Requires posthog-ios 3.64.7 or later and posthog-cli 0.7.12 or later.
+
+</Step>
+
 <Step title="Build and verify" badge="required">
 
 Build your app in Xcode. The dSYM upload script will automatically run and upload symbols to PostHog.

--- a/contents/docs/error-tracking/upload-source-maps/react-native.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/react-native.mdx
@@ -110,7 +110,7 @@ The plugin accepts the following options:
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `disableSandboxing` | `boolean` | `true` | iOS only. When `true`, sets `ENABLE_USER_SCRIPT_SANDBOXING=NO` on your main app target's Xcode build configurations during `expo prebuild`. This lets the source map upload script read `.git/` (for release metadata) and lets stock Expo projects build without manually declaring input/output files on every script phase. |
-| `skipOnConflict` | `boolean` | `false` | Adds `--skip-on-conflict` to JavaScript source map uploads on iOS and Android. Use this when the same build can upload the same source maps more than once and you want duplicate uploads to be skipped instead of failing. Requires `posthog-react-native` 4.49.1 or later. |
+| `skipOnConflict` | `boolean` | `false` | Adds `--skip-on-conflict` to JavaScript source map uploads on iOS and Android. Use this when the same build can upload the same source maps more than once and you want duplicate uploads to be skipped instead of failing. Requires `posthog-react-native` 4.49.1 or later. When `uploadNativeSymbols` is enabled, it also applies to native iOS dSYM uploads: a build whose dSYM already exists in PostHog with different content skips the upload and keeps the existing symbols instead of failing. The dSYM behavior requires `posthog-react-native` 4.56.1 or later, `posthog-ios` 3.64.7 or later, and `posthog-cli` 0.7.12 or later. |
 
 Example opting out of the sandbox change:
 


### PR DESCRIPTION
## Changes

Documents the new dSYM conflict-skipping behavior shipped in posthog-ios 3.64.7 (PostHog/posthog-ios#716) and the Expo plugin counterpart in PostHog/posthog-js#4148:

- **iOS source maps page**: new optional step for `POSTHOG_SKIP_ON_CONFLICT=1` on the upload-symbols Run Script phase — keeps release builds going when a dSYM with the same UUID but different content already exists (existing symbols are kept). Mirrors the existing `POSTHOG_INCLUDE_SOURCE` step format.
- **React Native source maps page**: the `skipOnConflict` plugin-option row now covers native iOS dSYM uploads when `uploadNativeSymbols` is enabled, with the version floors.

⚠️ Draft until PostHog/posthog-js#4148 is released: the row cites `posthog-react-native` **4.56.1** as the floor on the assumption the pending changeset releases as a patch on 4.56.0 — please confirm the actual version at release before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)