### PR TITLE
Use full size team images

### DIFF
--- a/src/components/Products/ReaderViewProduct/templates/Team.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/Team.tsx
@@ -26,7 +26,7 @@ interface ProfileNode {
     biography?: string
     pineappleOnPizza?: boolean | null
     startDate?: string | null
-    avatar?: { url?: string; formats?: { thumbnail?: { url?: string } } }
+    avatar?: { url?: string }
     teams?: {
         data?: Array<{
             id?: string | number
@@ -134,11 +134,6 @@ const Team = ({ id, productData }: SectionComponentProps) => {
                     startDate
                     avatar {
                         url
-                        formats {
-                            thumbnail {
-                                url
-                            }
-                        }
                     }
                     teams {
                         data {
@@ -221,7 +216,7 @@ const Team = ({ id, productData }: SectionComponentProps) => {
                         <li key={profile.id} className="m-0">
                             <TeamMember
                                 avatar={{
-                                    url: profile.avatar?.formats?.thumbnail?.url || profile.avatar?.url,
+                                    url: profile.avatar?.url,
                                 }}
                                 firstName={profile.firstName}
                                 lastName={profile.lastName}


### PR DESCRIPTION
## Changes

- Always use full-size team member images on product page team sections

|Before|After|
|----|----|
|<img width="1159" height="443" alt="image" src="https://github.com/user-attachments/assets/ebe8fd08-eb37-4625-a06e-b7541e23daf1" />|<img width="1160" height="436" alt="image" src="https://github.com/user-attachments/assets/deb72c07-3da4-4c26-9d90-ab349cab4c03" />|

