### PR TITLE
Add Codacy data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/codacy.md
+++ b/contents/docs/cdp/sources/codacy.md
@@ -1,0 +1,54 @@
+---
+title: Linking Codacy as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Codacy
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Codacy connector syncs your code quality data – organizations, repositories, per-file analysis, issues, pull requests, and commits – into PostHog, so you can track quality grades, issue counts, complexity, duplication, and coverage trends across your repositories.
+
+## Prerequisites
+
+You need a Codacy Cloud account with access to the organization you want to sync. Self-hosted Codacy installations are not yet supported.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Codacy, you'll need:
+
+- **Account API token** – generate one in your [Codacy account settings](https://app.codacy.com/account/access-management). The token grants access to the organizations and repositories your Codacy account can see.
+- **Git provider** – the provider hosting your organization: GitHub, GitLab, or Bitbucket.
+- **Organization name** – the name of the organization on your Git provider, as it appears in Codacy.
+
+## Sync modes
+
+<SyncModes />
+
+Codacy tables are full refresh only, since the Codacy API doesn't support filtering by update time. Each sync pulls the current snapshot of your organization's analysis data.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If your API token is invalid or has been revoked, generate a new account API token in your Codacy account settings, then reconnect.
+- If some repositories are missing, check that your Codacy account has access to them on the Git provider. After changing permissions, it can take a while for Codacy to refresh the repository list.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Codacy data warehouse import source, following the canonical source-doc template (shared snippets, `<SourceParameters />` + `<SourceTables />`, alpha release callout).

**Why:** the Codacy connector is being implemented in [PostHog/posthog#71221](https://github.com/PostHog/posthog/pull/71221) and ships with `docsUrl` pointing at `/docs/cdp/sources/codacy`, so this page needs to exist to avoid a 404. Draft until that PR merges, since `<SourceParameters />` / `<SourceTables />` render from the `public_source_configs` API and will only have data once the source is deployed.

`audit_source_docs` in the posthog repo passes for codacy against this checkout.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*