### PR TITLE
docs: document the Waitlist, Alpha, Beta onboarding flow in the handbook

### DIFF
--- a/contents/handbook/marketing/email-comms.md
+++ b/contents/handbook/marketing/email-comms.md
@@ -97,12 +97,18 @@ The goal of this flow is to set expectations for what the self-hosted experience
 
 Our open source onboarding email is essentially identical to the self-hosted onboarding flow, but excludes information about the sunsetting of the self-hosted product. 
 
-#### Beta onboarding emails
-When a user opts in to a beta via [the feature preview menu](https://app.posthog.com/settings/user-feature-previews) we enter them into an email flow designed to help us collect feedback from users. 
+#### Waitlist, alpha, and beta onboarding emails
+When a user joins a waitlist or opts in to a feature preview — via [the feature preview menu](https://app.posthog.com/settings/user-feature-previews) or a waitlist form on posthog.com — a `$feature_enrollment_update` event is sent to Customer.io through a data pipeline and enters them into the Waitlist, Alpha, Beta onboarding flow. The flow immediately segments on the `$feature_enrollment_stage` property:
 
-This flow currently comprises a single, personal email from either Joe or the team lead working on the beta feature. This email is sent one week after the user joins the beta and features tailored content based on which beta the user joined. 
+- **Concept:** an immediate, simple confirmation that they're on the waitlist.
+- **Alpha:** an immediate email warning of rough edges and asking for feedback.
+- **Beta:** a 5-day wait, then an email asking for feedback on the beta.
 
-When responses come in, Joe generally triages replies and directs feedback to the relevant team, as well as rewarding users with merch as thanks for their feedback. 
+When a feature moves from concept to alpha or beta, users who registered interest are automatically opted in to the new stage and a `user moved feature preview stage` event fires — we then email them to let them know the feature is enabled and now available, and ask for feedback.
+
+All beta feedback is centralized to the `beta-feedback@posthog.com` Google Group, and replies are relayed into the [#posthog-feedback Slack channel](https://posthog.slack.com/archives/C011L071P8U) for everyone to see. PMs and team leads are encouraged to respond to and action this feedback for their alpha and beta releases, and to reward users with merch credits as thanks where appropriate.
+
+See [onboarding and lifecycle emails](/handbook/marketing/onboarding-and-lifecycle-emails) for how this flow fits into the wider system.
 
 > **Launching a beta?** It helps to let the Brand team know in [the team Slack](https://posthog.slack.com/archives/C083V7C6GKE). The team can then add your beta to the beta onboarding flow, and plan ahead for marketing announcements as needed. 
 

--- a/contents/handbook/marketing/onboarding-and-lifecycle-emails.md
+++ b/contents/handbook/marketing/onboarding-and-lifecycle-emails.md
@@ -45,10 +45,24 @@ There are hundreds; you only need the families. Before building one, check it do
 | --- | --- | --- | --- |
 | **Onboarding 8.0** (flagship) | `user signed up` | 130+ emails that branch on product intent and behavior to tailor the first-run experience | Activate within 7 days |
 | **Long-running onboarding** | `user signed up` | Slower, spaced-out nurture over a longer window | Logs in again |
-| **Beta onboarding** | `$feature_enrollment_update` | One feedback email after someone joins *any* beta — you get this free for every beta | Activates a product |
+| **Waitlist, Alpha, Beta onboarding** | `$feature_enrollment_update` | Branches on `$feature_enrollment_stage`: waitlist confirmation (concept), rough-edges warning (alpha), or a feedback ask after 5 days (beta) — you get this free for every early access feature | Collects feedback, activates a product |
 | **Startups & YC** | *enters a segment* | Program-specific content (credits, job board, integrations) | Activation |
 
 The idea behind the flagship: **it's intent-aware and activation-aware** — it sends people content about the product they came for, and exits the moment they activate. (Avoid Customer.io's legacy "behavioral" campaign type for anything new — it silently excludes existing and backfilled people.)
+
+## The Waitlist, Alpha, Beta onboarding flow
+
+Every early access feature gets lifecycle emails automatically. When someone joins a waitlist or opts in to a feature preview — in the app, or via a waitlist form on posthog.com — posthog-js fires a `$feature_enrollment_update` event carrying `$early_access_feature_name` and `$feature_enrollment_stage`. These events reach Customer.io through the "Send events to Customer.io" [data pipeline destination](https://us.posthog.com/project/2/pipeline/destinations), and any `$feature_enrollment_update` with both properties present triggers the flow.
+
+The flow immediately segments on `$feature_enrollment_stage`:
+
+- **`concept`** — an immediate, simple confirmation that they're on the waitlist.
+- **`alpha`** — an immediate email warning of rough edges and asking for feedback.
+- **`beta`** — a 5-day wait, then an email asking for feedback on the beta.
+
+When a feature's stage changes from `concept` to `alpha` or `beta`, everyone who registered interest is automatically opted in to the new stage and PostHog fires a `user moved feature preview stage` event (with `from` and `to` properties) for each enrolled person. When `from` is `concept` and `to` is `alpha` or `beta`, we send an email letting them know the feature is enabled and now available, and asking for feedback.
+
+All beta feedback is centralized to the `beta-feedback@posthog.com` Google Group. Replies to this address are relayed into the [#posthog-feedback Slack channel](https://posthog.slack.com/archives/C011L071P8U) for everyone to see. PMs and team leads are encouraged to respond to and action this feedback for their alpha and beta releases, and to give merch credits as a thank you where appropriate.
 
 ## The personalized "next steps" block
 
@@ -72,7 +86,7 @@ The email's Liquid reads these to pick the person's top un-activated product (bi
 Not every step applies to every launch, but this is the path of least surprise:
 
 1. **Confirm intent + activation exist** (Growth Engineering owns these). Without them the system is blind — do this *before* public beta.
-2. **In beta, lean on what's there.** The beta flow already collects feedback for every opt-in, for free. Want more? Build a "Beta Users – [product]" segment and a small, single-purpose flow.
+2. **In beta, lean on what's there.** The [Waitlist, Alpha, Beta onboarding flow](#the-waitlist-alpha-beta-onboarding-flow) already collects feedback for every opt-in, for free. Want more? Build a "Beta Users – [product]" segment and a small, single-purpose flow.
 3. **Decide: extend or build new.**
    - *Extend Onboarding 8.0* for a core product — add your intent branch and a few product emails to the main flow. Usually the right call.
    - *Build a standalone flow* for a distinct audience or behavior — event trigger for "when X happens", segment trigger for "everyone who is X".

--- a/contents/handbook/product/releasing-new-products-and-features.md
+++ b/contents/handbook/product/releasing-new-products-and-features.md
@@ -30,6 +30,8 @@ Please refer to the RFC for what the actual steps are. Duplicating them here wou
 
 Adding items to the coming soon menu early offers several advantages. It enables us to gauge interest in a new feature via sign-ups, equips our marketing teams with news they can promote to users, and ensures that betas can have sample users ready from the moment they launch.
 
+When someone joins a coming soon waitlist (in-app or on posthog.com), a `$feature_enrollment_update` event with `$feature_enrollment_stage: concept` is sent to Customer.io through a data pipeline, and they immediately receive a simple confirmation that they're on the waitlist. See [onboarding and lifecycle emails](/handbook/marketing/onboarding-and-lifecycle-emails#the-waitlist-alpha-beta-onboarding-flow) for the full flow.
+
 Coming soon features can either be large or small, so use your judgement about what is of interest to users, but it should be something that you expect to work on in the next 3-6 months.
 
 ## Phase 2: Alpha
@@ -42,7 +44,7 @@ Beta is when you open up the product to all users who want to opt-in. Betas do n
 
 <CalloutBox icon="IconInfo" title="Moving from Concept to Beta" type="fyi">
 
-Once you are ready to move an item from the coming soon roadmap to a beta which users can interact with, update the stage from `concept` to `beta` (or `alpha`). This triggers an automatic notification to all subscribed users letting them know that the beta is available. Users who registered interest during the Concept stage can then opt in to enable the feature.
+Once you are ready to move an item from the coming soon roadmap to a beta which users can interact with, update the stage from `concept` to `beta` (or `alpha`). Users who registered interest during the concept stage are automatically opted in to the new stage, and a `user moved feature preview stage` event fires for each of them — when the `from` property is `concept` and the `to` property is `alpha` or `beta`, this triggers an automatic email letting them know the feature is enabled and now available, and asking for feedback.
 
 Make sure your early access feature flag includes a `product_key` on the payload field to give people access to the product in their sidebar. Check the new product RFC for more details.
 
@@ -86,9 +88,9 @@ Product teams are responsible for [writing documentation](/handbook/engineering/
 
 Teams are encouraged to collect feedback from users in current betas so that they can build better products and we have some automations in place to facilitate this.
 
-After a week in any new beta, users will trigger an automatic email from the `beta-feedback@posthog.com` Google Group. This email will ask them, essentially, for any suggested changes to the beta. By default, all team leads and exec team members are in this Google Group and will get daily digests of responses. Others are invited to add themselves to the group, or change their notification settings.
+Joining an alpha or beta triggers automatic feedback emails from the `beta-feedback@posthog.com` Google Group: alpha users get an immediate email warning of rough edges and asking for feedback, while beta users get an email asking for feedback after 5 days. By default, all team leads and exec team members are in this Google Group and will get daily digests of responses. Others are invited to add themselves to the group, or change their notification settings.
 
-Regardless, emails to this Google Group will sync to the PostHog Feedback Slack channel for general awareness. Team leads are encouraged to respond to beta feedback emails.
+Regardless, replies to this Google Group are relayed into the [#posthog-feedback Slack channel](https://posthog.slack.com/archives/C011L071P8U) for everyone to see. PMs and team leads are encouraged to respond to and action this feedback for their alpha and beta releases, and to give merch credits as a thank you where appropriate.
 
 Teams can collect additional feedback if needed and the <SmallTeam slug="website" /> is able to help with creating feedback emails or funnels.
 


### PR DESCRIPTION
## What

Documents how coming-soon waitlist and feature-preview enrollment events drive lifecycle emails, consistently across the three handbook pages that touch this:

- **[Onboarding and lifecycle emails](https://posthog.com/handbook/marketing/onboarding-and-lifecycle-emails)** — renames the "Beta onboarding" core flow to **Waitlist, Alpha, Beta onboarding** and adds a dedicated section: `$feature_enrollment_update` (with `$early_access_feature_name` + `$feature_enrollment_stage`) flows to Customer.io via the "Send events to Customer.io" data pipeline destination and triggers the flow, which segments immediately on stage — concept gets an instant waitlist confirmation, alpha gets an instant rough-edges/feedback email, beta gets a feedback ask after 5 days. Also documents the concept→alpha/beta stage move (`user moved feature preview stage` with `from`/`to` → "your feature is now enabled" email), the `beta-feedback@posthog.com` Google Group, the [#posthog-feedback](https://posthog.slack.com/archives/C011L071P8U) Slack relay, and the PM/team-lead expectation to action feedback and give merch credits where appropriate.
- **[Email comms](https://posthog.com/handbook/marketing/email-comms)** — replaces the stale "Beta onboarding emails" section (which described a single personal email one week after joining) with the current stage-segmented flow, cross-linked to the lifecycle-emails page.
- **[Releasing new products and features](https://posthog.com/handbook/product/releasing-new-products-and-features)** — Phase 1 now notes waitlist joiners get an instant confirmation; the "Moving from Concept to Beta" callout explains the actual mechanism (auto opt-in + `user moved feature preview stage` event → email); "Collecting beta feedback" corrected from "after a week" to 5 days, with the alpha immediate email, Slack relay link, and merch-credit guidance added.

## Verified against the codebase / project 2

- `$feature_enrollment_update` properties (`$early_access_feature_name`, `$feature_enrollment_stage`) confirmed in posthog-js; `user moved feature preview stage` (`from`/`to`/`feature_flag_key`/`feature_name`) confirmed in `posthog/tasks/early_access_feature.py`.
- The enabled "Send events to Customer.io" destination in project 2 forwards `$feature_enrollment_update`, `user moved feature preview stage`, and `survey sent`.
- Customer.io campaign internals (branch logic, delays) are per @joethreepwood, who is verifying that side.

Related: PostHog/posthog#65180 (in-app enrollment events, merged), #18648 (website enrollment events, master), #17803 (roadmap rebuild).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*