### PR TITLE
feat(docs): add babelforce data warehouse source doc

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -31,6 +31,7 @@ Auth0
 Avo
 AWS
 [Aa]zure
+[Bb]abelforce
 Balsamiq
 [Bb]amboo
 Bazel

--- a/contents/docs/cdp/sources/babelforce.md
+++ b/contents/docs/cdp/sources/babelforce.md
@@ -1,0 +1,52 @@
+---
+title: Linking babelforce as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Babelforce
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The babelforce connector syncs your contact center data – call reporting, agents, agent groups, queues, service numbers, recordings, SMS messages, and conversations – into PostHog.
+
+## Prerequisites
+
+You need a babelforce account with a user that has manager rights, so you can create API credentials in the manager app.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+To connect babelforce, you need:
+
+- **Environment (subdomain)**: the subdomain your babelforce account is served from. This is usually `services`, unless you are on a dedicated environment with a custom subdomain (check the URL you use to open the manager app).
+- **Access ID** and **Access token**: an API credential pair created in your babelforce manager app. See babelforce's [authentication guide](https://help.babelforce.com/hc/en-us/articles/6418329977108-Authentication-Best-Practice) for how to create one.
+
+## Sync modes
+
+<SyncModes />
+
+The `calls` table supports incremental syncs using the call's `dateCreated` timestamp. All other tables are reference data and use full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If the connection fails with an authentication error, check that the environment subdomain matches your account and that the access ID and access token belong to a user with manager rights.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new babelforce data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`). Companion to [PostHog/posthog#71231](https://github.com/PostHog/posthog/pull/71231), which implements the connector; the doc slug matches the source's `docsUrl` and `python manage.py audit_source_docs` passes against this file.

## Why

A finished warehouse source ships with a consistent doc; the connector's in-app links point at `/docs/cdp/sources/babelforce`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a - new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*