### PR TITLE
feat(careers): enhance team name formatting in job listings

### DIFF
--- a/src/components/Careers/JobListings/index.tsx
+++ b/src/components/Careers/JobListings/index.tsx
@@ -4,7 +4,7 @@ import Link from 'components/Link'
 import { Department, Location, Timezone } from 'components/NotProductIcons'
 import { CallToAction } from 'components/CallToAction'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
-import { slugifyTeamName } from 'lib/utils'
+import { formatTeamName, slugifyTeamName } from 'lib/utils'
 import OSButton from 'components/OSButton'
 import { TeamsSidebar } from 'components/Job/TeamsSidebar'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
@@ -463,7 +463,7 @@ export const JobListings = ({ embedded = false }: { embedded?: boolean }) => {
                             Select a role
                         </label>
                         <select
-                            className="block @2xl:hidden w-full p-2 border border-primary rounded text-xl font-bold relative z-10 mb-2"
+                            className="block @2xl:hidden w-full p-2 bg-primary text-primary border border-primary rounded text-xl font-bold relative z-10 mb-2"
                             value={selectedJob.fields.title}
                             onChange={(e) => {
                                 const selectedJobTitle = e.target.value
@@ -570,7 +570,7 @@ export const JobListings = ({ embedded = false }: { embedded?: boolean }) => {
                                                                                 return teams.length > 1
                                                                                     ? 'Multiple teams'
                                                                                     : teams.length === 1 &&
-                                                                                          `${teams[0]} Team`
+                                                                                          formatTeamName(teams[0])
                                                                             })()}
                                                                         </span>
                                                                     )}
@@ -636,7 +636,7 @@ export const JobListings = ({ embedded = false }: { embedded?: boolean }) => {
                                                                                 return teams.length > 1
                                                                                     ? 'Multiple teams'
                                                                                     : teams.length === 1 &&
-                                                                                          `${teams[0]} Team`
+                                                                                          formatTeamName(teams[0])
                                                                             })()}
                                                                         </span>
                                                                     )}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -114,3 +114,5 @@ export const slugifyTeamName = (name: string): string => {
         remove: /and/,
     })
 }
+
+export const formatTeamName = (name: string): string => `${name.trim().replace(/\s+team$/i, '')} Team`

--- a/src/templates/Job.tsx
+++ b/src/templates/Job.tsx
@@ -22,6 +22,7 @@ import { TeamsSidebar } from 'components/Job/TeamsSidebar'
 import ScrollArea from 'components/RadixUI/ScrollArea'
 import Mark from 'mark.js'
 import { OSInput } from 'components/OSForm'
+import { formatTeamName } from 'lib/utils'
 
 const Detail = ({ icon, title, value }: { icon: React.ReactNode; title: string; value: string }) => {
     return (
@@ -209,7 +210,7 @@ const LeftSidebarContent = React.memo(
                                                                         : []
                                                                     return teams.length > 1
                                                                         ? 'Multiple teams'
-                                                                        : teams.length === 1 && `${teams[0]} Team`
+                                                                        : teams.length === 1 && formatTeamName(teams[0])
                                                                 })()}
                                                             </span>
                                                         )}
@@ -260,7 +261,7 @@ const LeftSidebarContent = React.memo(
                                                                         : []
                                                                     return teams.length > 1
                                                                         ? 'Multiple teams'
-                                                                        : teams.length === 1 && `${teams[0]} Team`
+                                                                        : teams.length === 1 && formatTeamName(teams[0])
                                                                 })()}
                                                             </span>
                                                         )}


### PR DESCRIPTION
## Changes

- Some job listings included the suffix "team" in team name, causing them to be displayed as "[team name] team team". The suffix "team" is now added conditionally.
- Mobile job selector dropdown didn't use dark theme colors, fixed

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
