### PR TITLE
Align data stack pages with context warehouse messaging

### DIFF
--- a/src/components/Products/ProductsTest.tsx
+++ b/src/components/Products/ProductsTest.tsx
@@ -23,7 +23,7 @@ const statusDotColor: Record<string, string> = {
 
 const sections = [
     {
-        title: 'Data platform',
+        title: 'Context warehouse',
         description:
             'Having all your product data in one place means you can make more informed decisions. Push all your data to PostHog, then send it anywhere else you need, too.',
         link: { label: 'Data stack README', url: '/data-stack' },

--- a/src/hooks/useCustomerDataInfrastructureNavigation.tsx
+++ b/src/hooks/useCustomerDataInfrastructureNavigation.tsx
@@ -1,11 +1,11 @@
 import { navigate } from 'gatsby'
 
 export const customerDataInfrastructureNav = {
-    name: 'PostHog data stack',
+    name: 'PostHog context warehouse',
     url: '/data-stack',
     children: [
         {
-            name: 'PostHog data stack',
+            name: 'PostHog context warehouse',
         },
         {
             name: 'Overview',

--- a/src/pages/cdp/index.tsx
+++ b/src/pages/cdp/index.tsx
@@ -38,7 +38,7 @@ export default function CDP(): JSX.Element {
                     self-driving.
                 </p>
                 <p>
-                    Any event or action in PostHog can update user records or trigger workflows in other products in
+                    Any event or action in PostHog can update user records or trigger workflows in other tools in
                     your stack.
                 </p>
 

--- a/src/pages/data-stack/business-intelligence.tsx
+++ b/src/pages/data-stack/business-intelligence.tsx
@@ -42,7 +42,7 @@ const biFeatures: BIFeature[] = [
     },
     {
         title: 'Product analytics insights',
-        description: 'Leverage built-in product analytics insights for quick access to key metrics.',
+        description: 'Use built-in product analytics insights for quick access to key metrics.',
     },
     {
         title: 'Text-to-SQL with PostHog AI',
@@ -54,15 +54,15 @@ export default function BusinessIntelligence(): JSX.Element {
     return (
         <>
             <SEO
-                title="Business Intelligence (BI) - PostHog data stack"
+                title="Business Intelligence (BI) - PostHog context warehouse"
                 description="Learn about our business intelligence capabilities."
                 image="images/og/cdp.jpg"
             />
             <ReaderView leftSidebar={<LeftSidebarContent />} title="Business Intelligence (BI)">
                 <p>
-                    PostHog's business intelligence (BI) capabilities empower product and data teams to derive deep
-                    insights from their data. With integrated BI tools, teams can create interactive dashboards, perform
-                    ad-hoc analyses, and visualize key metrics to drive informed decision-making.
+                    PostHog's business intelligence (BI) capabilities let product and data teams dig into their data.
+                    With integrated BI tools, teams can create interactive dashboards, perform ad-hoc analyses, and
+                    visualize key metrics to drive informed decision-making.
                 </p>
                 <div className="dark:bg-dark bg-accent border border-input p-4 rounded mb-4">
                     <p className="!my-0">

--- a/src/pages/data-stack/data-modeling.tsx
+++ b/src/pages/data-stack/data-modeling.tsx
@@ -14,7 +14,7 @@ export default function DataModeling(): JSX.Element {
     return (
         <>
             <SEO
-                title="Data modeling - PostHog data stack"
+                title="Data modeling - PostHog context warehouse"
                 description="Learn how to model your data in PostHog"
                 image="images/og/cdp.jpg"
             />

--- a/src/pages/data-stack/posthog-ai.tsx
+++ b/src/pages/data-stack/posthog-ai.tsx
@@ -60,14 +60,15 @@ export default function PostHogAIDataStack(): JSX.Element {
     return (
         <>
             <SEO
-                title="PostHog AI - PostHog data stack"
+                title="PostHog AI - PostHog context warehouse"
                 description="Learn how to model your data in PostHog"
                 image="images/og/cdp.jpg"
             />
             <ReaderView leftSidebar={<LeftSidebarContent />} title="PostHog AI, wired all the way through">
                 <p>
-                    PostHog AI is not just an add-on feature; it's completely wired into and throughout our data stack.
-                    It's the sql-writing, code-completing, statistical-minded sidekick that helps you do the grunt work.
+                    PostHog AI is not just an add-on feature; it's completely wired into and throughout our context
+                    warehouse. It's the sql-writing, code-completing, statistical-minded sidekick that helps you do the
+                    grunt work.
                 </p>
                 <p>
                     PostHog queries your data warehouse tables, your clickstream event data, errors, and more to answer

--- a/src/pages/data-stack/reverse-etl-export.tsx
+++ b/src/pages/data-stack/reverse-etl-export.tsx
@@ -13,7 +13,7 @@ export default function ReverseETLExport(): JSX.Element {
     return (
         <>
             <SEO
-                title="Reverse ETL & export - PostHog data stack"
+                title="Reverse ETL & export - PostHog context warehouse"
                 description="Learn about all the ways to export data from PostHog"
                 image="images/og/cdp.jpg"
             />

--- a/src/pages/data-stack/sources.tsx
+++ b/src/pages/data-stack/sources.tsx
@@ -14,7 +14,7 @@ export default function Sources(): JSX.Element {
     return (
         <>
             <SEO
-                title="Data sources & import - PostHog data stack"
+                title="Data sources & import - PostHog context warehouse"
                 description="Learn about all the ways to get data into PostHog"
                 image="images/og/cdp.jpg"
             />

--- a/src/pages/data-stack/sql-editor.tsx
+++ b/src/pages/data-stack/sql-editor.tsx
@@ -105,7 +105,7 @@ export default function SQLEditor(): JSX.Element {
     return (
         <>
             <SEO
-                title="SQL editor - PostHog data stack"
+                title="SQL editor - PostHog context warehouse"
                 description="Unify and query data from any source and analyze it alongside your product data."
                 image="https://res.cloudinary.com/dmukukwp6/image/upload/dw_temp_528efa76a2.png"
             />

--- a/src/pages/data-stack/warehouse-native.tsx
+++ b/src/pages/data-stack/warehouse-native.tsx
@@ -24,6 +24,11 @@ export default function WarehouseNative(): JSX.Element {
                 <p className="text-xl font-semibold text-primary mt-2">
                     PostHog and Snowflake's relationship status: It's complicated.
                 </p>
+                <p>
+                    The short version: PostHog is a context warehouse, not just a data warehouse. It stores your product
+                    and business data together and lets your PostHog tools and agents query it directly – no separate
+                    pipeline to maintain.
+                </p>
 
                 <div className="rounded-md border border-primary bg-accent p-4 my-6 not-prose">
                     <p className="font-medium mb-2">tl;dr</p>
@@ -86,11 +91,11 @@ export default function WarehouseNative(): JSX.Element {
 
                 <h2>Why this approach?</h2>
                 <p>
-                    The benefit of using an integrated stack like PostHog is that it gives you a single place for tools
-                    such as product analytics, experiments, and feature targeting without hopping between your warehouse
-                    and a separate product tool. We chose to own the execution environment so we can deliver that
-                    experience consistently, while also offering users a way to eliminate point solutions that need to
-                    be stitched together into complex data stacks.
+                    The benefit of using an integrated platform like PostHog is that it gives you a single place for
+                    tools such as product analytics, experiments, and feature targeting without hopping between your
+                    warehouse and a separate product tool. We chose to own the execution environment so we can deliver
+                    that experience consistently, while also offering users a way to eliminate point solutions that
+                    you&apos;d otherwise stitch together yourself.
                 </p>
                 <p>
                     Companies like{' '}


### PR DESCRIPTION
## What

Copy updates to bring the data stack / product pages in line with the **context warehouse** positioning (per [brand foundations](https://posthog.com/handbook/brand/foundations#how-we-describe-posthog) and [positioning](https://posthog.com/handbook/marketing/positioning)). Scope and wording come from a review doc Lizzie signed off on. Excludes the homepage and `/data-stack` overview (already being worked on separately).

## Changes

**Breadcrumb (fixes every data stack sub-page at once)**
- `src/hooks/useCustomerDataInfrastructureNavigation.tsx` — section label `PostHog data stack` → `PostHog context warehouse`

**Page copy**
- `src/pages/data-stack/posthog-ai.tsx` — "wired into and throughout our data stack" → "…our context warehouse"
- `src/pages/cdp/index.tsx` — "trigger workflows in other **products** in your stack" → "…other **tools** in your stack" (tools, not products)
- `src/pages/data-stack/business-intelligence.tsx` — cut weasel words: "capabilities **empower** … to derive deep insights" → "…**let** … dig into their data"; "**Leverage** built-in product analytics insights" → "**Use** …"
- `src/components/Products/ProductsTest.tsx` — `/products` section heading `Data platform` → `Context warehouse`
- `src/pages/data-stack/warehouse-native.tsx` — drop "data stack(s)" / "integrated stack" phrasing, **and add a short lead paragraph** making the context-warehouse-vs-data-warehouse distinction ⚠️ *newly drafted copy — please sanity-check the wording*

**SEO `<title>` suffixes** `- PostHog data stack` → `- PostHog context warehouse`
- `posthog-ai`, `business-intelligence`, `sources`, `sql-editor`, `data-modeling`, `reverse-etl-export`