### PR TITLE
Update homepage context warehouse section copy

### DIFF
--- a/src/components/Home/Sections/DataStackSection.tsx
+++ b/src/components/Home/Sections/DataStackSection.tsx
@@ -6,8 +6,8 @@ import { ImageDW, TooltipDW } from 'components/Home/Decorations'
 export const DataStackSection = () => (
     <div id="customer-infrastructure">
         <h2>
-            The PostHog Context Warehouse: Built for data teams,{' '}
-            <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1">loved by engineers</span>
+            All your data,{' '}
+            <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1">working together</span>
         </h2>
 
         <div className="@lg:float-right text-sm @lg:max-w-xs bg-accent p-4 rounded-sm @lg:ml-6 @lg:mb-2 relative overflow-hidden">
@@ -31,20 +31,17 @@ export const DataStackSection = () => (
             <ImageDW />
         </div>
 
-        <Markdown className="[&_li]:marker:text-primary/50">{`Whether you're analyzing customer usage or directing an AI, you should be operating with the *full context*.
+        <Markdown className="[&_li]:marker:text-primary/50">{`Whether you're analyzing customer usage or directing AI, you should be operating with the *full* context.
 
-This includes things that happen outside your product:
+Combine everything in PostHog's context warehouse so that you, your agents, and your dashboard can query it directly. That includes:
 
-- payments from Stripe
-- enrichment from Clay
-- tickets in Zendesk
+- Data from 120+ external sources like Stripe, Postgres, and HubSpot
+- Insights from every other PostHog tool like Session Replays and Experiments
 
-Our context warehouse integrates with 120+ other tools and can push and pull data from our managed data warehouse.
+The data your agents need to make good decisions is already here. Ready to turn "tell me what happened" into "here's what to fix next."`}</Markdown>
 
-Combine it with all the other tools and PostHog isn't just a single source of truth. It's a single source of *everything*.`}</Markdown>
-
-        <Link to="/data-stack" state={{ newWindow: true }}>
-            README: PostHog data stack.md
+        <Link to="/data-stack/sources" state={{ newWindow: true }}>
+            Connect your first data source
         </Link>
     </div>
 )


### PR DESCRIPTION
## Changes

Refreshes the context warehouse section on the homepage (`DataStackSection`).

- New heading: "All your data, working together"
- Rewrote the body copy and bullets around external sources + insights from other PostHog tools
- CTA now reads "Connect your first data source" and links to `/data-stack/sources`

**Why:** With the new website design edits had been made to the data stack section to refer to context warehouse instead, these changes are a bit more comprehensive 

Note: I kept the existing "Built-in, Product OS ships with:" sidebar callout and the heading highlight treatment for visual consistency.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08CG24E3SR/p1783592546390069?thread_ts=1783592546.390069&cid=C08CG24E3SR)*
