### PR TITLE
Website: Fix logs free tier to 50 GB in start-here doc

### DIFF
--- a/contents/docs/logs/start-here.mdx
+++ b/contents/docs/logs/start-here.mdx
@@ -221,7 +221,7 @@ Add a Recent logs [widget](/docs/product-analytics/dashboards#adding-widgets) to
 
 <QuestLogItem 
   title="Use for free"
-  subtitle="Free 10 GB/mo"
+  subtitle="Free 50 GB/mo"
   icon="IconPiggyBank"
 >
 
@@ -230,8 +230,8 @@ PostHog's Logs is built to be cost-effective by default, with a generous free ti
 ## TL;DR 💸
 
 - No credit card required to start
-- First 10 GB of ingested logs per month are free
-- Above 10 GB we have usage-based pricing at $0.25/GB with discounts
+- First 50 GB of ingested logs per month are free
+- Above 50 GB we have usage-based pricing at $0.25/GB with discounts
 - All logs are retained 14 days by default, and we also offer 30-day or 90-day retention options for an additional storage charge – see [pricing](/pricing) for more details
 - Set billing limits to avoid surprise charges
 - See our [pricing page](/docs/logs/pricing) for more up-to-date details


### PR DESCRIPTION
## Changes

The Logs "Use for free" section in `contents/docs/logs/start-here.mdx` stated a 10 GB/month free tier, which is out of date. Every other mention of the logs free tier on the site (FAQ, `/docs/logs/pricing`, the logs GA blog post, comparison posts, and the sales handbook) says 50 GB. Updated the subtitle and both TL;DR bullets to 50 GB so it's consistent.

**Why:** Correcting a stale figure that conflicted with the rest of the website's pricing copy.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090NGM3S7M/p1784646789117759)*
