### PR TITLE
docs: update Slack warehouse source for bring-your-own app

### DIFF
--- a/contents/docs/cdp/sources/slack.md
+++ b/contents/docs/cdp/sources/slack.md
@@ -68,7 +68,7 @@ You need permission to create and install a Slack app in your workspace. If your
 }
 ```
 
-These bot scopes let the app list channels and users (`channels:read`, `groups:read`, `users:read`, `users:read.email`), read messages and reactions in channels the bot joins (`channels:history`, `groups:history`, `reactions:read`), and — if you turn on "Automatically join public channels" — join public channels on your behalf (`channels:join`).
+These bot scopes let the app list channels and users (`channels:read`, `groups:read`, `users:read`, `users:read.email`), read messages and reactions in channels the bot joins (`channels:history`, `groups:history`, `reactions:read`), and join public channels on your behalf for the "Automatically join public channels" option (`channels:join`).
 
 ### 2. Install the app and copy the token
 
@@ -80,7 +80,7 @@ These bot scopes let the app list channels and users (`channels:read`, `groups:r
 1. In PostHog, go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and select the **Sources** tab.
 2. Click **+ New source** and select Slack by clicking the **Link** button.
 3. Paste the **Bot User OAuth Token** into the **Bot User OAuth Token** field.
-4. _Optional:_ Turn on **Automatically join public channels** to have the bot join every public channel for you, so their messages sync without inviting it to each one. Leave it off to pick channels manually.
+4. Leave **Automatically join public channels** on (the default) to have the bot join every public channel for you, so their messages sync without inviting it to each one. Turn it off to pick channels manually.
 5. _Optional:_ Add a prefix to your table names.
 6. Select the tables you want to sync. Each channel appears as its own table you can enable or disable individually.
 7. Click **Import**.
