### PR TITLE
Fix transparent graphics on agent-first post rendering poorly in dark mode

### DIFF
--- a/contents/ko/newsletter/agent-first-product-engineering.md
+++ b/contents/ko/newsletter/agent-first-product-engineering.md
@@ -23,7 +23,7 @@ seo:
 
 오늘날 에이전트는 당신의 프로덕트와 유저 사이에서 상호작용하는 하나의 기능이다.
 
-![프로덕트와 유저 사이의 새로운 상호작용 계층으로서의 에이전트](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/agent0_191d5281bd.png)
+![프로덕트와 유저 사이의 새로운 상호작용 계층으로서의 에이전트](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/agent0_191d5281bd.png)
 
 따라서 에이전트를 핵심 인터페이스로 염두에 두고 개발해야 한다.
 
@@ -128,7 +128,7 @@ AI가 초기에 등장했을 때, 개발자들은 컨텍스트와 기능 부족�
 
 스킬들은 프로덕트가 할 수 있는 것과 에이전트 툴만으로 할 수 있는 것 사이의 갭을 채워준다.
 
-![에이전트를 위한 스킬 작성](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/agent1_b1e92e5899.png)
+![에이전트를 위한 스킬 작성](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/agent1_b1e92e5899.png)
 
 흔히 저지를 수 있는 실수는 스킬들을 하나하나 일일이 다 일러주는 매뉴얼처럼 작성하는 것이다. 당신이 너무 세세하게 지시한다면 에이전트는 당신의 지시를 너무 철저하게 따르느라 스스로 판단해서 처리할 수 있는 능력을 잃을 것이다. 이에 관해서는 세 번째 규칙에서 설명했다.
 
@@ -172,7 +172,7 @@ PostHog에서는 이를 위해 다음과 같은 습관과 행동을 실천한다
 
 - **헤드리스 도그푸딩.** 에이전트 기능을 테스트할 때, UI보다 CLI를 먼저 사용한다. 에이전트와 같은 환경에 있게 되고, 에이전트가 경험하는 것과 똑같은 오류, 문법, 마찰을 직접 경험할 수 있다. 내부적으로 MCP 툴 설명이 예상보다 더 많은 토큰을 낭비한다는 문제를 발견했다.
 
-![CLI를 통한 헤드리스 도그푸딩](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/q_auto,f_auto/Frame_10150_e3bde237da.png)
+![CLI를 통한 헤드리스 도그푸딩](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/Frame_10150_e3bde237da.png)
 
 - **수동 추적 리뷰 시간 갖기.** 매주 추적 리뷰 시간을 갖고, 사용자 피드백 평점이 달린 실제 사용자 세션을 검토한다. 예를 들어 PostHog AI가 피처 플래그가 예약 출시를 지원하지 않는다고 자신 있게 말했다가 이를 철회한 케이스를 발견했다. 에이전트가 응답했으니 자동화 테스트로는 파악할 수 없었고, 응답이 틀렸을 뿐이다.
 

--- a/contents/ko/newsletter/agent-first-product-engineering.md
+++ b/contents/ko/newsletter/agent-first-product-engineering.md
@@ -128,7 +128,7 @@ AI가 초기에 등장했을 때, 개발자들은 컨텍스트와 기능 부족�
 
 스킬들은 프로덕트가 할 수 있는 것과 에이전트 툴만으로 할 수 있는 것 사이의 갭을 채워준다.
 
-![에이전트를 위한 스킬 작성](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/agent1_b1e92e5899.png)
+![에이전트를 위한 스킬 작성](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/agent1_b1e92e5899.png)
 
 흔히 저지를 수 있는 실수는 스킬들을 하나하나 일일이 다 일러주는 매뉴얼처럼 작성하는 것이다. 당신이 너무 세세하게 지시한다면 에이전트는 당신의 지시를 너무 철저하게 따르느라 스스로 판단해서 처리할 수 있는 능력을 잃을 것이다. 이에 관해서는 세 번째 규칙에서 설명했다.
 
