### PR TITLE
Fix events container sizing in Firefox

### DIFF
--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -347,10 +347,10 @@ export const EventsContent = ({ initialSelectedId, initialSelectedEvent }: Event
             viewportClasses="[&>div>div]:h-full"
             showAddressBar={false}
         >
-            <div data-scheme="primary" className="flex flex-col @xl:flex-row text-primary h-full">
+            <div data-scheme="primary" className="flex flex-col @xl:flex-row text-primary h-full min-h-0 min-w-0">
                 <aside
                     data-scheme="secondary"
-                    className="basis-3/5 @xl:basis-80 bg-primary @xl:border-r border-primary flex flex-col h-full"
+                    className="basis-3/5 @xl:basis-80 bg-primary @xl:border-r border-primary flex flex-col h-full min-h-0"
                 >
                     <div className="border-b border-primary px-4 pt-4 pb-4">
                         <ToggleGroup
@@ -365,7 +365,7 @@ export const EventsContent = ({ initialSelectedId, initialSelectedEvent }: Event
                         />
                     </div>
 
-                    <ScrollArea className="flex-1">
+                    <ScrollArea className="flex-1 min-h-0">
                         <div className="p-4 h-96 @xl:h-full">
                             <div className="space-y-3">
                                 {isModerator && (
@@ -441,7 +441,7 @@ export const EventsContent = ({ initialSelectedId, initialSelectedEvent }: Event
                     </ScrollArea>
                 </aside>
 
-                <div className="flex-1 relative border-primary border-t @xl:border-t-0">
+                <div className="flex-1 min-h-0 min-w-0 relative overflow-hidden border-primary border-t @xl:border-t-0">
                     <AnimatePresence>
                         {(editingEvent || creatingEvent) && isModerator ? (
                             <EventCard


### PR DESCRIPTION
## Summary

- allow the `/events` list and map panes to shrink inside the fixed-height Explorer viewport
- keep the event scroller and Mapbox pane constrained at compact container widths
- preserve the existing container-query breakpoints and desktop layout

## Root cause

The stacked events layout used automatic flex-item minimum sizes. The event list's fixed-height inner content prevented its pane from shrinking to the intended basis, which squeezed the map pane in Firefox at compact container widths.

## Validation

- reproduced the sizing imbalance in Firefox 152 at 500×720
- `prettier --check src/pages/events.tsx`
- `git diff --check`

Closes #18812