### PR TITLE
docs: add Bitrise data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/bitrise.md
+++ b/contents/docs/cdp/sources/bitrise.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Bitrise connector pulls your CI data — apps, builds, workflows, and build artifacts — into the PostHog data warehouse, so you can analyze build durations, failure rates, and release cadence alongside your product data.
+The Bitrise connector pulls your CI data into the PostHog data warehouse, including apps, builds, workflows, and build artifacts, so you can analyze build durations, failure rates, and release cadence alongside your product data.
 
 ## Prerequisites
 

--- a/contents/docs/cdp/sources/bitrise.md
+++ b/contents/docs/cdp/sources/bitrise.md
@@ -1,0 +1,57 @@
+---
+title: Linking Bitrise as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Bitrise
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Bitrise connector pulls your CI data — apps, builds, workflows, and build artifacts — into the PostHog data warehouse, so you can analyze build durations, failure rates, and release cadence alongside your product data.
+
+## Prerequisites
+
+You need a Bitrise account with access to the apps you want to sync, and a personal access token or workspace API token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+You need a Bitrise API token:
+
+- **Personal access token**: create one in your [Bitrise security settings](https://app.bitrise.io/me/account/security). It has access to the same apps as your user.
+- **Workspace API token**: create one from your workspace's settings page. It is scoped to a single workspace and is the more secure option for team use.
+
+Paste the token in the **API token** field and click **Next**.
+
+## Sync modes
+
+<SyncModes />
+
+The `builds` table supports incremental sync on `triggered_at`. Note that the Bitrise API only returns builds from roughly the last 200 days, so older builds are not synced.
+
+The `artifacts` table is disabled by default because it makes one API request per build. Enable it only if you need artifact metadata.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- **Invalid Bitrise API token**: the token is invalid or has been revoked. Create a new token in your Bitrise security settings and reconnect the source.
+- **Missing builds**: the Bitrise API caps the builds listing at roughly the last 200 days. Builds older than that are not available to sync.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Bitrise data warehouse source, implemented in [PostHog/posthog#71166](https://github.com/PostHog/posthog/pull/71166). Follows the canonical warehouse source doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`), with `sourceId: Bitrise` matching the `ExternalDataSourceType` value and the filename matching the source's `docsUrl` slug.

`python manage.py audit_source_docs` in the posthog repo passes for Bitrise with this file in place.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
