### PR TITLE
docs(mcp-analytics): migrate mcp analytics to self driving IA

### DIFF
--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -125,9 +125,3 @@ Your tool calls are a signal source for [Self-driving](/docs/self-driving). A sc
 />
 
 You can also start this yourself: the per-tool quality view has a **Create fix task** button that opens the same kind of pull request from a specific failing tool. Problems in PostHog's hosted server that your team doesn't own are filed for human review instead. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how reports and fixes work.
-
-<CalloutBox icon="IconInfo" title="MCP Analytics vs. PostHog's MCP server" type="fyi">
-
-This is analytics *about* MCP usage. If you're looking for PostHog's own MCP server and the tools it exposes for querying your product data, see the [MCP docs](/docs/model-context-protocol).
-
-</CalloutBox>

--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -5,16 +5,17 @@ showTitle: true
 contentMaxWidthClass: max-w-5xl
 ---
 
-import { IconLaptop, IconPlug, IconCode, IconBrackets, IconBolt, IconList, IconWrench, IconAIText, IconNotebook, IconPullRequest, IconCheckCircle } from '@posthog/icons'
+import { IconPlug, IconBolt, IconNotebook, IconPullRequest, IconCheckCircle } from '@posthog/icons'
 import CalloutBox from 'components/Docs/CalloutBox'
 import OSButton from 'components/OSButton'
 import CustomSelfDrivingLoop from 'components/CustomSelfDrivingLoop'
+import { SurfaceCards, SurfaceCard } from 'components/Docs/SurfaceCards'
 
 MCP Analytics shows you how AI agents actually use your MCP tools: which ones get called, what the agent was trying to do, where calls fail, and which capabilities agents asked for that you don't offer yet. It works on PostHog's own hosted MCP server and on any server you instrument with the [`@posthog/mcp` SDK](/docs/mcp-analytics/installation).
 
 Every tool invocation lands as a single `$mcp_tool_call` event on your standard events table, so the same data powers the purpose-built MCP Analytics views and anything you build yourself in [product analytics](/docs/product-analytics) or [SQL](/docs/data-warehouse/sql). Those calls also feed [Self-driving](/docs/self-driving), which spots tools that need fixing and files a report – and opens a pull request when the server is one you own.
 
