### PR TITLE
docs: Remove Unity SDK beta label

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2571,10 +2571,6 @@ export const docsMenu = {
                         {
                             name: 'Unity',
                             url: '/docs/libraries/unity',
-                            badge: {
-                                title: 'Beta',
-                                className: '!bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50',
-                            },
                         },
                         {
                             name: 'C#/.NET',


### PR DESCRIPTION
## Changes

Removes the outdated **Beta** badge from the Unity SDK entry in the docs navigation because the SDK is now generally available.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
