### PR TITLE
SUPERDAY - The Hog Squad Ambassador Program

### DIFF
--- a/contents/handbook/community/ambassadors.mdx
+++ b/contents/handbook/community/ambassadors.mdx
@@ -1,0 +1,52 @@
+---
+title: The Hog Squad
+sidebar: Handbook
+showTitle: true
+---
+
+The Hog Squad is how PostHog recognizes the people already building, teaching, and shipping alongside us in the open.
+
+**Cohort one opens once our first 10 to 15 contributors are shortlisted.**
+
+## How it works
+
+The Hog Squad runs as small cohorts, not open enrollment. We watch the forum, Discord, GitHub, and r/posthog for people already doing the things below, and invite them directly. No application form. Each cohort is capped at 10 to 15 people so it stays a relationship, not a mailing list with a badge attached.
+
+## What counts
+
+Wider than code, on purpose:
+
+* **Code and OSS:** merged PRs, plugin authorship, bug reports with a real repro.
+* **Knowledge:** forum answers, docs fixes, HogQL examples, session-replay recipes.
+* **Visibility:** writing or talking about what you built with PostHog, especially unprompted.
+* **Stewardship:** running r/posthog, hosting a builder group, moderating Discord, running an AMA.
+
+## Support from PostHog
+
+* **Access:** early feature previews and a direct, async line to the team, plus input on roadmap discussions in your area.
+* **Platform:** a recurring spotlight on the blog, newsletter, and forum hub topics, not a one-off mention.
+* **IRL bridge:** Hedge House visits and comped travel to the annual Hog Squad Summit, plus first invites as builder groups become collectives.
+* **Money, where real:** paid writing, speaking, or contract work, surfaced to top contributors first.
+
+**Time commitment:** none fixed. Week one points you at one scoped opportunity, a docs gap, a stale thread, a good-first-issue, and you work it whenever you have time.
+
+## Who cohort one is for
+
+People with hands-on history on our public surfaces, not a title or a follower count:
+
+* Merged a PR, shipped a plugin, or filed a bug with a real repro.
+* Answered forum questions before we got to them.
+* Run a builder group, Discord community, or r/posthog.
+* Shared what you built with PostHog without being asked to.
+
+## The Hog Squad Summit
+
+Once a year, we fly our top tier of contributors out for a few days to meet each other and the team. The bar is TopHog and above, with a spread across different kinds of contributions rather than one maxed-out category. Ten people active in three places beat fifty who posted once.
+
+While we're there: a say in what the program focuses on next, direct roadmap time with product and engineering, and real unstructured time to just hang out.
+
+## Ground rules
+
+* Issues get handled the same way regardless of how prolific you are: a private word first, then a suspension, then removal if it keeps happening.
+* This isn't a support queue. Help because it's interesting, not because it's free labor.
+* We measure this in real relationships, not signups.


### PR DESCRIPTION
## Changes

Adds a new handbook page proposing "The Hog Squad," a community ambassador program for recognizing contributors across code, docs, forum support, and community stewardship. Covers how cohorts work, what counts as a contribution, what support PostHog offers members, criteria for cohort one, the Hog Squad Summit, and ground rules for handling issues.

No visual/UI changes. Content-only addition at `contents/handbook/community/ambassadors.mdx`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
