### PR TITLE
docs: add HoorayHR data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/hoorayhr.md
+++ b/contents/docs/cdp/sources/hoorayhr.md
@@ -1,0 +1,52 @@
+---
+title: Linking HoorayHR as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: HoorayHR
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The HoorayHR connector syncs your HR data (employees, time off, sick leave, contracts, time tracking, and more) into the PostHog Data warehouse, so you can analyze it alongside your product data.
+
+## Prerequisites
+
+You need the admin role in your HoorayHR company to create an API key. Personal API keys act as the user who created them.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking HoorayHR, you'll need:
+
+- **API key** – in HoorayHR, go to [Settings → API keys](https://app.hoorayhr.io/settings/api-keys) and click "New API key". The key (prefixed `pk_`) is shown only once, so copy it right away.
+
+## Sync modes
+
+<SyncModes />
+
+This source is full-refresh only. HoorayHR's API exposes no pagination, cursors, or timestamp filters, so every table is fully re-synced on each run.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- If you see an authentication error, your API key is invalid or has been revoked. Create a new key under Settings → API keys in HoorayHR, then reconnect.
+- If you see a permissions error, the user who created the key may have lost the admin role. API keys act as the user who created them, so make sure that user is still an admin.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the user-facing doc for the new HoorayHR data warehouse source, shipped in [PostHog/posthog#72636](https://github.com/PostHog/posthog/pull/72636). Follows the canonical source-doc template: shared snippets (`SourceSetupIntro`, `SyncModes`, `AlphaRelease`, `TroubleshootingLink`) plus auto-rendered `<SourceParameters />` and `<SourceTables />` (the source sets `lists_tables_without_credentials`, so the table catalog renders from the API).

**Why:** every finished warehouse source ships with a doc; the source's `docsUrl` points at `/docs/cdp/sources/hoorayhr`, so without this page it 404s. `audit_source_docs` passes for this source against this checkout.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a - new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
