### PR TITLE
Remove "VCs love them" customer logo breakdown

### DIFF
--- a/src/components/Home/Customers.tsx
+++ b/src/components/Home/Customers.tsx
@@ -34,7 +34,6 @@ export const COL2 = [
 ]
 
 export const companyBreakdowns = {
-    VCsLoveThem: { col1: 'VCs love them', col2: 'Product engineers love them' },
     colorful: { col1: 'Colorful logos', col2: '"Sleek" logos' },
     hardware: { col1: 'Hardware companies', col2: 'Not hardware companies' },
     planes: { col1: 'Builds planes', col2: "Doesn't build planes (yet)" },
@@ -56,17 +55,6 @@ export const companyBreakdowns = {
 }
 
 export const companyAttributes: Record<string, string[]> = {
-    VCsLoveThem: [
-        'ycombinator',
-        'airbus',
-        'nationaldesignstudio',
-        'ukgovt',
-        'trust',
-        'lovable',
-        'startengine',
-        'researchgate',
-        'heygen',
-    ],
     colorful: [
         'ycombinator',
         'convex',
@@ -226,7 +214,7 @@ export const companyAttributes: Record<string, string[]> = {
 
 export const Customers = ({ tableClassName = '' }: { tableClassName?: string }) => {
     const { getCustomers, hasCaseStudy } = useCustomers()
-    const [currentBreakdown, setCurrentBreakdown] = useState('VCsLoveThem')
+    const [currentBreakdown, setCurrentBreakdown] = useState('colorful')
     const [isAnimating, setIsAnimating] = useState(false)
     const logoRefs = React.useRef<Record<string, HTMLElement>>({})
 

--- a/src/components/Home/Test/Demos.tsx
+++ b/src/components/Home/Test/Demos.tsx
@@ -425,7 +425,6 @@ const COL1 = ['ycombinator', 'airbus', 'trust', 'lovable', 'startengine', 'resea
 const COL2 = ['supabase', 'mistralai', 'elevenlabs', 'hasura', 'raycast', 'posthog']
 
 const companyBreakdowns = {
-    VCsLoveThem: { col1: 'VCs love them', col2: 'Product engineers love them' },
     colorful: { col1: 'Colorful logos', col2: '"Sleek" logos' },
     hardware: { col1: 'Hardware companies', col2: 'Not hardware companies' },
     planes: { col1: 'Builds planes', col2: "Doesn't build planes (yet)" },
@@ -444,7 +443,6 @@ const companyBreakdowns = {
 }
 
 const companyAttributes = {
-    VCsLoveThem: ['ycombinator', 'airbus', 'trust', 'lovable', 'startengine', 'researchgate', 'exa', 'heygen'],
     colorful: ['ycombinator', 'trust', 'lovable', 'supabase', 'startengine', 'mistralai', 'raycast', 'posthog'],
     hardware: ['airbus', 'posthog'],
     planes: ['airbus'],
@@ -461,7 +459,7 @@ const companyAttributes = {
 
 const Customers = () => {
     const { getCustomers, hasCaseStudy } = useCustomers()
-    const [currentBreakdown, setCurrentBreakdown] = React.useState('VCsLoveThem')
+    const [currentBreakdown, setCurrentBreakdown] = React.useState('colorful')
     const [isAnimating, setIsAnimating] = React.useState(false)
     const logoRefs = React.useRef<Record<string, HTMLElement>>({})
 

--- a/src/components/Korean/KoreanHomeShared/index.tsx
+++ b/src/components/Korean/KoreanHomeShared/index.tsx
@@ -126,7 +126,7 @@ export function KoreanCustomers({
     translate?: TranslateFn
 }): JSX.Element {
     const { getCustomers, hasCaseStudy } = useCustomers()
-    const [currentBreakdown, setCurrentBreakdown] = React.useState('VCsLoveThem')
+    const [currentBreakdown, setCurrentBreakdown] = React.useState('colorful')
     const [isAnimating, setIsAnimating] = React.useState(false)
     const logoRefs = React.useRef<Record<string, HTMLElement>>({})
 

--- a/src/pages/ko/_translations.ts
+++ b/src/pages/ko/_translations.ts
@@ -315,8 +315,6 @@ const koTranslations: Record<string, string> = {
     'for deep cohort analysis': '심층 코호트 분석을 위해',
     'for multi-channel attribution': '멀티 채널 어트리뷰션을 위해',
 
-    'VCs love them': 'VC들이 선호하는 회사',
-    'Product engineers love them': '프로덕트 엔지니어들이 선호하는 회사',
     'Colorful logos': '컬러풀한 로고',
     '"Sleek" logos': '"세련된" 로고',
     'Hardware companies': '하드웨어 회사',


### PR DESCRIPTION
## Changes

Removes the "VCs love them" / "Product engineers love them" category from the homepage social-proof customer logo shuffle.

- Dropped the entry from `companyBreakdowns` and `companyAttributes` in `Customers.tsx` and the `Demos.tsx` A/B variant
- Repointed the default breakdown to `colorful` (including the Korean shared home component)
- Removed the now-unused Korean translation strings

**Why:** The "VCs love them" framing read as confusing and off-message next to the other playful logo breakdowns, so we're pulling that one category.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784280589262399?thread_ts=1784280589.262399&cid=C01V9AT7DK4)*
