### PR TITLE
Rewrite the influencers handbook page as a creator marketing guide

### DIFF
--- a/contents/handbook/marketing/influencers.md
+++ b/contents/handbook/marketing/influencers.md
@@ -26,7 +26,7 @@ Most of the value shows up later in this arc, not at the first collaboration, so
 
 ## Sourcing and evaluating influencers
 
-- You can find new influencers by looking at the creators engineers share or mention internally, searching for ones who have made relevant videos, looking at the recommendations of ones we've already sponsored, inbound, and [Kuli](https://kuli.one/#how-it-works).
+- You can find new influencers by looking at the creators engineers share or mention internally, searching for ones who have made relevant videos, looking at the recommendations of ones we've already sponsored, inbound, and [Kuli](https://kuli.one/#how-it-works) (AI-powered influener discovery tool).
 
 Don't limit yourself to individual creators. Great partnerships often come from other places too:
 
@@ -86,7 +86,7 @@ Treat agencies as an extension of the team, not a replacement for it.
 
 ## Working with PMMs
 
-Influencer marketing works best when we're involved early.
+Influencer marketing works best when involved early: i.e. if we have a big launch and we know exact dates, let #influence-wrangling channel in Slack know a month before (or just as soon as possible), this gives us time to prep the creators, make sure we fit in their schedules and have time to make a compelling story, naturally integrating new products into creators' content.
 
 For launches, we generally need:
 
@@ -96,8 +96,6 @@ For launches, we generally need:
 - visuals
 - launch timelines
 - someone available to answer technical questions
-
-The earlier we're involved, the more naturally creators can integrate new products into their content.
 
 ## What should the placement actually look like?
 
@@ -141,7 +139,7 @@ Consider both direct performance and longer-term strategic value when reviewing 
 
 ## Relationship management
 
-Creators are people, not inventory. The best partnerships are built over months or years, not a single sponsorship.
+We treat creators as people, not inventory. The best partnerships are built over months or years, not a single sponsorship.
 
 - Reply quickly.
 - Give thoughtful feedback.
@@ -153,7 +151,7 @@ The goal is for creators to think of PostHog first when they have a new idea and
 
 ## Events and conferences
 
-Conferences are rarely valuable because of the talks. They're valuable because of the people.
+Conferences are rarely valuable because of the talks, but they are really valuable because of the people that attend those. In the 2026 we've been to Stripe Sessions and VidCon - both of them provided us the opportunity to network with the right people and expand our creator roster.
 
 The biggest benefits usually come from:
 
@@ -170,8 +168,7 @@ If possible, prioritize speaking, hosting dinners, or organizing meetups over si
 We're constantly experimenting with new distribution channels. Current areas we're exploring include:
 
 - podcasts
-- TikTok creators
-- Instagram creators
+- Instagram & TikTok creators
 - startup founders as creators
 - agency partnerships
 - creator dinners and other IRL events

--- a/contents/handbook/marketing/influencers.md
+++ b/contents/handbook/marketing/influencers.md
@@ -4,19 +4,41 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We work with creators and influencers to make content about PostHog and sponsor placements to drive awareness and sign ups.
+We work with creators and influencers to make content about PostHog and sponsor placements that drive awareness and sign ups.
 
-We're open to inbound proposals, if you're interested in collaboration with us, you can send emails directly to <TeamMember name="Adlet Smykov" />, we're always open to seeing thoughtful proposals.
+We're always open to inbound proposals. If you'd like to collaborate with us, email <TeamMember name="Adlet Smykov" /> directly — we love seeing thoughtful ideas.
 
-Some of the influencers we sponsor include:
+## Our approach
 
