### PR TITLE
feat(careers): add Barbados 2026 and empty 2027 to off-site history table

### DIFF
--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -19,8 +19,6 @@ We understand organizing travel can be a challenge when you have personal/family
 > - **2021** [We shot this video at our Portugal offsite](https://www.youtube.com/watch?v=WOBH1Qy0xhA)
 > - **2023** [What we built at our sun-kissed Aruba hackathon](https://posthog.com/blog/aruba-hackathon)
 > - **2024** [What we built at our windswept Mykonos hackathon](https://posthog.com/blog/mykonos-hackathon)
-> - **2026** Barbados
-> - **2027**
 
 Once a year, the entire company will get together somewhere in the world for a week. Usually we'll all fly on Sunday, have an opening dinner, spend the week doing a mix of hard work, strategy, culture and fun activities and we then all fly back home on Friday. Our past offsites have been in Italy, Portugal and Iceland. We try to ensure that everyone has their own bedroom.
 

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -19,6 +19,8 @@ We understand organizing travel can be a challenge when you have personal/family
 > - **2021** [We shot this video at our Portugal offsite](https://www.youtube.com/watch?v=WOBH1Qy0xhA)
 > - **2023** [What we built at our sun-kissed Aruba hackathon](https://posthog.com/blog/aruba-hackathon)
 > - **2024** [What we built at our windswept Mykonos hackathon](https://posthog.com/blog/mykonos-hackathon)
+> - **2026** Barbados
+> - **2027**
 
 Once a year, the entire company will get together somewhere in the world for a week. Usually we'll all fly on Sunday, have an opening dinner, spend the week doing a mix of hard work, strategy, culture and fun activities and we then all fly back home on Friday. Our past offsites have been in Italy, Portugal and Iceland. We try to ensure that everyone has their own bedroom.
 

--- a/src/components/Careers/BenefitsUnexpected/index.tsx
+++ b/src/components/Careers/BenefitsUnexpected/index.tsx
@@ -94,6 +94,8 @@ const BenefitsUnexpected: React.FC = () => {
                         <div>2025</div>
                         <div>Tulum</div>
                         <div>2026</div>
+                        <div>Barbados</div>
+                        <div>2027</div>
                         <div>
                             <span className="inline-block bg-accent rounded-[2px] text-sm w-16 h-[16px] relative top-[2px]"></span>
                         </div>


### PR DESCRIPTION
## Changes

Updated the off-site history table on the careers page (`BenefitsUnexpected`):
- **2026** — Barbados
- **2027** — empty placeholder for the upcoming offsite

**Why:** Keep the careers page off-site history current with the next scheduled all-company offsite and a placeholder for the year after.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
