### PR TITLE
Rename "PostHog Cloud" to "PostHog Web" on marketing pages

### DIFF
--- a/src/components/Home/CTA.js
+++ b/src/components/Home/CTA.js
@@ -19,7 +19,7 @@ const ProductDetails = () => (
             </span>
             <span className="uppercase font-semibold text-xs text-white">Eco-friendly</span>
         </span>
-        <p className="text-4xl font-bold m-0 @xl:mt-2">PostHog Cloud</p>
+        <p className="text-4xl font-bold m-0 @xl:mt-2">PostHog Web</p>
         <p className="opacity-50 m-0 mb-4 text-sm">Digital download*</p>
     </>
 )
@@ -72,7 +72,7 @@ export default function CTA({ headline = true, card = false }) {
                     <div className="mb-2">
                         <CloudinaryImage
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/cloud-cd.jpg"
-                            alt="PostHog Cloud"
+                            alt="PostHog Web"
                             className="max-w-[443px]"
                         />
                     </div>

--- a/src/components/Pricing/CloudVsSelfHost/index.tsx
+++ b/src/components/Pricing/CloudVsSelfHost/index.tsx
@@ -12,7 +12,7 @@ export const CloudVsSelfHost = ({ className = '' }) => {
                     <span className="flex-grow-0">
                         <Logo wordmark={false} />
                     </span>
-                    <span className="flex-grow-1">PostHog Cloud</span>
+                    <span className="flex-grow-1">PostHog Web</span>
                 </h3>
                 <ul className="list-none m-0 p-0">
                     <li className="py-4 sm:text-lg md:text-xl">Hosted & managed by PostHog</li>

--- a/src/components/Pricing/Overlays/SelfHost.tsx
+++ b/src/components/Pricing/Overlays/SelfHost.tsx
@@ -8,7 +8,7 @@ const features = [
         description: 'Self-hosting PostHog makes it much easier to meet HIPAA, GDPR, and SOC 2 requirements.',
     },
     {
-        title: 'Capture up to 30% more events than PostHog Cloud',
+        title: 'Capture up to 30% more events than PostHog Web',
         description: 'First-party cookie means privacy trackers don’t block PostHog like a third-party script.',
     },
     {

--- a/src/components/Pricing/Test/Header.tsx
+++ b/src/components/Pricing/Test/Header.tsx
@@ -27,7 +27,7 @@ export default function Header() {
 
     return (
         <>
-            <h1 className="text-2xl mb-1">PostHog Cloud</h1>
+            <h1 className="text-2xl mb-1">PostHog Web</h1>
             {/* <ScrollLink to="g2-reviews" offset={-120} smooth className="flex items-center gap-2 mb-4 cursor-pointer">
                 <Stars rating={totalRating} />
                 <span className="text-[15px]">{allReviews.totalCount} reviews</span>

--- a/src/components/Product/ProductOS/index.tsx
+++ b/src/components/Product/ProductOS/index.tsx
@@ -403,7 +403,7 @@ export const ProductOS = () => {
                         />
                         <TextCard
                             title="Reverse proxy"
-                            description="Send events to PostHog Cloud using your own domain."
+                            description="Send events to PostHog Web using your own domain."
                         />
                     </ul>
                 </section>

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -1350,7 +1350,7 @@ const FAQ_ITEMS = [
         content: (
             <div className="space-y-3">
                 <p>
-                    PostHog AI is the product assistant built into PostHog Cloud. It's deeply integrated with your data
+                    PostHog AI is the product assistant built into PostHog Web. It's deeply integrated with your data
                     and helps with things like writing SQL and analyzing user behavior through natural-language prompts.
                 </p>
                 <p>

--- a/src/pages/flurry-migration.tsx
+++ b/src/pages/flurry-migration.tsx
@@ -66,7 +66,7 @@ export const FlurryMigration = () => {
                             <li>Complete the form below</li>
                             <li>
                                 <Link to="https://app.posthog.com/signup" external>
-                                    Sign up for PostHog Cloud
+                                    Sign up for PostHog Web
                                 </Link>
                             </li>
                             <li>

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -25,7 +25,7 @@ export default function Pricing() {
     const { search } = useLocation()
 
     const pricingTableOfContents = [
-        { url: 'cloud', value: 'PostHog Cloud', depth: 0 },
+        { url: 'cloud', value: 'PostHog Web', depth: 0 },
         { url: 'rates', value: 'Usage-based pricing', depth: 0 },
         { url: 'plans', value: 'Plans', depth: 0 },
         { url: 'calculator', value: 'Pricing calculator', depth: 0 },

--- a/src/pages/pricing/philosophy/index.tsx
+++ b/src/pages/pricing/philosophy/index.tsx
@@ -54,17 +54,17 @@ const PricingPhilosophy = (): JSX.Element => {
                     </li>
                     <li>
                         We have an open source product too - so if you must, you can self host. It is MIT licensed if
-                        you want to use it in a big organization that isn’t ready to move to PostHog Cloud yet.
+                        you want to use it in a big organization that isn’t ready to move to PostHog Web yet.
                         <Tooltip
                             content={() => (
                                 <div className="max-w-sm">
                                     <strong className="block">A disclaimer about self-hosting</strong>
                                     <p className="mb-2 text-sm">
                                         Being upfront, self-hosting PostHog has limitations and is usually a worse
-                                        experience (and more expensive) than PostHog Cloud.
+                                        experience (and more expensive) than PostHog Web.
                                     </p>
                                     <p className="mb-0 text-sm">
-                                        Main benefits of PostHog Cloud include our large, shared infrastructure and lack
+                                        Main benefits of PostHog Web include our large, shared infrastructure and lack
                                         of separate hosting costs, required maintenance, and upgrades that come with
                                         self-hosting.
                                     </p>

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -470,7 +470,7 @@ const compareRows: CompareRow[] = [
     },
     {
         label: 'Where it runs',
-        ai: "None – it's a panel in PostHog Cloud.",
+        ai: "None – it's a panel in PostHog Web.",
         slack: 'PostHog-managed cloud sandbox.',
         code: 'Local, an isolated worktree, or a PostHog-managed cloud sandbox.',
     },


### PR DESCRIPTION
## Changes

Renames the product name from **PostHog Cloud** to **PostHog Web** across marketing surfaces only:

- Homepage CTA (`Home/CTA.js`)
- Pricing page + philosophy, pricing header, and self-host overlay
- Cloud-vs-self-host comparison
- Product OS, Code, Slack, and Flurry migration pages

**Why:** We still referred to the hosted product as "PostHog Cloud" in a number of places and want the marketing copy to say "PostHog Web" instead.

Scoped to marketing pages by request. Deliberately left untouched: legal pages (terms/privacy/subprocessors), regional references (Cloud EU/US), customer quotes/testimonials, docs & handbook nav titles, and translations — a rename there would read incorrectly or desync with other content.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784278632701119)*