### PR TITLE
fix(replay-vision): center the waitlist elements on the landing page

### DIFF
--- a/src/pages/replay-vision.tsx
+++ b/src/pages/replay-vision.tsx
@@ -200,7 +200,7 @@ function HonestBit() {
                 actually talk to the people using it and get the quality right before we go wide. Join the list and
                 you'll be near the front.
             </p>
-            <div className="max-w-lg @container bg-yellow/10 border border-yellow rounded-md px-8 py-6 shadow-xl">
+            <div className="max-w-lg mx-auto @container bg-yellow/10 border border-yellow rounded-md px-8 py-6 shadow-xl">
                 <WaitlistForm
                     productHandle="replay_vision"
                     productName="Replay Vision"

--- a/src/pages/replay-vision.tsx
+++ b/src/pages/replay-vision.tsx
@@ -111,7 +111,7 @@ function HeroSection() {
                             bugs, scoring frustration, tagging behavior, and summarizing what happened. You get the
                             findings, while <strong>Replay Vision</strong> does the homework.
                         </p>
-                        <div className="@container max-w-sm">
+                        <div className="@container max-w-sm mx-auto">
                             {showForm ? (
                                 <WaitlistForm
                                     autoFocus
@@ -121,7 +121,7 @@ function HeroSection() {
                                     surveyId={SURVEY_ID}
                                 />
                             ) : (
-                                <div className="flex flex-wrap items-center gap-2">
+                                <div className="flex flex-wrap items-center justify-center gap-2">
                                     <OSButton variant="primary" size="lg" onClick={() => setShowForm(true)}>
                                         Join the waitlist
                                     </OSButton>


### PR DESCRIPTION
## Changes

Centers the two "Join the waitlist" elements on the `/replay-vision` landing page:

- The waitlist card at the bottom ("The honest bit" section) is capped at `max-w-lg` but was left-aligned inside the wider content column. Adds `mx-auto` so it sits centered.
- The hero button is centered on the text column above it (`mx-auto` on its container plus `justify-center`), which also centers the inline email form it expands into.

Verified on a local dev build (equal gaps on both sides, button center matches paragraph center, also checked narrow viewport and the expanded form state):

![honest-bit-centered](https://raw.githubusercontent.com/PostHog/pr-assets/a6649390b222a68ff4b175bb2acbec33e262196b/2026/07/32e753f0-f167-4fb6-8215-7b01905483e4.png)

![hero-centered](https://raw.githubusercontent.com/PostHog/pr-assets/d3528930301cee48d5b2350aa50589f8889fe0f4/2026/07/026517bd-5f15-42cb-aea8-4314b32e795f.png)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)