### PR TITLE
Remove background from QuestLog sidebar

### DIFF
--- a/src/components/Docs/QuestLog.tsx
+++ b/src/components/Docs/QuestLog.tsx
@@ -438,7 +438,7 @@ export const QuestLog: React.FC<{
                     </div>
 
                     {/* Quest List - Sticky Container */}
-                    <div className="quest-sidebar z-30 bg-primary">
+                    <div className="quest-sidebar z-30">
                         {/* Progress Indicator */}
                         <div className="mt-3 mb-3 px-1">
                             <div className="flex justify-start text-xs md:text-sm text-primary/40 dark:text-primary-dark/40 mb-2">


### PR DESCRIPTION
## Changes

Removes the `bg-primary` background fill on the QuestLog sticky sidebar wrapper, so the getting-started quest component (the one with the hedgehog stepping through steps, used on pages like [`/docs/distributed-tracing/start-here`](https://posthog.com/docs/distributed-tracing/start-here)) no longer shows a background. The individual step buttons keep their own solid styling.

**Why:** The background behind the quest component felt out of place on docs pages.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784285690104759?thread_ts=1784285690.104759&cid=C01V9AT7DK4)*
