### PR TITLE
docs(logs): remove "coming soon" notice from log alerts page

### DIFF
--- a/contents/docs/logs/alerts.mdx
+++ b/contents/docs/logs/alerts.mdx
@@ -2,14 +2,6 @@
 title: Set up log alerts
 ---
 
-import CalloutBox from "components/Docs/CalloutBox";
-
-<CalloutBox icon="IconInfo" title="Log alerts are coming soon" type="action">
-
-Log alerts aren't available yet. The documentation below describes how alerts will work once released.
-
-</CalloutBox>
-
 Log alerts notify you when the volume of logs matching specific filters crosses a threshold. Use them to catch spikes in errors, drops in expected traffic, or unusual patterns across your services.
 
 Alerts are checked every 5 minutes and can be configured with noise-reduction settings to avoid false positives from brief, one-off spikes.


### PR DESCRIPTION
## Changes

Log alerts are now available, but `/docs/logs/alerts` still opened with a callout saying "Log alerts aren't available yet. The documentation below describes how alerts will work once released."

This removes that callout (and the now-unused `CalloutBox` import). This was the only "coming soon" mention of log alerts anywhere in the repo — the rest of the page is already written in present tense, and there's no nav badge to update.

## Checklist

- [x] Verified no other "coming soon" / "aren't available yet" mentions of log alerts remain in `contents/` or `src/`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*