### PR TITLE
docs(mcp-analytics): unify PostHog import on the @posthog/mcp re-export

### DIFF
--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -75,8 +75,7 @@ npm install @posthog/mcp posthog-node
 
 ```ts
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
+import { PostHog, instrument } from "@posthog/mcp"
 
 const server = new Server({ name: "my-mcp-server", version: "1.0.0" })
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -33,7 +33,7 @@ npm install @posthog/mcp posthog-node
 # or yarn add @posthog/mcp posthog-node
 ```
 
-You bring your own [`posthog-node`](/docs/libraries/node) client (the same pattern as [`@posthog/ai`](/docs/ai-engineering)) and pass it to `instrument()` as the required second argument. You own its lifecycle — call `posthog.shutdown()` or `posthog.flush()` yourself.
+You bring your own [`posthog-node`](/docs/libraries/node) client (the same pattern as [`@posthog/ai`](/docs/ai-engineering)) and pass it to `instrument()` as the required second argument. You own its lifecycle — call `posthog.shutdown()` or `posthog.flush()` yourself. For convenience, `@posthog/mcp` re-exports the `PostHog` class, so a single import covers both — but `posthog-node` still needs to be installed, since it's a peer dependency.
 
 ## Wrap your server
 
@@ -45,8 +45,7 @@ If you registered your tools against the raw protocol `Server` from `@modelconte
 
 ```ts
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
+import { PostHog, instrument } from "@posthog/mcp"
 
 const server = new Server({ name: "my-mcp-server", version: "1.0.0" })
 
@@ -65,8 +64,7 @@ If you use the typed `McpServer` wrapper from `@modelcontextprotocol/sdk/server/
 
 ```ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
+import { PostHog, instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
 
@@ -277,8 +275,7 @@ The `posthog` client is passed as the required second positional argument — no
 The `posthog-node` client queues and batches events asynchronously, and you own its lifecycle. Call `posthog.shutdown()` from your `SIGTERM` / `beforeExit` handler so in-flight events aren't dropped:
 
 ```ts
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
+import { PostHog, instrument } from "@posthog/mcp"
 
 const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY)
 instrument(server, posthog)

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -45,8 +45,7 @@ npm install @posthog/mcp posthog-node
 
 ```ts
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
+import { PostHog, instrument } from "@posthog/mcp"
 
 const server = new Server({ name: "my-mcp-server", version: "1.0.0" })
 

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -12,7 +12,7 @@ import WizardCommand from 'components/WizardCommand'
 
 <CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="action">
 
-`@posthog/mcp` is published as a `0.1.x` release on npm. We're building it in public – the event shape, options, and tracing behavior may still change before `1.0`. Pin a specific version and don't depend on it for production reporting yet.
+`@posthog/mcp` is published as a pre-`1.0` release on npm. We're building it in public – the event shape, options, and tracing behavior may still change before `1.0`. Pin a specific version and don't depend on it for production reporting yet.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

The MCP analytics docs were split between two import styles for the same thing: five examples (index quick-install, start-here quickstart, and three snippets in installation) did

```ts
import { PostHog } from "posthog-node"
import { instrument } from "@posthog/mcp"
```

while the mcp-handler and NestJS examples used the single-import form via the re-export that [posthog-js#3925](https://github.com/PostHog/posthog-js/pull/3925) added precisely to unify this:

```ts
import { PostHog, instrument } from "@posthog/mcp"
```

This PR standardizes all snippets on the re-export and adds one sentence to the install section explaining it — making explicit that `posthog-node` still has to be installed, since it remains a peer dependency (the `npm install @posthog/mcp posthog-node` line is unchanged and still correct).

Also fixes a stale claim surfaced by review: the start-here beta callout said the SDK "is published as a `0.1.x` release" (it's at 0.9.x, and a pinned `0.1.x` lacks the re-export). Now says pre-`1.0` so it doesn't rot with each release.

## Verification

- `grep -rn 'from "posthog-node"' contents/docs/mcp-analytics/` returns nothing
- Confirmed against posthog-js main: `packages/mcp/src/index.ts` exports `PostHog` and `PostHogOptions`, and `posthog-node` is in `peerDependencies` (`^5.0.0`)
- `codex review --base master`: one finding (the stale `0.1.x` claim), fixed in the second commit; clean on re-run

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*