### PR TITLE
Fix mobile Safari horizontal overflow on homepage hero

### DIFF
--- a/src/components/PlatformInstall/index.tsx
+++ b/src/components/PlatformInstall/index.tsx
@@ -217,7 +217,7 @@ export default function PlatformInstall({
 
     return (
         <div
-            className={`not-prose min-w-96 max-w-md inline-block border border-primary rounded bg-accent/40 shadow-2xl mb-2 ${className}`}
+            className={`not-prose min-w-[min(24rem,100%)] max-w-md inline-block border border-primary rounded bg-accent/40 shadow-2xl mb-2 ${className}`}
         >
             <div className="p-3 space-y-2">
                 <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Changes

Fixes the horizontal overlap/overflow on the homepage hero on mobile Safari (iOS).

The "Get started" install card (`PlatformInstall`) used a hard `min-w-96` (384px min-width). On a ~390px phone viewport, once the page's horizontal padding is subtracted, 384px doesn't fit — so the card overflowed the right edge. On mobile the card also shares a single-column CSS grid track with the hero paragraphs, so that 384px minimum stretched the entire text column, clipping every line (paragraphs, "500,000+", the `npx` command, "Sign up via web", the footer links) at the same right edge.

This swaps `min-w-96` for `min-w-[min(24rem,100%)]`: it keeps the 384px floor wherever there's room (desktop is unchanged) but caps it at the container width so it can never overflow a narrow viewport. The change is self-contained and only reduces the minimum in the exact case where 384px was already overflowing, so other usages of the card are unaffected.

**Why:** reported as a "weird overlap" on Safari iOS on the homepage.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784063324467279)*
