### PR TITLE
Use AboutPostHog component for the reader-view "About" blurb

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -45,7 +45,6 @@ import CopyMarkdownActionsDropdown, { useMarkdownUrlExists } from 'components/Ma
 import CustomerMetadata from './CustomerMetadata'
 import { getVideoClasses } from '../../constants'
 import AboutPostHog from 'components/AboutPostHog'
-import { Blockquote } from 'components/BlockQuote'
 
 dayjs.extend(relativeTime)
 
@@ -1727,22 +1726,7 @@ function ReaderViewContent({
                                                     : contentMaxWidthClass || 'max-w-2xl'
                                             }`}
                                         >
-                                            <Blockquote>
-                                                PostHog is an all-in-one developer platform for building successful
-                                                products. We provide <a href="/product-analytics">product analytics</a>,{' '}
-                                                <a href="/web-analytics">web analytics</a>,{' '}
-                                                <a href="/session-replay">session replay</a>,{' '}
-                                                <a href="/error-tracking">error tracking</a>,{' '}
-                                                <a href="/feature-flags">feature flags</a>,{' '}
-                                                <a href="/experiments">experiments</a>, <a href="/surveys">surveys</a>,{' '}
-                                                <a href="/ai-observability">AI Observability</a>,{' '}
-                                                <a href="/logs">logs</a>, <a href="/workflows">workflows</a>,{' '}
-                                                <a href="/endpoints">endpoints</a>,{' '}
-                                                <a href="/data-warehouse">data warehouse</a>, <a href="/cdp">CDP</a>,
-                                                and an <a href="/ai">AI product assistant</a> to help debug your code,
-                                                ship features faster, and keep all your usage and customer data in one
-                                                stack.
-                                            </Blockquote>
+                                            <AboutPostHog />
                                         </div>
                                     )}
                                     {showQuestions && (


### PR DESCRIPTION
## Changes

The `AboutPostHog` component — the single source of truth for the standard "About PostHog" description (the new self-driving blurb) — was imported into `ReaderView` but never actually used. The old hardcoded product-list blockquote was left in place, so every content page (blog posts, newsletters, etc.) still rendered the stale copy.

This swaps the inline blockquote for `<AboutPostHog />` and removes the now-unused `Blockquote` import. All reader-view pages now show the current blurb from the shared component.

**Why:** The About snippet at the bottom of content pages (e.g. `/newsletter/code-review-tips`) was showing the old product-list copy despite the new self-driving blurb having been added to the shared component.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1784303303826209?thread_ts=1784303303.826209&cid=C09GU689J1X)*