### PR TITLE
Simplify posthog.com top navigation

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -1,8 +1,7 @@
 import { MenuType, MenuItemType } from 'components/RadixUI/MenuBar'
 import React from 'react'
-import { docsMenu, handbookSidebar } from '../../navs'
+import { docsMenu } from '../../navs'
 import * as Icons from '@posthog/icons'
-import { useSmallTeamsMenuItems } from './SmallTeamsMenuItems'
 import Logo from 'components/Logo'
 import { APP_COUNT } from '../../constants'
 import SearchableProductMenu from './SearchableProductMenu'
@@ -176,6 +175,11 @@ const processMenuItemWithGrouping = (item: DocsMenuItem): any => {
     return null
 }
 
+// Prioritized products, ordered to line up with the surfaces under the Products menu
+// (PostHog Code, Research, Slack, MCP, Context Warehouse) mapped to their docs categories.
+// Everything else falls through to alphabetical order below.
+const DOCS_PRIORITY = ['PostHog Code', 'PostHog AI', 'Slack app', 'MCP Analytics', 'Data Warehouse']
+
 const getDocsMenuItems = () => {
     let items = groupBySectionDividers((docsMenu as DocsMenu).children)
 
@@ -186,6 +190,21 @@ const getDocsMenuItems = () => {
         return true
     })
 
+    // Keep only real product entries (drop separators) so we can present one clean list:
+    // prioritized products first, then everything else alphabetically.
+    items = items
+        .filter((item) => item.type !== 'separator' && item.label)
+        .sort((a, b) => {
+            const aPriority = DOCS_PRIORITY.indexOf(a.label)
+            const bPriority = DOCS_PRIORITY.indexOf(b.label)
+            if (aPriority !== -1 || bPriority !== -1) {
+                if (aPriority === -1) return 1
+                if (bPriority === -1) return -1
+                return aPriority - bPriority
+            }
+            return a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+        })
+
     return items
 }
 
@@ -193,39 +212,6 @@ const mergedDocsMenu = (allProducts: any[]) => {
     const docsItems = getDocsMenuItems()
     const itemsWithMobileDestinations = addDocsMenuMobileDestinations(docsItems, allProducts)
     return [...DocsItemsStart, ...itemsWithMobileDestinations, ...DocsItemsEnd]
-}
-
-// Process handbookSidebar into menu item structure
-const processHandbookSidebar = (items: any[], isRoot = true): any[] => {
-    return items
-        .filter((item, idx) => {
-            // Omit the first 'Handbook' item at the root level
-            if (isRoot && idx === 0 && item.name === 'Handbook') return false
-            return !!item.name
-        })
-        .map((item) => {
-            if (item.children) {
-                return {
-                    type: 'submenu' as const,
-                    label: item.name,
-                    ...(item.url ? { link: item.url } : {}),
-                    items: processHandbookSidebar(item.children, false),
-                }
-            }
-            // If no url and no children, mark as disabled (label-like)
-            if (!item.url && !item.children) {
-                return {
-                    type: 'item' as const,
-                    label: item.name,
-                    disabled: true,
-                }
-            }
-            return {
-                type: 'item' as const,
-                label: item.name,
-                ...(item.url ? { link: item.url } : {}),
-            }
-        })
 }
 
 // Build Products menu items
