### PR TITLE
Remove misleading "Coming soon" labels from wizard framework list

### DIFF
--- a/src/components/WizardFrameworksTeaser/README.md
+++ b/src/components/WizardFrameworksTeaser/README.md
@@ -1,3 +1,3 @@
 # WizardFrameworksTeaser
 
-Short “Supports Next.js, React, Python, and N more” line (labels from taxonomy) with a tooltip listing every wizard-supported stack (logos, docs links, “Coming soon” for `status: wip`). Uses `getWizardFrameworkRows()` from `installation-taxonomy.ts`.
+Short “Supports Next.js, React, Python, and N more” line (labels from taxonomy) with a tooltip listing every wizard-supported stack (logos, docs links). Uses `getWizardFrameworkRows()` from `installation-taxonomy.ts`.

--- a/src/components/WizardFrameworksTeaser/index.tsx
+++ b/src/components/WizardFrameworksTeaser/index.tsx
@@ -65,9 +65,6 @@ export default function WizardFrameworksTeaser({ className }: { className?: stri
                                         <span className="w-6 h-6 shrink-0 rounded bg-accent" aria-hidden />
                                     )}
                                     <span className="flex-1 text-left text-sm leading-tight">{row.label}</span>
-                                    {row.badge ? (
-                                        <span className="text-[10px] uppercase text-muted shrink-0">{row.badge}</span>
-                                    ) : null}
                                 </Link>
                             ))}
                         </div>

--- a/src/components/WizardSupportedFrameworks/index.tsx
+++ b/src/components/WizardSupportedFrameworks/index.tsx
@@ -16,7 +16,6 @@ export default function WizardSupportedFrameworks({ className }: WizardSupported
                 label: row.label,
                 url: row.url,
                 image: row.image,
-                badge: row.badge,
             })),
         []
     )

--- a/src/constants/installation-taxonomy.ts
+++ b/src/constants/installation-taxonomy.ts
@@ -20,8 +20,6 @@ export type InstallItem = {
     wizardLabel?: string
     /** `getLogo` key when it differs from librarySlug-based resolution */
     wizardLogoKey?: string
-    /** Wizard lists the stack but install is not available yet */
-    status?: 'wip'
     /** Full URL when not `/docs/libraries/{librarySlug}` */
     wizardDocsUrl?: string
 }
@@ -136,9 +134,6 @@ export const TAXONOMY: InstallCategory[] = [
                 slug: 'flutter',
                 name: 'Flutter',
                 librarySlug: 'flutter',
-                wizard: true,
-                wizardOrder: 21,
-                status: 'wip',
             },
             {
                 slug: 'kmp',
@@ -171,39 +166,11 @@ export const TAXONOMY: InstallCategory[] = [
                 wizard: true,
                 wizardOrder: 13,
             },
-            {
-                slug: 'elixir',
-                name: 'Elixir',
-                librarySlug: 'elixir',
-                wizard: true,
-                wizardOrder: 20,
-                status: 'wip',
-            },
-            {
-                slug: 'go',
-                name: 'Go',
-                librarySlug: 'go',
-                wizard: true,
-                wizardOrder: 22,
-                status: 'wip',
-            },
-            {
-                slug: 'java',
-                name: 'Java',
-                librarySlug: 'java',
-                wizard: true,
-                wizardOrder: 23,
-                status: 'wip',
-            },
+            { slug: 'elixir', name: 'Elixir', librarySlug: 'elixir' },
+            { slug: 'go', name: 'Go', librarySlug: 'go' },
+            { slug: 'java', name: 'Java', librarySlug: 'java' },
             { slug: 'php', name: 'PHP', librarySlug: 'php' },
-            {
-                slug: 'rust',
-                name: 'Rust',
-                librarySlug: 'rust',
-                wizard: true,
-                wizardOrder: 24,
-                status: 'wip',
-            },
+            { slug: 'rust', name: 'Rust', librarySlug: 'rust' },
         ],
     },
     {
@@ -305,7 +272,6 @@ export type WizardFrameworkRow = {
     label: string
     url: string
     image?: string
-    badge?: string
     external: boolean
 }
 
@@ -329,7 +295,6 @@ export function getWizardFrameworkRows(): WizardFrameworkRow[] {
             label: item.wizardLabel ?? item.name,
             url,
             image: getLogo(logoKey),
-            badge: item.status === 'wip' ? 'Coming soon' : undefined,
             external: url.startsWith('http'),
         }
     })


### PR DESCRIPTION
## Changes

Flutter, Elixir, Go, Java, and Rust appeared in the PostHog Wizard's supported-frameworks list with a "Coming soon" badge. Since those SDKs already exist and are documented, the badge read as "the SDK is coming soon" instead of "wizard install isn't available for this stack yet" — which was misleading.

The wizard can't install these yet, so per the request they're removed from the wizard framework list entirely (they stay in the docs install taxonomy, so their library docs are unaffected). Also drops the now-unused "Coming soon" / `status: 'wip'` badge plumbing from the taxonomy and the two components that rendered it (`WizardSupportedFrameworks`, `WizardFrameworksTeaser`).

**Why:** Raised as feedback in Slack — the label is confusing because we already support these SDKs; the "coming soon" only ever referred to AI wizard install support, which wasn't obvious.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1784689124118309?thread_ts=1784689124.118309&cid=C09GTQY5RLZ)*