-- [Theo](https://www.youtube.com/watch?v=6xXSsu0YXWo). He is a great partner for us. His audience is ideal, he is doing YouTube right, and he's a PostHog user.
-- [Fireship](https://www.youtube.com/@Fireship)
-- [Chris Raroque](https://www.youtube.com/@raroque)
+We don't think of influencer marketing as buying ads. We think of it as building long-term relationships with people our ICP already trusts.
+
+The best creators are usually users first. We'd rather work with someone who genuinely likes PostHog than someone with a much larger audience who has no connection to the product.
+
+We optimize for recurring collaborations over one-off sponsorships. The goal is to become part of a creator's story, not interrupt it.
+
+## Creator lifecycle
+
+A sponsorship shouldn't be viewed as a single transaction. The ideal lifecycle looks something like:
+
+**Discover → Evaluate → Outreach → First collaboration → Feedback → Repeat collaboration → Long-term partnership**
+
+Most of the value shows up later in this arc, not at the first collaboration, so it's worth investing early in creators you can see yourself working with again across launches.
 
 ## Sourcing and evaluating influencers
 
-- You can find new influencers by looking at the creators engineers share or mention internally, searching for ones who have made relevant videos, looking at the recommendations of ones we've already sponsored, inbound, and [Passionfroot](https://www.passionfroot.me/).
+- You can find new influencers by looking at the creators engineers share or mention internally, searching for ones who have made relevant videos, looking at the recommendations of ones we've already sponsored, inbound, and [Kuli](https://kuli.one/#how-it-works).
+
+Don't limit yourself to individual creators. Great partnerships often come from other places too:
+
+- recommendations from existing creator partners
+- agencies
+- conferences and IRL events
+- founders building interesting products
+- people actively sharing what they've built with PostHog
+
+The creator economy is surprisingly small. Building a good reputation compounds over time, so investing in long-term relationships is usually more valuable than constantly sourcing new creators.
+
+When you're evaluating a specific creator:
 
 - Their audience needs to be relevant to us, ideally targeting our [ICP](/handbook/who-we-build-for), but broadly engineers and founders.
 
@@ -30,9 +52,25 @@ Some of the influencers we sponsor include:
   - **Good**: 0.002–0.005 comment/view, 0.03–0.05 like/view
   - **Excellent:** 0.005+ comment/view, 0.05+ like/view
 
-- Above 5k views per video. Anything below this is just not worth your time. This number will likely grow over time. Larger influencers, although they charge a lot more, are often more efficient, so we don't have an upper limit for size. 
+- Above 5k views per video. Anything below this is just not worth your time. This number will likely grow over time. Larger influencers, although they charge a lot more, are often more efficient, so we don't have an upper limit for size.
 
-- Both short video creators and podcasters **haven't** worked well for us in terms of conversion and signups. We're open to trying this again in the future though.
+Different formats have different goals. Long-form YouTube continues to be our strongest acquisition channel, while podcasts, Instagram, TikTok, and other short-form content are opportunities we're actively exploring. Don't expect every format to optimize for direct sign ups — some are better at awareness, others at education or reaching entirely new audiences.
+
+## Working with agencies
+
+We increasingly work with agencies to help scale sourcing and relationship management.
+
+[Fundlevel](https://www.fundlevel.co/), a Canadian agency, is a long-term partner we really enjoy working with.
+
+Agencies are particularly useful when:
+
+- expanding into new regions
+- testing new creator categories
+- increasing the number of collaborations without increasing internal workload
+
+They're less useful for strategic partnerships or flagship creators where a direct relationship with PostHog is more valuable.
+
+Treat agencies as an extension of the team, not a replacement for it.
 
 ## Negotiating with influencers
 
@@ -40,13 +78,26 @@ Some of the influencers we sponsor include:
 
 - Ask for examples of other ad slots they've run to judge the quality of ad read.
 
-- For influencers we've never worked with, you should negotiate quite aggressively. The number they give is usually pulled out of a hat and is often 2-3x higher than it should be.
-
-- Use <PrivateLink url="https://docs.google.com/spreadsheets/d/1nqF-oNqSaWw-LjLBHySlf8hbyQs79nEHFwv_-bR-F7s/edit?usp=sharing">our model for how much a placement should cost</PrivateLink> to get to a better number and work towards that. Feel free to make changes to the model if you think it's not accurate.
+- For creators we've never worked with, the initial quote is often negotiable. Understand the value of the placement before agreeing on a price, and use <PrivateLink url="https://docs.google.com/spreadsheets/d/1nqF-oNqSaWw-LjLBHySlf8hbyQs79nEHFwv_-bR-F7s/edit?usp=sharing">our pricing model</PrivateLink> as a reference rather than treating the first quote as fixed. Feel free to update the model if you think it's not accurate.
 
 - Make sure the link is in the top 3 lines of the description.
 
 - We pay invoices net 30 (30 days after they've sent them to us).
+
+## Working with PMMs
+
+Influencer marketing works best when we're involved early.
+
+For launches, we generally need:
+
+- product context
+- messaging
+- demo access
+- visuals
+- launch timelines
+- someone available to answer technical questions
+
+The earlier we're involved, the more naturally creators can integrate new products into their content.
 
 ## What should the placement actually look like?
 
@@ -54,14 +105,14 @@ Some of the influencers we sponsor include:
 
 - Make sure they tell their audience to "mention them on sign up" or "say that they heard about PostHog from them" so we can track the attribution.
 
-- We generally let influencers decide on what the ad read is like so that it best fits their audience. We can provide guidance on what to talk about though. These points are helpful to share:
-  - The frame we want everything to ladder up to: **PostHog makes _your_ product self-driving** — it has all your product's data in one place, turns it into signals, and uses agents to find problems and opportunities and ship the fix. Keep the creator's product (or their viewers' products) as the thing that becomes self-driving. Avoid "PostHog is self-driving software" — that centers us instead of the outcome.
-  - PostHog is the platform for self-driving products. It provides all the tools developers need to build successful products.
-  - This means product analytics, web analytics, session replay, error tracking, experimentation, feature flags, AI Observability, surveys, and more.
-  - We also have a CDP for sending data to 50+ destinations and a data warehouse that lets you connect to external sources like your database, Stripe or Hubspot to query with SQL (or no code insights) alongside your product data.
-  - The goal of these tools is to help founders and engineers debug their product, understand their customers, analyze usage, and ship a more successful product faster.
-  - We have a generous free tier for every one of our tools. You can sign up and get started with all of them for free right away. 90% of users use PostHog for free.
-  - Setup is as simple as installing one of our SDKs or pasting a snippet into your site header, we then autocapture data like pageviews, button clicks, and sessions. We also have SDKs for all the popular backend languages like Python, Node, Go, etc.
+- We generally let influencers decide what the ad read is like so it best fits their audience. We can provide guidance on what to talk about though — our [brand foundations](/handbook/brand/foundations) go deeper, but the key points to get right:
+  - The frame everything should ladder up to: **PostHog makes _your_ product self-driving** — it puts all your product's data in one place, turns it into signals, and uses agents to find problems and opportunities and ship the fix. Keep the creator's product (or their viewers' products) as the thing that becomes self-driving; avoid "PostHog is self-driving software," which centers us instead of the outcome.
+  - PostHog is the platform for [self-driving products](/self-driving) — a suite of tools that gives developers (and their AI agents) everything they need to build successful products. Don't call it "an analytics platform" (we've grown well beyond that) or pitch it as a single product.
+  - Be specific rather than benefits-y. Developers can smell marketing fluff instantly, so "it does X" beats "it empowers you to unlock X."
+  - The suite spans product analytics, web analytics, session replay, error tracking, experimentation, feature flags, AI observability, and surveys. There's also a CDP for sending data to 50+ destinations and a data warehouse that connects to external sources like your database, Stripe, or Hubspot so you can query them with SQL (or no-code insights) alongside your product data.
+  - The goal of these tools: help founders and engineers debug their product, understand their customers, and ship a more successful product faster.
+  - There's a generous free tier for every tool — you can sign up and start using all of them for free right away, and 90% of users stay on PostHog's free tier.
+  - Setup is simple: install an SDK or paste a snippet into your site header, and we autocapture data like pageviews, clicks, and sessions. There are SDKs for all the popular backend languages too — Python, Node, Go, and so on.
 
 - There are a handful of video assets for them to [use here](https://drive.google.com/drive/folders/1RFTEb4E1D71wYuQm9smZ9eK79glmHp1m?usp=sharing). Feel free to add more, but also suggest the website and in-app as sources.
 
@@ -75,4 +126,53 @@ Some metrics we look at for individual videos include:
 - Unique sessions from the custom link (or clicks if you're using a Dub link)
 - Sign ups, either from converting from sessions or <PrivateLink url="https://us.posthog.com/project/2/insights/jdJgByZC">who mentioned the influencer on sign up</PrivateLink>
 
-We track these on our <PrivateLink url="https://docs.google.com/spreadsheets/d/1MmNUd9fFlZM3-SDk-HQ9cOmBY8XtqT7F97JFOAehxh8/edit?gid=702711155#gid=702711155">marketing budget and spending spreadsheet</PrivateLink>. We also have an <PrivateLink url="https://us.posthog.com/project/2/dashboard/493906">influencer marketing performance dashboard in PostHog</PrivateLink> that can help you get an overall view of different influencer's performance.
+We track these on our <PrivateLink url="https://docs.google.com/spreadsheets/d/1MmNUd9fFlZM3-SDk-HQ9cOmBY8XtqT7F97JFOAehxh8/edit?gid=702711155#gid=702711155">marketing budget and spending spreadsheet</PrivateLink>. For a per-influencer and per-video breakdown, <PrivateLink url="/hogwatch/performance">HogWatch</PrivateLink> joins that sheet with live sign up attribution and YouTube view counts. We also have an <PrivateLink url="https://us.posthog.com/project/2/dashboard/493906">influencer marketing performance dashboard in PostHog</PrivateLink> that can help you get an overall view of different influencers' performance.
+
+Remember that not every collaboration should be judged purely on attributed sign ups. Some partnerships are valuable because they:
+
+- introduce us to new audiences
+- build long-term brand affinity
+- lead to future collaborations
+- generate clips that can be reused across channels
+- strengthen relationships with creators or platforms
+
+Consider both direct performance and longer-term strategic value when reviewing partnerships.
+
+## Relationship management
+
+Creators are people, not inventory. The best partnerships are built over months or years, not a single sponsorship.
+
+- Reply quickly.
+- Give thoughtful feedback.
+- Celebrate good work.
+- Stay in touch between campaigns.
+- Meet creators in person when it makes sense.
+
+The goal is for creators to think of PostHog first when they have a new idea.
+
+## Events and conferences
+
+Conferences are rarely valuable because of the talks. They're valuable because of the people.
+
+The biggest benefits usually come from:
+
+- meeting creators
+- meeting agencies
+- meeting platform teams
+- strengthening existing relationships
+- making introductions that continue after the event
+
+If possible, prioritize speaking, hosting dinners, or organizing meetups over simply attending conferences.
+
+## Current experiments
+
+We're constantly experimenting with new distribution channels. Current areas we're exploring include:
+
+- podcasts
+- TikTok creators
+- Instagram creators
+- startup founders as creators
+- agency partnerships
+- creator dinners and other IRL events
+
+Not every experiment will work, and that's fine. Document the results and share what you've learned so the next person doesn't have to repeat the same experiment.

--- a/contents/handbook/marketing/influencers.md
+++ b/contents/handbook/marketing/influencers.md
@@ -135,6 +135,7 @@ Remember that not every collaboration should be judged purely on attributed sign
 - lead to future collaborations
 - generate clips that can be reused across channels
 - strengthen relationships with creators or platforms
+- are just really cool and worth doing for taste/vibes
 
 Consider both direct performance and longer-term strategic value when reviewing partnerships.
 
@@ -148,7 +149,7 @@ Creators are people, not inventory. The best partnerships are built over months 
 - Stay in touch between campaigns.
 - Meet creators in person when it makes sense.
 
-The goal is for creators to think of PostHog first when they have a new idea.
+The goal is for creators to think of PostHog first when they have a new idea and to bring weird ideas to us.
 
 ## Events and conferences
 


### PR DESCRIPTION
Reframes the influencers handbook page from "how to buy influencer ads" to how PostHog approaches creator marketing.

### What changed
- New sections: Our approach, Creator lifecycle, Working with agencies, Working with PMMs, Relationship management, Events and conferences, Current experiments
- Dropped the stale named roster
- Softened the negotiation guidance
- Added HogWatch to Measuring impact (alongside the budget sheet + PostHog dashboard)
- Reworked the placement talking points around the self-driving framing (kept master's "make your product self-driving" guidance) and the brand foundations
- Swapped Passionfroot → Kuli, and added Fundlevel as a long-term agency partner

Built on current master, so it keeps the self-driving talking points recently added there.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*