### PR TITLE
fix(merch): don't crash product panel when an image_products reference no longer exists

### DIFF
--- a/gatsby/createResolvers.ts
+++ b/gatsby/createResolvers.ts
@@ -36,7 +36,7 @@ export const createResolvers: GatsbyNode['createResolvers'] = ({ createResolvers
         ShopifyProduct: {
             imageProducts: {
                 type: ['ShopifyProduct'],
-                resolve(source, args, context, info) {
+                async resolve(source, args, context, info) {
                     const metafields = source.metafields
                     let productIds = []
 
@@ -46,19 +46,25 @@ export const createResolvers: GatsbyNode['createResolvers'] = ({ createResolvers
                         }
                     }
 
-                    return productIds.map((shopifyId) => {
-                        return context.nodeModel.runQuery({
-                            query: {
-                                filter: {
-                                    shopifyId: {
-                                        eq: shopifyId,
+                    const products = await Promise.all(
+                        productIds.map((shopifyId) => {
+                            return context.nodeModel.runQuery({
+                                query: {
+                                    filter: {
+                                        shopifyId: {
+                                            eq: shopifyId,
+                                        },
                                     },
                                 },
-                            },
-                            type: 'ShopifyProduct',
-                            firstOnly: true,
+                                type: 'ShopifyProduct',
+                                firstOnly: true,
+                            })
                         })
-                    })
+                    )
+
+                    // Referenced products can be deleted or unpublished in Shopify,
+                    // in which case runQuery resolves to null
+                    return products.filter(Boolean)
                 },
             },
         },

--- a/src/templates/merch/ProductPanel.tsx
+++ b/src/templates/merch/ProductPanel.tsx
@@ -258,7 +258,7 @@ export function ProductPanel(props: ProductPanelProps): React.ReactElement {
                         You may have spotted these other fine PostHog products in the photos above.
                     </p>
                     <ul className="list-none m-0 p-0 grid grid-cols-2 gap-x-2">
-                        {product.imageProducts?.map((product) => {
+                        {product.imageProducts?.filter(Boolean).map((product) => {
                             const { handle } = product
                             const featuredImage = (product as any).featuredImage
                             return (


### PR DESCRIPTION
## Changes

Opening some products on [/merch](https://posthog.com/merch) (e.g. **copy_pasta.hoodie**) crashes the product panel with:

```
TypeError: Cannot destructure property 'handle' of 'e' as it is null.
    at ProductPanel.tsx:262
```

Root cause: the `imageProducts` resolver in `gatsby/createResolvers.ts` maps each shopify ID from the `image_products` metafield through `nodeModel.runQuery(..., firstOnly: true)`. When a referenced product has since been deleted/unpublished in Shopify, that query resolves to `null`, so `imageProducts` ends up containing `null` entries. `ProductPanel.tsx` then destructures `handle` from each entry in the "See something else you liked?" list and throws.

Two fixes:

- `gatsby/createResolvers.ts`: await the lookups and filter out `null`s so stale references never reach the frontend (also stops the section rendering when every reference is stale)
- `src/templates/merch/ProductPanel.tsx`: defensively `filter(Boolean)` before mapping, so a bad entry can't take down the whole panel again

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
