### PR TITLE
docs: add Pino logs installation guide

### DIFF
--- a/contents/docs/logs/installation/pino.mdx
+++ b/contents/docs/logs/installation/pino.mdx
@@ -1,0 +1,104 @@
+---
+title: Pino logs installation
+platformLogo: nodejs
+platformLabel: Pino
+showStepsToc: true
+---
+
+import { Steps, Step } from 'components/Docs/Steps'
+import LogsNextSteps from './_snippets/logs-next-steps.mdx'
+
+[Pino](https://github.com/pinojs/pino) is a popular logging library for Node.js. Because PostHog ingests logs over the OpenTelemetry Protocol (OTLP), you can ship your Pino logs to PostHog using a Pino [transport](https://getpino.io/#/docs/transports) - no PostHog-specific package required.
+
+> Prefer the generic OpenTelemetry SDK setup instead of Pino? See the [Node.js installation guide](/docs/logs/installation/nodejs).
+
+<Steps>
+
+<Step title="Install Pino and the OpenTelemetry transport" badge="required">
+
+```bash
+npm install pino pino-opentelemetry-transport
+```
+
+</Step>
+
+<Step title="Get your project token" badge="required">
+
+You'll need your PostHog project token to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
+
+> **Important:** Use your **project token** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project token in [Project Settings](https://app.posthog.com/settings).
+
+</Step>
+
+<Step title="Configure the transport" badge="required">
+
+Point Pino at the [`pino-opentelemetry-transport`](https://github.com/pinojs/pino-opentelemetry-transport) and set the service name that logs will be grouped under in PostHog:
+
+```javascript
+import pino from 'pino'
+
+const logger = pino({
+  transport: {
+    target: 'pino-opentelemetry-transport',
+    options: {
+      loggerName: 'my-node-service',
+      resourceAttributes: {
+        'service.name': 'my-node-service',
+      },
+    },
+  },
+})
+
+export default logger
+```
+
+The transport reads its OTLP destination from standard OpenTelemetry environment variables. Point it at PostHog's logs endpoint and pass your project token as a query parameter:
+
+```bash
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="<ph_client_api_host>/i/v1/logs?token=<ph_project_token>"
+```
+
+The transport defaults to the `http/protobuf` protocol, which PostHog's endpoint accepts, so no other configuration is required.
+
+Alternatively, you can pass the token as an `Authorization` header instead of a query parameter. The header value must be URL-encoded, so the space becomes `%20`:
+
+```bash
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="<ph_client_api_host>/i/v1/logs"
+OTEL_EXPORTER_OTLP_LOGS_HEADERS="Authorization=Bearer%20<ph_project_token>"
+```
+
+</Step>
+
+<Step title="Log with structured attributes" badge="required">
+
+Use Pino as you normally would. Pino's log levels are automatically mapped to the equivalent OpenTelemetry severity, and any object you pass is forwarded as structured attributes you can filter and search on in PostHog:
+
+```javascript
+logger.info({ userId: '123', action: 'login' }, 'User logged in')
+logger.warn({ endpoint: '/old-api' }, 'Deprecated API used')
+logger.error({ err }, 'Database connection failed')
+```
+
+> **Tip:** To connect a log line to the session and user who triggered it, include `posthogDistinctId` and `sessionId` as attributes. See [Link session replay](/docs/logs/link-session-replay).
+
+</Step>
+
+<Step title="Test your setup" badge="recommended">
+
+Once everything is configured, test that logs are flowing into PostHog:
+
+1. Send a test log from your application
+2. Check the PostHog Logs interface for your log entries
+3. Verify the logs appear in your project
+
+<CallToAction type="primary" to="https://app.posthog.com/logs">
+View your logs in PostHog
+</CallToAction>
+
+</Step>
+
+<LogsNextSteps />
+
+</Steps>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7257,6 +7257,7 @@ export const docsMenu = {
                     children: [
                         { name: 'Overview', url: '/docs/logs/installation' },
                         { name: 'Node.js', url: '/docs/logs/installation/nodejs' },
+                        { name: 'Pino', url: '/docs/logs/installation/pino' },
                         { name: 'Python', url: '/docs/logs/installation/python' },
                         { name: 'Go', url: '/docs/logs/installation/go' },
                         { name: 'Java', url: '/docs/logs/installation/java' },


### PR DESCRIPTION
This adds a dedicated Pino installation page for PostHog Logs, modeled on the existing Node.js page, and registers it in the logs installation sidebar.

The page shows how to ship [Pino](https://github.com/pinojs/pino) logs to PostHog via the `pino-opentelemetry-transport` transport (no PostHog-specific package), including transport config, the OTLP endpoint env vars (query-param token and header alternatives), structured-attribute logging, and session-replay linking.

## Why

A user reported in a call that setting up PostHog Logs with Pino was confusing — Pino does not ship to PostHog directly, and the OpenTelemetry path was not documented, so they had to figure it out from scratch. This gives Pino users a specific, searchable example.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1784580937640629?thread_ts=1784580937.640629&cid=C08S66N93FX)*