### PR TITLE
Attribute unassigned AI research + Semantic layer roadmap items

### DIFF
--- a/src/components/Roadmap/roadmapTeamOverrides.ts
+++ b/src/components/Roadmap/roadmapTeamOverrides.ts
@@ -31,6 +31,11 @@ export const ROADMAP_TEAM_OVERRIDES: Record<string, string> = {
     discussions: 'platform-features', // comments/discussions area
 
     // Alpha / concept
+    'self-driving-model': 'ai-research', // Tuning a self-driving model
+    'predictive-user-behavior-model': 'ai-research', // Training a predictive user behavior model
+    'session-replay-model': 'ai-research', // Training a session replay model
+    'replay-encoder-model': 'ai-research', // Training a Replay Encoder model
+    'semantic-layer': 'data-modeling', // Semantic layer
     tracing: 'apm',
     metrics: 'apm',
     'customer-success-platform': 'customer-analytics',


### PR DESCRIPTION
## Changes

Attributes the five early access features that currently render as **Unassigned** on `/roadmap`, using the existing `ROADMAP_TEAM_OVERRIDES` map (flag key → team slug):

- Tuning a self-driving model, Training a predictive user behavior model, Training a session replay model, Training a Replay Encoder model → **AI Research** team
- Semantic layer → **Data Modeling** team

I cross-referenced every concept/alpha/beta roadmap item against the override map and `useFeatureOwnership`; these five were the only ones with no team, so this clears out the remaining "Unassigned" chips.

This is deliberately small and standalone — no other changes — so it can merge right away. A separate PR ([#18882](https://github.com/PostHog/posthog.com/pull/18882)) additionally teaches the roadmap to read assignees from the API, but that depends on a monorepo change; this one doesn't.

**Why:** These features show no owning team on the roadmap, so visitors can't see who's building them.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
