### PR TITLE
docs: add Dub data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/dub.md
+++ b/contents/docs/cdp/sources/dub.md
@@ -1,0 +1,61 @@
+---
+title: Linking Dub as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Dub
+---
+
+import SourceSetupIntro from "../\_snippets/source-setup-intro.mdx"
+import SyncModes from "../\_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../\_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../\_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Dub connector syncs your link attribution data from [Dub](https://dub.co) into PostHog: short links, click, lead, and sale events, customers, tags, domains, folders, and your partner program's partners, commissions, and payouts.
+This lets you join link and affiliate performance with the rest of your product analytics.
+
+## Prerequisites
+
+You need a Dub workspace and a workspace API key.
+Some tables need more than the free plan:
+
+- The `click_events`, `lead_events`, and `sale_events` tables require a Dub [Business plan](https://dub.co/pricing) or higher.
+- The `payouts` table requires a Business partner program plan or higher.
+- The `partners` and `commissions` tables require a [Dub Partners](https://dub.co/partners) program.
+
+Tables your plan can't access show a permission note in the schema picker, so you can leave them unselected.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Dub, you'll need:
+
+- **Workspace API key**: create one in your [Dub workspace](https://app.dub.co) under **Settings** > **API Keys**. The key starts with `dub_` and is scoped to a single workspace.
+
+## Sync modes
+
+<SyncModes />
+
+The event tables (`click_events`, `lead_events`, `sale_events`) support incremental syncs on the event timestamp, which we recommend since events are append-only.
+All other tables sync as full refresh: the Dub API has no updated-since filter for them, and entities like commissions change status after creation, so a full reload keeps them accurate.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If a sync fails with a permission error, check your Dub plan: event and payout tables need a Business plan or higher, and partner tables need a partner program.
+Disable syncing for tables your plan doesn't include.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Dub data warehouse connector, implemented in [PostHog/posthog#72640](https://github.com/PostHog/posthog/pull/72640). Follows the canonical source-doc template: alpha callout, prerequisites with Dub plan gating, setup steps via the shared snippets, and `<SourceParameters />` / `<SourceTables />` rendered from the source config.

The connector sets `docsUrl` to `https://posthog.com/docs/cdp/sources/dub`, matching this file's slug. `audit_source_docs` passes for Dub against this checkout.

## Why

The Dub import source is shipping in [PostHog/posthog#72640](https://github.com/PostHog/posthog/pull/72640) and needs its user-facing doc so the source's docs link resolves.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*