### PR TITLE
docs: add customerly data warehouse source doc

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -71,6 +71,7 @@ Crossplane
 Crowdin
 [Cc]ursor
 Customer\.io
+Customerly
 Databricks
 Datadog
 DBeaver

--- a/contents/docs/cdp/sources/customerly.md
+++ b/contents/docs/cdp/sources/customerly.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Customerly connector syncs your customer support and marketing data – users, leads, tags, and knowledge base content – into the PostHog Data warehouse, so you can analyze your contacts and help center alongside your product data.
+The Customerly connector syncs your customer support and marketing data – users, leads, tags, and knowledge base content – into the PostHog Data Warehouse, so you can analyze your contacts and help center alongside your product data.
 
 ## Prerequisites
 

--- a/contents/docs/cdp/sources/customerly.md
+++ b/contents/docs/cdp/sources/customerly.md
@@ -1,0 +1,51 @@
+---
+title: Linking Customerly as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Customerly
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Customerly connector syncs your customer support and marketing data – users, leads, tags, and knowledge base content – into the PostHog Data warehouse, so you can analyze your contacts and help center alongside your product data.
+
+## Prerequisites
+
+You need a Customerly project with access to the public API so you can copy its access token.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Customerly, you'll need:
+
+- **Access token** – in Customerly, go to **Project Settings** → **Installation** → **Public API** and copy the access token. See the [Customerly guide](https://docs.customerly.io/en/api/how-to-obtain-your-api-access-token-in-customerly) for details.
+
+## Sync modes
+
+<SyncModes />
+
+All Customerly tables are full refresh only, since the API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your Customerly access token is invalid or expired. Generate a new token under **Project Settings** → **Installation** → **Public API**, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
Adds the user-facing doc for the new Customerly data warehouse source, implemented in [PostHog/posthog#71212](https://github.com/PostHog/posthog/pull/71212).

Follows the canonical source-doc template: shared snippets (`SourceSetupIntro`, `SyncModes`, `AlphaRelease`, `TroubleshootingLink`) plus `<SourceParameters />` and `<SourceTables />` rendered from the `public_source_configs` API (the source sets `lists_tables_without_credentials` and ships canonical table/column descriptions). `sourceId: Customerly` matches the `ExternalDataSourceType` value and the filename matches the source's `docsUrl` slug; `audit_source_docs` reports no customerly issues.

**Why:** a finished warehouse source ships with its posthog.com doc so the in-app `docsUrl` link and the public source catalog don't 404.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
