### PR TITLE
Add Next.js tracing installation docs

### DIFF
--- a/contents/docs/distributed-tracing/installation/nextjs.mdx
+++ b/contents/docs/distributed-tracing/installation/nextjs.mdx
@@ -1,0 +1,156 @@
+---
+title: Next.js tracing installation
+platformLogo: nextjs
+showStepsToc: true
+---
+
+import { Steps, Step } from 'components/Docs/Steps'
+import TracingNextSteps from './_snippets/tracing-next-steps.mdx'
+
+<Steps>
+
+<Step title="Install OpenTelemetry packages" badge="required">
+
+For the complete SDK reference, see the [OpenTelemetry JavaScript docs](https://opentelemetry.io/docs/languages/js/).
+
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/sdk-trace-base @opentelemetry/resources @opentelemetry/semantic-conventions @opentelemetry/exporter-trace-otlp-proto
+```
+
+`@opentelemetry/exporter-trace-otlp-proto` is the OTLP HTTP/protobuf trace exporter. The similarly named `-otlp-http` package sends HTTP/JSON and `-otlp-grpc` sends gRPC, so pick `-proto` to match this guide.
+
+</Step>
+
+<Step title="Get your project token" badge="required">
+
+You'll need your PostHog project token to authenticate trace requests. This is the same token you use for capturing events with the PostHog SDK.
+
+> **Important:** Use your **project token** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project token in [Project settings](https://app.posthog.com/settings).
+
+</Step>
+
+<Step title="Enable instrumentation in Next.js" badge="required">
+
+> **Note:** For Next.js 15 and later, the instrumentation hook is enabled by default. You can skip this step if you're on Next.js 15+.
+
+Add the following to your `next.config.js` (or `next.config.mjs`) to enable the instrumentation hook:
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+</Step>
+
+<Step title="Create the instrumentation file" badge="required">
+
+Create an `instrumentation.ts` (or `instrumentation.js`) file in the root of your project (or inside `src/` if you use that folder).
+
+```typescript
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+
+// Create the provider outside register() so it can be exported and flushed in route handlers
+export const tracerProvider = new NodeTracerProvider({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'my-nextjs-app',
+  }),
+  spanProcessors: [
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({
+        url: '<ph_client_api_host>/i/v1/traces',
+        headers: {
+          Authorization: 'Bearer <ph_project_token>',
+        },
+      })
+    ),
+  ],
+})
+
+export function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    tracerProvider.register()
+  }
+}
+```
+
+> **Note:** The `tracerProvider` is created outside of `register()` so it can be exported and used to flush spans in route handlers. This pattern is necessary because Route Handlers complete execution before batched spans have a chance to be sent to the collector. By exporting the provider, we can manually flush spans at the end of each request.
+
+Alternatively, you can pass the token as a query parameter:
+
+```typescript
+new OTLPTraceExporter({
+  url: '<ph_client_api_host>/i/v1/traces?token=<ph_project_token>',
+})
+```
+
+</Step>
+
+<Step title="Create spans" badge="required">
+
+Wrap the operations you want to measure in spans, and attach attributes for context. Then flush the provider before the serverless function freezes.
+
+```typescript
+import { trace, SpanStatusCode } from '@opentelemetry/api'
+import { after } from 'next/server'
+import { tracerProvider } from '@/instrumentation'
+
+const tracer = trace.getTracer('my-nextjs-app')
+
+export async function GET() {
+  await tracer.startActiveSpan('handle-request', async (span) => {
+    try {
+      span.setAttribute('endpoint', '/api/example')
+      span.setAttribute('method', 'GET')
+      // ... do work ...
+      span.setStatus({ code: SpanStatusCode.OK })
+    } catch (err) {
+      span.recordException(err)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+      throw err
+    } finally {
+      span.end()
+    }
+  })
+
+  // Ensure spans are flushed before the serverless function freezes
+  after(async () => {
+    await tracerProvider.forceFlush()
+  })
+
+  return Response.json({ success: true })
+}
+```
+
+> **Important:** Without calling `forceFlush()`, your spans may not be sent. When deploying to a serverless platform like Vercel, Route Handlers complete execution before the OpenTelemetry batch processor has a chance to export spans, and the function freezes before the batch is flushed. The `after()` function from `next/server` runs code after the response is sent, ensuring spans are flushed before the serverless function freezes.
+
+</Step>
+
+<Step title="Test your setup" badge="recommended">
+
+Once everything is configured, confirm spans are reaching PostHog:
+
+1. Run your application and trigger the instrumented code
+2. Open the PostHog Tracing interface
+3. Confirm your spans and traces appear
+
+<CallToAction type="primary" to="https://app.posthog.com/traces">
+View your traces in PostHog
+</CallToAction>
+
+</Step>
+
+<TracingNextSteps />
+
+</Steps>

--- a/contents/docs/distributed-tracing/installation/nextjs.mdx
+++ b/contents/docs/distributed-tracing/installation/nextjs.mdx
@@ -33,9 +33,9 @@ You can find your project token in [Project settings](https://app.posthog.com/se
 
 <Step title="Enable instrumentation in Next.js" badge="required">
 
-> **Note:** For Next.js 15 and later, the instrumentation hook is enabled by default. You can skip this step if you're on Next.js 15+.
+> **Note:** This step is only needed on Next.js 13.2–14.x. For Next.js 15 and later, `instrumentation.ts` is enabled by default and the `experimental.instrumentationHook` option is deprecated — remove it from your config if it's set.
 
-Add the following to your `next.config.js` (or `next.config.mjs`) to enable the instrumentation hook:
+On Next.js 14 and earlier, add the following to your `next.config.js` (or `next.config.mjs`) to enable the instrumentation hook:
 
 ```javascript
 /** @type {import('next').NextConfig} */
