### PR TITLE
Fix top-level menu overflow

### DIFF
--- a/src/components/RadixUI/MenuBar.tsx
+++ b/src/components/RadixUI/MenuBar.tsx
@@ -194,7 +194,7 @@ const MenuItem: React.FC<{
                     <RadixMenubar.Portal container={portalContainer || undefined}>
                         <RadixMenubar.SubContent
                             collisionBoundary={appContainer}
-                            className={`${ContentClasses} max-h-[var(--radix-menubar-content-available-height)] overflow-hidden flex flex-col`}
+                            className={`${ContentClasses} max-h-[calc(var(--radix-menubar-content-available-height)-0.75rem)] overflow-hidden flex flex-col`}
                             alignOffset={-5}
                             data-scheme="primary"
                         >
@@ -388,7 +388,7 @@ const MenuBar: React.FC<MenuBarProps> = ({ menus, className, triggerAsChild, cus
                         <RadixMenubar.Portal container={portalContainer || undefined}>
                             <RadixMenubar.Content
                                 collisionBoundary={appContainer}
-                                className={`${ContentClasses} max-h-[var(--radix-menubar-content-available-height)] overflow-hidden flex flex-col`}
+                                className={`${ContentClasses} max-h-[calc(var(--radix-menubar-content-available-height)-0.75rem)] overflow-hidden flex flex-col`}
                                 align="start"
                                 sideOffset={5}
                                 alignOffset={-3}

--- a/src/components/RadixUI/MenuBar.tsx
+++ b/src/components/RadixUI/MenuBar.tsx
@@ -388,22 +388,24 @@ const MenuBar: React.FC<MenuBarProps> = ({ menus, className, triggerAsChild, cus
                         <RadixMenubar.Portal container={portalContainer || undefined}>
                             <RadixMenubar.Content
                                 collisionBoundary={appContainer}
-                                className={ContentClasses}
+                                className={`${ContentClasses} max-h-[var(--radix-menubar-content-available-height)] overflow-hidden flex flex-col`}
                                 align="start"
                                 sideOffset={5}
                                 alignOffset={-3}
                                 data-scheme="primary"
                             >
-                                {menu.items.map((item, itemIndex) => (
-                                    <MenuItem
-                                        key={`${menuIndex}-${itemIndex}`}
-                                        item={item}
-                                        menuIndex={menuIndex}
-                                        portalContainer={portalContainer}
-                                        appContainer={appContainer}
-                                        onCloseMenu={closeMenu}
-                                    />
-                                ))}
+                                <ScrollArea className="min-h-0 !overflow-y-auto overscroll-contain">
+                                    {menu.items.map((item, itemIndex) => (
+                                        <MenuItem
+                                            key={`${menuIndex}-${itemIndex}`}
+                                            item={item}
+                                            menuIndex={menuIndex}
+                                            portalContainer={portalContainer}
+                                            appContainer={appContainer}
+                                            onCloseMenu={closeMenu}
+                                        />
+                                    ))}
+                                </ScrollArea>
                             </RadixMenubar.Content>
                         </RadixMenubar.Portal>
                     </RadixMenubar.Menu>


### PR DESCRIPTION
## Changes

- Ensures that long nav menu items have a self-contained scroll bar rather than causing route layout overflow. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
