### PR TITLE
refactor(docs): restrict in-app docs navigation to internal paths

### DIFF
--- a/src/components/Layout/context.tsx
+++ b/src/components/Layout/context.tsx
@@ -3,6 +3,7 @@ import menu, { docsMenu } from '../../navs'
 import { IMenu } from 'components/PostLayout/types'
 import { useLocation } from '@reach/router'
 import { navigate } from 'gatsby'
+import { isSafeInternalPath } from 'lib/utils'
 import { useActions } from 'kea'
 import { layoutLogic } from 'logic/layoutLogic'
 
@@ -140,7 +141,7 @@ export const LayoutProvider = ({ children, ...other }: IProps) => {
                 window.__setPreferredTheme(e.data.isDarkModeOn ? 'dark' : 'light')
                 return
             }
-            if (e.data.type === 'navigate') {
+            if (e.data.type === 'navigate' && isSafeInternalPath(e.data.url)) {
                 navigate(e.data.url)
             }
         }

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react'
 import { AppWindow } from './Window'
 import { navigate } from 'gatsby'
+import { isSafeInternalPath } from 'lib/utils'
 import SignIn from 'components/Squeak/components/Classic/SignIn'
 import Register from 'components/Squeak/components/Classic/Register'
 import ForgotPassword from 'components/Squeak/components/Classic/ForgotPassword'
@@ -2717,7 +2718,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                 window.__setPreferredTheme(e.data.isDarkModeOn ? 'dark' : 'light')
                 return
             }
-            if (e.data.type === 'navigate') {
+            if (e.data.type === 'navigate' && isSafeInternalPath(e.data.url)) {
                 navigate(e.data.url)
             }
         }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -94,6 +94,21 @@ export const isURL = (s: string): boolean => {
     }
 }
 
+// Guard for `navigate()` targets that arrive from cross-window postMessage. Only
+// same-origin absolute paths like "/docs/foo" are allowed. This blocks "javascript:"
+// and "data:" URLs (which Gatsby's navigate() would run via window.location, giving
+// XSS) as well as "//" and "/\" host paths (open redirect) from an untrusted sender.
+export const isSafeInternalPath = (path: unknown): path is string => {
+    if (typeof path !== 'string' || !path.startsWith('/') || /^\/[/\\]/.test(path)) {
+        return false
+    }
+    try {
+        return new URL(path, 'https://posthog.com').origin === 'https://posthog.com'
+    } catch {
+        return false
+    }
+}
+
 export const groupMenuItems = (items: IMenu[]): Record<string, IMenu[]> => {
     const grouped: Record<string, IMenu[]> = {}
     let currGroup: string


### PR DESCRIPTION
## Changes

The embedded-docs `message` handler forwarded `event.data.url` straight into Gatsby's `navigate()`. This restricts it to same-origin internal paths (e.g. `/docs/...`) via a small shared `isSafeInternalPath` guard, and ignores anything else.

In-app docs navigation only ever sends internal paths, so this is a no-op for existing usage.

## Checklist

- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
