### PR TITLE
docs: add StreamElements data warehouse source

### DIFF
--- a/contents/docs/cdp/sources/streamelements.md
+++ b/contents/docs/cdp/sources/streamelements.md
@@ -1,0 +1,54 @@
+---
+title: Linking StreamElements as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: StreamElements
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The StreamElements connector syncs your channel's tips, activity feed events, loyalty points leaderboards, store items and redemptions, chatbot commands and timers, and channel details into the PostHog Data warehouse, so you can analyze your stream's community and revenue alongside your product data.
+
+## Prerequisites
+
+You need a StreamElements account. Any account can use the API, but the token you connect with only sees the channel it belongs to.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking StreamElements, you'll need:
+
+- **JWT token** – in the StreamElements dashboard, click your avatar and open your account page, enable **Show secrets** under **Channels**, then copy the JWT token for your channel.
+
+An OAuth2 access token also works in place of the JWT token, as long as it has the `channel:read`, `tips:read`, `activities:read`, `loyalty:read` and `store:read` scopes.
+
+## Sync modes
+
+<SyncModes />
+
+The `tips` and `activities` tables support incremental sync on `createdAt`. Points leaderboards are snapshots of the current standings, so they are full refresh only.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see a `401 Unauthorized` error, your token is invalid or expired. Copy a fresh JWT token from the StreamElements dashboard, then reconnect.
+- If you see a `403 Forbidden` error, your OAuth2 token is missing a scope needed for one of the selected tables. Reconnect with the scopes listed above, or deselect the tables you don't need.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new StreamElements data warehouse import source, following the canonical source-doc template (shared snippets, `<SourceParameters />`, `<SourceTables />`).

Companion to the source implementation PR in PostHog/posthog (linked once open). The table list and connection fields render from the `public_source_configs` API, so this page fills in once that PR deploys.

**Why:** the new StreamElements source sets `docsUrl` to `/docs/cdp/sources/streamelements`; this page needs to exist so the in-app link doesn't 404.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*