### PR TITLE
fix: self-driving ticker shows real merge dates, not "2949w ago"

### DIFF
--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -431,8 +431,10 @@ const TICKER_FADE = 'linear-gradient(to right, transparent, black 4%, black 96%,
 
 // Short, human "merged N ago" – computed in the browser so it stays fresh between rebuilds.
 const timeAgo = (iso: string): string => {
+    if (!iso) return ''
     const then = new Date(iso).getTime()
-    if (Number.isNaN(then)) return ''
+    // Guard against missing/epoch dates (e.g. a PR with no merge date) rendering as "2949w ago".
+    if (Number.isNaN(then) || then <= 0) return ''
     const seconds = Math.max(0, (Date.now() - then) / 1000)
     const days = Math.floor(seconds / 86400)
     if (days >= 7) return `${Math.floor(days / 7)}w ago`
@@ -1227,7 +1229,11 @@ export default function SelfDrivingPage({
 
 export const query = graphql`
     query SelfDrivingPage {
-        allSelfDrivingPullRequest(sort: { fields: mergedAt, order: DESC }, limit: 24) {
+        allSelfDrivingPullRequest(
+            filter: { state: { eq: "merged" } }
+            sort: { fields: mergedAt, order: DESC }
+            limit: 24
+        ) {
             nodes {
                 prNumber
                 summary


### PR DESCRIPTION
## Changes

The PR ticker on [/self-driving](https://posthog.com/self-driving) was showing every card as merged "2949w ago" (epoch 0).

Root cause: the ticker's GraphQL query pulled *all* `SelfDrivingPullRequest` nodes sorted by `mergedAt` descending, with no state filter. Unmerged draft PRs have a null merge date, and in Gatsby's DESC sort those nulls sort to the top — so the ticker filled up with unmerged draft PRs, each rendered with a hardcoded "merged" badge and a null date that `timeAgo` coerced to the Unix epoch.

- Filter the query to `state: { eq: "merged" }`, so only genuinely merged PRs appear (matching the section's intent and the `SelfDrivingLoop` component, which already filters this way in JS). This fixes both the dates and the incorrect "merged" badges on draft PRs.
- Harden `timeAgo` to return an empty string for missing/epoch dates, so a null date can never render as "2949w ago" again.

**Why:** Reported as a papercut — the PRs in the carousel were all dated "2950w ago".

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784194012247629?thread_ts=1784194012.247629&cid=C0ACRAMJUAG)*
