### PR TITLE
docs(self-driving): document custom scout self-improvement reports

### DIFF
--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -58,6 +58,16 @@ Scout report events are captured against a synthetic per-scout ID with person pr
 
 PostHog ships with a set of scouts that watch common patterns out of the box. You can turn each on or off per project, and teams can add their own scouts for the patterns specific to their product. See [scout examples](/docs/self-driving/scout-examples) for the scouts PostHog ships with and ideas for your own.
 
+## Custom scouts suggest improvements to themselves
+
+A custom scout doesn't just report on your product – it also reports on itself. Its instructions were authored by your team, and the scout is the only one that sees where those instructions steer a real run wrong. When a run produces concrete evidence that its instructions misdirected it – they pointed at an event or table that doesn't exist in your project, set a default threshold it had to correct again, or missed a pitfall it keeps hitting – the scout records the specific change it would suggest in its durable memory, with the evidence from that run attached.
+
+When a suggestion re-confirms across runs, or a single failure was material – it burned most of the run's budget, or steered the scout into a wrong finding – the scout escalates it to your [inbox](/docs/self-driving/inbox) as a report titled `Scout self-improvement: <scout-name> – <topic>`, carrying the suggested change and the evidence behind it. Self-improvement reports are always marked as requiring human input: applying one is an edit to instructions your team owns, so the scout proposes and you decide. (A custom scout that only emits signals keeps its suggestions in its memory instead, where they surface when you next review or edit the scout.)
+
+The bar is deliberately high – a suggestion needs a concrete failure or wasted budget observed on a real run, not generic polish. And like any other scout report, a self-improvement report fires a `$scout_report_emitted` event, with `report_kind` set to `self_improvement`, so you can track how often your fleet is asking for tune-ups.
+
+Built-in scouts don't do this. Their instructions are maintained by PostHog and kept current automatically, so feedback about them routes to PostHog instead. The moment you edit a built-in scout to make it your own, it starts self-reporting like any custom scout.
+
 ## Scouts and signal sources
 
 Scouts aren't the only thing that emits [signals](/docs/self-driving/signals). PostHog also has **signal sources**: built-in pipelines that watch one specific stream continuously, like error tracking, session replay, Zendesk, GitHub Issues, and Linear.


### PR DESCRIPTION
## Changes

Adds a section to the scouts docs (`/docs/self-driving/scouts`) covering the fact that custom scouts emit self-improvement reports – a feature that wasn't documented anywhere on the site.

What the new section covers:

- Custom scouts (hand-authored, or built-in scouts a team has edited) watch for evidence that their own instructions misdirected a run, and record the suggested fix plus evidence in their durable memory.
- When a suggestion re-confirms across runs or a failure was material, the scout escalates it to the inbox as a `Scout self-improvement: <scout-name> – <topic>` report, always marked as requiring human input – the team decides whether to apply the edit.
- Signal-only custom scouts keep suggestions in memory rather than filing reports.
- Self-improvement reports fire `$scout_report_emitted` with `report_kind` = `self_improvement`, so they're queryable like any other scout report.
- Built-in scouts don't self-report (their instructions are synced from PostHog); editing one flips it to custom and enables this.

Behavior sourced from the monorepo: `products/signals/backend/scout_harness/prompt.py` (self-improvement prompt section, title prefix) and `products/signals/backend/scout_harness/tools/report.py` (event classification).

## Checklist

- [x] Words are spelled using American English
- [x] Sentence case for headings
- [x] Relative URLs for internal links