### PR TITLE
Update homepage meta title and description

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ export default function Home() {
     return (
         <>
             <SEO
-                title="PostHog – Shift your product into self-driving mode"
+                title="PostHog – We make your product self-driving"
                 updateWindowTitle={false}
                 description="PostHog automatically diagnoses problems, fixes bugs, and generates pull requests – all without you having to prompt it."
                 image="/images/og/default.png"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,9 +6,9 @@ export default function Home() {
     return (
         <>
             <SEO
-                title="PostHog – We make your product self-driving"
+                title="PostHog – Shift your product into self-driving mode"
                 updateWindowTitle={false}
-                description="All your developer tools in one place. PostHog gives engineers everything to build, test, measure, and ship successful products faster. Get started free."
+                description="PostHog automatically diagnoses problems, fixes bugs, and generates pull requests – all without you having to prompt it."
                 image="/images/og/default.png"
                 languageAlternates={[
                     { hrefLang: 'en', href: '/' },


### PR DESCRIPTION
## Changes

Updates the homepage meta title and description to match the new self-driving positioning:

- **Title:** `PostHog – Shift your product into self-driving mode`
- **Description:** `PostHog automatically diagnoses problems, fixes bugs, and generates pull requests – all without you having to prompt it.`

**Why:** The homepage `<title>` / `og:title` / meta description still used older "we make your product self-driving" copy. This aligns the SEO metadata with the new website design and messaging.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1784226690533709?thread_ts=1784226690.533709&cid=C09GU689J1X)*
