### PR TITLE
fix(docs): add bigquery.tables.update to BigQuery source permissions

### DIFF
--- a/contents/docs/cdp/sources/bigquery.md
+++ b/contents/docs/cdp/sources/bigquery.md
@@ -42,6 +42,7 @@ To securely connect your BigQuery account to PostHog, create a dedicated service
   bigquery.tables.list
   bigquery.tables.getData
   bigquery.tables.create
+  bigquery.tables.update
   bigquery.tables.updateData
   bigquery.tables.delete
   ```


### PR DESCRIPTION
## Changes

Adds `bigquery.tables.update` to the custom-role permission list in the [BigQuery source docs](https://posthog.com/docs/cdp/sources/bigquery).

**Why:** the BigQuery source connector copies incremental / view / row-filtered reads into its own temporary tables using a `WRITE_TRUNCATE` query job before reading them. BigQuery gates that truncate-write under the `bigquery.tables.update` permission (even though no schema is actually altered), so a service account built from the documented *custom minimal role* — which listed `bigquery.tables.updateData` but not `bigquery.tables.update` — fails with `Permission bigquery.tables.update denied on table <temp table>`. Users who followed the recommended **BigQuery Data Editor** predefined role were unaffected, since that role already includes it. This was surfaced by a customer using the custom-role path.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*