### PR TITLE
docs(flags): document client-side access to remote config flags

### DIFF
--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -12,15 +12,33 @@ Boolean and multivariate flags are helpful for dynamic values that differ from u
 
 Remote config flags enable you to configure a simple flag that always returns the same payload wherever it is called. Remote config flags can also be stored as encrypted values and decrypted on the server side when requested. Encryption/decryption is handled automatically.
 
-There are 3 steps to start using remote config flags:
+You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. By default, enabled remote config flags roll out to 100% of all users.
 
-## Step 1: Find your feature flags secure API key
+## Using remote config in client-side apps
+
+Non-encrypted remote config flags are served through the [`/flags` endpoint](/docs/api/flags) like any other feature flag, using your project API key (the one starting with `phc_`), which is safe to expose publicly. Read the payload with your SDK's flag payload function. For example, in [posthog-js](/docs/libraries/js):
+
+```js
+const config = posthog.getFeatureFlagPayload('landing-page-config')
+```
+
+This also works for CLIs, scripts, or anything else that can call `/flags` with your project API key.
+
+> **Note:** Flags with encrypted payloads are excluded from `/flags` entirely, so they can't be read client-side and require a server.
+
+## Using remote config on the server
+
+Server-side SDKs fetch remote config payloads using your feature flags secure API key. This key is only required for [local evaluation](/docs/feature-flags/local-evaluation) and encrypted payloads – not for remote config in general. Unlike your project API key, it must never be exposed publicly.
+
+There are 3 steps to use remote config flags on the server:
+
+### Step 1: Find your feature flags secure API key
 
 import ObtainFeatureFlagsSecureAPIKey from "../integrate/_snippets/obtain-flags-secure-key.mdx"
 
 <ObtainFeatureFlagsSecureAPIKey />
 
-## Step 2: Initialize PostHog with your feature flags secure API key in options
+### Step 2: Initialize PostHog with your feature flags secure API key in options
 
 import ConfigureFlagsSecureKey from "../integrate/_snippets/configure-flags-secure-key.mdx"
 
@@ -29,7 +47,7 @@ import ConfigureFlagsSecureKey from "../integrate/_snippets/configure-flags-secu
 > **Note:** By default, initializing PostHog with your feature flags secure API key enables local evaluation, but this can be disabled in `posthog-node` by setting `enableLocalEvaluation: false` in your config.
 
 
-## Step 3: Use remote config flags
+### Step 3: Use remote config flags
 
 <MultiLanguage>
 
@@ -60,9 +78,11 @@ var config = await posthog.GetRemoteConfigPayloadAsync("landing-page-config");
 
 </MultiLanguage>
 
-You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. By default, enabled remote config flags roll out to 100% of all users.
-
 > **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead, the SDK simply returns `true`
+
+## Encrypted payloads
+
+Encrypted payloads are only available server-side, through the authenticated remote config API. Authenticate with a [personal API key](/docs/api/personal-api-keys) to receive the decrypted payload – the feature flags secure API key returns encrypted payloads redacted.
 
 ## Related
 


### PR DESCRIPTION
## Changes

Fixes a gap on the [remote config docs page](https://posthog.com/docs/feature-flags/remote-config) that led readers to conclude remote config can't be used from webapps or CLIs, since the page only documented server-side fetching with the feature flags secure API key ([community question](https://posthog.com/questions/what-about-public-usage), Zendesk #62493).

- Adds a "Using remote config in client-side apps" section: non-encrypted remote config flags are served through the public `/flags` endpoint with the project API key (`phc_...`), read via `getFeatureFlagPayload` — works for webapps, CLIs, and anything else that can call `/flags`.
- Clarifies the feature flags secure API key is only required for server-side local evaluation and encrypted payloads, not remote config in general.
- Adds an "Encrypted payloads" section: encrypted payloads are excluded from `/flags` and are server-side only — personal API keys get decrypted payloads, the secure key gets them redacted.

Verified against the `rust/feature-flags` service behavior in the posthog monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)