### PR TITLE
docs: add swarmia data warehouse source

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -250,6 +250,7 @@ Substack
 Supabase
 [Ss]uperhuman
 [Ss]uperset
+Swarmia
 Synthesia
 Tailscale
 Temporal\.io

--- a/contents/docs/cdp/sources/swarmia.md
+++ b/contents/docs/cdp/sources/swarmia.md
@@ -16,11 +16,11 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Swarmia connector syncs your engineering effectiveness reports — pull request metrics, DORA metrics, investment balance, software capitalization, and effort reporting — into the PostHog Data warehouse, so you can blend engineering metrics with your product, finance, and headcount data.
+The Swarmia connector syncs your engineering effectiveness reports – pull request metrics, DORA metrics, investment balance, software capitalization, and effort reporting – into the PostHog Data Warehouse, so you can blend engineering metrics with your product, finance, and headcount data.
 
 ## Prerequisites
 
-You need a Swarmia account with permission to create API tokens. Some reports (investment balance, software capitalization, effort) map to Swarmia features that may not be enabled on every plan — tables your token can't access are flagged in the table picker.
+You need a Swarmia account with permission to create API tokens. Some reports (investment balance, software capitalization, effort) map to Swarmia features that may not be enabled on every plan – tables your token can't access are flagged in the table picker.
 
 ## Adding a data source
 

--- a/contents/docs/cdp/sources/swarmia.md
+++ b/contents/docs/cdp/sources/swarmia.md
@@ -1,0 +1,53 @@
+---
+title: Linking Swarmia as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Swarmia
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Swarmia connector syncs your engineering effectiveness reports — pull request metrics, DORA metrics, investment balance, software capitalization, and effort reporting — into the PostHog Data warehouse, so you can blend engineering metrics with your product, finance, and headcount data.
+
+## Prerequisites
+
+You need a Swarmia account with permission to create API tokens. Some reports (investment balance, software capitalization, effort) map to Swarmia features that may not be enabled on every plan — tables your token can't access are flagged in the table picker.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Swarmia, you'll need:
+
+- **API token** – create one in your Swarmia workspace under **Settings → API tokens**.
+
+## Sync modes
+
+<SyncModes />
+
+Swarmia's export API returns time-windowed aggregate reports rather than individual records, so each table is built from complete reporting windows: ISO weeks for pull request and DORA metrics, calendar months for investment, capitalization, and effort. The current (incomplete) week or month is only synced once it has ended.
+
+Swarmia generates FTE-based data (investment, capitalization, effort) around the 10th day of the following month, so the most recent month can lag. Incremental tables re-read a trailing window on each sync to pick up late or regenerated data.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If a table fails to sync with a permissions error, your Swarmia API token can't access that report. This usually means the matching Swarmia feature (for example investment balance or software capitalization) isn't enabled for your organization or plan.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Swarmia data warehouse source, `contents/docs/cdp/sources/swarmia.md`, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, alpha callout).

Companion to the source implementation in [PostHog/posthog#71215](https://github.com/PostHog/posthog/pull/71215) — the doc's slug matches the source's `docsUrl` (`/docs/cdp/sources/swarmia`) and its `sourceId` (`Swarmia`) matches the `ExternalDataSourceType` value, verified with `python manage.py audit_source_docs`. Should merge once that PR's stack lands so the source config API has data for the rendered components.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
