### PR TITLE
chore(ci): add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,50 @@
+name: 'Handle stale PRs'
+on:
+    schedule:
+        - cron: '30 7 * * 1-5'
+    workflow_dispatch:
+
+permissions:
+    issues: write
+    pull-requests: write
+
+jobs:
+    stale:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 60
+        steps:
+            - name: Check if holiday period
+              id: holiday
+              run: |
+                  # Skip during Christmas/New Year holidays (Dec 20 - Jan 3)
+                  MONTH=$(TZ=UTC date +%m)
+                  DAY=$(TZ=UTC date +%-d)
+                  if [[ "$MONTH" == "12" && $DAY -ge 20 ]] || [[ "$MONTH" == "01" && $DAY -le 3 ]]; then
+                    echo "skip=true" >> "$GITHUB_OUTPUT"
+                    echo "Skipping stale check during holiday period"
+                  else
+                    echo "skip=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            # GITHUB_TOKEN is capped at 1,000 API requests/hour per repo, so
+            # operations-per-run stays bounded below that; the daily schedule
+            # works through any backlog across runs.
+            - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+              if: steps.holiday.outputs.skip != 'true'
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  days-before-issue-stale: 730
+                  days-before-issue-close: 14
+                  stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, please remove the `stale` label – otherwise this will be closed in two weeks."
+                  close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-issue-label: stale
+                  remove-issue-stale-when-updated: true
+                  days-before-pr-stale: 7
+                  days-before-pr-close: 7
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanently keep it open, use the `waiting` label."
+                  close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-pr-label: stale
+                  remove-pr-stale-when-updated: true
+                  exempt-pr-labels: 'waiting'
+                  enable-statistics: true
+                  operations-per-run: 400

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,9 +39,9 @@ jobs:
                   close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-issue-label: stale
                   remove-issue-stale-when-updated: true
-                  days-before-pr-stale: 7
+                  days-before-pr-stale: 14
                   days-before-pr-close: 7
-                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanently keep it open, use the `waiting` label."
+                  stale-pr-message: "This PR hasn't seen activity in two weeks! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanently keep it open, use the `waiting` label."
                   close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
                   remove-pr-stale-when-updated: true


### PR DESCRIPTION
## Changes

Adds a stale bot, matching the one in PostHog/posthog: PRs go stale after 2 weeks of inactivity and close a week later, issues go stale after 2 years and close 2 weeks later. Commenting or removing the `stale` label resets the clock, and the `waiting` label exempts a PR permanently. Runs weekday mornings and skips the Christmas/New Year period.

Uses `GITHUB_TOKEN` with `operations-per-run` capped at 400 to stay inside its rate budget, so the first runs work through the existing backlog over a few days.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides. N/A (CI change, no site content)
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links. N/A
- [x] I've checked the pages added or changed in the Vercel preview build. N/A
- [x] If I moved a page, I added a redirect in `vercel.json`. N/A