### PR TITLE
docs(privacy): clarify HIPAA callout wording for PostHog AI

### DIFF
--- a/contents/docs/privacy/hipaa-compliance.mdx
+++ b/contents/docs/privacy/hipaa-compliance.mdx
@@ -69,7 +69,7 @@ The [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) is **not
 
 <CalloutBox type="caution" title="PostHog AI is not HIPAA-compliant">
 
-[PostHog AI](/docs/posthog-ai/overview) and other AI features are **not** covered by BAAs and should not be enabled on projects that process Protected Health Information (PHI). These features send your data to [third-party LLM providers](/docs/posthog-ai/faq) who are not party to your BAA with PostHog. Org admins can [disable PostHog AI and all AI data analysis](/docs/posthog-ai/faq#how-can-i-disable-posthog-ai) in your organization settings.
+[PostHog AI](/docs/posthog-ai/overview) and other AI features are **not** covered by BAAs and should not be enabled in organizations where any project processes Protected Health Information (PHI). These features send your data to [third-party LLM providers](/docs/posthog-ai/faq) that are not currently set up in a HIPAA-compliant way. Org admins can [disable PostHog AI and all AI data analysis](/docs/posthog-ai/faq#how-can-i-disable-posthog-ai) in your organization settings.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Summary
- Follow-up to #18915, which merged before addressing review feedback: https://github.com/PostHog/posthog.com/pull/18915#discussion_r3646588642
- Clarifies that PostHog AI consent is an org-wide setting, not per-project, so the caution applies at the organization level
- Rewords the LLM-provider sentence: the issue isn't that subprocessors "aren't party to your BAA with PostHog" (they were never expected to be) — it's that PostHog doesn't currently have HIPAA-compliant agreements with those subprocessors

## Test plan
- [x] `pnpm format` / lint-staged ran clean on commit
- [x] Preview build renders the callout correctly on `/docs/privacy/hipaa-compliance`