### PR TITLE
Add Display options link to the More menu

### DIFF
--- a/src/components/Korean/KoreanTaskBarMenu/menuData.tsx
+++ b/src/components/Korean/KoreanTaskBarMenu/menuData.tsx
@@ -729,6 +729,16 @@ export function useMenuData(): MenuType[] {
                 },
                 {
                     type: 'item',
+                    label: 'Display options',
+                    onClick: () => {
+                        navigate('/display-options', { state: { newWindow: true } })
+                    },
+                    icon: <Icons.IconBrightness className="size-4 text-yellow" />,
+                    shortcut: [','],
+                    mobileDestination: false, // Already exposed as a system item in the mobile logo menu
+                },
+                {
+                    type: 'item',
                     label: 'Keyboard shortcuts',
                     link: '/kbd',
                     icon: <Icons.IconKeyboard className="size-4 text-primary" />,

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -737,6 +737,15 @@ export function useMenuData(): MenuType[] {
                 },
                 {
                     type: 'item',
+                    label: 'Display options',
+                    onClick: () => {
+                        navigate('/display-options', { state: { newWindow: true } })
+                    },
+                    icon: <Icons.IconBrightness className="size-4 text-yellow" />,
+                    shortcut: [','],
+                },
+                {
+                    type: 'item',
                     label: 'Keyboard shortcuts',
                     link: '/kbd',
                     icon: <Icons.IconKeyboard className="size-4 text-primary" />,

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -743,6 +743,7 @@ export function useMenuData(): MenuType[] {
                     },
                     icon: <Icons.IconBrightness className="size-4 text-yellow" />,
                     shortcut: [','],
+                    mobileDestination: false, // Already exposed as a system item in the mobile logo menu
                 },
                 {
                     type: 'item',


### PR DESCRIPTION
## Changes

Adds a **Display options** entry to the **More** menu in the top bar. Previously it was only reachable from the logo (PostHog icon) menu, so people looking for theme/wallpaper settings under More couldn't find them. This reuses the exact same `navigate('/display-options', { newWindow: true })` pattern as the logo menu, so it opens the same window with no duplicated state — just a second discoverable entry point (still bound to the `,` shortcut).

**Why:** Raised in a Slack thread — someone went looking for the desktop theme/wallpaper settings under More and missed them, since they only lived in the logo menu.

*Screenshots: this is a menu-item addition; grab one from the Vercel preview if needed.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784277570335779?thread_ts=1784277570.335779&cid=C01V9AT7DK4)*
