### PR TITLE
Add YouTube and Editorial team goals

### DIFF
--- a/contents/teams/editorial/objectives.mdx
+++ b/contents/teams/editorial/objectives.mdx
@@ -72,12 +72,12 @@
 
 **We'll know we're successful when:** We ship the newsletter, share the graphs on social, and have a good idea what it takes to produce one of these. 
 
-## James' social leadership
+## James social
 
 **Owner:** <TeamMember name="Andy Vandervell" photo />
 
-**Motivation:** Make James famous for self-driving.
+**Motivation:** Make PostHog famous for self-driving through James
 
-**What we'll ship:** Two posts a week from James sharing how we think about self-driving and our post-experts strategy.
+**What we'll ship:** Two posts a week from James sharing how we think about self-driving, our strategy and ideas generally.
 
-**We'll know we're successful when:** Posts consistently perform well and we see cut-through — people talking about PostHog off the back of them.
+**We'll know we're successful when:** Posts consistently perform well and we see cut-through — i.e. people talking about PostHog off the back of them.

--- a/contents/teams/editorial/objectives.mdx
+++ b/contents/teams/editorial/objectives.mdx
@@ -71,3 +71,13 @@
 **What we'll ship:** A data-heavy newsletter leveraging our first-party data that acts as a sort of minimum viable brand study. It should include some pretty graphs. 
 
 **We'll know we're successful when:** We ship the newsletter, share the graphs on social, and have a good idea what it takes to produce one of these. 
+
+## James' social leadership
+
+**Owner:** <TeamMember name="Andy Vandervell" photo />
+
+**Motivation:** Make James famous for self-driving.
+
+**What we'll ship:** Two posts a week from James sharing how we think about self-driving and our post-experts strategy.
+
+**We'll know we're successful when:** Posts consistently perform well and we see cut-through — people talking about PostHog off the back of them.

--- a/contents/teams/youtube/objectives.mdx
+++ b/contents/teams/youtube/objectives.mdx
@@ -62,3 +62,13 @@
 - **We'll know we're successful when:** Views, subscribers and watch time are growing Month-on-Month.
 
 </details>
+
+<details>
+<summary>Converting editorial work into scripts</summary>
+
+- **Owner:** <TeamMember name="Andy Vandervell" photo />
+- **Motivation:** Script writing is a blocker for Dennis. Help him by delivering shoot-ready scripts using our existing content.
+- **What we'll ship:** Our best content turned into scripts Dennis can iterate on.
+- **We'll know we're successful when:** We have a surplus of ready scripts for Dennis to shoot, and videos based on these scripts perform well.
+
+</details>


### PR DESCRIPTION
Adds one new goal to each of two team goals pages.

### YouTube — `contents/teams/youtube/objectives.mdx`
**Converting editorial work into scripts** (Owner: Andy Vandervell)
- Motivation: Script writing is a blocker for Dennis. Help him by delivering shoot-ready scripts using our existing content.
- What we'll ship: Our best content turned into scripts Dennis can iterate on.
- Success: A surplus of ready scripts for Dennis to shoot, and videos based on these scripts perform well.

### Editorial — `contents/teams/editorial/objectives.mdx`
**James social** (Owner: Andy Vandervell)
- Motivation: Make PostHog famous for self-driving through James.
- What we'll ship: Two posts a week from James sharing how we think about self-driving, our strategy and ideas generally.
- Success: Posts consistently perform well and we see cut-through — i.e. people talking about PostHog off the back of them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*