### PR TITLE
Add changelog link card to Beta roadmap lane

### DIFF
--- a/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
+++ b/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
@@ -372,7 +372,9 @@ const PitchIdeaPanel = (): JSX.Element => {
 const ChangelogCard = (): JSX.Element => (
     <Link
         to="/changelog"
-        className="flex w-full items-center justify-between gap-3 rounded-md border border-dashed border-primary bg-transparent p-3 text-left hover:border-secondary hover:bg-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red dark:focus-visible:ring-yellow"
+        // The Editor's prose styles hit this anchor (underline, semibold, link color) — reset
+        // them so the text matches the PitchIdeaCard button above.
+        className="flex w-full items-center justify-between gap-3 rounded-md border border-dashed border-primary bg-transparent p-3 text-left !font-normal !text-primary !no-underline hover:border-secondary hover:bg-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red dark:focus-visible:ring-yellow"
     >
         <span className="min-w-0">
             <span className="block text-sm font-bold leading-snug">What's just shipped?</span>

--- a/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
+++ b/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
@@ -369,6 +369,19 @@ const PitchIdeaPanel = (): JSX.Element => {
     )
 }
 
+const ChangelogCard = (): JSX.Element => (
+    <Link
+        to="/changelog"
+        className="flex w-full items-center justify-between gap-3 rounded-md border border-dashed border-primary bg-transparent p-3 text-left hover:border-secondary hover:bg-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red dark:focus-visible:ring-yellow"
+    >
+        <span className="min-w-0">
+            <span className="block text-sm font-bold leading-snug">What's just shipped?</span>
+            <span className="mt-0.5 block text-xs text-secondary">Check the changelog</span>
+        </span>
+        <IconArrowRight className="size-5 shrink-0 text-red dark:text-yellow" />
+    </Link>
+)
+
 const FeatureCard = ({
     feature,
     team,
@@ -504,6 +517,16 @@ const RoadmapLane = ({
                         className="m-0 list-none p-0"
                     >
                         <PitchIdeaCard onClick={onPitchClick} />
+                    </motion.li>
+                )}
+                {/* Features graduate from beta by shipping — point onward to the changelog. */}
+                {definition.stage === 'beta' && (
+                    <motion.li
+                        layout={shouldReduceMotion ? false : 'position'}
+                        transition={{ layout: layoutTransition }}
+                        className="m-0 list-none p-0"
+                    >
+                        <ChangelogCard />
                     </motion.li>
                 )}
             </ul>

--- a/src/components/Roadmap/README.md
+++ b/src/components/Roadmap/README.md
@@ -26,7 +26,7 @@ Cards intentionally contain only:
 
 `New` means the feature was created within the configured new-feature window. `Popular` is assigned to the top features with a positive build-time waitlist count. Badges never change the card border; the selected card uses the standard accent background.
 
-Every lane ends with the same dashed `Your idea here` card. It opens the shared overlay drawer containing the roadmap pitch form; the form is not duplicated per lane.
+The Concept lane ends with the dashed `Your idea here` card. It opens the shared overlay drawer containing the roadmap pitch form; the form is not duplicated per lane. The Beta lane ends with a matching dashed `What's just shipped?` card that links to `/changelog`, pointing onward from the last pre-release stage.
 
 ## Filtering
 
@@ -69,6 +69,7 @@ The drawer's copy control always copies the canonical URL, without unrelated fil
 - **Beta:** a full-width external `Enable` button opens the matching feature preview in the PostHog app. It uses the same medium primary `OSButton` sizing and full-width contract as the notification form. Do not enroll the anonymous website visitor locally.
 - **Alpha:** `SurveySignup` records the linked waitlist survey response without a concept enrollment event.
 - **Concept:** `SurveySignup` records the linked waitlist survey and receives the flag key, preserving the existing concept-stage enrollment behavior.
-- **Pitch an idea:** the dashed card at the bottom of every lane opens the shared drawer and records the existing roadmap concept-pitch survey. The idea and optional email fields use the same stacked, bold-label form treatment. Its submit action uses the same medium primary full-width button treatment as the feature actions.
+- **Pitch an idea:** the dashed card at the bottom of the Concept lane opens the shared drawer and records the existing roadmap concept-pitch survey. The idea and optional email fields use the same stacked, bold-label form treatment. Its submit action uses the same medium primary full-width button treatment as the feature actions.
+- **Check the changelog:** the dashed card at the bottom of the Beta lane is a plain link to `/changelog` for features that have already shipped.
 
 `SurveySignup` owns returning-user state in local storage. Keep these flows delegated to the shared components so analytics and persistence remain consistent elsewhere on the site.


### PR DESCRIPTION
## Changes

Adds a dashed card at the bottom of the **Beta** column on [/roadmap](https://posthog.com/roadmap), styled to match the Concept lane's "Your idea here" card. It reads "What's just shipped? / Check the changelog" and links to `/changelog`.

**Why:** the Beta lane is the last pre-release stage, so it's a natural place to point visitors onward to features that have already shipped.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*