### PR TITLE
Rename logged-in nav CTA from "Dashboard" to "Open PostHog"

### DIFF
--- a/src/components/Korean/KoreanTaskBarMenu/index.tsx
+++ b/src/components/Korean/KoreanTaskBarMenu/index.tsx
@@ -338,7 +338,7 @@ export default function TaskBarMenu() {
                                 }
                                 className=""
                             >
-                                {posthogInstance ? translateKo('Dashboard') : translateKo('Get started – free')}
+                                {posthogInstance ? translateKo('Open PostHog') : translateKo('Get started – free')}
                             </OSButton>
                         </div>
                         <Tooltip

--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -359,7 +359,7 @@ function TaskBarMenu() {
                                     }
                                     className=""
                                 >
-                                    {posthogInstance ? 'Dashboard' : 'Get started – free'}
+                                    {posthogInstance ? 'Open PostHog' : 'Get started – free'}
                                 </OSButton>
                             </div>
                             <Tooltip

--- a/src/hooks/usePostHogInstance.ts
+++ b/src/hooks/usePostHogInstance.ts
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
  * (i.e. the `ph_current_instance` cookie is set), or undefined if not.
  *
  * This is the same cookie check used by the main nav to show
- * "Dashboard" vs "Get started free".
+ * "Open PostHog" vs "Get started free".
  */
 export default function usePostHogInstance(): string | undefined {
     const [instance, setInstance] = useState<string>()

--- a/src/pages/ko/_translations.ts
+++ b/src/pages/ko/_translations.ts
@@ -21,6 +21,7 @@ const koTranslations: Record<string, string> = {
     Store: '스토어',
     Trash: '휴지통',
     Dashboard: '대시보드',
+    'Open PostHog': 'PostHog 열기',
     'Get started – free': '무료로 시작하기',
     'Get started - free': '무료로 시작하기',
     'Install with AI': 'AI로 설치하기',


### PR DESCRIPTION
## Changes

For logged-in users the top-nav CTA now reads **"Open PostHog"** instead of the ambiguous **"Dashboard"**. This also updates the Korean nav variant (with a matching translation) and a doc comment.

**Why:** "Dashboard" was needlessly ambiguous for the logged-in CTA — "Open PostHog" makes it clear the button takes you into the app.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784306767877529?thread_ts=1784306767.877529&cid=C01V9AT7DK4)*