### PR TITLE
feat(data-warehouse): add frill source doc

### DIFF
--- a/contents/docs/cdp/sources/frill.md
+++ b/contents/docs/cdp/sources/frill.md
@@ -1,0 +1,51 @@
+---
+title: Linking Frill as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Frill
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Frill connector syncs your Frill ideas, votes, comments, followers, and announcements into PostHog, so you can prioritize your roadmap against actual product usage.
+
+## Prerequisites
+
+You need a Frill account with access to its API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Frill, you'll need:
+
+- **API key** – find your API key under **Settings → Company** in your [Frill dashboard](https://app.frill.co/settings/company).
+
+## Sync modes
+
+<SyncModes />
+
+Frill list endpoints do not expose a server-side updated-since filter, so this source is full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key may be invalid or revoked. Find your API key under **Settings → Company** in your Frill dashboard, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Frill data warehouse source, implemented in [PostHog/posthog#71164](https://github.com/PostHog/posthog/pull/71164). Follows the canonical source-doc template: shared snippets, `<SourceParameters />`, and `<SourceTables />` (the source sets `lists_tables_without_credentials` and ships canonical table descriptions, so the Supported tables section renders fully).

**Why:** the source sets `docsUrl` to `/docs/cdp/sources/frill`, so the connector links here once released.

`audit_source_docs` passes for Frill with this file in place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