@@ -172,7 +172,7 @@ PostHog에서는 이를 위해 다음과 같은 습관과 행동을 실천한다
 
 - **헤드리스 도그푸딩.** 에이전트 기능을 테스트할 때, UI보다 CLI를 먼저 사용한다. 에이전트와 같은 환경에 있게 되고, 에이전트가 경험하는 것과 똑같은 오류, 문법, 마찰을 직접 경험할 수 있다. 내부적으로 MCP 툴 설명이 예상보다 더 많은 토큰을 낭비한다는 문제를 발견했다.
 
-![CLI를 통한 헤드리스 도그푸딩](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/Frame_10150_e3bde237da.png)
+![CLI를 통한 헤드리스 도그푸딩](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/q_auto,f_auto/Frame_10150_e3bde237da.png)
 
 - **수동 추적 리뷰 시간 갖기.** 매주 추적 리뷰 시간을 갖고, 사용자 피드백 평점이 달린 실제 사용자 세션을 검토한다. 예를 들어 PostHog AI가 피처 플래그가 예약 출시를 지원하지 않는다고 자신 있게 말했다가 이를 철회한 케이스를 발견했다. 에이전트가 응답했으니 자동화 테스트로는 파악할 수 없었고, 응답이 틀렸을 뿐이다.
 

--- a/contents/newsletter/2030-shaped-software.md
+++ b/contents/newsletter/2030-shaped-software.md
@@ -43,7 +43,7 @@ If a human can do something with your product, agents should be able to do it to
 
 Missing capabilities are a failure mode. Say you ask an agent to set up an [A/B test](/experiments). It creates the [feature flag](/feature-flags), builds the insight, wires up the events, and stops because you never exposed a tool to create the experiment. It now has to ask you to do that part which defeats the purpose of using agents.
 
-![Agent-first infrastructure diagram](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/image_7820f5d295.jpg)
+![Agent-first infrastructure diagram](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/image_7820f5d295.jpg)
 
 <Caption>Agent-first infrastructure</Caption>
 

--- a/contents/newsletter/agent-first-product-engineering.md
+++ b/contents/newsletter/agent-first-product-engineering.md
@@ -22,7 +22,7 @@ Companies building for agents often treat them as a bolt-on feature. This is a m
 
 Agents today are more like a new form factor – an interaction layer that sits between your product and your users:
 
-![Agents as a new interaction layer between your product and users](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/agent0_191d5281bd.png)
+![Agents as a new interaction layer between your product and users](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/agent0_191d5281bd.png)
 
 That means you need to build for agents as a *primary* surface, not an afterthought.
 
@@ -121,7 +121,7 @@ Everything else gets pulled later. We let the agent figure out when.
 
 Skills help you fill the gap between what your product can do and what an agent can do out of the box with your tools:
 
-![Writing skills for agents](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/agent1_b1e92e5899.png)
+![Writing skills for agents](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/agent1_b1e92e5899.png)
 
 The biggest mistake people make is writing them like step-by-step manuals. If you're too prescriptive, agents will follow your instructions too rigidly and lose the ability to improvise.
 
@@ -167,7 +167,7 @@ Here are a few habits and behaviors we adopt at PostHog to achieve this:
 
 - **Dogfooding headlessly.** When testing our agent features, we reach for the CLI before the UI. This puts us in the same environment the agent operates in and exposes us to the same types of errors, syntax, and friction they'd experience. It's how we caught an issue internally and found that our MCP tool descriptions were eating up way more tokens than it should.
 
-![Dogfooding headlessly via the CLI](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/q_auto,f_auto/Frame_10150_e3bde237da.png)
+![Dogfooding headlessly via the CLI](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/Frame_10150_e3bde237da.png)
 
 - **Doing manual trace reviews.** We hold a weekly "traces hour" where we go through real user sessions that have user feedback ratings. For example, we found a case where PostHog AI confidently told a user that feature flags don't support scheduled releases and then backtracked. Automated tests wouldn't have caught that since the agent did respond; the response was just incorrect.
 

