### PR TITLE
Add AskNicely data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/asknicely.md
+++ b/contents/docs/cdp/sources/asknicely.md
@@ -1,0 +1,50 @@
+---
+title: Linking AskNicely as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Asknicely
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The AskNicely connector syncs your survey response history – NPS, CSAT, and 5-star scores, comments, and contact details – into PostHog, so you can join satisfaction data with product usage and revenue data.
+
+## Prerequisites
+
+You need an AskNicely account with API access. Your API key is available in AskNicely under **Settings > API**.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking AskNicely, you'll need:
+
+- **Account subdomain** – the first part of your AskNicely URL. If you sign in at `https://yourcompany.asknice.ly`, the subdomain is `yourcompany`.
+- **API key** – found in your AskNicely account under **Settings > API**.
+
+## Sync modes
+
+<SyncModes />
+
+For the `responses` table, we recommend incremental sync on the `responded` field: each sync then only fetches responses received since the previous one.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new AskNicely data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`). Companion to [PostHog/posthog#71179](https://github.com/PostHog/posthog/pull/71179), which implements the source with `docsUrl` pointing at `/docs/cdp/sources/asknicely`.

The connector ships as alpha, so the doc renders the `<AlphaRelease />` callout. `audit_source_docs` passes for this source against this checkout.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a – new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
