### PR TITLE
Update PostHog Code copy to reflect usage-based pricing

### DIFF
--- a/contents/handbook/engineering/ai/ai-platform.md
+++ b/contents/handbook/engineering/ai/ai-platform.md
@@ -123,7 +123,7 @@ Analyze hundreds of session recordings in minutes instead of hours. Session summ
 An agent development environment that solves the messy workflow problem of engineering with coding agents. Each task gets its own isolated workspace where an agent works — you can guide the agent, review changes, and switch between workspaces, with everything related to a task in one place instead of across your terminal, editor, and GitHub.
 
 **Best for**: Product engineers who work on multiple tasks simultaneously and already use agents heavily
-**Status**: Beta | **Pricing**: TBD
+**Status**: Beta | **Pricing**: Usage-based (AI credits, no markup) with free tier
 
 [Learn more →](/handbook/engineering/ai/products#posthog-code)
 

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -1546,13 +1546,17 @@ const FAQ_ITEMS = [
         content: (
             <div className="space-y-3">
                 <p>
-                    PostHog Code is a monthly seat-based subscription. If you've participated in previous betas with
-                    PostHog, you might be surprised to hear that we are charging for this one.
+                    PostHog Code is usage-based – there's no fixed subscription. You spend AI credits as you go (100
+                    credits = $1), and credits reflect the underlying model's cost exactly, with no markup on top.
                 </p>
                 <p>
-                    Every user gets a free tier with enough credits for roughly 10 tasks. If you want to use it for
-                    meaningful engineering work (and cancel your Codex and Claude Code subscriptions in the process),
-                    the Pro plan comes with a very generous credit limit.
+                    Every organization gets a $20/month free tier to explore, plus a default $50 billing limit so you
+                    don't rack up costs by accident (customize it anytime). Simple tasks use very few credits; larger,
+                    multi-file work uses more. See the{' '}
+                    <a href="/docs/posthog-code/pricing" className="underline">
+                        pricing docs
+                    </a>{' '}
+                    for the full breakdown.
                 </p>
             </div>
         ),

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -493,7 +493,7 @@ const faqItems = [
         trigger: 'Do I need PostHog Code to use the PostHog Slack app?',
         content: (
             <p>
-                No. The Slack app isn't gated on a{' '}
+                No. The Slack app isn't gated behind{' '}
                 <Link
                     to="/code"
                     state={{ newWindow: true }}
@@ -501,7 +501,7 @@ const faqItems = [
                 >
                     PostHog Code
                 </Link>{' '}
-                subscription. They share the same coding agent under the hood – the Slack app is just the front door if
+                usage. They share the same coding agent under the hood – the Slack app is just the front door if
                 you'd rather work from a thread than a desktop app.
             </p>
         ),


### PR DESCRIPTION
## Changes

PostHog Code moved to [usage-based pricing](https://posthog.com/docs/posthog-code/pricing) (AI credits, no fixed subscription, $20/month free tier, $50 default billing limit, no markup on token costs). A few spots still described the old subscription model:

- **`src/pages/code.tsx`** — the "How much does it cost?" FAQ called PostHog Code a "monthly seat-based subscription" with a "Pro plan" and a "~10 tasks" free tier. Rewritten to describe usage-based AI credits, the $20/month free tier, and the $50 default billing limit, with a link to the pricing docs.
- **`contents/handbook/engineering/ai/ai-platform.md`** — status line said `Pricing: TBD`; now reflects usage-based credits with a free tier.
- **`src/pages/slack/index.tsx`** — reworded the Slack-app FAQ so it no longer calls Code access a "subscription".

**Why:** Raised in a Slack thread asking where the site still contradicts the new PostHog Code pricing doc. This aligns the marketing/handbook copy with the pricing docs.

Note: `contents/handbook/engineering/ai/implementation.md` mentions passing on AI costs "with a small markup" — left unchanged here because it reads as a broader AI-pricing policy statement (PostHog AI, session summaries, deep research) rather than Code-specific. Worth a separate confirmation with whoever owns AI pricing.

The in-app copy (Plan & usage tab, billing pages) lives in the PostHog monorepo, not this repo, so it is not covered by this PR.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1784134608591349)*