### PR TITLE
Update project transfer requirements in documentation

### DIFF
--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -60,8 +60,7 @@ You can move a project from one organization to another through [project setting
 
 Before moving a project, keep these requirements in mind:
 
-- You need to be an owner or admin of the originating organization to transfer a project
-- You need to be a member of the target organization
+- You need to be an owner or admin of both the originating organization and the target organization to transfer a project
 - The originating organization must have at least two projects before you can move one
 - Since free organizations are limited to one project, you may need to temporarily upgrade your plan and add billing details to create a second project
 - After the move is complete, you can downgrade the original organization back to the free plan if desired


### PR DESCRIPTION
Clarified requirements for transferring a project between organizations.

## Changes

Updated to reflect the need to be an admin or owner in both the originating and target organization, removed the bullet that said you only needed to be a member of the ladder.



## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English

