### PR TITLE
docs: add Leexi data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/leexi.md
+++ b/contents/docs/cdp/sources/leexi.md
@@ -1,0 +1,63 @@
+---
+title: Linking Leexi as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Leexi
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Leexi connector pulls your Leexi conversation intelligence data — calls with transcripts and AI summaries, call notes, meeting events, users, and teams — into the PostHog data warehouse.
+
+## Prerequisites
+
+- A Leexi plan with API access.
+- A Leexi admin account to create the API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+You need a Leexi API key pair. Create one in Leexi under **Settings** > **Company settings** > **API keys** (requires an admin account), then copy the key ID and key secret.
+
+Grant these permission scopes so every table can sync:
+
+- `read_calls` (calls and call notes)
+- `read_meeting_events`
+- `read_users`
+- `read_teams`
+
+The key's call access scope also controls which calls sync: a whole-company key syncs every call, while a key restricted to one user or to access rules only syncs the calls it can see.
+
+## Sync modes
+
+<SyncModes />
+
+The `calls` table supports incremental syncs on `updated_at` (recommended), `created_at`, or `performed_at`. The other tables reload in full on each sync because the Leexi API exposes no update-time filter for them.
+
+The `call_notes` table fetches notes one call at a time, so syncing it on a large call history can be slow under Leexi's API rate limit. It's disabled by default; enable it only if you need the per-note translations it adds over the summaries already included on each call row.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- **Source validation fails**: check that the key ID and secret were copied correctly and that the key wasn't revoked in Leexi.
+- **A table shows a permission error**: the API key is missing that table's permission scope. Edit the key's scopes in Leexi or create a new key with the scopes listed above.
+- **Syncs fail with `402 Payment Required`**: your Leexi subscription is inactive, or your plan doesn't include API access.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Leexi data warehouse connector, which is being added in the main repo (PR link to follow in a comment). Follows the canonical warehouse source doc template: alpha callout, prerequisites, setup steps with required API key scopes, sync mode notes, and the `<SourceParameters />` / `<SourceTables />` components that render from the source registry.

**Why:** the Leexi import source ships with `docsUrl` pointing at `/docs/cdp/sources/leexi`, so this page needs to exist for the in-app link.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*