### PR TITLE
docs: document allowed special characters for $ai_session_id

### DIFF
--- a/contents/docs/ai-observability/sessions.mdx
+++ b/contents/docs/ai-observability/sessions.mdx
@@ -33,6 +33,8 @@ Sessions are useful when you want to:
 
 Set the `$ai_session_id` property when capturing LLM events using the `posthogProperties` (JavaScript) or `posthog_properties` (Python) parameter in PostHog's AI Observability SDKs. Use any identifier that makes sense for grouping related traces in your application.
 
+The `$ai_session_id` value must contain only letters, numbers, and the special characters `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, `:`, and `|`.
+
 ## Analyzing sessions
 
 Once you've set session IDs on your events, you can analyze them in several ways:


### PR DESCRIPTION
## Changes

Adds the same allowed-characters guidance we document for `$ai_trace_id` to `$ai_session_id` in the AI observability Sessions doc. Users setting a custom session ID previously had no guidance on which characters are valid.

**Why:** Trace IDs document their allowed character set (via the onboarding trace event snippet), but sessions did not, so users had no way to know which characters were safe to use in a `$ai_session_id`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784228960193579)*
