### PR TITLE
Add SmartEngage data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/smartengage.md
+++ b/contents/docs/cdp/sources/smartengage.md
@@ -1,0 +1,53 @@
+---
+title: Linking SmartEngage as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: SmartEngage
+---
+
+import SourceSetupIntro from "../\_snippets/source-setup-intro.mdx"
+import SyncModes from "../\_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../\_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../\_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The SmartEngage connector syncs your marketing automation data into the PostHog Data warehouse, so you can analyze your avatars, tags, custom fields, and automation sequences alongside your product data.
+
+## Prerequisites
+
+You need a SmartEngage account with access to your API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking SmartEngage, you'll need:
+
+- **API key** – find it in your [SmartEngage](https://smartengage.com/) account settings. The key grants access to the avatars on your account and the tags, custom fields, and sequences scoped to them.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full-refresh only. The SmartEngage API has no timestamp filters, so every table is fully re-synced on each run.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+Tags, custom fields, and sequences are scoped per avatar: PostHog lists your avatars first and then fetches each avatar's records, so these tables include an `avatar_id` column you can join back to the `avatars` table.
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Generate a new key in your SmartEngage account settings, then reconnect.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new SmartEngage data warehouse connector, following the canonical source-doc template (`<SourceParameters />` + `<SourceTables />`, shared snippets, alpha callout).

Pairs with the connector implementation in the posthog repo (`feat(data-warehouse): implement smartengage import source`) — the `sourceId: SmartEngage` and `docsUrl` slug match that source's registration, so this doc should merge once that PR lands.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*