### PR TITLE
Add privacy policy link to /slack landing page

### DIFF
--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -883,6 +883,13 @@ export default function SlackAppPage(): JSX.Element {
                                         </Link>
                                     </span>
                                 </div>
+                                <p className="text-sm text-secondary mt-3 mb-0">
+                                    Read our{' '}
+                                    <Link to="/privacy" className="font-bold">
+                                        privacy policy
+                                    </Link>{' '}
+                                    to see how the PostHog Slack app collects, manages, and stores your data.
+                                </p>
                             </div>
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_app_chat_2_e5993b2331.png"


### PR DESCRIPTION
## Changes

Adds a visible link to [posthog.com/privacy](https://posthog.com/privacy) on the `/slack` landing page (`src/components/SlackPage/index.tsx`).

## Why

Slack Marketplace review flagged that our app's landing page must include a visible link to an accessible privacy policy. The privacy policy URL was already set in the Slack app config, but the `/slack` landing page itself had no in-page link. This adds one line pointing users to the privacy policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)