### PR TITLE
Fix background flicker

### DIFF
--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -35,9 +35,7 @@ import usePostHog from '../../hooks/usePostHog'
 import Modal from 'components/RadixUI/Modal'
 import { ToggleGroup } from 'components/RadixUI/ToggleGroup'
 import FloatingModal from 'components/FloatingModal'
-import { getSurfaceMotionLayer, getWindowSurfaceBg } from '../../constants/frostedSurfaces'
-
-export { getWindowSurfaceBg } from '../../constants/frostedSurfaces'
+import { MOTION_LAYER, WINDOW_BG } from '../../constants/frostedSurfaces'
 
 const recursiveSearch = (array: MenuItem[] | undefined, value: string): boolean => {
     if (!array) return false
@@ -743,11 +741,11 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             : item.windowed
                             ? 'h-[95%] w-[80%]'
                             : 'size-full'
-                    } !select-auto flex flex-col border-primary ${getWindowSurfaceBg(
-                        siteSettings.reduceTransparency
-                    )} ${getSurfaceMotionLayer(siteSettings.reduceTransparency, isCompositorActive)} rounded-lg ${
-                        item.appSettings?.size?.fixed ? 'border' : item.expanded ? 'border-t' : ''
-                    } ${item.expanded ? 'shadow-none' : 'shadow-md'} ${
+                    } !select-auto flex flex-col border-primary ${WINDOW_BG} ${
+                        isCompositorActive ? MOTION_LAYER : ''
+                    } rounded-lg ${item.appSettings?.size?.fixed ? 'border' : item.expanded ? 'border-t' : ''} ${
+                        item.expanded ? 'shadow-none' : 'shadow-md'
+                    } ${
                         item.expanded
                             ? 'rounded-tr-none rounded-tl-none'
                             : item.snapped === 'left'

--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -744,8 +744,8 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             ? 'h-[95%] w-[80%]'
                             : 'size-full'
                     } !select-auto flex flex-col border-primary ${getWindowSurfaceBg(
-                        siteSettings.heaterMode
-                    )} ${getSurfaceMotionLayer(siteSettings.heaterMode, isCompositorActive)} rounded-lg ${
+                        siteSettings.reduceTransparency
+                    )} ${getSurfaceMotionLayer(siteSettings.reduceTransparency, isCompositorActive)} rounded-lg ${
                         item.appSettings?.size?.fixed ? 'border' : item.expanded ? 'border-t' : ''
                     } ${item.expanded ? 'shadow-none' : 'shadow-md'} ${
                         item.expanded

--- a/src/components/Desktop/Wallpapers.tsx
+++ b/src/components/Desktop/Wallpapers.tsx
@@ -1,47 +1,28 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React from 'react'
 import CloudinaryImage from 'components/CloudinaryImage'
 
 /**
  * Wallpapers
  *
- * Renders the desktop OS wallpaper ("scene") behind everything. Two transitions:
+ * Renders every desktop scene; visibility is driven by `body[data-wallpaper]`,
+ * set from localStorage in theme-init.js before React hydrates (and kept in sync
+ * by App.tsx). That way the saved wallpaper paints on first frame — no flash of
+ * the default scene.
  *
- * 1. Light ↔ dark within a scene (700ms fade) — pure CSS. Both light and dark
- *    layers are always rendered and stacked; the persistent `dark` class on <body>
- *    drives `dark:` opacity/color transitions.
- * 2. Scene ↔ scene (500ms horizontal push) — React-managed. The incoming scene
- *    slides in from the right while the outgoing one is pushed off to the left.
- *    Only the active scene (plus the outgoing one mid-slide) is mounted, so each
- *    visitor only loads the images for scenes they actually view.
- *
- * When `reduceMotion` (the `performanceBoost` setting) is on, transitions are
- * dropped and scenes swap instantly.
+ * Light ↔ dark within a scene is a CSS fade via the persistent `dark` class.
+ * Scene ↔ scene is an instant swap.
  */
 
-const WALLPAPER_SLIDE_MS = 500
+const FADE_OPACITY = 'transition-opacity duration-700 ease-in-out'
+const FADE_COLORS = 'transition-colors duration-700 ease-in-out'
 
-// Light/dark fade helpers — class strings are written out in full so Tailwind's
-// JIT scanner can see them.
-const fadeOpacity = (reduceMotion?: boolean) => (reduceMotion ? '' : 'transition-opacity duration-700 ease-in-out')
-const fadeColors = (reduceMotion?: boolean) => (reduceMotion ? '' : 'transition-colors duration-700 ease-in-out')
-
-interface SceneProps {
-    reduceMotion?: boolean
-}
-
-const Hogzilla = ({ reduceMotion }: SceneProps) => (
+const Hogzilla = () => (
     <>
-        {/* Background gradient (light) */}
         <div
-            className={`absolute inset-0 bg-[linear-gradient(268.63deg,#E3E1E4_0%,#FDFDFD_80%,#FDFDFD_100%)] opacity-100 dark:opacity-0 ${fadeOpacity(
-                reduceMotion
-            )}`}
+            className={`absolute inset-0 bg-[linear-gradient(268.63deg,#E3E1E4_0%,#FDFDFD_80%,#FDFDFD_100%)] opacity-100 dark:opacity-0 ${FADE_OPACITY}`}
         />
-        {/* Background gradient (dark) */}
         <div
-            className={`absolute inset-0 bg-[linear-gradient(180deg,#141E40_0%,#46368B_100%)] opacity-0 dark:opacity-100 ${fadeOpacity(
-                reduceMotion
-            )}`}
+            className={`absolute inset-0 bg-[linear-gradient(180deg,#141E40_0%,#46368B_100%)] opacity-0 dark:opacity-100 ${FADE_OPACITY}`}
         />
         <CloudinaryImage
             loading="lazy"
@@ -55,18 +36,16 @@ const Hogzilla = ({ reduceMotion }: SceneProps) => (
     </>
 )
 
-const StartupMonopoly = ({ reduceMotion }: SceneProps) => (
+const StartupMonopoly = () => (
     <>
-        <div className={`absolute inset-0 bg-[#E7E0DA] dark:bg-[#686E88] ${fadeColors(reduceMotion)}`} />
+        <div className={`absolute inset-0 bg-[#E7E0DA] dark:bg-[#686E88] ${FADE_COLORS}`} />
         <CloudinaryImage
             loading="lazy"
             src="https://res.cloudinary.com/dmukukwp6/image/upload/9000_monopoly_light_6614a8a5d5.jpg"
             alt=""
             width={2967}
             height={1463}
-            className={`absolute right-0 top-0 w-[1483.5px] h-[731.5px] max-w-full opacity-100 dark:opacity-0 ${fadeOpacity(
-                reduceMotion
-            )}`}
+            className={`absolute right-0 top-0 w-[1483.5px] h-[731.5px] max-w-full opacity-100 dark:opacity-0 ${FADE_OPACITY}`}
         />
         <CloudinaryImage
             loading="lazy"
@@ -74,14 +53,12 @@ const StartupMonopoly = ({ reduceMotion }: SceneProps) => (
             alt=""
             width={1582}
             height={782}
-            className={`absolute right-0 top-0 w-[1483.5px] h-[731.5px] max-w-full opacity-0 dark:opacity-100 ${fadeOpacity(
-                reduceMotion
-            )}`}
+            className={`absolute right-0 top-0 w-[1483.5px] h-[731.5px] max-w-full opacity-0 dark:opacity-100 ${FADE_OPACITY}`}
         />
     </>
 )
 
-const OfficeParty = ({ reduceMotion }: SceneProps) => (
+const OfficeParty = () => (
     <>
         <div
             className="absolute inset-0 opacity-100"
@@ -92,7 +69,7 @@ const OfficeParty = ({ reduceMotion }: SceneProps) => (
             }}
         />
         <div
-            className={`absolute inset-0 opacity-0 dark:opacity-100 ${fadeOpacity(reduceMotion)}`}
+            className={`absolute inset-0 opacity-0 dark:opacity-100 ${FADE_OPACITY}`}
             style={{
                 backgroundImage: "url('https://res.cloudinary.com/dmukukwp6/image/upload/carpet_dark_f1c9f5ce39.png')",
                 backgroundSize: '200px 198px',
@@ -110,13 +87,12 @@ const OfficeParty = ({ reduceMotion }: SceneProps) => (
     </>
 )
 
-const KeyboardGarden = ({ reduceMotion }: SceneProps) => (
+const KeyboardGarden = () => (
     <>
         <div className="absolute inset-0 bg-gradient-to-b from-[#FDEECD] to-[#FFFEF4]" />
 
-        {/* Mobile background (light) */}
         <div
-            className={`absolute inset-0 sm:hidden opacity-100 dark:opacity-0 ${fadeOpacity(reduceMotion)}`}
+            className={`absolute inset-0 sm:hidden opacity-100 dark:opacity-0 ${FADE_OPACITY}`}
             style={{
                 backgroundImage:
                     "url('https://res.cloudinary.com/dmukukwp6/image/upload/9000_mobile_bg_light_95ed14e5a3.jpg')",
@@ -125,10 +101,8 @@ const KeyboardGarden = ({ reduceMotion }: SceneProps) => (
                 backgroundPosition: 'right bottom',
             }}
         />
-
-        {/* Mobile background (dark) */}
         <div
-            className={`absolute inset-0 sm:hidden opacity-0 dark:opacity-100 ${fadeOpacity(reduceMotion)}`}
+            className={`absolute inset-0 sm:hidden opacity-0 dark:opacity-100 ${FADE_OPACITY}`}
             style={{
                 backgroundImage:
                     "url('https://res.cloudinary.com/dmukukwp6/image/upload/9000_mobile_bg_dark_8a84515f2d.jpg')",
@@ -137,10 +111,8 @@ const KeyboardGarden = ({ reduceMotion }: SceneProps) => (
                 backgroundPosition: 'right bottom',
             }}
         />
-
-        {/* Desktop background (light) */}
         <div
-            className={`absolute inset-0 hidden sm:block opacity-100 dark:opacity-0 ${fadeOpacity(reduceMotion)}`}
+            className={`absolute inset-0 hidden sm:block opacity-100 dark:opacity-0 ${FADE_OPACITY}`}
             style={{
                 backgroundImage:
                     "url('https://res.cloudinary.com/dmukukwp6/image/upload/9000_bg_light_07316896be.jpg')",
@@ -149,10 +121,8 @@ const KeyboardGarden = ({ reduceMotion }: SceneProps) => (
                 backgroundPosition: 'right bottom',
             }}
         />
-
-        {/* Desktop background (dark) */}
         <div
-            className={`absolute inset-0 hidden sm:block opacity-0 dark:opacity-100 ${fadeOpacity(reduceMotion)}`}
+            className={`absolute inset-0 hidden sm:block opacity-0 dark:opacity-100 ${FADE_OPACITY}`}
             style={{
                 backgroundImage: "url('https://res.cloudinary.com/dmukukwp6/image/upload/9000_bg_dark_9a32796f77.jpg')",
                 backgroundSize: 'cover',
@@ -161,55 +131,44 @@ const KeyboardGarden = ({ reduceMotion }: SceneProps) => (
             }}
         />
 
-        {/* Hedge scene — light/dark stacked in a single grid cell so layout sizing is preserved */}
         <div className="absolute grid bottom-24 md:bottom-0 -right-4 xs:right-8 md:right-0">
-            {/* Hedge scene (light) */}
             <CloudinaryImage
                 loading="lazy"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/9000_hedge_light_42c729131e.png"
                 width={1555}
                 height={1262}
-                className={`col-start-1 row-start-1 opacity-100 dark:opacity-0 w-full max-w-full md:w-[777px] ${fadeOpacity(
-                    reduceMotion
-                )}`}
+                className={`col-start-1 row-start-1 opacity-100 dark:opacity-0 w-full max-w-full md:w-[777px] ${FADE_OPACITY}`}
                 draggable={false}
             />
-            {/* Hedge scene (dark) */}
             <CloudinaryImage
                 loading="lazy"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/9000_hedge_dark_b36706e924.png"
                 width={1555}
                 height={1262}
-                className={`col-start-1 row-start-1 opacity-0 dark:opacity-100 w-full max-w-full md:w-[777px] ${fadeOpacity(
-                    reduceMotion
-                )}`}
+                className={`col-start-1 row-start-1 opacity-0 dark:opacity-100 w-full max-w-full md:w-[777px] ${FADE_OPACITY}`}
                 draggable={false}
             />
         </div>
     </>
 )
 
-const WALLPAPER_COMPONENTS: Record<string, React.FC<SceneProps>> = {
-    hogzilla: Hogzilla,
-    'startup-monopoly': StartupMonopoly,
-    'office-party': OfficeParty,
-    'keyboard-garden': KeyboardGarden,
-}
+// Visibility classes written out in full so Tailwind's JIT scanner can see them.
+const SCENES: { key: string; Scene: React.FC; visible: string }[] = [
+    { key: 'hogzilla', Scene: Hogzilla, visible: 'wallpaper-hogzilla:block' },
+    { key: 'startup-monopoly', Scene: StartupMonopoly, visible: 'wallpaper-startup-monopoly:block' },
+    { key: 'office-party', Scene: OfficeParty, visible: 'wallpaper-office-party:block' },
+    { key: 'keyboard-garden', Scene: KeyboardGarden, visible: 'wallpaper-keyboard-garden:block' },
+]
 
 export interface WallpaperGlow {
     light: string
     dark: string
 }
 
-// Hover-glow colors for desktop GlassIcons, per wallpaper. Any wallpaper not
-// listed here falls back to keyboard-garden (see getWallpaperGlow).
 export const WALLPAPER_GLOW: Record<string, WallpaperGlow> = {
     'keyboard-garden': { light: '#53FFCB', dark: '#49BAC5' },
-    // Fire breath (light) / night-sky purple from the dark gradient (dark)
     hogzilla: { light: '#FF9528', dark: '#9370F0' },
-    // Board green (light) / cool periwinkle from the dark scene (dark)
     'startup-monopoly': { light: '#37B878', dark: '#96B4F0' },
-    // Warm carpet coral (light) / party purple from the dark carpet (dark)
     'office-party': { light: '#FF6E54', dark: '#D084F8' },
 }
 
@@ -218,87 +177,14 @@ export const DEFAULT_WALLPAPER_GLOW: WallpaperGlow = WALLPAPER_GLOW['keyboard-ga
 export const getWallpaperGlow = (wallpaper: string): WallpaperGlow =>
     WALLPAPER_GLOW[wallpaper] ?? DEFAULT_WALLPAPER_GLOW
 
-interface WallpapersProps {
-    wallpaper: string
-    reduceMotion?: boolean
-}
-
-export default function Wallpapers({ wallpaper, reduceMotion }: WallpapersProps): JSX.Element {
-    // Scenes currently in the DOM, in slide order: outgoing scene(s) first, the
-    // active scene last (incoming scenes are appended). The incoming scene is
-    // appended to the right of the active one, then `active` flips so it slides in.
-    const [mounted, setMounted] = useState<string[]>([wallpaper])
-    // The scene that should occupy the screen (translate-x-0). Lags `wallpaper` by
-    // a frame so a freshly mounted scene slides in from the right edge.
-    const [active, setActive] = useState<string>(wallpaper)
-
-    const pruneTimeout = useRef<ReturnType<typeof setTimeout>>()
-    const raf = useRef<number>()
-    const isFirstRender = useRef(true)
-
-    useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false
-            return
-        }
-
-        clearTimeout(pruneTimeout.current)
-        if (raf.current) cancelAnimationFrame(raf.current)
-
-        if (reduceMotion) {
-            setMounted([wallpaper])
-            setActive(wallpaper)
-            return
-        }
-
-        // Mount the incoming scene to the right (offscreen) of the current one.
-        setMounted((prev) => (prev.includes(wallpaper) ? prev : [...prev, wallpaper]))
-
-        // Next frame, flip the active scene so the push animates: the incoming
-        // scene slides from the right to center, the outgoing one off to the left.
-        raf.current = requestAnimationFrame(() => {
-            raf.current = requestAnimationFrame(() => setActive(wallpaper))
-        })
-
-        // Once the slide is done, drop the outgoing scene(s).
-        pruneTimeout.current = setTimeout(() => {
-            setMounted([wallpaper])
-        }, WALLPAPER_SLIDE_MS + 50)
-    }, [wallpaper, reduceMotion])
-
-    useEffect(
-        () => () => {
-            clearTimeout(pruneTimeout.current)
-            if (raf.current) cancelAnimationFrame(raf.current)
-        },
-        []
-    )
-
+export default function Wallpapers(): JSX.Element {
     return (
-        <div className="fixed inset-0 -z-10 select-none overflow-hidden">
-            {mounted.map((name, index) => {
-                const Scene = WALLPAPER_COMPONENTS[name]
-                if (!Scene) return null
-                const activeIndex = mounted.indexOf(active)
-                // Active = centered; scenes before it are pushed off left, scenes
-                // after it wait offscreen right (incoming, before the active flip).
-                const position =
-                    index === activeIndex
-                        ? 'translate-x-0'
-                        : index < activeIndex
-                        ? '-translate-x-full'
-                        : 'translate-x-full'
-                return (
-                    <div
-                        key={name}
-                        className={`absolute inset-0 pointer-events-none ${
-                            reduceMotion ? '' : 'transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]'
-                        } ${position}`}
-                    >
-                        <Scene reduceMotion={reduceMotion} />
-                    </div>
-                )
-            })}
+        <div className="fixed inset-0 -z-10 select-none overflow-hidden pointer-events-none">
+            {SCENES.map(({ key, Scene, visible }) => (
+                <div key={key} className={`hidden ${visible} absolute inset-0`}>
+                    <Scene />
+                </div>
+            ))}
         </div>
     )
 }

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -976,7 +976,7 @@ const LeftSidebar = ({
     onMobileClose,
 }: LeftSidebarProps) => {
     const { siteSettings } = useAppSettings()
-    const panelBg = getPanelSurfaceBg(siteSettings.heaterMode)
+    const panelBg = getPanelSurfaceBg(siteSettings.reduceTransparency)
     const { searchQuery } = useSearch()
     const { hasMounted } = useReaderView()
     const hasActiveSearch = !!searchQuery && searchQuery.length >= 2
@@ -1378,7 +1378,7 @@ function ReaderViewContent({
 }: ReaderViewProps) {
     const { compact } = useApp()
     const { siteSettings } = useAppSettings()
-    const panelBg = getPanelSurfaceBg(siteSettings.heaterMode)
+    const panelBg = getPanelSurfaceBg(siteSettings.reduceTransparency)
     const { appWindow, activeInternalMenu } = useWindow()
     const { hash } = useLocation()
     const contentRef = useRef<HTMLDivElement>(null)

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -36,8 +36,7 @@ import { InlineSearch } from 'components/Search/InlineSearch'
 import { algoliaIndexName, algoliaSearchClient } from 'lib/algoliaSearch'
 import { useLocation } from '@reach/router'
 import { getProseClasses, isMarkdownContentPath } from '../../constants'
-import { getPanelSurfaceBg } from '../../constants/frostedSurfaces'
-import { useAppSettings } from '../../context/App'
+import { PANEL_BG } from '../../constants/frostedSurfaces'
 import { useWindow } from '../../context/Window'
 import { MenuItem, useApp } from '../../context/App'
 import { useActiveFeatureFlags, filterMenuByFlags } from '../../hooks/useActiveFeatureFlags'
@@ -975,8 +974,6 @@ const LeftSidebar = ({
     mobileOpen = false,
     onMobileClose,
 }: LeftSidebarProps) => {
-    const { siteSettings } = useAppSettings()
-    const panelBg = getPanelSurfaceBg(siteSettings.reduceTransparency)
     const { searchQuery } = useSearch()
     const { hasMounted } = useReaderView()
     const hasActiveSearch = !!searchQuery && searchQuery.length >= 2
@@ -1119,9 +1116,9 @@ const LeftSidebar = ({
                     // On mobile the panel is always an overlay drawer above the
                     // content; it just slides off-screen when closed.
                     mobile
-                        ? `z-50 shadow-2xl ${panelBg} ${mobileOpen ? '' : 'pointer-events-none'}`
+                        ? `z-50 shadow-2xl ${PANEL_BG} ${mobileOpen ? '' : 'pointer-events-none'}`
                         : !isPinned && expanded
-                        ? `z-50 shadow-2xl ${panelBg}`
+                        ? `z-50 shadow-2xl ${PANEL_BG}`
                         : 'z-30'
                 }`}
             >
@@ -1377,8 +1374,6 @@ function ReaderViewContent({
     className = '',
 }: ReaderViewProps) {
     const { compact } = useApp()
-    const { siteSettings } = useAppSettings()
-    const panelBg = getPanelSurfaceBg(siteSettings.reduceTransparency)
     const { appWindow, activeInternalMenu } = useWindow()
     const { hash } = useLocation()
     const contentRef = useRef<HTMLDivElement>(null)
@@ -1528,7 +1523,7 @@ function ReaderViewContent({
                             type="button"
                             aria-label="Open navigation"
                             onClick={() => setMobileNavOpen(true)}
-                            className={`absolute bottom-4 right-4 z-30 flex size-11 items-center justify-center rounded-full border border-primary text-primary shadow-lg transition-opacity duration-200 hover:bg-accent ${panelBg} ${
+                            className={`absolute bottom-4 right-4 z-30 flex size-11 items-center justify-center rounded-full border border-primary text-primary shadow-lg transition-opacity duration-200 hover:bg-accent ${PANEL_BG} ${
                                 mobileNavOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'
                             }`}
                         >

--- a/src/components/SpotlightSearch/actions.tsx
+++ b/src/components/SpotlightSearch/actions.tsx
@@ -143,15 +143,15 @@ export const useSpotlightActions = (): SpotlightAction[] => {
                 }),
         },
         {
-            id: 'heater-mode',
-            label: siteSettings.heaterMode ? 'Turn on reduce transparency' : 'Turn off reduce transparency',
+            id: 'reduce-transparency',
+            label: siteSettings.reduceTransparency ? 'Turn off reduce transparency' : 'Turn on reduce transparency',
             icon: <IconBolt />,
-            keywords: ['transparency', 'blur', 'frosted', 'visual', 'separation', 'accessibility'],
+            keywords: ['transparency', 'blur', 'frosted', 'visual', 'separation', 'accessibility', 'heater'],
             keepOpen: true,
             perform: () => {
-                const next = !siteSettings.heaterMode
-                updateSiteSettings({ ...siteSettings, heaterMode: next })
-                if (!next) {
+                const next = !siteSettings.reduceTransparency
+                updateSiteSettings({ ...siteSettings, reduceTransparency: next })
+                if (next) {
                     toast(
                         <IconBolt className="size-5 inline-block mr-1" />,
                         'Reduce transparency on – solid panels, less GPU'

--- a/src/components/SpotlightSearch/actions.tsx
+++ b/src/components/SpotlightSearch/actions.tsx
@@ -154,7 +154,7 @@ export const useSpotlightActions = (): SpotlightAction[] => {
                 if (next) {
                     toast(
                         <IconBolt className="size-5 inline-block mr-1" />,
-                        'Reduce transparency on – solid panels, less GPU'
+                        'Reduce transparency on - solid window backgrounds'
                     )
                 }
             },

--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -28,7 +28,7 @@ import { useMenuData } from './menuData'
 import CloudinaryImage from 'components/CloudinaryImage'
 import MediaUploadModal from 'components/MediaUploadModal'
 import KeyboardShortcut from 'components/KeyboardShortcut'
-import { getTaskbarMotionLayer, getTaskbarSurfaceBg } from '../../constants/frostedSurfaces'
+import { MOTION_LAYER, TASKBAR_BG } from '../../constants/frostedSurfaces'
 
 function TaskBarMenu() {
     const {
@@ -290,9 +290,9 @@ function TaskBarMenu() {
                         width: '100%',
                         boxSizing: 'border-box',
                     }}
-                    className={`${getTaskbarSurfaceBg()} ${getTaskbarMotionLayer(
-                        isAnimating
-                    )} skin-classic:bg-accent wallpaper-keyboard-garden:dark:bg-black/15 border-secondary rounded pl-0.5 pr-2 shadow-2xl`}
+                    className={`${TASKBAR_BG} ${
+                        isAnimating ? MOTION_LAYER : ''
+                    } skin-classic:bg-accent wallpaper-keyboard-garden:dark:bg-black/15 border-secondary rounded pl-0.5 pr-2 shadow-2xl`}
                 >
                     {/* Top and bottom edges of the 3D box — visible during rotation */}
                     <div

--- a/src/constants/frostedSurfaces.ts
+++ b/src/constants/frostedSurfaces.ts
@@ -10,9 +10,8 @@ export const WINDOW_BG =
 export const PANEL_BG =
     'bg-primary/75 dark:bg-primary backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
 
-/** Taskbar — always blurred (still respects OS/site reduce transparency) */
-export const TASKBAR_BG =
-    'bg-primary/50 backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
+/** Taskbar — always frosted; not tied to reduce transparency */
+export const TASKBAR_BG = 'bg-primary/50 backdrop-blur-3xl transform-gpu'
 
 /** Promote compositor layers while a surface is moving */
 export const MOTION_LAYER = 'will-change-[transform,backdrop-filter] reduce-transparency:will-change-transform'

--- a/src/constants/frostedSurfaces.ts
+++ b/src/constants/frostedSurfaces.ts
@@ -1,32 +1,18 @@
 // OS window chrome — full literal strings so Tailwind JIT picks up every class.
-// Default: frosted glass with blur. Reduce transparency: solid bg-primary, no blur.
-// `reduce-transparency:` is a custom variant for prefers-reduced-transparency (macOS).
+// Default: frosted glass. Solid opaque when body[data-reduce-transparency="true"]
+// or prefers-reduced-transparency (via the `reduce-transparency:` variant).
 
-/** Solid opaque — used when reduce transparency is on */
-export const WINDOW_BG = 'bg-primary transform-gpu reduce-transparency:!bg-primary'
-export const PANEL_BG = 'bg-primary transform-gpu reduce-transparency:!bg-primary'
+/** App windows — frosted by default; solid when reduce transparency is on */
+export const WINDOW_BG =
+    'bg-primary/75 backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
 
-/** Taskbar — always blurred */
+/** Reader sidebar overlays */
+export const PANEL_BG =
+    'bg-primary/75 dark:bg-primary backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
+
+/** Taskbar — always blurred (still respects OS/site reduce transparency) */
 export const TASKBAR_BG =
     'bg-primary/50 backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
 
-/** Frosted glass (windows + sidebar overlays) — default when reduce transparency is off */
-export const FROSTED_WINDOW_BG =
-    'bg-primary/75 backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
-export const FROSTED_PANEL_BG =
-    'bg-primary/75 dark:bg-primary backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
-
 /** Promote compositor layers while a surface is moving */
-export const MOTION_LAYER = 'will-change-transform'
-export const FROSTED_MOTION_LAYER = 'will-change-[transform,backdrop-filter]'
-
-export const getWindowSurfaceBg = (reduceTransparency?: boolean) => (reduceTransparency ? WINDOW_BG : FROSTED_WINDOW_BG)
-export const getTaskbarSurfaceBg = () => TASKBAR_BG
-export const getPanelSurfaceBg = (reduceTransparency?: boolean) => (reduceTransparency ? PANEL_BG : FROSTED_PANEL_BG)
-export const getSurfaceMotionLayer = (reduceTransparency?: boolean, active?: boolean) =>
-    active ? (reduceTransparency ? MOTION_LAYER : FROSTED_MOTION_LAYER) : ''
-/** Taskbar always blurs — promote backdrop-filter while animating. */
-export const getTaskbarMotionLayer = (active?: boolean) => (active ? FROSTED_MOTION_LAYER : '')
-
-/** @deprecated Use TASKBAR_BG / getTaskbarSurfaceBg() */
-export const FROSTED_TASKBAR_BG = TASKBAR_BG
+export const MOTION_LAYER = 'will-change-[transform,backdrop-filter] reduce-transparency:will-change-transform'

--- a/src/constants/frostedSurfaces.ts
+++ b/src/constants/frostedSurfaces.ts
@@ -1,38 +1,32 @@
 // OS window chrome — full literal strings so Tailwind JIT picks up every class.
-// Default (heaterMode): frosted glass with blur. Reduce transparency: solid bg-primary, no blur.
+// Default: frosted glass with blur. Reduce transparency: solid bg-primary, no blur.
 // `reduce-transparency:` is a custom variant for prefers-reduced-transparency (macOS).
 
-/** Default — opaque, no blur */
+/** Solid opaque — used when reduce transparency is on */
 export const WINDOW_BG = 'bg-primary transform-gpu reduce-transparency:!bg-primary'
 export const PANEL_BG = 'bg-primary transform-gpu reduce-transparency:!bg-primary'
 
-/** Taskbar — always blurred (unchanged from the original frosted taskbar) */
+/** Taskbar — always blurred */
 export const TASKBAR_BG =
     'bg-primary/50 backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
 
 /** Frosted glass (windows + sidebar overlays) — default when reduce transparency is off */
-export const HEATER_WINDOW_BG =
+export const FROSTED_WINDOW_BG =
     'bg-primary/75 backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
-export const HEATER_PANEL_BG =
+export const FROSTED_PANEL_BG =
     'bg-primary/75 dark:bg-primary backdrop-blur-3xl transform-gpu reduce-transparency:!bg-primary reduce-transparency:backdrop-blur-none'
 
 /** Promote compositor layers while a surface is moving */
 export const MOTION_LAYER = 'will-change-transform'
-export const HEATER_MOTION_LAYER = 'will-change-[transform,backdrop-filter]'
+export const FROSTED_MOTION_LAYER = 'will-change-[transform,backdrop-filter]'
 
-export const getWindowSurfaceBg = (heaterMode?: boolean) => (heaterMode ? HEATER_WINDOW_BG : WINDOW_BG)
+export const getWindowSurfaceBg = (reduceTransparency?: boolean) => (reduceTransparency ? WINDOW_BG : FROSTED_WINDOW_BG)
 export const getTaskbarSurfaceBg = () => TASKBAR_BG
-export const getPanelSurfaceBg = (heaterMode?: boolean) => (heaterMode ? HEATER_PANEL_BG : PANEL_BG)
-export const getSurfaceMotionLayer = (heaterMode?: boolean, active?: boolean) =>
-    active ? (heaterMode ? HEATER_MOTION_LAYER : MOTION_LAYER) : ''
+export const getPanelSurfaceBg = (reduceTransparency?: boolean) => (reduceTransparency ? PANEL_BG : FROSTED_PANEL_BG)
+export const getSurfaceMotionLayer = (reduceTransparency?: boolean, active?: boolean) =>
+    active ? (reduceTransparency ? MOTION_LAYER : FROSTED_MOTION_LAYER) : ''
 /** Taskbar always blurs — promote backdrop-filter while animating. */
-export const getTaskbarMotionLayer = (active?: boolean) => (active ? HEATER_MOTION_LAYER : '')
+export const getTaskbarMotionLayer = (active?: boolean) => (active ? FROSTED_MOTION_LAYER : '')
 
-/** @deprecated Use getWindowSurfaceBg() */
-export const FROSTED_WINDOW_BG = WINDOW_BG
-/** @deprecated Use getTaskbarSurfaceBg() */
+/** @deprecated Use TASKBAR_BG / getTaskbarSurfaceBg() */
 export const FROSTED_TASKBAR_BG = TASKBAR_BG
-/** @deprecated Use getPanelSurfaceBg() */
-export const FROSTED_PANEL_BG = PANEL_BG
-/** @deprecated Use getSurfaceMotionLayer() */
-export const FROSTED_MOTION_LAYER = MOTION_LAYER

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -2680,6 +2680,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
         if (siteSettings.wallpaper) {
             document.body.setAttribute('data-wallpaper', siteSettings.wallpaper)
         }
+        document.body.setAttribute('data-reduce-transparency', siteSettings.reduceTransparency ? 'true' : 'false')
     }, [siteSettings])
 
     useEffect(() => {

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -356,7 +356,7 @@ export const Context = createContext<AppContextType>({
         cursor: 'default',
         wallpaper: 'keyboard-garden',
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
         clickBehavior: 'double',
         performanceBoost: false,
     },
@@ -443,7 +443,7 @@ export const SettingsContext = createContext<AppSettingsContextType>({
         cursor: 'default',
         wallpaper: 'keyboard-garden',
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
         clickBehavior: 'double',
         performanceBoost: false,
     },
@@ -1593,7 +1593,7 @@ export interface SiteSettings {
     cursor: 'default' | 'xl' | 'james'
     wallpaper: 'keyboard-garden' | 'hogzilla' | 'startup-monopoly' | 'office-party'
     screensaverDisabled?: boolean
-    heaterMode?: boolean
+    reduceTransparency?: boolean
     clickBehavior?: 'single' | 'double'
     performanceBoost?: boolean
 }
@@ -1602,8 +1602,8 @@ const isLabel = (item: any) => !item?.url && item?.name
 
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
-const getInitialSiteSettings = () => {
-    const siteSettings = {
+const getInitialSiteSettings = (): SiteSettings => {
+    const siteSettings: SiteSettings = {
         colorMode: (typeof window !== 'undefined' && (window as any).__theme) || 'light',
         theme: (typeof window !== 'undefined' && (window as any).__theme) || 'light',
         skinMode: 'modern',
@@ -1612,7 +1612,7 @@ const getInitialSiteSettings = () => {
         clickBehavior: 'double',
         performanceBoost: false,
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
         ...(typeof window !== 'undefined' ? JSON.parse(localStorage.getItem('siteSettings') || '{}') : {}),
     }
 
@@ -1642,7 +1642,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
         clickBehavior: 'double',
         performanceBoost: false,
         screensaverDisabled: true,
-        heaterMode: true,
+        reduceTransparency: false,
     })
     const [taskbarHeight, setTaskbarHeight] = useState(59)
     const [lastClickedElementRect, setLastClickedElementRect] = useState<{ x: number; y: number } | null>(null)

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -37,7 +37,12 @@ export default function HTML(props: HTMLProps): JSX.Element {
 
                 {props.headComponents}
             </head>
-            <body {...props.bodyAttributes} className="light" data-wallpaper="keyboard-garden">
+            <body
+                {...props.bodyAttributes}
+                className="light"
+                data-wallpaper="keyboard-garden"
+                data-reduce-transparency="false"
+            >
                 {props.preBodyComponents}
                 {/* nosemgrep: typescript.react.security.audit.react-dangerouslysetinnerhtml.react-dangerouslysetinnerhtml - Gatsby body content from build, not user input */}
                 <div key={`body`} id="___gatsby" dangerouslySetInnerHTML={{ __html: props.body }} />

--- a/src/pages/display-options.tsx
+++ b/src/pages/display-options.tsx
@@ -262,7 +262,7 @@ export default function DisplayOptions() {
                         <span className="text-sm">Reduce transparency</span>
                         <Tooltip trigger={<IconInfo className="size-4 inline-block relative -top-px" />} delay={0}>
                             <p className="max-w-sm my-0 leading-snug">
-                                Solid, opaque backgrounds for windows and sidebars instead of frosted blur.
+                                Solid, opaque backgrounds for windows and sidebars instead of blurred transparency.
                             </p>
                         </Tooltip>
                     </div>

--- a/src/pages/display-options.tsx
+++ b/src/pages/display-options.tsx
@@ -139,9 +139,9 @@ const WallpaperSelect = ({ value, onValueChange, title }: WallpaperSelectProps) 
                 open={isOpen}
                 onOpenChange={setIsOpen}
             >
-                <ScrollArea>
+                <ScrollArea className="min-h-0 !overflow-y-auto overscroll-contain max-h-[calc(var(--radix-popover-content-available-height)-0.75rem)]">
                     <div className="@container">
-                        <div className="grid md:@xl:grid-cols-2 md:@2xl:grid-cols-3 md:@xl:gap-2 p-2 min-h-[200px] h-[400px]">
+                        <div className="grid md:@xl:grid-cols-2 md:@2xl:grid-cols-3 md:@xl:gap-2 p-2">
                             {themeOptions.map((option) => {
                                 const optionThumb = isDark
                                     ? option.background?.thumb?.dark

--- a/src/pages/display-options.tsx
+++ b/src/pages/display-options.tsx
@@ -274,9 +274,9 @@ export default function DisplayOptions() {
                                 { label: 'Enabled', value: 'true' },
                             ]}
                             onValueChange={(value) => {
-                                updateSiteSettings({ ...siteSettings, heaterMode: value !== 'true' })
+                                updateSiteSettings({ ...siteSettings, reduceTransparency: value === 'true' })
                             }}
-                            value={siteSettings.heaterMode ? 'false' : 'true'}
+                            value={siteSettings.reduceTransparency ? 'true' : 'false'}
                         />
                     </div>
                 </div>

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -926,7 +926,7 @@ export default function SelfDrivingPage({
     const { siteSettings } = useAppSettings()
 
     const selfDrivingPRs = data?.allSelfDrivingPullRequest?.nodes ?? []
-    const humanRoleCardBackground = getWindowSurfaceBg(siteSettings.heaterMode)
+    const humanRoleCardBackground = getWindowSurfaceBg(siteSettings.reduceTransparency)
     return (
         <>
             <SEO

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -12,8 +12,7 @@ import type { TabbedCarouselTab } from 'components/TabbedCarousel'
 import Link from 'components/Link'
 import WizardCommand from 'components/WizardCommand'
 import { SignalsCallout } from 'components/Code/SignalsCallout'
-import { getWindowSurfaceBg } from '../../constants/frostedSurfaces'
-import { useAppSettings } from '../../context/App'
+import { WINDOW_BG } from '../../constants/frostedSurfaces'
 import {
     IconArrowRight,
     IconAtSign,
@@ -923,10 +922,8 @@ export default function SelfDrivingPage({
 }: {
     data?: { allSelfDrivingPullRequest?: { nodes: SelfDrivingPR[] } }
 }): JSX.Element {
-    const { siteSettings } = useAppSettings()
-
     const selfDrivingPRs = data?.allSelfDrivingPullRequest?.nodes ?? []
-    const humanRoleCardBackground = getWindowSurfaceBg(siteSettings.reduceTransparency)
+    const humanRoleCardBackground = WINDOW_BG
     return (
         <>
             <SEO

--- a/static/scripts/theme-init.js
+++ b/static/scripts/theme-init.js
@@ -27,11 +27,15 @@
     }
     setTheme(preferredTheme === 'system' ? (darkQuery.matches ? 'dark' : 'light') : preferredTheme)
 
-    // Set initial skin value
+    // Set initial skin / wallpaper / reduce-transparency before React hydrates
     try {
         // The classic skin has been retired; always render the modern skin
         document.body.setAttribute('data-skin', 'modern')
-        const savedWallpaper = JSON.parse(localStorage.getItem('siteSettings') || '{}').wallpaper || 'keyboard-garden'
-        document.body.setAttribute('data-wallpaper', savedWallpaper)
+        var siteSettings = JSON.parse(localStorage.getItem('siteSettings') || '{}')
+        document.body.setAttribute('data-wallpaper', siteSettings.wallpaper || 'keyboard-garden')
+        document.body.setAttribute(
+            'data-reduce-transparency',
+            siteSettings.reduceTransparency ? 'true' : 'false'
+        )
     } catch (err) {}
 })()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -525,7 +525,11 @@ module.exports = {
             addVariant('wallpaper-hogzilla', 'body[data-wallpaper="hogzilla"] &')
             addVariant('wallpaper-office-party', 'body[data-wallpaper="office-party"] &')
             addVariant('wallpaper-startup-monopoly', 'body[data-wallpaper="startup-monopoly"] &')
-            addVariant('reduce-transparency', '@media (prefers-reduced-transparency: reduce)')
+            // Site toggle (data attr, set early in theme-init) + OS prefers-reduced-transparency
+            addVariant('reduce-transparency', [
+                'body[data-reduce-transparency="true"] &',
+                '@media (prefers-reduced-transparency: reduce)',
+            ])
         },
     ],
 }


### PR DESCRIPTION
Background flickered on load when reduce transparency was on.

## Changes

- Rename `heaterMode` -> `reduceTransparency` (default off = frosted windows)
- Drive frosted vs solid chrome via `data-reduce-transparency` on `body` (set in `theme-init` before paint) to avoid a hydration flash
- Simplifies how we load wallpapers/fixes a bug where saved wallpapers animate in on load
- Prevents the desktop background selector popover from extending beyond the viewport (adds scroll)