### PR TITLE
Fix flickering self-driving PR ticker

### DIFF
--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -578,13 +578,18 @@ const TickerRow = ({ prs, direction }: { prs: SelfDrivingPR[]; direction: 1 | -1
         if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) return
 
         let frame = 0
+        // Keep a float accumulator: writing to scrollLeft rounds to whole pixels, so a
+        // sub-pixel step read back from scrollLeft rounds away to nothing (the reverse row
+        // never moves and the wrap logic teleports it). Track the true position ourselves
+        // and wrap by modulo so both directions advance smoothly at the intended speed.
+        let pos = rail.scrollLeft
         const step = () => {
             if (!pausedRef.current) {
-                rail.scrollLeft += 0.5 * direction
                 const half = rail.scrollWidth / 2
                 if (half > 0) {
-                    if (rail.scrollLeft >= half) rail.scrollLeft -= half
-                    else if (rail.scrollLeft <= 0) rail.scrollLeft += half
+                    pos = (pos + 0.5 * direction) % half
+                    if (pos < 0) pos += half
+                    rail.scrollLeft = pos
                 }
             }
             frame = requestAnimationFrame(step)


### PR DESCRIPTION
## Problem

Follow-up to #18378 (the live merged-PR ticker on `/self-driving`). A user reported the bottom (reverse-direction) row shaking/flickering rather than scrolling.

**Root cause** (thanks to the reporter's Playwright trace): the animation drove `scrollLeft` directly:

```js
rail.scrollLeft += 0.5 * direction
```

Chrome rounds fractional `scrollLeft` writes to whole pixels. The `-= 0.5` step rounds back to its starting value, so the reverse row can't move, and the loop-wrap logic then teleports it between `0` and `scrollWidth / 2` every frame — reading as shaking. The top row scrolled, but at ~2× the intended speed as a rounding artifact.

## Fix

Keep the true position in a float accumulator and wrap it by modulo before assigning to `scrollLeft`. Only the write gets rounded (for rendering); the accumulator preserves sub-pixel progress across frames, so both rows advance smoothly at the intended 0.5px/frame.

```js
let pos = rail.scrollLeft
const step = () => {
    if (!pausedRef.current) {
        const half = rail.scrollWidth / 2
        if (half > 0) {
            pos = (pos + 0.5 * direction) % half
            if (pos < 0) pos += half
            rail.scrollLeft = pos
        }
    }
    frame = requestAnimationFrame(step)
}
```

This fixes the reverse-row shaking and the top row's 2× speed, and replaces the branchy teleport wrap with a seamless modulo loop in both directions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*