### PR TITLE
Fix cramped status column in BI features table

### DIFF
--- a/src/pages/data-stack/FeatureTable.tsx
+++ b/src/pages/data-stack/FeatureTable.tsx
@@ -15,7 +15,7 @@ export default function FeatureTable({ features }: FeatureTableProps): JSX.Eleme
     const columns = [
         { name: 'Feature', width: 'minmax(150px, 1fr)', align: 'left' as const },
         { name: 'Description', width: 'minmax(300px, 2fr)', align: 'left' as const },
-        { name: '', width: '60px', align: 'center' as const },
+        { name: 'Status', width: 'minmax(110px, auto)', align: 'center' as const },
     ]
 
     const featureRows = features?.map((feature) => ({
@@ -25,7 +25,7 @@ export default function FeatureTable({ features }: FeatureTableProps): JSX.Eleme
             {
                 content:
                     feature.status === 'coming_soon' ? (
-                        <span className="rounded-sm bg-highlight py-0.5 px-1 text-xs font-bold text-red dark:text-yellow">
+                        <span className="inline-block whitespace-nowrap rounded-sm bg-highlight py-0.5 px-1 text-xs font-bold text-red dark:text-yellow">
                             Coming soon
                         </span>
                     ) : (


### PR DESCRIPTION
## Changes

The "Features" table on [/data-stack/business-intelligence](https://posthog.com/data-stack/business-intelligence) had a status column pinned to a fixed `60px`, too narrow for the "Coming soon" badge. The badge wrapped/overflowed, making the table look broken. This widens that column to fit the badge, keeps the badge text on one line, and gives the column a "Status" header instead of a blank one.

## Why

Raised in #team-website — the table wasn't formatting well on the managed-warehouse BI page and was a bad look in sales demos.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784281143532189?thread_ts=1784281143.532189&cid=C01V9AT7DK4)*
