### PR TITLE
docs: add Travis CI data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/travis-ci.md
+++ b/contents/docs/cdp/sources/travis-ci.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Travis CI connector syncs your CI/CD data – repositories, builds, jobs, and branches – into the PostHog Data warehouse, so you can analyze build durations, failure rates, and delivery metrics alongside your product data.
+The Travis CI connector syncs your CI/CD data – repositories, builds, jobs, and branches – into the PostHog Data Warehouse, so you can analyze build durations, failure rates, and delivery metrics alongside your product data.
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ When linking Travis CI, you'll need:
 
 <SyncModes />
 
-Builds and jobs sync incrementally: each sync pages newest-first and stops at the last synced id. Builds or jobs that were still running when a sync last saw them keep the state from that sync – run a full refresh to re-pull final states. Repositories and branches are full refresh only.
+Builds and jobs sync incrementally: each sync pages newest-first and stops at the last synced ID. Builds or jobs that were still running when a sync last saw them keep the state from that sync – run a full refresh to re-pull final states. Repositories and branches are full refresh only.
 
 ## Configuration
 

--- a/contents/docs/cdp/sources/travis-ci.md
+++ b/contents/docs/cdp/sources/travis-ci.md
@@ -1,0 +1,51 @@
+---
+title: Linking Travis CI as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: TravisCI
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Travis CI connector syncs your CI/CD data – repositories, builds, jobs, and branches – into the PostHog Data warehouse, so you can analyze build durations, failure rates, and delivery metrics alongside your product data.
+
+## Prerequisites
+
+You need a Travis CI (travis-ci.com) account with an API token. The token can read every repository its owning user has access to, and only those repositories are synced. Self-hosted Travis CI Enterprise instances are not supported.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Travis CI, you'll need:
+
+- **API token** – find or generate it in your [Travis CI settings](https://app.travis-ci.com/account/preferences) under **API authentication**, or run `travis token --com` with the Travis CI CLI.
+
+## Sync modes
+
+<SyncModes />
+
+Builds and jobs sync incrementally: each sync pages newest-first and stops at the last synced id. Builds or jobs that were still running when a sync last saw them keep the state from that sync – run a full refresh to re-pull final states. Repositories and branches are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an "access denied" or authorization error, your Travis CI API token is invalid or has been revoked. Generate a new token in your Travis CI settings, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Travis CI data warehouse connector, implemented in [PostHog/posthog#71220](https://github.com/PostHog/posthog/pull/71220). Follows the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`), with the alpha callout since the source ships as `releaseStatus=ALPHA`. `sourceId: TravisCI` and the filename match the source's `docsUrl` (`/docs/cdp/sources/travis-ci`); `audit_source_docs` in the main repo reports no travis-related failures.

This should merge alongside (or after) the connector PR so the doc doesn't point at a source that isn't registered yet.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
