### PR TITLE
Restore frosted-glass default and fix transparency flash on refresh

### DIFF
--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -744,8 +744,8 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             ? 'h-[95%] w-[80%]'
                             : 'size-full'
                     } !select-auto flex flex-col border-primary ${getWindowSurfaceBg(
-                        siteSettings.heaterMode
-                    )} ${getSurfaceMotionLayer(siteSettings.heaterMode, isCompositorActive)} rounded-lg ${
+                        siteSettings.reduceTransparency
+                    )} ${getSurfaceMotionLayer(siteSettings.reduceTransparency, isCompositorActive)} rounded-lg ${
                         item.appSettings?.size?.fixed ? 'border' : item.expanded ? 'border-t' : ''
                     } ${item.expanded ? 'shadow-none' : 'shadow-md'} ${
                         item.expanded

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -976,7 +976,7 @@ const LeftSidebar = ({
     onMobileClose,
 }: LeftSidebarProps) => {
     const { siteSettings } = useAppSettings()
-    const panelBg = getPanelSurfaceBg(siteSettings.heaterMode)
+    const panelBg = getPanelSurfaceBg(siteSettings.reduceTransparency)
     const { searchQuery } = useSearch()
     const { hasMounted } = useReaderView()
     const hasActiveSearch = !!searchQuery && searchQuery.length >= 2
@@ -1378,7 +1378,7 @@ function ReaderViewContent({
 }: ReaderViewProps) {
     const { compact } = useApp()
     const { siteSettings } = useAppSettings()
-    const panelBg = getPanelSurfaceBg(siteSettings.heaterMode)
+    const panelBg = getPanelSurfaceBg(siteSettings.reduceTransparency)
     const { appWindow, activeInternalMenu } = useWindow()
     const { hash } = useLocation()
     const contentRef = useRef<HTMLDivElement>(null)

--- a/src/components/SpotlightSearch/actions.tsx
+++ b/src/components/SpotlightSearch/actions.tsx
@@ -143,15 +143,15 @@ export const useSpotlightActions = (): SpotlightAction[] => {
                 }),
         },
         {
-            id: 'heater-mode',
-            label: siteSettings.heaterMode ? 'Turn on reduce transparency' : 'Turn off reduce transparency',
+            id: 'reduce-transparency',
+            label: siteSettings.reduceTransparency ? 'Turn off reduce transparency' : 'Turn on reduce transparency',
             icon: <IconBolt />,
             keywords: ['transparency', 'blur', 'frosted', 'visual', 'separation', 'accessibility'],
             keepOpen: true,
             perform: () => {
-                const next = !siteSettings.heaterMode
-                updateSiteSettings({ ...siteSettings, heaterMode: next })
-                if (!next) {
+                const next = !siteSettings.reduceTransparency
+                updateSiteSettings({ ...siteSettings, reduceTransparency: next })
+                if (next) {
                     toast(
                         <IconBolt className="size-5 inline-block mr-1" />,
                         'Reduce transparency on – solid panels, less GPU'

--- a/src/constants/frostedSurfaces.ts
+++ b/src/constants/frostedSurfaces.ts
@@ -1,8 +1,8 @@
 // OS window chrome — full literal strings so Tailwind JIT picks up every class.
-// Default (heaterMode): frosted glass with blur. Reduce transparency: solid bg-primary, no blur.
+// Default: frosted glass with blur. Reduce transparency (opt-in): solid bg-primary, no blur.
 // `reduce-transparency:` is a custom variant for prefers-reduced-transparency (macOS).
 
-/** Default — opaque, no blur */
+/** Reduce-transparency — opaque, no blur */
 export const WINDOW_BG = 'bg-primary transform-gpu reduce-transparency:!bg-primary'
 export const PANEL_BG = 'bg-primary transform-gpu reduce-transparency:!bg-primary'
 
@@ -20,11 +20,11 @@ export const HEATER_PANEL_BG =
 export const MOTION_LAYER = 'will-change-transform'
 export const HEATER_MOTION_LAYER = 'will-change-[transform,backdrop-filter]'
 
-export const getWindowSurfaceBg = (heaterMode?: boolean) => (heaterMode ? HEATER_WINDOW_BG : WINDOW_BG)
+export const getWindowSurfaceBg = (reduceTransparency?: boolean) => (reduceTransparency ? WINDOW_BG : HEATER_WINDOW_BG)
 export const getTaskbarSurfaceBg = () => TASKBAR_BG
-export const getPanelSurfaceBg = (heaterMode?: boolean) => (heaterMode ? HEATER_PANEL_BG : PANEL_BG)
-export const getSurfaceMotionLayer = (heaterMode?: boolean, active?: boolean) =>
-    active ? (heaterMode ? HEATER_MOTION_LAYER : MOTION_LAYER) : ''
+export const getPanelSurfaceBg = (reduceTransparency?: boolean) => (reduceTransparency ? PANEL_BG : HEATER_PANEL_BG)
+export const getSurfaceMotionLayer = (reduceTransparency?: boolean, active?: boolean) =>
+    active ? (reduceTransparency ? MOTION_LAYER : HEATER_MOTION_LAYER) : ''
 /** Taskbar always blurs — promote backdrop-filter while animating. */
 export const getTaskbarMotionLayer = (active?: boolean) => (active ? HEATER_MOTION_LAYER : '')
 

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -356,7 +356,7 @@ export const Context = createContext<AppContextType>({
         cursor: 'default',
         wallpaper: 'keyboard-garden',
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
         clickBehavior: 'double',
         performanceBoost: false,
     },
@@ -443,7 +443,7 @@ export const SettingsContext = createContext<AppSettingsContextType>({
         cursor: 'default',
         wallpaper: 'keyboard-garden',
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
         clickBehavior: 'double',
         performanceBoost: false,
     },
@@ -1593,7 +1593,7 @@ export interface SiteSettings {
     cursor: 'default' | 'xl' | 'james'
     wallpaper: 'keyboard-garden' | 'hogzilla' | 'startup-monopoly' | 'office-party'
     screensaverDisabled?: boolean
-    heaterMode?: boolean
+    reduceTransparency?: boolean
     clickBehavior?: 'single' | 'double'
     performanceBoost?: boolean
 }
@@ -1612,8 +1612,14 @@ const getInitialSiteSettings = () => {
         clickBehavior: 'double',
         performanceBoost: false,
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
         ...(typeof window !== 'undefined' ? JSON.parse(localStorage.getItem('siteSettings') || '{}') : {}),
+    }
+
+    // `heaterMode` was retired when transparency became the default. Drop any stale persisted
+    // value so it can't be mistaken for the current `reduceTransparency` setting.
+    if ('heaterMode' in siteSettings) {
+        delete (siteSettings as Record<string, unknown>).heaterMode
     }
 
     const retiredWallpapers = ['action-figure', '2001-bliss', 'parade', 'coding-at-night']
@@ -1642,7 +1648,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
         clickBehavior: 'double',
         performanceBoost: false,
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
     })
     const [taskbarHeight, setTaskbarHeight] = useState(59)
     const [lastClickedElementRect, setLastClickedElementRect] = useState<{ x: number; y: number } | null>(null)

--- a/src/pages/display-options.tsx
+++ b/src/pages/display-options.tsx
@@ -274,9 +274,9 @@ export default function DisplayOptions() {
                                 { label: 'Enabled', value: 'true' },
                             ]}
                             onValueChange={(value) => {
-                                updateSiteSettings({ ...siteSettings, heaterMode: value !== 'true' })
+                                updateSiteSettings({ ...siteSettings, reduceTransparency: value === 'true' })
                             }}
-                            value={siteSettings.heaterMode ? 'false' : 'true'}
+                            value={siteSettings.reduceTransparency ? 'true' : 'false'}
                         />
                     </div>
                 </div>

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -926,7 +926,7 @@ export default function SelfDrivingPage({
     const { siteSettings } = useAppSettings()
 
     const selfDrivingPRs = data?.allSelfDrivingPullRequest?.nodes ?? []
-    const humanRoleCardBackground = getWindowSurfaceBg(siteSettings.heaterMode)
+    const humanRoleCardBackground = getWindowSurfaceBg(siteSettings.reduceTransparency)
     return (
         <>
             <SEO


### PR DESCRIPTION
## Changes

Fixes the lost window transparency (frosted glass) effect and the flash-on-refresh that appeared after #18668.

That PR reused the existing `heaterMode` boolean to drive the new "reduce transparency" toggle and flipped its default. The problem: returning visitors already have `heaterMode: false` persisted in `localStorage` (the old default, written whenever any setting changed). Under the new code that stale value was read as "reduce transparency on", so windows and sidebars rendered as solid `bg-primary` with no blur. And because SSR/first paint used the new frosted default before hydration swapped in the stale opaque value, every refresh flashed.

This renames the setting to `reduceTransparency` (default off), so:

- The stale `heaterMode` value is ignored and the new key defaults to frosted glass for everyone → transparency restored.
- No persisted key on first paint means SSR and client agree → no more flash for the vast majority of users.
- The boolean now matches the "Reduce transparency" UI label (no more inverted logic), and the display-options toggle + Spotlight action are corrected to match.
- A small migration strips the retired `heaterMode` key from persisted settings.

Users who genuinely want opaque panels can still opt in via Display options or Spotlight; that choice persists under the new key.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784361111735919?thread_ts=1784361111.735919&cid=C01V9AT7DK4)*
