### PR TITLE
Update referral bonus payment process details

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -257,7 +257,7 @@ We welcome referrals of family members as long as they will not work on the same
 
 #### Referral payouts
 
-You'll get paid the bonus 3 months from the new team member's start date, and it will be processed as part of payroll. If this date falls close to the payroll cutoff for that month, it may be included in the following month's payroll instead. Bear in mind that you might be liable for income tax on the bonus.
+You'll get paid the bonus 3 months from the new team member's start date, and it will be processed as part of payroll so you won't have to physical do anything as Talent will notify our Ops team upon hire of your referral. If this date falls close to the payroll cutoff for that month, it may be included in the following month's payroll instead. Bear in mind that you might be liable for income tax on the bonus.
 
 #### Non-team referrals
 


### PR DESCRIPTION
Clarified the referral bonus payment process by specifying that Talent will notify the Ops team upon hire.

## Changes

Added info about the referral payout that talent will notify ops - no further action needed on the team member who refers the new hire. 

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
