### PR TITLE
docs(metrics): add demo recordings to installation guides

### DIFF
--- a/contents/docs/metrics/installation/nodejs.mdx
+++ b/contents/docs/metrics/installation/nodejs.mdx
@@ -11,6 +11,12 @@ import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
 The [posthog-node](/docs/libraries/node) SDK includes the `posthog.metrics` API, so you can record metrics with the same client you use for events and feature flags.
 
+Here's the whole flow, from install to flushed metrics:
+
+{/* TODO(cloudinary): rehost this demo on Cloudinary and swap the URL before marking ready for review. Source recording: https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/29b006eb-04b8-4e92-a6dc-c278e7a4978b.cast */}
+
+![Installing posthog-node and sending metrics](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/29b006eb-04b8-4e92-a6dc-c278e7a4978b.gif)
+
 <Steps>
 
 <Step title="Install posthog-node" badge="required">

--- a/contents/docs/metrics/installation/python.mdx
+++ b/contents/docs/metrics/installation/python.mdx
@@ -11,6 +11,12 @@ import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
 The [posthog-python](/docs/libraries/python) SDK includes the `posthog.metrics` API, so you can record metrics with the same client you use for events and feature flags.
 
+Here's the whole flow, from install to flushed metrics:
+
+{/* TODO(cloudinary): rehost this demo on Cloudinary and swap the URL before marking ready for review. Source recording: https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/35783905-e14c-4954-8be8-a7f03dd41f04.cast */}
+
+![Installing posthog-python and sending metrics](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/35783905-e14c-4954-8be8-a7f03dd41f04.gif)
+
 <Steps>
 
 <Step title="Install posthog-python" badge="required">


### PR DESCRIPTION
## Changes

Adds terminal demo recordings to the Python and Node.js metrics installation pages that merged in #18700 — the full flow: install the SDK, write the `posthog.metrics` snippet, run it, flush.

These are **real runs**, not mockups: both demos sent metrics to the ingest endpoint under service `metrics-docs-demo`, and I verified arrival through the metrics query API before recording (each series shows its data point).

**Python demo:**

![Installing posthog-python and sending metrics](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/35783905-e14c-4954-8be8-a7f03dd41f04.gif)

**Node.js demo:**

![Installing posthog-node and sending metrics](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/29b006eb-04b8-4e92-a6dc-c278e7a4978b.gif)

> [!NOTE]
> The embeds currently point at `PostHog/pr-assets` and are flagged with `TODO(cloudinary)` comments at the embed sites. Before marking ready for review, someone with Cloudinary access should rehost (Cloudinary transcodes GIF→mp4 automatically) and swap the URLs. The asciinema `.cast` sources are alongside the GIFs on pr-assets ([python](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/35783905-e14c-4954-8be8-a7f03dd41f04.cast), [node](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/07/29b006eb-04b8-4e92-a6dc-c278e7a4978b.cast)) for re-rendering at other themes/sizes with `agg`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*