### PR TITLE
Docs: add toolbar bookmarklet launch instructions

### DIFF
--- a/contents/docs/toolbar/index.mdx
+++ b/contents/docs/toolbar/index.mdx
@@ -42,6 +42,30 @@ With it, you can interact with elements to [create actions](/tutorials/how-to-ca
     classes = {"rounded"}
 />
 
+### Launch the toolbar with a bookmarklet
+
+Once a URL is authorized, you can skip the **Launch Toolbar** page entirely and open the toolbar on whatever page you're currently viewing using a browser [bookmarklet](https://en.wikipedia.org/wiki/Bookmarklet). It reloads the current page through PostHog's `redirect_to_site` endpoint, which injects the toolbar.
+
+To set it up:
+
+1. Create a new bookmark in your browser (right-click the bookmarks bar → **Add page**, or ⌘/Ctrl+D and edit it).
+2. Give it a name, like "Launch PostHog toolbar".
+3. Paste the following as the bookmark's **URL**:
+
+```js
+javascript:(function(){var u=location.href.split('#')[0];location.href='https://us.posthog.com/api/user/redirect_to_site/?appUrl='+encodeURIComponent(u);})();
+```
+
+4. Save it. Now, on any authorized page, click the bookmark to launch the toolbar.
+
+> **EU Cloud:** Replace `us.posthog.com` with `eu.posthog.com` in the snippet above.
+
+A few things to keep in mind:
+
+- You need to be logged into your PostHog account in the same browser.
+- The page's URL must be added to your list of [authorized URLs](https://app.posthog.com/toolbar) first, otherwise the redirect won't inject the toolbar.
+- Clicking the bookmark triggers a quick page refresh before the toolbar appears.
+
 ## Creating actions using the toolbar
 
 The toolbar enables you to easily create [actions](/docs/data/actions) by clicking elements directly on your website.

--- a/contents/docs/toolbar/index.mdx
+++ b/contents/docs/toolbar/index.mdx
@@ -44,27 +44,29 @@ With it, you can interact with elements to [create actions](/tutorials/how-to-ca
 
 ### Launch the toolbar with a bookmarklet
 
-Once a URL is authorized, you can skip the **Launch Toolbar** page entirely and open the toolbar on whatever page you're currently viewing using a browser [bookmarklet](https://en.wikipedia.org/wiki/Bookmarklet). It reloads the current page through PostHog's `redirect_to_site` endpoint, which injects the toolbar.
+Instead of visiting the **Launch Toolbar** page each time, you can create a browser [bookmarklet](https://en.wikipedia.org/wiki/Bookmarklet) that opens the toolbar on whatever page you're currently viewing in one click. It works by reloading the current page through PostHog's `redirect_to_site` endpoint, which injects the toolbar.
 
 To set it up:
 
-1. Create a new bookmark in your browser (right-click the bookmarks bar → **Add page**, or ⌘/Ctrl+D and edit it).
-2. Give it a name, like "Launch PostHog toolbar".
-3. Paste the following as the bookmark's **URL**:
+1. Create a new bookmark in your browser (right-click the bookmarks bar → **Add page**, or press ⌘/Ctrl+D and edit it).
+2. Name it something like "Launch PostHog toolbar".
+3. Copy the snippet for your region below and paste it into the bookmark's **URL** field, then save.
 
-```js
+<MultiLanguage>
+
+```js file=US
 javascript:(function(){var u=location.href.split('#')[0];location.href='https://us.posthog.com/api/user/redirect_to_site/?appUrl='+encodeURIComponent(u);})();
 ```
 
-4. Save it. Now, on any authorized page, click the bookmark to launch the toolbar.
+```js file=EU
+javascript:(function(){var u=location.href.split('#')[0];location.href='https://eu.posthog.com/api/user/redirect_to_site/?appUrl='+encodeURIComponent(u);})();
+```
 
-> **EU Cloud:** Replace `us.posthog.com` with `eu.posthog.com` in the snippet above.
+</MultiLanguage>
 
-A few things to keep in mind:
+Now, on any [authorized page](https://app.posthog.com/toolbar), click the bookmark and the toolbar launches after a quick refresh.
 
-- You need to be logged into your PostHog account in the same browser.
-- The page's URL must be added to your list of [authorized URLs](https://app.posthog.com/toolbar) first, otherwise the redirect won't inject the toolbar.
-- Clicking the bookmark triggers a quick page refresh before the toolbar appears.
+For this to work, you need to be logged into your PostHog account in the same browser, and the page's URL must already be in your list of [authorized URLs](https://app.posthog.com/toolbar).
 
 ## Creating actions using the toolbar
 

--- a/contents/docs/toolbar/index.mdx
+++ b/contents/docs/toolbar/index.mdx
@@ -44,13 +44,14 @@ With it, you can interact with elements to [create actions](/tutorials/how-to-ca
 
 ### Launch the toolbar with a bookmarklet
 
-Instead of visiting the **Launch Toolbar** page each time, you can create a browser [bookmarklet](https://en.wikipedia.org/wiki/Bookmarklet) that opens the toolbar on whatever page you're currently viewing in one click. It works by reloading the current page through PostHog's `redirect_to_site` endpoint, which injects the toolbar.
+Instead of visiting the **Launch Toolbar** page each time, you can create a browser bookmarklet that opens the toolbar on whatever page you're currently viewing in one click. It works by reloading the current page through PostHog's `redirect_to_site` endpoint, which injects the toolbar.
 
 To set it up:
 
-1. Create a new bookmark in your browser (right-click the bookmarks bar → **Add page**, or press ⌘/Ctrl+D and edit it).
-2. Name it something like "Launch PostHog toolbar".
-3. Copy the snippet for your region below and paste it into the bookmark's **URL** field, then save.
+1. Make sure you're logged into your PostHog account in the same browser, and that the page's URL is in your list of [authorized URLs](https://app.posthog.com/toolbar).
+2. Create a new bookmark in your browser (right-click the bookmarks bar → **Add page**, or press ⌘/Ctrl+D and edit it).
+3. Name it something like "Launch PostHog toolbar".
+4. Copy the snippet for your region below and paste it into the bookmark's **URL** field, then save.
 
 <MultiLanguage>
 
@@ -64,9 +65,7 @@ javascript:(function(){var u=location.href.split('#')[0];location.href='https://
 
 </MultiLanguage>
 
-Now, on any [authorized page](https://app.posthog.com/toolbar), click the bookmark and the toolbar launches after a quick refresh.
-
-For this to work, you need to be logged into your PostHog account in the same browser, and the page's URL must already be in your list of [authorized URLs](https://app.posthog.com/toolbar).
+Now, on any authorized page, click the bookmark and the toolbar launches after a quick refresh.
 
 ## Creating actions using the toolbar
 


### PR DESCRIPTION
## Changes

Adds a "Launch the toolbar with a bookmarklet" subsection to the [Toolbar docs](https://posthog.com/docs/toolbar). It documents the `redirect_to_site` bookmarklet that opens the toolbar on the current page in one click, with step-by-step instructions for adding it to the browsers bookmarks bar, an EU Cloud note, and the prerequisites (logged in + URL authorized).

**Why:** A user asked whether we could document this bookmarklet trick and make it easy to add to browser bookmarks, since it is a much faster way to launch the toolbar than going through the Launch Toolbar page each time.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1784064528053789)*