### PR TITLE
docs: document tracing_headers in the Vue.js and Nuxt 2 guides

### DIFF
--- a/contents/docs/libraries/nuxt-js-2.mdx
+++ b/contents/docs/libraries/nuxt-js-2.mdx
@@ -4,6 +4,7 @@ platformLogo: nuxt
 ---
 
 import NuxtApiKeysSecurity from "../integrate/_snippets/nuxt-api-keys-security.mdx"
+import TracingHeaders from "../_snippets/tracing-headers.mdx"
 
 PostHog makes it easy to get data about usage of your [Nuxt.js](https://nuxt.com/) app. Integrating PostHog into your app enables analytics about user behavior, custom events capture, session replays, feature flags, and more.
 
@@ -63,6 +64,8 @@ plugins: [
     { src: './plugins/posthog', mode: 'client' }
   ],
 ```
+
+<TracingHeaders />
 
 ## Usage
 

--- a/contents/docs/libraries/vue-js/index.mdx
+++ b/contents/docs/libraries/vue-js/index.mdx
@@ -14,6 +14,7 @@ features:
 import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx";
 import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx";
 import DetailPostHogIPs from "../../integrate/_snippets/details/posthog-ips.mdx";
+import TracingHeaders from "../../_snippets/tracing-headers.mdx";
 
 PostHog makes it easy to get data about usage of your [Vue.js](https://vuejs.org/) app. Integrating PostHog into your app enables analytics about user behavior, custom events capture, session replays, feature flags, and more.
 
@@ -39,6 +40,8 @@ import VueSetup from "../../integrate/_snippets/vuejs/vue-setup.mdx";
 import IdentifyFrontendCallout from "../../_snippets/identify-frontend-callout.mdx";
 
 <IdentifyFrontendCallout />
+
+<TracingHeaders />
 
 ## Capturing custom events, using feature flags, and more
 


### PR DESCRIPTION
## Changes

Add `tracing_headers` documentation to the two client-side JS framework guides that were missing it:

- **Vue.js** (`libraries/vue-js`) — snippet placed after the "Identifying users" callout, matching the Angular guide.
- **Nuxt 2** (`libraries/nuxt-js-2`) — snippet placed after the client-side plugin setup, matching the Nuxt (v3+) and Nuxt 3.0–3.6 guides.

Both reuse the canonical shared `_snippets/tracing-headers.mdx` — no new prose, so they stay in sync if that snippet changes.

## Why

`tracing_headers` is how a frontend links its session/distinct ID to backend events (via `X-POSTHOG-SESSION-ID` / `X-POSTHOG-DISTINCT-ID`). These two guides were the only client-side framework guides that omitted it, which was inconsistent with their peers (Vue vs Angular/React/Svelte; Nuxt 2 vs the other Nuxt guides).

## Audit scope

Swept every `libraries/*` guide. The shared snippet is already rendered by Angular, React, Svelte, Nuxt (v3+), Nuxt 3.0–3.6, Astro, Remix, TanStack Start, and Next.js, and the backend SDK guides (Node, Python/Django, Flask, Laravel, NestJS, PHP, Go, Java, .NET, Elixir, Ruby on Rails) document reading the headers. `js/config` documents the option in full and correctly labels `addTracingHeaders` / `__add_tracing_headers` as deprecated aliases. Deliberately left out: Gatsby (configured via the community `gatsby-plugin-posthog`, not a direct `posthog.init`, so the snippet's example wouldn't apply cleanly), and no-code/CMS/mobile/backend-only pages where a client-side `posthog.init` option doesn't fit.