### PR TITLE
Remove beta tag from sequential testing docs

### DIFF
--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -217,7 +217,7 @@ You can choose between 90%, 95%, or 99% confidence levels, which correspond to a
 
 To set the default confidence level for all experiments, go to **Experiments > Settings**. You can also override this for individual experiments in the **Statistics** section of the experiment.
 
-## Sequential testing (beta)
+## Sequential testing
 
 The standard fixed-horizon t-test assumes you check results once at a predetermined sample size. In practice, experimenters check dashboards continuously, which inflates the false positive rate – this is known as the "peeking problem." Sequential testing solves this by producing always-valid p-values and confidence sequences that remain valid no matter how many times you check.
 


### PR DESCRIPTION
## Changes

Removed the "(beta)" tag from the "Sequential testing" heading in the Frequentist statistics docs, since the feature is no longer in beta.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B67AZ5U0H/p1784906816818119)*
