### PR TITLE
docs(session-replay): document where video exports land

### DIFF
--- a/contents/docs/session-replay/sharing.mdx
+++ b/contents/docs/session-replay/sharing.mdx
@@ -118,6 +118,17 @@ const accessToken = response.accessToken
 </iframe>
 ```
 
+## Exporting a video (MP4 or GIF)
+
+To share a replay outside PostHog, you can export it as a video file:
+
+1. **Full recording:** Click the **...** menu in the top right of the player and select **Export to MP4**.
+2. **Short clip:** Click the clip icon in the player controls (or press `X`), choose MP4 or GIF and a duration of 5, 10, or 15 seconds, then click **Create clip**.
+
+Videos render in the background and usually take a few minutes. When the render finishes, the export is ready in the [exports panel](https://us.posthog.com/exports), which you can also open from the export toast or from **Settings** > **Exports**. Exported videos are kept for 12 months.
+
+Video exports (including clips) are limited per project each calendar month: 10 on the free plan, 15 on paid plans, and 25 on enterprise plans.
+
 ## Limitations
 
 1. We make **no guarantees** about sensitive information contained in the recording. We recommend you only sharing recordings that you are certain contain no sensitive information or embed them only where authorized users can see them.


### PR DESCRIPTION
## Changes

Adds an "Exporting a video (MP4 or GIF)" section to the session replay sharing page.

Customers exporting a replay as MP4 see "Export started" and then nothing, because the render happens in the background and the finished file lands in the exports panel (Settings > Exports). That location was undocumented, so neither customers nor the support AI could answer "where did my export go?" (came up in a support ticket this week). This documents the two export entry points (full recording and clips), where exports land, the 12 month retention, and the monthly limits per plan tier.

Values cross-checked against the app code: retention and limits come from `ExportedAsset.get_expiry_delta` and `FULL_VIDEO_EXPORTS_LIMIT_BY_TIER` in PostHog/posthog. Companion UX fix: PostHog/posthog#72948

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code while debugging the support ticket above.