### PR TITLE
Remove duplicate careers job listings

### DIFF
--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -1,7 +1,6 @@
 import { graphql, useStaticQuery } from 'gatsby'
 import React, { useRef, useState } from 'react'
 import { CareersHero } from '../components/Careers/CareersHero'
-import { OpenRoles } from '../components/Careers/OpenRoles'
 import { Transparency } from '../components/Careers/Transparency'
 import { SEO } from '../components/seo'
 import MegaQuote from 'components/Careers/MegaQuote'
@@ -161,9 +160,6 @@ const IndexPage = () => {
                         </div>
                         <div id="team-quotes">
                             <TeamQuotes />
-                        </div>
-                        <div id="open-roles">
-                            <OpenRoles />
                         </div>
                     </div>
                 </ScrollArea>


### PR DESCRIPTION
## Summary

- keep the primary job listings browser directly beneath the careers hero
- remove the stale second `OpenRoles` render at the bottom of the page
- leave the shared `JobListings` component and its search, filtering, and responsive behavior unchanged

## Why

The careers page rendered the same Ashby-backed job browser twice. The bottom render was left behind during the OS-style careers page migration and still passed the obsolete `noId` prop, while the top render matches the page's “Open roles” navigation entry.

Candidates will now see the job browser once, in the most prominent position near the top of the page.

## Checks

- `pnpm exec prettier --check src/pages/careers.tsx`
- repository pre-commit Prettier and ESLint hooks
- targeted render-count check: one `JobListings`, zero `OpenRoles` on the careers page
- `git diff --check`

Closes #18813