### PR TITLE
docs: refresh @posthog/next guide for 0.8.3

### DIFF
--- a/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
@@ -1,7 +1,19 @@
-Use `getPostHog()` in server components, route handlers, and server actions to capture events and evaluate feature flags. The client is automatically scoped to the current user via the identity cookie set by the middleware.
+Create a shared PostHog module with `createPostHog()`, then use the returned `getPostHog` in Server Components, Route Handlers, and Server Actions to capture events and evaluate feature flags.
 
-```tsx
-import { getPostHog } from '@posthog/next'
+```ts file=lib/posthog.ts
+import 'server-only'
+import { createPostHog } from '@posthog/next'
+import { auth } from '@/auth'
+
+export const { getPostHog } = createPostHog({
+    // Optional: resolve a trusted distinct ID from your auth session.
+    // Return null or undefined to fall back to the client identity.
+    getDistinctId: async () => (await auth())?.user?.id,
+})
+```
+
+```tsx file=app/dashboard/page.tsx
+import { getPostHog } from '@/lib/posthog'
 
 export default async function DashboardPage() {
     const posthog = await getPostHog()
@@ -15,6 +27,8 @@ export default async function DashboardPage() {
 }
 ```
 
-> **Note:** `getPostHog()` calls `cookies()` internally, which opts the route into dynamic rendering. Pages using it cannot be statically generated.
+Without `getDistinctId`, PostHog can use the identity cookie and tracing headers supplied by the client as request context. When you need a strict guarantee that analytics uses the identity from your authenticated session, pass an authoritative distinct ID directly when capturing events or evaluating feature flags. When the resolver returns an ID, PostHog uses it as the request default ahead of client-provided identity, while an ID passed directly to a capture or flag method still takes precedence. Session and device linkage can remain connected to the browser. The resolver runs at most once per request and is not called for users who opted out of capture.
 
-**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` via `serverOptions` on the `PostHogProvider`, or events will be batched and flushed normally.
+> **Note:** `getPostHog()` calls `cookies()` and `headers()` internally, which opts the route into dynamic rendering. Pages using it cannot be statically generated. Keep `import 'server-only'` in the shared module so accidental imports from Client Components fail at build time.
+
+**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, pass a custom `waitUntil` in the server client options with `createPostHog({ options: { waitUntil } })`, or events will be batched and flushed normally.

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-app-server-setup.mdx
@@ -1,4 +1,4 @@
-Create a shared PostHog module with `createPostHog()`, then use the returned `getPostHog` in Server Components, Route Handlers, and Server Actions to capture events and evaluate feature flags.
+Create a shared PostHog module with `createPostHog()`. Use the returned `getPostHog` to evaluate feature flags in Server Components and capture events from request or action handlers.
 
 ```ts file=lib/posthog.ts
 import 'server-only'
@@ -19,7 +19,6 @@ export default async function DashboardPage() {
     const posthog = await getPostHog()
 
     const flags = await posthog.getAllFlags()
-    posthog.capture({ event: 'dashboard_viewed' })
 
     return (
         <div>{flags['new-dashboard'] ? <NewDashboard /> : <OldDashboard />}</div>

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
@@ -9,7 +9,7 @@ export const { getPostHog } = createPostHog({
     // Optional: resolve a trusted distinct ID from your auth session.
     // The resolver receives the GetServerSidePropsContext.
     getDistinctId: async (ctx) =>
-        ctx ? (await getServerSession(ctx.req, ctx.res, authOptions))?.user?.id : undefined,
+        (await getServerSession(ctx.req, ctx.res, authOptions))?.user?.id,
 })
 ```
 

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
@@ -1,30 +1,46 @@
-Use `getServerSidePostHog` inside `getServerSideProps` to capture events and evaluate feature flags for the current user:
+Create a shared PostHog module with `createPostHog()`, then call the returned `getPostHog` with the request context inside `getServerSideProps` to capture events and evaluate feature flags.
+
+```ts file=lib/posthog.ts
+import { createPostHog } from '@posthog/next/pages'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+export const { getPostHog } = createPostHog({
+    // Optional: resolve a trusted distinct ID from your auth session.
+    // The resolver receives the GetServerSidePropsContext.
+    getDistinctId: async (ctx) =>
+        ctx ? (await getServerSession(ctx.req, ctx.res, authOptions))?.user?.id : undefined,
+})
+```
 
 ```tsx file=pages/dashboard.tsx
 import type { GetServerSideProps } from 'next'
-import { getServerSidePostHog } from '@posthog/next/pages'
+import { getPostHog } from '@/lib/posthog'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const posthog = await getServerSidePostHog(ctx)
+    const posthog = await getPostHog(ctx)
 
-    const flags = await posthog.getAllFlags()
-    posthog.capture({ event: 'dashboard_viewed' })
+    const flags = await posthog.evaluateFlags({ flagKeys: ['new-dashboard'] })
+    const showNewDashboard = flags.isEnabled('new-dashboard')
+    posthog.capture({ event: 'dashboard_viewed', flags })
 
-    return { props: { showNewDashboard: flags['new-dashboard'] ?? false } }
+    return { props: { showNewDashboard } }
 }
 ```
+
+Without `getDistinctId`, PostHog can use the identity cookie and tracing headers supplied by the client as request context. When you need a strict guarantee that analytics uses the identity from your authenticated session, pass an authoritative distinct ID directly when capturing events or evaluating feature flags. When the resolver returns an ID, PostHog uses it as the request default ahead of client-provided identity, while an ID passed directly to a capture or flag method still takes precedence. Session and device linkage can remain connected to the browser. The resolver runs once per `getPostHog(ctx)` call and is not called for users who opted out of capture.
 
 To bootstrap feature flags and eliminate flicker on page load, pass the flag data through `pageProps`:
 
 ```tsx file=pages/dashboard.tsx
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const posthog = await getServerSidePostHog(ctx)
+    const posthog = await getPostHog(ctx)
     const bootstrap = await posthog.getAllFlagsAndPayloads()
     return { props: { posthogBootstrap: bootstrap } }
 }
 ```
 
-**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, you can pass a custom `waitUntil` via `serverOptions` on the `PostHogProvider`, or events will be batched and flushed normally.
+**Event flushing:** On Vercel, `@posthog/next` auto-detects [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions` so events are flushed after the response is sent without blocking it. No manual `shutdown()` call is needed. In other environments, pass a custom `waitUntil` in the server client options with `createPostHog({ options: { waitUntil } })`, or events will be batched and flushed normally.
 
 Then wire the bootstrap data into the provider:
 
@@ -36,8 +52,10 @@ export default function App({ Component, pageProps }: AppProps) {
     return (
         <PostHogProvider
             apiKey={process.env.NEXT_PUBLIC_POSTHOG_KEY!}
-            clientOptions={{ api_host: '/ingest' }}
-            bootstrap={pageProps.posthogBootstrap}
+            clientOptions={{
+                api_host: '/ingest',
+                bootstrap: pageProps.posthogBootstrap,
+            }}
         >
             <PostHogPageView />
             <Component {...pageProps} />

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-server-setup.mdx
@@ -1,4 +1,4 @@
-Create a shared PostHog module with `createPostHog()`, then call the returned `getPostHog` with the request context inside `getServerSideProps` to capture events and evaluate feature flags.
+Create a shared PostHog module with `createPostHog()`, then call the returned `getPostHog` with the request context inside `getServerSideProps` to evaluate feature flags.
 
 ```ts file=lib/posthog.ts
 import { createPostHog } from '@posthog/next/pages'
@@ -22,7 +22,6 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
     const flags = await posthog.evaluateFlags({ flagKeys: ['new-dashboard'] })
     const showNewDashboard = flags.isEnabled('new-dashboard')
-    posthog.capture({ event: 'dashboard_viewed', flags })
 
     return { props: { showNewDashboard } }
 }
@@ -30,13 +29,13 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
 Without `getDistinctId`, PostHog can use the identity cookie and tracing headers supplied by the client as request context. When you need a strict guarantee that analytics uses the identity from your authenticated session, pass an authoritative distinct ID directly when capturing events or evaluating feature flags. When the resolver returns an ID, PostHog uses it as the request default ahead of client-provided identity, while an ID passed directly to a capture or flag method still takes precedence. Session and device linkage can remain connected to the browser. The resolver runs once per `getPostHog(ctx)` call and is not called for users who opted out of capture.
 
-To bootstrap feature flags and eliminate flicker on page load, pass the flag data through `pageProps`:
+The Pages Router provider doesn't have the App Router's `bootstrapFlags` prop. For the same no-flicker behavior, evaluate flags in `getServerSideProps` and pass the result through `pageProps`:
 
 ```tsx file=pages/dashboard.tsx
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
     const posthog = await getPostHog(ctx)
-    const bootstrap = await posthog.getAllFlagsAndPayloads()
-    return { props: { posthogBootstrap: bootstrap } }
+    const posthogBootstrap = await posthog.getAllFlagsAndPayloads()
+    return { props: { posthogBootstrap } }
 }
 ```
 

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -270,6 +270,10 @@ For server-side events and feature flag evaluations, PostHog can use the client-
     </Tab.Panels>
 </Tab.Group>
 
+> **Note:** Avoid capturing page views or other navigation events while rendering a Server Component or running `getServerSideProps`. Rendering doesn't prove that a navigation completed. The App Router can execute render code while [prefetching](https://nextjs.org/docs/app/guides/prefetching), and Next.js can retry renders. Use `PostHogPageView` for page views, and capture server-side events from handlers invoked for the action you want to measure.
+>
+> Dynamic rendering keeps personalized flag decisions out of Next.js's shared Full Route Cache. The App Router can still reuse a React Server Component payload from its client Router Cache. After an authentication or identity change, use [`router.refresh()`](https://nextjs.org/docs/app/api-reference/functions/use-router#userouter) when the current route's server-rendered flag decisions must be evaluated again.
+
 </Step>
 
 <Step title="Capture server-side request errors" badge="recommended">

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -313,7 +313,7 @@ You can also limit the flags evaluated and provide properties used for evaluatio
 </PostHogProvider>
 ```
 
-Enabling `bootstrapFlags` calls `cookies()` internally, which opts the route into dynamic rendering. In the Pages Router, evaluate feature flags inside `getServerSideProps` and pass the result through `clientOptions.bootstrap` as shown in the server setup above.
+Enabling `bootstrapFlags` calls `cookies()` internally, which opts every page route rendered through that provider into dynamic rendering. If the provider is in your root layout, this includes every page in your app. To preserve static rendering elsewhere, enable `bootstrapFlags` in the narrowest layout that needs server-evaluated flags. In the Pages Router, evaluate feature flags inside `getServerSideProps` and pass the result through `clientOptions.bootstrap` as shown in the server setup above.
 
 ### Tracing headers
 

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -41,6 +41,16 @@ tableOfContents: [
         depth: 1,
     },
     {
+        url: 'capture-server-side-request-errors',
+        value: 'Capture server-side request errors',
+        depth: 1,
+    },
+    {
+        url: 'configure-advanced-options',
+        value: 'Configure advanced options',
+        depth: 1,
+    },
+    {
         url: 'further-reading',
         value: 'Further reading',
         depth: 1,
@@ -74,11 +84,12 @@ import PagesServerSetup from "./_snippets/posthog-next-pages-server-setup.mdx"
 
 `@posthog/next` is a unified package for integrating PostHog into your Next.js app. It provides a simplified interface that handles common patterns out of the box:
 
-- **Synchronized identity across client and server**, so both sides share the same user automatically
+- **Synchronized analytics identity across client and server**, so both sides share the same user automatically
+- **Trusted server-side identity resolution** from your authentication session for server events and feature flag evaluations
 - **Server-side feature flag bootstrapping** so hooks return real values immediately with no flicker
 - **Eager client initialization** ensures PostHog is always available when your components render
 - **Built-in API proxy** that routes SDK traffic through your domain to avoid ad blockers
-- **Automatic event flushing** with no manual `shutdown()` or `flush()` calls needed
+- **Automatic browser exception capture and event flushing** with no manual `shutdown()` or `flush()` calls needed
 
 This guide covers both the App Router and Pages Router. You'll need a PostHog instance ([Cloud](https://app.posthog.com/signup) or [self-hosted](/docs/self-host)) and a Next.js 13.0.0+ application.
 
@@ -238,6 +249,8 @@ export function LoginButton() {
 
 See our guide on [identifying users](/docs/getting-started/identify-users) for more details.
 
+For server-side events and feature flag evaluations, PostHog can use the client-provided identity cookie and tracing headers to link analytics across the request. These values come from the client. When you need a strict guarantee that analytics uses the identity from your authenticated session, provide an authoritative distinct ID directly when capturing an event or evaluating feature flags, or configure `getDistinctId` in `createPostHog()` to resolve it from your server session by default.
+
 </Step>
 
 <Step title="Use PostHog on the server" badge="recommended">
@@ -259,11 +272,25 @@ See our guide on [identifying users](/docs/getting-started/identify-users) for m
 
 </Step>
 
+<Step title="Capture server-side request errors" badge="recommended">
+
+`@posthog/next` enables automatic browser exception capture by default. On Next.js 15 and later, capture server-side request errors by exporting `onRequestError` from your root `instrumentation.ts` file:
+
+```ts file=instrumentation.ts
+export { onRequestError } from '@posthog/next'
+```
+
+Next.js calls this hook when a Server Component, Route Handler, or Server Action throws during a request. When available, the PostHog identity cookie links the exception to the same user and session. Import this hook from `@posthog/next` for both App Router and Pages Router applications.
+
+Use `createOnRequestError()` when you need to add properties, filter errors, or customize the server client. You can disable automatic browser exception capture with `clientOptions={{ capture_exceptions: false }}`.
+
+</Step>
+
 <Step title="Configure advanced options" badge="optional">
 
-### Feature flag bootstrap
+### Bootstrap feature flags
 
-Set `bootstrapFlags` to evaluate feature flags on the server and pass the results to the client, which avoids flag flicker on first render:
+In the App Router, set `bootstrapFlags` to evaluate feature flags on the server and pass the results to the client, which avoids flag flicker on first render:
 
 ```tsx
 <PostHogProvider bootstrapFlags>{children}</PostHogProvider>
@@ -286,7 +313,17 @@ You can also limit the flags evaluated and provide properties used for evaluatio
 </PostHogProvider>
 ```
 
-Enabling `bootstrapFlags` calls `cookies()` internally, which opts the route into dynamic rendering.
+Enabling `bootstrapFlags` calls `cookies()` internally, which opts the route into dynamic rendering. In the Pages Router, evaluate feature flags inside `getServerSideProps` and pass the result through `clientOptions.bootstrap` as shown in the server setup above.
+
+### Tracing headers
+
+`@posthog/next` adds `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to same-origin browser requests by default. This connects server events and feature flag evaluations to the browser user and session.
+
+Pass `clientOptions.tracing_headers` to customize the hostnames that receive these headers, or use an empty array to disable them:
+
+```tsx
+<PostHogProvider clientOptions={{ tracing_headers: [] }}>{children}</PostHogProvider>
+```
 
 ### Consent-aware setup
 
@@ -299,7 +336,7 @@ export default postHogMiddleware({
 })
 ```
 
-Then initialize the client with capture disabled until the user opts in:
+Then initialize the client with capture disabled until you opt in:
 
 ```tsx
 <PostHogProvider clientOptions={{ opt_out_capturing_by_default: true }}>{children}</PostHogProvider>
@@ -330,6 +367,7 @@ When you change the proxy path, use the same path in `clientOptions.api_host`:
 
 - [How to set up Next.js analytics, Feature Flags, and more](/tutorials/nextjs-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
+- [Upload source maps for Next.js Error Tracking](/docs/error-tracking/upload-source-maps/nextjs)
 
 </Step>
 


### PR DESCRIPTION
## Changes

- Refresh the dedicated pre-release `@posthog/next` guide for the published v0.8.3 API.
- Replace removed server helper imports with router-specific `createPostHog()` setup and document trusted server-side identity resolution and precedence.
- Correct Pages Router bootstrap and server feature flag evaluation examples.
- Add Next.js 15+ server request-error capture, automatic browser exception capture, tracing-header configuration, and source-map guidance.
- Clarify App Router versus Pages Router behavior for feature flag bootstrapping, rendering, and event flushing.

No screenshots are needed because this only changes documentation content and code examples.

https://ea9fa105.posthog-preview.pages.dev/docs/libraries/next-js/posthog-next

## Validation

- Built fresh Next.js 15 App Router and Pages Router apps with exactly `@posthog/next@0.8.3`.
- Exercised provider setup, middleware proxying, client hooks, server `createPostHog()`, request-scoped flag evaluation, Pages bootstrap, and synthetic server capture against the shared live test project.
- Confirmed the App and Pages production builds and browser runtime flows; durable event ingestion could not be queried because the shared test personal API key was rejected.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A: no pages moved)