@@ -300,7 +286,6 @@ const buildProductsMenuItems = (allProducts: any[]) => {
 }
 
 export function useMenuData(): MenuType[] {
-    const smallTeamsMenuItems = useSmallTeamsMenuItems()
     const allProducts = useProduct() as any[]
     const { isMobile } = useAppSettings()
     const [hedgehogModeEnabled, setHedgehogModeEnabled] = useHedgehogMode()
@@ -321,67 +306,13 @@ export function useMenuData(): MenuType[] {
                 },
                 {
                     type: 'item',
-                    label: 'Pricing calculator',
-                    link: '/pricing#calculator',
-                },
-                {
-                    type: 'item',
-                    label: 'Add-ons',
-                    link: '/pricing#addons',
-                },
-                {
-                    type: 'separator',
-                },
-                {
-                    type: 'item',
-                    label: 'PostHog for...',
-                    disabled: true,
-                },
-                {
-                    type: 'item',
-                    label: 'Founder stack',
-                    link: '/founder-stack',
-                },
-                {
-                    type: 'item',
-                    label: 'Startups',
-                    link: '/startups',
-                },
-                { type: 'separator' },
-                {
-                    type: 'item',
-                    label: 'Mildly interesting reads',
-                    disabled: true,
-                },
-                {
-                    type: 'item',
-                    label: 'Pricing philosophy',
-                    link: '/pricing#philosophy',
-                },
-                {
-                    type: 'item',
                     label: 'How we do "sales"',
                     link: '/sales',
                 },
                 {
                     type: 'item',
-                    label: 'Side project insurance',
-                    link: '/side-project-insurance',
-                },
-                {
-                    type: 'item',
-                    label: "You'll hate PostHog if...",
-                    link: '/vibe-check',
-                },
-                {
-                    type: 'item',
-                    label: "Don't get discount bamboozled",
-                    link: '/discounts',
-                },
-                {
-                    type: 'item',
-                    label: 'Social validation for enterprise',
-                    link: '/enterprise',
+                    label: 'Startups',
+                    link: '/startups',
                 },
                 { type: 'separator' },
                 {
@@ -410,9 +341,15 @@ export function useMenuData(): MenuType[] {
             items: [
                 {
                     type: 'item',
-                    label: 'PostHog newspaper',
-                    link: '/community',
+                    label: 'Newsletter',
+                    link: '/newsletter',
                     icon: <Icons.IconNewspaper className="size-4 text-orange" />,
+                },
+                {
+                    type: 'item',
+                    label: 'Blog',
+                    link: '/blog',
+                    icon: <Icons.IconPencil className="size-4 text-yellow" />,
                 },
                 {
                     type: 'item' as const,
@@ -444,39 +381,6 @@ export function useMenuData(): MenuType[] {
                     link: '/places',
                     icon: <Icons.IconMap className="size-4 text-red" />,
                 },
-                {
-                    type: 'separator',
-                },
-                {
-                    type: 'item',
-                    label: 'Content',
-                    disabled: true,
-                },
-                {
-                    type: 'item',
-                    label: 'Newsletter',
-                    link: '/newsletter',
-                },
-                {
-                    type: 'item',
-                    label: 'Blog',
-                    link: '/blog',
-                },
-                {
-                    type: 'item',
-                    label: 'Product Engineer Handbook',
-                    link: '/product-engineer',
-                },
-                {
-                    type: 'item',
-                    label: 'Product engineers hub',
-                    link: '/product-engineers',
-                },
-                {
-                    type: 'item',
-                    label: 'Founders hub',
-                    link: '/founders',
-                },
             ],
         },
         {
@@ -494,15 +398,8 @@ export function useMenuData(): MenuType[] {
                 },
                 {
                     type: 'item',
-                    label: 'Blog',
-                    link: '/blog',
-                },
-                {
-                    type: 'submenu',
                     label: 'Handbook',
                     link: '/handbook',
-                    items: processHandbookSidebar(handbookSidebar),
-                    mobileDestination: '/handbook',
                 },
                 {
                     type: 'item',
@@ -533,9 +430,9 @@ export function useMenuData(): MenuType[] {
                     link: '/people',
                 },
                 {
-                    type: 'submenu',
+                    type: 'item',
                     label: 'Small teams',
-                    items: smallTeamsMenuItems,
+                    link: '/small-teams',
                 },
                 {
                     type: 'item',
@@ -931,18 +828,6 @@ export const DocsItemsEnd = [
         link: '/tutorials',
         icon: <Icons.IconBook className="size-4 text-purple" />,
     },
-    {
-        type: 'item' as const,
-        label: 'Dashboard templates',
-        link: '/templates',
-        icon: <Icons.IconDashboard className="size-4 text-blue" />,
-    },
-    {
-        type: 'item' as const,
-        label: 'Tracks',
-        link: '/tracks',
-        icon: <Icons.IconGraduationCap className="size-4 text-black" />,
-    },
 ]
 
 import type { AppIconName } from 'components/OSIcons/AppIcon'
@@ -1046,9 +931,7 @@ export function useMenuSelectOptions() {
             label: 'Pricing',
             items: [
                 { value: 'pricing', label: 'Plans & usage-based pricing' },
-                { value: 'pricing#calculator', label: 'Pricing calculator' },
-                { value: 'pricing#addons', label: 'Add-ons' },
-                { value: 'founder-stack', label: 'Founder stack' },
+                { value: 'sales', label: 'How we do "sales"' },
                 { value: 'startups', label: 'Startups' },
             ],
         },
@@ -1058,11 +941,7 @@ export function useMenuSelectOptions() {
         },
         {
             label: 'Library',
-            items: [
-                { value: 'blog', label: 'Blog' },
-                { value: 'product-engineers', label: 'Product engineers hub' },
-                { value: 'founders', label: 'Founders hub' },
-            ],
+            items: [{ value: 'blog', label: 'Blog' }],
         },
         {
             label: 'Company',


### PR DESCRIPTION
## Changes

Simplifies the posthog.com top navigation (the OS-style TaskBar menu), which had grown crowded with long lists of niche links. All changes are contained in `src/components/TaskBarMenu/menuData.tsx`.

- **Pricing:** trimmed to Plans & usage-based pricing, How we do "sales" (moved up to 2nd), Startups, then the Learn more section (Watch a demo, Talk to a human). Removed the pricing calculator, add-ons, and the "PostHog for…" / "Mildly interesting reads" sections.
- **Docs:** reordered the product list to lead with the surfaces shown under **Products** (PostHog Code, PostHog AI, Slack app, MCP Analytics, Data Warehouse), then alphabetical for the rest. Removed Dashboard templates and Tracks. The reorder is done locally in `menuData.tsx` — the shared docs sidebar in `navs/index.js` is untouched.
- **Community:** promoted Newsletter (keeping the orange newspaper logo) and Blog (new pencil icon) to the top, and removed the Content section.
- **Company:** dropped the duplicate Blog link and turned Handbook and Small teams into direct links (`/handbook`, `/small-teams`) instead of expanding submenus.

**Products**, **More**, the logo, and the Learn more / Overview / Tutorials items are unchanged. No pages were moved or renamed, so no `vercel.json` redirects are needed.

**Why:** the nav had accumulated too many low-value links; this focuses each menu on what people actually use. A 90-day web-analytics check confirmed the removed links are low-traffic — the one meaningful exception (the Startups page) was kept in the Pricing menu.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
