### PR TITLE
fix(docs): use secret_key in prompt management Python snippet

### DIFF
--- a/contents/docs/prompt-management/index.mdx
+++ b/contents/docs/prompt-management/index.mdx
@@ -214,7 +214,7 @@ from posthog.ai.prompts import Prompts
 posthog = Posthog(
     '<your_project_api_key>',
     host='https://us.posthog.com',
-    personal_api_key='<your_personal_api_key>'
+    secret_key='<your_personal_api_key>'
 )
 prompts = Prompts(posthog)
 


### PR DESCRIPTION
## Problem

posthog-python 7.28 deprecated `personal_api_key=` on the `Posthog` constructor in favor of `secret_key=`. The prompt management docs still teach the deprecated kwarg in the Python example.

## Changes

Swap `personal_api_key=` for `secret_key=` in the `Posthog(...)` constructor example. The direct `Prompts(personal_api_key=...)` init and the JS examples are unchanged since neither is deprecated.

## How did you test this code?

One-line snippet change, verified the kwarg names against posthog-python master.

Companion app PR: PostHog/posthog#73429
