### PR TITLE
docs(cdp): add Splunk AppDynamics (Cisco) source doc

### DIFF
--- a/contents/docs/cdp/sources/appdynamics.md
+++ b/contents/docs/cdp/sources/appdynamics.md
@@ -1,0 +1,61 @@
+---
+title: Linking Splunk AppDynamics (Cisco) as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Appdynamics
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Splunk AppDynamics (Cisco) connector syncs your APM data into the PostHog Data warehouse, including applications, business transactions, tiers, nodes, health rule violations, and metric time series. This lets you join application performance signals with your product data for SLA and SLO reporting.
+
+## Prerequisites
+
+You need access to an AppDynamics controller (SaaS or on-premises) and either:
+
+- an **API client** created under **Administration → API Clients** in your controller (recommended), or
+- a **username and password** for a local controller user.
+
+The API client or user needs read access to the applications you want to sync. If your account signs in via Cisco Identity Provider, basic authentication is disabled and an API client is required.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking AppDynamics, you'll need:
+
+- **Controller URL** – your controller's base URL, e.g. `https://mycompany.saas.appdynamics.com`.
+- **Account name** – your controller account name, e.g. `mycompany`. You can find it under **Settings → License** in the controller.
+- **Authentication** – either an API client name and client secret, or a username and password.
+- **Metric paths** (optional) – the metric browser paths to sync into the `metric_data` table, one per line. Wildcards are supported, e.g. `Business Transaction Performance|*|*|Average Response Time (ms)`. Defaults to `Overall Application Performance|*`.
+
+## Sync modes
+
+<SyncModes />
+
+The `health_rule_violations` and `metric_data` tables sync incrementally using the row's start time (`startTimeInMillis`). Violations are synced when they start, so status changes to previously synced violations (for example, a violation resolving) are only picked up on a full refresh. The other tables support full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your credentials are invalid or expired, or the OAuth token exchange failed. Check your controller URL, account name, and API client name and secret, then reconnect.
+- If you see a permissions error, your user or API client is missing read access to application data. Grant the required roles in the controller, then reconnect.
+- If the `metric_data` table is empty, check that your configured metric paths match entries in the controller's metric browser for the synced applications.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new `appdynamics` data warehouse source, implemented in [PostHog/posthog#71214](https://github.com/PostHog/posthog/pull/71214) (stacked on the scaffold PR [PostHog/posthog#71137](https://github.com/PostHog/posthog/pull/71137)). Follows the canonical source-doc template with the shared snippets, `<SourceParameters />`, and `<SourceTables />`; `sourceId: Appdynamics` matches the `ExternalDataSourceType` value and the filename matches the source's `docsUrl` slug. `audit_source_docs` reports no issues for this source.

This should merge alongside (or after) the source implementation PR.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*