@@ -87,6 +87,8 @@ export function register() {
 
 > **Note:** The `tracerProvider` is created outside of `register()` so it can be exported and used to flush spans in route handlers. This pattern is necessary because Route Handlers complete execution before batched spans have a chance to be sent to the collector. By exporting the provider, we can manually flush spans at the end of each request.
 
+> **Note:** `@opentelemetry/sdk-trace-node` only works in the Node.js runtime. If parts of your app use the [edge runtime](https://nextjs.org/docs/app/api-reference/edge) (e.g. middleware), the [Next.js OpenTelemetry guide](https://nextjs.org/docs/app/guides/open-telemetry) recommends moving Node-only setup into a separate file that `register()` dynamically imports behind the `NEXT_RUNTIME === 'nodejs'` check.
+
 Alternatively, you can pass the token as a query parameter:
 
 ```typescript
@@ -102,11 +104,11 @@ new OTLPTraceExporter({
 Wrap the operations you want to measure in spans, and attach attributes for context. Then flush the provider before the serverless function freezes.
 
 ```typescript
-import { trace, SpanStatusCode } from '@opentelemetry/api'
+import { SpanStatusCode } from '@opentelemetry/api'
 import { after } from 'next/server'
 import { tracerProvider } from '@/instrumentation'
 
-const tracer = trace.getTracer('my-nextjs-app')
+const tracer = tracerProvider.getTracer('my-nextjs-app')
 
 export async function GET() {
   await tracer.startActiveSpan('handle-request', async (span) => {
@@ -134,6 +136,13 @@ export async function GET() {
 ```
 
 > **Important:** Without calling `forceFlush()`, your spans may not be sent. When deploying to a serverless platform like Vercel, Route Handlers complete execution before the OpenTelemetry batch processor has a chance to export spans, and the function freezes before the batch is flushed. The `after()` function from `next/server` runs code after the response is sent, ensuring spans are flushed before the serverless function freezes.
+
+> **Note:** `after()` is stable in Next.js 15.1+ (available as `unstable_after` in 15.0). On Next.js 14 and earlier, it doesn't exist — flush before returning instead:
+>
+> ```typescript
+> await tracerProvider.forceFlush()
+> return Response.json({ success: true })
+> ```
 
 </Step>
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7485,6 +7485,7 @@ export const docsMenu = {
                     children: [
                         { name: 'Overview', url: '/docs/distributed-tracing/installation' },
                         { name: 'Node.js', url: '/docs/distributed-tracing/installation/nodejs' },
+                        { name: 'Next.js', url: '/docs/distributed-tracing/installation/nextjs' },
                         { name: 'Python', url: '/docs/distributed-tracing/installation/python' },
                         { name: 'Go', url: '/docs/distributed-tracing/installation/go' },
                         { name: 'Java', url: '/docs/distributed-tracing/installation/java' },


### PR DESCRIPTION
## Changes

Adds a **Next.js tracing installation** page under `docs/distributed-tracing/installation`, mirroring the existing Next.js logs page. The key addition it documents is the serverless function freeze: on platforms like Vercel, a Route Handler returns before the OpenTelemetry `BatchSpanProcessor` flushes, and the function freezes before spans are exported — so spans silently go missing. The page shows exporting the tracer provider and calling `forceFlush()` inside `next/server`'s `after()` to flush before the freeze, the same pattern the logs docs already use.

Also adds the page to the distributed tracing installation sidebar in `src/navs/index.js` so it shows up in the platform list.

**Why:** A user reported that the Next.js/Vercel tracing docs should stress flushing traces after a serverless request finishes, just like the logs docs already do.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1784791124134249?thread_ts=1784791124.134249&cid=C08S66N93FX)*