### PR TITLE
Add Lemon Squeezy data warehouse source doc

### DIFF
--- a/contents/docs/cdp/sources/lemon-squeezy.md
+++ b/contents/docs/cdp/sources/lemon-squeezy.md
@@ -1,0 +1,60 @@
+---
+title: Linking Lemon Squeezy as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: LemonSqueezy
+beta: true
+---
+
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+
+<AlphaRelease />
+
+The Lemon Squeezy connector syncs your merchant-of-record data – stores, orders, subscriptions, customers, license keys, discounts, and more – into PostHog, so you can analyze revenue alongside your product data.
+
+## Prerequisites
+
+You need a Lemon Squeezy account and an API key. Note that Lemon Squeezy API keys expire after one year, and test-mode keys only return test-mode data.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Lemon Squeezy, you'll need:
+
+- **API key** – in your Lemon Squeezy dashboard, go to [Settings > API](https://app.lemonsqueezy.com/settings/api) and click **+** to create a new API key. Use a live-mode key to sync your production data.
+
+## Sync modes
+
+<SyncModes />
+
+Lemon Squeezy's API doesn't expose an "updated since" filter, so full refresh is the default for mutable tables (subscriptions, customers, license keys). Append-mostly tables (orders, order items, subscription invoices, discount redemptions, usage records) support incremental sync on `created_at`. For real-time updates to orders, subscriptions, subscription invoices, and license keys, enable webhook syncing.
+
+## Setting up webhooks for real-time syncing
+
+Orders, subscriptions, subscription invoices, and license keys can also sync via webhooks: Lemon Squeezy pushes each event to PostHog the moment it happens, which is the only mode that captures updates to existing rows (like a subscription changing status) without a full refresh.
+
+To enable it, open your source and go to the **Webhook** tab, then click **Create webhook**. PostHog registers a webhook on each of your Lemon Squeezy stores using your API key, with a generated signing secret used to verify every delivery.
+
+If automatic creation fails, you can create the webhook manually in [Settings > Webhooks](https://app.lemonsqueezy.com/settings/webhooks): paste the webhook URL PostHog shows you, set a signing secret (6-40 characters), select the order, subscription, subscription payment, and license key events, and save. Then paste the same signing secret into PostHog.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+If syncs start failing with an authorization error, your API key has likely expired – Lemon Squeezy keys are valid for one year. Create a new key under [Settings > API](https://app.lemonsqueezy.com/settings/api) and update the source.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Lemon Squeezy data warehouse connector, which is being added in PostHog/posthog (`feat(data-warehouse): implement lemon_squeezy import source`). Follows the canonical source-doc template: `<SourceParameters />` and `<SourceTables />` render from the `public_source_configs` API (the source sets `lists_tables_without_credentials`), with an alpha callout, webhook setup steps, and a key-expiry troubleshooting note.

**Why:** every shipped warehouse source needs a matching doc at `/docs/cdp/sources/<slug>` — the source's `docsUrl` points at this page.

Merge after the connector PR lands so `sourceId: LemonSqueezy` resolves in the `public_source_configs` API.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — new page)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
