### PR TITLE
Add to Observability + AI category list

### DIFF
--- a/contents/handbook/support/support-smes.md
+++ b/contents/handbook/support/support-smes.md
@@ -20,7 +20,7 @@ The various PostHog products have been split into the following product groups:
 - Flags (experiments, feature flags, surveys)
 - Data (batch exports, data stack, ingestion, workflows)
 - Replay (replay)
-- Observability + AI & client libraries (error tracking, PostHog AI, AI Observability, SDK/Implementation, mobile)
+- Observability + AI & client libraries (AI observability, error tracking, logs, mobile, PostHog AI, self-driving, SDKs/implementation)
 - Accounts & Billing (platform features, login/SSO, billing)
 
 **A note on these groupings**: These product groups are based on current ticket volumes. As products grow or new ones launch, we'll split or reorganize them. This structure will evolve with our needs.


### PR DESCRIPTION
Adding `logs` and `self-driving` to the list for the `Observability + AI & client libraries` group, for the classification agent (to reduce the number of tickets that need to be triaged) and for curious humans. 

(Also alphabetized the list because I couldn't not. 🙂)


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English

