### PR TITLE
docs: clarify how free credits are structured in special terms

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -129,7 +129,15 @@ You should follow the same [inbound sales process](https://posthog.com/handbook/
 
 All free credits associated with startup plan roll-offs are one-time only, and should be denoted in the special terms of the contract as "An additional credit in the amount of XXXXX (offered to customers in exchange for rolling off the Startup plan) to be applied to Customer's account upon signature with the same expiration date."
 
-For contracting purposes, these free credits should either be applied before the contract term or included in the 12 month credit amount. If they are being applied before the contract term, adjust the contract date to start 2 months later and the one-time credits can be applied to cover the 2 invoices before the contract start date. In this case, the credits do not need to be called out in the contract, and the opportunity owner can add these credits as a one time credit in billing admin.
+#### How to structure free credits in special terms
+
+There are two ways we structure free credits, and it's important to be clear which one applies, because they're added at different times and treated differently at contract start:
+
+1. **Fixed amount included in the 12-month term.** The free credits are part of the contract term and are added to the customer's balance alongside the purchased (prepaid) credits at contract start. Use this when a specific dollar amount of free credit is explicitly called out under Special Terms as part of the term. Example: a contract starting June 15 that includes $19k of one-time credits as part of the term — those $19k are added together with the prepaid credits on June 15.
+
+2. **Coverage for a specific number of months (the startup roll-off case).** The free credits are *not* part of the contract term. We add enough free credits to cover the promised period (for example, up to the contract start date), top up if the customer comes up short before then, and add the prepaid credits only when the contract actually starts. Any free-credit balance still remaining at contract start is removed at that point. These credits are added now via billing admin as a one-time credit and don't need to be called out as part of the term.
+
+If the Special Terms wording is ambiguous, default to option 2 (coverage for a period). In that case you can add the free credits now, the customer pays the issued invoice, and the prepaid credits become available on the contract start date. When applying credits before the contract term, adjust the contract date to start 2 months later so the one-time credits cover the invoices before the contract start date; the credits then don't need to be called out in the contract and the opportunity owner adds them as a one-time credit in billing admin.
 
 ### Margin negative deals
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -129,15 +129,15 @@ You should follow the same [inbound sales process](https://posthog.com/handbook/
 
 All free credits associated with startup plan roll-offs are one-time only, and should be denoted in the special terms of the contract as "An additional credit in the amount of XXXXX (offered to customers in exchange for rolling off the Startup plan) to be applied to Customer's account upon signature with the same expiration date."
 
+For contracting purposes, these free credits should either be applied before the contract term or included in the 12 month credit amount. If they are being applied before the contract term, adjust the contract date to start 2 months later and the one-time credits can be applied to cover the 2 invoices before the contract start date. In this case, the credits do not need to be called out in the contract, and the opportunity owner can add these credits as a one time credit in billing admin.
+
 #### How to structure free credits in special terms
 
 There are two ways we structure free credits, and it's important to be clear which one applies, because they're added at different times and treated differently at contract start:
 
-1. **Fixed amount included in the 12-month term.** The free credits are part of the contract term and are added to the customer's balance alongside the purchased (prepaid) credits at contract start. Use this when a specific dollar amount of free credit is explicitly called out under Special Terms as part of the term. Example: a contract starting June 15 that includes $19k of one-time credits as part of the term — those $19k are added together with the prepaid credits on June 15.
+1. **Fixed amount included in the 12 month term.** The free credits are part of the contract term and are added to the customer's balance alongside the purchased (prepaid) credits at contract start. Use this when a specific dollar amount of free credit is explicitly called out under Special Terms as part of the term.
 
-2. **Coverage for a specific number of months (the startup roll-off case).** The free credits are *not* part of the contract term. We add enough free credits to cover the promised period (for example, up to the contract start date), top up if the customer comes up short before then, and add the prepaid credits only when the contract actually starts. Any free-credit balance still remaining at contract start is removed at that point. These credits are added now via billing admin as a one-time credit and don't need to be called out as part of the term.
-
-If the Special Terms wording is ambiguous, default to option 2 (coverage for a period). In that case you can add the free credits now, the customer pays the issued invoice, and the prepaid credits become available on the contract start date. When applying credits before the contract term, adjust the contract date to start 2 months later so the one-time credits cover the invoices before the contract start date; the credits then don't need to be called out in the contract and the opportunity owner adds them as a one-time credit in billing admin.
+2. **Coverage for a specific number of months.** The free credits are *not* part of the contract term. We add enough free credits to cover the promised period (for example, up to the contract start date), top up if the customer comes up short before then, and add the prepaid credits only when the contract actually starts. Any free-credit balance still remaining at contract start is removed at that point. These credits can be added via billing admin as a one time credit and don't need to be called out as part of the term.
 
 ### Margin negative deals
 


### PR DESCRIPTION
## Changes

Clarifies the **Startup plan discounts** section of the contract rules handbook page, which previously conflated the two different ways free credits get structured. It now spells out both explicitly, since they're added at different times and treated differently at contract start:

1. **Fixed amount included in the 12-month term** — added alongside the prepaid credits at contract start.
2. **Coverage for a specific number of months (startup roll-off case)** — added now to cover the promised period, topped up if needed, with any remaining balance removed once the prepaid credits go in at contract start.

Also adds guidance to default to option 2 when the Special Terms wording is ambiguous.

## Why

A recent renewal surfaced that the existing wording ("either applied before the contract term or included in the 12 month credit amount") wasn't clear enough about which structure applies or how each behaves at contract start, so account owners were unsure how to handle free credits. This makes the distinction explicit.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08UNFX75ST/p1783638711989369?thread_ts=1783638711.989369&cid=C08UNFX75ST)*