### PR TITLE
Replace em dashes with en dashes in Comparisons blog posts

### DIFF
--- a/contents/blog/best-activecampaign-alternatives.mdx
+++ b/contents/blog/best-activecampaign-alternatives.mdx
@@ -37,7 +37,7 @@ This means it's not only an alternative to ActiveCampaign but also tools like [A
 
 #### Key features
 
-- **Workflows:** Automate messaging and multi-step automations based on user behavior — trigger emails, SMS, Slack messages, or webhooks when users complete (or don't complete) key actions.
+- **Workflows:** Automate messaging and multi-step automations based on user behavior – trigger emails, SMS, Slack messages, or webhooks when users complete (or don't complete) key actions.
 
 - **CDP:** Ingest data from anywhere, transform it, enrich person profiles, and send it to other tools or platforms in real-time or via batch export.
 

--- a/contents/blog/best-heap-alternatives.mdx
+++ b/contents/blog/best-heap-alternatives.mdx
@@ -105,7 +105,7 @@ You can also [create and label events using the PostHog toolbar](/tutorials/how-
 - Both include product analytics with funnels, retention charts, user paths, and cohorts.
 - Both support heatmaps for understanding where users click and scroll.
 - Both support group analytics for account-level analysis in B2B products.
-- Both offer data warehouse exports — Heap Connect syncs to Snowflake, BigQuery, Redshift, and S3; PostHog exports to S3, BigQuery, Snowflake, and Redshift via batch exports.
+- Both offer data warehouse exports – Heap Connect syncs to Snowflake, BigQuery, Redshift, and S3; PostHog exports to S3, BigQuery, Snowflake, and Redshift via batch exports.
 
 </details>
 

--- a/contents/blog/best-hotjar-alternatives.mdx
+++ b/contents/blog/best-hotjar-alternatives.mdx
@@ -814,7 +814,7 @@ Yes. PostHog includes [heatmaps](/heatmaps) that visualize clicks (including rag
 
 The top session replay tools in 2026 include:
 
-- **[PostHog](/session-replay)** (best all-in-one for engineering teams — replays integrated with analytics, feature flags, and error tracking)
+- **[PostHog](/session-replay)** (best all-in-one for engineering teams – replays integrated with analytics, feature flags, and error tracking)
 - **Microsoft Clarity** (best free option with unlimited recordings)
 - **Mouseflow** (best like-for-like Hotjar replacement with form analytics)
 - **Smartlook** (best for mobile-first apps with native rendering and crash reports)

--- a/contents/blog/best-mobile-app-ab-testing-tools.mdx
+++ b/contents/blog/best-mobile-app-ab-testing-tools.mdx
@@ -427,13 +427,13 @@ Unlike web A/B testing where you can deploy changes instantly, mobile experiment
 <details>
   <summary>What's the difference between client-side and server-side A/B testing?</summary>
 
-Both approaches make requests to a server to determine which variation a user sees — the difference is where that request happens.
+Both approaches make requests to a server to determine which variation a user sees – the difference is where that request happens.
 
 **Client-side testing** makes the request from the app or browser. It's easier to set up, but can cause "flicker" as the UI updates after the response comes back. Tools like **VWO** offer visual editors for this approach on web.
 
 **Server-side testing** makes the request from your backend (e.g. a Django or Node service) before sending anything to the client, which eliminates flicker. It's better for testing algorithms, pricing logic, API responses, and anything involving backend changes. Tools like **PostHog**, **Statsig**, and **LaunchDarkly** support this approach.
 
-Most mobile teams need server-side testing because mobile apps can't be updated instantly like websites — you need [feature flags](/docs/feature-flags) to control which variation users see without waiting for an app store review. You can also use techniques like [bootstrapping](/docs/feature-flags/bootstrapping) and [local evaluation](/docs/feature-flags/local-evaluation) to reduce latency and avoid flicker on the client side.
+Most mobile teams need server-side testing because mobile apps can't be updated instantly like websites – you need [feature flags](/docs/feature-flags) to control which variation users see without waiting for an app store review. You can also use techniques like [bootstrapping](/docs/feature-flags/bootstrapping) and [local evaluation](/docs/feature-flags/local-evaluation) to reduce latency and avoid flicker on the client side.
 
 </details>
 

--- a/contents/blog/best-mobile-app-analytics-tools.mdx
+++ b/contents/blog/best-mobile-app-analytics-tools.mdx
@@ -367,7 +367,7 @@ It's completely free to get started – no credit card required. Our [setup wiza
 <details>
   <summary>What is mobile app analytics?</summary>
 
-**Mobile app analytics** is the process of collecting, measuring, and analyzing user behavior data from iOS and Android applications. It helps product teams understand how users interact with their app — from which features get the most engagement to where users drop off in key flows. 
+**Mobile app analytics** is the process of collecting, measuring, and analyzing user behavior data from iOS and Android applications. It helps product teams understand how users interact with their app – from which features get the most engagement to where users drop off in key flows. 
 
 Most mobile analytics platforms track events (like button taps, screen views, and purchases), user properties (like device type, OS version, and location), and session data (like session length and frequency). Advanced platforms also include [session replay](/session-replay), [A/B testing](/experiments), and crash analytics to give teams a complete picture of the mobile experience.
 
@@ -385,9 +385,9 @@ Mobile analytics platforms typically track app-specific metrics like crash-free 
 <details>
   <summary>What's the difference between product analytics and marketing analytics for mobile apps?</summary>
 
-Product analytics focuses on what users do *inside* your app — which features they use, where they get stuck, how often they return, and what drives retention. Tools like **PostHog**, **Mixpanel**, and **Amplitude** excel here. 
+Product analytics focuses on what users do *inside* your app – which features they use, where they get stuck, how often they return, and what drives retention. Tools like **PostHog**, **Mixpanel**, and **Amplitude** excel here. 
 
-Marketing analytics (also called attribution or mobile measurement) focuses on how users *found* your app — which ad campaigns drove installs, what the cost per acquisition was, and which channels have the best ROI. **AppsFlyer** is the leading tool for this. 
+Marketing analytics (also called attribution or mobile measurement) focuses on how users *found* your app – which ad campaigns drove installs, what the cost per acquisition was, and which channels have the best ROI. **AppsFlyer** is the leading tool for this. 
 
 Most teams need both: marketing analytics to optimize acquisition spend, and product analytics to understand and improve the in-app experience.
 
@@ -398,14 +398,14 @@ Most teams need both: marketing analytics to optimize acquisition spend, and pro
 
 You need an MMP if you're running paid user acquisition campaigns and want to know which ads, networks, and creatives are driving installs and conversions. MMPs like **AppsFlyer** handle the complex work of attributing installs to specific campaigns across dozens of ad networks (Meta, Google, TikTok, etc.) while navigating iOS privacy restrictions like SKAdNetwork. 
 
-If you're not running paid campaigns or are relying primarily on organic growth, you can skip the MMP and focus on product analytics instead. Many teams use both — an MMP for acquisition data and a product analytics tool like **PostHog** for in-app behavior.
+If you're not running paid campaigns or are relying primarily on organic growth, you can skip the MMP and focus on product analytics instead. Many teams use both – an MMP for acquisition data and a product analytics tool like **PostHog** for in-app behavior.
 
 </details>
 
 <details>
   <summary>How do I choose between self-hosted and cloud-hosted analytics?</summary>
 
-Cloud-hosted analytics (like **Mixpanel**, **Amplitude**, or **PostHog** Cloud) is easier to set up and maintain — you just integrate the SDK and start tracking. Self-hosted analytics gives you complete control over your data, which matters for companies in regulated industries (healthcare, finance, government) or those with strict data residency requirements. 
+Cloud-hosted analytics (like **Mixpanel**, **Amplitude**, or **PostHog** Cloud) is easier to set up and maintain – you just integrate the SDK and start tracking. Self-hosted analytics gives you complete control over your data, which matters for companies in regulated industries (healthcare, finance, government) or those with strict data residency requirements. 
 
 **Countly** specializes in self-hosted deployments. The trade-off is that self-hosting requires infrastructure management and ongoing maintenance. For more options, see our guide to the [best GDPR-compliant analytics tools](/blog/best-gdpr-compliant-analytics-tools).
 
@@ -428,7 +428,7 @@ For most teams, starting with core product analytics (events, funnels, retention
 <details>
   <summary>How do iOS privacy changes (ATT, SKAdNetwork) affect mobile analytics?</summary>
 
-Apple's App Tracking Transparency (ATT) framework requires apps to ask permission before tracking users across other apps and websites. Most users opt out, which significantly impacts marketing attribution — you can no longer reliably track which ad drove an install for users who decline. 
+Apple's App Tracking Transparency (ATT) framework requires apps to ask permission before tracking users across other apps and websites. Most users opt out, which significantly impacts marketing attribution – you can no longer reliably track which ad drove an install for users who decline. 
 
 SKAdNetwork is Apple's privacy-preserving alternative that provides aggregate attribution data with limited granularity and delayed reporting. Product analytics (tracking behavior within your own app) is less affected since it relies on first-party data. However, cross-app user identification and some cohort analysis capabilities are limited. Tools like **AppsFlyer** and **Mixpanel** have built SKAdNetwork support to help marketers adapt to these restrictions.
 
@@ -446,7 +446,7 @@ The main considerations are SDK bloat (each SDK adds to your app size and can im
 <details>
   <summary>What's the best free mobile analytics tool?</summary>
 
-**Firebase** offers the most generous free tier — its analytics is completely free with no event limits. **PostHog**'s free tier includes 1 million events and 2,500 mobile session recordings per month. **Mixpanel** offers 1 million events per month free, including 10,000 session replays. **Countly** Lite is free and open-source if you self-host, though it lacks advanced features like funnels and retention. For pure marketing attribution, **AppsFlyer**'s Zero plan includes 12,000 lifetime conversions free.
+**Firebase** offers the most generous free tier – its analytics is completely free with no event limits. **PostHog**'s free tier includes 1 million events and 2,500 mobile session recordings per month. **Mixpanel** offers 1 million events per month free, including 10,000 session replays. **Countly** Lite is free and open-source if you self-host, though it lacks advanced features like funnels and retention. For pure marketing attribution, **AppsFlyer**'s Zero plan includes 12,000 lifetime conversions free.
 
 The best choice depends on which features matter most to your team.
 
@@ -455,7 +455,7 @@ The best choice depends on which features matter most to your team.
 <details>
   <summary>Which mobile app analytics tool has the best session replay?</summary>
 
-**PostHog** and **UXCam** both offer strong mobile session replay. **UXCam** is purpose-built for mobile and captures gestures like swipes, pinches, and rage taps with dedicated heatmaps. **PostHog** offers session replay as part of a broader platform that includes analytics, feature flags, and A/B testing — so you can jump from a funnel drop-off directly into the replays that show why users are leaving.
+**PostHog** and **UXCam** both offer strong mobile session replay. **UXCam** is purpose-built for mobile and captures gestures like swipes, pinches, and rage taps with dedicated heatmaps. **PostHog** offers session replay as part of a broader platform that includes analytics, feature flags, and A/B testing – so you can jump from a funnel drop-off directly into the replays that show why users are leaving.
 
 **Mixpanel** added session replay in 2024 with a server-side stitching feature that lets you view replays for backend events. **Amplitude** also added replay but it's limited to Growth and Enterprise plans.
 
@@ -466,7 +466,7 @@ For a detailed comparison, see our guide to the [best mobile app session replay 
 <details>
   <summary>How is PostHog different from other mobile analytics tools?</summary>
 
-**PostHog** is more than a mobile analytics tool. It gives developers full context by combining all the tools needed to build a successful product in one platform — with a single SDK for mobile.
+**PostHog** is more than a mobile analytics tool. It gives developers full context by combining all the tools needed to build a successful product in one platform – with a single SDK for mobile.
 
 - **All-in-one toolkit:** [Product analytics](/product-analytics), [web analytics](/web-analytics), [session replay](/session-replay), [feature flags](/feature-flags), [experiments](/experiments), [surveys](/surveys), [error tracking](/error-tracking), [logs](/logs), [workflows](/workflows), and more.
 - **Built for mobile:** Native iOS and Android SDKs with offline event queuing, gesture tracking, and mobile session replay

--- a/contents/blog/best-open-source-feature-flag-tools.md
+++ b/contents/blog/best-open-source-feature-flag-tools.md
@@ -259,7 +259,7 @@ It's completely free to get started – no credit card required. Our [setup wiza
 <details>
   <summary>What is the best free feature flag tool?</summary>
 
-- **PostHog** is the best option for product teams that want feature flags alongside [a full suite of developer tools](/products) in one platform — its free tier includes 1 million feature flag requests per month. 
+- **PostHog** is the best option for product teams that want feature flags alongside [a full suite of developer tools](/products) in one platform – its free tier includes 1 million feature flag requests per month. 
 - **GrowthBook** is the best choice for teams with a data warehouse – it's completely free to self-host with no limits. 
 - **Flipt** is the best choice if you want a tool that is 100% open source with no paid tiers at all. 
 
@@ -272,7 +272,7 @@ For more options beyond open source, check out our guide to the [best feature fl
 
 [Feature flags](/docs/feature-flags) let you toggle features on or off for specific users without deploying new code. [A/B testing](/docs/experiments) uses feature flags to randomly split users into groups (variants) and then measures which variant performs better against a goal metric. 
 
-In practice, most A/B testing tools — including **PostHog**, **GrowthBook**, and **FeatBit** – are built on top of a feature flagging engine. The distinction matters because tools like Unleash, Flagsmith, and Flipt are primarily feature flag tools that can be _used_ for basic split testing, while PostHog and GrowthBook provide end-to-end experimentation with built-in statistical analysis.
+In practice, most A/B testing tools – including **PostHog**, **GrowthBook**, and **FeatBit** – are built on top of a feature flagging engine. The distinction matters because tools like Unleash, Flagsmith, and Flipt are primarily feature flag tools that can be _used_ for basic split testing, while PostHog and GrowthBook provide end-to-end experimentation with built-in statistical analysis.
 
 To learn more, read our guide on [what is a feature flag (and how it compares to remote config and A/B testing)](/blog/what-is-a-feature-flag).
 

--- a/contents/blog/best-web-analytics-tools.mdx
+++ b/contents/blog/best-web-analytics-tools.mdx
@@ -384,7 +384,7 @@ That's why many modern tools pair pageviews with [events](/docs/product-analytic
 
 Yes, especially tools that rely entirely on client-side JavaScript. Privacy-first tools, server-side collection, or edge-based analytics (like Cloudflare's) tend to be more resilient, but no analytics setup is 100% immune. You can also [set up a reverse proxy](/docs/advanced/proxy) to route analytics through your own domain, or combine client-side and server-side tracking to fill in gaps.
 
-Even then, it's best to treat web analytics as directionally accurate and focus on trends and patterns — not exact counts.
+Even then, it's best to treat web analytics as directionally accurate and focus on trends and patterns – not exact counts.
 
 </details>
 
@@ -421,7 +421,7 @@ Watch for how tools measure usage. Some charge by pageviews, others by events, o
 <details>
   <summary>Do I need session replay with web analytics?</summary>
 
-Not always — but it's extremely useful when debugging issues or understanding drop-offs. Tools like **PostHog** link analytics directly to [session replay](/blog/best-session-replay-tools), so you can see exactly what users did instead of guessing from charts.
+Not always – but it's extremely useful when debugging issues or understanding drop-offs. Tools like **PostHog** link analytics directly to [session replay](/blog/best-session-replay-tools), so you can see exactly what users did instead of guessing from charts.
 
 </details>
 

--- a/contents/blog/posthog-vs-amplitude.mdx
+++ b/contents/blog/posthog-vs-amplitude.mdx
@@ -449,7 +449,7 @@ No. Amplitude does not offer error tracking. If you need error tracking alongsid
 <details>
 <summary>Does Amplitude have LLM observability?</summary>
 
-No. Amplitude does not offer LLM observability or analytics. PostHog includes [LLM observability](/docs/ai-observability) for tracking AI product usage, monitoring model performance, and analyzing costs—all connected to your existing user data.
+No. Amplitude does not offer LLM observability or analytics. PostHog includes [LLM observability](/docs/ai-observability) for tracking AI product usage, monitoring model performance, and analyzing costs–all connected to your existing user data.
 
 </details>
 
@@ -492,7 +492,7 @@ No. Amplitude does not offer LLM observability or analytics. PostHog includes [L
 - You don&apos;t have a data warehouse yet or want to simplify your stack
 - You want transparent, usage-based pricing
 
-PostHog provides a complete product analytics platform with warehouse capabilities built in. If you use PostHog as your integrated warehouse, data stays in PostHog and is accessible across many PostHog tools — eliminating the need to stitch multiple vendors together.
+PostHog provides a complete product analytics platform with warehouse capabilities built in. If you use PostHog as your integrated warehouse, data stays in PostHog and is accessible across many PostHog tools – eliminating the need to stitch multiple vendors together.
 
 </details>
 

--- a/contents/blog/posthog-vs-growthbook.mdx
+++ b/contents/blog/posthog-vs-growthbook.mdx
@@ -186,7 +186,7 @@ PostHog's [feature flag pricing](/pricing) is pay-per-request (and A/B tests use
 
 Like PostHog, GrowthBook is free to self-host. GrowthBook Cloud uses a seat-based model. The Starter plan is free for up to 3 users with basic features. The Pro plan is $40/user/month for up to 50 users and unlocks advanced statistics, the visual editor, CUPED, sequential testing, and more. 
 
-GrowthBook uses usage-based pricing for CDN requests — capped at 1M/month on Starter and 2M/month on Pro, with overage fees beyond that.
+GrowthBook uses usage-based pricing for CDN requests – capped at 1M/month on Starter and 2M/month on Pro, with overage fees beyond that.
 
 Features, like flag scheduling, permissions, custom fields, and the visual editor are only available on the GrowthBook Pro paid plan.
 

--- a/contents/blog/posthog-vs-launchdarkly.mdx
+++ b/contents/blog/posthog-vs-launchdarkly.mdx
@@ -151,7 +151,7 @@ As mentioned earlier, many of the security, approval, and workflow features that
 |---|---|---|
 | **Startup (1M requests/mo)** | **$0** (free tier) | Foundation plan depends on service connections and MAU. Example: ~5 connections + 5k MAU ≈ **$110/mo minimum** |
 | **Scaleup (10M requests/mo)** | **$460/mo** (1M free + 1M @ $0.0001 + 8M @ $0.000045) | Mid-size setup: ~20 connections + 25k MAU ≈ **$490/mo**, not counting Experimentation MAU |
-| **Enterprise (50M requests/mo)** | **$1,460/mo** (1M free + 1M @ $0.0001 + 8M @ $0.000045 + 40M @ $0.000025) | **Custom Enterprise pricing — contact sales** |
+| **Enterprise (50M requests/mo)** | **$1,460/mo** (1M free + 1M @ $0.0001 + 8M @ $0.000045 + 40M @ $0.000025) | **Custom Enterprise pricing – contact sales** |
 
 ### Reporting and analytics
 

--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -385,7 +385,7 @@ Many tools like **Sentry** offer both, while **PostHog** combines error tracking
 <details>
   <summary>Can error tracking tools work with serverless and edge functions?</summary>
 
-Yes. Modern error trackers support serverless and edge runtimes—including AWS Lambda, Vercel Edge Functions, and Cloudflare Workers. Both PostHog and Sentry provide SDKs and guides for these environments (for example, **Sentry**'s AWS Lambda and Cloudflare Workers guides; **PostHog**'s [Vercel](/docs/libraries/vercel) and [Cloudflare Workers](/docs/libraries/cloudflare-workers) docs). Configuration can differ from traditional servers because of cold starts, runtime differences (e.g., Edge runtimes), and execution/time limits imposed by the platforms.
+Yes. Modern error trackers support serverless and edge runtimes–including AWS Lambda, Vercel Edge Functions, and Cloudflare Workers. Both PostHog and Sentry provide SDKs and guides for these environments (for example, **Sentry**'s AWS Lambda and Cloudflare Workers guides; **PostHog**'s [Vercel](/docs/libraries/vercel) and [Cloudflare Workers](/docs/libraries/cloudflare-workers) docs). Configuration can differ from traditional servers because of cold starts, runtime differences (e.g., Edge runtimes), and execution/time limits imposed by the platforms.
 
 </details>
 

--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -385,7 +385,7 @@ Many tools like **Sentry** offer both, while **PostHog** combines error tracking
 <details>
   <summary>Can error tracking tools work with serverless and edge functions?</summary>
 
-Yes. Modern error trackers support serverless and edge runtimes–including AWS Lambda, Vercel Edge Functions, and Cloudflare Workers. Both PostHog and Sentry provide SDKs and guides for these environments (for example, **Sentry**'s AWS Lambda and Cloudflare Workers guides; **PostHog**'s [Vercel](/docs/libraries/vercel) and [Cloudflare Workers](/docs/libraries/cloudflare-workers) docs). Configuration can differ from traditional servers because of cold starts, runtime differences (e.g., Edge runtimes), and execution/time limits imposed by the platforms.
+Yes. Modern error trackers support serverless and edge runtimes – including AWS Lambda, Vercel Edge Functions, and Cloudflare Workers. Both PostHog and Sentry provide SDKs and guides for these environments (for example, **Sentry**'s AWS Lambda and Cloudflare Workers guides; **PostHog**'s [Vercel](/docs/libraries/vercel) and [Cloudflare Workers](/docs/libraries/cloudflare-workers) docs). Configuration can differ from traditional servers because of cold starts, runtime differences (e.g., Edge runtimes), and execution/time limits imposed by the platforms.
 
 </details>
 


### PR DESCRIPTION
## Changes

Replaces every em dash (—) with an en dash (–) in blog posts tagged `Comparisons`. 23 replacements across 11 files, all in body prose and one pricing-table cell — no code blocks or frontmatter touched.

**Why:** Because Andy hates them and I hate them too

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9AKT9NTY/p1784828224872099)*
