### PR TITLE
docs(self-driving): document per-scout Slack delivery

### DIFF
--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -42,6 +42,8 @@ When a scout emits a report, PostHog also captures a `$scout_report_emitted` eve
 
 Because it's a regular event in your stream, everything in PostHog can build on your scouts' output with nothing to wire up: query scout activity with [SQL](/docs/sql), chart it in an insight, set an [alert](/docs/alerts) on it, or point a [destination](/docs/cdp) at it – like forwarding every surfaced report to a [Slack channel](/docs/cdp/destinations/slack), templated from the event's title, summary, and link.
 
+If you want Slack delivery without wiring up a CDP destination, configure a Slack output on an individual scout instead. PostHog sends that scout's findings and any surfaced report updates straight to the channel you pick, using your project's Slack integration.
+
 Try it: this query lists your fleet's most recent findings.
 
 ```sql


### PR DESCRIPTION
## Changes

Adds a short note to the Scouts docs (`contents/docs/self-driving/scouts.mdx`) covering the per-scout Slack output option, placed right after the existing paragraph on pointing a CDP destination at `$scout_report_emitted`. It tells users they can get Slack delivery of a scout's findings and surfaced report updates by configuring a Slack output on the individual scout, without wiring up a destination.

**Why:** The per-scout Slack delivery capability shipped but the public docs only described the generic CDP-destination route, leaving the direct option undocumented. Raised as a docs-gap report by the `signals-scout-scouts-docs` scout.

I made the editorial call the report flagged for a human — keeping it as a brief note on the existing Scouts concepts page rather than a new page. Happy to expand into a dedicated setup/reference section if you'd prefer.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1784901113270259)*