### PR TITLE
fix(wizard): stop Grammarly/spellcheck underlining the editable page copy

### DIFF
--- a/src/components/MDXEditor/index.tsx
+++ b/src/components/MDXEditor/index.tsx
@@ -132,16 +132,29 @@ export default function MDXEditor({
     // The whole page is an editable playground, so Grammarly and the browser's
     // native spellchecker underline words in the copy (e.g. "automagically"),
     // which clashes with the underscores we use for emphasis. Turn both off on
-    // the Lexical contentEditable element.
+    // the Lexical contentEditable element. It can mount a tick after this effect
+    // runs, so watch the container and apply the attributes as soon as it exists.
     useEffect(() => {
         if (isSSR || readOnly) return
-        const editable = mdxEditorContainerRef.current?.querySelector('[contenteditable="true"]')
-        if (editable) {
+        const container = mdxEditorContainerRef.current
+        if (!container) return
+
+        const disableSpellcheck = () => {
+            const editable = container.querySelector('[contenteditable="true"]')
+            if (!editable) return false
             editable.setAttribute('spellcheck', 'false')
             editable.setAttribute('data-gramm', 'false')
             editable.setAttribute('data-gramm_editor', 'false')
             editable.setAttribute('data-enable-grammarly', 'false')
+            return true
         }
+
+        if (disableSpellcheck()) return
+        const observer = new MutationObserver(() => {
+            if (disableSpellcheck()) observer.disconnect()
+        })
+        observer.observe(container, { childList: true, subtree: true })
+        return () => observer.disconnect()
     }, [isSSR, readOnly])
 
     const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/components/MDXEditor/index.tsx
+++ b/src/components/MDXEditor/index.tsx
@@ -129,6 +129,21 @@ export default function MDXEditor({
         setIsSSR(false)
     }, [])
 
+    // The whole page is an editable playground, so Grammarly and the browser's
+    // native spellchecker underline words in the copy (e.g. "automagically"),
+    // which clashes with the underscores we use for emphasis. Turn both off on
+    // the Lexical contentEditable element.
+    useEffect(() => {
+        if (isSSR || readOnly) return
+        const editable = mdxEditorContainerRef.current?.querySelector('[contenteditable="true"]')
+        if (editable) {
+            editable.setAttribute('spellcheck', 'false')
+            editable.setAttribute('data-gramm', 'false')
+            editable.setAttribute('data-gramm_editor', 'false')
+            editable.setAttribute('data-enable-grammarly', 'false')
+        }
+    }, [isSSR, readOnly])
+
     const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
         const href = (event.target as HTMLElement).closest('a.mdx-editor-link')?.getAttribute('href')
         if (href) {


### PR DESCRIPTION
## Changes

The `/wizard` page renders its copy inside an editable Lexical/MDXEditor, so the whole page is a `contentEditable`. That makes Grammarly and the browser's native spellchecker underline words like "automagically" — and since the page uses underscores for emphasis, the extra red underlines look like broken formatting.

This disables spellcheck and Grammarly on the editor's `contentEditable` element (`spellcheck`, `data-gramm`, `data-gramm_editor`, `data-enable-grammarly`), so it covers every word, not just "automagically". The read-only render path is unaffected.

**Why:** raised in a Slack thread — the Grammarly underline under "automagically" on posthog.com/wizard clashes with the underscore emphasis and reads as a mistake.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1784668559526399?thread_ts=1784668559.526399&cid=C01V9AT7DK4)*