### PR TITLE
Fix newsletter hero images broken by Cloudinary version segment

### DIFF
--- a/.claude/skills/post-newsletter/SKILL.md
+++ b/.claude/skills/post-newsletter/SKILL.md
@@ -136,11 +136,13 @@ upload() {
 Name each image descriptively: `{slug}-tip{N}-{description}` (e.g. `how-to-demo-tip4-phone-number`).
 
 The upload response returns a Cloudinary URL in the format:
-`https://res.cloudinary.com/dmukukwp6/image/upload/v.../filename.png`
+`https://res.cloudinary.com/dmukukwp6/image/upload/v1783662227/filename.png`
+
+**Strip the `/v<number>` version segment from the `featuredImage` URL before writing it to frontmatter.** The build derives a Cloudinary public ID from this URL by taking everything after `/upload/` (`gatsby/onCreateNode.ts` → `getPublicID`). If the version segment is left in (`.../upload/v1783662227/filename.png`), the derived public ID becomes `v1783662227/filename` instead of `filename`, which misses the Cloudinary metadata cache — so `gatsbyImageData` resolves to `null` and the hero image silently fails to render (while the direct image URL itself still returns 200). Always write the featured image as `https://res.cloudinary.com/dmukukwp6/image/upload/filename.png` — no `v.../` segment. (This only matters for `featuredImage`, which goes through the image transformer; body images are plain `<img>` tags and render fine with or without the version.)
 
 ### 3d: Update the markdown
 
-Replace all `[PLACEHOLDER_...]` and `![PLACEHOLDER: ...](PLACEHOLDER)` entries with the real Cloudinary URLs and descriptive alt text. Match each uploaded image to its placeholder using the quoted anchor text from step 3b — find that exact sentence or heading in the file and insert the image there — never by list position or order. Before moving on, re-read the finished file and confirm each image's description actually matches the paragraph it now sits next to.
+Replace all `[PLACEHOLDER_...]` and `![PLACEHOLDER: ...](PLACEHOLDER)` entries with the real Cloudinary URLs and descriptive alt text. Remember to strip the `/v<number>` version segment from the `featuredImage` URL (see 3c). Match each uploaded image to its placeholder using the quoted anchor text from step 3b — find that exact sentence or heading in the file and insert the image there — never by list position or order. Before moving on, re-read the finished file and confirm each image's description actually matches the paragraph it now sits next to.
 
 **Indentation rule:** Example paragraphs and images that follow a numbered tip and illustrate it should be indented as list continuations (3 spaces for tips 1–9, 4 spaces for tips 10+). Checklists inside a tip should be wrapped in a blockquote (`>`).
 

--- a/contents/newsletter/code-review-tips.md
+++ b/contents/newsletter/code-review-tips.md
@@ -4,7 +4,7 @@ date: 2026-07-09
 author:
   - jina-yoon
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1783662227/stop_being_the_code_review_bottleneck_hero_a734a37558.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/stop_being_the_code_review_bottleneck_hero_a734a37558.png
 featuredImageType: full
 tags:
   - Product engineers

--- a/contents/newsletter/context-engineering.md
+++ b/contents/newsletter/context-engineering.md
@@ -4,7 +4,7 @@ date: 2026-06-24
 author:
   - edwin-lim
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1782746594/context_engineering_hero_7ee47b4915.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/context_engineering_hero_7ee47b4915.png
 featuredImageType: full
 tags:
   - Product engineers

--- a/contents/newsletter/how-to-demo.md
+++ b/contents/newsletter/how-to-demo.md
@@ -4,7 +4,7 @@ date: 2026-05-28
 author:
   - jina-yoon
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1780424772/how_to_demo_hero_b2c8462dee.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/how_to_demo_hero_b2c8462dee.png
 featuredImageType: full
 tags:
   - Product engineers


### PR DESCRIPTION
## Changes

Three newsletters weren't rendering their hero (`featuredImage`) images: [code-review-tips](https://posthog.com/newsletter/code-review-tips), [context-engineering](https://posthog.com/newsletter/context-engineering), and [how-to-demo](https://posthog.com/newsletter/how-to-demo).

The cause: their `featuredImage` URLs included a Cloudinary `/v<number>/` version segment. The build derives a Cloudinary public ID by taking everything after `/upload/` (`gatsby/onCreateNode.ts` → `getPublicID`), so the version segment got baked into the ID (`v1783662227/filename` instead of `filename`). That misses the Cloudinary metadata cache, `gatsbyImageData` resolves to `null`, and the hero silently fails to render — even though the raw image URL still returns 200. Newsletters whose URLs had no version segment were unaffected.

- Removed the `/v<number>` segment from the three `featuredImage` frontmatter URLs.
- Updated the `post-newsletter` skill to strip the version segment when writing `featuredImage`, since the skill was producing the versioned URLs (body images are plain `<img>` tags and render fine either way, so only `featuredImage` needs it).

## Why

The hero images were missing on three newsletter pages; the `post-newsletter` skill was generating `featuredImage` URLs with a version segment that the image transformer can't resolve.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1784725703152839)*