### PR TITLE
docs: clarify recurring surveys stop automatically when schedule ends

### DIFF
--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -351,14 +351,7 @@ A few things to keep in mind:
 - **Dismissing counts as answering.** A user who dismisses the survey won't see it again until the next iteration, same as a user who submitted a response.
 - **Iteration boundaries are approximate.** PostHog processes iteration changes a few times per day, so a new iteration can begin a few hours after its scheduled start.
 - **Users must still match your display conditions** each time the survey becomes eligible to show again.
-- **The survey stops automatically when the last iteration ends.** A recurring survey is not open-ended. It runs for exactly the number of repetitions multiplied by the cycle length, counted from its launch date, and then PostHog sets an end date on it and stops showing it. In the example above, the survey runs for 90 days (3 iterations of 30 days) and then closes on its own.
-
-To keep collecting responses after the schedule has completed, you have two options:
-
-- **Add more repetitions.** Increasing "Show up to N times total" extends the schedule with more iterations. Because the schedule is anchored to the original launch date rather than to today, add enough repetitions for the final iteration's window to end in the future. Otherwise the newly added iterations are already in the past and the survey stays closed.
-- **Switch to a non-recurring survey.** Turn off "Repeat on a schedule" (or use [Every time the display conditions are met](#every-time-the-display-conditions-are-met)) to run the survey continuously with no automatic end date.
-
-> **Note:** Manually removing the end date on a survey whose schedule has already finished won't restart it. PostHog re-checks recurring schedules a few times a day, finds the schedule has elapsed, and sets the end date again within a few hours. Extend the schedule or make the survey non-recurring instead.
+- **The survey stops automatically when the last iteration ends.** A recurring survey isn't open-ended: it runs for the number of repetitions times the cycle length, counted from the launch date, then PostHog sets an end date and stops showing it. In the example above, it runs for 90 days (3 iterations of 30 days) and closes on its own. To keep collecting responses, either increase "Show up to N times total" (adding enough repetitions that the final iteration ends in the future, since the schedule stays anchored to the original launch date) or turn off "Repeat on a schedule" to run it continuously. Clearing the end date by hand won't restart a completed schedule — PostHog re-applies it within a few hours.
 
 If you want per-user spacing instead, like "don't show this user a survey more than once every 30 days, no matter the calendar," use [Every time the display conditions are met](#every-time-the-display-conditions-are-met) combined with the **Wait period** display condition. Note that the wait period applies across all your surveys: it hides the survey from users who have seen _any_ survey within that period, not just this one.
 

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -351,7 +351,14 @@ A few things to keep in mind:
 - **Dismissing counts as answering.** A user who dismisses the survey won't see it again until the next iteration, same as a user who submitted a response.
 - **Iteration boundaries are approximate.** PostHog processes iteration changes a few times per day, so a new iteration can begin a few hours after its scheduled start.
 - **Users must still match your display conditions** each time the survey becomes eligible to show again.
-- **The survey stops automatically when the last iteration ends.** A recurring survey isn't open-ended: it runs for the number of repetitions times the cycle length, counted from the launch date, then PostHog sets an end date and stops showing it. In the example above, it runs for 90 days (3 iterations of 30 days) and closes on its own. To keep collecting responses, either increase "Show up to N times total" (adding enough repetitions that the final iteration ends in the future, since the schedule stays anchored to the original launch date) or turn off "Repeat on a schedule" to run it continuously. Clearing the end date by hand won't restart a completed schedule — PostHog re-applies it within a few hours.
+- **The survey stops automatically when the last iteration ends.** A recurring survey is not open-ended. It runs for the number of repetitions times the cycle length, starting from the launch date. After the last iteration, PostHog sets an end date and stops showing the survey. In the example above, it runs for 90 days (3 iterations of 30 days) and then closes on its own.
+
+  To keep collecting responses after the schedule finishes, you have two options:
+
+  - **Add more repetitions.** Increase "Show up to N times total" to extend the schedule. PostHog anchors the schedule to the original launch date, so add enough repetitions to push the final iteration into the future. Older repetitions land in the past and leave the survey closed.
+  - **Switch to a non-recurring survey.** Turn off "Repeat on a schedule" to keep the survey running with no end date.
+
+  Removing the end date by hand does not restart a finished schedule. PostHog re-checks the schedule within a few hours and sets it again.
 
 If you want per-user spacing instead, like "don't show this user a survey more than once every 30 days, no matter the calendar," use [Every time the display conditions are met](#every-time-the-display-conditions-are-met) combined with the **Wait period** display condition. Note that the wait period applies across all your surveys: it hides the survey from users who have seen _any_ survey within that period, not just this one.
 

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -351,14 +351,12 @@ A few things to keep in mind:
 - **Dismissing counts as answering.** A user who dismisses the survey won't see it again until the next iteration, same as a user who submitted a response.
 - **Iteration boundaries are approximate.** PostHog processes iteration changes a few times per day, so a new iteration can begin a few hours after its scheduled start.
 - **Users must still match your display conditions** each time the survey becomes eligible to show again.
-- **The survey stops automatically when the last iteration ends.** A recurring survey is not open-ended. It runs for the number of repetitions times the cycle length, starting from the launch date. After the last iteration, PostHog sets an end date and stops showing the survey. In the example above, it runs for 90 days (3 iterations of 30 days) and then closes on its own.
+- **The survey stops automatically when the last iteration ends.** A recurring survey is not open-ended. It runs for the number of repetitions times the cycle length, starting from the launch date. After the last iteration, PostHog sets an end date and stops showing the survey. In the example above, it runs for 90 days (3 iterations of 30 days) and then closes on its own. Removing the end date does not restart a finished survey. PostHog re-checks the schedule within a few hours and re-applies the end date.
 
   To keep collecting responses after the schedule finishes, you have two options:
 
   - **Add more repetitions.** Increase "Show up to N times total" to extend the schedule. PostHog anchors the schedule to the original launch date, so add enough repetitions to push the final iteration into the future. Older repetitions land in the past and leave the survey closed.
   - **Switch to a non-recurring survey.** Turn off "Repeat on a schedule" to keep the survey running with no end date.
-
-  Removing the end date by hand does not restart a finished schedule. PostHog re-checks the schedule within a few hours and sets it again.
 
 If you want per-user spacing instead, like "don't show this user a survey more than once every 30 days, no matter the calendar," use [Every time the display conditions are met](#every-time-the-display-conditions-are-met) combined with the **Wait period** display condition. Note that the wait period applies across all your surveys: it hides the survey from users who have seen _any_ survey within that period, not just this one.
 

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -351,6 +351,14 @@ A few things to keep in mind:
 - **Dismissing counts as answering.** A user who dismisses the survey won't see it again until the next iteration, same as a user who submitted a response.
 - **Iteration boundaries are approximate.** PostHog processes iteration changes a few times per day, so a new iteration can begin a few hours after its scheduled start.
 - **Users must still match your display conditions** each time the survey becomes eligible to show again.
+- **The survey stops automatically when the last iteration ends.** A recurring survey is not open-ended. It runs for exactly the number of repetitions multiplied by the cycle length, counted from its launch date, and then PostHog sets an end date on it and stops showing it. In the example above, the survey runs for 90 days (3 iterations of 30 days) and then closes on its own.
+
+To keep collecting responses after the schedule has completed, you have two options:
+
+- **Add more repetitions.** Increasing "Show up to N times total" extends the schedule with more iterations. Because the schedule is anchored to the original launch date rather than to today, add enough repetitions for the final iteration's window to end in the future. Otherwise the newly added iterations are already in the past and the survey stays closed.
+- **Switch to a non-recurring survey.** Turn off "Repeat on a schedule" (or use [Every time the display conditions are met](#every-time-the-display-conditions-are-met)) to run the survey continuously with no automatic end date.
+
+> **Note:** Manually removing the end date on a survey whose schedule has already finished won't restart it. PostHog re-checks recurring schedules a few times a day, finds the schedule has elapsed, and sets the end date again within a few hours. Extend the schedule or make the survey non-recurring instead.
 
 If you want per-user spacing instead, like "don't show this user a survey more than once every 30 days, no matter the calendar," use [Every time the display conditions are met](#every-time-the-display-conditions-are-met) combined with the **Wait period** display condition. Note that the wait period applies across all your surveys: it hides the survey from users who have seen _any_ survey within that period, not just this one.
 


### PR DESCRIPTION
## Changes

Clarifies the [Repeat on a schedule](https://posthog.com/docs/surveys/creating-surveys#repeat-on-a-schedule) section of the surveys docs to explain what happens when a recurring survey's schedule completes.

**Why:** A user was confused about why their recurring survey kept "disabling itself." The behavior is by design — a recurring survey runs for a fixed number of iterations from its launch date, then PostHog automatically sets an end date and stops it — but the docs never said this.

This adds a single bullet to the existing "few things to keep in mind" list stating that the survey stops automatically when the last iteration ends (repetitions × cycle length, from launch), plus a short note on the two ways to keep collecting responses and the gotcha that clearing the end date won't restart a completed schedule.

No visual changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1784318523201349)*