### PR TITLE
feat(docs): add Railway data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/railway.md
+++ b/contents/docs/cdp/sources/railway.md
@@ -7,7 +7,6 @@ availability:
   selfServe: full
   enterprise: full
 sourceId: Railway
-beta: true
 ---
 
 import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"

--- a/contents/docs/cdp/sources/railway.md
+++ b/contents/docs/cdp/sources/railway.md
@@ -1,0 +1,58 @@
+---
+title: Linking Railway as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Railway
+beta: true
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Railway connector syncs your [Railway](https://railway.com/) projects, services, environments, deployments, project members, and volumes into PostHog. This is useful for analyzing deployment activity and failure rates alongside your product data.
+
+## Prerequisites
+
+You need a Railway account with access to the projects you want to sync, and permission to create an API token for your account or workspace.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+You need a Railway API token:
+
+1. Go to your [Railway account settings](https://railway.com/account/tokens).
+2. Create a new token. To sync a specific workspace's projects, select that workspace when creating the token. A token created without a workspace is an account token and syncs all projects your account can access.
+3. Back in PostHog, paste the token into the `API token` field and click **Next**.
+
+Project tokens are not supported. They are scoped to a single environment and can't list your projects.
+
+Railway rate limits API requests per plan (as low as 100 requests/hour on the Free plan), so a large initial sync can take a while.
+
+## Sync modes
+
+<SyncModes />
+
+The `deployments` table supports incremental syncs: each run pulls deployments created since the last sync, plus a one-day lookback so recent status changes (for example a deployment moving from `DEPLOYING` to `SUCCESS`) are picked up. Status changes on older deployments are only reflected on a full refresh. All other tables are small and sync as full refreshes.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+**"Your Railway API token is invalid, revoked, or lacks access"**: create a new account or workspace token in your [Railway account settings](https://railway.com/account/tokens) and reconnect. Make sure you didn't paste a project token.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/railway.md
+++ b/contents/docs/cdp/sources/railway.md
@@ -29,7 +29,7 @@ You need a Railway account with access to the projects you want to sync, and per
 You need a Railway API token:
 
 1. Go to your [Railway account settings](https://railway.com/account/tokens).
-2. Create a new token. To sync a specific workspace's projects, select that workspace when creating the token. A token created without a workspace is an account token and syncs all projects your account can access.
+2. Create a new token. To sync projects from a specific workspace, select that workspace when creating the token. A token created without a workspace is an account token and syncs all projects your account can access.
 3. Back in PostHog, paste the token into the `API token` field and click **Next**.
 
 Project tokens are not supported. They are scoped to a single environment and can't list your projects.
@@ -40,7 +40,7 @@ Railway rate limits API requests per plan (as low as 100 requests/hour on the Fr
 
 <SyncModes />
 
-The `deployments` table supports incremental syncs: each run pulls deployments created since the last sync, plus a one-day lookback so recent status changes (for example a deployment moving from `DEPLOYING` to `SUCCESS`) are picked up. Status changes on older deployments are only reflected on a full refresh. All other tables are small and sync as full refreshes.
+The `deployments` table supports incremental syncs: each run pulls deployments created since the last sync, and also re-syncs the previous day of deployments so recent status changes (for example a deployment moving from `DEPLOYING` to `SUCCESS`) are picked up. Status changes on older deployments are only reflected on a full refresh. All other tables are small and sync as full refreshes.
 
 ## Configuration
 


### PR DESCRIPTION
## Changes

Adds the source doc for the new Railway data warehouse connector, shipped in [PostHog/posthog#71204](https://github.com/PostHog/posthog/pull/71204). Follows the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`); the source sets `lists_tables_without_credentials = True`, so the Supported tables section renders from the API.

**Why:** the connector ships with `docsUrl` pointing at `/docs/cdp/sources/railway`, so this page needs to exist to avoid a 404 from the source setup wizard.

`manage.py audit_source_docs` in the posthog repo passes for this doc (filename, slug, and `sourceId: Railway` all agree).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
