### PR TITLE
docs: add Spotler CRM data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/spotlercrm.md
+++ b/contents/docs/cdp/sources/spotlercrm.md
@@ -1,0 +1,51 @@
+---
+title: Linking Spotler CRM as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: SpotlerCRM
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Spotler CRM (formerly Really Simple Systems) connector syncs your CRM data – accounts, contacts, opportunities, activities, and more – into PostHog, so you can analyze your sales pipeline alongside your product data.
+
+## Prerequisites
+
+You need a Spotler CRM account on a plan with API access (Professional or Enterprise). Some record types need paid add-ons: campaigns require the Marketing tool, and cases require the Service & Support tool.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Spotler CRM, you'll need:
+
+- **API access token** – in Spotler CRM, go to **Settings**, then **Integrations**, then **API V4**, and click **Generate new key**. The token is shown only once, so copy it right away.
+
+## Sync modes
+
+<SyncModes />
+
+The Spotler CRM API doesn't support server-side incremental filtering, so all tables sync as a full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If a table fails to sync with a permission error, check that your plan includes that record type: campaigns need the Marketing tool add-on, and cases need the Service & Support tool add-on.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Spotler CRM (formerly Really Simple Systems) data warehouse import source, at `contents/docs/cdp/sources/spotlercrm.md`. It follows the canonical source-doc template (`<SourceParameters />` + `<SourceTables />`, shared snippets, alpha callout) and its slug matches the `docsUrl` set in the source config.

Companion to the source implementation PR in PostHog/posthog (linked from there). This doc should merge once that PR lands.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*