### PR TITLE
docs: add TVmaze data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/tvmaze.md
+++ b/contents/docs/cdp/sources/tvmaze.md
@@ -1,0 +1,51 @@
+---
+title: Linking TVmaze as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: TVMaze
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The TVmaze connector syncs the [TVmaze](https://www.tvmaze.com/) TV show catalog – shows, people (cast and crew), and their last-updated timestamps – into PostHog.
+
+## Prerequisites
+
+None. TVmaze exposes a free public API, so no account, API key, or other credentials are needed.
+
+TVmaze data is licensed [CC BY-SA](https://creativecommons.org/licenses/by-sa/4.0/), which requires attribution to TVmaze and share-alike distribution. Make sure your use of the data complies with the license.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+TVmaze needs no credentials – just select the tables you want to sync.
+
+## Sync modes
+
+<SyncModes />
+
+TVmaze has no server-side change filter, so every table syncs as a full refresh. The `show_updates` and `person_updates` tables hold a last-updated timestamp per record, which you can query to see what changed between syncs.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+The connector doesn't sync per-show child resources like episodes, seasons, or cast: TVmaze allows around 20 requests per 10 seconds, so fetching them for the full catalog of tens of thousands of shows isn't practical.
+
+## Troubleshooting
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new TVmaze data warehouse import source ([PostHog/posthog#72625](https://github.com/PostHog/posthog/pull/72625)), following the canonical source-doc template: shared snippets, `<SourceParameters />` and `<SourceTables />` rendered from the public source configs API, and an alpha release callout.

The slug (`tvmaze`), the source's `docsUrl`, and the frontmatter `sourceId` (`TVMaze`) all agree — verified with `python manage.py audit_source_docs` against this checkout.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*