@@ -89,7 +89,7 @@ These bot scopes let the app list channels and users (`channels:read`, `groups:r
 
 The bot only sees channels it belongs to.
 
-- **Public channels:** if you turned on **Automatically join public channels**, the bot joins them for you (including channels created later, on the next sync). Otherwise, invite it to each one.
+- **Public channels:** with **Automatically join public channels** on (the default), the bot joins them for you (including channels created later, on the next sync). If you turned it off, invite it to each one.
 - **Private channels:** always invite the bot manually — it can't add itself.
 
 To invite the bot, run `/invite @PostHog data warehouse` in the channel, or add it from the channel's **Integrations** settings.

--- a/contents/docs/cdp/sources/slack.md
+++ b/contents/docs/cdp/sources/slack.md
@@ -50,6 +50,7 @@ You need permission to create and install a Slack app in your workspace. If your
     "scopes": {
       "bot": [
         "channels:read",
+        "channels:join",
         "groups:read",
         "channels:history",
         "groups:history",
@@ -67,7 +68,7 @@ You need permission to create and install a Slack app in your workspace. If your
 }
 ```
 
-These bot scopes let the app list channels and users (`channels:read`, `groups:read`, `users:read`, `users:read.email`), read messages and reactions in channels the bot joins (`channels:history`, `groups:history`, `reactions:read`).
+These bot scopes let the app list channels and users (`channels:read`, `groups:read`, `users:read`, `users:read.email`), read messages and reactions in channels the bot joins (`channels:history`, `groups:history`, `reactions:read`), and — if you turn on "Automatically join public channels" — join public channels on your behalf (`channels:join`).
 
 ### 2. Install the app and copy the token
 
@@ -79,13 +80,19 @@ These bot scopes let the app list channels and users (`channels:read`, `groups:r
 1. In PostHog, go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and select the **Sources** tab.
 2. Click **+ New source** and select Slack by clicking the **Link** button.
 3. Paste the **Bot User OAuth Token** into the **Bot User OAuth Token** field.
-4. _Optional:_ Add a prefix to your table names.
-5. Select the tables you want to sync. Each channel appears as its own table you can enable or disable individually.
-6. Click **Import**.
+4. _Optional:_ Turn on **Automatically join public channels** to have the bot join every public channel for you, so their messages sync without inviting it to each one. Leave it off to pick channels manually.
+5. _Optional:_ Add a prefix to your table names.
+6. Select the tables you want to sync. Each channel appears as its own table you can enable or disable individually.
+7. Click **Import**.
 
-### 4. Invite the bot to your channels
+### 4. Make sure the bot is in your channels
 
-The bot only sees channels it belongs to. In Slack, run `/invite @PostHog data warehouse` in each channel whose messages you want to sync (or add it from the channel's **Integrations** settings). Private channels must be joined manually — the bot can't add itself.
+The bot only sees channels it belongs to.
+
+- **Public channels:** if you turned on **Automatically join public channels**, the bot joins them for you (including channels created later, on the next sync). Otherwise, invite it to each one.
+- **Private channels:** always invite the bot manually — it can't add itself.
+
+To invite the bot, run `/invite @PostHog data warehouse` in the channel, or add it from the channel's **Integrations** settings.
 
 ## Setting up the webhook for message syncing
 

--- a/contents/docs/cdp/sources/slack.md
+++ b/contents/docs/cdp/sources/slack.md
@@ -7,9 +7,12 @@ availability:
   selfServe: full
   enterprise: full
 sourceId: Slack
+beta: true
 ---
 
 The Slack connector syncs channels, users, and messages from your Slack workspace into PostHog's data warehouse.
+
+You connect it using your own Slack app: you create an app in your workspace, install it, and paste its bot token into PostHog. Using your own app keeps message syncing within [Slack's API terms](https://slack.com/terms-of-service/api), which restrict third-party apps from bulk-exporting message data.
 
 <CalloutBox icon="IconWarning" title="Messages aren't backfilled" type="caution">
 
@@ -21,57 +24,42 @@ Channel message tables are **webhook-only**. Only messages sent **after** you se
 
 | Table                      | Description                                                                                           | Sync method  |
 | -------------------------- | ----------------------------------------------------------------------------------------------------- | ------------ |
-| `$channels`                | All public and private channels accessible to the connected account                                   | Full refresh |
+| `$channels`                | All public and private channels the bot can access                                                    | Full refresh |
 | `$users`                   | All users in the workspace                                                                            | Full refresh |
 | Per-channel message tables | One table per channel, named by the channel's Slack ID (e.g. `C01ABC123`) with a human-readable label | Webhook only |
 
+## Prerequisites
+
+You need permission to create and install a Slack app in your workspace. If your workspace requires admin approval for new apps, ask an admin to approve it.
+
 ## Adding a data source
 
-1. In PostHog, go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and select the **Sources** tab.
-2. Click **+ New source** and select Slack by clicking the **Link** button.
-3. Click **Connect** and authorize PostHog to access your Slack workspace.
-4. _Optional:_ Add a prefix to your table names.
-5. Select the tables you want to sync. Each channel appears as its own table you can enable or disable individually.
-6. Click **Import**.
+### 1. Create your Slack app
 
-PostHog requests the following OAuth scopes from your Slack workspace:
-
-| Scope              | Purpose                           |
-| ------------------ | --------------------------------- |
-| `channels:read`    | List public channels              |
-| `groups:read`      | List private channels             |
-| `channels:history` | Read messages in public channels  |
-| `groups:history`   | Read messages in private channels |
-| `users:read`       | List workspace users              |
-| `users:read.email` | Include user email addresses      |
-| `reactions:read`   | Include message reactions         |
-
-## Setting up the webhook for message syncing
-
-Because channel message tables rely entirely on webhooks, you need to create a Slack app that forwards message events to PostHog. Without this step, your channel tables stay empty.
-
-1. Go to your Slack source in the [data pipeline sources tab](https://app.posthog.com/data-management/sources) and click the **Webhook** tab.
-2. Copy the **webhook URL** shown – you'll paste it into the manifest below.
-3. Open [Slack apps](https://api.slack.com/apps?new_app=1) and click **From a manifest**.
-4. Pick your workspace and click **Next**.
-5. Paste the following manifest into the editor, replacing `{webhook_url}` with the URL you copied in step 2:
+1. Open [Slack apps](https://api.slack.com/apps?new_app=1) and click **From a manifest**.
+2. Pick your workspace and click **Next**.
+3. Paste the manifest below into the editor, click **Next**, then **Create**:
 
 ```json
 {
   "display_information": {
     "name": "PostHog data warehouse",
-    "description": "Sync Slack messages and channels to PostHog data warehouse"
+    "description": "Sync Slack channels, users, and messages to PostHog data warehouse"
   },
   "oauth_config": {
     "scopes": {
-      "user": ["channels:history", "groups:history"]
+      "bot": [
+        "channels:read",
+        "groups:read",
+        "channels:history",
+        "groups:history",
+        "users:read",
+        "users:read.email",
+        "reactions:read"
+      ]
     }
   },
   "settings": {
-    "event_subscriptions": {
-      "request_url": "{webhook_url}",
-      "user_events": ["message.channels", "message.groups"]
-    },
     "org_deploy_enabled": false,
     "socket_mode_enabled": false,
     "token_rotation_enabled": false
@@ -79,27 +67,56 @@ Because channel message tables rely entirely on webhooks, you need to create a S
 }
 ```
 
-6. Click **Next**, then **Create**.
-7. In the left sidebar, click **Install App**, then **Install to Workspace**, and authorize.
-8. Go to **Basic Information** > **App Credentials**, copy the **Signing secret**.
-9. Back in PostHog, paste the signing secret into the **Signing secret** field on the **Webhook** tab and save.
+These bot scopes let the app list channels and users (`channels:read`, `groups:read`, `users:read`, `users:read.email`), read messages and reactions in channels the bot joins (`channels:history`, `groups:history`, `reactions:read`).
 
-PostHog uses the signing secret to verify that incoming events actually came from Slack. Once the webhook is active, new messages in your enabled channels start appearing in their tables.
+### 2. Install the app and copy the token
+
+1. In the left sidebar, click **Install App**, then **Install to Workspace**, and authorize.
+2. Copy the **Bot User OAuth Token** — it starts with `xoxb-`.
+
+### 3. Connect the source in PostHog
+
+1. In PostHog, go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and select the **Sources** tab.
+2. Click **+ New source** and select Slack by clicking the **Link** button.
+3. Paste the **Bot User OAuth Token** into the **Bot User OAuth Token** field.
+4. _Optional:_ Add a prefix to your table names.
+5. Select the tables you want to sync. Each channel appears as its own table you can enable or disable individually.
+6. Click **Import**.
+
+### 4. Invite the bot to your channels
+
+The bot only sees channels it belongs to. In Slack, run `/invite @PostHog data warehouse` in each channel whose messages you want to sync (or add it from the channel's **Integrations** settings). Private channels must be joined manually — the bot can't add itself.
+
+## Setting up the webhook for message syncing
+
+Because channel message tables rely entirely on webhooks, your Slack app needs to forward message events to PostHog. Without this step, your channel tables stay empty. You add these events to the **same app** you created above.
+
+1. Go to your Slack source in the [data pipeline sources tab](https://app.posthog.com/data-management/sources) and click the **Webhook** tab.
+2. Copy the **webhook URL** shown.
+3. Open your app in [Slack apps](https://api.slack.com/apps), go to **Event Subscriptions**, and toggle it on.
+4. Paste the webhook URL into the **Request URL** field. Slack sends a verification challenge — wait for the green **Verified** check.
+5. Under **Subscribe to bot events**, add `message.channels` and `message.groups`.
+6. Click **Save Changes**. Reinstall the app if Slack prompts you to.
+7. Go to **Basic Information** > **App Credentials**, copy the **Signing Secret**.
+8. Back in PostHog, paste the signing secret into the **Signing secret** field on the **Webhook** tab and save.
+
+PostHog uses the signing secret to verify that incoming events actually came from Slack. Once the webhook is active, new messages in the channels the bot has joined start appearing in their tables.
+
+## Migrating from the legacy connection
+
+Slack sources created before bring-your-own-app used a shared PostHog Slack app. To move an existing source onto your own app:
+
+1. Create and install your own Slack app using the [manifest above](#1-create-your-slack-app).
+2. Open your existing Slack source, paste the new **Bot User OAuth Token** into the token field, and save.
+3. Re-add the webhook Event Subscriptions to your new app (see [webhook setup](#setting-up-the-webhook-for-message-syncing)) and update the signing secret.
+
+The source switches to your app as soon as the token is saved. If you'd rather start fresh, delete the old source and add a new one instead.
 
 ## Common issues
 
-### Bot not installed
+### Bot not in the channel
 
-Events won't be sent to PostHog if the Slack app hasn't been installed to your workspace. Even after creating the app and configuring the webhook, you still need to explicitly install it.
-
-To verify:
-
-1. Go to your [Slack app settings](https://api.slack.com/apps).
-2. Select your PostHog data warehouse app.
-3. Click **Settings** > **Install App** in the left sidebar.
-4. Confirm the app shows as installed. If not, click **Install to Workspace** and authorize it.
-
-See Slack's [Installing with OAuth](https://api.slack.com/authentication/oauth-v2) documentation for more details.
+The bot only receives events and reads history for channels it has joined. If a channel table stays empty or a sync reports `not_in_channel`, invite the bot to that channel with `/invite @PostHog data warehouse`. Private channels must be joined manually.
 
 ### Webhook shows "Doesn't respond"
 
@@ -116,14 +133,14 @@ If verification keeps failing:
 
 - Confirm the webhook URL is correct (copy it fresh from PostHog).
 - Check that your PostHog source is still active and hasn't been deleted.
-- Wait a few seconds and try again – transient network issues can cause failures.
+- Confirm you set the signing secret on the webhook tab, or the handshake is rejected once a secret is expected.
 
 See Slack's [Events API](https://api.slack.com/apis/events-api) documentation for more on how URL verification works.
+
+### Invalid or revoked token
+
+If a sync reports `invalid_auth` or `token_revoked`, the bot token is no longer valid — for example the app was reinstalled or removed. Copy a fresh **Bot User OAuth Token** from **Settings > Install App** in your Slack app and update it on the source.
 
 ## Configuration
 
 <SourceParameters />
-
-## Supported tables
-
-<SourceTables />


### PR DESCRIPTION
## Changes

Rewrites the Slack data warehouse source doc for the new **bring your own Slack app** setup, replacing the old shared-app OAuth flow.

- Create-your-own-app walkthrough with a ready-to-paste manifest (bot scopes), install, and copy the bot token.
- Webhook setup now adds Event Subscriptions (`message.channels` / `message.groups` bot events) to the **same** app, plus the signing secret.
- New "Migrating from the legacy connection" section for sources created before bring-your-own.
- Updated troubleshooting (bot not in channel, verification handshake, invalid/revoked token) and marked the source `beta`.

Pairs with the backend change in PostHog/posthog#72870.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
