### PR TITLE
Add OpenGraph image to /side-project-insurance page

### DIFF
--- a/src/pages/side-project-insurance.tsx
+++ b/src/pages/side-project-insurance.tsx
@@ -3,95 +3,103 @@ import Link from 'components/Link'
 import { CallToAction } from 'components/CallToAction'
 import CloudinaryImage from 'components/CloudinaryImage'
 import Editor from 'components/Editor'
+import SEO from 'components/seo'
 
 const SideProjectInsurance: React.FC = () => {
     return (
-        <Editor
-            // title="Side project insurance"
-            type="mdx"
-            slug="/side-project-insurance"
-            bookmark={{
-                title: 'Side project insurance',
-                description:
-                    "If you get hit with an unexpectedly large bill in your first month because of a spike in volume, we'll refund it.",
-            }}
-        >
-            <div className="@container">
-                <div className="opacity-70 text-[15px] font-medium">Unexpected stardom?</div>
-                <h1 className="!text-2xl">Side project insurance</h1>
-                <p>
-                    So you got your first bill from PostHog – <em>and it came out of nowhere?!</em>{' '}
-                    <strong>(Rest assured, we'll get this worked out.)</strong>
-                </p>
-                <CloudinaryImage
-                    src="https://res.cloudinary.com/dmukukwp6/image/upload/money_f6cb7907a3.png"
-                    width={600}
-                    className="w-full @xl:w-80 @2xl:w-96 @xl:float-right @xl:ml-4"
-                />
-                <p>
-                    We often see this happen with a side project that unexpectedly goes viral (like{' '}
-                    <Link href="https://x.com/jxnlco/status/1777673854770463072" external>
-                        this one
-                    </Link>{' '}
-                    or{' '}
-                    <Link href="https://x.com/gabriel__xyz/status/1876188221983633535" external>
-                        this one
-                    </Link>
-                    ).
-                </p>
-                <p>
-                    First, congrats on your unexpected stardom! It's the best kind of problem to have – and hopefully
-                    the beginning of great things to come.
-                </p>
-                <p>
-                    Let's face it, PostHog isn't successful because we nickel and dime builders with hobby projects.
-                    We're here to grow with you for the long-term.
-                </p>
-                <p>
-                    That's why{' '}
-                    <strong>
-                        if you get hit with an unexpectedly large bill in your first month because of a spike in volume,
-                        we'll refund it.
-                    </strong>
-                </p>
-                <p>Here's the criteria:</p>
-                <ul>
-                    <li>
-                        It's your first bill of &gt;$1 or usage spiked &gt;200% compared to average use over the past
-                        three months
-                    </li>
-                    <li>You or your company doesn't have revenue, or is a hobby project</li>
-                </ul>
-                <p>
-                    Just reach out using the in-app Help button and we'll get you sorted out. You may also be interested
-                    in{' '}
-                    <Link
-                        href="/docs/billing/estimating-usage-costs#how-to-reduce-your-posthog-costs"
-                        state={{ newWindow: true }}
-                    >
-                        ways to reduce your costs
-                    </Link>{' '}
-                    going forward.
-                </p>
+        <>
+            <SEO
+                title="Side project insurance"
+                description="If you get hit with an unexpectedly large bill in your first month because of a spike in volume, we'll refund it."
+                image="/images/og/side-project-insurance.png"
+            />
+            <Editor
+                // title="Side project insurance"
+                type="mdx"
+                slug="/side-project-insurance"
+                bookmark={{
+                    title: 'Side project insurance',
+                    description:
+                        "If you get hit with an unexpectedly large bill in your first month because of a spike in volume, we'll refund it.",
+                }}
+            >
+                <div className="@container">
+                    <div className="opacity-70 text-[15px] font-medium">Unexpected stardom?</div>
+                    <h1 className="!text-2xl">Side project insurance</h1>
+                    <p>
+                        So you got your first bill from PostHog – <em>and it came out of nowhere?!</em>{' '}
+                        <strong>(Rest assured, we'll get this worked out.)</strong>
+                    </p>
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/money_f6cb7907a3.png"
+                        width={600}
+                        className="w-full @xl:w-80 @2xl:w-96 @xl:float-right @xl:ml-4"
+                    />
+                    <p>
+                        We often see this happen with a side project that unexpectedly goes viral (like{' '}
+                        <Link href="https://x.com/jxnlco/status/1777673854770463072" external>
+                            this one
+                        </Link>{' '}
+                        or{' '}
+                        <Link href="https://x.com/gabriel__xyz/status/1876188221983633535" external>
+                            this one
+                        </Link>
+                        ).
+                    </p>
+                    <p>
+                        First, congrats on your unexpected stardom! It's the best kind of problem to have – and
+                        hopefully the beginning of great things to come.
+                    </p>
+                    <p>
+                        Let's face it, PostHog isn't successful because we nickel and dime builders with hobby projects.
+                        We're here to grow with you for the long-term.
+                    </p>
+                    <p>
+                        That's why{' '}
+                        <strong>
+                            if you get hit with an unexpectedly large bill in your first month because of a spike in
+                            volume, we'll refund it.
+                        </strong>
+                    </p>
+                    <p>Here's the criteria:</p>
+                    <ul>
+                        <li>
+                            It's your first bill of &gt;$1 or usage spiked &gt;200% compared to average use over the
+                            past three months
+                        </li>
+                        <li>You or your company doesn't have revenue, or is a hobby project</li>
+                    </ul>
+                    <p>
+                        Just reach out using the in-app Help button and we'll get you sorted out. You may also be
+                        interested in{' '}
+                        <Link
+                            href="/docs/billing/estimating-usage-costs#how-to-reduce-your-posthog-costs"
+                            state={{ newWindow: true }}
+                        >
+                            ways to reduce your costs
+                        </Link>{' '}
+                        going forward.
+                    </p>
 
-                <p>Keep building amazing things. We can't wait to see what you do next! 💫</p>
+                    <p>Keep building amazing things. We can't wait to see what you do next! 💫</p>
 
-                <hr className="my-8" />
-                <p className="!text-sm">
-                    Please note: this is not an <em>actual insurance policy</em>. We offer this out of the goodness of
-                    our hearts and reserve the right to make the final call on any refunds.
-                </p>
+                    <hr className="my-8" />
+                    <p className="!text-sm">
+                        Please note: this is not an <em>actual insurance policy</em>. We offer this out of the goodness
+                        of our hearts and reserve the right to make the final call on any refunds.
+                    </p>
 
-                <div className="flex flex-col @sm:flex-row gap-3 @sm:gap-2 pb-8">
-                    <CallToAction to="https://app.posthog.com/signup" size="md">
-                        Get started - free
-                    </CallToAction>
-                    <CallToAction to="/product-analytics" type="secondary" size="md">
-                        Explore products
-                    </CallToAction>
+                    <div className="flex flex-col @sm:flex-row gap-3 @sm:gap-2 pb-8">
+                        <CallToAction to="https://app.posthog.com/signup" size="md">
+                            Get started - free
+                        </CallToAction>
+                        <CallToAction to="/product-analytics" type="secondary" size="md">
+                            Explore products
+                        </CallToAction>
+                    </div>
                 </div>
-            </div>
-        </Editor>
+            </Editor>
+        </>
     )
 }
 


### PR DESCRIPTION
## Changes

The `/side-project-insurance` page had no OpenGraph image, so link previews fell back to the site default. This wires the existing `static/images/og/side-project-insurance.png` (1200×630) into the page via the `SEO` component, so it now renders as `og:image` / `twitter:image` when the page is shared.

No visual change to the page itself — this only affects social/link previews.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1784761479569939)*
