### PR TITLE
docs(error-tracking): document the Expo plugin dotenvFile option for React Native source map uploads

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/react-native.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/react-native.mdx
@@ -111,6 +111,7 @@ The plugin accepts the following options:
 | --- | --- | --- | --- |
 | `disableSandboxing` | `boolean` | `true` | iOS only. When `true`, sets `ENABLE_USER_SCRIPT_SANDBOXING=NO` on your main app target's Xcode build configurations during `expo prebuild`. This lets the source map upload script read `.git/` (for release metadata) and lets stock Expo projects build without manually declaring input/output files on every script phase. |
 | `skipOnConflict` | `boolean` | `false` | Adds `--skip-on-conflict` to JavaScript source map uploads on iOS and Android. Use this when the same build can upload the same source maps more than once and you want duplicate uploads to be skipped instead of failing. Requires `posthog-react-native` 4.49.1 or later. When `uploadNativeSymbols` is enabled, it also applies to native iOS dSYM uploads: a build whose dSYM already exists in PostHog with different content skips the upload and keeps the existing symbols instead of failing. The dSYM behavior requires `posthog-react-native` 4.56.1 or later, `posthog-ios` 3.64.7 or later, and `posthog-cli` 0.7.12 or later. |
+| `dotenvFile` | `string` | – | Path to a dotenv file containing your `POSTHOG_CLI_*` credentials (API key, project ID, optional host), relative to the project root or absolute. During `expo prebuild` the path is wired into every upload hook as `POSTHOG_CLI_DOTENV_FILE` — an Xcode build setting on iOS and a `posthog.dotenvFile` entry in `android/gradle.properties` on Android — so the JavaScript source map, dSYM, and ProGuard/R8 mapping uploads all read credentials from the file regardless of how the native build is started. Real environment variables take precedence and a missing file only logs a warning, so the same config works unchanged in CI. Requires `posthog-react-native` 4.60.0 or later and `posthog-cli` 0.8.4 or later (older CLIs ignore the variable). |
 
 Example opting out of the sandbox change:
 
@@ -146,6 +147,25 @@ Example skipping duplicate JavaScript source map uploads:
     ]
   }
 }
+```
+
+Example reading CLI credentials from a gitignored `.env` file at build time:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["posthog-react-native/expo", { "dotenvFile": ".env" }]
+    ]
+  }
+}
+```
+
+```bash file=.env
+POSTHOG_CLI_API_KEY=phx_your_personal_api_key
+POSTHOG_CLI_PROJECT_ID=12345
+# EU Cloud only
+POSTHOG_CLI_HOST=https://eu.posthog.com
 ```
 
 2. Android: Update the `/android/app/build.gradle` file from your app's root directory so that it looks like this:
@@ -207,6 +227,8 @@ Symbolicated native crashes need all three of these working together:
 ### Prerequisites
 
 Both platforms upload through `posthog-cli`, which must be installed and authenticated – the same setup covered in the **Download CLI** and **Authenticate** steps above. In CI/CD builds (such as EAS Build), set the `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` environment variables (and `POSTHOG_CLI_HOST` for EU). See [authenticating the CLI](/docs/error-tracking/upload-source-maps/cli) for the full list.
+
+For local builds, the easiest way to supply these credentials is the `dotenvFile` plugin option described in the **Upload** step — it covers the native symbol uploads on both platforms too. On bare React Native, you get the same behavior by adding `posthog.dotenvFile=../.env` to `android/gradle.properties` (relative paths resolve against the `android/` directory; the mapping upload needs `posthog-android-gradle-plugin` 1.4.0 or later) and, on iOS, defining a `POSTHOG_CLI_DOTENV_FILE` build setting (for example `$(SRCROOT)/../.env`) on your app target.
 
 <Tab.Group tabs={['Expo', 'Bare React Native']}>
 <Tab.List>
@@ -294,7 +316,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.posthog:posthog-android-gradle-plugin:1.2.0")
+        classpath("com.posthog:posthog-android-gradle-plugin:1.4.0")
     }
 }
 ```


### PR DESCRIPTION
## Changes

[posthog-react-native 4.60.0](https://github.com/PostHog/posthog-js/pull/4219) added a `dotenvFile` option to the `posthog-react-native/expo` config plugin: point it at a dotenv file with `POSTHOG_CLI_*` credentials and `expo prebuild` wires the path into every upload hook as `POSTHOG_CLI_DOTENV_FILE` — an Xcode build setting on iOS, a `posthog.dotenvFile` gradle property on Android — so the Hermes source map, dSYM, and R8 mapping uploads all read credentials from a gitignored `.env` regardless of how the native build is started. Env vars still take precedence and a missing file is only a warning, so the same config works unchanged in CI.

This PR documents it in the React Native source maps upload page:

- Adds `dotenvFile` to the Expo plugin options table (with the version floors: `posthog-react-native` >= 4.60.0, `posthog-cli` >= 0.8.4) plus a usage example with a sample `.env`.
- Notes the local-build credentials path in the **Native crash symbolication** prerequisites, including the bare React Native equivalents (`posthog.dotenvFile` in `android/gradle.properties`, a `POSTHOG_CLI_DOTENV_FILE` build setting in Xcode).
- Bumps the bare RN gradle plugin classpath example to 1.4.0 — the release that reads `posthog.dotenvFile`, and the version the Expo plugin now injects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
