### PR TITLE
docs(handbook): reference posthog-php release workflow for new SDKs

### DIFF
--- a/contents/handbook/engineering/sdks/releases.mdx
+++ b/contents/handbook/engineering/sdks/releases.mdx
@@ -139,12 +139,22 @@ The release workflow needs access to shared organization secrets. Grant your SDK
 > **Important:** Our release workflows use [GitHub Actions OIDC tokens](https://docs.github.com/en/actions/concepts/security/openid-connect) for secure authentication with package registries. Make sure your workflow uses a version that supports OIDC for your registry:
 > - **npm:** Node.js v22+
 
-Copy the release workflow from an existing SDK (e.g., [posthog-rs](https://github.com/posthog/posthog-rs/blob/main/.github/workflows/release.yml)) and adapt it:
+Copy the release workflow from [posthog-php](https://github.com/PostHog/posthog-php/blob/main/.github/workflows/release.yml) — it's the reference implementation for new SDKs and includes security hardening the older workflows lack:
+
+- The release candidate is prepared once, uploaded as a patch artifact, and verified by sha256 before publishing — the approved diff is exactly what ships
+- `persist-credentials: false` on every checkout
+- The version bump script is pinned by sha256, so it can't be swapped out between approval and publish
+- Checks that the tag and GitHub release don't already exist, and that `main` hasn't moved since the release candidate was prepared
+- Minimal `permissions` on every job
+
+Adapt it to your SDK:
 
 1. Update the environment variable prefix to match your SDK name
 2. Modify the changelog generation logic if needed for your language's conventions
 3. Update the version bumping logic for your package manager (npm, pip, etc.)
 4. Update the publishing steps for your package registry
+
+> **Don't re-run build/test in the release workflow.** PR CI and the CI run on push to `main` already gate what lands on `main`, so the release workflow should only version, verify, and publish — re-running the build and test suite there just slows down releases without adding safety.
 
 #### npm packages: set up trusted publishing before enabling the workflow
 
@@ -205,9 +215,7 @@ Once set up, releases are triggered by having a `release` label added to the PR 
 
 <CalloutBox type="fyi">
 
-We're slowly migrating all SDKs to use [`sampo`](https://github.com/bruits/sampo). This is a language-agnostic version of the famous `changesets` library.
-
-If you're feeling inspired, I highly recommend you build an adapter for Sampo for the language you're working on. We'll all thank you for that.
+For changelog and version management, prefer JS [`changesets`](https://github.com/changesets/changesets) (`@changesets/cli`) even for non-JS SDKs — it only needs Node in CI, which the release tooling already uses. This is what [posthog-php](https://github.com/PostHog/posthog-php/blob/main/.github/workflows/release.yml) does. Some SDKs use [`sampo`](https://github.com/bruits/sampo), a language-agnostic take on `changesets`, but it pulls in a Rust toolchain and is slower in CI, so we don't recommend it for new SDKs.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Updates the [SDK releases handbook page](https://posthog.com/handbook/engineering/sdks/releases) based on maintainer feedback on PostHog/posthog-kmp#14, which asked new SDKs to copy posthog-php's hardened release pipeline. The page previously didn't mention posthog-php at all — it pointed at posthog-rs and endorsed sampo.

- Point new SDKs at [posthog-php's `release.yml`](https://github.com/PostHog/posthog-php/blob/main/.github/workflows/release.yml) as the reference implementation, listing the security hardening it adds (sha256-verified release-candidate patch artifact, `persist-credentials: false`, pinned bump script, tag/release-existence and main-moved checks, minimal job permissions)
- Recommend JS changesets (`@changesets/cli`) over sampo for changelog/version management (sampo pulls a Rust toolchain and is slower in CI)
- Note that release workflows should not re-run build/test — PR CI and main-push CI already gate that

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
