### PR TITLE
docs(cdp): clarify Klaviyo list membership vs subscription consent

### DIFF
--- a/contents/docs/cdp/sources/klaviyo.md
+++ b/contents/docs/cdp/sources/klaviyo.md
@@ -42,6 +42,8 @@ JOIN klaviyo_list_profiles lp ON lp.profile_id = p.id
 WHERE lp.list_id = 'your_list_id'
 ```
 
+> **Note:** List membership isn't the same as subscription. A profile can belong to a list without being subscribed to any of its communications. To check what a profile is actually subscribed to, look at the `$consent` array in the profile's `properties` column — it lists the channels (`sms`, `email`, and/or `push`) the profile currently consents to. Avoid relying on `$consent_timestamp` for this: it records when consent was given, but Klaviyo doesn't always clear it when a profile unsubscribes.
+
 ## Configuration
 
 <SourceParameters />

--- a/contents/docs/cdp/sources/klaviyo.md
+++ b/contents/docs/cdp/sources/klaviyo.md
@@ -33,6 +33,8 @@ When linking Klaviyo, you'll need:
 
 The `events` table is append-only, since Klaviyo events are immutable. On the initial sync, only the last 365 days of events are imported.
 
+## List profiles
+
 The opt-in `list_profiles` table maps which profiles belong to which list as `{list_id, profile_id, joined_group_at}` rows. This is disabled by default, but can be toggled on in the schema configuration when setting up or editing your Klaviyo source. It supports incremental sync on `joined_group_at` (the datetime when the profile most recently joined the list). Incremental syncs only pick up new joins and re-joins, and will not account for profiles removed from a list. A full refresh is required if profiles need to be removed. Once synced, you can join it with your profiles table:
 
 ```sql

--- a/contents/docs/cdp/sources/klaviyo.md
+++ b/contents/docs/cdp/sources/klaviyo.md
@@ -46,6 +46,16 @@ WHERE lp.list_id = 'your_list_id'
 
 > **Note:** List membership isn't the same as subscription. A profile can belong to a list without being subscribed to any of its communications. To check what a profile is actually subscribed to, look at the `$consent` array in the profile's `properties` column — it lists the channels (`sms`, `email`, and/or `push`) the profile currently consents to. Avoid relying on `$consent_timestamp` for this: it records when consent was given, but Klaviyo doesn't always clear it when a profile unsubscribes.
 
+To find profiles that are on a list **and** actually subscribed to a given channel, filter on `$consent` too:
+
+```sql
+SELECT p.id, p.email
+FROM klaviyo_profiles p
+JOIN klaviyo_list_profiles lp ON lp.profile_id = p.id
+WHERE lp.list_id = 'your_list_id'
+  AND arrayExists(x -> x = 'email', JSONExtractArrayRaw(p.properties, '$consent'))
+```
+
 ## Configuration
 
 <SourceParameters />


### PR DESCRIPTION
## Changes

The Klaviyo source docs show an example query joining `klaviyo_profiles` with `klaviyo_list_profiles` to find everyone on a given list, with no caveat that list membership isn't the same as subscription — a profile can be on a list without being subscribed to any of its communications.

Adds a note right after that example explaining that the actual subscription signal is the `$consent` array in a profile's `properties` (which lists the channels a profile currently consents to: sms, email, and/or push), and that `$consent_timestamp` is unreliable for this since Klaviyo doesn't always clear it on unsubscribe.

Companion to [PostHog/posthog#73149](https://github.com/PostHog/posthog/pull/73149), which makes the same clarification in the in-product column descriptions for the warehouse source.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`