### PR TITLE
Fix blank AI observability pricing slide

### DIFF
--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -53,7 +53,10 @@ export default function useProducts() {
             initialProducts.map((product) => {
                 const billingData =
                     product.billingData ||
-                    billingProducts.find((billingProduct: any) => billingProduct.type === product.handle)
+                    billingProducts.find(
+                        (billingProduct: any) =>
+                            billingProduct.type === ((product as any).billingType || product.handle)
+                    )
                 const paidPlan = billingData?.plans.find((plan: any) => plan.tiers)
                 const startsAt = paidPlan?.tiers?.find((tier: any) => tier.unit_amount_usd !== '0')?.unit_amount_usd
                 const freeLimit = paidPlan?.tiers?.find((tier: any) => tier.unit_amount_usd === '0')?.up_to


### PR DESCRIPTION
## Changes

The AI Observability pricing slide (and its pricing-page rate row) was rendering **blank**.

Root cause: the billing service still exposes this product under its pre-rename type `llm_analytics`, so the product data sets `billingType: 'llm_analytics'`. But the billing-data join in `useProducts` still matched on `product.handle` (`'ai_observability'`), which no longer matches any billing product. `billingData` came back undefined, so `PlanComparison` bailed out with `return null` → blank slide.

Fix: join on `product.billingType || product.handle`, so a product can override the billing lookup key when its billing type differs from its site handle.

**Why:** Reported in Slack — the pricing panel on posthog.com/ai-observability was blank (and docs/other panels looked off), surfacing while pricing is being reworked.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784559626521599?thread_ts=1784559626.521599&cid=C087XQ7K9K7)*
