### PR TITLE
Fix Next.js version caveats in logs installation docs

### DIFF
--- a/contents/docs/logs/installation/nextjs.mdx
+++ b/contents/docs/logs/installation/nextjs.mdx
@@ -29,9 +29,9 @@ You can find your project token in [Project Settings](https://app.posthog.com/se
 
 <Step title="Enable instrumentation in Next.js" badge="required">
 
-> **Note:** For Next.js 15 and later, the instrumentation hook is enabled by default. You can skip this step if you're on Next.js 15+.
+> **Note:** This step is only needed on Next.js 13.2–14.x. For Next.js 15 and later, `instrumentation.ts` is enabled by default and the `experimental.instrumentationHook` option is deprecated — remove it from your config if it's set.
 
-Add the following to your `next.config.js` (or `next.config.mjs`) to enable the instrumentation hook:
+On Next.js 14 and earlier, add the following to your `next.config.js` (or `next.config.mjs`) to enable the instrumentation hook:
 
 ```javascript
 /** @type {import('next').NextConfig} */
@@ -127,6 +127,13 @@ export async function GET() {
 ```
 
 > **Important:** Without calling `forceFlush()`, your logs may not be sent. Route Handlers complete execution before the OpenTelemetry batch processor has a chance to send logs to the collector. The `after()` function from `next/server` runs code after the response is sent, ensuring logs are flushed before the serverless function freezes.
+
+> **Note:** `after()` is stable in Next.js 15.1+ (available as `unstable_after` in 15.0). On Next.js 14 and earlier, it doesn't exist — flush before returning instead:
+>
+> ```typescript
+> await loggerProvider.forceFlush()
+> return Response.json({ success: true })
+> ```
 
 </Step>
 


### PR DESCRIPTION
## Changes

Fixes two version caveats on the Next.js logs installation page, verified against the official Next.js docs:

- **`after()` requires Next.js 15.1+** (`unstable_after` on 15.0; nonexistent on 14). The page told Next.js <15 users to enable `experimental.instrumentationHook`, then handed them flush code that imports `after` from `next/server` — which fails on their version. Added a version note with a pre-15 fallback that awaits `loggerProvider.forceFlush()` before returning the response.
- **`experimental.instrumentationHook` is deprecated on Next.js 15+** (setting it emits a deprecation warning). Reworded the config step from "skip on 15+" to "only for 13.2–14.x; remove it on 15+".

Same fixes as applied to the new tracing page in #18840.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*