--- a/contents/newsletter/agent-first-product-engineering.md
+++ b/contents/newsletter/agent-first-product-engineering.md
@@ -121,7 +121,7 @@ Everything else gets pulled later. We let the agent figure out when.
 
 Skills help you fill the gap between what your product can do and what an agent can do out of the box with your tools:
 
-![Writing skills for agents](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/agent1_b1e92e5899.png)
+![Writing skills for agents](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/agent1_b1e92e5899.png)
 
 The biggest mistake people make is writing them like step-by-step manuals. If you're too prescriptive, agents will follow your instructions too rigidly and lose the ability to improvise.
 
@@ -167,7 +167,7 @@ Here are a few habits and behaviors we adopt at PostHog to achieve this:
 
 - **Dogfooding headlessly.** When testing our agent features, we reach for the CLI before the UI. This puts us in the same environment the agent operates in and exposes us to the same types of errors, syntax, and friction they'd experience. It's how we caught an issue internally and found that our MCP tool descriptions were eating up way more tokens than it should.
 
-![Dogfooding headlessly via the CLI](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/Frame_10150_e3bde237da.png)
+![Dogfooding headlessly via the CLI](https://res.cloudinary.com/dmukukwp6/image/upload/c_scale,w_0.75,fl_relative/q_auto,f_auto/Frame_10150_e3bde237da.png)
 
 - **Doing manual trace reviews.** We hold a weekly "traces hour" where we go through real user sessions that have user feedback ratings. For example, we found a case where PostHog AI confidently told a user that feature flags don't support scheduled releases and then backtracked. Automated tests wouldn't have caught that since the agent did respond; the response was just incorrect.
 

--- a/contents/newsletter/code-review-tips.md
+++ b/contents/newsletter/code-review-tips.md
@@ -43,7 +43,7 @@ For the same reason, it’s better to have multiple agents with different instru
 
 Here’s how one of our engineers, [Paul D’Ambra](/community/profiles/30173), makes his own custom agent review system work:
 
-![qa-swarm review-triage agent pipeline diagram](https://res.cloudinary.com/dmukukwp6/image/upload/v1783662229/stop_being_the_code_review_bottleneck_1_qa_swarm_diagram_d728ab2551.png)
+![qa-swarm review-triage agent pipeline diagram](https://res.cloudinary.com/dmukukwp6/image/upload/b_rgb:eeefe9,fl_flatten,q_auto,f_auto/v1783662229/stop_being_the_code_review_bottleneck_1_qa_swarm_diagram_d728ab2551.png)
 
 1. First, **[qa-swarm](https://github.com/pauldambra/dotfiles/tree/main/ai/skills/qa-swarm)** spawns four reviewer agents, each with their own special instructions:
 


### PR DESCRIPTION
## Changes

The three inline diagram graphics in the [Agent-first product engineering](https://posthog.com/newsletter/agent-first-product-engineering) newsletter are transparent PNGs. Their dark strokes and text nearly disappear against the dark-mode background.

This adds a Cloudinary `b_rgb:eeefe9,fl_flatten` transform to each image URL — in both the English and Korean versions — which bakes in PostHog’s brand cream (`#EEEFE9`, the `tan` token). The graphics now blend into the page in light mode and render as a readable cream card in dark mode, with no re-upload required.

**Why:** Reported in the thread — the first graphic looked like a transparent PNG and did not render well in dark mode; suggestion was to give it a cream background so it works in both modalities. The other two inline graphics had the same issue, so they got the same treatment.

_Verified the transformed URLs return opaque PNGs (the `tRNS` transparency chunk is gone)._

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1784575136687529?thread_ts=1784575136.687529&cid=C09GU689J1X)*