### PR TITLE
Add Plunk data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/plunk.md
+++ b/contents/docs/cdp/sources/plunk.md
@@ -1,0 +1,54 @@
+---
+title: Linking Plunk as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Plunk
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+Sync your Plunk contacts, campaigns, templates, and segments into the PostHog data warehouse, so you can join email engagement with product analytics, for example to compare campaign performance against activation or retention.
+
+## Prerequisites
+
+You need the secret API key for your Plunk project. It starts with `sk_` and is shown in your Plunk project settings. The public key (`pk_`) only works for event tracking and cannot read data.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+1. In Plunk, open **Project Settings** and go to the **API Keys** section, then copy the secret key (`sk_...`).
+2. Back in PostHog, enter the secret API key.
+3. If you self-host Plunk, set the API URL to your Plunk API host (for example `https://plunk-api.example.com`). Leave it blank to use the hosted Plunk at `https://next-api.useplunk.com`.
+4. Click **Next**, select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+## Sync modes
+
+<SyncModes />
+
+Plunk's API exposes no server-side timestamp filter on its list endpoints, so every table is full refresh only and reloads all records on each sync.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If a sync fails with an authentication error, check that you are using the secret key (`sk_`), not the public key (`pk_`), and that the key was not regenerated in Plunk. Copy the current secret key from your Plunk project settings and reconnect the source.
+
+If Plunk rejects requests with a permission error, check that your Plunk project is active and that your account email is verified.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Plunk (useplunk.com) data warehouse import source, which is landing in posthog/posthog. Follows the canonical warehouse source template: alpha callout, prerequisites, setup steps, shared sync-modes snippet, and `<SourceParameters />` / `<SourceTables />` rendered from the source registry (`sourceId: Plunk`).

**Why:** every shipped warehouse source needs a matching posthog.com doc; the source's `docsUrl` points at `/docs/cdp/sources/plunk`, so this page must exist to avoid a 404.

This should merge around the time the source PR merges in posthog/posthog.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*