### PR TITLE
fix(wizard): drop no-op --region flag from install command

### DIFF
--- a/contents/docs/integrate/_snippets/agent-prompt.mdx
+++ b/contents/docs/integrate/_snippets/agent-prompt.mdx
@@ -1,19 +1,5 @@
-<IsEU>
-
 ```Prompt
 
-npx -y @posthog/wizard@latest --region eu
+npx -y @posthog/wizard@latest
 
-``` 
-
-</IsEU>
-
-<IsUS>
-
-```Prompt
-
-npx -y @posthog/wizard@latest --region us
-
-``` 
-
-</IsUS>
+```

--- a/contents/handbook/engineering/posthog-com/markdown.mdx
+++ b/contents/handbook/engineering/posthog-com/markdown.mdx
@@ -663,7 +663,7 @@ Use `<WizardCommand />` to render a copyable install button for the PostHog wiza
 
 <WizardCommand />
 
-The displayed command is always the clean `npx @posthog/wizard …`; the copied command always pins `-y` and `@latest`. The `--region eu` / `--region us` suffix is added automatically based on the user's feature flags. `<WizardCommand />` is a thin alias for `<PlatformInstall variant="inline" />`.
+The displayed command is always the clean `npx @posthog/wizard …`; the copied command always pins `-y` and `@latest`. The wizard reads the user's region off their auth token, so no `--region` flag is added. `<WizardCommand />` is a thin alias for `<PlatformInstall variant="inline" />`.
 
 **Props:**
 

--- a/src/components/PlatformInstall/buildCommand.ts
+++ b/src/components/PlatformInstall/buildCommand.ts
@@ -1,25 +1,22 @@
-type Cloud = 'eu' | 'us' | null
-
 /**
  * Single source of truth for how the PostHog wizard command string is assembled.
  *
  * `buildWizardCommand` builds the inline command (the consolidated WizardCommand): the displayed
  * command is always the clean form, while the copied command always pins `-y` and `@latest`.
- * `buildSchemaCommand` handles the schema-driven card, appending an optional subcommand and the
- * user's cloud region to arbitrary base strings.
+ * `buildSchemaCommand` handles the schema-driven card, appending an optional subcommand to arbitrary
+ * base strings.
  */
 
 /**
  * Inline wizard command. The display is always the clean `npx @posthog/wizard …`; the copy always
  * pins `-y` (auto-confirms the npx prompt) and `@latest` (freshness). There is intentionally no flag
- * to toggle `@latest` — it is always copied, never displayed. The subcommand then the
- * `--region <cloud>` suffix are appended last, to both.
+ * to toggle `@latest` — it is always copied, never displayed. The subcommand is appended last, to both.
  */
-export function buildWizardCommand({ subcommand, cloud = null }: { subcommand?: string; cloud?: Cloud }): {
+export function buildWizardCommand({ subcommand }: { subcommand?: string }): {
     displayCommand: string
     copyCommand: string
 } {
-    const tail = `${subcommand ? ` ${subcommand}` : ''}${cloud ? ` --region ${cloud}` : ''}`
+    const tail = subcommand ? ` ${subcommand}` : ''
     return {
         displayCommand: `npx @posthog/wizard${tail}`,
         copyCommand: `npx -y @posthog/wizard@latest${tail}`,
@@ -27,8 +24,8 @@ export function buildWizardCommand({ subcommand, cloud = null }: { subcommand?: 
 }
 
 /**
- * Schema-based card command: append an optional subcommand and the cloud region to arbitrary base
- * strings (`schema.defaultCommand` / `schema.defaultCopyCommand`). Returns `copyCommand: undefined`
+ * Schema-based card command: append an optional subcommand to arbitrary base strings
+ * (`schema.defaultCommand` / `schema.defaultCopyCommand`). Returns `copyCommand: undefined`
  * when nothing overrides the display so the card copies the displayed text verbatim (preserves the
  * MCP `npx @posthog/wizard mcp add` flow, which has no separate copy string).
  */
@@ -36,19 +33,13 @@ export function buildSchemaCommand({
     base,
     copyBase,
     subcommand,
-    appendRegion = false,
-    cloud = null,
 }: {
     base: string
     copyBase?: string
     subcommand?: string
-    appendRegion?: boolean
-    cloud?: Cloud
 }): { displayCommand: string; copyCommand?: string } {
     const commandSuffix = subcommand ? ` ${subcommand}` : ''
-    const regionSuffix = appendRegion && cloud ? ` --region ${cloud}` : ''
-    const displayCommand = `${base}${commandSuffix}${regionSuffix}`
-    const copyCommand =
-        copyBase || subcommand || regionSuffix ? `${copyBase ?? base}${commandSuffix}${regionSuffix}` : undefined
+    const displayCommand = `${base}${commandSuffix}`
+    const copyCommand = copyBase || subcommand ? `${copyBase ?? base}${commandSuffix}` : undefined
     return { displayCommand, copyCommand }
 }

--- a/src/components/PlatformInstall/index.tsx
+++ b/src/components/PlatformInstall/index.tsx
@@ -4,7 +4,6 @@ import Link from 'components/Link'
 import Tooltip from 'components/RadixUI/Tooltip'
 import { cn } from '../../utils'
 import ZoomHover from 'components/ZoomHover'
-import useCloud from 'hooks/useCloud'
 import IconButton from './IconButton'
 import { CopyableCommand } from './CopyableCommand'
 import { InlineCommand } from './InlineCommand'
@@ -185,13 +184,12 @@ export default function PlatformInstall({
     }
 
     // `selfDriving` is shorthand for the `self-driving` subcommand; `command` is the escape hatch.
-    const cloud = useCloud()
     const subcommand = selfDriving ? 'self-driving' : command || undefined
 
     // Inline variant: the bare command button (consolidated WizardCommand look). Builds the command
     // from flags via the shared builder so display/copy semantics can never drift from the card.
     if (variant === 'inline') {
-        const inline = buildWizardCommand({ subcommand, cloud })
+        const inline = buildWizardCommand({ subcommand })
         return (
             <InlineCommand
                 displayCommand={inline.displayCommand}
@@ -205,14 +203,12 @@ export default function PlatformInstall({
         )
     }
 
-    // Card variant: append the subcommand + the user's cloud region (when the schema opts in) to the
-    // schema's base command(s), e.g. `npx @posthog/wizard self-driving --region eu`.
+    // Card variant: append the subcommand to the schema's base command(s), e.g.
+    // `npx @posthog/wizard self-driving`.
     const { displayCommand, copyCommand } = buildSchemaCommand({
         base: schema.defaultCommand,
         copyBase: schema.defaultCopyCommand,
         subcommand,
-        appendRegion: schema.appendRegion,
-        cloud,
     })
 
     return (

--- a/src/components/PlatformInstall/schema.tsx
+++ b/src/components/PlatformInstall/schema.tsx
@@ -59,8 +59,6 @@ export type InstallSchema = {
     defaultCommand: string
     /** Clipboard override for `defaultCommand` (display shows `defaultCommand`, copy writes this). */
     defaultCopyCommand?: string
-    /** Append `--region <cloud>` (from the user's region) after the command, matching WizardCommand. */
-    appendRegion?: boolean
     /** Line shown below the command, e.g. "Supports Next.js, React, Python, and 21 more" */
     supports?: React.ReactNode
     platforms: Platform[]
@@ -538,10 +536,8 @@ export const wizardInstallSchema: InstallSchema = {
     },
     // Display shows a clean command; the copy adds `-y` (auto-confirm) and `@latest` (freshness).
     // `self-driving` is intentionally NOT baked in here — it's opt-in via PlatformInstall's `selfDriving` prop.
-    // The user's cloud region (`--region eu|us`) is appended automatically via `appendRegion`.
     defaultCommand: 'npx @posthog/wizard',
     defaultCopyCommand: 'npx -y @posthog/wizard@latest',
-    appendRegion: true,
     supports: supportsFrameworks,
     // Secondary install-methods row hidden for now on the homepage. Restore by
     // uncommenting installPlatforms (or swap in a custom array to diverge from MCP).


### PR DESCRIPTION
## Changes

The PostHog wizard ignores `--region` on the interactive path — it reads the region off the user's OAuth token — so appending `--region eu` / `--region us` to the docs install command did nothing.

This removes the region flag from the install command everywhere it was appended:

- `PlatformInstall/buildCommand.ts` — drop the `cloud` / region plumbing from both `buildWizardCommand` (inline) and `buildSchemaCommand` (card).
- `PlatformInstall/index.tsx` — drop the `useCloud()` call and the region args.
- `PlatformInstall/schema.tsx` — drop the `appendRegion` schema field and the `appendRegion: true` on the wizard schema.
- `agent-prompt.mdx` snippet — collapse the `IsEU` / `IsUS` split (which only differed by the region flag) into one `npx -y @posthog/wizard@latest` block.
- Handbook `markdown.mdx` — update the `<WizardCommand />` note to reflect that no `--region` flag is added.

No user-visible copy command changes other than the removed flag.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)