### PR TITLE
fix(blog): standardize AI Observability tag on two posts

### DIFF
--- a/contents/blog/ai-observability-for-mvps.mdx
+++ b/contents/blog/ai-observability-for-mvps.mdx
@@ -12,7 +12,7 @@ featuredImage: >-
 featuredImageType: full
 category: General
 tags:
-    - ai-observability
+    - AI Observability
 seo:
     metaTitle: 'AI observability for your MVP'
     metaDescription: 'A practical guide to LLM observability for early-stage AI apps and startups. What to instrument on day one and what to add as you scale.'

--- a/contents/blog/what-is-ai-observability.mdx
+++ b/contents/blog/what-is-ai-observability.mdx
@@ -12,7 +12,7 @@ featuredImage: >-
 featuredImageType: full
 category: General
 tags:
-    - ai-observability
+    - AI Observability
 seo:
     metaTitle: 'AI observability: what it is, how it works, and which tools to use'
     metaDescription: 'A comprehensive guide to AI observability: how it differs from traditional APM, what tools like PostHog actually do, and how to pick the right one for your stage.'


### PR DESCRIPTION
## Changes

Standardizes the AI observability blog tag on two posts — "What is AI observability" and "AI observability for your MVP" — which used a lowercase `ai-observability` tag instead of the `AI Observability` tag used by the other posts in this cluster. This split them off from the rest of the AI observability content on the tag index; this folds them back together.

**Why:** raised in a Slack thread — the two posts used a slightly different AI observability tag from the rest of the blog.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1784810509071549?thread_ts=1784810509.071549&cid=C09GU689J1X)*