### PR TITLE
docs: use public posthog-js customizations entrypoint

### DIFF
--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -195,7 +195,7 @@ To include current browser and device properties (like `$browser`, `$os`, `$devi
 
 ```js
 import posthog from 'posthog-js'
-import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/src/customizations'
+import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/customizations'
 
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_client_api_host>',

--- a/contents/docs/libraries/js/usage.mdx
+++ b/contents/docs/libraries/js/usage.mdx
@@ -553,7 +553,7 @@ We offer a pre-built `sampleByEvent` function to sample by event name. You can i
 <MultiLanguage>
 
 ```ts file=Import
-import { sampleByEvent } from 'posthog-js/lib/src/customizations'
+import { sampleByEvent } from 'posthog-js/customizations'
 
 posthog.init('<ph_project_token>', {
   // capture only half of dead click and web vitals events
@@ -603,7 +603,7 @@ We offer a pre-built `sampleByDistinctId` function to sample a percentage of eve
 <MultiLanguage>
 
 ```ts file=Import
-import { sampleByDistinctId } from 'posthog-js/lib/src/customizations'
+import { sampleByDistinctId } from 'posthog-js/customizations'
 
 posthog.init('<ph_project_token>', {
   before_send: sampleByDistinctId(0.4)
@@ -633,7 +633,7 @@ We offer a pre-built `sampleBySessionId` function to sample a percentage of even
 <MultiLanguage>
 
 ```ts file=Import
-import { sampleBySessionId } from 'posthog-js/lib/src/customizations'
+import { sampleBySessionId } from 'posthog-js/customizations'
 
 posthog.init('<ph_project_token>', {
   before_send: sampleBySessionId(0.25)

--- a/contents/docs/web-analytics/web-vitals.mdx
+++ b/contents/docs/web-analytics/web-vitals.mdx
@@ -170,7 +170,7 @@ You can also roll your own function if you prefer a tighter control over the sam
 <MultiLanguage>
 
 ```ts file=Import
-import { sampleByEvent } from 'posthog-js/lib/src/customizations'
+import { sampleByEvent } from 'posthog-js/customizations'
 
 posthog.init('<ph_project_token>', {
     // Capture only half of web vitals events


### PR DESCRIPTION
## Changes

Replace five examples that import browser SDK customizations from the internal `posthog-js/lib/src/customizations` build path with the public `posthog-js/customizations` entrypoint.

This updates the JavaScript usage, web vitals, and feature flag property override documentation. The documented sampling helpers and feature flag helper were verified against the public subpath with a bundled consumer smoke test.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
