### PR TITLE
Update research mode model to Claude Opus 4.6

### DIFF
--- a/contents/docs/posthog-ai/research-mode.mdx
+++ b/contents/docs/posthog-ai/research-mode.mdx
@@ -5,7 +5,7 @@ title: Research mode (Deep research)
 Research mode is currently in closed beta. Results may not be accurate or complete. If you find issues or have suggestions, please <a href="https://us.posthog.com/project/2/settings/#panel=support%3Asupport%3A%3A%3Afalse">reach out to us</a> to help us improve PostHog AI.
 </CalloutBox>
 
-Research mode is a powerful workflow for in-depth data analysis. It uses Claude Opus 4.5 with extended thinking capabilities to tackle complex, multi-faceted research projects that require deep investigation and synthesis.
+Research mode is a powerful workflow for in-depth data analysis. It uses Claude Opus 4.6 with extended thinking capabilities to tackle complex, multi-faceted research projects that require deep investigation and synthesis.
 
 ## What is research mode?
 
@@ -75,7 +75,7 @@ Research mode has access to:
 | Aspect | Regular chat | Research mode |
 |--------|-------------|---------------|
 | Best for | Quick questions, simple tasks | Deep investigations, multi-faceted analysis |
-| Model | Claude Sonnet | Claude Opus 4.5 with extended thinking |
+| Model | Claude Sonnet 4.6 | Claude Opus 4.6 with extended thinking |
 | Planning | Optional | Required (plan approval before research) |
 | Duration | Seconds to minutes | Up to 60 minutes for complex research |
 | Output | Direct answers, insights | Comprehensive research report notebook |


### PR DESCRIPTION
## Changes

The [research mode docs](https://posthog.com/docs/posthog-ai/research-mode) referenced **Claude Opus 4.5**, but research mode now runs on **Claude Opus 4.6** (and regular chat on **Sonnet 4.6**), per `ee/hogai/research_agent/executables.py` in the monorepo. Updated the intro sentence and the comparison table to match.

**Why:** Flagged in Slack — the stated model was out of date.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr)*
