### PR TITLE
docs: update workflows pricing copy for GA, drop beta framing

### DIFF
--- a/contents/docs/workflows/_snippets/beta.mdx
+++ b/contents/docs/workflows/_snippets/beta.mdx
@@ -1,9 +1,0 @@
-import CalloutBox from 'components/Docs/CalloutBox'
-
-<CalloutBox icon="IconFlask" title="Workflows is in beta" type="action">
-
-Workflows is currently in early beta. While in beta, workflows is free to use. See the overview page for the [proposed pricing model](/docs/workflows#pricing).
-
-We're always looking for feedback to improve workflows, please [reach out to us directly](https://app.posthog.com/workflows#panel=support%3Afeedback%3A%3Alow%3Atrue) in app. 
-
-</CalloutBox>

--- a/contents/docs/workflows/best-practices.mdx
+++ b/contents/docs/workflows/best-practices.mdx
@@ -101,7 +101,7 @@ When a variable size error occurs:
 
 ### Be mindful of costs and rate limits
 
-PostHog plans to price Workflows based on the number of real-time destinations and monthly messages after beta. Design workflows to minimize unnecessary messages. For example, avoid sending multiple messages to the same user around the same event, and use batching or deduplication logic where possible.
+PostHog prices Workflows based on the number of real-time destinations and monthly messages. Design workflows to minimize unnecessary messages. For example, avoid sending multiple messages to the same user around the same event, and use batching or deduplication logic where possible.
 
 Clean up unused/outdated workflows to reduce unnecessary triggers and costs.
 

--- a/src/pages/docs/workflows/index.tsx
+++ b/src/pages/docs/workflows/index.tsx
@@ -7,7 +7,6 @@ import Link from 'components/Link'
 import { ProductScreenshot } from 'components/ProductScreenshot'
 import { Caption } from 'components/Caption'
 import ChannelPlatforms from '../../../../contents/docs/workflows/_snippets/channel-platforms'
-import PricingTable from '../../../../contents/docs/workflows/_snippets/pricing-table.mdx'
 
 export const Content = () => {
     return (
@@ -78,12 +77,10 @@ export const Content = () => {
                     Pricing
                 </h2>
                 <p>
-                    After our beta period ends, pricing will be based on how many real-time destinations you use and how
-                    many messages you send each month. You'll get 10,000 destinations or messages free each month, with
-                    discounts as your usage grows. We are constantly striving to make pricing the best possible and will
-                    start with the following tiers:
+                    Pricing is based on how many real-time destinations you use and how many messages you send each
+                    month. You get 10,000 destinations or messages free every month, with discounts as your usage grows.
+                    See our <Link to="/pricing">pricing page</Link> for the latest rates.
                 </p>
-                <PricingTable />
             </section>
 
             <section className="mb-8">


### PR DESCRIPTION
## Changes

Workflows [went GA on 2025-12-30](https://posthog.com/blog/workflows-ga) and is now billed, but the docs still framed pricing as something that kicks in "after our beta period ends."

- **Workflows docs overview** (`/docs/workflows`): rewrote the pricing section to state pricing is active, and replaced the duplicated tiered pricing table with a link to the [pricing page](https://posthog.com/pricing) so the most accurate rates always show in one place.
- **Best practices**: dropped the "after beta" phrasing from the cost note.
- Removed the now-unused `_snippets/beta.mdx` beta callout.

**Why:** Raised from Slack — workflows is out of beta and being billed, so the docs saying pricing starts "after our beta period ends" is stale and contradicts the pricing page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BGJ0BD8KH/p1784719977268439)*