### PR TITLE
Remove specific pay review dates from handbook

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -74,7 +74,7 @@ The reason for less sophistication here is that we have very few executives, and
 
 ## Pay reviews
 
-We review pay proactively and currently run pay reviews for the whole team 3x per year - usually around March, July, and November. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask.
+We review pay proactively 2-3 times a year, and everybody on the team is reviewed at every pay review. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask.
 
 As we do these much more frequently than regular companies, team members should definitely not expect these to result in a change to their Step or Level each time - mostly they will stay the same. Additionally, team members will find that their Step, or place within a Step's range, will change more frequently than their Level.
 
@@ -124,7 +124,7 @@ Check out our [share options FAQs](/handbook/people/share-options#frequently-ask
 
 Every employee will be eligible for equity refreshes each year you are working at PostHog. These grants are between 18%-25% of the value of a new grant for your current role. The percentage is based on your performance and can vary year by year. 
 
-These equity refreshes will be decided at our pay review cycles that happen 3 times a year, in roughly March, July & November, and are communicated by the relevant #team-blitzscale member at that time. Grants are approved quarterly by the board, though vesting is back-dated begins on the actual anniversary date. You'll be made aware of your grant being approved when you get an email from Carta regarding the grant. These refresher grants will be on the same terms as your original grant with a 12 month cliff, they will likely be subject to a different strike price due to changes in valuations.
+These equity refreshes will be decided at our pay review cycles, and are communicated by the relevant #team-blitzscale member at that time. Grants are approved quarterly by the board, though vesting is back-dated begins on the actual anniversary date. You'll be made aware of your grant being approved when you get an email from Carta regarding the grant. These refresher grants will be on the same terms as your original grant with a 12 month cliff, they will likely be subject to a different strike price due to changes in valuations.
 
 Funding rounds disrupt when we are able to issue new grants, so approvals my be delayed if we are actively fundraising. 
 


### PR DESCRIPTION
## Changes

Updates the pay reviews section of the compensation handbook to say we review pay proactively 2-3 times a year and everybody on the team is reviewed at every pay review, rather than naming specific months. Also drops the specific months from the equity refresh cadence for consistency.

**Why:** Publishing the exact pay review timing was leading to people lobbying for pay rises around those dates.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0993H38LLT/p1784043721201999?thread_ts=1784043721.201999&cid=C0993H38LLT)*