### PR TITLE
docs(kmp): move Android setup example from Activity to Application class

### DIFF
--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -545,4 +545,4 @@ Yes. The [Android SDK](/docs/libraries/android) is for native Android apps. The 
 
 ### Why don't I see surveys or logs?
 
-The KMP wrapper currently exposes event capture, identification, feature flags, group analytics, screen tracking, session replay, and error tracking. Surveys and logs aren't wrapped yet. Follow along or request them on [GitHub](https://github.com/PostHog/posthog-kmp/issues).
+The KMP wrapper currently exposes event capture, identification, feature flags, group analytics, screen tracking, session replay, and error tracking. Surveys and logs aren't wrapped yet. Follow along or [request them on GitHub](https://github.com/PostHog/posthog-kmp/issues/new?template=feature_request.yml).

--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -64,19 +64,27 @@ The only platform difference is how you build `PostHogContext`. Everything else 
 
 #### Android
 
-Android requires the `Application` instance, so pass it to `PostHogContext`:
+Android requires the `Application` instance, so call `setup` from your `Application` class – not from an Activity, whose `onCreate` re-runs on every recreation (for example, on rotation):
 
 ```kotlin
-class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+import android.app.Application
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
 
         PostHog.setup(
             config = PostHogConfig(apiKey = "<ph_project_token>"),
-            context = PostHogContext(application),
+            context = PostHogContext(this),
         )
     }
 }
+```
+
+Register the class in your `AndroidManifest.xml`:
+
+```xml
+<application android:name=".MyApplication" ...>
 ```
 
 #### iOS


### PR DESCRIPTION
## Changes

The KMP docs' Android setup example called `PostHog.setup()` inside `MainActivity.onCreate()`. An Activity's `onCreate` re-runs on every recreation (rotation, dark-mode toggle, process-death restore), so the example had setup running repeatedly — contradicting the page's own instruction to "Initialize PostHog once, early in your app's lifecycle".

- Swaps the Android example to an `Application` subclass with `PostHogContext(this)` and adds the `android:name` manifest registration line. Matches the fix already applied to the SDK README in PostHog/posthog-kmp.
- Links the "Why don't I see surveys or logs?" FAQ to the feature request template (`issues/new?template=feature_request.yml`) instead of the plain issues list.

## Checklist

- [x] Words are spelled using American English
- [ ] Titles are in sentence case
- [x] Feature names are in sentence case too
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)