### PR TITLE
fix(desktop): move Discord badge next to waitlist heading on smallest screens

### DIFF
--- a/src/components/WaitlistForm/index.tsx
+++ b/src/components/WaitlistForm/index.tsx
@@ -23,6 +23,8 @@ interface WaitlistFormProps {
     showTitle?: boolean
     buttonLabel?: string
     showDiscord?: boolean
+    /** Optional element rendered right-aligned next to the "Join the waitlist" heading (pre-submit only). */
+    titleAccessory?: React.ReactNode
 }
 
 export function WaitlistForm({
@@ -35,6 +37,7 @@ export function WaitlistForm({
     showTitle = true,
     buttonLabel = 'Get updates',
     showDiscord = true,
+    titleAccessory,
 }: WaitlistFormProps) {
     const posthog = usePostHog()
     const selectedProduct = useProduct({ handle: productHandle })
@@ -100,7 +103,12 @@ export function WaitlistForm({
 
     return (
         <form onSubmit={handleSubmit} className="space-y-2">
-            {showTitle && <h3 className="text-lg font-bold mb-2 !mt-0">Join the waitlist</h3>}
+            {showTitle && (
+                <div className="flex items-center justify-between gap-2 mb-2">
+                    <h3 className="text-lg font-bold !mt-0 !mb-0">Join the waitlist</h3>
+                    {titleAccessory}
+                </div>
+            )}
             <Input
                 ref={inputRef}
                 autoFocus={autoFocus}

--- a/src/pages/desktop.tsx
+++ b/src/pages/desktop.tsx
@@ -381,10 +381,10 @@ function HeroSection() {
             {/* Top header bar: the page's own title strip (scroller + Discord) with a divider line */}
             <div className="mb-8 flex items-center justify-between gap-4 border-b border-primary pb-3">
                 <LetPostHogScroller className="text-xl @xl:text-2xl font-bold tracking-tight" />
-                {/* Below 2xs the scroller ("…instrument") needs the full row, so the Discord badge
-                    moves down next to the "Join the waitlist" heading instead (see HeroSection form). */}
+                {/* On phone-width viewports the scroller ("…instrument") needs the full row, so the
+                    Discord badge moves down next to the "Join the waitlist" heading (see HeroSection form). */}
                 <Link
-                    className="group hidden 2xs:flex shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
+                    className="group hidden sm:flex shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
                     to="https://discord.com/invite/E9xV2WnR98"
                     externalNoIcon
                 >
@@ -444,7 +444,7 @@ function HeroSection() {
                                     <WaitlistForm
                                         titleAccessory={
                                             <Link
-                                                className="group flex 2xs:hidden shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
+                                                className="group flex sm:hidden shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
                                                 to="https://discord.com/invite/E9xV2WnR98"
                                                 externalNoIcon
                                             >

--- a/src/pages/desktop.tsx
+++ b/src/pages/desktop.tsx
@@ -381,8 +381,10 @@ function HeroSection() {
             {/* Top header bar: the page's own title strip (scroller + Discord) with a divider line */}
             <div className="mb-8 flex items-center justify-between gap-4 border-b border-primary pb-3">
                 <LetPostHogScroller className="text-xl @xl:text-2xl font-bold tracking-tight" />
+                {/* Below 2xs the scroller ("…instrument") needs the full row, so the Discord badge
+                    moves down next to the "Join the waitlist" heading instead (see HeroSection form). */}
                 <Link
-                    className="group flex shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
+                    className="group hidden 2xs:flex shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
                     to="https://discord.com/invite/E9xV2WnR98"
                     externalNoIcon
                 >
@@ -439,7 +441,18 @@ function HeroSection() {
                                 </ul>
 
                                 <div className="@container max-w-sm">
-                                    <WaitlistForm />
+                                    <WaitlistForm
+                                        titleAccessory={
+                                            <Link
+                                                className="group flex 2xs:hidden shrink-0 items-center gap-1 text-sm font-semibold text-secondary hover:text-primary"
+                                                to="https://discord.com/invite/E9xV2WnR98"
+                                                externalNoIcon
+                                            >
+                                                <IconDiscord className="size-6 text-secondary group-hover:text-primary" />
+                                                <span className="group-hover:underline">Discord</span>
+                                            </Link>
+                                        }
+                                    />
                                     <p className="mt-4 text-sm text-secondary">
                                         Have an invite code?{' '}
                                         <Link


### PR DESCRIPTION
## Changes

On very narrow viewports the `/desktop` page's header row put the animated "Let PostHog …" scroller and the Discord badge side-by-side (`justify-between`), so they fought for horizontal space and the longest scroller word ("instrument") had no room.

At the smallest breakpoint (below `2xs`), the header Discord badge is now hidden and reappears right-aligned next to the **Join the waitlist** heading in the hero form. This frees the full row for the scroller. Everything at `2xs` and above is unchanged.

- `WaitlistForm` gains an optional `titleAccessory` prop, rendered right-aligned next to the heading (pre-submit only).
- The hero passes the Discord badge as `titleAccessory` with `2xs:hidden`; the header badge becomes `hidden 2xs:flex`.

*No visual change on tablet/desktop or on phones at/above `2xs` (425px). If the crunch still shows on slightly wider phones, the two `2xs` classes can be bumped to `xs`.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784650912787879?thread_ts=1784650912.787879&cid=C01V9AT7DK4)*