### PR TITLE
Fix AI roadmap data source

### DIFF
--- a/src/components/AI/CustomRoadmapSlide.tsx
+++ b/src/components/AI/CustomRoadmapSlide.tsx
@@ -1,146 +1,81 @@
 import React from 'react'
-import Markdown from 'components/Squeak/components/Markdown'
-import { IconCheck } from '@posthog/icons'
 import Link from 'components/Link'
-import { graphql, useStaticQuery } from 'gatsby'
-import { useRoadmaps } from 'hooks/useRoadmaps'
+import useRoadmapEarlyAccessFeatures, { RoadmapEarlyAccessFeature } from 'hooks/useRoadmapEarlyAccessFeatures'
+import { ROADMAP_STAGE_STYLES } from 'components/Roadmap/roadmapStageStyles'
 
-interface RoadmapItem {
-    id: string
-    strapiID: string
-    title: string
-    description: string
-    projectedCompletion?: string
-    complete?: boolean
-}
+type RoadmapStage = Extract<RoadmapEarlyAccessFeature['stage'], 'concept' | 'alpha' | 'beta'>
+
+const STAGES: Array<{ stage: RoadmapStage; title: string; description: string }> = [
+    { stage: 'concept', title: 'Concept', description: 'Ideas we have committed to exploring.' },
+    { stage: 'alpha', title: 'Alpha', description: 'In testing with a small group of users.' },
+    { stage: 'beta', title: 'Beta', description: 'Ready to enable and try in PostHog.' },
+]
+
+const featureUrl = (flagKey: string): string => `/roadmap?feature=${encodeURIComponent(flagKey)}`
+
+const stripMarkdown = (text: string): string => text.replace(/[*_~`#]/g, '').replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
 
 export default function CustomRoadmapSlide(): JSX.Element {
-    const { roadmaps: clientRoadmaps } = useRoadmaps({
-        params: {
-            filters: {
-                $or: [
-                    {
-                        teams: {
-                            name: {
-                                $eq: 'PostHog AI',
-                            },
-                        },
-                    },
-                ],
-            },
-        },
-    })
-    const { roadmaps } = useStaticQuery(graphql`
-        {
-            roadmaps: allRoadmap(
-                filter: { teams: { data: { elemMatch: { attributes: { name: { eq: "PostHog AI" } } } } } }
-            ) {
-                nodes {
-                    id
-                    strapiID
-                    title
-                    description
-                    projectedCompletion
-                    complete
-                }
-            }
-        }
-    `)
-
-    const underConsideration = roadmaps.nodes.filter(
-        (roadmap: any) => !roadmap.projectedCompletion && !roadmap.complete
-    )
-    const inProgress = roadmaps.nodes.filter((roadmap: any) => roadmap.projectedCompletion && !roadmap.complete)
-    const shipped = roadmaps.nodes.filter((roadmap: any) => roadmap.complete)
+    const { features, loading } = useRoadmapEarlyAccessFeatures({ teamSlug: 'self-driving' })
 
     return (
         <div data-scheme="primary" className="h-full bg-primary text-primary p-4 @md:p-8 overflow-auto">
             <h2 className="text-3xl @md:text-4xl font-bold mb-6 text-center">Roadmap</h2>
 
             <div className="grid @lg:grid-cols-3 gap-4 max-w-7xl mx-auto">
-                {/* Under Consideration */}
-                <div className="border border-primary rounded overflow-hidden">
-                    <h3 className="text-sm @md:text-base text-center bg-accent px-4 py-2 mb-0 font-semibold">
-                        Under consideration
-                    </h3>
-                    <div className="divide-y divide-primary overflow-y-auto">
-                        {underConsideration
-                            .filter((r) => !!r.description?.trim())
-                            .slice(0, 3)
-                            .map((roadmap: RoadmapItem) => {
-                                const clientRoadmap = clientRoadmaps.find((r: any) => r.id === roadmap.strapiID)
-                                const likeCount = clientRoadmap?.attributes?.likes?.data?.length || 0
-                                return (
-                                    <div key={roadmap.id} className="p-3">
+                {STAGES.map(({ stage, title, description }) => {
+                    const stageFeatures = features.filter((feature) => feature.stage === stage).slice(0, 3)
+                    const styles = ROADMAP_STAGE_STYLES[stage]
+
+                    return (
+                        <section key={stage} className="border border-primary rounded overflow-hidden">
+                            <header className={`border-b px-4 py-2 ${styles.border} ${styles.surface}`}>
+                                <h3 className={`text-sm @md:text-base text-center mb-0 font-semibold ${styles.text}`}>
+                                    {title}
+                                </h3>
+                                <p className="mb-0 mt-1 text-center text-xs text-secondary">{description}</p>
+                            </header>
+                            <div className="divide-y divide-primary overflow-y-auto">
+                                {stageFeatures.map((feature) => (
+                                    <Link
+                                        key={feature.flagKey}
+                                        to={featureUrl(feature.flagKey)}
+                                        state={{ newWindow: true }}
+                                        className="block p-3 text-primary hover:bg-accent"
+                                    >
                                         <div className="flex gap-2">
-                                            <div className="shrink-0">
-                                                <div className="bg-[#F5E2B2] rounded px-2 py-1 text-xs font-semibold">
-                                                    <span className={clientRoadmaps?.length > 0 ? '' : 'opacity-0'}>
-                                                        {likeCount}
-                                                    </span>
-                                                </div>
-                                            </div>
-                                            <div className="flex-1 min-w-0">
-                                                <h4 className="text-sm font-bold mb-1 leading-tight truncate">
-                                                    {roadmap.title}
+                                            {typeof feature.waitlistCount === 'number' && feature.waitlistCount > 0 && (
+                                                <span
+                                                    className={`h-min shrink-0 rounded border px-2 py-1 text-xs font-semibold ${styles.border} ${styles.surface} ${styles.text}`}
+                                                >
+                                                    {feature.waitlistCount} interested
+                                                </span>
+                                            )}
+                                            <div className="min-w-0 flex-1">
+                                                <h4 className="mb-1 truncate text-sm font-bold leading-tight">
+                                                    {feature.name}
                                                 </h4>
-                                                <div className="text-xs line-clamp-2">
-                                                    <Markdown>{roadmap.description}</Markdown>
-                                                </div>
+                                                {feature.description && (
+                                                    <p className="m-0 line-clamp-2 text-xs">
+                                                        {stripMarkdown(feature.description)}
+                                                    </p>
+                                                )}
                                             </div>
                                         </div>
-                                    </div>
-                                )
-                            })}
-                    </div>
-                </div>
-
-                {/* In Progress */}
-                <div className="border border-primary rounded overflow-hidden">
-                    <h3 className="text-sm @md:text-base text-center bg-orange text-white px-4 py-2 mb-0 font-semibold">
-                        In progress
-                    </h3>
-                    <div className="divide-y divide-primary overflow-y-auto">
-                        {inProgress.slice(0, 3).map((roadmap: RoadmapItem) => (
-                            <div key={roadmap.id} className="p-3">
-                                <div className="flex gap-2">
-                                    <div className="flex-1 min-w-0">
-                                        <h4 className="text-sm font-bold mb-1 leading-tight truncate">
-                                            {roadmap.title}
-                                        </h4>
-                                        <div className="text-xs line-clamp-2">
-                                            <Markdown>{roadmap.description}</Markdown>
-                                        </div>
-                                    </div>
-                                </div>
+                                    </Link>
+                                ))}
+                                {!loading && stageFeatures.length === 0 && (
+                                    <p className="m-0 p-3 text-center text-xs text-secondary">
+                                        Nothing in this stage right now.
+                                    </p>
+                                )}
+                                {loading && stageFeatures.length === 0 && (
+                                    <p className="m-0 p-3 text-center text-xs text-secondary">Loading roadmap…</p>
+                                )}
                             </div>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Shipped */}
-                <div className="border border-primary rounded overflow-hidden">
-                    <h3 className="text-sm @md:text-base text-center bg-green px-4 py-2 mb-0 font-semibold text-white">
-                        Shipped
-                    </h3>
-                    <div className="divide-y divide-primary overflow-y-auto">
-                        {shipped.slice(0, 3).map((roadmap: RoadmapItem) => (
-                            <div key={roadmap.id} className="p-3">
-                                <div className="flex gap-2">
-                                    <div className="shrink-0">
-                                        <IconCheck className="w-4 h-4 text-green" />
-                                    </div>
-                                    <div className="flex-1 min-w-0">
-                                        <h4 className="text-sm font-bold mb-1 leading-tight">{roadmap.title}</h4>
-                                        <div className="text-xs line-clamp-2">
-                                            <Markdown>{roadmap.description}</Markdown>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
+                        </section>
+                    )
+                })}
             </div>
 
             <div className="text-center mt-6">

--- a/src/components/AI/TerminalRoadmap.tsx
+++ b/src/components/AI/TerminalRoadmap.tsx
@@ -1,137 +1,68 @@
 import React from 'react'
-import { graphql, useStaticQuery } from 'gatsby'
-import { useRoadmaps } from 'hooks/useRoadmaps'
 import Link from 'components/Link'
+import useRoadmapEarlyAccessFeatures, { RoadmapEarlyAccessFeature } from 'hooks/useRoadmapEarlyAccessFeatures'
 
-interface RoadmapItem {
-    id: string
-    strapiID: string
-    title: string
-    description: string
-    projectedCompletion?: string
-    complete?: boolean
-}
+type RoadmapStage = Extract<RoadmapEarlyAccessFeature['stage'], 'concept' | 'alpha' | 'beta'>
+
+const STAGES: Array<{ stage: RoadmapStage; title: string; headerClassName: string }> = [
+    { stage: 'concept', title: '[?] CONCEPT', headerClassName: 'text-[#F1A82C] border-[#F1A82C]' },
+    { stage: 'alpha', title: '[→] ALPHA', headerClassName: 'text-[#1D4AFF] border-[#1D4AFF]' },
+    { stage: 'beta', title: '[✓] BETA', headerClassName: 'text-[#00FF00] border-[#00FF00]' },
+]
+
+const featureUrl = (flagKey: string): string => `/roadmap?feature=${encodeURIComponent(flagKey)}`
+
+const stripMarkdown = (text: string): string => text.replace(/[*_~`#]/g, '').replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
 
 export default function TerminalRoadmap(): JSX.Element {
-    const { roadmaps: clientRoadmaps } = useRoadmaps({
-        params: {
-            filters: {
-                $or: [
-                    {
-                        teams: {
-                            name: {
-                                $eq: 'PostHog AI',
-                            },
-                        },
-                    },
-                ],
-            },
-        },
-    })
-
-    const { roadmaps } = useStaticQuery(graphql`
-        {
-            roadmaps: allRoadmap(
-                filter: { teams: { data: { elemMatch: { attributes: { name: { eq: "PostHog AI" } } } } } }
-            ) {
-                nodes {
-                    id
-                    strapiID
-                    title
-                    description
-                    projectedCompletion
-                    complete
-                }
-            }
-        }
-    `)
-
-    const underConsideration = roadmaps.nodes.filter(
-        (roadmap: RoadmapItem) => !roadmap.projectedCompletion && !roadmap.complete
-    )
-    const inProgress = roadmaps.nodes.filter((roadmap: RoadmapItem) => roadmap.projectedCompletion && !roadmap.complete)
-    const shipped = roadmaps.nodes.filter((roadmap: RoadmapItem) => roadmap.complete)
-
-    const stripMarkdown = (text: string): string => {
-        return text.replace(/[*_~`#]/g, '').replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    }
+    const { features, loading } = useRoadmapEarlyAccessFeatures({ teamSlug: 'self-driving' })
 
     return (
         <div className="space-y-6">
             <div className="grid grid-cols-1 @2xl:grid-cols-3 gap-6">
-                {/* Under Consideration */}
-                <div className="space-y-3">
-                    <div className="text-[#F1A82C] text-sm font-bold border-b border-[#F1A82C] pb-2">
-                        [?] UNDER CONSIDERATION
-                    </div>
-                    {underConsideration
-                        .filter((r: RoadmapItem) => !!r.description?.trim())
-                        .slice(0, 3)
-                        .map((roadmap: RoadmapItem) => {
-                            const clientRoadmap = clientRoadmaps.find((r: any) => r.id === roadmap.strapiID)
-                            const likeCount = clientRoadmap?.attributes?.likes?.data?.length || 0
-                            return (
-                                <div key={roadmap.id} className="space-y-1">
+                {STAGES.map(({ stage, title, headerClassName }) => {
+                    const stageFeatures = features.filter((feature) => feature.stage === stage).slice(0, 3)
+
+                    return (
+                        <section key={stage} className="space-y-3">
+                            <div className={`border-b pb-2 text-sm font-bold ${headerClassName}`}>{title}</div>
+                            {stageFeatures.map((feature) => (
+                                <Link
+                                    key={feature.flagKey}
+                                    to={featureUrl(feature.flagKey)}
+                                    state={{ newWindow: true }}
+                                    className="block space-y-1 hover:opacity-75"
+                                >
                                     <div className="flex items-start gap-2">
-                                        {clientRoadmaps?.length > 0 && likeCount > 0 && (
-                                            <span className="text-[#F1A82C] text-[12px] bg-[#F1A82C]/20 px-2 py-0.5 rounded shrink-0">
-                                                {likeCount}★
+                                        {typeof feature.waitlistCount === 'number' && feature.waitlistCount > 0 && (
+                                            <span className="shrink-0 rounded bg-[#F1A82C]/20 px-2 py-0.5 text-[12px] text-[#F1A82C]">
+                                                {feature.waitlistCount}★
                                             </span>
                                         )}
-                                        <div className="flex-1">
-                                            <div className="text-[rgba(238,239,233,0.9)] text-sm font-bold leading-tight">
-                                                {roadmap.title.substring(0, 60)}
-                                                {roadmap.title.length > 60 ? '...' : ''}
+                                        <div className="min-w-0 flex-1">
+                                            <div className="text-sm font-bold leading-tight text-[rgba(238,239,233,0.9)]">
+                                                {feature.name.substring(0, 60)}
+                                                {feature.name.length > 60 ? '...' : ''}
                                             </div>
-                                            {roadmap.description && (
-                                                <div className="text-[#666] text-[12px] leading-tight mt-1">
-                                                    {stripMarkdown(roadmap.description).substring(0, 80)}...
+                                            {feature.description && (
+                                                <div className="mt-1 text-[12px] leading-tight text-[#666]">
+                                                    {stripMarkdown(feature.description).substring(0, 80)}
+                                                    {stripMarkdown(feature.description).length > 80 ? '...' : ''}
                                                 </div>
                                             )}
                                         </div>
                                     </div>
-                                </div>
-                            )
-                        })}
-                </div>
-
-                {/* In Progress */}
-                <div className="space-y-3">
-                    <div className="text-[#F54E00] text-sm font-bold border-b border-[#F54E00] pb-2">
-                        [→] IN PROGRESS
-                    </div>
-                    {inProgress.slice(0, 3).map((roadmap: RoadmapItem) => (
-                        <div key={roadmap.id} className="space-y-1">
-                            <div className="text-[rgba(238,239,233,0.9)] text-sm font-bold leading-tight">
-                                {roadmap.title.substring(0, 60)}
-                                {roadmap.title.length > 60 ? '...' : ''}
-                            </div>
-                            {roadmap.description && (
-                                <div className="text-[#666] text-[12px] leading-tight">
-                                    {stripMarkdown(roadmap.description).substring(0, 80)}...
-                                </div>
+                                </Link>
+                            ))}
+                            {!loading && stageFeatures.length === 0 && (
+                                <div className="text-[12px] text-[#666]">No items in this stage.</div>
                             )}
-                        </div>
-                    ))}
-                </div>
-
-                {/* Shipped */}
-                <div className="space-y-3">
-                    <div className="text-[#00FF00] text-sm font-bold border-b border-[#00FF00] pb-2">[✓] SHIPPED</div>
-                    {shipped.slice(0, 3).map((roadmap: RoadmapItem) => (
-                        <div key={roadmap.id} className="space-y-1">
-                            <div className="text-[rgba(238,239,233,0.9)] text-sm font-bold leading-tight">
-                                {roadmap.title.substring(0, 60)}
-                                {roadmap.title.length > 60 ? '...' : ''}
-                            </div>
-                            {roadmap.description && (
-                                <div className="text-[#666] text-[12px] leading-tight">
-                                    {stripMarkdown(roadmap.description).substring(0, 80)}...
-                                </div>
+                            {loading && stageFeatures.length === 0 && (
+                                <div className="text-[12px] text-[#666]">Loading roadmap...</div>
                             )}
-                        </div>
-                    ))}
-                </div>
+                        </section>
+                    )
+                })}
             </div>
 
             {/* Footer */}

--- a/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
+++ b/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
@@ -25,10 +25,9 @@ import { Select } from 'components/RadixUI/Select'
 import Tooltip from 'components/RadixUI/Tooltip'
 import SmallTeam from 'components/SmallTeam'
 import SurveySignup from 'components/SurveySignup'
-import useEarlyAccessFeatures, { EarlyAccessFeature, EarlyAccessFeatureStage } from 'hooks/useEarlyAccessFeatures'
-import { useFeatureOwnership } from 'hooks/useFeatureOwnership'
+import { EarlyAccessFeature, EarlyAccessFeatureStage } from 'hooks/useEarlyAccessFeatures'
+import useRoadmapEarlyAccessFeatures from 'hooks/useRoadmapEarlyAccessFeatures'
 import usePostHog from 'hooks/usePostHog'
-import { ROADMAP_TEAM_OVERRIDES } from './roadmapTeamOverrides'
 import { ROADMAP_STAGE_STYLES } from './roadmapStageStyles'
 
 const featurePreviewUrl = (flagKey: string): string =>
@@ -154,12 +153,6 @@ const StageChip = ({ stage, size = 'sm' }: { stage: BoardStage; size?: ChipSize 
         </span>
     )
 }
-
-const slugify = (text: string): string =>
-    text
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '')
 
 const roadmapUrl = (search: string, feature?: string): string => {
     const params = new URLSearchParams(search)
@@ -681,8 +674,7 @@ const bySignupAvailability = (a: EarlyAccessFeature, b: EarlyAccessFeature): num
 export default function EarlyAccessFeaturesSection(): JSX.Element | null {
     const roadmapRootRef = useRef<HTMLDivElement>(null)
     const location = useLocation()
-    const { grouped, loading } = useEarlyAccessFeatures()
-    const { features: ownedFeatures } = useFeatureOwnership()
+    const { grouped, loading, teamForFeature } = useRoadmapEarlyAccessFeatures()
     const [query, setQuery] = useState('')
     const [teamFilter, setTeamFilter] = useState('all')
     const [pitchOpen, setPitchOpen] = useState(false)
@@ -738,21 +730,6 @@ export default function EarlyAccessFeaturesSection(): JSX.Element | null {
         return { teamInfoBySlug: teams, peopleByTeamSlug: people }
     }, [allSqueakTeam])
 
-    const teamByFeatureSlug = useMemo(() => {
-        const map: Record<string, string> = {}
-        ownedFeatures.forEach((feature) => {
-            if (feature.owner?.[0]) {
-                map[feature.slug] = feature.owner[0]
-            }
-        })
-        return map
-    }, [ownedFeatures])
-
-    const teamForFeature = (feature: EarlyAccessFeature): string | undefined =>
-        ROADMAP_TEAM_OVERRIDES[feature.flagKey] ||
-        teamByFeatureSlug[feature.flagKey] ||
-        teamByFeatureSlug[slugify(feature.name)]
-
     const allFeatures = useMemo(() => [...grouped.comingSoon, ...grouped.beta], [grouped.beta, grouped.comingSoon])
     const total = allFeatures.length
 
@@ -769,10 +746,7 @@ export default function EarlyAccessFeaturesSection(): JSX.Element | null {
         const counts: Record<string, number> = {}
         let unassigned = 0
         allFeatures.forEach((feature) => {
-            const slug =
-                ROADMAP_TEAM_OVERRIDES[feature.flagKey] ||
-                teamByFeatureSlug[feature.flagKey] ||
-                teamByFeatureSlug[slugify(feature.name)]
+            const slug = teamForFeature(feature)
             if (slug) {
                 counts[slug] = (counts[slug] || 0) + 1
             } else {
@@ -790,7 +764,7 @@ export default function EarlyAccessFeaturesSection(): JSX.Element | null {
             options.push({ value: 'unassigned', label: `Unassigned (${unassigned})` })
         }
         return options
-    }, [allFeatures, teamByFeatureSlug, teamInfoBySlug])
+    }, [allFeatures, teamForFeature, teamInfoBySlug])
 
     const requestedFlagKey = useMemo(
         () => new URLSearchParams(location.search).get('feature') || undefined,

--- a/src/components/Roadmap/README.md
+++ b/src/components/Roadmap/README.md
@@ -6,7 +6,7 @@
 
 - `useEarlyAccessFeatures` owns the feature data. It starts with Gatsby's build-time `EarlyAccessFeature` nodes, then revalidates with PostHog JS in the browser.
 - The hook supplies the feature stage, title, description, documentation URL, flag key, creation date, waitlist count, and waitlist survey payload.
-- `useFeatureOwnership` supplies the shared feature-to-small-team map. `roadmapTeamOverrides.ts` is the curated flag-key override and takes precedence over that map.
+- `useRoadmapEarlyAccessFeatures` adds the shared feature-to-small-team map to that data. It resolves `roadmapTeamOverrides.ts` first, then `useFeatureOwnership`, and can filter the canonical roadmap to one team for embedded views such as `/ai`.
 - `allSqueakTeam` supplies display names, mini crests, and member profiles. Features without a match remain visible and can be filtered as `Unassigned`.
 
 Do not duplicate this data in the component or add hard-coded feature cards. Update the source early-access feature, shared ownership data, or the roadmap override map instead.

--- a/src/hooks/useRoadmapEarlyAccessFeatures.ts
+++ b/src/hooks/useRoadmapEarlyAccessFeatures.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from 'react'
+import useEarlyAccessFeatures, { EarlyAccessFeature } from './useEarlyAccessFeatures'
+import { useFeatureOwnership } from './useFeatureOwnership'
+import { ROADMAP_TEAM_OVERRIDES } from 'components/Roadmap/roadmapTeamOverrides'
+
+export interface RoadmapEarlyAccessFeature extends EarlyAccessFeature {
+    teamSlug?: string
+}
+
+interface UseRoadmapEarlyAccessFeaturesOptions {
+    teamSlug?: string
+}
+
+type UseRoadmapEarlyAccessFeaturesResult = Omit<ReturnType<typeof useEarlyAccessFeatures>, 'features' | 'grouped'> & {
+    features: RoadmapEarlyAccessFeature[]
+    grouped: {
+        beta: RoadmapEarlyAccessFeature[]
+        comingSoon: RoadmapEarlyAccessFeature[]
+    }
+    teamForFeature: (feature: EarlyAccessFeature) => string | undefined
+}
+
+const slugify = (text: string): string =>
+    text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+
+/**
+ * Adds the roadmap's canonical team ownership to each Early Access Feature.
+ * Consumers can optionally select one small team's roadmap without duplicating
+ * the override and feature-ownership resolution used by /roadmap.
+ */
+export function useRoadmapEarlyAccessFeatures({
+    teamSlug,
+}: UseRoadmapEarlyAccessFeaturesOptions = {}): UseRoadmapEarlyAccessFeaturesResult {
+    const earlyAccessFeatures = useEarlyAccessFeatures()
+    const { features: ownedFeatures } = useFeatureOwnership()
+
+    const teamByFeatureSlug = useMemo(() => {
+        const map: Record<string, string> = {}
+        ownedFeatures.forEach((feature) => {
+            if (feature.owner?.[0]) {
+                map[feature.slug] = feature.owner[0]
+            }
+        })
+        return map
+    }, [ownedFeatures])
+
+    const teamForFeature = useCallback(
+        (feature: EarlyAccessFeature): string | undefined =>
+            ROADMAP_TEAM_OVERRIDES[feature.flagKey] ||
+            teamByFeatureSlug[feature.flagKey] ||
+            teamByFeatureSlug[slugify(feature.name)],
+        [teamByFeatureSlug]
+    )
+
+    const features = useMemo<RoadmapEarlyAccessFeature[]>(() => {
+        const withTeams = earlyAccessFeatures.features.map((feature) => ({
+            ...feature,
+            teamSlug: teamForFeature(feature),
+        }))
+        return teamSlug ? withTeams.filter((feature) => feature.teamSlug === teamSlug) : withTeams
+    }, [earlyAccessFeatures.features, teamForFeature, teamSlug])
+
+    const grouped = useMemo(
+        () => ({
+            beta: features.filter((feature) => feature.stage === 'beta'),
+            comingSoon: features.filter((feature) => feature.stage === 'concept' || feature.stage === 'alpha'),
+        }),
+        [features]
+    )
+
+    return {
+        ...earlyAccessFeatures,
+        features,
+        grouped,
+        teamForFeature,
+    }
+}
+
+export default useRoadmapEarlyAccessFeatures


### PR DESCRIPTION
## Summary

- reconnect both `/ai` roadmap presentations to the canonical Early Access Feature source
- centralize roadmap team ownership resolution so `/roadmap` and embedded views share the same override and ownership mapping
- show Self-driving roadmap items in Concept, Alpha, and Beta columns with interest counts
- deep-link each item to its `/roadmap?feature=<flagKey>` detail

## Why

The `/ai` page still queried the legacy `allRoadmap`/Squeak model filtered to the old PostHog AI team. The main `/roadmap` page has moved to Early Access Features, so the embedded AI roadmap was no longer populated from the live roadmap source.

## Impact

Both the marketing slide and developer-mode terminal view now stay aligned with the current roadmap data and open the selected roadmap item directly.

## Validation

- Prettier passed on changed files
- ESLint passed on changed files, aside from the repository's existing React-version configuration warning
- changed TypeScript files transpiled without syntax errors
- `git diff --check` passed
- full TypeScript remains blocked before project files by the repository's TypeScript 4.9 incompatibility with current `zod` and `@types/d3-dispatch` declarations

Fixes #18823