### PR TITLE
Attribute AI research + Semantic layer early access features on roadmap

### DIFF
--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -137,6 +137,10 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       maintainer: String,
       imageUrl: String,
     }
+    type EarlyAccessFeatureAssignee {
+      type: String,
+      name: String,
+    }
     type EarlyAccessFeature implements Node {
       name: String,
       description: String,
@@ -146,6 +150,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       featureId: String,
       waitlistCount: Int,
       payload: JSON,
+      assignee: EarlyAccessFeatureAssignee,
     }
     type Plugin implements Node {
       name: String,

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -1493,6 +1493,10 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
                         // API key at build time, or no linked survey).
                         waitlistCount: payload.survey_id != null ? waitlistCounts[payload.survey_id] ?? null : null,
                         payload,
+                        // Person or role the feature is assigned to in PostHog — {type, name} or
+                        // null. Served by the public EAF endpoint once PostHog/posthog#73466 is
+                        // deployed; null until then. The roadmap maps it to a small team.
+                        assignee: feature.assignee || null,
                     })
                 })
         } catch (error) {

--- a/src/components/Roadmap/roadmapTeamOverrides.ts
+++ b/src/components/Roadmap/roadmapTeamOverrides.ts
@@ -31,6 +31,11 @@ export const ROADMAP_TEAM_OVERRIDES: Record<string, string> = {
     discussions: 'platform-features', // comments/discussions area
 
     // Alpha / concept
+    'self-driving-model': 'ai-research', // Tuning a self-driving model
+    'predictive-user-behavior-model': 'ai-research', // Training a predictive user behavior model
+    'session-replay-model': 'ai-research', // Training a session replay model
+    'replay-encoder-model': 'ai-research', // Training a Replay Encoder model
+    'semantic-layer': 'data-modeling', // Semantic layer
     tracing: 'apm',
     metrics: 'apm',
     'customer-success-platform': 'customer-analytics',

--- a/src/components/Roadmap/roadmapTeamOverrides.ts
+++ b/src/components/Roadmap/roadmapTeamOverrides.ts
@@ -1,7 +1,10 @@
 /**
  * Owning small team per Early Access Feature flag key, for the /roadmap team chips and
- * team filter. Checked before the hand-maintained feature-ownership map (useFeatureOwnership),
- * which only covers a handful of roadmap items.
+ * team filter. See useRoadmapEarlyAccessFeatures for the full resolution order: a role
+ * assignee set on the feature in PostHog takes precedence over this map, this map beats
+ * person assignees (often just the creation default) and the hand-maintained
+ * feature-ownership map (useFeatureOwnership), which only covers a handful of roadmap items.
+ * Once features are assigned to roles in the app, entries here become redundant.
  *
  * Derived 2026-07-20 by cross-referencing each feature flag's creator (project activity log)
  * with current small-team rosters, then correcting for product area where the creator has

--- a/src/hooks/useEarlyAccessFeatures.ts
+++ b/src/hooks/useEarlyAccessFeatures.ts
@@ -24,6 +24,12 @@ export interface EarlyAccessFeature {
      * passes it through at runtime — see PostHog/posthog-js#2642.)
      */
     payload?: Record<string, any>
+    /**
+     * Display name of the person or role the feature is assigned to in PostHog. Served by
+     * the public EAF endpoint once PostHog/posthog#73466 is deployed; null/undefined until
+     * then. The roadmap resolves it to a small team (see useRoadmapEarlyAccessFeatures).
+     */
+    assignee?: { type: 'user' | 'role'; name: string } | null
 }
 
 /**
@@ -102,6 +108,10 @@ export function useEarlyAccessFeatures(options: UseEarlyAccessFeaturesOptions = 
                     featureId
                     waitlistCount
                     payload
+                    assignee {
+                        type
+                        name
+                    }
                 }
             }
         }

--- a/src/hooks/useRoadmapEarlyAccessFeatures.ts
+++ b/src/hooks/useRoadmapEarlyAccessFeatures.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { graphql, useStaticQuery } from 'gatsby'
 import useEarlyAccessFeatures, { EarlyAccessFeature } from './useEarlyAccessFeatures'
 import { useFeatureOwnership } from './useFeatureOwnership'
 import { ROADMAP_TEAM_OVERRIDES } from 'components/Roadmap/roadmapTeamOverrides'
@@ -26,16 +27,59 @@ const slugify = (text: string): string =>
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '')
 
+interface SqueakTeamAttributionNode {
+    slug?: string
+    name?: string
+    profiles?: {
+        data?: {
+            attributes?: {
+                firstName?: string
+                lastName?: string
+            }
+        }[]
+    }
+}
+
 /**
  * Adds the roadmap's canonical team ownership to each Early Access Feature.
  * Consumers can optionally select one small team's roadmap without duplicating
  * the override and feature-ownership resolution used by /roadmap.
+ *
+ * Resolution order per feature:
+ *  1. A role assignee from the PostHog app (an explicit statement of team ownership),
+ *     matched to a small team by slugified role name.
+ *  2. `ROADMAP_TEAM_OVERRIDES` — manual corrections by flag key.
+ *  3. A person assignee from the PostHog app (often just the creation default), matched
+ *     to the first small team whose roster includes them.
+ *  4. The feature-ownership map (`useFeatureOwnership`).
+ *
+ * Assignees come from the public EAF endpoint and require PostHog/posthog#73466 to be
+ * deployed; until then only steps 2 and 4 apply.
  */
 export function useRoadmapEarlyAccessFeatures({
     teamSlug,
 }: UseRoadmapEarlyAccessFeaturesOptions = {}): UseRoadmapEarlyAccessFeaturesResult {
     const earlyAccessFeatures = useEarlyAccessFeatures()
     const { features: ownedFeatures } = useFeatureOwnership()
+
+    const { allSqueakTeam } = useStaticQuery<{ allSqueakTeam: { nodes: SqueakTeamAttributionNode[] } }>(graphql`
+        query RoadmapTeamAttributionQuery {
+            allSqueakTeam {
+                nodes {
+                    slug
+                    name
+                    profiles {
+                        data {
+                            attributes {
+                                firstName
+                                lastName
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `)
 
     const teamByFeatureSlug = useMemo(() => {
         const map: Record<string, string> = {}
@@ -47,12 +91,53 @@ export function useRoadmapEarlyAccessFeatures({
         return map
     }, [ownedFeatures])
 
+    const { teamSlugByTeamName, teamSlugByPersonName } = useMemo(() => {
+        const byTeamName: Record<string, string> = {}
+        const byPersonName: Record<string, string> = {}
+        ;(allSqueakTeam?.nodes || []).forEach((team) => {
+            if (!team.slug) {
+                return
+            }
+            byTeamName[team.slug] = team.slug
+            if (team.name) {
+                byTeamName[slugify(team.name)] = team.slug
+            }
+            team.profiles?.data?.forEach((profile) => {
+                const personKey = slugify(
+                    [profile.attributes?.firstName, profile.attributes?.lastName].filter(Boolean).join(' ')
+                )
+                // People can be on multiple teams — first team wins.
+                if (personKey && !byPersonName[personKey]) {
+                    byPersonName[personKey] = team.slug
+                }
+            })
+        })
+        return { teamSlugByTeamName: byTeamName, teamSlugByPersonName: byPersonName }
+    }, [allSqueakTeam])
+
+    const teamFromAssignee = useCallback(
+        (assignee: EarlyAccessFeature['assignee']): string | undefined => {
+            if (!assignee?.name) {
+                return undefined
+            }
+            const key = slugify(assignee.name)
+            return assignee.type === 'role' ? teamSlugByTeamName[key] : teamSlugByPersonName[key]
+        },
+        [teamSlugByTeamName, teamSlugByPersonName]
+    )
+
     const teamForFeature = useCallback(
-        (feature: EarlyAccessFeature): string | undefined =>
-            ROADMAP_TEAM_OVERRIDES[feature.flagKey] ||
-            teamByFeatureSlug[feature.flagKey] ||
-            teamByFeatureSlug[slugify(feature.name)],
-        [teamByFeatureSlug]
+        (feature: EarlyAccessFeature): string | undefined => {
+            const assigneeTeam = teamFromAssignee(feature.assignee)
+            return (
+                (feature.assignee?.type === 'role' ? assigneeTeam : undefined) ||
+                ROADMAP_TEAM_OVERRIDES[feature.flagKey] ||
+                (feature.assignee?.type === 'user' ? assigneeTeam : undefined) ||
+                teamByFeatureSlug[feature.flagKey] ||
+                teamByFeatureSlug[slugify(feature.name)]
+            )
+        },
+        [teamByFeatureSlug, teamFromAssignee]
     )
 
     const features = useMemo<RoadmapEarlyAccessFeature[]>(() => {


### PR DESCRIPTION
> [!NOTE]
> The pure hard-coded attribution (the five override entries, no API changes) is also available as a smaller standalone PR that can merge on its own: [#18884](https://github.com/PostHog/posthog.com/pull/18884). This PR keeps those entries and adds the API-driven resolution on top.

> [!IMPORTANT]
> **Dependency:** the API-driven attribution added here reads the `assignee` field served by https://github.com/PostHog/posthog/pull/72993. This PR is safe to merge first — the field is simply absent until that PR merges and deploys, and everything falls back to the hard-coded overrides below — but the roadmap only starts reflecting in-app assignments once #73466 is live.

## Changes

**1. Immediate fix — attribute five early access features that show as "Unassigned" on `/roadmap`:**

- Tuning a self-driving model, Training a predictive user behavior model, Training a session replay model, and Training a Replay Encoder model → **AI Research** team
- Semantic layer → **Data Modeling** team

Done via `ROADMAP_TEAM_OVERRIDES` (flag key → team slug), the existing mechanism for team attribution on roadmap cards.

**2. Read assignees from the API:** [PostHog/posthog#73466](https://github.com/PostHog/posthog/pull/73466) lets early access features be assigned to a person or role in the app (defaulting to the creator) and exposes the assignee's display name on the public EAF endpoint. This PR sources that field (build-time in `gatsby/sourceNodes.ts` + client-side revalidation) and resolves it to a small team in `useRoadmapEarlyAccessFeatures`:

1. Role assignee (an explicit team-ownership statement) — matched by slugified role name against team slugs/names — takes precedence over the overrides
2. `ROADMAP_TEAM_OVERRIDES` (manual corrections)
3. Person assignee (often just the creation default) — matched against small-team rosters
4. The existing `useFeatureOwnership` map

Once features are assigned to roles in the app, the override map becomes redundant and can be trimmed over time.

**Why:** These features render with no owning team on the roadmap; attributing them helps visitors see who's building what — and reading assignees from the API means future attribution happens in PostHog itself instead of website PRs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

