### PR TITLE
docs(data-warehouse): add cronitor source doc

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -67,6 +67,7 @@ Coinbase
 Contentful
 [Cc]onvex
 Crazy Egg
+Cronitor
 Crossplane
 Crowdin
 [Cc]ursor

--- a/contents/docs/cdp/sources/cronitor.md
+++ b/contents/docs/cdp/sources/cronitor.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Cronitor connector syncs your monitors, their recent job invocations, and time-series reliability metrics into the PostHog Data warehouse, so you can analyze scheduled-job reliability, run durations, and failure trends alongside your product data.
+The Cronitor connector syncs your monitors, their recent job invocations, and time-series reliability metrics into the PostHog Data Warehouse, so you can analyze scheduled-job reliability, run durations, and failure trends alongside your product data.
 
 ## Prerequisites
 

--- a/contents/docs/cdp/sources/cronitor.md
+++ b/contents/docs/cdp/sources/cronitor.md
@@ -1,0 +1,52 @@
+---
+title: Linking Cronitor as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Cronitor
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Cronitor connector syncs your monitors, their recent job invocations, and time-series reliability metrics into the PostHog Data warehouse, so you can analyze scheduled-job reliability, run durations, and failure trends alongside your product data.
+
+## Prerequisites
+
+You need a Cronitor account and an API key with the `monitor:read` scope. Cronitor creates default API keys for every account, and you can create additional scoped keys at any time.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Cronitor, you'll need:
+
+- **API key** – find or create one under **Settings → API keys** in your Cronitor account. The key needs the `monitor:read` scope.
+
+## Sync modes
+
+<SyncModes />
+
+The `monitors` and `invocations` tables have no server-side time filter in the Cronitor API, so they always sync as a full refresh. The `invocations` table is a snapshot of each monitor's most recent runs; for long-term trends, use the `metrics` table, which syncs incrementally over time windows using its `stamp` field.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key in your Cronitor account's API settings, then reconnect.
+- If you see a permissions error, the key is missing the `monitor:read` scope. Update the key's scopes, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Cronitor data warehouse source, implemented in [PostHog/posthog#71208](https://github.com/PostHog/posthog/pull/71208). Follows the canonical source-doc template: alpha callout, shared snippets, and `<SourceParameters />` / `<SourceTables />` rendered from the source config API (`sourceId: Cronitor`).

Validated with `python manage.py audit_source_docs` from the posthog repo: filename, `docsUrl`, and `sourceId` all agree.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*