### PR TITLE
Update "PostHog products" to "PostHog tools" in product "Works with" section

### DIFF
--- a/src/components/Products/ReaderViewProduct/templates/PairsWith.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/PairsWith.tsx
@@ -14,7 +14,7 @@ const PairsWith = ({ id, productData, allProducts }: SectionComponentProps) => {
 
     return (
         <section id={id} className="scroll-mt-20 not-prose">
-            <h2 className="text-3xl font-bold text-primary mt-0 mb-3">Works with other PostHog products</h2>
+            <h2 className="text-3xl font-bold text-primary mt-0 mb-3">Works with other PostHog tools</h2>
             <p className="text-base text-secondary leading-relaxed m-0 mb-4">
                 Use {productData?.name} with these other PostHog apps to maximize shareholder value.
             </p>


### PR DESCRIPTION
## Changes

Changes the "Works with other PostHog products" heading to "Works with other PostHog tools" in the shared `PairsWith` section template.

**Why:** Requested tweak to the wording on the session-replay page. Note this heading is shared across all product landing pages, so the change applies everywhere the "Works with..." section renders — not just session-replay.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784639665618219)*