### PR TITLE
Add icons to navigation menus

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -331,7 +331,6 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'Learn more',
                     disabled: true,
-                    icon: <Icons.IconBook className="size-4 text-gray" />,
                 },
                 {
                     type: 'item',

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -428,7 +428,7 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'WIP',
                     link: '/wip',
-                    icon: getMenuIcon(companyMenu.children, '/wip', 'IconWrench', 'orange'),
+                    icon: getMenuIcon(companyMenu.children, '/wip', 'IconWrench', 'green'),
                 },
                 {
                     type: 'item',
@@ -440,7 +440,7 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'Media',
                     link: '/media',
-                    icon: getMenuIcon(companyMenu.children, '/media', 'IconNewspaper', 'orange'),
+                    icon: getMenuIcon(companyMenu.children, '/media', 'IconNewspaper', 'salmon'),
                 },
                 {
                     type: 'separator',
@@ -456,7 +456,7 @@ export function useMenuData(): MenuType[] {
                     label: 'Small teams',
                     link: '/small-teams',
                     items: smallTeamsMenuItems,
-                    icon: getMenuIcon(companyMenu.children, '/small-teams', 'IconShieldPeople', 'seagreen'),
+                    icon: getMenuIcon(companyMenu.children, '/small-teams', 'IconShieldPeople', 'teal'),
                 },
                 {
                     type: 'item',
@@ -468,7 +468,7 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'Partnerships',
                     link: '/partnerships',
-                    icon: getMenuIcon(companyMenu.children, '/partnerships', 'IconPuzzle', 'seagreen'),
+                    icon: getMenuIcon(companyMenu.children, '/partnerships', 'IconPuzzle', 'lilac'),
                 },
                 {
                     type: 'separator',
@@ -476,7 +476,7 @@ export function useMenuData(): MenuType[] {
                 {
                     type: 'submenu',
                     label: 'Like and subscribe',
-                    icon: <Icons.IconMegaphone className="size-4 text-red" />,
+                    icon: <Icons.IconMegaphone className="size-4 text-orange" />,
                     mobileDestination: false, // Omit from mobile menu
                     items: [
                         {

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -1,6 +1,6 @@
 import { MenuType, MenuItemType } from 'components/RadixUI/MenuBar'
 import React from 'react'
-import { docsMenu } from '../../navs'
+import { companyMenu, docsMenu, pricingMenu } from '../../navs'
 import * as Icons from '@posthog/icons'
 import Logo from 'components/Logo'
 import { APP_COUNT } from '../../constants'
@@ -20,6 +20,7 @@ import { useAppSettings } from '../../context/App'
 import { IconChevronDown } from '@posthog/icons'
 import { useHedgehogMode } from 'components/HedgehogMode'
 import { navigate } from 'gatsby'
+import { useSmallTeamsMenuItems } from './SmallTeamsMenuItems'
 
 interface DocsMenuItem {
     name: string
@@ -31,6 +32,13 @@ interface DocsMenuItem {
 
 interface DocsMenu {
     children: DocsMenuItem[]
+}
+
+const getMenuIcon = (items: DocsMenuItem[], link: string, fallbackIcon: keyof typeof Icons, fallbackColor: string) => {
+    const sourceItem = items.find((item) => item.url === link)
+    const IconComponent = Icons[(sourceItem?.icon || fallbackIcon) as keyof typeof Icons]
+
+    return IconComponent ? <IconComponent className={`size-4 text-${sourceItem?.color || fallbackColor}`} /> : undefined
 }
 
 // Add mobile destinations for docs menu items based on the product data
@@ -286,6 +294,7 @@ const buildProductsMenuItems = (allProducts: any[]) => {
 }
 
 export function useMenuData(): MenuType[] {
+    const smallTeamsMenuItems = useSmallTeamsMenuItems()
     const allProducts = useProduct() as any[]
     const { isMobile } = useAppSettings()
     const [hedgehogModeEnabled, setHedgehogModeEnabled] = useHedgehogMode()
@@ -303,32 +312,38 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'Plans & usage-based pricing',
                     link: '/pricing',
+                    icon: getMenuIcon(pricingMenu.children, '/pricing', 'IconReceipt', 'blue'),
                 },
                 {
                     type: 'item',
                     label: 'How we do "sales"',
                     link: '/sales',
+                    icon: getMenuIcon(pricingMenu.children, '/sales', 'IconPercentage', 'green'),
                 },
                 {
                     type: 'item',
                     label: 'Startups',
                     link: '/startups',
+                    icon: getMenuIcon(pricingMenu.children, '/startups', 'IconRocket', 'purple'),
                 },
                 { type: 'separator' },
                 {
                     type: 'item',
                     label: 'Learn more',
                     disabled: true,
+                    icon: <Icons.IconBook className="size-4 text-gray" />,
                 },
                 {
                     type: 'item',
                     label: 'Watch a demo',
                     link: '/demo',
+                    icon: getMenuIcon(pricingMenu.children, '/demo', 'IconPlay', 'blue'),
                 },
                 {
                     type: 'item',
                     label: 'Talk to a human',
                     link: '/talk-to-a-human',
+                    icon: getMenuIcon(pricingMenu.children, '/talk-to-a-human', 'IconHeadset', 'purple'),
                 },
             ],
         },
@@ -390,36 +405,43 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'About',
                     link: '/about',
+                    icon: getMenuIcon(companyMenu.children, '/about', 'IconLogomark', 'gray'),
                 },
                 {
                     type: 'item',
                     label: 'Customers',
                     link: '/customers',
+                    icon: getMenuIcon(companyMenu.children, '/customers', 'IconPerson', 'yellow'),
                 },
                 {
                     type: 'item',
                     label: 'Handbook',
                     link: '/handbook',
+                    icon: getMenuIcon(companyMenu.children, '/handbook', 'IconBook', 'seagreen'),
                 },
                 {
                     type: 'item',
                     label: 'Roadmap',
                     link: '/roadmap',
+                    icon: getMenuIcon(companyMenu.children, '/roadmap', 'IconMap', 'orange'),
                 },
                 {
                     type: 'item',
                     label: 'WIP',
                     link: '/wip',
+                    icon: getMenuIcon(companyMenu.children, '/wip', 'IconWrench', 'orange'),
                 },
                 {
                     type: 'item',
                     label: 'Changelog',
                     link: '/changelog',
+                    icon: getMenuIcon(companyMenu.children, '/changelog', 'IconCalendar', 'red'),
                 },
                 {
                     type: 'item',
                     label: 'Media',
                     link: '/media',
+                    icon: getMenuIcon(companyMenu.children, '/media', 'IconNewspaper', 'orange'),
                 },
                 {
                     type: 'separator',
@@ -428,21 +450,26 @@ export function useMenuData(): MenuType[] {
                     type: 'item',
                     label: 'People',
                     link: '/people',
+                    icon: getMenuIcon(companyMenu.children, '/people', 'IconPeople', 'blue'),
                 },
                 {
-                    type: 'item',
+                    type: 'submenu',
                     label: 'Small teams',
                     link: '/small-teams',
+                    items: smallTeamsMenuItems,
+                    icon: getMenuIcon(companyMenu.children, '/small-teams', 'IconShieldPeople', 'seagreen'),
                 },
                 {
                     type: 'item',
                     label: 'Careers',
                     link: '/careers',
+                    icon: getMenuIcon(companyMenu.children, '/careers', 'IconLaptop', 'purple'),
                 },
                 {
                     type: 'item',
                     label: 'Partnerships',
                     link: '/partnerships',
+                    icon: getMenuIcon(companyMenu.children, '/partnerships', 'IconPuzzle', 'seagreen'),
                 },
                 {
                     type: 'separator',
@@ -450,6 +477,7 @@ export function useMenuData(): MenuType[] {
                 {
                     type: 'submenu',
                     label: 'Like and subscribe',
+                    icon: <Icons.IconMegaphone className="size-4 text-red" />,
                     mobileDestination: false, // Omit from mobile menu
                     items: [
                         {


### PR DESCRIPTION
## Changes

Adds complete icon coverage to the Pricing and Company taskbar menus.

- Reuses icon names and colors from the existing `pricingMenu` and `companyMenu` navigation data when links match.
- Adds semantic fallback icons for menu items without shared metadata.
- Connects Small teams to the existing dynamic team crest submenu.
- Keeps the existing Products, Docs, and Community icon behavior unchanged.

This makes the primary navigation menus visually consistent while keeping shared navigation data as the source of truth where available.

Screenshots are not included yet; this draft can be checked in the Vercel preview.

## Validation

- Prettier check
- ESLint: no errors (existing warnings only)
- Icon export verification
- `git diff --check`

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
