### PR TITLE
docs: add Razorpay data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/razorpay.md
+++ b/contents/docs/cdp/sources/razorpay.md
@@ -1,0 +1,50 @@
+---
+title: Linking Razorpay as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+sourceId: Razorpay
+---
+
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+
+<AlphaRelease />
+
+The Razorpay connector syncs your payments data – payments, orders, refunds, settlements, subscriptions, and more – into PostHog, so you can analyze revenue and payment activity alongside your product data.
+
+## Prerequisites
+
+You need a Razorpay account and an API key pair (key ID and key secret). Razorpay issues separate key pairs for test mode (`rzp_test_`) and live mode (`rzp_live_`), so use a live-mode key to sync production data.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Razorpay, you'll need:
+
+- **Key ID** and **Key secret** – in your [Razorpay Dashboard](https://dashboard.razorpay.com/), go to **Account & Settings > API keys**, then generate or regenerate a key. Copy both the key ID and the key secret (the secret is only shown once, at generation time).
+
+## Sync modes
+
+<SyncModes />
+
+Razorpay's API filters on creation time only, so incremental syncs pick up newly created records plus a short trailing window of recent ones. Status changes on older records (for example, a payment refunded weeks after it was created) are only captured by a full refresh, so consider an occasional full refresh on mutable tables like payments and settlements. Tables without a creation-time filter (disputes, invoices, and virtual accounts) sync as full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Razorpay data warehouse connector, following the canonical source-doc template. The connection fields and Supported tables sections render automatically via `<SourceParameters />` and `<SourceTables />` once the connector PR (PostHog/posthog) ships, since the source sets `lists_tables_without_credentials` and provides canonical table/column descriptions.

Companion to the connector implementation PR in PostHog/posthog (razorpay import source). The doc slug matches the source's `docsUrl` (`/docs/cdp/sources/razorpay`) and `sourceId: Razorpay` matches the `ExternalDataSourceType` value; `audit_source_docs` passes for this source.

**Why:** the Razorpay warehouse source is shipping as a visible alpha connector and needs its user-facing doc so the in-app docs link doesn't 404.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*