-<CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="action">
+<CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="fyi">
 
 The in-app MCP Analytics views are behind a feature preview – [turn on the MCP Analytics preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to enable them. The `@posthog/mcp` SDK is published as a `0.x` release, so event names, properties, and tracing behavior may change before `1.0`. Pin a version and don't depend on it for production reporting yet.
 
@@ -26,89 +27,49 @@ The in-app MCP Analytics views are behind a feature preview – [turn on the MCP
 
 You explore MCP usage in the PostHog web app. The other surfaces let you query the same data, act on it, and pull it into your own tools.
 
-<div className="not-prose grid grid-cols-1 @md:grid-cols-2 gap-x-6 gap-y-6 my-6">
+<SurfaceCards columns={2}>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconLaptop className="size-6 shrink-0 text-blue mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary flex items-center gap-1.5">Web app <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Dashboards, session replay for agents, per-tool quality, and intent clustering.</p>
-      <a href="/docs/mcp-analytics/surfaces/web-app" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Explore MCP usage →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconLaptop" color="blue" title="Web app" badge="Beta" url="/docs/mcp-analytics/surfaces/web-app" cta="Explore MCP usage">
+Dashboards, session replay for agents, per-tool quality, and intent clustering.
+</SurfaceCard>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconPlug className="size-6 shrink-0 text-purple mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary">MCP</p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Query sessions, tool stats, failures, and intent clusters from any MCP client.</p>
-      <a href="/docs/mcp-analytics/surfaces/mcp" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Query over MCP →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconPlug" color="purple" title="MCP" url="/docs/mcp-analytics/surfaces/mcp" cta="Query over MCP">
+Query sessions, tool stats, failures, and intent clusters from any MCP client.
+</SurfaceCard>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconCode className="size-6 shrink-0 text-orange mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary flex items-center gap-1.5">PostHog Desktop <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Read Self-driving reports about failing tools, and merge the fixes for servers you own.</p>
-      <a href="/docs/mcp-analytics/surfaces/desktop" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Fix tools in PostHog Desktop →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconCode" color="orange" title="PostHog Desktop" badge="Beta" url="/docs/mcp-analytics/surfaces/desktop" cta="Fix tools in PostHog Desktop">
+Read Self-driving reports about failing tools, and merge the fixes for servers you own.
+</SurfaceCard>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconBrackets className="size-6 shrink-0 text-seagreen mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary">API</p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Pull sessions, tool calls, intent clusters, and feedback into your own systems.</p>
-      <a href="/docs/mcp-analytics/surfaces/api" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Use the API →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconBrackets" color="seagreen" title="API" url="/docs/mcp-analytics/surfaces/api" cta="Use the API">
+Pull sessions, tool calls, intent clusters, and feedback into your own systems.
+</SurfaceCard>
 
-</div>
+</SurfaceCards>
 
 ## Where its data comes from
 
 MCP Analytics runs on the events your MCP server sends to PostHog. The [SDK](/docs/mcp-analytics/installation) emits them automatically, and PostHog's hosted MCP server is instrumented the same way.
 
-<div className="not-prose grid grid-cols-1 @md:grid-cols-2 gap-x-6 gap-y-6 my-6">
+<SurfaceCards columns={2}>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconBolt className="size-6 shrink-0 text-orange mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary">Tool calls</p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">The canonical <code>$mcp_tool_call</code> event: tool name, client, latency, errors, and session.</p>
-      <a href="/docs/mcp-analytics/events" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Event reference →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconBolt" color="orange" title="Tool calls" url="/docs/mcp-analytics/events" cta="Event reference">
+The canonical <code>$mcp_tool_call</code> event: tool name, client, latency, errors, and session.
+</SurfaceCard>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconList className="size-6 shrink-0 text-blue mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary">Lifecycle and discovery</p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Initialize handshakes, <code>tools/list</code>, resource reads, and prompt fetches power client breakdowns.</p>
-      <a href="/docs/mcp-analytics/events" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">See all events →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconList" color="blue" title="Lifecycle and discovery" url="/docs/mcp-analytics/events" cta="See all events">
+Initialize handshakes, <code>tools/list</code>, resource reads, and prompt fetches power client breakdowns.
+</SurfaceCard>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconAIText className="size-6 shrink-0 text-purple mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary">Agent intent</p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">What the agent said it was trying to do, clustered into themes across sessions.</p>
-      <a href="/docs/mcp-analytics/intent" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Capture intent →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconAIText" color="purple" title="Agent intent" url="/docs/mcp-analytics/intent" cta="Capture intent">
+What the agent said it was trying to do, clustered into themes across sessions.
+</SurfaceCard>
 
-  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
-    <IconWrench className="size-6 shrink-0 text-red mt-0.5" />
-    <div>
-      <p className="m-0 font-bold text-primary">Missing capabilities</p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Gaps agents report through the <code>get_more_tools</code> virtual tool when the right tool doesn't exist.</p>
-      <a href="/docs/mcp-analytics/missing-capability" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Track missing capabilities →</a>
-    </div>
-  </div>
+<SurfaceCard icon="IconWrench" color="red" title="Missing capabilities" url="/docs/mcp-analytics/missing-capability" cta="Track missing capabilities">
+Gaps agents report through the <code>get_more_tools</code> virtual tool when the right tool doesn't exist.
+</SurfaceCard>
 
-</div>
+</SurfaceCards>
 
 ## How MCP Analytics works with Self-driving
 

--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -1,112 +1,133 @@
 ---
 title: MCP Analytics
+sidebar: Docs
+showTitle: true
+contentMaxWidthClass: max-w-5xl
 ---
 
+import { IconLaptop, IconPlug, IconCode, IconBrackets, IconBolt, IconList, IconWrench, IconAIText, IconNotebook, IconPullRequest, IconCheckCircle } from '@posthog/icons'
 import CalloutBox from 'components/Docs/CalloutBox'
 import OSButton from 'components/OSButton'
+import CustomSelfDrivingLoop from 'components/CustomSelfDrivingLoop'
+
+MCP Analytics shows you how AI agents actually use your MCP tools: which ones get called, what the agent was trying to do, where calls fail, and which capabilities agents asked for that you don't offer yet. It works on PostHog's own hosted MCP server and on any server you instrument with the [`@posthog/mcp` SDK](/docs/mcp-analytics/installation).
+
+Every tool invocation lands as a single `$mcp_tool_call` event on your standard events table, so the same data powers the purpose-built MCP Analytics views and anything you build yourself in [product analytics](/docs/product-analytics) or [SQL](/docs/data-warehouse/sql). Those calls also feed [Self-driving](/docs/self-driving), which spots tools that need fixing and opens pull requests you review and merge.
 
 <CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="action">
 
-`@posthog/mcp` instruments Model Context Protocol (MCP) servers with PostHog analytics. It's published on npm as a `0.x` release while we build it in public, so the API, event names, properties, and tracing behavior may change before the SDK reaches `1.0` – pin a version and don't depend on it for production reporting yet. Both [TypeScript and Python](/docs/mcp-analytics/installation#python) servers are supported.
-
-PostHog also has a purpose-built **MCP Analytics** view – a dashboard, a sessions explorer, per-tool quality breakdowns, and intent clustering – all built on the `$mcp_*` events the SDK sends. It's in beta behind a feature preview: [enable the MCP Analytics feature preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to turn it on. You don't have to wait for it, though – because every signal is a normal PostHog event, you can query and visualize the same data today through [Product Analytics](/docs/product-analytics), the [SQL editor](/docs/data-warehouse/sql), [Dashboards](/docs/product-analytics/dashboards), and [Error Tracking](/docs/error-tracking).
+The in-app MCP Analytics views are behind a feature preview – [turn on the MCP Analytics preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to enable them. The `@posthog/mcp` SDK is published as a `0.x` release, so event names, properties, and tracing behavior may change before `1.0`. Pin a version and don't depend on it for production reporting yet.
 
 </CalloutBox>
 
-MCP Analytics helps you understand how AI agents actually use the MCP server you ship: which tools get called, how often, what intent the agent had, where calls are failing, what tools the agent asked for but you don't offer yet, and how individual sessions flow end to end.
+<OSButton variant="primary" asLink to="/docs/mcp-analytics/start-here">Get started</OSButton>
 
-The SDK wraps your existing MCP server and emits PostHog events on every tool call, resource read, prompt fetch, and initialize handshake – no additional ingestion plumbing required.
+## Where you can use it
 
-<OSButton variant="primary" asLink to="/docs/mcp-analytics/start-here">
-Get started
-</OSButton>
+You explore MCP usage in the PostHog web app. The other surfaces let you query the same data, act on it, and pull it into your own tools.
 
-## What you can answer
+<div className="not-prose grid grid-cols-1 @md:grid-cols-2 gap-x-6 gap-y-6 my-6">
 
-- Which tools is each MCP client calling, and how often?
-- What is the agent actually trying to do (`$mcp_intent`)?
-- Which tools are advertised in `tools/list` responses but never get called?
-- What's the error rate and p95 latency of a given tool?
-- Did an agent hit `get_more_tools` because the right capability didn't exist?
-- How does a single MCP session unfold across tool calls?
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconLaptop className="size-6 shrink-0 text-blue mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary flex items-center gap-1.5">Web app <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Dashboards, session replay for agents, per-tool quality, and intent clustering.</p>
+      <a href="/docs/mcp-analytics/surfaces/web-app" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Explore MCP usage →</a>
+    </div>
+  </div>
 
-The MCP Analytics dashboard answers most of these at a glance – tool call volume, error rate, p95 latency, and the share of traffic per client:
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconPlug className="size-6 shrink-0 text-purple mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary">MCP</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Query sessions, tool stats, failures, and intent clusters from any MCP client.</p>
+      <a href="/docs/mcp-analytics/surfaces/mcp" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Query over MCP →</a>
+    </div>
+  </div>
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_dashboard_light_0907967b56.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_dashboard_dark_5023c584d4.png"
-  alt="MCP Analytics dashboard showing sessions, tool calls, error rate, p95 latency, daily activity, and share of calls by client"
-  classes="rounded"
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconCode className="size-6 shrink-0 text-orange mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary flex items-center gap-1.5">PostHog Desktop <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Review Self-driving reports about failing tools and merge the fixes they open.</p>
+      <a href="/docs/mcp-analytics/surfaces/desktop" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Fix tools in PostHog Desktop →</a>
+    </div>
+  </div>
+
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconBrackets className="size-6 shrink-0 text-seagreen mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary">API</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Pull sessions, tool calls, intent clusters, and feedback into your own systems.</p>
+      <a href="/docs/mcp-analytics/surfaces/api" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Use the API →</a>
+    </div>
+  </div>
+
+</div>
+
+## Where its data comes from
+
+MCP Analytics runs on the events your MCP server sends to PostHog. The [SDK](/docs/mcp-analytics/installation) emits them automatically, and PostHog's hosted MCP server is instrumented the same way.
+
+<div className="not-prose grid grid-cols-1 @md:grid-cols-2 gap-x-6 gap-y-6 my-6">
+
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconBolt className="size-6 shrink-0 text-orange mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary">Tool calls</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">The canonical <code>$mcp_tool_call</code> event: tool name, client, latency, errors, and session.</p>
+      <a href="/docs/mcp-analytics/events" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Event reference →</a>
+    </div>
+  </div>
+
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconList className="size-6 shrink-0 text-blue mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary">Lifecycle and discovery</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Initialize handshakes, <code>tools/list</code>, resource reads, and prompt fetches power client breakdowns.</p>
+      <a href="/docs/mcp-analytics/events" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">See all events →</a>
+    </div>
+  </div>
+
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconAIText className="size-6 shrink-0 text-purple mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary">Agent intent</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">What the agent said it was trying to do, clustered into themes across sessions.</p>
+      <a href="/docs/mcp-analytics/intent" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Capture intent →</a>
+    </div>
+  </div>
+
+  <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+    <IconWrench className="size-6 shrink-0 text-red mt-0.5" />
+    <div>
+      <p className="m-0 font-bold text-primary">Missing capabilities</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Gaps agents report through the <code>get_more_tools</code> virtual tool when the right tool doesn't exist.</p>
+      <a href="/docs/mcp-analytics/missing-capability" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Track missing capabilities →</a>
+    </div>
+  </div>
+
+</div>
+
+## How MCP Analytics works with Self-driving
+
+Your tool calls are a signal source for [Self-driving](/docs/self-driving). A scout watches `$mcp_tool_call` telemetry for tools that need attention – high failure rates, agents retrying the same call, slow or bloated responses – and groups them by tool category into a report. When the problem is in a server your team owns, the report carries a fix loop metric and hands off to a coding agent that opens a pull request.
+
+<CustomSelfDrivingLoop
+  stages={[
+    { label: 'Tool calls', icon: IconBolt, color: '#F54E00', description: 'Every agent invocation of your MCP tools' },
+    { label: 'Signals', icon: IconPlug, color: '#FFA81C', description: 'Failures, retries, and slow responses surfaced by a scout' },
+    { label: 'One report', icon: IconNotebook, color: '#29DBBB', description: 'Grouped by tool category, with a fix loop metric' },
+    { label: 'Draft PR', icon: IconPullRequest, color: '#A737D2', description: 'When your team owns the server' },
+    { label: 'You merge', icon: IconCheckCircle, color: '#47C861', description: 'Nothing ships without a human' },
+  ]}
 />
 
-Drill into any single MCP session to step through its tool calls, intents, and errors in order:
+You can also start this yourself: the per-tool quality view has a **Create fix task** button that opens the same kind of pull request from a specific failing tool. Problems in PostHog's hosted server that your team doesn't own are filed for human review instead. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how reports and fixes work.
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_sessions_light_bdd1eb84cb.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_sessions_dark_d5b4aa4577.png"
-  alt="MCP Analytics sessions explorer showing a session's tool calls, intents, and an errored call"
-  classes="rounded"
-/>
+<CalloutBox icon="IconInfo" title="MCP Analytics vs. PostHog's MCP server" type="fyi">
 
-## How it works
+This is analytics *about* MCP usage. If you're looking for PostHog's own MCP server and the tools it exposes for querying your product data, see the [MCP docs](/docs/model-context-protocol).
 
-`instrument(server, posthog, options?)` patches your MCP server's request handlers and returns an analytics handle. The `posthog` client (a [`posthog-node`](/docs/libraries/node) instance) is a required positional argument. When the agent calls a tool, the SDK:
-
-1. Builds a structured event with the tool name, parameters, response, duration, and error state.
-2. Runs the payload through sanitization (image/audio/binary stubs, sensitive-key masking), truncation, and your optional `beforeSend` hook.
-3. Sends it to PostHog via the `posthog-node` client you pass in, batched and flushed by that client.
-
-Your tool handlers are untouched. The only payload change the agent sees is an optional injected `context` argument (see [Capturing agent intent](/docs/mcp-analytics/intent)) and an optional injected `conversation_id` argument (see [Conversation IDs](/docs/mcp-analytics/conversation-id)).
-
-```mermaid
-graph LR
-Agent["AI agent"] -->|tools/call| MCP["Your MCP server"]
-MCP --> Wrapper["@posthog/mcp wrapper"]
-Wrapper --> Handler["Your tool handler"]
-Wrapper --> Event["$mcp_tool_call event"]
-Event --> PostHog["PostHog"]
-```
-
-## Quick install
-
-```bash
-npm install @posthog/mcp posthog-node
-```
-
-```ts
-import { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import { PostHog } from "posthog-node"
-import { instrument } from "@posthog/mcp"
-
-const server = new Server({ name: "my-mcp-server", version: "1.0.0" })
-
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
-host: "https://us.i.posthog.com",
-})
-
-instrument(server, posthog)
-```
-
-That's the minimum. With this in place, every `tools/call`, `tools/list`, `initialize`, `resources/read`, and `prompts/get` request emits a PostHog event prefixed with `$mcp_*`.
-
-<OSButton variant="primary" asLink to="/docs/mcp-analytics/installation">
-Full installation guide
-</OSButton>
-
-## Where to go next
-
-- **[Getting started](/docs/mcp-analytics/start-here)** – the guided onboarding flow
-- **[Installation](/docs/mcp-analytics/installation)** – full setup, server type variants, BYO PostHog client
-- **[Custom servers](/docs/mcp-analytics/custom-servers)** – `PostHogMCP` for Hono/edge dispatchers with no server object to wrap
-- **[Capturing agent intent](/docs/mcp-analytics/intent)** – the `context` argument and `intentFallback`
-- **[Conversation IDs](/docs/mcp-analytics/conversation-id)** – stitching multi-turn conversations together
-- **[Identifying users](/docs/mcp-analytics/identifying-users)** – attaching events to your own users
-- **[Missing capability tracking](/docs/mcp-analytics/missing-capability)** – the `get_more_tools` virtual tool
-- **[Custom events and metadata](/docs/mcp-analytics/custom-events)** – `analytics.capture()` and `eventProperties`
-- **[Privacy and redaction](/docs/mcp-analytics/privacy)** – what's sanitized automatically, customer redaction hook
-- **[Event and property reference](/docs/mcp-analytics/events)** – every event the SDK emits and what's on it
-- **[Sample queries](/docs/mcp-analytics/queries)** – HogQL recipes for the most common dashboards
-
-## Building in public
-
-The SDK source lives in the [`posthog-js` monorepo](https://github.com/PostHog/posthog-js/tree/main/packages/mcp) alongside the rest of PostHog's JavaScript and TypeScript SDKs. Issues, PRs, and feedback are welcome. We started from a duplicated copy of the MIT-licensed [MCPcat TypeScript SDK](https://github.com/MCPCat/mcpcat-typescript-sdk) – the event schema, identity model, and feature surface have since diverged.
+</CalloutBox>

--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -12,7 +12,7 @@ import CustomSelfDrivingLoop from 'components/CustomSelfDrivingLoop'
 
 MCP Analytics shows you how AI agents actually use your MCP tools: which ones get called, what the agent was trying to do, where calls fail, and which capabilities agents asked for that you don't offer yet. It works on PostHog's own hosted MCP server and on any server you instrument with the [`@posthog/mcp` SDK](/docs/mcp-analytics/installation).
 
-Every tool invocation lands as a single `$mcp_tool_call` event on your standard events table, so the same data powers the purpose-built MCP Analytics views and anything you build yourself in [product analytics](/docs/product-analytics) or [SQL](/docs/data-warehouse/sql). Those calls also feed [Self-driving](/docs/self-driving), which spots tools that need fixing and opens pull requests you review and merge.
+Every tool invocation lands as a single `$mcp_tool_call` event on your standard events table, so the same data powers the purpose-built MCP Analytics views and anything you build yourself in [product analytics](/docs/product-analytics) or [SQL](/docs/data-warehouse/sql). Those calls also feed [Self-driving](/docs/self-driving), which spots tools that need fixing and files a report – and opens a pull request when the server is one you own.
 
 <CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="action">
 
@@ -50,7 +50,7 @@ You explore MCP usage in the PostHog web app. The other surfaces let you query t
     <IconCode className="size-6 shrink-0 text-orange mt-0.5" />
     <div>
       <p className="m-0 font-bold text-primary flex items-center gap-1.5">PostHog Desktop <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
-      <p className="m-0 mt-0.5 text-sm text-secondary">Review Self-driving reports about failing tools and merge the fixes they open.</p>
+      <p className="m-0 mt-0.5 text-sm text-secondary">Read Self-driving reports about failing tools, and merge the fixes for servers you own.</p>
       <a href="/docs/mcp-analytics/surfaces/desktop" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Fix tools in PostHog Desktop →</a>
     </div>
   </div>
@@ -112,16 +112,18 @@ MCP Analytics runs on the events your MCP server sends to PostHog. The [SDK](/do
 
 ## How MCP Analytics works with Self-driving
 
-Your tool calls are a signal source for [Self-driving](/docs/self-driving). A scout watches `$mcp_tool_call` telemetry for tools that need attention – high failure rates, agents retrying the same call, slow or bloated responses – and groups them by tool category into a report. When the problem is in a server your team owns, the report carries a fix loop metric and hands off to a coding agent that opens a pull request.
+Your tool calls are a signal source for [Self-driving](/docs/self-driving). A scout watches `$mcp_tool_call` telemetry for tools that need attention – high failure rates, agents retrying the same call, slow or bloated responses – weighs them by volume and reach, and files a report grouped by the team that owns the tools.
+
+What comes after the report depends on who owns the MCP server it's about. If it's your own server, the report carries a fix loop metric and hands off to a coding agent that opens a pull request. If it's PostHog's hosted server – which is what most projects are analyzing – the report is filed for a human with no repository attached, and nothing opens a pull request.
 
 <CustomSelfDrivingLoop
   stages={[
     { label: 'Tool calls', icon: IconBolt, color: '#F54E00', description: 'Every agent invocation of your MCP tools' },
     { label: 'Signals', icon: IconPlug, color: '#FFA81C', description: 'Failures, retries, and slow responses surfaced by a scout' },
-    { label: 'One report', icon: IconNotebook, color: '#29DBBB', description: 'Grouped by tool category, with a fix loop metric' },
-    { label: 'Draft PR', icon: IconPullRequest, color: '#A737D2', description: 'When your team owns the server' },
+    { label: 'One report', icon: IconNotebook, color: '#29DBBB', description: 'Grouped by owning team, with the evidence behind it' },
+    { label: 'Draft PR', icon: IconPullRequest, color: '#A737D2', description: 'Only when you own the server and the fix is concrete' },
     { label: 'You merge', icon: IconCheckCircle, color: '#47C861', description: 'Nothing ships without a human' },
   ]}
 />
 
-You can also start this yourself: the per-tool quality view has a **Create fix task** button that opens the same kind of pull request from a specific failing tool. Problems in PostHog's hosted server that your team doesn't own are filed for human review instead. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how reports and fixes work.
+You can also start a fix yourself: the per-tool quality view has a **Create fix task** button that runs the same coding agent against a repository you choose. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how reports and fixes work.

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -5,7 +5,7 @@ title: Installing the MCP Analytics SDK
 import CalloutBox from 'components/Docs/CalloutBox'
 import WizardCommand from 'components/WizardCommand'
 
-<CalloutBox icon="IconFlask" title="Beta SDK" type="action">
+<CalloutBox icon="IconFlask" title="Beta SDK" type="fyi">
 
 `@posthog/mcp` is in beta (pre-1.0). The API may still change – including breaking changes in minor `0.x` releases – until `v1`, so pin a version while we iterate.
 

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -10,7 +10,7 @@ import OSButton from 'components/OSButton'
 import CalloutBox from 'components/Docs/CalloutBox'
 import WizardCommand from 'components/WizardCommand'
 
-<CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="action">
+<CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="fyi">
 
 `@posthog/mcp` is published as a `0.1.x` release on npm. We're building it in public – the event shape, options, and tracing behavior may still change before `1.0`. Pin a specific version and don't depend on it for production reporting yet.
 

--- a/contents/docs/mcp-analytics/surfaces/api.mdx
+++ b/contents/docs/mcp-analytics/surfaces/api.mdx
@@ -1,0 +1,48 @@
+---
+title: MCP Analytics API
+sidebar: Docs
+showTitle: true
+---
+
+<CalloutBox icon="IconFlask" title="Open beta" type="action">
+
+The MCP Analytics API is in beta and requires the MCP Analytics feature preview to be enabled. Endpoints may change before general availability.
+
+</CalloutBox>
+
+Use the API to pull MCP Analytics data into your own dashboards, reports, or workflows. Reading requires the `mcp_analytics:read` scope; submitting feedback or recomputing clusters requires `mcp_analytics:write`.
+
+For the raw event stream, you can also query `$mcp_*` events directly through the [query API](/docs/api/query) – see [sample queries](/docs/mcp-analytics/queries) for HogQL recipes.
+
+## What's available
+
+**Sessions**
+
+List MCP sessions, then drill into one for its tool calls. You can also generate an intent summary for a session, fetch an intent digest, and pull an activity overview.
+
+**Intent clusters**
+
+Retrieve clustered agent intents with their tool distribution and error rates, or trigger a recompute after new data lands.
+
+**Feedback**
+
+Read and submit feedback about your MCP tools, including the client, session, and trace context it came from.
+
+**Missing capabilities**
+
+Read and submit the capability gaps agents report through the [`get_more_tools`](/docs/mcp-analytics/missing-capability) virtual tool.
+
+## Authentication
+
+Use a [personal API key](/docs/api#authentication) with the scopes above, passed as a bearer token:
+
+```bash
+curl -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  https://us.posthog.com/api/projects/:project_id/mcp_sessions/
+```
+
+## Related
+
+- Explore the same data in the [web app](/docs/mcp-analytics/surfaces/web-app).
+- Query it conversationally over [MCP](/docs/mcp-analytics/surfaces/mcp).
+- See the full [PostHog API reference](/docs/api).

--- a/contents/docs/mcp-analytics/surfaces/api.mdx
+++ b/contents/docs/mcp-analytics/surfaces/api.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<CalloutBox icon="IconFlask" title="Open beta" type="action">
+<CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
 The MCP Analytics API is in beta and requires the MCP Analytics feature preview to be enabled. Endpoints may change before general availability.
 

--- a/contents/docs/mcp-analytics/surfaces/desktop.mdx
+++ b/contents/docs/mcp-analytics/surfaces/desktop.mdx
@@ -10,33 +10,41 @@ PostHog Desktop is in beta.
 
 </CalloutBox>
 
-[PostHog Desktop](/docs/posthog-desktop) is where you review and merge the [Self-driving](/docs/self-driving) work that MCP Analytics generates. Your tool call telemetry doesn't just sit in a dashboard – a scout reads it, finds tools that need fixing, and hands concrete problems to a coding agent that opens a pull request.
+[PostHog Desktop](/docs/posthog-desktop) is where you act on the [Self-driving](/docs/self-driving) reports MCP Analytics generates. A scout reads your tool call telemetry, finds tools that need fixing, and files a report. Whether that report arrives with a pull request attached depends on who owns the server it's about.
 
-## How a tool problem becomes a pull request
+## Whether you get a pull request depends on who owns the server
 
-A scout watches `$mcp_tool_call` events for tools that need attention:
+The scout can only propose a code fix for code you control, so the same finding takes one of two paths:
+
+- **You own the server.** Your own MCP server, instrumented with the [`@posthog/mcp` SDK](/docs/mcp-analytics/installation). The report carries a **fix loop metric** – the number the fix is supposed to move – and auto-starts an implementation task. The coding agent works in a sandbox against your connected repo, pushes a branch, and opens a draft pull request.
+- **You don't own the server.** You're analyzing PostHog's hosted MCP server, which is what most projects are doing. The report is filed for human review with no repository attached, and nothing opens a pull request. Read it as an upstream bug report and decide what to do with it.
+
+Even on a server you own, a report that bundles unrelated fixes across several tools goes to a human – there's no single pull request that would cover it. The automatic path is for a concrete, localized change: a schema or description fix, or a bug in one handler.
+
+## What the scout watches
+
+A scout reads `$mcp_tool_call` events for tools that need attention:
 
 - **High failure rates** – a tool erroring far more than the rest
 - **Retries and hammering** – agents calling the same tool over and over to get what they need
 - **Slow or bloated responses** – calls that take too long or return so much that they crowd the agent's context
 
-It groups what it finds by tool category and files a report. When the problem is in a server your team owns, the report includes a **fix loop metric** – the number the fix is supposed to move – and auto-starts an implementation task. The coding agent works in a sandbox against your connected repo, pushes a branch, and opens a draft pull request.
-
-Problems found in PostHog's hosted MCP server that your team doesn't own are filed for human review instead, with no repository attached.
+It weighs each of these by volume and reach, so a tool failing for one developer in one session doesn't earn a report. What clears the bar gets grouped by the team that owns the tools and filed as a single report.
 
 ## What you can do here
 
 - **Read the report** – the failing tool, the pattern behind it, and the evidence from real calls.
 - **Ask questions** – start a research task against the report to dig further before acting.
-- **Create a PR** – auto-started for owned servers, or kick one off manually.
-- **Watch the agent work** – follow the live transcript and review the files it changed.
+- **Watch the agent work** – when there's an implementation task, follow the live transcript and review the files it changed.
 - **Merge** – the pull request opens on GitHub, and PostHog reflects the merged state back.
 
 Nothing ships without you. The merge happens on GitHub, so a human is always the last step.
 
 ## Start a fix yourself
 
-You don't have to wait for the scout. The **Create fix task** button on the [tool quality view](/docs/mcp-analytics/surfaces/web-app#tool-quality) starts the same coding agent run from a specific tool's failures.
+You don't have to wait for the scout, and you don't need it to have taken the automatic path. The **Create fix task** button on the [tool quality view](/docs/mcp-analytics/surfaces/web-app#tool-quality) starts the same coding agent run from a specific tool's failures.
+
+It needs the GitHub integration connected – the button stays disabled without it – and you pick the repository the agent works in. That's the same constraint as the automatic path, just made explicit: the agent can only fix a codebase you've pointed it at.
 
 ## Related
 

--- a/contents/docs/mcp-analytics/surfaces/desktop.mdx
+++ b/contents/docs/mcp-analytics/surfaces/desktop.mdx
@@ -1,0 +1,44 @@
+---
+title: Fix MCP tools in PostHog Desktop
+sidebar: Docs
+showTitle: true
+---
+
+<CalloutBox icon="IconFlask" title="Open beta" type="action">
+
+PostHog Desktop is in beta.
+
+</CalloutBox>
+
+[PostHog Desktop](/docs/posthog-desktop) is where you review and merge the [Self-driving](/docs/self-driving) work that MCP Analytics generates. Your tool call telemetry doesn't just sit in a dashboard – a scout reads it, finds tools that need fixing, and hands concrete problems to a coding agent that opens a pull request.
+
+## How a tool problem becomes a pull request
+
+A scout watches `$mcp_tool_call` events for tools that need attention:
+
+- **High failure rates** – a tool erroring far more than the rest
+- **Retries and hammering** – agents calling the same tool over and over to get what they need
+- **Slow or bloated responses** – calls that take too long or return so much that they crowd the agent's context
+
+It groups what it finds by tool category and files a report. When the problem is in a server your team owns, the report includes a **fix loop metric** – the number the fix is supposed to move – and auto-starts an implementation task. The coding agent works in a sandbox against your connected repo, pushes a branch, and opens a draft pull request.
+
+Problems found in PostHog's hosted MCP server that your team doesn't own are filed for human review instead, with no repository attached.
+
+## What you can do here
+
+- **Read the report** – the failing tool, the pattern behind it, and the evidence from real calls.
+- **Ask questions** – start a research task against the report to dig further before acting.
+- **Create a PR** – auto-started for owned servers, or kick one off manually.
+- **Watch the agent work** – follow the live transcript and review the files it changed.
+- **Merge** – the pull request opens on GitHub, and PostHog reflects the merged state back.
+
+Nothing ships without you. The merge happens on GitHub, so a human is always the last step.
+
+## Start a fix yourself
+
+You don't have to wait for the scout. The **Create fix task** button on the [tool quality view](/docs/mcp-analytics/surfaces/web-app#tool-quality) starts the same coding agent run from a specific tool's failures.
+
+## Related
+
+- Explore tool quality in the [web app](/docs/mcp-analytics/surfaces/web-app).
+- Learn how the loop works in the [Self-driving docs](/docs/self-driving).

--- a/contents/docs/mcp-analytics/surfaces/desktop.mdx
+++ b/contents/docs/mcp-analytics/surfaces/desktop.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<CalloutBox icon="IconFlask" title="Open beta" type="action">
+<CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
 PostHog Desktop is in beta.
 

--- a/contents/docs/mcp-analytics/surfaces/mcp.mdx
+++ b/contents/docs/mcp-analytics/surfaces/mcp.mdx
@@ -57,4 +57,4 @@ Point your agent at these once the tools are connected:
 
 - Explore the same data visually in the [web app](/docs/mcp-analytics/surfaces/web-app).
 - See the full list of PostHog MCP tools in the [MCP docs](/docs/model-context-protocol).
-- Review Self-driving fixes for failing tools in [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop).
+- Act on Self-driving reports about failing tools in [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop).

--- a/contents/docs/mcp-analytics/surfaces/mcp.mdx
+++ b/contents/docs/mcp-analytics/surfaces/mcp.mdx
@@ -1,0 +1,60 @@
+---
+title: Query MCP Analytics over MCP
+sidebar: Docs
+showTitle: true
+---
+
+<CalloutBox icon="IconFlask" title="Open beta" type="action">
+
+MCP Analytics tools are in beta and require the MCP Analytics feature preview to be enabled.
+
+</CalloutBox>
+
+PostHog's [MCP server](/docs/model-context-protocol) exposes MCP Analytics as a set of tools, so you can investigate how agents use your server from Claude Code, Cursor, or any other MCP client – without switching to the web app. It's the fastest way to ask "which of my tools is failing, and why?" while you're already in your editor.
+
+## Setup
+
+Follow the [MCP server setup](/docs/model-context-protocol) to connect PostHog to your client. MCP Analytics tools need the `mcp_analytics:read` scope, and the ones that write data (feedback, missing capabilities, recomputing clusters) need `mcp_analytics:write`.
+
+## What you can do here
+
+**Explore sessions**
+
+- List MCP sessions and filter them down
+- Open a single session and read its tool calls in order
+- Generate an intent summary for a session
+
+**Understand intent**
+
+- Retrieve intent clusters and their tool distribution
+- Recompute clusters after new data lands
+
+**Dig into tool quality**
+
+- Per-tool stats: volume, error rate, and latency
+- Daily trend for a tool over time
+- Recent failures, with error type and message
+- Top users of a given tool
+- Neighboring tools that get called alongside it
+- Sample intents behind its calls
+- Harness and client breakdown
+
+**Send feedback**
+
+- Submit feedback about a tool
+- Report a missing capability your agent needed but couldn't find
+
+## Example prompts
+
+Point your agent at these once the tools are connected:
+
+- "Which of my MCP tools has the highest error rate this week?"
+- "Show me the last 10 failed calls to `search_docs` and what the errors were."
+- "What are agents actually trying to do when they call `create_issue`? Summarize the intent clusters."
+- "Which tools get called right before `run_query`?"
+
+## Related
+
+- Explore the same data visually in the [web app](/docs/mcp-analytics/surfaces/web-app).
+- See the full list of PostHog MCP tools in the [MCP docs](/docs/model-context-protocol).
+- Review Self-driving fixes for failing tools in [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop).

--- a/contents/docs/mcp-analytics/surfaces/mcp.mdx
+++ b/contents/docs/mcp-analytics/surfaces/mcp.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<CalloutBox icon="IconFlask" title="Open beta" type="action">
+<CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
 MCP Analytics tools are in beta and require the MCP Analytics feature preview to be enabled.
 

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -34,7 +34,7 @@ Every MCP session, with notable ones surfaced first. Open a session to step thro
 
 Per-tool stats: call volume, error rate, latency, and the failure modes behind them. Drill into any tool to see the calls that failed and why.
 
-This tab has a **Create fix task** button. It hands the failing tool to a coding agent, which opens a pull request the same way a [Self-driving](/docs/self-driving) report would. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how that flow works.
+This tab has a **Create fix task** button. It hands the failing tool to a coding agent, which works against a repository you choose and opens a pull request – the same run a [Self-driving](/docs/self-driving) report starts automatically when you own the server. It needs the GitHub integration connected, and stays disabled without it. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how that flow works.
 
 ### Intent clustering
 

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<CalloutBox icon="IconFlask" title="Open beta" type="action">
+<CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
 The MCP Analytics views are behind a feature preview. [Turn on the MCP Analytics preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to enable them.
 

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -12,8 +12,6 @@ The MCP Analytics views are behind a feature preview. [Turn on the MCP Analytics
 
 The [PostHog web app](https://app.posthog.com) is where you explore how agents use your MCP tools. Once your server is [sending events](/docs/mcp-analytics/installation), open **MCP Analytics** to get dashboards, session drill-downs, per-tool quality, and clustered intent – all built on the `$mcp_tool_call` stream.
 
-{/*TODO: screenshot of the MCP Analytics scene tab bar*/}
-
 ## What you can do here
 
 The scene is organized into tabs, each answering a different question.

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -1,0 +1,55 @@
+---
+title: MCP Analytics in the web app
+sidebar: Docs
+showTitle: true
+---
+
+<CalloutBox icon="IconFlask" title="Open beta" type="action">
+
+The MCP Analytics views are behind a feature preview. [Turn on the MCP Analytics preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to enable them.
+
+</CalloutBox>
+
+The [PostHog web app](https://app.posthog.com) is where you explore how agents use your MCP tools. Once your server is [sending events](/docs/mcp-analytics/installation), open **MCP Analytics** to get dashboards, session drill-downs, per-tool quality, and clustered intent – all built on the `$mcp_tool_call` stream.
+
+{/*TODO: screenshot of the MCP Analytics scene tab bar*/}
+
+## What you can do here
+
+The scene is organized into tabs, each answering a different question.
+
+### Dashboard
+
+The at-a-glance view: KPI tiles for sessions, tool calls, error rate, and p95 latency, a breakdown of which clients and harnesses are calling you, and charts for tool usage and errors over time.
+
+### Activity
+
+A live feed of tool calls as they arrive. Useful when you're verifying a new instrumentation or watching a release land.
+
+### Sessions
+
+Every MCP session, with notable ones surfaced first. Open a session to step through its tool calls, intents, and errors in order – the agent equivalent of a [session replay](/docs/session-replay). You can filter into a playlist and jump between sessions from the detail view.
+
+### Tool quality
+
+Per-tool stats: call volume, error rate, latency, and the failure modes behind them. Drill into any tool to see the calls that failed and why.
+
+This tab has a **Create fix task** button. It hands the failing tool to a coding agent, which opens a pull request the same way a [Self-driving](/docs/self-driving) report would. See [PostHog Desktop](/docs/mcp-analytics/surfaces/desktop) for how that flow works.
+
+### Intent clustering
+
+Groups what agents said they were trying to do into themes, so you can see the jobs your server actually gets used for. Includes a journey view of how agents move between tools within a cluster. Intent comes from [`$mcp_intent`](/docs/mcp-analytics/intent) plus generated session summaries.
+
+## Ask PostHog AI
+
+[PostHog AI](/docs/posthog-ai) works over this data directly in the web app – it's an interaction mode here, not a separate surface. Ask it to explore sessions, dig into tool usage or quality, break down intent clusters, or suggest improvements to your tools, and it answers using the same MCP Analytics data. Views include an **Ask PostHog AI** link that opens it with the relevant question prefilled.
+
+## Build your own views
+
+Every signal is a normal PostHog event, so you aren't limited to these tabs. Query `$mcp_*` events in [product analytics](/docs/product-analytics), the [SQL editor](/docs/data-warehouse/sql), and [dashboards](/docs/product-analytics/dashboards). See [sample queries](/docs/mcp-analytics/queries) for recipes.
+
+## Related
+
+- Query the same data from your editor over [MCP](/docs/mcp-analytics/surfaces/mcp).
+- Pull it into your own systems with the [API](/docs/mcp-analytics/surfaces/api).
+- Learn what lands on each event in the [event reference](/docs/mcp-analytics/events).

--- a/src/components/Docs/SurfaceCards.README.md
+++ b/src/components/Docs/SurfaceCards.README.md
@@ -1,0 +1,56 @@
+# SurfaceCards
+
+A card grid for docs overview pages. Used for the two grids the tool docs IA calls for – "Where you
+can use it" (the surfaces a tool runs on) and "Where its data comes from" (its context/data sources).
+
+Before this component, each overview page hand-rolled the same `<div className="not-prose grid ...">`
+markup inline, which meant every tool's overview repeated ~10 lines of Tailwind per card and the
+styling drifted between pages.
+
+## Usage
+
+```mdx
+import { SurfaceCards, SurfaceCard } from 'components/Docs/SurfaceCards'
+
+<SurfaceCards columns={2}>
+
+<SurfaceCard icon="IconLaptop" color="blue" title="Web app" badge="Beta"
+  url="/docs/mcp-analytics/surfaces/web-app" cta="Explore MCP usage">
+Dashboards, session replay for agents, per-tool quality, and intent clustering.
+</SurfaceCard>
+
+<SurfaceCard icon="IconPlug" color="purple" title="MCP"
+  url="/docs/mcp-analytics/surfaces/mcp" cta="Query over MCP">
+Query sessions, tool stats, failures, and intent clusters from any MCP client.
+</SurfaceCard>
+
+</SurfaceCards>
+```
+
+## `SurfaceCards` props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columns` | `2 \| 3` | `3` | Grid width at the largest breakpoint. `2` → 1/2 columns, `3` → 1/2/3 columns. Uses `@container` queries, so it responds to the window's width, not the viewport. |
+| `children` | `ReactNode` | – | `SurfaceCard` elements. |
+
+Pick `columns` to avoid an orphaned card: four cards look better at `columns={2}` (a 2×2) than at
+`columns={3}` (a 3+1).
+
+## `SurfaceCard` props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `icon` | `string` | – | Name of a `@posthog/icons` icon, e.g. `"IconLaptop"`. Falls back to `IconInfo` if unknown. |
+| `color` | `string` | `"primary"` | Project color token for the icon, e.g. `"blue"`, `"purple"`, `"seagreen"`. Rendered as `text-{color}`, so the token must exist in `safelist.txt`. Do not use stock Tailwind colors. |
+| `title` | `string` | – | Card heading, e.g. `"Web app"`. |
+| `badge` | `string` | – | Optional pill after the title, e.g. `"Beta"`. |
+| `url` | `string` | – | Relative link for the CTA, e.g. `/docs/mcp-analytics/surfaces/mcp`. |
+| `cta` | `string` | – | CTA text. The `→` is appended automatically – do not include it. |
+| `children` | `ReactNode` | – | The card body. Inline markup such as `<code>` is fine. |
+
+## Notes
+
+- The wrapper sets `not-prose`, so surrounding docs typography styles do not leak into the cards.
+- Leave a blank line between `SurfaceCard` elements in MDX so the children parse as MDX rather than
+  as a single text block.

--- a/src/components/Docs/SurfaceCards.tsx
+++ b/src/components/Docs/SurfaceCards.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import * as Icons from '@posthog/icons'
+
+const columnStyles: Record<number, string> = {
+    2: 'grid-cols-1 @md:grid-cols-2',
+    3: 'grid-cols-1 @md:grid-cols-2 @3xl:grid-cols-3',
+}
+
+interface SurfaceCardProps {
+    icon: string
+    color?: string
+    title: string
+    badge?: string
+    url: string
+    cta: string
+    children: React.ReactNode
+}
+
+export const SurfaceCard = ({ icon, color = 'primary', title, badge, url, cta, children }: SurfaceCardProps) => {
+    const Icon = Icons[icon] || Icons.IconInfo
+
+    return (
+        <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
+            <Icon className={`size-6 shrink-0 text-${color} mt-0.5`} />
+            <div>
+                <p className="m-0 font-bold text-primary flex items-center gap-1.5">
+                    {title}
+                    {badge && (
+                        <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">
+                            {badge}
+                        </span>
+                    )}
+                </p>
+                <p className="m-0 mt-0.5 text-sm text-secondary">{children}</p>
+                <a href={url} className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">
+                    {cta} →
+                </a>
+            </div>
+        </div>
+    )
+}
+
+interface SurfaceCardsProps {
+    columns?: 2 | 3
+    children: React.ReactNode
+}
+
+export const SurfaceCards = ({ columns = 3, children }: SurfaceCardsProps) => (
+    <div className={`not-prose grid ${columnStyles[columns] || columnStyles[3]} gap-x-6 gap-y-6 my-6`}>{children}</div>
+)
+
+export default SurfaceCards

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6606,7 +6606,7 @@ export const docsMenu = {
                     color: 'seagreen',
                 },
                 {
-                    name: 'Getting started',
+                    name: 'Get started',
                 },
                 {
                     name: 'Start here',
@@ -6629,7 +6629,44 @@ export const docsMenu = {
                     color: 'teal',
                 },
                 {
-                    name: 'Concepts',
+                    name: 'Surfaces',
+                },
+                {
+                    name: 'Web app',
+                    url: '/docs/mcp-analytics/surfaces/web-app',
+                    icon: 'IconLaptop',
+                    color: 'blue',
+                    featured: true,
+                },
+                {
+                    name: 'MCP',
+                    url: '/docs/mcp-analytics/surfaces/mcp',
+                    icon: 'IconPlug',
+                    color: 'purple',
+                    featured: true,
+                },
+                {
+                    name: 'PostHog Desktop',
+                    url: '/docs/mcp-analytics/surfaces/desktop',
+                    icon: 'IconCode',
+                    color: 'orange',
+                    featured: true,
+                },
+                {
+                    name: 'API',
+                    url: '/docs/mcp-analytics/surfaces/api',
+                    icon: 'IconBrackets',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'Events',
+                },
+                {
+                    name: 'Event & property reference',
+                    url: '/docs/mcp-analytics/events',
+                    icon: 'IconList',
+                    color: 'red',
+                    featured: true,
                 },
                 {
                     name: 'Capturing agent intent',
@@ -6639,10 +6676,13 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
-                    name: 'Conversation IDs',
-                    url: '/docs/mcp-analytics/conversation-id',
-                    icon: 'IconMessage',
-                    color: 'salmon',
+                    name: 'Missing capabilities',
+                    url: '/docs/mcp-analytics/missing-capability',
+                    icon: 'IconWrench',
+                    color: 'orange',
+                },
+                {
+                    name: 'Instrumentation',
                 },
                 {
                     name: 'Identifying users',
@@ -6651,10 +6691,10 @@ export const docsMenu = {
                     color: 'seagreen',
                 },
                 {
-                    name: 'Missing capabilities',
-                    url: '/docs/mcp-analytics/missing-capability',
-                    icon: 'IconWrench',
-                    color: 'orange',
+                    name: 'Conversation IDs',
+                    url: '/docs/mcp-analytics/conversation-id',
+                    icon: 'IconMessage',
+                    color: 'salmon',
                 },
                 {
                     name: 'Custom events & metadata',
@@ -6670,14 +6710,7 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
-                    name: 'Reference',
-                },
-                {
-                    name: 'Event & property reference',
-                    url: '/docs/mcp-analytics/events',
-                    icon: 'IconList',
-                    color: 'red',
-                    featured: true,
+                    name: 'Resources',
                 },
                 {
                     name: 'Sample queries',


### PR DESCRIPTION
## What changed

Restructures MCP Analytics docs to the new tool [IA](https://posthog.com/handbook/wizard-and-docs/writing-product-docs): **Overview → Get started → Surfaces → Context → Resources**.

- **Overview** rewritten with surface cards, data-source cards, and the Self-driving loop (tool calls → scout → report → PR *when you own the server*).
- **Surfaces** – four new pages. The docs previously only covered the `@posthog/mcp` SDK, so the in-app views, MCP tools, Signals scout, and API were undocumented: **Web app**, **MCP**, **PostHog Desktop**, **API**.
- **Context** – the old Concepts/Reference grouping split into **Events** (what your server sends) and **Instrumentation** (how you shape it).
- **The auto-PR condition leads.** `signals-scout-mcp-tool-calls` can set `actionability=immediately_actionable`, but only when your team owns the MCP server being analyzed. Most projects analyze PostHog's hosted server and get `requires_human_input` + `NO_REPO` – a report, no pull request. That condition was buried below the fold, so auto-PR read as the default when it's the exception. The Desktop page and the Overview now open on the ownership split, and the loop's *Draft PR* stage says it only happens when you own the server and the fix is concrete. The fix-loop-metric detail and the manual **Create fix task** path (both real) are kept, with its verified constraint added: it needs the GitHub integration and a repository you pick.

PostHog AI is documented as an in-app mode on the web app page, not a surface. Slack and CLI aren't listed as surfaces since neither is wired up here.

## Before / after

before:
<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/d2e36c21-0454-47a7-ae90-82efd10ac35c" />

after:
<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/307bf0e9-4977-4b13-8c24-6f6eb804939e" />

## Blast radius

Nav changes are scoped to the MCP Analytics block only. **No pages moved or deleted, so no redirects needed** – this is additions plus a nav regroup.

## Todo

- [ ] Add screenshot of the MCP Analytics scene tab bar
- [ ] Screenshots on the Overview and new surface pages
- [ ] Verify API endpoint paths against the current viewsets
- [ ] Confirm the MCP tool list matches `tools.yaml`
- [ ] Link check (`pnpm check-links-post-build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

