### PR TITLE
docs(error-tracking): document ASP.NET Core exception capture

### DIFF
--- a/contents/docs/error-tracking/installation/dotnet.mdx
+++ b/contents/docs/error-tracking/installation/dotnet.mdx
@@ -121,48 +121,24 @@ posthog.CaptureException(
 );
 ```
 
-<CalloutBox icon="IconInfo" title="Automatic capture" type="fyi">
-
-Automatic exception capture is not available in the .NET SDK yet. Wrap the code paths you want to monitor and call `CaptureException` from your exception handlers.
-
-</CalloutBox>
+For ASP.NET Core, you can opt into automatic capture for unhandled request exceptions in the next step. Other .NET apps continue to use `CaptureException` manually.
 
 </Step>
 
 <Step title="Capture ASP.NET Core request exceptions" badge="recommended">
 
-For ASP.NET Core apps, add middleware to capture unhandled request exceptions and then rethrow them so your existing error handling still runs:
+ASP.NET Core automatic capture is available in `PostHog.AspNetCore` version 2.7.0 and later. Add the PostHog request context middleware after building the app, and enable exception capture:
 
 ```csharp
-using Microsoft.Extensions.DependencyInjection;
-using PostHog;
+var app = builder.Build();
 
-app.Use(async (context, next) =>
+app.UsePostHogRequestContext(options =>
 {
-    try
-    {
-        await next();
-    }
-    catch (Exception exception)
-    {
-        var posthog = context.RequestServices.GetRequiredService<IPostHogClient>();
-        var distinctId = context.User.Identity?.Name ?? context.TraceIdentifier;
-
-        posthog.CaptureException(
-            exception,
-            distinctId,
-            new Dictionary<string, object>
-            {
-                ["$current_url"] = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}",
-                ["$request_method"] = context.Request.Method,
-                ["$pathname"] = context.Request.Path.ToString(),
-            }
-        );
-
-        throw;
-    }
+    options.CaptureExceptions = true;
 });
 ```
+
+Place it before the request handlers whose unhandled exceptions you want to capture. If you use exception-handling middleware, register it first so it can handle the exception after PostHog throws it again. The PostHog middleware captures the exception with the active request context and adds the HTTP response status.
 
 </Step>
 


### PR DESCRIPTION
## Problem

The .NET Error Tracking guide says automatic exception capture is unavailable and implements custom ASP.NET Core middleware. `PostHog.AspNetCore` 2.7.0 already ships opt-in request exception capture in its official request context middleware.

## Exact released behavior

- `PostHog.AspNetCore` 2.7.0 and later expose `UsePostHogRequestContext` with `PostHogRequestContextOptions.CaptureExceptions`.
- `CaptureExceptions` defaults to `false`.
- When enabled, the middleware captures unhandled downstream ASP.NET Core request exceptions with the active request context and HTTP response status, then throws them again.
- Other .NET applications still capture exceptions manually with `CaptureException`.

`CaptureExceptions` was introduced in [posthog-dotnet PR #198](https://github.com/PostHog/posthog-dotnet/pull/198). Release availability was verified against tag `PostHog.AspNetCore-v2.7.0`, its shipped public API baseline, the current `posthog-dotnet` main branch, and the signed NuGet 2.7.0 package.

## Changes

- Replace the handwritten ASP.NET Core exception middleware with the released PostHog middleware configuration.
- State the minimum supported package version.
- Clarify middleware ordering and preserve the generic .NET manual-capture guidance.

## Validation

- `pnpm format:docs`
- `pnpm exec markdownlint-cli2 contents/docs/error-tracking/installation/dotnet.mdx` – 0 errors
- `vale contents/docs/error-tracking/installation/dotnet.mdx` – 0 errors; 2 unchanged dictionary warnings for `dotnet` and `Blazor`
- Published NuGet 2.7.0 package metadata and DLL API inspection
- Autoreview against `origin/master` – clean, no accepted/actionable findings
- Full Gatsby build, bundle checks, and Cloudflare Pages deploy – passed in the remote preview workflow
- All 19 PR checks – passed

## Screenshot proof

The updated automatic-capture section in the [rendered preview](https://e11379d6.posthog-preview.pages.dev/docs/error-tracking/installation/dotnet):

<img width="1280" height="720" alt="Rendered .NET Error Tracking guide showing the PostHog.AspNetCore automatic exception capture configuration" src="https://github.com/user-attachments/assets/80e3403f-e9f6-41a6-b1b8-74ddfe78fc7f" />

## Residual risks

- The released NuGet DLL and metadata were inspected directly, but a separate local compile smoke test could not run because the .NET SDK was unavailable and the machine lacked space to install it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English.
- [x] Internal links remain relative.
- [x] I've checked the changed page in the Cloudflare Pages preview build.
- [x] No page was moved, so no redirect is required.
