### PR TITLE
Add PostHog one-liner to brand foundations

### DIFF
--- a/contents/handbook/brand/foundations.md
+++ b/contents/handbook/brand/foundations.md
@@ -91,7 +91,11 @@ Because it's a capability, not a product, always write it lowercase and hyphenat
 
 ### The standard description
 
-Use this whenever you need a standard description of PostHog:
+When you need a one-liner:
+
+> PostHog automatically diagnoses problems, fixes bugs, and generates pull requests – all without you having to prompt it.
+
+For a fuller standard description of PostHog, use this:
 
 <AboutPostHog />
 


### PR DESCRIPTION
## Changes

Adds a one-liner above the standard product description in the "How we describe PostHog" section of the brand foundations page:

> PostHog automatically diagnoses problems, fixes bugs, and generates pull requests – all without you having to prompt it.

**Why:** The full standard description reads as a mouthful in quick, everyday conversations, so this gives people a short one-liner to reach for while keeping the fuller `<AboutPostHog />` description for articles and official use.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0351B1DMUY/p1784562539886829?thread_ts=1784562539.886829&cid=C0351B1DMUY)*