### PR TITLE
Guard missing $ref in API endpoint request body parsing

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -315,8 +315,8 @@ function Security({ item }) {
 
 function RequestBody({ item, objects }) {
     const objectKey =
-        item.requestBody?.content?.['application/json']?.schema['$ref'].split('/').at(-1) ||
-        item.requestBody?.content?.['application/json']?.schema.items?.['$ref'].split('/').at(-1)
+        item.requestBody?.content?.['application/json']?.schema?.['$ref']?.split('/').at(-1) ||
+        item.requestBody?.content?.['application/json']?.schema?.items?.['$ref']?.split('/').at(-1)
     if (!objectKey) return null
     const object = objects.schemas[objectKey]
     if (!object?.properties) return null


### PR DESCRIPTION
## Changes

- Guards missing $ref in API endpoint request body parsing (fix failing builds)