### PR TITLE
docs: add Jamf Pro data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/jamf-pro.md
+++ b/contents/docs/cdp/sources/jamf-pro.md
@@ -1,0 +1,60 @@
+---
+title: Linking Jamf Pro as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: JamfPro
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Jamf Pro connector syncs your Apple device management data – computer inventory, mobile devices, groups, buildings, departments, categories, sites, scripts, and packages – into PostHog.
+
+## Prerequisites
+
+You need a Jamf Pro instance (cloud-hosted like `yourcompany.jamfcloud.com`, or self-hosted) and either an API client or a user account with read access to the objects you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Jamf Pro, you'll need your **Jamf Pro URL** (e.g. `yourcompany.jamfcloud.com`) and one of the following:
+
+### Option 1: API client (recommended)
+
+1. In Jamf Pro, go to **Settings** > **System** > **API roles and clients**.
+2. On the **API roles** tab, create a role with **read** privileges for the objects you want to sync, for example: Computers, Mobile Devices, Buildings, Departments, Categories, Sites, Smart Computer Groups, Static Computer Groups, Scripts, and Packages.
+3. On the **API clients** tab, create a client, assign it the role, and click **Enable API client**.
+4. Copy the **client ID** and generate a **client secret**. The secret is only shown once.
+
+### Option 2: Username and password
+
+Use a Jamf Pro user account with read access to the objects you want to sync. PostHog only uses the credentials to mint short-lived API tokens.
+
+## Sync modes
+
+<SyncModes />
+
+The `computers` table supports incremental syncs using the inventory report date, so only computers that submitted inventory since the last sync are fetched. Jamf collects device inventory once a day by default, so syncing more often than every few hours rarely surfaces new data.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If a sync fails with a permissions error, check that the API role grants the **read** privilege for each object you selected – Jamf Pro privileges are granted per object type.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Jamf Pro data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`, alpha callout).

Companion to [PostHog/posthog#71219](https://github.com/PostHog/posthog/pull/71219), which implements the source with `docsUrl` pointing at `/docs/cdp/sources/jamf-pro` and `sourceId: JamfPro`; `manage.py audit_source_docs` passes for this source against this file. Should merge once that PR lands so the rendered parameters/tables have API data.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a - new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
