### PR TITLE
docs(cdp): add Neon source doc

### DIFF
--- a/contents/docs/cdp/sources/neon.mdx
+++ b/contents/docs/cdp/sources/neon.mdx
@@ -1,0 +1,76 @@
+---
+title: Linking Neon as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Neon
+beta: true
+---
+
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Neon connector can link your Neon database tables to PostHog. Neon is serverless Postgres, so this connector uses the same underlying integration as the [Postgres source](/docs/cdp/sources/postgres).
+
+To link Neon:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Neon
+3. Enter your Neon connection details. To find them, open your project in the [Neon Console](https://console.neon.tech) and click **Connect** — the connection details are shown there. Turn off the **Connection pooling** toggle to see the direct host:
+   - **Host:** The direct host for your Neon endpoint, e.g. `ep-cool-darkness-123456.us-east-2.aws.neon.tech`. Avoid the pooled host (the one with `-pooler` in it) — pooled connections work for standard syncs, but change data capture (CDC) requires the direct host.
+   - **Port:** The port your database is listening on. The default is `5432`.
+   - **Database:** The name of the database. Neon defaults this to `neondb`.
+   - **User:** A user with read access to the schemas and tables you want to sync. Neon defaults this to `neondb_owner`.
+   - **Password:** The password for the user.
+   - **Schema:** (Optional) The schema where your tables are located. Leave blank to browse and sync tables from all schemas, or specify one to limit the selection. Neon defaults this to `public`.
+4. If you need to connect through an SSH tunnel, enable and configure it (optional):
+   - **Tunnel host:** The hostname of your SSH server.
+   - **Tunnel port:** The port your SSH server is listening on.
+   - **Authentication type:**
+     - For password authentication, enter your SSH username and password.
+     - For key-based authentication, enter your SSH username, private key, and optional passphrase.
+   - **Require TLS through tunnel?** - Whether to require TLS encryption through the SSH tunnel. Enabled by default. Disable if your database does not support TLS.
+5. Click **Link**
+
+The data warehouse then starts syncing your Neon data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
+
+## Configuration
+
+<SourceParameters />
+
+## Change data capture (CDC)
+
+Because Neon uses the Postgres integration, you can also enable change data capture (CDC) sync. See the [Postgres source documentation](/docs/cdp/sources/postgres#sync-methods) for details. CDC sync is currently in **alpha**.
+
+To use CDC with Neon:
+
+1. Enable **logical replication** in your Neon project settings. Note that this can't be disabled once enabled, and keeping an active replication connection prevents your compute from suspending.
+2. Use the direct host (without `-pooler`) when setting up the source — logical replication doesn't work through the connection pooler.
+
+## Selecting columns
+
+By default, PostHog syncs all columns from each table. To sync only specific columns:
+
+1. During source setup, click **Columns** next to any table in the table picker.
+2. Uncheck columns you don't want to sync.
+3. Primary key columns and the incremental sync field (if configured) are always synced and cannot be disabled.
+
+You can also change column selection after setup:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) and click your Neon source.
+2. Click **Configure** next to any schema.
+3. Under **Columns**, select which columns to sync.
+
+See the [Postgres source documentation](/docs/cdp/sources/postgres#selecting-columns) for details on resync behavior when adding columns.
+
+> **Permissions** The Neon source only requires read permissions on the schemas and tables you intend to sync. We recommend creating a dedicated read-only role in Neon rather than using the default `neondb_owner` role.
+
+Neon requires SSL/TLS for all connections, which PostHog uses by default.
+
+import InboundIpAddresses from "../_snippets/inbound-ip-addresses.mdx";
+
+<InboundIpAddresses />

--- a/contents/docs/cdp/sources/neon.mdx
+++ b/contents/docs/cdp/sources/neon.mdx
@@ -20,12 +20,12 @@ To link Neon:
 
 1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
 2. Click **New source** and select Neon
-3. Enter your Neon connection details. To find them, open your project in the [Neon Console](https://console.neon.tech) and click **Connect** — the connection details are shown there. Turn off the **Connection pooling** toggle to see the direct host:
-   - **Host:** The direct host for your Neon endpoint, e.g. `ep-cool-darkness-123456.us-east-2.aws.neon.tech`. Avoid the pooled host (the one with `-pooler` in it) — pooled connections work for standard syncs, but change data capture (CDC) requires the direct host.
+3. Enter your Neon connection details. To find them, open your project in the [Neon Console](https://console.neon.tech) and click **Connect** – the connection details are shown there. Turn off the **Connection pooling** toggle to see the direct host:
+   - **Host:** The direct host for your Neon endpoint, e.g. `ep-cool-darkness-123456.us-east-2.aws.neon.tech`. Avoid the pooled host (the one with `-pooler` in it) – pooled connections work for standard syncs, but change data capture (CDC) requires the direct host.
    - **Port:** The port your database is listening on. The default is `5432`.
    - **Database:** The name of the database. Neon defaults this to `neondb`.
    - **User:** A user with read access to the schemas and tables you want to sync. Neon defaults this to `neondb_owner`.
-   - **Password:** The password for the user.
+   - **Password:** The password for the database user.
    - **Schema:** (Optional) The schema where your tables are located. Leave blank to browse and sync tables from all schemas, or specify one to limit the selection. Neon defaults this to `public`.
 4. If you need to connect through an SSH tunnel, enable and configure it (optional):
    - **Tunnel host:** The hostname of your SSH server.
@@ -33,30 +33,30 @@ To link Neon:
    - **Authentication type:**
      - For password authentication, enter your SSH username and password.
      - For key-based authentication, enter your SSH username, private key, and optional passphrase.
-   - **Require TLS through tunnel?** - Whether to require TLS encryption through the SSH tunnel. Enabled by default. Disable if your database does not support TLS.
+   - **Require TLS through tunnel?** – Whether to require TLS encryption through the SSH tunnel. Enabled by default. Disable if your database does not support TLS.
 5. Click **Link**
 
-The data warehouse then starts syncing your Neon data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
+PostHog then starts syncing your Neon data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
 
 ## Configuration
 
 <SourceParameters />
 
-## Change data capture (CDC)
+## CDC sync
 
 Because Neon uses the Postgres integration, you can also enable change data capture (CDC) sync. See the [Postgres source documentation](/docs/cdp/sources/postgres#sync-methods) for details. CDC sync is currently in **alpha**.
 
 To use CDC with Neon:
 
 1. Enable **logical replication** in your Neon project settings. Note that this can't be disabled once enabled, and keeping an active replication connection prevents your compute from suspending.
-2. Use the direct host (without `-pooler`) when setting up the source — logical replication doesn't work through the connection pooler.
+2. Use the direct host (without `-pooler`) when setting up the source – logical replication doesn't work through the connection pooler.
 
 ## Selecting columns
 
 By default, PostHog syncs all columns from each table. To sync only specific columns:
 
 1. During source setup, click **Columns** next to any table in the table picker.
-2. Uncheck columns you don't want to sync.
+2. Clear the checkbox for any columns you don't want to sync.
 3. Primary key columns and the incremental sync field (if configured) are always synced and cannot be disabled.
 
 You can also change column selection after setup:


### PR DESCRIPTION
## Summary

Adds the user-facing doc for the new Neon warehouse source, implemented in PostHog/posthog#72737.

Neon is serverless Postgres, so the doc follows the Supabase wrapper style: Neon-specific connection steps (Neon Console **Connect** widget, direct vs pooled host, `neondb` / `neondb_owner` defaults), a CDC section (enable logical replication in Neon project settings, direct host required — the `-pooler` host doesn't support logical replication), column selection, a read-only-role recommendation, and the shared inbound-IPs snippet. Alpha callout + `beta: true` frontmatter since the source ships as alpha.

No nav change needed — the sources sidebar auto-populates via `dynamicChildren`.

## Merge order

Merge after PostHog/posthog#72737 deploys, so `<SourceParameters />` has data from `public_source_configs` (slug `neon` matches the source's `docsUrl`; `audit_source_docs` passes for Neon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)