### PR TITLE
Add event form redirect to partnerships page

### DIFF
--- a/src/pages/partnerships/index.tsx
+++ b/src/pages/partnerships/index.tsx
@@ -35,6 +35,11 @@ export default function Partnerships(): JSX.Element {
                     programs. If you're unsure which category fits best, just pick "Other" and tell us more.
                 </p>
 
+                <p>
+                    Want us to sponsor or speak at your event? Head to our{' '}
+                    <a href="/handbook/marketing/events#event-submission-form">event form</a> instead.
+                </p>
+
                 <PartnershipsSurvey />
             </Editor>
         </>


### PR DESCRIPTION
## Changes

Adds a one-sentence paragraph to the partnerships page pointing event organizers (sponsorship or speaking requests — hackathons, conferences, dinners, meetups, workshops) to the [event form](https://posthog.com/handbook/marketing/events#event-submission-form) instead of the partnerships survey.

**Why:** Event sponsorship and speaking requests were coming through the partnerships form, which isn't the right intake path for them.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AB78YBCNA/p1783347981042819)*