### PR TITLE
scrollbars get shy after a bit

### DIFF
--- a/src/components/RadixUI/ScrollArea.tsx
+++ b/src/components/RadixUI/ScrollArea.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ScrollArea as RadixScrollArea } from 'radix-ui'
 import { useHorizontalScrollFade, HorizontalScrollFades } from '../../hooks/useHorizontalScrollFade'
 
 interface ScrollAreaProps {
@@ -37,35 +38,35 @@ const ScrollArea = ({
             if (typeof viewportRef === 'function') {
                 viewportRef(node)
             } else if (viewportRef) {
-                ;(viewportRef as React.MutableRefObject<HTMLDivElement | null>).current = node
+                const mutableViewportRef = viewportRef as React.MutableRefObject<HTMLDivElement | null>
+                mutableViewportRef.current = node
             }
         },
         [viewportRef]
     )
 
     return (
-        <div
+        <RadixScrollArea.Root
+            type="scroll"
             data-scheme={dataScheme}
-            className={`relative overflow-hidden h-full flex-1 ${fullWidth ? 'max-w-screen' : ''} ${className}`}
+            className={`app-scroll-area relative overflow-hidden h-full flex-1 [&>div>div]:!block ${
+                fullWidth ? 'max-w-screen' : ''
+            } ${className}`}
             style={style}
         >
-            <div
+            <RadixScrollArea.Viewport
                 ref={setViewportRef}
-                // Kept for backwards-compatibility: many components locate the
-                // scrolling viewport via `.closest('[data-radix-scroll-area-viewport]')`
-                // (virtualization, scroll restoration, scroll-to-element, IO roots).
-                // This is now a native scroller, but the contract is preserved.
-                data-radix-scroll-area-viewport=""
-                className={`app-scroll-viewport size-full overflow-auto ${viewportClasses} ${
-                    fadeHeight ? `pb-${fadeHeight}` : ''
-                }`}
+                className={`app-scroll-viewport size-full ${viewportClasses} ${fadeHeight ? `pb-${fadeHeight}` : ''}`}
             >
-                {/* Inner wrapper mirrors the extra node Radix's Viewport used to
-                    render (min-width: 100%, block). Callers target it via
-                    descendant selectors like `[&>div>div]`, so the DOM nesting
-                    (wrapper → viewport → content) must be preserved. */}
-                <div className="block min-w-full">{children}</div>
-            </div>
+                {fullWidth ? <div>{children}</div> : children}
+            </RadixScrollArea.Viewport>
+            <RadixScrollArea.Scrollbar className="app-scrollbar" orientation="vertical">
+                <RadixScrollArea.Thumb className="app-scrollbar-thumb" />
+            </RadixScrollArea.Scrollbar>
+            <RadixScrollArea.Scrollbar className="app-scrollbar" orientation="horizontal">
+                <RadixScrollArea.Thumb className="app-scrollbar-thumb" />
+            </RadixScrollArea.Scrollbar>
+            <RadixScrollArea.Corner className="app-scrollbar-corner" />
             {fadeHeight > 0 && (
                 <div className="block pointer-events-none">
                     <div
@@ -74,7 +75,7 @@ const ScrollArea = ({
                 </div>
             )}
             {fadeX && <HorizontalScrollFades showStart={showStart} showEnd={showEnd} />}
-        </div>
+        </RadixScrollArea.Root>
     )
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -611,10 +611,107 @@ hr {
     }
 }
 
-/* App window + taskbar menu scrollbars — leave rail sizing to the browser so
-   overlay scrollbars can follow the OS visibility preference, while visually
-   floating the thumb clear of rounded corners. MenuBar portals into
-   [data-menu-container] (taskbar), which sits outside AppWindow. */
+/* Shared app scrollbars use Radix-rendered overlay rails so their geometry and
+   scroll-only visibility stay consistent across browsers and OS preferences. */
+
+.app-scrollbar {
+    position: absolute;
+    z-index: 10;
+    display: flex;
+    touch-action: none;
+    user-select: none;
+    padding: 2px;
+
+    &[data-orientation='vertical'] {
+        top: 6px !important;
+        right: 2px !important;
+        bottom: 6px !important;
+        width: 10px;
+    }
+
+    &[data-orientation='horizontal'] {
+        right: 6px !important;
+        bottom: 2px !important;
+        left: 6px !important;
+        height: 10px;
+        flex-direction: column;
+    }
+
+    &[data-state='visible'] {
+        animation: app-scrollbar-fade-in 160ms ease-out;
+    }
+
+    &[data-state='hidden'] {
+        animation: app-scrollbar-fade-out 240ms ease-in forwards;
+    }
+}
+
+/* Keep top-level window scrollbars clear of toolbar-less window controls. */
+[data-app='AppWindow']
+    .app-scroll-area:not(.app-scroll-area .app-scroll-area)
+    > .app-scrollbar[data-orientation='vertical'] {
+    top: 32px !important;
+}
+
+@keyframes app-scrollbar-fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes app-scrollbar-fade-out {
+    from {
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .app-scrollbar {
+        animation-duration: 1ms !important;
+    }
+}
+
+.app-scrollbar-thumb {
+    position: relative;
+    flex: 1;
+    border-radius: 9999px;
+    background-color: rgb(var(--text-primary) / 0.28);
+
+    &:hover {
+        background-color: rgb(var(--text-primary) / 0.4);
+    }
+
+    &:active {
+        background-color: rgb(var(--text-primary) / 0.5);
+    }
+
+    &::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 100%;
+        height: 100%;
+        min-width: 44px;
+        min-height: 44px;
+        content: '';
+        transform: translate(-50%, -50%);
+    }
+}
+
+.app-scrollbar-corner {
+    background: transparent;
+}
+
+/* Native fallback for overflow containers that do not use the shared
+   ScrollArea. MenuBar portals into [data-menu-container] outside AppWindow. */
 
 [data-app='AppWindow'] *::-webkit-scrollbar-track,
 [data-menu-container] *::-webkit-scrollbar-track {
@@ -670,6 +767,10 @@ hr {
 }
 
 @media (forced-colors: active) {
+    .app-scrollbar-thumb {
+        background-color: CanvasText;
+    }
+
     [data-app='AppWindow'] *,
     [data-menu-container] * {
         scrollbar-color: auto;


### PR DESCRIPTION
## Changes

Updates scrollbars to ignore OS-level setting to persist scrollbars. All scrollbars are now styled consistently across browsers and various OS settings.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
