### PR TITLE
Fix broken session replay link in "opening their own pull requests" post

### DIFF
--- a/contents/blog/session-replays-opening-pull-requests.md
+++ b/contents/blog/session-replays-opening-pull-requests.md
@@ -17,7 +17,7 @@ tags:
 
 Errors are the easiest data to act on in our [product improvement pipeline](/blog/what-if-your-product-built-itself). They arrive with a stack trace that's groupable and says exactly what broke and where. This makes it easy for agents to research each one, and if it's actionable, open a PR to fix it. 
 
-[Session replays](/session-play) are a lot trickier. Someone clicks a button that doesn't respond, clicks it three more times, and leaves. Typically, nothing lands in your logs for this type of error. The only evidence is a recording nobody has time to watch. That's the most common kind of bug, and it's almost invisible to everything except a human watching the replay.
+[Session replays](/session-replay) are a lot trickier. Someone clicks a button that doesn't respond, clicks it three more times, and leaves. Typically, nothing lands in your logs for this type of error. The only evidence is a recording nobody has time to watch. That's the most common kind of bug, and it's almost invisible to everything except a human watching the replay.
 
 [Replay Vision](/docs/replay-vision) is our solution to this. It is our AI layer over session replay. You set up a scanner, aim it at the sessions you care about, and it reads them for you – all of them, not a sample. Scanners come in a few shapes: summarizers write up what happened in a session, scorers put a number on something like frustration, and classifiers sort sessions into buckets. 
 


### PR DESCRIPTION
## Problem

In [Our session replays are opening their own pull requests](https://posthog.com/blog/session-replays-opening-pull-requests), the **Session replays** link near the top of the post points to `/session-play`, which 404s.

## Fix

Corrected the target to `/session-replay` (the live product page, returns 200).

One-line change in `contents/blog/session-replays-opening-pull-requests.md`.

/cc @SaraMiteva — flagging you since it's your post. Requested your review for approval. 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
