### PR TITLE
Add Bettermode data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/bettermode.md
+++ b/contents/docs/cdp/sources/bettermode.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Bettermode (formerly Tribe) connector syncs your community data into the PostHog Data warehouse, so you can join community activity — members, spaces, posts, replies, and moderation items — with your product, CRM, and support data.
+The Bettermode (formerly Tribe) connector syncs your community data into the PostHog Data Warehouse, so you can join community activity (members, spaces, posts, replies, and moderation items) with your product, CRM, and support data.
 
 ## Prerequisites
 

--- a/contents/docs/cdp/sources/bettermode.md
+++ b/contents/docs/cdp/sources/bettermode.md
@@ -1,0 +1,61 @@
+---
+title: Linking Bettermode as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Bettermode
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Bettermode (formerly Tribe) connector syncs your community data into the PostHog Data warehouse, so you can join community activity — members, spaces, posts, replies, and moderation items — with your product, CRM, and support data.
+
+## Prerequisites
+
+You need a Bettermode plan with API access, and permission to create an app in the [Bettermode developer portal](https://developers.bettermode.com/). The app must be **published and installed on your community** before PostHog can connect.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Bettermode, you'll need:
+
+- **Region** – where your community is hosted. Most communities use the US region; pick EU if your community is hosted in Bettermode's EU (eu-central-1) region.
+- **Client ID** and **Client secret** – from your app in the Bettermode developer portal. Create an app, publish it, and install it on your community.
+- **Network ID** – your community's unique ID, shown for your community in the developer portal.
+
+PostHog exchanges the client ID and secret for a short-lived app access token, and refreshes it automatically on every sync.
+
+## Sync modes
+
+<SyncModes />
+
+The **posts** table supports incremental syncs on `createdAt`, `publishedAt`, or `updatedAt`. Other tables sync as full refreshes: Bettermode's API doesn't expose server-side timestamp filters for them.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+Reaction data is included on each post and reply row: `reactionsCount` holds the total, and `reactions` holds a per-reaction summary of `{reaction, count}` objects.
+
+The **replies** table fetches the direct replies of every post that has replies, one post at a time, so its sync time grows with the size of your community.
+
+## Troubleshooting
+
+- **App not found** – the client ID or secret is wrong. Copy both again from your app in the developer portal.
+- **Forbidden / access errors** – the app isn't published and installed on the community, or the network ID doesn't match the community the app is installed on.
+- **Slow syncs** – Bettermode rate-limits API traffic per 10-second window and per day. PostHog honors these limits and retries automatically, but very large communities may take a while to backfill, especially the replies table.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Bettermode (formerly Tribe) data warehouse source, implemented in [PostHog/posthog#71239](https://github.com/PostHog/posthog/pull/71239) (stacked on the source scaffolding PR [PostHog/posthog#71137](https://github.com/PostHog/posthog/pull/71137)).

Follows the canonical source doc template: shared snippets (`source-setup-intro`, `sync-modes`, `alpha-release`, `dw-troubleshooting-link`), `<SourceParameters />` and `<SourceTables />` rendered from the source config API, `sourceId: Bettermode` matching the `ExternalDataSourceType` value, and the `bettermode` slug matching the source's `docsUrl`.

This doc should merge once the source PR lands, so the config API has the Bettermode source for `<SourceParameters />` / `<SourceTables />` to render.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
