### PR TITLE
Desktop: drag-to-select (marquee) icon selection

### DIFF
--- a/src/components/Desktop/DesktopIcon.tsx
+++ b/src/components/Desktop/DesktopIcon.tsx
@@ -4,11 +4,18 @@ import ZoomHover from 'components/ZoomHover'
 
 interface DesktopIconProps {
     app: AppItem
+    /** Highlighted by the desktop's marquee selection (see useMarqueeSelection) */
+    selected?: boolean
 }
 
-export default function DesktopIcon({ app }: DesktopIconProps) {
+export default function DesktopIcon({ app, selected }: DesktopIconProps) {
     return (
-        <li data-icon-label={app.label} className="w-28 min-h-[84px] flex justify-center items-start">
+        <li
+            data-icon-label={app.label}
+            className={`w-28 min-h-[84px] flex justify-center items-start ${
+                selected ? 'rounded-md bg-blue/20 ring-1 ring-inset ring-blue/40' : ''
+            }`}
+        >
             <ZoomHover>
                 <AppLink {...app} />
             </ZoomHover>

--- a/src/components/Desktop/DesktopIcon.tsx
+++ b/src/components/Desktop/DesktopIcon.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { AppLink, AppItem } from 'components/OSIcons/AppIcon'
 import ZoomHover from 'components/ZoomHover'
+import { SELECTED_ICON_CLASSES } from './useMarqueeSelection'
 
 interface DesktopIconProps {
     app: AppItem
@@ -8,12 +9,12 @@ interface DesktopIconProps {
     selected?: boolean
 }
 
-export default function DesktopIcon({ app, selected }: DesktopIconProps) {
+function DesktopIcon({ app, selected }: DesktopIconProps) {
     return (
         <li
             data-icon-label={app.label}
-            className={`w-28 min-h-[84px] flex justify-center items-start ${
-                selected ? 'rounded-md bg-blue/20 ring-1 ring-inset ring-blue/40' : ''
+            className={`w-28 min-h-[84px] flex justify-center items-start${
+                selected ? ` ${SELECTED_ICON_CLASSES}` : ''
             }`}
         >
             <ZoomHover>
@@ -22,3 +23,7 @@ export default function DesktopIcon({ app, selected }: DesktopIconProps) {
         </li>
     )
 }
+
+// Memoized so a selection change only re-renders the icons whose `selected`
+// flipped (the `app` objects are kept referentially stable in Desktop).
+export default React.memo(DesktopIcon)

--- a/src/components/Desktop/README.md
+++ b/src/components/Desktop/README.md
@@ -1,0 +1,41 @@
+# Desktop
+
+The OS desktop surface rendered behind all app windows: wallpaper, desktop icons, screensaver, notifications, and the right-click context menu. Mounted once in `components/Wrapper` as a sibling of the window list, and memoized (`React.memo`) so window opens/closes don't re-render it.
+
+## Files
+
+- `index.tsx` – the desktop surface. Defines the icon data (`useProductLinks()` for the left column, `apps` for the right), applies wallpaper-driven icon glow, and composes the layers described below.
+- `DesktopIcon.tsx` – a single icon cell: `<li data-icon-label>` → `ZoomHover` → `AppLink` (from `components/OSIcons/AppIcon`). The `data-icon-label` attribute is load-bearing: marquee selection uses it for hit-testing, keyed by the (unique) icon label.
+- `useMarqueeSelection.ts` – rubber-band selection logic (see below).
+- `Wallpapers.tsx` – wallpaper scenes with light/dark and scene-to-scene transitions.
+
+## Layer stacking
+
+The desktop container is `fixed inset-0 pointer-events-none` — the container itself never intercepts clicks (this protects the taskbar strip and anything stacked above). Because `fixed` creates a stacking context, paint/hit-test order inside it is self-contained. Children, in order:
+
+1. **Wallpaper** – absolutely positioned, inert (inherits `pointer-events-none`).
+2. **Capture layer** – a transparent `absolute pointer-events-auto` div starting at `top: DESKTOP_TOP_OFFSET` (below the taskbar). It exists so empty desktop space has a pointer target: it's what makes marquee selection and right-click → context menu work between the icon columns. Without it, clicks in the empty middle fall through to the window list wrapper.
+3. **Icon nav** – `relative` so it paints/hit-tests above the capture layer. The `<ul>`s are `pointer-events-auto`; the empty space inside their tall columns also bubbles pointer events to the container.
+4. **Marquee rectangle** – always mounted, `hidden`, `pointer-events-none`. Geometry is written imperatively during a drag.
+
+Windows always paint and hit-test above all of this (the window list renders after `<Desktop />` with positioned roots), so a marquee sweeps *beneath* open windows — same as a real OS.
+
+`DESKTOP_TOP_OFFSET` is a hardcoded taskbar clearance (8px container padding + 42px taskbar) rather than the live `taskbarHeight` from context, to avoid layout shift on SSR hydration.
+
+## Marquee selection (`useMarqueeSelection`)
+
+Drag on empty desktop space to select icons, like a real OS. **Visual-only v1**: selection highlights icons and persists; it doesn't enable dragging or opening them.
+
+Behavior:
+
+- Primary-button drag (mouse/pen; touch ignored) draws a rectangle after a 4px threshold. Icons intersecting it highlight live.
+- Shift at drag start adds to the existing selection; a plain drag replaces it.
+- Clears on: plain click on empty desktop, Escape, or pressing an icon (the icon still opens its app as usual — `AppLink` is untouched).
+- Right-click is ignored by the marquee, so the context menu works as before.
+
+Implementation notes:
+
+- Pointer listeners are window-level and capture-phase for the duration of a drag, so it survives sweeping over open windows and releases outside the viewport (`e.buttons === 0` guard in pointermove).
+- Icon rects are snapshotted once per drag from `li[data-icon-label]`, **filtering zero-size rects**: the `sm:hidden` mobile icon list duplicates every label at 0×0, which would otherwise false-select on marquees touching the top-left corner. The same filter makes narrow-viewport mouse selection work against the mobile grid.
+- The rectangle's geometry is ref-driven (direct style writes); the only React state is the `ReadonlySet<string>` of selected labels, updated only when membership actually changes.
+- Selection state is local to the desktop — nothing in `context/App.tsx` is involved.

--- a/src/components/Desktop/README.md
+++ b/src/components/Desktop/README.md
@@ -28,14 +28,18 @@ Drag on empty desktop space to select icons, like a real OS. **Visual-only v1**:
 
 Behavior:
 
-- Primary-button drag (mouse/pen; touch ignored) draws a rectangle after a 4px threshold. Icons intersecting it highlight live.
+- Primary-button **mouse** drag draws a rectangle after a 4px threshold. Icons intersecting it highlight live. Touch and pen are ignored: touch keeps native scrolling, and pen press-and-hold is Radix's context-menu long-press gesture (Radix treats pen like touch), which must not also start a marquee.
 - Shift at drag start adds to the existing selection; a plain drag replaces it.
-- Clears on: plain click on empty desktop, Escape, or pressing an icon (the icon still opens its app as usual — `AppLink` is untouched).
+- Clears on: plain click on empty desktop, Escape, or pressing an icon (the icon still opens its app as usual — `AppLink` is untouched). Escape handlers call `preventDefault` when they act, so a window's `closeOnEscape` and the selection never both consume one press.
 - Right-click is ignored by the marquee, so the context menu works as before.
 
 Implementation notes:
 
 - Pointer listeners are window-level and capture-phase for the duration of a drag, so it survives sweeping over open windows and releases outside the viewport (`e.buttons === 0` guard in pointermove).
 - Icon rects are snapshotted once per drag from `li[data-icon-label]`, **filtering zero-size rects**: the `sm:hidden` mobile icon list duplicates every label at 0×0, which would otherwise false-select on marquees touching the top-left corner. The same filter makes narrow-viewport mouse selection work against the mobile grid.
-- The rectangle's geometry is ref-driven (direct style writes); the only React state is the `ReadonlySet<string>` of selected labels, updated only when membership actually changes.
+- The rectangle's geometry is ref-driven (direct style writes); the only React state is the `ReadonlySet<string>` of selected labels, updated only when membership actually changes. `DesktopIcon` is memoized (with referentially-stable `app` objects from the memoized glow mapping), so only icons whose `selected` flag flips re-render.
 - Selection state is local to the desktop — nothing in `context/App.tsx` is involved.
+
+### Theming
+
+The selection color is the project `blue` token — the same idiom as the window snap indicator — deliberately independent of light/dark mode, skin, and wallpaper; the translucency keeps it legible everywhere. It is intentionally *not* wired to the semantic scheme variables (`--accent` etc.), which restyle app chrome, not OS selection. If a future skin needs a different selection color, `MARQUEE_BOX_CLASSES` and `SELECTED_ICON_CLASSES` in `useMarqueeSelection.ts` are the single knob.

--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -20,6 +20,7 @@ import { AppItem } from 'components/OSIcons/AppIcon'
 import ContextMenu from 'components/RadixUI/ContextMenu'
 import CloudinaryImage from 'components/CloudinaryImage'
 import DesktopIcon from './DesktopIcon'
+import useMarqueeSelection from './useMarqueeSelection'
 import { Screensaver } from '../Screensaver'
 import { useInactivityDetection } from '../../hooks/useInactivityDetection'
 import NotificationsPanel from 'components/NotificationsPanel'
@@ -152,6 +153,7 @@ function Desktop() {
     const [navVisible, setNavVisible] = useState(false)
     const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
     const { addToast } = useToast()
+    const { selectedLabels, marqueeRef, onDesktopPointerDown } = useMarqueeSelection()
 
     useEffect(() => {
         return () => {
@@ -276,19 +278,28 @@ function Desktop() {
                     className="fixed inset-0 pointer-events-none"
                     onMouseEnter={handleMouseEnter}
                     onMouseLeave={handleMouseLeave}
+                    onPointerDown={onDesktopPointerDown}
                 >
                     <Wallpapers wallpaper={siteSettings.wallpaper} reduceMotion={siteSettings.performanceBoost} />
 
-                    <nav className="px-1" style={{ paddingTop: DESKTOP_TOP_OFFSET + 16 }}>
+                    {/* Pointer target for empty desktop space (marquee selection + right-click menu).
+                        Sits below the taskbar strip; the nav is `relative` so icons hit-test above it. */}
+                    <div
+                        aria-hidden
+                        className="absolute inset-x-0 bottom-0 pointer-events-auto select-none"
+                        style={{ top: DESKTOP_TOP_OFFSET }}
+                    />
+
+                    <nav className="relative px-1" style={{ paddingTop: DESKTOP_TOP_OFFSET + 16 }}>
                         <ul className={mobileIconListClassName}>
                             {[...leftApps, ...rightApps].map((app) => (
-                                <DesktopIcon key={app.label} app={app} />
+                                <DesktopIcon key={app.label} app={app} selected={selectedLabels.has(app.label)} />
                             ))}
                         </ul>
                         <div className="hidden sm:flex sm:justify-between items-start">
                             <ul className={`${desktopIconListClassName} flex-wrap`} style={desktopIconListStyle}>
                                 {leftApps.map((app) => (
-                                    <DesktopIcon key={app.label} app={app} />
+                                    <DesktopIcon key={app.label} app={app} selected={selectedLabels.has(app.label)} />
                                 ))}
                             </ul>
                             <ul
@@ -296,11 +307,19 @@ function Desktop() {
                                 style={desktopIconListStyle}
                             >
                                 {rightApps.map((app) => (
-                                    <DesktopIcon key={app.label} app={app} />
+                                    <DesktopIcon key={app.label} app={app} selected={selectedLabels.has(app.label)} />
                                 ))}
                             </ul>
                         </div>
                     </nav>
+
+                    {/* Marquee rectangle: geometry is written imperatively during a drag (see useMarqueeSelection) */}
+                    <div
+                        ref={marqueeRef}
+                        data-marquee
+                        aria-hidden
+                        className="absolute hidden pointer-events-none border border-blue bg-blue/20"
+                    />
                 </div>
                 {!compact && (
                     <Screensaver

--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -20,7 +20,7 @@ import { AppItem } from 'components/OSIcons/AppIcon'
 import ContextMenu from 'components/RadixUI/ContextMenu'
 import CloudinaryImage from 'components/CloudinaryImage'
 import DesktopIcon from './DesktopIcon'
-import useMarqueeSelection from './useMarqueeSelection'
+import useMarqueeSelection, { MARQUEE_BOX_CLASSES } from './useMarqueeSelection'
 import { Screensaver } from '../Screensaver'
 import { useInactivityDetection } from '../../hooks/useInactivityDetection'
 import NotificationsPanel from 'components/NotificationsPanel'
@@ -141,6 +141,22 @@ const APP_CONTAINER_TOP_PADDING = 8
 const TASKBAR_HEIGHT = 42
 const DESKTOP_TOP_OFFSET = APP_CONTAINER_TOP_PADDING + TASKBAR_HEIGHT
 
+// Drive the desktop icons' hover-glow color from the active wallpaper (light + dark).
+// Module-scope so the result can be memoized: DesktopIcon is React.memo'd, which
+// only pays off if the `app` object identities are stable across renders.
+const applyGlow = (items: AppItem[], glow: { light: string; dark: string }) =>
+    items.map((app) =>
+        React.isValidElement(app.Icon) && app.Icon.type === GlassIcon
+            ? {
+                  ...app,
+                  Icon: React.cloneElement(app.Icon as React.ReactElement, {
+                      glowColor: glow.light,
+                      glowColorDark: glow.dark,
+                  }),
+              }
+            : app
+    )
+
 function Desktop() {
     const productLinks = useProductLinks()
     const { setScreensaverPreviewActive, setConfetti, updateSiteSettings } = useAppActions()
@@ -177,22 +193,12 @@ function Desktop() {
         }, 2000)
     }
 
-    // Drive the desktop icons' hover-glow color from the active wallpaper (light + dark).
+    // getWallpaperGlow returns stable references from a module-level map, so
+    // these lists only rebuild when the wallpaper actually changes — not on
+    // every selection change during a marquee drag.
     const glow = getWallpaperGlow(siteSettings.wallpaper)
-    const applyGlow = (items: AppItem[]) =>
-        items.map((app) =>
-            React.isValidElement(app.Icon) && app.Icon.type === GlassIcon
-                ? {
-                      ...app,
-                      Icon: React.cloneElement(app.Icon as React.ReactElement, {
-                          glowColor: glow.light,
-                          glowColorDark: glow.dark,
-                      }),
-                  }
-                : app
-        )
-    const leftApps = applyGlow(productLinks)
-    const rightApps = applyGlow(apps)
+    const leftApps = React.useMemo(() => applyGlow(productLinks, glow), [productLinks, glow])
+    const rightApps = React.useMemo(() => applyGlow(apps, glow), [glow])
 
     // Mobile: one continuous wrapping grid (avoids a gap when left apps don't fill a row).
     // sm+: classic left/right desktop columns that wrap into extra columns when short on height.
@@ -318,7 +324,7 @@ function Desktop() {
                         ref={marqueeRef}
                         data-marquee
                         aria-hidden
-                        className="absolute hidden pointer-events-none border border-blue bg-blue/20"
+                        className={`absolute hidden pointer-events-none ${MARQUEE_BOX_CLASSES}`}
                     />
                 </div>
                 {!compact && (

--- a/src/components/Desktop/useMarqueeSelection.ts
+++ b/src/components/Desktop/useMarqueeSelection.ts
@@ -1,0 +1,220 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+/**
+ * useMarqueeSelection
+ *
+ * Rubber-band ("marquee") selection for the desktop icons, like dragging a
+ * rectangle on a real OS desktop. Visual-only: selection highlights icons and
+ * persists until dismissed; it doesn't (yet) enable dragging or opening them.
+ *
+ * - A drag starting on empty desktop space (primary button, mouse/pen only)
+ *   draws a rectangle once it passes a small movement threshold; below the
+ *   threshold it's treated as a plain click, which clears the selection.
+ * - Icons whose bounding boxes intersect the rectangle are selected live.
+ * - Shift held at drag start adds to the existing selection instead of
+ *   replacing it.
+ * - Selection clears on: click on empty desktop, Escape, or pointerdown on an
+ *   icon (the icon's own click still opens its app as usual).
+ *
+ * Wiring (see Desktop/index.tsx):
+ * - `onDesktopPointerDown` goes on the desktop container; it receives bubbled
+ *   pointerdowns from both the transparent capture layer and empty space
+ *   inside the pointer-events-auto icon lists.
+ * - `marqueeRef` goes on an always-mounted, `hidden` rectangle div. Its
+ *   geometry is written imperatively so mousemove never re-renders React;
+ *   only selection membership changes trigger a render.
+ */
+
+const DRAG_THRESHOLD_PX = 4
+const EMPTY_SET: ReadonlySet<string> = new Set()
+
+interface DragState {
+    originX: number
+    originY: number
+    /** True once the pointer has moved past DRAG_THRESHOLD_PX */
+    active: boolean
+    /** Selection to union with (existing selection when shift-dragging) */
+    shiftBase: ReadonlySet<string>
+    container: HTMLElement
+    /** Icon label → bounding rect, snapshotted once per drag */
+    iconRects: Map<string, DOMRect>
+}
+
+const setsEqual = (a: ReadonlySet<string>, b: ReadonlySet<string>): boolean => {
+    if (a.size !== b.size) return false
+    for (const item of a) {
+        if (!b.has(item)) return false
+    }
+    return true
+}
+
+/**
+ * All drag logic lives in a closure created once per hook instance so the
+ * window-level listeners keep stable identities: they're added at drag start
+ * and removed at drag end, while React re-renders (from selection changes)
+ * happen in between.
+ */
+const createMarqueeController = (
+    marqueeRef: React.RefObject<HTMLDivElement>,
+    setSelectedLabels: (next: ReadonlySet<string>) => void
+) => {
+    let selected: ReadonlySet<string> = EMPTY_SET
+    let drag: DragState | null = null
+
+    const applySelection = (next: ReadonlySet<string>) => {
+        if (setsEqual(next, selected)) return
+        selected = next
+        setSelectedLabels(next)
+    }
+
+    const clearSelection = () => applySelection(EMPTY_SET)
+
+    const handlePointerMove = (e: PointerEvent) => {
+        if (!drag) return
+        // Button was released outside the viewport and we missed pointerup
+        if (e.buttons === 0) {
+            endDrag()
+            return
+        }
+        const dx = e.clientX - drag.originX
+        const dy = e.clientY - drag.originY
+        if (!drag.active) {
+            if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return
+            drag.active = true
+            // Snapshot icon rects once per drag (the desktop never scrolls).
+            // Zero-size rects are the display:none duplicate mobile icon list —
+            // without this filter they'd all sit at (0,0) and false-select on
+            // any marquee touching the top-left corner.
+            drag.container.querySelectorAll<HTMLElement>('li[data-icon-label]').forEach((el) => {
+                const label = el.dataset.iconLabel
+                const rect = el.getBoundingClientRect()
+                if (label && rect.width > 0 && rect.height > 0) {
+                    drag?.iconRects.set(label, rect)
+                }
+            })
+            // Inline display overrides the `hidden` class while dragging
+            if (marqueeRef.current) marqueeRef.current.style.display = 'block'
+        }
+        const left = Math.min(drag.originX, e.clientX)
+        const top = Math.min(drag.originY, e.clientY)
+        const width = Math.abs(dx)
+        const height = Math.abs(dy)
+        const marquee = marqueeRef.current
+        if (marquee) {
+            marquee.style.left = `${left}px`
+            marquee.style.top = `${top}px`
+            marquee.style.width = `${width}px`
+            marquee.style.height = `${height}px`
+        }
+        const next = new Set(drag.shiftBase)
+        drag.iconRects.forEach((rect, label) => {
+            if (rect.left <= left + width && rect.right >= left && rect.top <= top + height && rect.bottom >= top) {
+                next.add(label)
+            }
+        })
+        applySelection(next)
+    }
+
+    const handlePointerUp = (e: PointerEvent) => {
+        if (!drag || e.button !== 0) return
+        const wasActive = drag.active
+        endDrag()
+        // A sub-threshold press-and-release is a plain click on empty desktop
+        if (!wasActive) clearSelection()
+    }
+
+    // OS-level interruptions (pointercancel, cmd-tab away): end the drag but
+    // keep whatever was selected so far, mirroring pointerup.
+    const handlePointerCancel = () => endDrag()
+    const handleWindowBlur = () => endDrag()
+
+    const handleDragKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            endDrag()
+            clearSelection()
+        }
+    }
+
+    // Capture phase so the drag survives content that stops propagation as the
+    // pointer sweeps over open windows or the taskbar.
+    const attachDragListeners = () => {
+        window.addEventListener('pointermove', handlePointerMove, true)
+        window.addEventListener('pointerup', handlePointerUp, true)
+        window.addEventListener('pointercancel', handlePointerCancel, true)
+        window.addEventListener('keydown', handleDragKeyDown, true)
+        window.addEventListener('blur', handleWindowBlur)
+    }
+
+    const detachDragListeners = () => {
+        window.removeEventListener('pointermove', handlePointerMove, true)
+        window.removeEventListener('pointerup', handlePointerUp, true)
+        window.removeEventListener('pointercancel', handlePointerCancel, true)
+        window.removeEventListener('keydown', handleDragKeyDown, true)
+        window.removeEventListener('blur', handleWindowBlur)
+    }
+
+    const endDrag = () => {
+        if (!drag) return
+        drag = null
+        // Clearing the inline display lets the `hidden` class reapply
+        if (marqueeRef.current) marqueeRef.current.style.display = ''
+        detachDragListeners()
+    }
+
+    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        // Touch gets the mobile layout and native scrolling; right/middle
+        // click must stay free for the context menu. No preventDefault here —
+        // it would interfere with Radix's contextmenu handling.
+        if (e.button !== 0 || e.pointerType === 'touch' || drag) return
+        if ((e.target as Element).closest('[data-icon-label]')) {
+            // Pressing an icon clears the selection; the icon's own click
+            // proceeds and opens its app as usual
+            clearSelection()
+            return
+        }
+        drag = {
+            originX: e.clientX,
+            originY: e.clientY,
+            active: false,
+            shiftBase: e.shiftKey ? selected : EMPTY_SET,
+            container: e.currentTarget,
+            iconRects: new Map(),
+        }
+        attachDragListeners()
+    }
+
+    return { onPointerDown, clearSelection, destroy: endDrag }
+}
+
+export default function useMarqueeSelection(): {
+    selectedLabels: ReadonlySet<string>
+    marqueeRef: React.RefObject<HTMLDivElement>
+    onDesktopPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+} {
+    const [selectedLabels, setSelectedLabels] = useState<ReadonlySet<string>>(EMPTY_SET)
+    const marqueeRef = useRef<HTMLDivElement>(null)
+
+    const controllerRef = useRef<ReturnType<typeof createMarqueeController> | null>(null)
+    if (!controllerRef.current) {
+        controllerRef.current = createMarqueeController(marqueeRef, setSelectedLabels)
+    }
+    const controller = controllerRef.current
+
+    // Escape clears a persisted selection. Only listens while one exists, in
+    // the bubble phase with a defaultPrevented guard so an Escape consumed
+    // elsewhere (e.g. Radix closing the context menu) doesn't double-act.
+    const hasSelection = selectedLabels.size > 0
+    useEffect(() => {
+        if (!hasSelection) return
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && !e.defaultPrevented) controller.clearSelection()
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [hasSelection])
+
+    // Detach any in-flight drag listeners if the desktop ever unmounts
+    useEffect(() => () => controller.destroy(), [])
+
+    return { selectedLabels, marqueeRef, onDesktopPointerDown: controller.onPointerDown }
+}

--- a/src/components/Desktop/useMarqueeSelection.ts
+++ b/src/components/Desktop/useMarqueeSelection.ts
@@ -7,7 +7,9 @@ import React, { useEffect, useRef, useState } from 'react'
  * rectangle on a real OS desktop. Visual-only: selection highlights icons and
  * persists until dismissed; it doesn't (yet) enable dragging or opening them.
  *
- * - A drag starting on empty desktop space (primary button, mouse/pen only)
+ * - A drag starting on empty desktop space (primary mouse button only; touch
+ *   and pen keep their native behavior — pen press-and-hold is the Radix
+ *   context-menu long-press gesture, so it must not double as a marquee)
  *   draws a rectangle once it passes a small movement threshold; below the
  *   threshold it's treated as a plain click, which clears the selection.
  * - Icons whose bounding boxes intersect the rectangle are selected live.
@@ -27,6 +29,14 @@ import React, { useEffect, useRef, useState } from 'react'
 
 const DRAG_THRESHOLD_PX = 4
 const EMPTY_SET: ReadonlySet<string> = new Set()
+
+// Selection color is the project `blue` token, matching the window snap
+// indicator (AppWindow) — deliberately independent of light/dark, skin, and
+// wallpaper; the translucency is what keeps it legible everywhere. If a future
+// skin ever needs a different selection color, these two constants are the
+// single knob (full class strings so Tailwind's JIT scanner can see them).
+export const MARQUEE_BOX_CLASSES = 'border border-blue bg-blue/20'
+export const SELECTED_ICON_CLASSES = 'rounded-md bg-blue/20 ring-1 ring-inset ring-blue/40'
 
 interface DragState {
     originX: number
@@ -129,7 +139,10 @@ const createMarqueeController = (
     const handleWindowBlur = () => endDrag()
 
     const handleDragKeyDown = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
+        if (e.key === 'Escape' && !e.defaultPrevented) {
+            // Claim the Escape so window-level handlers (e.g. AppWindow's
+            // closeOnEscape) don't also act on the same press
+            e.preventDefault()
             endDrag()
             clearSelection()
         }
@@ -162,10 +175,12 @@ const createMarqueeController = (
     }
 
     const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-        // Touch gets the mobile layout and native scrolling; right/middle
-        // click must stay free for the context menu. No preventDefault here —
-        // it would interfere with Radix's contextmenu handling.
-        if (e.button !== 0 || e.pointerType === 'touch' || drag) return
+        // Mouse only: touch keeps native scrolling, and pen press-and-hold is
+        // Radix's context-menu long-press gesture (it treats pen like touch),
+        // which must not also start a marquee. Right/middle click stay free
+        // for the context menu. No preventDefault here — it would interfere
+        // with Radix's contextmenu handling.
+        if (e.button !== 0 || e.pointerType !== 'mouse' || drag) return
         if ((e.target as Element).closest('[data-icon-label]')) {
             // Pressing an icon clears the selection; the icon's own click
             // proceeds and opens its app as usual
@@ -183,14 +198,10 @@ const createMarqueeController = (
         attachDragListeners()
     }
 
-    return { onPointerDown, clearSelection, destroy: endDrag }
+    return { onPointerDown, clearSelection, endDrag }
 }
 
-export default function useMarqueeSelection(): {
-    selectedLabels: ReadonlySet<string>
-    marqueeRef: React.RefObject<HTMLDivElement>
-    onDesktopPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
-} {
+export default function useMarqueeSelection() {
     const [selectedLabels, setSelectedLabels] = useState<ReadonlySet<string>>(EMPTY_SET)
     const marqueeRef = useRef<HTMLDivElement>(null)
 
@@ -207,14 +218,19 @@ export default function useMarqueeSelection(): {
     useEffect(() => {
         if (!hasSelection) return
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape' && !e.defaultPrevented) controller.clearSelection()
+            if (e.key === 'Escape' && !e.defaultPrevented) {
+                // Claim the Escape so a focused closeOnEscape window doesn't
+                // also close on the same press (it guards on defaultPrevented)
+                e.preventDefault()
+                controller.clearSelection()
+            }
         }
         window.addEventListener('keydown', handleKeyDown)
         return () => window.removeEventListener('keydown', handleKeyDown)
     }, [hasSelection])
 
     // Detach any in-flight drag listeners if the desktop ever unmounts
-    useEffect(() => () => controller.destroy(), [])
+    useEffect(() => () => controller.endDrag(), [])
 
     return { selectedLabels, marqueeRef, onDesktopPointerDown: controller.onPointerDown }
 }


### PR DESCRIPTION
Force of habit, but literally the first thing I want to do every time I get on the PostHog website home screen is mindlessly click and drag because the OS look is so convincing. I'd love it if this actually drew a rectangle and selected icons (it doesn't offer any actual practical benefit!).

## What this does

Drag a rectangle on empty desktop space to multi-select icons — same as a real OS. **Visual-only v1**: selection highlights icons and persists; it doesn't (yet) let you open or drag them.

- Primary-button drag on empty desktop draws a translucent rectangle after a 4px threshold; icons intersecting it highlight live as it sweeps over them.
- On release, the selection persists.
- **Shift-drag** adds to the existing selection; a plain drag replaces it.
- Clears on: click on empty desktop, **Escape**, or pressing an icon (the icon still opens its app as usual).
- Mouse only — touch keeps native scrolling, and pen press-and-hold stays the context-menu long-press gesture.
- Right-click context menu is untouched. Bonus fix: the new pointer-capture layer means right-click now opens the context menu in the empty *middle* of the desktop too, which previously fell through to the window list and did nothing.

## How it works

- `useMarqueeSelection.ts` (new hook, colocated in `components/Desktop/`): window-level capture-phase pointer listeners for the duration of a drag (so it survives sweeping over open windows and releases outside the viewport), icon rects snapshotted once per drag from `li[data-icon-label]` with zero-size rects filtered (the hidden `sm:hidden` mobile icon list duplicates every label at 0×0), and ref-driven rectangle geometry — the only React state is the `Set` of selected labels, updated only when membership changes.
- Desktop container gets a transparent `pointer-events-auto` capture layer below the taskbar strip; the icon nav becomes `relative` so icons hit-test above it. Windows still paint and hit-test above everything (the marquee sweeps *beneath* open windows, like a real OS).
- Marquee + highlight use the project `blue` token, matching the window snap indicator idiom (`border-blue bg-blue/20`). Highlight is an inset ring + translucent background on the icon cell, so zero layout shift.
- Selection state is local to `Desktop` — `context/App.tsx` untouched.
- Added a `README.md` for the Desktop folder documenting the layer stacking and marquee behavior.

## Things to try on the preview

1. Drag from empty space in any direction — rectangle anchors correctly, icons light up live, selection persists on release.
2. Drag starting in the empty strip *below* the icon columns, and from the screen edges.
3. Shift-drag to add the other column to the selection; plain drag replaces.
4. Escape clears; a plain click on empty desktop clears; clicking an icon clears and opens its window as before.
5. Right-click anywhere on empty desktop (including dead center) → context menu.
6. Open a window and sweep the marquee under it — it keeps tracking.
7. Light/dark across the wallpapers; mobile viewport is unaffected (touch does nothing).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
