### PR TITLE
Add Cisco Duo data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/cisco-duo.md
+++ b/contents/docs/cdp/sources/cisco-duo.md
@@ -1,0 +1,62 @@
+---
+title: Linking Cisco Duo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: CiscoDuo
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Cisco Duo connector syncs your Duo Admin API data into the PostHog Data warehouse: authentication, administrator, telephony, and activity logs, plus users, groups, phones, admins, and integrations. This lets you analyze MFA success and failure rates, enrollment coverage, and unusual access patterns alongside your product data.
+
+## Prerequisites
+
+You need a Duo account on an edition that includes the Admin API, and a Duo administrator with the **Owner** role to create the Admin API application.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Cisco Duo, you'll need credentials from a Duo **Admin API** application:
+
+1. In the [Duo Admin Panel](https://admin.duosecurity.com/), go to **Applications** and click **Protect an Application**.
+2. Search for **Admin API** and click **Protect**.
+3. Copy the **integration key**, **secret key**, and **API hostname** (e.g. `api-XXXXXXXX.duosecurity.com`) into PostHog.
+
+Grant the application the permissions matching the tables you want to sync:
+
+- **Grant read log** – authentication, administrator, telephony, and activity logs
+- **Grant read resource** – users, groups, phones
+- **Grant administrators** – admins
+- **Grant applications** – integrations
+
+## Sync modes
+
+<SyncModes />
+
+The log tables sync incrementally using Duo's time-based filters. Administrator log events have no unique id, so that table is append-only. The resource tables (users, groups, phones, admins, integrations) are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, the integration key, secret key, or API hostname is wrong, or the keys were revoked. Duo also rejects requests from servers with significant clock skew.
+- If you see a permissions error, your Admin API application is missing the permission needed for that table. Grant the matching permission (read log, read resource, administrators, or applications) in the Duo Admin Panel, then try again.
+- Duo retains logs for a limited period (around 180 days depending on edition), so the first sync of a log table only reaches back that far.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Cisco Duo data warehouse source, implemented in [PostHog/posthog#71218](https://github.com/PostHog/posthog/pull/71218). Follows the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`), with `sourceId: CiscoDuo` matching the enum and the slug matching the source's `docsUrl` (`/docs/cdp/sources/cisco-duo`).

Should merge alongside (or after) the source PR so the `public_source_configs` API has the CiscoDuo entry the components render from.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
