### PR TITLE
chore(ci): auto-label docs and Inkeep PRs

### DIFF
--- a/.github/workflows/auto-label-docs.yml
+++ b/.github/workflows/auto-label-docs.yml
@@ -1,0 +1,42 @@
+name: Auto Label Docs
+
+# Adds the `docs` label to PRs opened by the Inkeep docs bot, or whose title uses
+# the conventional-commit `docs` type (`docs:` / `docs(scope):`). The website
+# team's project board uses this label to exclude docs PRs, since GitHub project
+# filters can't match on author.
+#
+# Uses `pull_request_target` so it gets a write token for PRs from any author
+# (including the Inkeep app). It never checks out or runs PR code, the PR title
+# is only read inside `if:` expressions (never interpolated into a shell), and
+# the only mutation is applying one fixed, pre-approved label — so an untrusted
+# PR has nothing to inject. Changes here only take effect once merged to master.
+on:
+    pull_request_target:
+        types: [opened, reopened, ready_for_review, edited]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+# A PR opened then quickly edited (title/base) queues redundant runs. Labeling
+# is idempotent, so drop any in-flight run for the same PR.
+concurrency:
+    group: auto-label-docs-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    label-docs:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: >-
+            github.event.pull_request.user.login == 'inkeep[bot]' ||
+            startsWith(github.event.pull_request.title, 'docs:') ||
+            startsWith(github.event.pull_request.title, 'docs(')
+        steps:
+            - name: Add docs label
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label docs

--- a/.github/workflows/auto-label-docs.yml
+++ b/.github/workflows/auto-label-docs.yml
@@ -11,10 +11,11 @@ name: Auto Label Docs
 # the only mutation is applying one fixed, pre-approved label — so an untrusted
 # PR has nothing to inject. Changes here only take effect once merged to master.
 #
-# nosemgrep: github-actions-pull-request-target -- No checkout/build of the PR head
-# (no `actions/checkout` at all), permissions are scoped to the minimum, and the PR
-# title is only read inside `if:` expressions, never interpolated into a shell — so
-# there is no "pwn request" surface. Justified per the security team's rule guidance.
+# This safety (no checkout/build of the PR head, minimal permissions, title only
+# read inside `if:`) is why the security-team `pull_request_target` rule is
+# suppressed below. The `nosemgrep` marker must sit on the line directly above
+# the trigger for the suppression to apply.
+# nosemgrep: github-actions-pull-request-target
 on:
     pull_request_target:
         types: [opened, reopened, ready_for_review, edited]

--- a/.github/workflows/auto-label-docs.yml
+++ b/.github/workflows/auto-label-docs.yml
@@ -1,20 +1,11 @@
 name: Auto Label Docs
 
-# Adds the `docs` label to PRs opened by the Inkeep docs bot, or whose title uses
-# the conventional-commit `docs` type (`docs:` / `docs(scope):`). The website
-# team's project board uses this label to exclude docs PRs, since GitHub project
-# filters can't match on author.
+# Adds the `docs` label to PRs from the Inkeep bot or with a `docs:`/`docs(scope):`
+# title, so the website team's board can exclude them (project filters can't match
+# on author).
 #
-# Uses `pull_request_target` so it gets a write token for PRs from any author
-# (including the Inkeep app). It never checks out or runs PR code, the PR title
-# is only read inside `if:` expressions (never interpolated into a shell), and
-# the only mutation is applying one fixed, pre-approved label — so an untrusted
-# PR has nothing to inject. Changes here only take effect once merged to master.
-#
-# This safety (no checkout/build of the PR head, minimal permissions, title only
-# read inside `if:`) is why the security-team `pull_request_target` rule is
-# suppressed below. The `nosemgrep` marker must sit on the line directly above
-# the trigger for the suppression to apply.
+# `pull_request_target` gives a write token for fork/bot PRs. Safe: no checkout of
+# PR code, minimal permissions, title only read in `if:` (never in a shell).
 # nosemgrep: github-actions-pull-request-target
 on:
     pull_request_target:

--- a/.github/workflows/auto-label-docs.yml
+++ b/.github/workflows/auto-label-docs.yml
@@ -10,6 +10,11 @@ name: Auto Label Docs
 # is only read inside `if:` expressions (never interpolated into a shell), and
 # the only mutation is applying one fixed, pre-approved label — so an untrusted
 # PR has nothing to inject. Changes here only take effect once merged to master.
+#
+# nosemgrep: github-actions-pull-request-target -- No checkout/build of the PR head
+# (no `actions/checkout` at all), permissions are scoped to the minimum, and the PR
+# title is only read inside `if:` expressions, never interpolated into a shell — so
+# there is no "pwn request" surface. Justified per the security team's rule guidance.
 on:
     pull_request_target:
         types: [opened, reopened, ready_for_review, edited]


### PR DESCRIPTION
## Changes

New `Auto Label Docs` workflow that adds the `docs` label to a PR when either:

- it was opened by the Inkeep docs bot (`inkeep[bot]`), or
- its title uses the conventional-commit `docs` type (`docs:` or `docs(scope):`).

This lets the website team's project board exclude docs PRs from being auto-added — GitHub project filters can't match on author, so a label is the reliable lever.

It runs on `pull_request_target` so it has a write token for PRs from any author (including the Inkeep app). It never checks out or runs PR code, reads the title only inside `if:` expressions, and its only mutation is applying one fixed, pre-approved label. A matching workflow is going up in `PostHog/posthog`, so both sides of the Inkeep flow get labeled. Like all `pull_request_target` workflows, it only takes effect once merged to `master`.

Verified with `actionlint` (clean) and confirmed the `docs` label already exists in this repo.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1784633985261369?thread_ts=1784633985.261369&cid=C09GTQY5RLZ)*
