### PR TITLE
docs(error-tracking): add Rust debug symbol upload guide

### DIFF
--- a/contents/docs/error-tracking/_snippets/StepVerifySymbolSetsUpload.tsx
+++ b/contents/docs/error-tracking/_snippets/StepVerifySymbolSetsUpload.tsx
@@ -3,7 +3,7 @@ import { Step } from '../../../../src/components/Docs/Steps'
 import { CallToAction } from '../../../../src/components/CallToAction'
 
 interface StepVerifySymbolSetsUploadProps {
-    symbolType?: 'source maps' | 'mappings' | 'dSYMs'
+    symbolType?: 'source maps' | 'mappings' | 'dSYMs' | 'debug symbols'
 }
 
 export const StepVerifySymbolSetsUpload: React.FC<StepVerifySymbolSetsUploadProps> = ({

--- a/contents/docs/error-tracking/_snippets/upload-symbol-sets-platforms.tsx
+++ b/contents/docs/error-tracking/_snippets/upload-symbol-sets-platforms.tsx
@@ -54,6 +54,11 @@ const UploadSymbolSetsPlatforms = () => {
             image: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/ios.svg',
         },
         {
+            label: 'Rust',
+            url: '/docs/error-tracking/upload-source-maps/rust',
+            image: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/rust.svg',
+        },
+        {
             label: 'Rollup',
             url: '/docs/error-tracking/upload-source-maps/rollup',
             image: 'https://res.cloudinary.com/dmukukwp6/image/upload/Rollup_js_c306a2fde3.svg',

--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -26,7 +26,7 @@ posthog-rs = { version = "*", default-features = false, features = ["error-track
 
 <CalloutBox icon="IconInfo" title="Debug symbol uploads" type="fyi">
 
-The Rust SDK resolves stack traces in-process, so captured frames include file names, line numbers, and function names without any symbol uploads. For server-side symbolication of your exact production build, inlined frame resolution, and source context (the surrounding lines of code in the error tracking UI), [upload debug symbols](/docs/error-tracking/upload-source-maps/rust).
+The Rust SDK resolves stack traces in-process, so when the running binary carries debug info (as development builds do), captured frames include file names, line numbers, and function names without any symbol uploads. For resolved stack traces from release builds — which omit debug info by default — plus inlined frame resolution and source context (the surrounding lines of code in the error tracking UI), [upload debug symbols](/docs/error-tracking/upload-source-maps/rust).
 
 </CalloutBox>
 

--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -24,9 +24,9 @@ Error tracking ships enabled by default through the `error-tracking` feature. If
 posthog-rs = { version = "*", default-features = false, features = ["error-tracking"] }
 ```
 
-<CalloutBox icon="IconInfo" title="Source context not yet supported" type="fyi">
+<CalloutBox icon="IconInfo" title="Debug symbol uploads" type="fyi">
 
-The Rust SDK resolves stack traces in-process, so captured frames include file names, line numbers, and function names without any symbol uploads. Source context (displaying the surrounding lines of code in the error tracking UI) is not yet supported.
+The Rust SDK resolves stack traces in-process, so captured frames include file names, line numbers, and function names without any symbol uploads. For server-side symbolication of your exact production build, inlined frame resolution, and source context (the surrounding lines of code in the error tracking UI), [upload debug symbols](/docs/error-tracking/upload-source-maps/rust).
 
 </CalloutBox>
 

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -7,7 +7,7 @@ import CLIDownload from "../_snippets/cli/download.mdx"
 import CLIAuthenticate from "../_snippets/cli/authenticate.mdx"
 import StepVerifySymbolSetsUpload from "../_snippets/StepVerifySymbolSetsUpload"
 
-The [Rust SDK](/docs/error-tracking/installation/rust) resolves stack traces in-process, so captured exceptions include function names, file names, and line numbers without any uploads. Uploading debug symbols improves on that: PostHog symbolicates frames server-side from the exact build that crashed, resolves inlined frames, and can display the source code around each frame.
+The [Rust SDK](/docs/error-tracking/installation/rust) resolves stack traces in-process from whatever debug info the running binary carries — which works well in development, but release builds omit that debug info by default. Uploading debug symbols gives you fully resolved production stack traces: PostHog symbolicates frames server-side from the exact build that crashed, resolves inlined frames, and can display the source code around each frame.
 
 <CalloutBox icon="IconInfo" title="Version requirements" type="action">
 

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -1,0 +1,126 @@
+---
+title: Upload debug symbols for Rust
+showStepsToc: true
+---
+
+import CLIDownload from "../_snippets/cli/download.mdx"
+import CLIAuthenticate from "../_snippets/cli/authenticate.mdx"
+import StepVerifySymbolSetsUpload from "../_snippets/StepVerifySymbolSetsUpload"
+
+The [Rust SDK](/docs/error-tracking/installation/rust) resolves stack traces in-process, so captured exceptions include function names, file names, and line numbers without any uploads. Uploading debug symbols improves on that: PostHog symbolicates frames server-side from the exact build that crashed, resolves inlined frames, and can display the source code around each frame.
+
+<CalloutBox icon="IconInfo" title="Version requirements" type="action">
+
+- [posthog-rs 0.16.0](https://github.com/PostHog/posthog-rs/releases) or later, which records the instruction addresses server-side symbolication needs. We recommend the latest version — inlined frame resolution needs 0.20.0 or later.
+- [CLI 0.7.31](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.31) or later for Linux binaries. Uploading macOS `.dSYM` bundles with the same command needs [CLI 0.8.0](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.8.0) or later. As always, we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli).
+
+</CalloutBox>
+
+<Steps>
+
+<Step title="Download CLI" badge="required">
+
+<CLIDownload />
+
+</Step>
+
+<Step title="Authenticate" badge="required">
+
+<CLIAuthenticate />
+
+</Step>
+
+<Step title="Keep debug info in release builds" badge="required">
+
+Cargo omits debug info from release builds by default, and there is nothing to upload without it. Enable it in your `Cargo.toml`:
+
+```toml
+[profile.release]
+debug = "line-tables-only"
+```
+
+`line-tables-only` is enough to resolve file names, line numbers, and inlined frames while keeping binaries small. Use `debug = "full"` if you want complete debug info. Enabling debug info also stops Cargo from stripping it out of release binaries, which it otherwise does by default.
+
+If you strip binaries before deploying them, upload first and strip after. Debug info split into separate files also works: the CLI picks up `objcopy --only-keep-debug` companion files alongside the binaries.
+
+</Step>
+
+<Step title="Check for a build ID" badge="required">
+
+PostHog matches stack frames to uploaded symbols by the binary's unique build ID: a GNU build ID on Linux, or the Mach-O UUID on macOS. macOS binaries always carry a UUID, and most Linux toolchains emit a GNU build ID by default. Confirm yours does:
+
+```bash
+readelf -n target/release/<your-binary> | grep "Build ID"
+```
+
+If nothing shows up, tell the linker to add one in `.cargo/config.toml`:
+
+```toml
+[build]
+rustflags = ["-C", "link-arg=-Wl,--build-id=sha1"]
+```
+
+</Step>
+
+<Step title="Build and upload" badge="required">
+
+After your release build, point the CLI at the build output directory:
+
+```bash
+cargo build --release
+posthog-cli symbol-sets upload --directory target/release
+```
+
+The CLI scans the directory and uploads every executable and shared library that carries debug info and a build ID, skipping everything else. On macOS it also uploads `.dSYM` bundles (this needs `dwarfdump`, which ships with Xcode). The upload is associated with a [release](/docs/error-tracking/releases) automatically when the build directory is inside a git checkout.
+
+Run this as part of the same pipeline that produces your production binary. Each build has its own build ID, so symbols must be re-uploaded for every build you deploy.
+
+</Step>
+
+<Step title="Optional: Include source code context" badge="optional">
+
+By default, only debug symbols are uploaded. To also display the source code around each frame in your stack traces, add `--include-source`:
+
+```bash
+posthog-cli symbol-sets upload --directory target/release --include-source
+```
+
+This bundles the project source files referenced by the debug info into the upload. It increases upload size, so only enable it if you want source context in the error tracking UI.
+
+</Step>
+
+<Step title="Optional: Upload from CI" badge="optional">
+
+In CI, authenticate with environment variables instead of `posthog-cli login`. For GitHub Actions:
+
+```yaml
+- name: Build and upload debug symbols
+  run: |
+    cargo build --release
+    posthog-cli symbol-sets upload --directory target/release --include-source
+  env:
+    POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+    POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
+    POSTHOG_CLI_HOST: ${{ secrets.POSTHOG_CLI_HOST }}
+```
+
+If your binary is built inside a Dockerfile, run the upload in the build stage right after the build, and pass the credentials in as build secrets so they never reach the runtime image.
+
+</Step>
+
+<StepVerifySymbolSetsUpload symbolType="debug symbols" />
+
+<Step title="Test it end-to-end" badge="optional">
+
+Capture a test exception from the same release binary the symbols were uploaded for:
+
+```rust
+let error = std::io::Error::new(std::io::ErrorKind::Other, "This is a test exception from Rust");
+client.capture_exception(&error).await.unwrap();
+```
+
+Run the binary, then check the [error tracking issues view](https://app.posthog.com/error_tracking): the stack trace should resolve to your source files, including source context if you uploaded with `--include-source`. A rebuild changes the build ID, so if you rebuild, upload again before testing.
+
+</Step>
+
+</Steps>

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -43,7 +43,7 @@ debug = "line-tables-only"
 
 On macOS, also set `split-debuginfo = "packed"` in the same profile. Cargo's macOS default (`unpacked`) leaves debug info in intermediate object files instead of producing the `.dSYM` bundle the CLI uploads.
 
-Watch out for stripping: Cargo only strips release binaries by default when no debug info is requested, but if your profile sets `strip` explicitly, set it to `"none"` — or strip only after the upload runs. Debug info split into separate files also works: the CLI picks up `objcopy --only-keep-debug` companion files alongside the binaries.
+Watch out for stripping: if your profile sets `strip` explicitly, set it to `"none"` — or strip only after the upload runs. Debug info split into separate files also works: the CLI picks up `objcopy --only-keep-debug` companion files alongside the binaries.
 
 </Step>
 
@@ -52,8 +52,10 @@ Watch out for stripping: Cargo only strips release binaries by default when no d
 PostHog matches stack frames to uploaded symbols by the binary's unique build ID: a GNU build ID on Linux, or the Mach-O UUID on macOS. macOS binaries always carry a UUID, and most Linux toolchains emit a GNU build ID by default. Confirm yours does:
 
 ```bash
-readelf -n target/release/<your-binary> | grep "Build ID"
+readelf -n target/release/my-app | grep "Build ID"
 ```
+
+Replace `my-app` with your binary's name.
 
 If nothing shows up, tell the linker to add one in `.cargo/config.toml`:
 
@@ -99,7 +101,7 @@ In CI, authenticate with environment variables instead of `posthog-cli login`. F
 - name: Build and upload debug symbols
   run: |
     cargo build --release
-    posthog-cli symbol-sets upload --directory target/release --include-source
+    posthog-cli symbol-sets upload --directory target/release
   env:
     POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
     POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -11,8 +11,8 @@ The [Rust SDK](/docs/error-tracking/installation/rust) resolves stack traces in-
 
 <CalloutBox icon="IconInfo" title="Version requirements" type="action">
 
-- [posthog-rs 0.16.0](https://github.com/PostHog/posthog-rs/releases) or later, which records the instruction addresses server-side symbolication needs. We recommend the latest version — inlined frame resolution needs 0.20.0 or later.
-- [CLI 0.7.31](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.31) or later for Linux binaries. Uploading macOS `.dSYM` bundles with the same command needs [CLI 0.8.0](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.8.0) or later. As always, we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli).
+- [posthog-rs 0.16.0](https://github.com/PostHog/posthog-rs/releases) or later, which records the instruction addresses server-side symbolication needs. We recommend the latest version.
+- [CLI 0.7.32](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.32) or later for Linux binaries. Uploading macOS `.dSYM` bundles with the same command needs [CLI 0.8.1](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.8.1) or later. As always, we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli).
 
 </CalloutBox>
 
@@ -39,9 +39,11 @@ Cargo omits debug info from release builds by default, and there is nothing to u
 debug = "line-tables-only"
 ```
 
-`line-tables-only` is enough to resolve file names, line numbers, and inlined frames while keeping binaries small. Use `debug = "full"` if you want complete debug info. Enabling debug info also stops Cargo from stripping it out of release binaries, which it otherwise does by default.
+`line-tables-only` is enough to resolve file names, line numbers, and inlined frames while keeping binaries small. Use `debug = "full"` if you want complete debug info.
 
-If you strip binaries before deploying them, upload first and strip after. Debug info split into separate files also works: the CLI picks up `objcopy --only-keep-debug` companion files alongside the binaries.
+On macOS, also set `split-debuginfo = "packed"` in the same profile. Cargo's macOS default (`unpacked`) leaves debug info in intermediate object files instead of producing the `.dSYM` bundle the CLI uploads.
+
+Watch out for stripping: Cargo only strips release binaries by default when no debug info is requested, but if your profile sets `strip` explicitly, set it to `"none"` — or strip only after the upload runs. Debug info split into separate files also works: the CLI picks up `objcopy --only-keep-debug` companion files alongside the binaries.
 
 </Step>
 
@@ -101,8 +103,9 @@ In CI, authenticate with environment variables instead of `posthog-cli login`. F
   env:
     POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
     POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
-    POSTHOG_CLI_HOST: ${{ secrets.POSTHOG_CLI_HOST }}
 ```
+
+The CLI defaults to US Cloud. If you are on EU Cloud or self-hosted, also set `POSTHOG_CLI_HOST` (for example `https://eu.posthog.com`).
 
 If your binary is built inside a Dockerfile, run the upload in the build stage right after the build, and pass the credentials in as build secrets so they never reach the runtime image.
 

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -49,7 +49,7 @@ Watch out for stripping: if your profile sets `strip` explicitly, set it to `"no
 
 <Step title="Check for a build ID" badge="required">
 
-PostHog matches stack frames to uploaded symbols by the binary's unique build ID: a GNU build ID on Linux, or the Mach-O UUID on macOS. macOS binaries always carry a UUID, and most Linux toolchains emit a GNU build ID by default. Confirm yours does:
+PostHog matches stack frames to uploaded symbols by the binary's unique build ID: a GNU build ID on Linux, or the Mach-O UUID on macOS. macOS binaries always carry a UUID, so there is nothing to check there. Most Linux toolchains emit a GNU build ID by default — confirm yours does:
 
 ```bash
 readelf -n target/release/my-app | grep "Build ID"

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -98,14 +98,17 @@ This bundles the project source files referenced by the debug info into the uplo
 In CI, authenticate with environment variables instead of `posthog-cli login`. For GitHub Actions:
 
 ```yaml
-- name: Build and upload debug symbols
-  run: |
-    cargo build --release
-    posthog-cli symbol-sets upload --directory target/release
+- name: Build release binary
+  run: cargo build --release
+
+- name: Upload debug symbols
+  run: posthog-cli symbol-sets upload --directory target/release
   env:
     POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
     POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
 ```
+
+Scope the credentials to the upload step only — the build itself doesn't need them.
 
 The CLI defaults to US Cloud. If you are on EU Cloud or self-hosted, also set `POSTHOG_CLI_HOST` (for example `https://eu.posthog.com`).
 

--- a/contents/docs/error-tracking/upload-source-maps/rust.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/rust.mdx
@@ -57,10 +57,10 @@ readelf -n target/release/my-app | grep "Build ID"
 
 Replace `my-app` with your binary's name.
 
-If nothing shows up, tell the linker to add one in `.cargo/config.toml`:
+If nothing shows up, tell the linker to add one in `.cargo/config.toml`, scoped to Linux builds (Apple's linker embeds a UUID on its own and rejects this flag):
 
 ```toml
-[build]
+[target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-Wl,--build-id=sha1"]
 ```
 
@@ -75,7 +75,7 @@ cargo build --release
 posthog-cli symbol-sets upload --directory target/release
 ```
 
-The CLI scans the directory and uploads every executable and shared library that carries debug info and a build ID, skipping everything else. On macOS it also uploads `.dSYM` bundles (this needs `dwarfdump`, which ships with Xcode). The upload is associated with a [release](/docs/error-tracking/releases) automatically when the build directory is inside a git checkout.
+The CLI scans the directory and uploads every executable and shared library that carries debug info and a build ID, skipping everything else. On macOS it also uploads `.dSYM` bundles (this needs `dwarfdump`, which ships with Xcode). Windows binaries (PDB debug info) are not supported yet. The upload is associated with a [release](/docs/error-tracking/releases) automatically when the build directory is inside a git checkout.
 
 Run this as part of the same pipeline that produces your production binary. Each build has its own build ID, so symbols must be re-uploaded for every build you deploy.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5300,6 +5300,10 @@ export const docsMenu = {
                             url: '/docs/error-tracking/upload-source-maps/ios',
                         },
                         {
+                            name: 'Rust',
+                            url: '/docs/error-tracking/upload-source-maps/rust',
+                        },
+                        {
                             name: 'Rollup',
                             url: '/docs/error-tracking/upload-source-maps/rollup',
                         },


### PR DESCRIPTION
## Changes

Adds a guide for uploading Rust debug symbols to Error Tracking, now that the Rust SDK (posthog-rs 0.16+) records instruction addresses and `posthog-cli symbol-sets upload` handles native binaries.

- New page: `/docs/error-tracking/upload-source-maps/rust` — Cargo profile setup (debug info, macOS `split-debuginfo`), build ID checks, `symbol-sets upload`, `--include-source`, CI example, verification.
- Installation page callout updated: the "source context not yet supported" note is replaced with a pointer to the new upload guide.
- Rust added to the upload platforms grid and the docs sidebar nav (`src/navs/index.js` — flagging per the "ask first" note in AGENTS.md; it's a single child entry under the existing "Upload source maps" section, mirroring the Android entry).
- `StepVerifySymbolSetsUpload` gains a `debug symbols` symbol-type variant.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page only)
