### PR TITLE
Fix missing title and opaque background on /about page

### DIFF
--- a/contents/about.mdx
+++ b/contents/about.mdx
@@ -1,12 +1,10 @@
 ---
-title: We're here to help you build successful products
+title: We're here to help make your product self-driving
 ---
 
 <Letterhead />
 
 <LottieAnimation variant="kendrick" />
-
-## We're here to help make your product self-driving
 
 Literally every piece of software that a product engineer needs.
 

--- a/src/components/About/v2/Letterhead.tsx
+++ b/src/components/About/v2/Letterhead.tsx
@@ -6,17 +6,18 @@ import CloudinaryImage from 'components/CloudinaryImage'
 import { useApp } from '../../../context/App'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
 
-export const Letterhead = () => {
+export const Letterhead = ({ title }: { title?: string }) => {
     const { siteSettings } = useApp()
 
     return (
         <div className="not-prose border-b border-primary py-4 flex flex-col gap-2 @sm:flex-row items-center justify-between">
-            <div>
+            <div className="flex flex-col gap-1 text-center @sm:text-left">
                 <Logo
                     className="inline-block"
                     variant={siteSettings.theme === 'dark' ? 'mono' : 'gradient'}
                     color={siteSettings.theme === 'dark' ? 'white' : undefined}
                 />
+                {title && <h1 className="text-xl @md:text-2xl font-bold m-0 mt-1">{title}</h1>}
             </div>
             <div className="@sm:hidden uppercase text-xs tracking-wider text-center text-muted pt-2">
                 From the desk of

--- a/src/components/About/v2/Letterhead.tsx
+++ b/src/components/About/v2/Letterhead.tsx
@@ -11,13 +11,15 @@ export const Letterhead = ({ title }: { title?: string }) => {
 
     return (
         <div className="not-prose border-b border-primary py-4 flex flex-col gap-2 @sm:flex-row items-center justify-between">
-            <div className="flex flex-col gap-1 text-center @sm:text-left">
+            <div className="flex flex-col gap-1 text-center @sm:text-left max-w-md">
                 <Logo
                     className="inline-block"
                     variant={siteSettings.theme === 'dark' ? 'mono' : 'gradient'}
                     color={siteSettings.theme === 'dark' ? 'white' : undefined}
                 />
-                {title && <h1 className="text-xl @md:text-2xl font-bold m-0 mt-1">{title}</h1>}
+                {title && (
+                    <h1 className="text-xl @md:text-2xl font-bold m-0 mt-1 leading-tight text-balance">{title}</h1>
+                )}
             </div>
             <div className="@sm:hidden uppercase text-xs tracking-wider text-center text-muted pt-2">
                 From the desk of

--- a/src/components/About/v2/Letterhead.tsx
+++ b/src/components/About/v2/Letterhead.tsx
@@ -11,7 +11,7 @@ export const Letterhead = ({ title }: { title?: string }) => {
 
     return (
         <div className="not-prose border-b border-primary py-4 flex flex-col gap-2 @sm:flex-row items-center justify-between">
-            <div className="flex flex-col gap-1 text-center @sm:text-left max-w-md">
+            <div className="text-center @sm:text-left max-w-md">
                 <Logo
                     className="inline-block"
                     variant={siteSettings.theme === 'dark' ? 'mono' : 'gradient'}

--- a/src/components/About/v2/Letterhead.tsx
+++ b/src/components/About/v2/Letterhead.tsx
@@ -1,25 +1,14 @@
 import React from 'react'
 import Link from 'components/Link'
 import { IconXNotTwitter } from 'components/OSIcons'
-import Logo from 'components/Logo'
 import CloudinaryImage from 'components/CloudinaryImage'
-import { useApp } from '../../../context/App'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
 
 export const Letterhead = ({ title }: { title?: string }) => {
-    const { siteSettings } = useApp()
-
     return (
         <div className="not-prose border-b border-primary py-4 flex flex-col gap-2 @sm:flex-row items-center justify-between">
             <div className="text-center @sm:text-left max-w-md">
-                <Logo
-                    className="inline-block"
-                    variant={siteSettings.theme === 'dark' ? 'mono' : 'gradient'}
-                    color={siteSettings.theme === 'dark' ? 'white' : undefined}
-                />
-                {title && (
-                    <h1 className="text-xl @md:text-2xl font-bold m-0 mt-1 leading-tight text-balance">{title}</h1>
-                )}
+                {title && <h1 className="text-xl @md:text-2xl font-bold m-0 leading-tight text-balance">{title}</h1>}
             </div>
             <div className="@sm:hidden uppercase text-xs tracking-wider text-center text-muted pt-2">
                 From the desk of

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -68,8 +68,14 @@ export default function About({ data }: AboutProps) {
             >
                 <div className="min-h-full px-4 @xl:px-8 py-4">
                     <div className="max-w-3xl mx-auto pb-12">
-                        <MDXProvider components={mdxComponents}>
-                            {data.mdx.frontmatter?.title && <h1>{data.mdx.frontmatter.title}</h1>}
+                        <MDXProvider
+                            components={{
+                                ...mdxComponents,
+                                Letterhead: (props: any) => (
+                                    <Letterhead {...props} title={data.mdx.frontmatter?.title} />
+                                ),
+                            }}
+                        >
                             <MDXRenderer>{data.mdx.body}</MDXRenderer>
                         </MDXProvider>
                     </div>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -66,9 +66,10 @@ export default function About({ data }: AboutProps) {
                     description: 'Learn about PostHog',
                 }}
             >
-                <div className="bg-primary min-h-full px-4 @xl:px-8 py-4">
+                <div className="min-h-full px-4 @xl:px-8 py-4">
                     <div className="max-w-3xl mx-auto pb-12">
                         <MDXProvider components={mdxComponents}>
+                            {data.mdx.frontmatter?.title && <h1>{data.mdx.frontmatter.title}</h1>}
                             <MDXRenderer>{data.mdx.body}</MDXRenderer>
                         </MDXProvider>
                     </div>


### PR DESCRIPTION
## Changes

The [/about](https://posthog.com/about) page ("Why PostHog") was missing its title and rendering with an opaque white background instead of the standard translucent app background.

- Render the page's frontmatter `title` as an `<h1>` — it was being queried in the GraphQL but never actually rendered.
- Remove the `bg-primary` wrapper `<div>` so the page inherits the `data-scheme="primary"` translucent background from the `Editor` template (the opaque `bg-primary` was the sole thing forcing the white look).

**Why:** Reported in Slack — the page was visibly missing a title and had the wrong (white/opaque) background.

*Screenshots to be verified in the Vercel preview build.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784285400505259?thread_ts=1784285400.505259&cid=C01V9AT7DK4)*