### PR TITLE
docs: add Hex data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/hex.md
+++ b/contents/docs/cdp/sources/hex.md
@@ -1,0 +1,54 @@
+---
+title: Linking Hex as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Hex
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Hex connector syncs your Hex workspace data into the PostHog Data warehouse, so you can analyze your projects, scheduled notebook runs, users, groups, and collections alongside your product data. It's especially useful for monitoring the reliability, duration, and error rates of scheduled Hex project runs.
+
+## Prerequisites
+
+You need a Hex account with access to the [Hex API](https://learn.hex.tech/docs/api-integrations/api/overview) so you can create an API token. A personal token inherits your permissions; workspace tokens are available on some Hex plans and can read across the whole workspace.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Hex, you'll need:
+
+- **API token** – create one in Hex under **Workspace settings → API keys**.
+- **Workspace URL** – only needed for single-tenant or self-hosted Hex deployments (for example `https://acme.hex.tech`). Leave it empty if your workspace is on Hex's multi-tenant cloud at `app.hex.tech`.
+
+## Sync modes
+
+<SyncModes />
+
+All Hex tables are full refresh only, since the Hex API exposes no incremental sync filter.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you get an authorization error, your API token is invalid or was revoked. Create a new token under **Workspace settings → API keys** in Hex, then reconnect.
+- If you get a permission error, your token can't read this data. Personal tokens only see what your Hex user can see, so use a token from a user with broader access (or a workspace token), then reconnect.
+- The `project_runs` table only contains runs of published projects triggered via the API, a schedule, or an app refresh. Runs from editing a project in the notebook view don't appear in Hex's API.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new Hex data warehouse source, following the canonical source-doc template (shared snippets, `<SourceParameters />` + `<SourceTables />`, alpha callout). The connector itself ships in [PostHog/posthog#72619](https://github.com/PostHog/posthog/pull/72619) — its `docsUrl` points at `/docs/cdp/sources/hex`, matching this filename, and `audit_source_docs` passes against this checkout.

**Why:** the Hex source lands released (alpha) and needs its linked doc so the in-app docs link and the sources catalog page don't 404.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*