### PR TITLE
docs: add semantic layer (data catalog) alpha documentation

### DIFF
--- a/contents/docs/data-warehouse/join.mdx
+++ b/contents/docs/data-warehouse/join.mdx
@@ -29,6 +29,8 @@ Once joined, source properties can be used in filters, breakdowns, and [SQL expr
 
 To edit or delete a table join, click the three dots next to your source table, click **View table schema**, click the three dots next to your joined table, and select **Edit** or **Delete**.
 
+Joins can also come from the [semantic layer](/docs/semantic-layer) (alpha): when a human accepts an AI-proposed [table relationship](/docs/semantic-layer/certifications-and-relationships#relationship-proposals), it's promoted to a regular table join.
+
 ## Person joins
 
 Person joins are a special type of table joins. They are joins on the `persons` table in PostHog. When you join external data on this table, we enable you to use it like a person filter in insights.

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -53,7 +53,7 @@ Once connected, your agent can read and write across PostHog's products. Here's 
   outcome="Updates issue status and creates an assignment rule in one go."
 />
 
-There's a lot more – analytics queries, feature flag and experiment management, SQL, CDP destinations, support ticket triage, and multi-step recipes that chain it all together.
+There's a lot more – analytics queries, feature flag and experiment management, SQL, CDP destinations, support ticket triage, and multi-step recipes that chain it all together. You can also run governed metrics from your [semantic layer](/docs/semantic-layer) (alpha), so every agent session answers "what's our MRR?" with the same canonical definition.
 
 **[Browse all use cases →](/docs/model-context-protocol/use-cases)**
 

--- a/contents/docs/model-context-protocol/tools.mdx
+++ b/contents/docs/model-context-protocol/tools.mdx
@@ -19,6 +19,8 @@ Click any category to expand the full list of tools it contains.
 
 <MCPTools />
 
+> **Note:** Some tools are in alpha behind a feature flag and don't appear here yet – like the [semantic layer tools](/docs/semantic-layer/mcp-tools) for governed metrics, table certifications, and relationships.
+
 ## Keep exploring
 
 - [Use cases](/docs/model-context-protocol/use-cases) – example prompts and multi-step recipes

--- a/contents/docs/semantic-layer/_snippets/alpha-callout.mdx
+++ b/contents/docs/semantic-layer/_snippets/alpha-callout.mdx
@@ -1,0 +1,7 @@
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconFlask" title="The semantic layer is in alpha" type="action">
+
+The semantic layer is in alpha, enabled per organization for a small group of customers. There's no dedicated UI yet – you work with it through MCP tools and SQL. Tool names and behavior may change between releases. Found a bug, or want access? [Contact support](https://app.posthog.com/home#supportModal) and mention the semantic layer alpha.
+
+</CalloutBox>

--- a/contents/docs/semantic-layer/certifications-and-relationships.mdx
+++ b/contents/docs/semantic-layer/certifications-and-relationships.mdx
@@ -1,0 +1,72 @@
+---
+title: Certifications and relationships
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+[Metrics](/docs/semantic-layer/metrics) govern your *answers*. Certifications and relationships govern the *tables the answers come from*: which sources to trust, which to avoid, and how tables join – so agents stop guessing.
+
+<AlphaCallout />
+
+## Table certifications
+
+A certification is a human-vouched trust mark on a warehouse table or view:
+
+| Status | Meaning |
+|--------|---------|
+| `proposed` | An agent (or human) suggested a trust mark; not yet vouched. |
+| `certified` | Prefer this source. A human has vouched for it. |
+| `deprecated` | Avoid this source. A human has warned against it. |
+
+The classic case: your warehouse has both a synced `stripe_charges` table and a hand-rolled `payments_backup` someone loaded last year. Certify `stripe_charges` with a note like "canonical payments source, synced daily" and deprecate `payments_backup` with "superseded by stripe_charges, stale since March". The notes matter – agents read them when choosing between sources.
+
+The flow mirrors the rest of the semantic layer: anyone proposes with [`data-catalog-certification-propose`](/docs/semantic-layer/mcp-tools#certification-tools) (targets can be addressed by id or by name – an ambiguous name returns candidates to pick from), and a human resolves it with `data-catalog-certification-certify` or `data-catalog-certification-deprecate`, both of which require typing "confirm". Revoking a certification deletes it outright, with the change activity-logged.
+
+Certifications surface wherever schemas do: `system.information_schema.tables` rows carry each table's trust mark in the `certification` column, so anything exploring your schema sees them inline:
+
+```sql
+SELECT table_name, table_type, description, certification
+FROM system.information_schema.tables
+WHERE table_name IN ('stripe_charges', 'payments_backup')
+```
+
+## Relationship proposals
+
+A relationship proposal is a reviewed join fact between two warehouse tables. Instead of every session rediscovering that `orders.customer_id` matches `stripe_customers.id`, an agent proposes the join once – with evidence – and a human accepts it.
+
+A proposal records the two tables, the join keys, a confidence score, reasoning, and sampling evidence: the agent shows its work, like "98% of `orders.customer_id` values match `stripe_customers.id` in a sample". Proposals are deduped regardless of direction, so `orders → stripe_customers` and `stripe_customers → orders` count as the same pair.
+
+| Status | Meaning |
+|--------|---------|
+| `proposed` | Suggested with evidence; awaiting review. |
+| `accepted` | Promoted to a real [data warehouse join](/docs/data-warehouse/join), after re-validating and probing the keys. |
+| `rejected` | Vetoed. Permanent – the pair is never re-proposed. |
+
+Acceptance and rejection both go through a human with a typed "confirm" ([`data-catalog-relationship-accept`](/docs/semantic-layer/mcp-tools#relationship-tools) and `data-catalog-relationship-reject`).
+
+<CalloutBox icon="IconWarning" title="Rejection is permanent" type="caution">
+
+Rejecting a proposal persists forever and suppresses the pair from ever being re-proposed – that's what stops agents from suggesting a join you've already vetoed, but it also means there's no undo. Be sure before you confirm a rejection.
+
+</CalloutBox>
+
+Accepted joins become real lazy joins and surface in `system.information_schema.relationships`, carrying the proposal's confidence and reasoning:
+
+```sql
+SELECT source_table, source_column, target_table, target_column, confidence, reasoning
+FROM system.information_schema.relationships
+WHERE confidence IS NOT NULL
+```
+
+## How agents use trust marks
+
+When the semantic layer is enabled, agents exploring your schema:
+
+- **Prefer certified tables** and mention when they're using one
+- **Avoid deprecated tables**, citing the deprecation note if they must touch one
+- **Join along accepted relationships** instead of inferring keys from column names
+
+The effect compounds: each certification and accepted join is a decision made once, by a human, that every future session inherits.

--- a/contents/docs/semantic-layer/governance.mdx
+++ b/contents/docs/semantic-layer/governance.mdx
@@ -1,0 +1,72 @@
+---
+title: Governance
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+
+The semantic layer's whole design reduces to one sentence: **AI generates, a human owns.** This page explains how that principle is enforced – lifecycles, typed confirmations, API scopes, and provenance – and how to run it day to day.
+
+<AlphaCallout />
+
+## AI generates, a human owns
+
+Agents are good at drafting metric definitions, spotting untrusted tables, and finding join keys. They are not accountable for what MRR means at your company – a person is. So the semantic layer splits the work:
+
+- **Agents propose.** Any write an agent makes – a metric, a certification, a relationship – lands in a `proposed` state with zero authority. Proposals are cheap and safe.
+- **Humans promote.** Approving, certifying, accepting, and rejecting are human acts, gated by a separate API scope and a typed confirmation.
+
+The result: your agents build the catalog for you during normal work, and nothing becomes canonical without a person signing it.
+
+## Lifecycle across the catalog
+
+| Primitive | Lands as | Human promotes to | Demoted or terminal |
+|-----------|----------|-------------------|---------------------|
+| [Metric](/docs/semantic-layer/metrics) | `proposed` | `approved` | Editing the definition or drifting from the source insight resets it toward `proposed`; deleted names stay reserved forever |
+| [Certification](/docs/semantic-layer/certifications-and-relationships#table-certifications) | `proposed` | `certified` or `deprecated` | Revoking deletes the mark (activity-logged) |
+| [Relationship](/docs/semantic-layer/certifications-and-relationships#relationship-proposals) | `proposed` | `accepted` (becomes a real join) | `rejected` – permanent, never re-proposed |
+
+## Typed confirmations
+
+Every promoting or vetoing tool requires the user to reply with the literal word "confirm" before it executes:
+
+- `data-catalog-metric-approve` – additionally blocked while the metric is drifted
+- `data-catalog-certification-certify`
+- `data-catalog-certification-deprecate`
+- `data-catalog-relationship-accept`
+- `data-catalog-relationship-reject`
+
+The point is simple: an agent can't autocomplete your signature. However agentic your workflow gets, the moment something becomes canonical is always a human typing a word.
+
+## API scopes
+
+Two scopes split proposing from promoting:
+
+| Scope | Grants |
+|-------|--------|
+| `data_catalog` | Read and write: search the catalog, run metrics, propose metrics/certifications/relationships, update drafts |
+| `data_catalog_approval` | Promote and veto: approve metrics, certify or deprecate tables, accept or reject relationships |
+
+Practical setup: the API key you hand your MCP server or CI agent gets `data_catalog` only – it can build and use the catalog but never bless anything. Your own key carries both scopes, so approvals happen through you. (`data-catalog-metric-run` also needs `query:read`, and `data-catalog-relationship-accept` needs `warehouse_view:write` to create the join.)
+
+## Provenance
+
+Every AI-authored object records its origin: `created_source: ai_generated`, the `ai_model` that wrote it, a `confidence` score from 0 to 1, and the model's `reasoning`. Reviewers see who proposed what, how sure it was, and why – before signing. Relationship proposals go further and attach sampling evidence, like key match rates from real data.
+
+## Recommended workflow for teams
+
+You don't need a cataloging project. Let the catalog grow out of normal work:
+
+1. **Agents propose as they go.** When an agent derives a number that gets reused, it offers to save the derivation as a proposed metric. When it notices a stale table or an obvious join, it proposes a trust mark.
+2. **A data owner reviews the queue weekly.** The review queue is one query away:
+
+   ```sql
+   SELECT name, display_name, description, confidence, reasoning
+   FROM system.information_schema.metrics
+   WHERE status = 'proposed'
+   ```
+
+3. **Approvals happen with the approval-scoped key.** Run the metric, read the compiled query, then approve with the typed "confirm" – or update the draft and leave it proposed.
+
+Each review is a few minutes; each approval is a decision your whole team (and every future agent session) stops re-making.

--- a/contents/docs/semantic-layer/index.mdx
+++ b/contents/docs/semantic-layer/index.mdx
@@ -1,0 +1,63 @@
+---
+title: Semantic layer
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+
+Ask three AI tools "what's our MRR?" and you get three different queries and three different numbers. Not because the tools are bad, but because what "MRR" means at your company lives in people's heads. Every agent session reinvents the definition from scratch, and every reinvention is slightly different.
+
+The semantic layer fixes this. It's a per-project catalog of governed definitions that every agent – and every human – reads from the same place. Define MRR once, approve it once, and every session from then on returns the same number.
+
+The guiding principle: **AI generates, a human owns.** Agents can propose metrics, trust marks, and joins all day. Only a human can approve them, and approval is what makes them canonical.
+
+One naming note: the semantic layer is powered by PostHog's data catalog, so you'll see `data-catalog` in MCP tool names (like `data-catalog-metric-run`) and API scopes (`data_catalog`, `data_catalog_approval`).
+
+<AlphaCallout />
+
+## What's in the semantic layer
+
+The catalog holds three kinds of governed facts:
+
+### Metrics
+
+A [metric](/docs/semantic-layer/metrics) is a canonical business measure: a write-once name like `mrr`, a description, a unit, an owner, and a definition that's either an executable query or a set of calculation steps. Metrics move through a `proposed` → `approved` lifecycle, and PostHog detects when an approved definition drifts from the insight it was created from.
+
+### Table certifications
+
+A [certification](/docs/semantic-layer/certifications-and-relationships) is a human-vouched trust mark on a warehouse table or view: `certified` means "prefer this source," `deprecated` means "avoid it." Agents exploring your schema see these marks and pick sources accordingly.
+
+### Relationships
+
+A [relationship](/docs/semantic-layer/certifications-and-relationships#relationship-proposals) is a reviewed join fact between two warehouse tables, proposed with evidence (match rates, sample values) and, once accepted, promoted to a real [data warehouse join](/docs/data-warehouse/join). No more agents guessing join keys.
+
+## How you use it
+
+There's no UI during the alpha. You work with the semantic layer through two surfaces:
+
+**From an AI agent (the main surface).** Connect the [PostHog MCP server](/docs/model-context-protocol) to Claude Code, Cursor, Claude Desktop, or any other MCP client. When the semantic layer is enabled, agents route metric questions through the catalog first: ask `What was our MRR last quarter?` and the agent runs the governed `mrr` metric instead of writing its own SQL. See [MCP tools](/docs/semantic-layer/mcp-tools).
+
+**From SQL.** The catalog is queryable from the [SQL editor](/docs/data-warehouse/query) or the `execute-sql` MCP tool:
+
+```sql
+SELECT name, display_name, description, status, is_drifted
+FROM system.information_schema.metrics
+WHERE name ILIKE '%mrr%'
+```
+
+See the [SQL reference](/docs/semantic-layer/query) for the full schema.
+
+## The trust model in 30 seconds
+
+Everything an agent creates lands as `proposed`. A human promotes it – approving a metric, certifying a table, accepting a join – and every promotion requires literally typing "confirm" in the conversation. Editing an approved metric's definition resets it to `proposed`. If a metric was created from an insight and someone later edits that insight, the metric is flagged as drifted.
+
+The rule agents live by: a result is canonical only when `status = 'approved'` and `is_drifted = false`. Everything else gets labeled noncanonical.
+
+Read more in [governance](/docs/semantic-layer/governance).
+
+## Next steps
+
+- [Get started](/docs/semantic-layer/start-here) – catalog your first metric in a 10-minute agent conversation
+- [Metrics](/docs/semantic-layer/metrics) – definitions, lifecycle, and drift in depth
+- [MCP tools](/docs/semantic-layer/mcp-tools) – the full tool reference and example prompts

--- a/contents/docs/semantic-layer/mcp-tools.mdx
+++ b/contents/docs/semantic-layer/mcp-tools.mdx
@@ -1,0 +1,63 @@
+---
+title: Semantic layer MCP tools
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+
+The [PostHog MCP server](/docs/model-context-protocol) is how agents work with the semantic layer. This page is the reference for the semantic layer's tools – they're alpha-only, so they don't appear in the [general MCP tools list](/docs/model-context-protocol/tools) yet, and they only show up in your client when the alpha is enabled for your organization.
+
+This works in any MCP client – Claude Code, Claude Desktop, Cursor, Codex, Windsurf, VS Code, and others. Install with the [AI wizard](/docs/ai-engineering/ai-wizard) (`npx @posthog/wizard mcp add`) – see the [MCP server docs](/docs/model-context-protocol) for full setup instructions.
+
+<AlphaCallout />
+
+## Catalog-first routing
+
+With the semantic layer enabled, the MCP server changes how agents answer metric questions. For any named business measure or KPI – revenue, MRR, activation, retention, conversion, including breakdowns and comparisons of them – the agent:
+
+1. Searches `system.information_schema.metrics` for a matching governed metric
+2. If exactly one `approved`, non-drifted match exists, runs it with `data-catalog-metric-run`
+3. If several materially different approved matches exist, asks you which one and stops
+4. Otherwise falls back to raw queries – and labels the result **noncanonical**
+
+This routing takes precedence over the agent's generic query-writing behavior. The effect: governed definitions win by default, and you always know when a number is a one-off derivation instead.
+
+## Metric tools
+
+| Tool | What it does | Confirmation | Scopes |
+|------|--------------|--------------|--------|
+| `data-catalog-metric-run` | Runs a governed metric. Executable metrics return results, the compiled query, and a `posthog_url` deep link; markdown metrics return calculation steps in `instructions`. Accepts `date_from`/`date_to`/`interval` overrides (rejected for `HogQLQuery` metrics) and a `refresh` cache option. | – | `data_catalog:read`, `query:read` |
+| `data-catalog-metric-create` | Creates a metric, or refines the one already holding that name (upserts on `name`). Always lands `proposed`. The definition is an executable query or a `MarkdownDefinition`. | – | `data_catalog:write` |
+| `data-catalog-metric-update` | Updates a metric's fields. Editing an approved metric's definition resets it to `proposed`. | – | `data_catalog:write` |
+| `data-catalog-metric-approve` | Blesses a metric as canonical. Blocked while the metric is drifted from its source insight. | Typed "confirm" | `data_catalog_approval:write`, `data_catalog:read` |
+
+There's deliberately no "list metrics" tool: agents discover metrics with `execute-sql` over `system.information_schema.metrics` – see the [SQL reference](/docs/semantic-layer/query).
+
+## Certification tools
+
+| Tool | What it does | Confirmation | Scopes |
+|------|--------------|--------------|--------|
+| `data-catalog-certification-propose` | Proposes a trust mark on a warehouse table or view. Address the target by id or by name – an ambiguous name returns the candidate ids to pick from. | – | `data_catalog:write` |
+| `data-catalog-certification-certify` | Marks a table or view as `certified` (prefer this source). | Typed "confirm" | `data_catalog_approval:write`, `data_catalog:read` |
+| `data-catalog-certification-deprecate` | Marks a table or view as `deprecated` (avoid this source). | Typed "confirm" | `data_catalog_approval:write`, `data_catalog:read` |
+
+## Relationship tools
+
+| Tool | What it does | Confirmation | Scopes |
+|------|--------------|--------------|--------|
+| `data-catalog-relationship-propose` | Proposes a reviewed join between two warehouse tables, with confidence and sampling evidence (match rates, sample values). Proposals are deduped regardless of direction. | – | `data_catalog:write` |
+| `data-catalog-relationship-accept` | Promotes a proposal to a real [warehouse join](/docs/data-warehouse/join), after re-validating and probing it. | Typed "confirm" | `data_catalog_approval:write`, `data_catalog:read`, `query:read`, `warehouse_view:write` |
+| `data-catalog-relationship-reject` | Rejects a proposal. Permanent – the pair is never re-proposed. | Typed "confirm" | `data_catalog_approval:write`, `data_catalog:read` |
+
+## Example prompts
+
+Try these with your MCP-enabled agent:
+
+- `What governed metrics do we have around revenue?`
+- `Run the mrr metric for the last 6 months, monthly.`
+- `Create a semantic layer metric named weekly_active_teams from the "Active teams" insight.`
+- `Show me the compiled query for weekly_active_teams, then approve it.`
+- `Certify stripe_charges as the source of truth for payments, and deprecate payments_backup with a note that it's stale.`
+- `Propose a relationship between orders and stripe_customers on customer_id, with sampling evidence.`
+- `List every proposed metric waiting for review.`

--- a/contents/docs/semantic-layer/metrics.mdx
+++ b/contents/docs/semantic-layer/metrics.mdx
@@ -1,0 +1,110 @@
+---
+title: Metrics
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+A metric is a named, governed answer to a business question: one definition, one owner, one source of truth. Instead of every AI session (and every teammate) deriving "MRR" or "activation rate" from scratch, you define it once in the semantic layer and everything downstream runs the same definition.
+
+<AlphaCallout />
+
+## Anatomy of a metric
+
+| Field | What it is |
+|-------|------------|
+| `name` | Identifier-safe handle (`mrr`, `weekly_active_teams`), unique per project. **Write-once and reserved forever**, even after deletion. |
+| `display_name` | Human-friendly label. Mutable, unlike `name`. |
+| `description` | What the metric means and how to interpret it. This is load-bearing text – agents read it to decide whether the metric answers a question. |
+| `unit` | Unit of the result, e.g. `usd`, `percent`, `cents`. |
+| `owner` | The human accountable for the metric. |
+| `definition` | The machine-readable query, or markdown calculation steps. Omit it for a name-and-description-only stub. |
+| `definition_kind` | Query kind of the definition (`HogQLQuery`, `TrendsQuery`, ...), or null for a stub. |
+| `status` | Lifecycle state: `proposed` or `approved`. |
+| `is_drifted` | Whether the definition has drifted from its source insight. Computed at read time, never stored. |
+| `source_insight_short_id` | Set when the metric was created from an insight – the insight's query is snapshotted server-side. Mutually exclusive with `definition`. |
+| `created_source`, `ai_model`, `confidence`, `reasoning` | Provenance: whether a human (`user`) or an agent (`ai_generated`) authored it, and if an agent did, which model, how confident it was, and why. |
+
+<CalloutBox icon="IconInfo" title="Why names are reserved forever" type="fyi">
+
+Agents and integrations store metric names and call them later. If a deleted name could be reused, a stored reference to `mrr` could silently start meaning something else. So names are write-once: deleting a metric retires its name permanently. Treat naming a metric like naming an API route.
+
+</CalloutBox>
+
+## Two kinds of definition
+
+**Executable query.** A `HogQLQuery`, `TrendsQuery`, `FunnelsQuery`, or a bare event node, executed by the same query runner that powers insights – running the metric gives identical results to running the query directly. This is the kind to prefer: deterministic, auditable, and overridable with date ranges at run time.
+
+```json
+{
+  "kind": "HogQLQuery",
+  "query": "SELECT sum(amount) AS mrr FROM stripe_subscriptions WHERE status = 'active'"
+}
+```
+
+**Markdown definition.** Numbered steps that an agent follows to produce the number, for calculations that can't be one query or that need judgment:
+
+```json
+{
+  "kind": "MarkdownDefinition",
+  "markdown": "1. Sum MRR of customers active both this month and 12 months ago.\n2. Divide by those customers' MRR 12 months ago.\n3. Exclude internal and test accounts (email ends in @posthog.com)."
+}
+```
+
+Running a markdown metric doesn't execute anything – the steps come back in the `instructions` field and the agent computes the number, still anchored to the one governed procedure.
+
+Use an executable definition whenever the metric is deterministic. Reach for markdown only when the calculation genuinely can't be a single query.
+
+## Lifecycle: proposed → approved
+
+Every metric lands as `proposed` – whether a human or an agent created it, and even when an existing name is refined (`data-catalog-metric-create` upserts on `name`). A human then approves it, which requires typing "confirm" and the `data_catalog_approval` scope.
+
+Editing an approved metric's definition resets it to `proposed`. A metric is never silently redefined: any change to what the number means goes back through a human.
+
+## Drift
+
+Drift is how the semantic layer notices when a definition goes stale behind your back.
+
+When a metric is created from an insight (via `source_insight_short_id`), PostHog snapshots the insight's query. From then on, `is_drifted` is computed at read time by comparing the snapshot to the insight's current query. Nothing is stored or scanned in the background – drift is always evaluated against the live insight.
+
+A worked example:
+
+1. You create a `signups` metric from your "Weekly signups" insight and approve it.
+2. A teammate edits the insight to exclude a country.
+3. The metric now reports `is_drifted: true`. The approved snapshot no longer matches the insight it came from.
+4. Runs still work, but results are labeled noncanonical, and re-approval is blocked until a human resolves the drift – either update the metric to re-snapshot the new query, or unlink it from the insight.
+
+<CalloutBox icon="IconWarning" title="The canonical rule" type="caution">
+
+A result is canonical only when `status = 'approved'` and `is_drifted = false`. Agents never present a `proposed` or drifted metric's result as canonical – they label it noncanonical instead.
+
+</CalloutBox>
+
+## Running a metric
+
+Agents run metrics with the [`data-catalog-metric-run`](/docs/semantic-layer/mcp-tools#metric-tools) MCP tool. Every run returns a normalized envelope:
+
+| Field | What it is |
+|-------|------------|
+| `status` | Lifecycle state of the metric that produced the results. |
+| `is_drifted` | Whether the definition has drifted. Check this and `status` before trusting the result. |
+| `unit` | Unit of the result. |
+| `kind` | Query kind that was executed. |
+| `results` | The query results, for an executable metric. Null for a markdown metric. |
+| `compiled_query` | The compiled HogQL, when available. |
+| `posthog_url` | Deep link to open the exact query in PostHog – the audit trail for any number an agent hands you. |
+| `instructions` | For a markdown metric, the calculation steps to follow. Null for an executable metric. |
+
+Runs accept optional overrides: `date_from` (e.g. `-7d`), `date_to`, and `interval` reshape the query window without touching the definition. Overrides are rejected for `HogQLQuery` metrics, whose window is fixed in the SQL. A `refresh` parameter controls caching with the same semantics as insights (`blocking`, `async`, `force_blocking`, and friends) – by default a fresh cache hit is served and stale results are recalculated.
+
+## Naming metrics well
+
+Names are an API contract. Choose accordingly:
+
+- Lowercase, terse, unambiguous: `mrr`, `nrr`, `weekly_active_teams`
+- No versions or qualifiers in the name – that's what `description` and the lifecycle are for
+- If two teams mean different things by "activation", make two metrics with honest names (`activation_signup`, `activation_first_insight`) rather than one contested one
+
+The description does the heavy lifting for discovery: agents match questions against it, so write it the way a teammate would ask the question.

--- a/contents/docs/semantic-layer/query.mdx
+++ b/contents/docs/semantic-layer/query.mdx
@@ -1,0 +1,88 @@
+---
+title: Query the semantic layer with SQL
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+The whole semantic layer is queryable with [SQL](/docs/data-warehouse/query) through `system.information_schema` – from the SQL editor in PostHog or the `execute-sql` MCP tool. This is also how agents discover metrics: there's no "list metrics" tool by design, just these tables.
+
+<AlphaCallout />
+
+## system.information_schema.metrics
+
+One row per metric in your project:
+
+| Column | Type | What it is |
+|--------|------|------------|
+| `id` | String | The metric's id. |
+| `name` | String | Write-once identifier, e.g. `mrr`. |
+| `display_name` | Nullable string | Human-friendly label. |
+| `description` | String | What the metric means – the text agents match questions against. |
+| `unit` | Nullable string | e.g. `usd`, `percent`. |
+| `status` | String | `proposed` or `approved`. |
+| `is_drifted` | Boolean | Whether the definition has drifted from its source insight. Computed at read time. |
+| `definition` | Nullable string | The machine-readable definition, or null for a stub. |
+| `definition_kind` | Nullable string | `HogQLQuery`, `TrendsQuery`, `MarkdownDefinition`, ... |
+| `owner` | Nullable string | Email of the accountable human. |
+| `confidence` | Nullable float | AI author's confidence, 0-1, when AI-authored. |
+| `reasoning` | Nullable string | AI author's reasoning, as review context. |
+| `source_insight_short_id` | Nullable string | The insight the metric was created from, if any. |
+| `last_run_at` | Nullable string | When the metric last ran. |
+| `created_at` | String | When the metric was created. |
+
+Metrics whose definitions reference tables you don't have access to are hidden from your results.
+
+### Find a metric
+
+```sql
+SELECT name, display_name, description, status, is_drifted
+FROM system.information_schema.metrics
+WHERE name ILIKE '%mrr%' OR description ILIKE '%revenue%'
+```
+
+### List everything canonical
+
+```sql
+SELECT name, display_name, unit, owner
+FROM system.information_schema.metrics
+WHERE status = 'approved' AND is_drifted = false
+```
+
+### The review queue
+
+```sql
+SELECT name, display_name, confidence, reasoning
+FROM system.information_schema.metrics
+WHERE status = 'proposed'
+```
+
+<CalloutBox icon="IconWarning" title="Check before you trust" type="caution">
+
+A result is canonical only when `status = 'approved'` and `is_drifted = false`. Always check both columns before treating a metric – or its output – as the source of truth.
+
+</CalloutBox>
+
+## Certifications in system.information_schema.tables
+
+Each table row carries its trust mark in the `certification` column (`certified`, `deprecated`, or null):
+
+```sql
+SELECT table_name, table_type, description, certification
+FROM system.information_schema.tables
+WHERE certification IS NOT NULL
+```
+
+## Relationships in system.information_schema.relationships
+
+Relationships lists every joinable path between tables. Rows that came from an accepted catalog proposal carry the reviewed `confidence` and `reasoning`:
+
+```sql
+SELECT source_table, source_column, target_table, target_column, confidence, reasoning
+FROM system.information_schema.relationships
+WHERE confidence IS NOT NULL
+```
+
+For the rest of the `information_schema` surface – columns, data types, statistics – see the [data warehouse SQL docs](/docs/data-warehouse/query).

--- a/contents/docs/semantic-layer/start-here.mdx
+++ b/contents/docs/semantic-layer/start-here.mdx
@@ -1,0 +1,87 @@
+---
+title: Getting started with the semantic layer
+hideRightSidebar: true
+contentMaxWidthClass: max-w-5xl
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+In this guide you'll take a metric that only exists in people's heads – MRR – and turn it into a governed definition every AI session agrees on. The whole thing is one agent conversation: the agent proposes, you approve, and from then on every client that asks about MRR gets the same number.
+
+<AlphaCallout />
+
+## Prerequisites
+
+- The semantic layer alpha enabled for your organization
+- The [PostHog MCP server](/docs/model-context-protocol) connected to your agent (Claude Code, Cursor, Claude Desktop, or any MCP client)
+- An API key with the `data_catalog` scope – add `data_catalog_approval` too, since you'll approve a metric in this guide (see [governance](/docs/semantic-layer/governance#api-scopes) for why they're separate)
+- Some revenue-ish data in your [data warehouse](/docs/data-warehouse), like a synced `stripe_subscriptions` table
+
+## Step 1: See the problem
+
+Start by asking the question the way you would today:
+
+> **You:** What's our MRR?
+>
+> **Agent:** There's no governed metric for MRR in your semantic layer, so I'll derive it myself. _Runs `execute-sql` over `stripe_subscriptions`..._ Summing active subscription amounts, your MRR is **$142,300**. Note that this is a **noncanonical** number – I picked the tables and the definition myself, and a different session might pick differently.
+
+That last sentence is the problem. Ask again tomorrow, in a different tool, or with slightly different wording, and the agent might exclude trials, include one-time charges, or use a different table entirely.
+
+## Step 2: Propose the metric
+
+Instead of letting every session re-derive MRR, catalog it:
+
+> **You:** Create a semantic layer metric named `mrr` for monthly recurring revenue: the sum of active subscription amounts in `stripe_subscriptions`, in USD.
+>
+> **Agent:** _Calls `data-catalog-metric-create`..._ Created the metric `mrr` with status `proposed`. It's recorded as AI-generated, with my model, confidence, and reasoning attached so a reviewer can see how I built it. It won't be treated as canonical until a human approves it.
+
+The metric now exists, but it has no authority yet. Every AI-created object in the catalog lands as `proposed` – that's the "AI generates" half of the model.
+
+<CalloutBox icon="IconInfo" title="Names are write-once" type="fyi">
+
+A metric's `name` is an identifier, like an API route: lowercase, no spaces, unique in your project. It can never be renamed or reused – even after deletion, the name stays reserved so a stored reference never silently changes meaning. Pick `mrr`, not `monthly_recurring_revenue_v2_final`. The `display_name` is the human label and stays editable.
+
+</CalloutBox>
+
+## Step 3: Review and approve
+
+Now the "a human owns" half. Look at what the agent proposed before you sign it:
+
+> **You:** Show me the compiled query for the `mrr` metric.
+>
+> **Agent:** _Calls `data-catalog-metric-run`..._ Here's the compiled HogQL – it sums `amount` over `stripe_subscriptions` where the subscription status is active. The response includes a `posthog_url` deep link if you want to inspect or tweak it in the SQL editor.
+>
+> **You:** Looks right. Approve the `mrr` metric.
+>
+> **Agent:** _Calls `data-catalog-metric-approve`._ About to approve metric 'mrr' as a canonical, human-vouched metric. Reply 'confirm' to proceed.
+>
+> **You:** confirm
+>
+> **Agent:** Done – `mrr` is now `approved`.
+
+The typed "confirm" is deliberate: it's the human signature that makes a metric canonical, and an agent can't autocomplete it. Approval also requires the `data_catalog_approval` scope, so a key without it can propose but never promote.
+
+## Step 4: Use it everywhere
+
+Open a new session – or a completely different MCP client – and ask a real question:
+
+> **You:** What was MRR last quarter, month by month?
+>
+> **Agent:** _Searches `system.information_schema.metrics`, finds one approved, non-drifted match: `mrr`. Calls `data-catalog-metric-run` with `date_from`, `date_to`, and a monthly `interval`._ Using your governed `mrr` metric: April **$128,400**, May **$135,100**, June **$142,300**. This is the canonical definition, approved by you – and here's the `posthog_url` deep link if you want to open the exact query in PostHog.
+
+This is the payoff. The agent didn't reinvent MRR – it found the approved metric, ran it with your date range, and labeled the result canonical. Every session, every tool, every teammate now gets the same answer, and the [deep link](/docs/semantic-layer/metrics#running-a-metric) lets anyone audit exactly what ran.
+
+## What you built
+
+One conversation gave you the full trust chain:
+
+1. **AI proposed** – the agent drafted `mrr` and recorded its reasoning
+2. **You approved** – with a typed "confirm" that only a human can give
+3. **Everyone consumes** – every agent session routes MRR questions through the one governed definition
+
+From here:
+
+- [Metrics](/docs/semantic-layer/metrics) – definition kinds, the lifecycle, and what happens when a metric drifts
+- [Certifications and relationships](/docs/semantic-layer/certifications-and-relationships) – govern the tables your answers come from, not just the answers
+- [MCP tools](/docs/semantic-layer/mcp-tools) – the full tool reference and more example prompts

--- a/contents/docs/semantic-layer/troubleshooting.mdx
+++ b/contents/docs/semantic-layer/troubleshooting.mdx
@@ -1,0 +1,60 @@
+---
+title: Troubleshooting and limitations
+sidebar: Docs
+showTitle: true
+---
+
+import AlphaCallout from './_snippets/alpha-callout'
+
+<AlphaCallout />
+
+## Have a question? Ask PostHog AI
+
+<AskAIInput placeholder="Type your question and hit enter..." />
+
+## I don't see the semantic layer tools in my MCP client
+
+The alpha is enabled per organization. If the `data-catalog-*` tools are missing:
+
+1. Confirm your organization is in the alpha – [contact support](https://app.posthog.com/home#supportModal) to request access.
+2. Reconnect or restart your MCP client after enablement; clients cache the tool list.
+3. Check your API key has the `data_catalog` scope.
+
+Similarly, if `system.information_schema.metrics` raises "Unknown table", the alpha isn't enabled for your organization yet.
+
+## My agent can't approve a metric
+
+Three causes, in order of likelihood:
+
+1. **Missing scope.** Approval needs `data_catalog_approval` on the API key – `data_catalog` alone can propose but never promote. This split is deliberate; see [governance](/docs/semantic-layer/governance#api-scopes).
+2. **The metric is drifted.** Approval is blocked while `is_drifted` is true. Resolve the drift first (below), then approve.
+3. **You didn't type "confirm".** Approval only executes after you reply with the literal word "confirm". The agent can't do it for you – that's the point.
+
+## Why is my metric drifted?
+
+The metric was created from an insight, and that insight's query has changed since the snapshot (or the insight was deleted). To resolve:
+
+- **Keep the new definition:** update the metric to re-snapshot the insight's current query, then re-approve.
+- **Keep the old definition:** unlink the metric from the insight (set `source_insight_short_id` to null) so it stands on its own definition, then re-approve.
+
+Compare the metric's `compiled_query` (from a run) with the insight's current query to see what changed. Until it's re-approved, results are labeled noncanonical.
+
+## I deleted a metric but can't reuse the name
+
+By design. Names are write-once and stay reserved after deletion, so a stored reference to a name can never silently point at a different definition. Pick a new name.
+
+## An agent keeps proposing a join we don't want
+
+Reject the proposal with `data-catalog-relationship-reject`. Rejection persists forever and the pair is never re-proposed – in either direction.
+
+The flip side: **rejection has no undo** in the alpha. If you rejected a proposal by mistake and need the join anyway, create it directly as a [data warehouse join](/docs/data-warehouse/join) – the catalog's rejection only suppresses re-proposals, not manual joins.
+
+## Where's the UI?
+
+There isn't one yet. During the alpha the semantic layer is MCP tools and SQL only – no catalog page in the app. Also worth knowing:
+
+- Tool names and behavior may change between releases
+- The alpha is enabled per organization, not per user or project
+- `last_run_at` is updated at most every 30 minutes, so treat it as approximate
+
+Feedback on any of this shapes what the beta looks like – [tell us what's missing](https://app.posthog.com/home#supportModal).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5929,6 +5929,80 @@ export const docsMenu = {
             ],
         },
         {
+            name: 'Semantic layer',
+            url: '/docs/semantic-layer',
+            color: 'purple',
+            icon: 'IconBook',
+            description: 'Govern your metrics, certify your tables, and give every AI agent the same source of truth',
+            badge: {
+                title: 'Alpha',
+                className: 'uppercase !bg-red/10 !text-red !dark:text-white !dark:bg-red/50',
+            },
+            children: [
+                {
+                    name: 'Semantic layer',
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/semantic-layer',
+                    icon: 'IconHome',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'Getting started',
+                },
+                {
+                    name: 'Start here',
+                    url: '/docs/semantic-layer/start-here',
+                    icon: 'IconListCheck',
+                    color: 'orange',
+                    featured: true,
+                },
+                {
+                    name: 'Concepts',
+                },
+                {
+                    name: 'Metrics',
+                    url: '/docs/semantic-layer/metrics',
+                    icon: 'IconGraph',
+                    color: 'blue',
+                },
+                {
+                    name: 'Certifications and relationships',
+                    url: '/docs/semantic-layer/certifications-and-relationships',
+                    icon: 'IconShield',
+                    color: 'purple',
+                },
+                {
+                    name: 'Governance',
+                    url: '/docs/semantic-layer/governance',
+                    icon: 'IconLock',
+                    color: 'red',
+                },
+                {
+                    name: 'Reference',
+                },
+                {
+                    name: 'MCP tools',
+                    url: '/docs/semantic-layer/mcp-tools',
+                    icon: 'IconSparkles',
+                    color: 'purple',
+                },
+                {
+                    name: 'SQL reference',
+                    url: '/docs/semantic-layer/query',
+                    icon: 'IconCode',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'Troubleshooting',
+                    url: '/docs/semantic-layer/troubleshooting',
+                    icon: 'IconQuestion',
+                    color: 'gray',
+                },
+            ],
+        },
+        {
             name: 'AI Observability',
             url: '/docs/ai-observability',
             color: '[#681291]',


### PR DESCRIPTION
## Changes

Net-new public docs section for the **semantic layer** (data catalog) alpha at `/docs/semantic-layer` – 8 pages plus a reusable alpha callout snippet:

- **Overview** – the "same question, three tools, three numbers" problem, the three primitives (metrics, table certifications, relationship proposals), the two alpha surfaces (MCP + SQL), and the trust model
- **Start here** – a getting-started tutorial told as one agent conversation: propose `mrr` → review → approve with the typed "confirm" → every future session returns the same canonical number
- **Metrics** – anatomy, executable vs markdown definitions, `proposed` → `approved` lifecycle, drift, the run envelope, naming guidance
- **Certifications and relationships** – trust marks on warehouse tables, evidence-backed join proposals, permanent rejection
- **Governance** – "AI generates, a human owns": lifecycle table, typed confirmations, `data_catalog` vs `data_catalog_approval` scopes, provenance, team workflow
- **MCP tools** – hand-written reference for the 10 flag-gated `data-catalog-*` tools (they don't appear in the auto-generated tools page), catalog-first routing contract, example prompts
- **SQL reference** – `system.information_schema.metrics` / `.tables` / `.relationships`
- **Troubleshooting** – honest alpha limitations (per-org flag, no UI, no rejection undo, reserved names)

Also:

- Registers the section in `src/navs/index.js` next to Data Warehouse with an **Alpha** badge
- Cross-links from the MCP overview, MCP tools reference, and the data warehouse join page

No screenshots: the pages are text/MDX only – there's no product UI in the alpha, so the docs use agent-conversation transcripts instead.

Notes for reviewers:

- Every tool name, scope, status value, and `information_schema` column was verified against monorepo source (`products/data_catalog/mcp/tools.yaml`, the DRF serializers, `posthog/hogql/database/schema/information_schema.py`)
- The REST API is intentionally undocumented – the customer-facing alpha surfaces are MCP tools and SQL only
- The canonical rule (`status = 'approved'` and `is_drifted = false`) appears verbatim on the overview, metrics, and SQL pages since these docs will be read by agents as well as humans

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build (all 8 pages return 200 on the preview with the alpha callout rendered)
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved – all net-new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
