### PR TITLE
chore(docs): add Lightfield data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/lightfield.md
+++ b/contents/docs/cdp/sources/lightfield.md
@@ -1,0 +1,51 @@
+---
+title: Linking Lightfield as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Lightfield
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Lightfield connector syncs your CRM data – accounts, contacts, opportunities, meetings, tasks, notes, lists, members, and emails – into PostHog.
+
+## Prerequisites
+
+You need admin access to your Lightfield organization to create an API key. Keys are scoped per resource, so grant the read scope (for example `accounts:read`) for each table you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Lightfield, you'll need:
+
+- **API key** – create one in your Lightfield settings. It starts with `sk_lf_`. Grant the read scope for every table you plan to sync: `accounts:read`, `contacts:read`, `opportunities:read`, `meetings:read`, `tasks:read`, `notes:read`, `lists:read`, `members:read`, and `emails:read`. Tables without their scope show a permission warning in the schema picker.
+
+## Sync modes
+
+<SyncModes />
+
+Lightfield's API doesn't support filtering records by their last update time, so all tables sync with full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+Emails sync without the message body, and subjects may be redacted when the connected mailbox only shares metadata.
+
+## Troubleshooting
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Lightfield data warehouse connector, shipping in [PostHog/posthog](https://github.com/PostHog/posthog) as an alpha source. The doc follows the canonical source-doc template: shared snippets (`SourceSetupIntro`, `SyncModes`, `AlphaRelease`, `TroubleshootingLink`) plus `<SourceParameters />` and `<SourceTables />`, which render from the `public_source_configs` API once the connector PR merges.

**Why:** the connector's `docsUrl` points at `/docs/cdp/sources/lightfield`, so this page needs to exist when the source ships. Merge after (or together with) the connector PR so `sourceId: Lightfield` resolves.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a - new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*