### PR TITLE
docs(ai-observability): document minimum volume for clusters

### DIFF
--- a/contents/docs/ai-observability/clusters.mdx
+++ b/contents/docs/ai-observability/clusters.mdx
@@ -10,6 +10,7 @@ import { ProductVideo } from 'components/ProductVideo'
 
 - **Traces or generations captured** – Set up LLM event capture using the [installation guide](/docs/ai-observability/installation).
 - **AI data processing enabled** – Your organization must have AI data processing consent enabled, the same requirement as [trace summarization](/docs/ai-observability/summarization).
+- **Minimum weekly volume** – Clustering runs only for projects with at least 1,000 traces or 1,000 generations captured in the past 7 days. The two thresholds are checked independently, so reaching 1,000 of either level is enough to qualify. Projects below this volume won't generate clusters, since small datasets tend to produce noisy, low-value groupings.
 - **Automatic daily runs** – Clustering runs automatically based on your configured [clustering jobs](#managing-clustering-jobs). No manual setup is needed.
 
 </details>
@@ -25,7 +26,7 @@ Clusters automatically group similar LLM [traces](/docs/ai-observability/traces)
 
 ## How clusters work
 
-1. PostHog analyzes your recent traces or generations from the past 7 days.
+1. PostHog analyzes your recent traces or generations from the past 7 days. This requires at least 1,000 traces or 1,000 generations in that window (see the requirements above); projects below this volume won't generate clusters.
 2. Similar items are grouped together based on their content.
 3. AI generates a title and description for each cluster.
 4. Metrics like average cost, latency, token usage, and error rate are computed per cluster.


### PR DESCRIPTION
### Changes

The Clusters requirements didn't mention the minimum weekly volume needed for clustering to run, so users below the threshold saw no clusters despite meeting every documented requirement. This adds that requirement in two places:

- A new **Minimum weekly volume** bullet in the Requirements section, stating clustering needs at least 1,000 traces or 1,000 generations in the past 7 days (thresholds checked independently per level).
- A clarifying note in the "How clusters work" step describing the same 7-day window minimum.

The 1,000-item threshold matches the current eligibility gate in the clustering backend (`MIN_TRACES_FOR_CLUSTERING`), raised from 20 in PostHog/posthog#65278.

### Why

A customer following the docs had clustering silently stop when the eligibility threshold was raised on 22 June. Their volume (tens of traces and ~100 generations per week) had cleared the old bar of 20 but sits well below the new 1,000, and nothing on the requirements checklist explained why clusters disappeared.

Note for reviewers: this figure is a backend constant, so if `MIN_TRACES_FOR_CLUSTERING` is tuned again, please ping docs so this page stays accurate.
