### PR TITLE
docs: show Kotlin Multiplatform in the install page Libraries list

### DIFF
--- a/contents/docs/getting-started/_snippets/install.mdx
+++ b/contents/docs/getting-started/_snippets/install.mdx
@@ -11,7 +11,7 @@ import { WebsiteJSHtmlSnippet } from '../../product-analytics/installation/_snip
     <Tab.List>  
         <Tab>AI wizard</Tab>
         <Tab>JS snippet</Tab>
-        <Tab count="16">Libraries</Tab>
+        <Tab count="17">Libraries</Tab>
         <Tab count="22">Framework guides</Tab>
         <Tab>API</Tab>
     </Tab.List>

--- a/src/components/Docs/Integrate.tsx
+++ b/src/components/Docs/Integrate.tsx
@@ -98,6 +98,7 @@ const query = graphql`
                             "/docs/libraries/go"
                             "/docs/libraries/ios"
                             "/docs/libraries/java"
+                            "/docs/libraries/kmp"
                             "/docs/libraries/node"
                             "/docs/libraries/php"
                             "/docs/libraries/python"


### PR DESCRIPTION
## Changes

The KMP pieces all shipped yesterday — [SDK library page #18472](https://github.com/PostHog/posthog.com/pull/18472), [wizard support #906](https://github.com/PostHog/wizard/pull/906), and the [install taxonomy entry #18516](https://github.com/PostHog/posthog.com/pull/18516). The **AI wizard** tab is taxonomy-driven so it already surfaces KMP. But the **Libraries** tab on `getting-started/install` is a *separate* hardcoded slug allowlist in `Integrate.tsx` that #18516 never touched — so KMP was missing there.

- Add `/docs/libraries/kmp` to the SDKs allowlist in `Integrate.tsx`
- Bump the Libraries tab count 16 → 17 in `install.mdx`

The KMP page already has `platformLogo: kmp`, so it renders with the correct logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)