### PR TITLE
feat(docs): add tinyEmail data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/tinyemail.md
+++ b/contents/docs/cdp/sources/tinyemail.md
@@ -1,0 +1,52 @@
+---
+title: Linking tinyEmail as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Tinyemail
+beta: true
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The tinyEmail connector syncs your email marketing data – campaigns, contact lists, contact members, and sender details – into PostHog, so you can analyze campaign performance and audience growth alongside your product data.
+
+## Prerequisites
+
+You need a tinyEmail account on an Enterprise plan, since tinyEmail restricts API access to Enterprise accounts. If you're on a lower tier, contact tinyEmail about upgrading before connecting.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking tinyEmail, you'll need:
+
+- **API key** – in [tinyEmail](https://app.tinyemail.com), go to **My account > API keys** and generate a new key.
+
+The tinyEmail API allows 60 requests per minute per API key. PostHog automatically backs off and retries when this limit is hit, but if you have very large contact lists you can ask tinyEmail support to raise the limit.
+
+## Sync modes
+
+<SyncModes />
+
+The tinyEmail API doesn't offer a way to filter records by modification time, so all tables sync as full refresh.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new tinyEmail data warehouse connector, implemented in [PostHog/posthog#72613](https://github.com/PostHog/posthog/pull/72613).

Follows the canonical source-doc template: `sourceId: Tinyemail` frontmatter, alpha release callout, shared snippets, and `<SourceParameters />` / `<SourceTables />` (the source sets `lists_tables_without_credentials = True`, so the table catalog renders from the API). `audit_source_docs` run from the posthog repo reports no issues for this doc.

Should merge alongside (or after) the connector PR so the source config exists for the components to render.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
