### PR TITLE
docs: KMP platform logo + wizard taxonomy (no wip — merge last)

### DIFF
--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -4,6 +4,7 @@ sidebarTitle: Kotlin Multiplatform
 sidebar: Docs
 showTitle: true
 github: 'https://github.com/PostHog/posthog-kmp'
+platformLogo: kmp
 features:
   eventCapture: true
   userIdentification: true

--- a/src/constants/installation-taxonomy.ts
+++ b/src/constants/installation-taxonomy.ts
@@ -146,7 +146,6 @@ export const TAXONOMY: InstallCategory[] = [
                 librarySlug: 'kmp',
                 wizard: true,
                 wizardOrder: 25,
-                status: 'wip',
             },
         ],
     },

--- a/src/constants/installation-taxonomy.ts
+++ b/src/constants/installation-taxonomy.ts
@@ -140,6 +140,14 @@ export const TAXONOMY: InstallCategory[] = [
                 wizardOrder: 21,
                 status: 'wip',
             },
+            {
+                slug: 'kmp',
+                name: 'Kotlin Multiplatform',
+                librarySlug: 'kmp',
+                wizard: true,
+                wizardOrder: 25,
+                status: 'wip',
+            },
         ],
     },
     {

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -66,6 +66,7 @@ export const LOGOS = {
     java: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/java.svg',
     javascript: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/js.svg',
     klaviyo: 'https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_02_02_T12_13_09_301_Z_1c73fd1ac6.png',
+    kmp: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/kmp.svg',
     kubernetes: 'https://res.cloudinary.com/dmukukwp6/image/upload/kubernetes_svgrepo_com_b9716be409.svg',
     langgraph: 'https://res.cloudinary.com/dmukukwp6/image/upload/langgraph_e5fee77551.svg',
     linear: 'https://res.cloudinary.com/dmukukwp6/image/upload/linear_c186e02f3c.png',


### PR DESCRIPTION
Follow-up to #18472 (merged).

> ⚠️ **Merge LAST.** This PR drops the `wip` status, so it advertises KMP as a fully-working wizard target — only true once wizard auto-install is live. **Do not merge until the context-mill release is out AND wizard PostHog/wizard#906 has landed.** Kept as a draft until then.

## Changes

1. **Kotlin logo** — added to `src/constants/logos.ts` under key `kmp` (uploaded to Cloudinary next to the other `integrate/` SDK logos), and referenced from the KMP docs page via `platformLogo: kmp`.
2. **Wizard taxonomy entry** — re-added the Kotlin Multiplatform entry to `src/constants/installation-taxonomy.ts` (it was dropped from the #18472 squash-merge), registered in the Mobile category.
3. **No `wip`** — the entry ships without `status: 'wip'`, so KMP shows as a full wizard target with no "Coming soon" badge. This is why the PR merges last.

Both the docs page header and the wizard framework row resolve the same `getLogo('kmp')`, so this one logo entry lights up both surfaces.

## Release order this depends on

```
context-mill#240  ✅ MERGED
  →  ⚠️ context-mill RELEASE  ← NOT yet cut. #240 merged without the `mcp-publish`
                                 label, so Build-and-Release skipped. A maintainer
                                 must run the "Build and Release MCP Resources"
                                 workflow (workflow_dispatch) to publish it.
  →  wizard#906  merged/released
  →  THIS PR  merged
```

`posthog-kmp` is already published on Maven Central (`0.0.2`); the gating here is wizard auto-install coverage, not the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
