### PR TITLE
Add dbt data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/dbt.md
+++ b/contents/docs/cdp/sources/dbt.md
@@ -1,0 +1,57 @@
+---
+title: Linking dbt as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Dbt
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The dbt connector syncs metadata from the dbt platform (dbt Cloud) into PostHog – accounts, projects, environments, job definitions, users, and the full job run history – so you can analyze pipeline reliability, run durations, and failure rates alongside your product data.
+
+## Prerequisites
+
+You need a dbt platform account and an API token:
+
+- A **service account token** (recommended) – available on Team and Enterprise plans under **Account settings** > **API tokens** > **Service tokens**. Read-only access to the resources you want to sync is enough.
+- A **personal access token** also works, under **Account settings** > **API tokens** > **Personal tokens**.
+
+Syncing the `users` table requires a token with user read permissions, which many read-only tokens lack. It's deselected by default.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking dbt, you'll need:
+
+- **Account ID** – the number after `/deploy/` in your dbt URL.
+- **API token** – a service account token or personal access token.
+- **Region** – where your dbt account is hosted: US (`cloud.getdbt.com`), EMEA (`emea.dbt.com`), or APAC (`au.dbt.com`).
+- **Custom base URL** (optional) – for cell-based or single-tenant deployments (for example `https://ab123.us1.dbt.com`). When set, it overrides the region.
+
+## Sync modes
+
+<SyncModes />
+
+The `runs` table supports incremental sync on `created_at`: each sync fetches runs newest-first and stops once it reaches already-synced rows, with a 24 hour overlap so recently created runs pick up their final status. The other tables are small and sync as a full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new dbt (dbt Cloud / dbt platform) data warehouse import source, shipping in [PostHog/posthog#71227](https://github.com/PostHog/posthog/pull/71227).

Follows the canonical source-doc template: alpha callout, prerequisites (service account token or PAT), setup steps via the shared snippets, and the auto-rendered `<SourceParameters />` / `<SourceTables />` sections fed by the `public_source_configs` API. `sourceId: Dbt` matches the `ExternalDataSourceType` value, and the slug matches the source's `docsUrl` (`/docs/cdp/sources/dbt`) – verified with `manage.py audit_source_docs` against this checkout.

The rendered configuration and table sections will populate once the source PR is deployed, so this should merge after (or together with) PostHog/posthog#71227.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
