### PR TITLE
docs(data-warehouse): add managed warehouse usage docs

### DIFF
--- a/contents/docs/data-warehouse/managed-warehouse/connect.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/connect.mdx
@@ -1,0 +1,82 @@
+---
+title: Connecting to the managed warehouse
+sidebar: Docs
+showTitle: true
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconFlask" title="The managed warehouse is in beta" type="action">
+
+Need access first? [Join the waitlist](/data-stack/managed-warehouse), then [set up your warehouse](/docs/data-warehouse/managed-warehouse/setup).
+
+</CalloutBox>
+
+The managed warehouse speaks the PostgreSQL wire protocol, so you connect with the same clients, drivers, and BI tools you'd point at any Postgres database. No PostHog-specific SDK involved.
+
+## Connection details
+
+Your connection details live in [Data ops](https://app.posthog.com/data-ops) under the **Settings** tab once the warehouse is ready:
+
+| Field | Value |
+|---|---|
+| Host | `<your-warehouse-name>.dw.us.postwh.com` (US) or `<your-warehouse-name>.dw.eu.postwh.com` (EU) |
+| Port | `5432` |
+| Database | `ducklake` – always, regardless of warehouse name |
+| Username | `root`, or a [database user](#database-users) you've created |
+| Password | Shown once at provisioning or user creation; reset it from the app if lost |
+
+TLS is required, so include `sslmode=require`. A complete `psql` connection looks like:
+
+```bash
+psql "host=my-warehouse.dw.us.postwh.com port=5432 dbname=ducklake user=root sslmode=require"
+```
+
+The same details work in anything that talks Postgres: pgAdmin, DBeaver, Metabase, Grafana, Superset, Tableau, and the standard drivers (psycopg, pgx, JDBC, node-postgres, SQLAlchemy, and friends).
+
+## Database users
+
+The `root` user is created when you provision the warehouse. Rather than sharing it around, create a user per teammate or per tool from the **DB users** tab in Data ops (organization admins only):
+
+- **Create** a user and share the generated password – it's shown once, at creation.
+- **Reset password** if one is lost or needs rotating. The old password stops working immediately.
+- **Disable** a user to block new connections and end their live sessions, without deleting them.
+- **Delete** a user to remove their access permanently. The root user can't be deleted or disabled.
+
+## Find your way around
+
+Your first stop after connecting should be discovering what's there:
+
+```sql
+-- List schemas and tables
+\dn
+\dt
+
+-- DuckDB's DESCRIBE and SUMMARIZE work too
+DESCRIBE events_prod;
+SUMMARIZE persons_prod;
+```
+
+With a project schema named `prod`, the layout looks like:
+
+```sql
+-- Your PostHog events and persons
+SELECT count(*) FROM events_prod;
+
+-- Imported source tables live in a per-project imports schema
+SELECT * FROM posthog_data_imports_prod.stripe_charge LIMIT 10;
+```
+
+## What SQL works
+
+Standard PostgreSQL queries work as-is: `SELECT`, joins, CTEs, window functions, prepared statements, transactions, and `COPY ... TO STDOUT` for bulk export (including `\copy` in `psql`).
+
+Because the engine is DuckDB, its analytical SQL passes through transparently as well – `DESCRIBE`, `SUMMARIZE`, `QUALIFY`, `SELECT * EXCLUDE (...)`, `FROM`-first queries, and `ASOF` joins all work. You get DuckDB's full function library on top of the Postgres compatibility layer.
+
+You can also write: `CREATE TABLE`, `CREATE VIEW`, `INSERT`, `UPDATE`, and `DELETE` are supported, so the warehouse can hold your own derived tables next to the synced data. Keep your own work in tables or schemas you create – the PostHog-managed tables are maintained by sync, and anything you write into them can be overwritten.
+
+A few things a Postgres veteran will notice are absent: server-side functions and triggers (PL/pgSQL), sequences, and `LISTEN`/`NOTIFY` don't exist in DuckDB, and role management happens through database users in the app rather than `CREATE ROLE`.
+
+## Querying from PostHog
+
+You don't need an external client to use the warehouse. Once provisioned, it's available in PostHog's [SQL editor](/docs/data-warehouse/query) alongside your other sources, and PostHog's AI features can use it as context. External connections are for everything else – dashboards in your BI tool, notebooks, scheduled jobs, or ad-hoc `psql` sessions.

--- a/contents/docs/data-warehouse/managed-warehouse/connect.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/connect.mdx
@@ -23,8 +23,8 @@ Your connection details live in [Data ops](https://app.posthog.com/data-ops) und
 | Host | `<your-warehouse-name>.dw.us.postwh.com` (US) or `<your-warehouse-name>.dw.eu.postwh.com` (EU) |
 | Port | `5432` |
 | Database | `ducklake` – always, regardless of warehouse name |
-| Username | `root`, or a [database user](#database-users) you've created |
-| Password | Shown once at provisioning or user creation; reset it from the app if lost |
+| Username | `root` |
+| Password | Shown once at provisioning; reset it from the Settings tab if lost |
 
 TLS is required, so include `sslmode=require`. A complete `psql` connection looks like:
 
@@ -33,15 +33,6 @@ psql "host=my-warehouse.dw.us.postwh.com port=5432 dbname=ducklake user=root ssl
 ```
 
 The same details work in anything that talks Postgres: pgAdmin, DBeaver, Metabase, Grafana, Superset, Tableau, and the standard drivers (psycopg, pgx, JDBC, node-postgres, SQLAlchemy, and friends).
-
-## Database users
-
-The `root` user is created when you provision the warehouse. Rather than sharing it around, create a user per teammate or per tool from the **DB users** tab in Data ops (organization admins only):
-
-- **Create** a user and share the generated password – it's shown once, at creation.
-- **Reset password** if one is lost or needs rotating. The old password stops working immediately.
-- **Disable** a user to block new connections and end their live sessions, without deleting them.
-- **Delete** a user to remove their access permanently. The root user can't be deleted or disabled.
 
 ## Find your way around
 
@@ -75,7 +66,7 @@ Because the engine is DuckDB, its analytical SQL passes through transparently as
 
 You can also write: `CREATE TABLE`, `CREATE VIEW`, `INSERT`, `UPDATE`, and `DELETE` are supported, so the warehouse can hold your own derived tables next to the synced data. Keep your own work in tables or schemas you create – the PostHog-managed tables are maintained by sync, and anything you write into them can be overwritten.
 
-A few things a Postgres veteran will notice are absent: server-side functions and triggers (PL/pgSQL), sequences, and `LISTEN`/`NOTIFY` don't exist in DuckDB, and role management happens through database users in the app rather than `CREATE ROLE`.
+A few things a Postgres veteran will notice are absent: server-side functions and triggers (PL/pgSQL), sequences, and `LISTEN`/`NOTIFY` don't exist in DuckDB, and credentials are managed by PostHog rather than through `CREATE ROLE`.
 
 ## Querying from PostHog
 

--- a/contents/docs/data-warehouse/managed-warehouse/index.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/index.mdx
@@ -1,0 +1,46 @@
+---
+title: Managed warehouse
+sidebar: Docs
+showTitle: true
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconFlask" title="The managed warehouse is in beta" type="action">
+
+Not yet available to everyone – [join the waitlist](/data-stack/managed-warehouse) and we'll let you in as soon as it's ready.
+
+</CalloutBox>
+
+The managed warehouse is a full analytical database that PostHog provisions and runs for your organization. Your PostHog data and your [connected sources](/docs/cdp/sources) land in it continuously, and you query it like any Postgres database – from `psql`, from BI tools like Metabase or Grafana, from your own code, or from PostHog itself.
+
+It's the difference between "PostHog can query my data" and "PostHog **is** my data warehouse": you get a real database endpoint with its own hostname, credentials, and database users, holding your product data and business data side by side.
+
+## How it works
+
+Under the hood, the managed warehouse is built on [DuckDB](https://duckdb.org/), with data stored in the open [DuckLake](https://ducklake.select/) lakehouse format on durable object storage. You don't need to know any of that to use it, but it explains the shape of the product:
+
+1. **Provisioning** – When you set up the warehouse, PostHog creates a dedicated database for your organization with its own hostname, like `my-warehouse.dw.us.postwh.com`. Compute is isolated per organization: your queries run on workers spun up for you, not on a shared cluster.
+2. **Getting data in** – PostHog backfills your historical events and persons, then keeps the warehouse up to date as new data arrives. [Sources](/docs/cdp/sources) you've connected (Stripe, Postgres, Salesforce, HubSpot, and so on) sync into the warehouse on the same schedule as their regular imports.
+3. **Storage** – Data lives as columnar files in S3-compatible object storage with a transactional catalog on top. Storage and compute scale independently, and your data survives any individual machine.
+4. **Querying** – The warehouse speaks the PostgreSQL wire protocol over TLS, so any Postgres client, driver, or BI tool connects without special adapters. DuckDB's analytical SQL (things like `SUMMARIZE` and `QUALIFY`) works too.
+
+## What's in your warehouse
+
+Each project in your organization gets its own schema, chosen during setup. Within a project you'll find:
+
+| Data | Where it lives |
+|---|---|
+| Events | An events table named after your project's schema, e.g. `events_prod` |
+| Persons | A persons table, e.g. `persons_prod` |
+| Source imports | A schema per project for imported sources, e.g. `posthog_data_imports_prod`, with one table per synced source table |
+| Modeled data | A schema holding the outputs of your data models |
+| Your own tables | Anything you create yourself with `CREATE TABLE` or `CREATE VIEW` |
+
+The exact layout is still settling during the beta, so the reliable way to see what you have is to ask the warehouse itself – `\dn` and `\dt` in `psql`, or `DESCRIBE` on any table.
+
+## Where to go next
+
+- **Getting access?** [Join the waitlist](/data-stack/managed-warehouse).
+- **Access enabled?** Walk through [setting up the managed warehouse](/docs/data-warehouse/managed-warehouse/setup).
+- **Warehouse ready?** [Connect and query it](/docs/data-warehouse/managed-warehouse/connect) with your favorite tools.

--- a/contents/docs/data-warehouse/managed-warehouse/index.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/index.mdx
@@ -25,6 +25,20 @@ Under the hood, the managed warehouse is built on [DuckDB](https://duckdb.org/),
 3. **Storage** – Data lives as columnar files in S3-compatible object storage with a transactional catalog on top. Storage and compute scale independently, and your data survives any individual machine.
 4. **Querying** – The warehouse speaks the PostgreSQL wire protocol over TLS, so any Postgres client, driver, or BI tool connects without special adapters. DuckDB's analytical SQL (things like `SUMMARIZE` and `QUALIFY`) works too.
 
+## Architecture
+
+A closer look at the pieces PostHog manages for you:
+
+- **A Postgres-compatible front end.** Connections terminate at a control plane that handles TLS, authenticates your database users, and translates PostgreSQL syntax to DuckDB syntax where the two differ. That's why any Postgres tool works unmodified.
+- **Dedicated DuckDB workers.** Queries run on DuckDB workers reserved for your organization, spun up on demand and retired when idle. There's no shared query queue, so a heavy query from another customer never competes with yours.
+- **Open storage.** Tables are columnar Parquet files in object storage, tracked by DuckLake's transactional catalog. Workers come and go; your data doesn't, and it lives in an open format rather than a proprietary store.
+
+## How this fits into PostHog
+
+The managed warehouse doesn't replace ClickHouse or any other part of PostHog. Insights, product analytics, and every other PostHog feature keep running on PostHog's existing query engine, unchanged, and your events keep flowing in exactly as before.
+
+The warehouse is an addition: a dedicated database that receives the same data, where you can run isolated workloads with the benefits of DuckDB and DuckLake built in and managed for you. Point BI dashboards, notebooks, and scheduled jobs at it, build your own tables in it, and none of it competes with the queries powering your PostHog project.
+
 ## What's in your warehouse
 
 Each project in your organization gets its own schema, chosen during setup. Within a project you'll find:

--- a/contents/docs/data-warehouse/managed-warehouse/index.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/index.mdx
@@ -14,7 +14,7 @@ Not yet available to everyone – [join the waitlist](/data-stack/managed-wareho
 
 The managed warehouse is a full analytical database that PostHog provisions and runs for your organization. Your PostHog data and your [connected sources](/docs/cdp/sources) land in it continuously, and you query it like any Postgres database – from `psql`, from BI tools like Metabase or Grafana, from your own code, or from PostHog itself.
 
-It's the difference between "PostHog can query my data" and "PostHog **is** my data warehouse": you get a real database endpoint with its own hostname, credentials, and database users, holding your product data and business data side by side.
+It's the difference between "PostHog can query my data" and "PostHog **is** my data warehouse": you get a real database endpoint with its own hostname and credentials, holding your product data and business data side by side.
 
 ## How it works
 
@@ -29,7 +29,7 @@ Under the hood, the managed warehouse is built on [DuckDB](https://duckdb.org/),
 
 A closer look at the pieces PostHog manages for you:
 
-- **A Postgres-compatible front end.** Connections terminate at a control plane that handles TLS, authenticates your database users, and translates PostgreSQL syntax to DuckDB syntax where the two differ. That's why any Postgres tool works unmodified.
+- **A Postgres-compatible front end.** Connections terminate at a control plane that handles TLS, authenticates your connections, and translates PostgreSQL syntax to DuckDB syntax where the two differ. That's why any Postgres tool works unmodified.
 - **Dedicated DuckDB workers.** Queries run on DuckDB workers reserved for your organization, spun up on demand and retired when idle. There's no shared query queue, so a heavy query from another customer never competes with yours.
 - **Open storage.** Tables are columnar Parquet files in object storage, tracked by DuckLake's transactional catalog. Workers come and go; your data doesn't, and it lives in an open format rather than a proprietary store.
 

--- a/contents/docs/data-warehouse/managed-warehouse/setup.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/setup.mdx
@@ -1,0 +1,61 @@
+---
+title: Setting up the managed warehouse
+sidebar: Docs
+showTitle: true
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconFlask" title="The managed warehouse is in beta" type="action">
+
+Setup requires beta access. Not in yet? [Join the waitlist](/data-stack/managed-warehouse) and we'll be in touch.
+
+</CalloutBox>
+
+Setting up the warehouse takes a few minutes: you pick a name, PostHog provisions the infrastructure, and then historical data starts loading. Everything happens in the **Data ops** section of the app, which appears in your navigation once your organization has beta access.
+
+## Before you start
+
+- You need to be an **organization admin** to provision, deprovision, or manage credentials. Other members can see status but can't change anything.
+- One warehouse serves your whole organization. Each project you onboard gets its own schema inside it.
+
+## Provision the warehouse
+
+1. Go to [Data ops](https://app.posthog.com/data-ops) and open the **Settings** tab.
+2. Choose a **warehouse name** – lowercase letters, numbers, and hyphens. This becomes the subdomain you connect to: pick `my-warehouse` and your host is `my-warehouse.dw.us.postwh.com` (or `.dw.eu.postwh.com` on EU Cloud). PostHog checks availability as you type.
+3. Choose a **schema name** for the current project – lowercase letters, numbers, and underscores. This names your project's schema and its tables, so a schema name of `prod` gives you `events_prod` and `persons_prod`. Choose carefully: the schema name can't be changed later.
+4. Click **Provision warehouse**, and **save the password it returns**. It's shown exactly once. If you lose it, an admin can use **Reset password** in the same Settings tab to generate a new one (which invalidates the old one immediately).
+
+Provisioning runs in the background and should take less than 5 minutes. The Settings tab shows the state as it moves through provisioning to ready, and once ready it displays your full connection details.
+
+## Watch your data arrive
+
+Once the warehouse is ready, the **Overview** tab shows warehouse data readiness: how the historical backfill is going and whether recent imports have reached the warehouse.
+
+- **Events** and **Persons** cards track the one-time historical backfill and ongoing updates. Events backfill month by month, so you'll see partitions complete progressively; persons load as a single export.
+- **Imported source tables** lists every source currently syncing into the warehouse, with two timestamps that matter: **Last source import** (when PostHog last finished importing from the source) and **Applied to warehouse** (when that data actually landed in your warehouse). Click a row to see per-table detail.
+
+Each dataset shows one of these statuses:
+
+| Status | Meaning |
+|---|---|
+| Waiting | Queued up, work hasn't started yet |
+| Backfilling | Historical data is being copied in |
+| Up to date | Loaded, and new data is applied as it arrives |
+| Sync paused | Sync is off for this table; data already in the warehouse is unaffected |
+| Needs attention | Something failed and needs a retry or a fresh copy |
+| Not configured | This dataset isn't enabled for the warehouse |
+
+You don't need to wait for backfills to finish before connecting – data that's already landed is queryable immediately.
+
+## Add sources
+
+Anything you connect as a [source](/docs/cdp/sources) syncs into the warehouse automatically alongside its regular imports – there's no separate warehouse configuration per source. Manage sources as usual in [Data pipelines > Sources](https://app.posthog.com/data-management/sources).
+
+## Add more projects
+
+To bring another project into the same warehouse, an organization admin opens [Data ops](https://app.posthog.com/data-ops) while in that project, picks a schema name for it in the **Settings** tab, and clicks **Enable this project**. Each project's data stays in its own schema, and like at provisioning, the schema name is permanent.
+
+## Turning it off
+
+Admins can deprovision the warehouse from the Settings tab. This deletes the managed warehouse for your organization and every project in it – including any tables you created in it yourself – and it can't be undone. Your PostHog data and your source connections live outside the warehouse and are unaffected.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5835,6 +5835,27 @@ export const docsMenu = {
                     color: 'red',
                 },
                 {
+                    name: 'Managed warehouse',
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/data-warehouse/managed-warehouse',
+                    icon: 'IconDatabase',
+                    color: 'purple',
+                },
+                {
+                    name: 'Set up your warehouse',
+                    url: '/docs/data-warehouse/managed-warehouse/setup',
+                    icon: 'IconListCheck',
+                    color: 'blue',
+                },
+                {
+                    name: 'Connect and query',
+                    url: '/docs/data-warehouse/managed-warehouse/connect',
+                    icon: 'IconCode',
+                    color: 'orange',
+                },
+                {
                     name: 'Concepts',
                 },
                 {


### PR DESCRIPTION
## Changes

Drafts end-user docs for the managed data warehouse (beta), as a new "Managed warehouse" group in the Data warehouse docs section:

- `/docs/data-warehouse/managed-warehouse` – overview: what it is, how it works (DuckDB engine, DuckLake storage on object storage, Postgres wire protocol endpoint), architecture, how it fits alongside the rest of PostHog, and what lives in the warehouse
- `/docs/data-warehouse/managed-warehouse/setup` – setup walkthrough: provisioning from Data ops, data readiness states, adding sources and projects, deprovisioning
- `/docs/data-warehouse/managed-warehouse/connect` – connecting and querying: connection details, schema discovery, supported SQL, querying from PostHog

Each page opens with a beta `CalloutBox` linking to the waitlist at `/data-stack/managed-warehouse`, following the Replay Vision closed-beta pattern, so these docs work as part of the waitlist funnel.

Also wires the three pages into the Data Warehouse sidebar in `src/navs/index.js` (flagging explicitly since that file is "ask first").

Notes for review:

- The product is behind a waitlist, so these docs describe surfaces most readers can't see yet; copy was checked against the current in-app Data ops scene rather than screenshots.
- Database user management docs were drafted but pulled back out since that surface hasn't shipped; they'll come back in a follow-up once it does.
- No screenshots yet; can add once there's a good demo org to capture from.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
