### PR TITLE
Add BDR and FDE coverage to customer journey model

### DIFF
--- a/contents/handbook/growth/sales/customer-journey.md
+++ b/contents/handbook/growth/sales/customer-journey.md
@@ -55,11 +55,11 @@ Who covers the account at each stage. Stages run top to bottom in the order a cu
 Notes:
 
 - Automation is the base level everywhere a direct human coverage isn't needed. Below-$500 MRR accounts and sub-$20k steady-state accounts have no human owner by design.
--  TAM allocation can start during Implementing when a deal closed with a known expansion path.
+- TAM allocation can start during Implementing when a deal closed with a qualified expansion opp.
 - Growth TAM pickup can happen during Implementing for a fast-ramping sub-$20k account.
-- The onboarding team's lane is wide because its trigger is first payment, which can land anywhere from Exploring through Ramping.
+- The onboarding team's coverage is wide because its trigger is first payment, which can land anywhere from Exploring through Ramping.
 - BDR coverage is top-of-funnel only: BDRs source and qualify accounts at Exploring (primarily via cold outbound to accounts with no inbound buying signal) and hand off to the TAE at Evaluating. They don't carry the account past that handoff.
-- FDE coverage is conditional and account-specific: an FDE runs a short-term, hands-on technical engagement for a small number of high-spend or technically complex accounts where the implementation need is more than a TAM or CSM can deliver. The 🟡 at Proving covers the case where an FDE helps prove technical fit during a POC with a top prospect; drop it if you want FDE kept strictly post-sales.
+- FDE coverage is conditional where TAM, CSM, or TAE sell an FDE engagement to a customer accoun and then an FDE runs a short-term, hands-on technical engagement where the implementation need is more than a TAM or CSM can deliver. The 🟡 at Proving covers the case where an FDE helps prove technical fit during a POC with a top prospect
 
 ## Ownership rules
 
@@ -71,4 +71,4 @@ Notes:
 
 **BDRs feed the funnel, they don't own the deal.** BDRs own top-of-funnel sourcing at Exploring and hand off to the TAE at Evaluating. Coverage ends at the handoff; the TAE owns the account from there.
 
-**FDE is a conditional technical layer, like TAM.** An FDE is added to an account only when a high-spend or technically complex implementation justifies dedicated engineering beyond what a TAM or CSM can deliver, and released when the engagement closes. It is never the base layer and never replaces the CSM.
+**FDE is a conditional technical layer, like TAM.** An FDE is added to an account only when a high-spend or technically complex implementation justifies dedicated engineering beyond what a TAM or CSM can deliver, and released when the engagement is done.

--- a/contents/handbook/growth/sales/customer-journey.md
+++ b/contents/handbook/growth/sales/customer-journey.md
@@ -40,16 +40,16 @@ Who covers the account at each stage. Stages run top to bottom in the order a cu
 
 ✅ active coverage &nbsp;·&nbsp; 🟡 conditional (see notes) &nbsp;·&nbsp; blank = not involved
 
-| Stage            | TAE | CSM | TAM | Growth TAM | Onboarding |
-| ---------------- | :-: | :-: | :-: | :--------: | :--------: |
-| **Exploring**    |     |     |     |            |     🟡     |
-| **Evaluating**   | ✅  |     |     |            |     🟡     |
-| **Proving**      | ✅  |     |     |            |     🟡     |
-| **Buying**       | ✅  | 🟡  |     |            |     🟡     |
-| **Implementing** |     | ✅  | 🟡  |     🟡     |     🟡     |
-| **Ramping**      |     | ✅  | ✅  |     ✅     |     🟡     |
-| **Expanding**    |     | ✅  | ✅  |     ✅     |            |
-| **Steady state** |     | ✅  |     |            |            |
+| Stage            | BDR | TAE | CSM | TAM | Growth TAM | FDE | Onboarding |
+| ---------------- | :-: | :-: | :-: | :-: | :--------: | :-: | :--------: |
+| **Exploring**    | ✅  |     |     |     |            |     |     🟡     |
+| **Evaluating**   | 🟡  | ✅  |     |     |            |     |     🟡     |
+| **Proving**      |     | ✅  |     |     |            | 🟡  |     🟡     |
+| **Buying**       |     | ✅  | 🟡  |     |            |     |     🟡     |
+| **Implementing** |     |     | ✅  | 🟡  |     🟡     | 🟡  |     🟡     |
+| **Ramping**      |     |     | ✅  | ✅  |     ✅     | 🟡  |     🟡     |
+| **Expanding**    |     |     | ✅  | ✅  |     ✅     | 🟡  |            |
+| **Steady state** |     |     | ✅  |     |            |     |            |
 
 
 Notes:
@@ -58,6 +58,8 @@ Notes:
 -  TAM allocation can start during Implementing when a deal closed with a known expansion path.
 - Growth TAM pickup can happen during Implementing for a fast-ramping sub-$20k account.
 - The onboarding team's lane is wide because its trigger is first payment, which can land anywhere from Exploring through Ramping.
+- BDR coverage is top-of-funnel only: BDRs source and qualify accounts at Exploring (primarily via cold outbound to accounts with no inbound buying signal) and hand off to the TAE at Evaluating. They don't carry the account past that handoff.
+- FDE coverage is conditional and account-specific: an FDE runs a short-term, hands-on technical engagement for a small number of high-spend or technically complex accounts where the implementation need is more than a TAM or CSM can deliver. The 🟡 at Proving covers the case where an FDE helps prove technical fit during a POC with a top prospect; drop it if you want FDE kept strictly post-sales.
 
 ## Ownership rules
 
@@ -66,3 +68,7 @@ Notes:
 **TAM coverage is the exception, not the default.** A TAM is added to an account only when a clear expansion or cross-sell opportunity justifies it, and released when the opportunity is exhausted. 
 
 **TAE handoff goes to CSM, always** (above threshold). Optionally the TAE also hands to a TAM, but only when the handoff doc names the specific opportunity that justifies the layer. "Still ramping" is not a justification. 
+
+**BDRs feed the funnel, they don't own the deal.** BDRs own top-of-funnel sourcing at Exploring and hand off to the TAE at Evaluating. Coverage ends at the handoff; the TAE owns the account from there.
+
+**FDE is a conditional technical layer, like TAM.** An FDE is added to an account only when a high-spend or technically complex implementation justifies dedicated engineering beyond what a TAM or CSM can deliver, and released when the engagement closes. It is never the base layer and never replaces the CSM.


### PR DESCRIPTION
## Changes

Adds **BDR** and **FDE** columns to the coverage map on the customer journey page so it reflects the full set of functions that touch an account, not just the post-sales overlay roles.

- **BDR** — top-of-funnel sourcing at Exploring, conditional at Evaluating during handoff to the TAE. Blank thereafter (they don't carry the deal).
- **FDE** — conditional technical layer across Implementing → Ramping → Expanding for high-spend or technically complex accounts where the implementation need exceeds what a TAM/CSM can deliver. Includes a conditional Proving cell for POC technical-fit support, flagged in the notes as optional to drop if FDE should stay strictly post-sales.

Also adds two coverage-map notes and two ownership rules describing how each function enters and exits an account. Existing TAE/CSM/TAM/Growth TAM/Onboarding cells are unchanged.

**Why:** Requested in #team-sales so the shared handbook language covers the two functions the map was missing — useful both internally for coverage/allocation and for sharing with CSM/TAM/TAE/BDR/FDE candidates. Copy is a first pass for the sales team to refine.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in \`vercel.json\`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090RCG671C/p1784743252623079?thread_ts=1784743252.623079&cid=C090RCG671C)*