### PR TITLE
Update onboarding handbook to reflect current process

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -8,17 +8,11 @@ Welcome to PostHog!
 
 Giving a new joiner a great onboarding experience is super important to us. We want new joiners to feel they’ve made the right decision to join us, and that they are excited and committed to what we’re doing as a company.
 
-> Want to introduce a new joiner to the People team for onboarding, but don't know who on the team does what? Just introduce them to people@posthog.com and a member of the team will jump in and take it from there!
-
 Our [team](/people) is spread across the world, and so are our new joiners. In order to ensure the best possible onboarding experience, we aim for the new joiner to meet up with someone from their team in their first week. Depending on the new joiner's location, they might fly out to one of our team members, or the other way around. So the onboarding experience will look a little bit different, depending on where the new joiner is based and which team they will be joining.
 
-## Onboarding checklist
+## Onboarding email
 
-This is maintained as <PrivateLink url="https://github.com/PostHog/company-internal/blob/master/.github/ISSUE_TEMPLATE/onboarding.md">an issue template in GitHub</PrivateLink>. The People team will create a new onboarding issue for each new joiner.
-
-### Onboarding email
-
-We send an introductory email to all new hires to welcome them to the team and ease them in the some of the essential actions we need them to take. This needs communicating openly, as users may not be able to access the `company-internal` repo yet. So, we send them an email.
+We send an introductory email to all new hires to welcome them to the team and ease them into some of the essential actions we need them to take. Once they've completed their items and signed their contracts, People & Ops will get them onboarded into their initial accesses and onboarding channel.
 
 > Once you've joined PostHog, we will **not** use email for communicating with each other. For example, James or Tim will never ask you to do something critical over email only – they'll always confirm it over Slack, and so will everyone else. Be extremely cautious of direct emails from James, Tim, or other people of PostHog.
 
@@ -28,16 +22,24 @@ The onboarding email is sent by the People team directly. We want to strike a ba
 
 ![onboarding image](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/handbook/handbook-onboarding-email.jpg)
 
+## Onboarding checklist
+
+Everything you need to do, including the role-specific tasks your team adds, is tracked in one place in our [Ops Platform](https://ops.posthog.dev/welcome). When you first log in, you'll land on a welcome page with a short set of preboarding tasks, and your full checklist lives on your employee profile.
+
 ## Onboarding buddy
 
-Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner will meet their onboarding buddy in person during their first week. In case in-person onboarding isn't an option, we will make alternative arrangements. The onboarding buddy is usually a member of the team a new joiner is joining - ideally the team lead - and they can help with any questions that pop up and with socializing during the first couple of weeks at PostHog. Of course, everyone is available to help, but it’s nice to have a dedicated person to help.
+Every new joiner at PostHog has an onboarding buddy, usually the team lead. If the team lead can't take it on (timing, leave, etc.), they'll arrange for another team member to be the buddy instead. Whoever it is, please make sure you don't have any leave booked in the week before and the two weeks after the new starter joins.
+
+If possible, a new joiner will meet their onboarding buddy in person during their first week. In case in-person onboarding isn't an option, we will make alternative arrangements. They can help with questions that pop up and with socializing during the first couple of weeks at PostHog. Of course, everyone is available to help, but it's nice to have a dedicated person to help.
+
+Each new joiner will have a dedicated Slack channel just for onboarding, named `#onboarding-[who]-[team]-[month]-[year]-[where]`. The team lead and the People & Ops team are automatically in there. Other team members who will be involved in the onboarding can choose to join or be added to the channel as well.
+
+It's the best place to ask questions during your onboarding and first few days. Once you've signed your contract, we'll get you set up with everything you need to hit the ground running: your PostHog Google account and email, Slack, GitHub, a company card, access to the ops platform, and the tools specific to your role.
 
 ### Guidance for onboarding buddies
 
--   Once we have decided which team a new joiner will join, the People & Ops team will reach out to the team to find an onboarding buddy. _Please make sure that you don't have any leave booked in the week before and the two weeks after the new starter joins_
--   We will intro the new joiner and the onboarding buddy via email - please say hi and decide together where and when the in person onboarding will happen.
-    > If any travel is needed for the in-person onboarding, please check our [Spending Money page](/handbook/people/spending-money) and book your travel accordingly. _You don't need to let us team know, just use your Brex/Revolut card._
--   Please make sure you spend at least 3 days together, working through the [first week onboarding list](/handbook/people/onboarding#during-their-first-week) and spending time working on any role-specific tasks that are outlined in the new joiner's personal onboarding issue.
+-   Say hi to your new joiner in their onboarding channel and decide together where and when the in-person onboarding will happen. Request a budget through the Slack offsite app `/offsite`! For the budget and travel, see [In-person onboarding](/handbook/people/onboarding#in-person-onboarding).
+-   Please make sure you spend at least 3 days together, working through the [first week onboarding list](/handbook/people/onboarding#your-first-week) and spending time working on any role-specific tasks that are outlined in the new joiner's personal onboarding checklist.
     -   Make sure to add the details of the in-person onboarding to the [In-person Onboarding Calendar](https://calendar.google.com/calendar/u/0?cid=Y19lMzdjNjE0NzM0NDAyOGJlY2ZkMTc0Y2MxZjUxZjY5ZTkxMzY0NzVlNTFjMTE3MjA4OGM2NWQwNjE1YTczNmRlQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) so that other PostHog team members can join, if possible. Simply create an event in your calendar and then invite the in-person onboarding calendar as a guest.
 -   You will remain the new joiner's main point of contact for the first few weeks, so please continue to check in with them at least once a week for the first month or so.
 -   As onboarding buddy, you are responsible for making sure the onboarding is fun and effective, so you should make sure there's a clear plan for work _and_ social time. Great in-person onboarding is crucial for getting someone started at PostHog.
@@ -47,24 +49,19 @@ Every new joiner at PostHog has an onboarding buddy. If possible, a new joiner w
 
 ## In-person onboarding
 
-Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. Upon acceptance of an offer, your Team Lead will notify the People & Operations team who will help you coordinate travel if necessary. With very few exceptions (visa issues or excessive travel time), in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way more fun, and means you'll meet more people. Regardless of location, everyone should have their own bedroom.
+Except under special circumstances, new joiners meet with members of their team in-person to go through the onboarding process. With very few exceptions (visa issues or excessive travel time), in-person onboarding should happen at [Hogpatch](/handbook/people/hogpatch-operations) in San Francisco or the [Hedge House](/handbook/company/offsites#hedge-house) in London. Both are set up for it, remove most of the planning friction, and you'll always be in the same space as other PostHog teams — which is way more fun, and means you'll meet more people. Regardless of location, everyone should have their own bedroom.
 
-In these cases, the process is:
-
--   Preemptively create the new team member a Google account
--   Issue them a Brex card to their work email with a sufficiently high temporary balance to cover travel costs
--   Have the new team member book travel as usual
+To stay at the Hedge House London, book a bedroom through the @HedgeHouse London app via Slack; booking a room automatically reserves you a desk for the week. Message Kendal with any questions.
 
 While there is no fixed budget for onboardings they should be relatively less expensive than a small team offsite, which is $2,000 per person. Some considerations to reduce the cost:
 
 -   Avoid intercontinental travel or choose a location that limits it to the minimum number of people possible
 -   Consider doing more casual social activities that are less expensive: dinners, drinks etc
--   You can request budget for the team lead +1 more team member as an onboarding budget, any other team members joining can use their working together budget (be mindful that onboardings are distracting so the more team members you have join, the less productive the team will be that week, you also have offsites for the team to all get together).
-    -   Create a Slack channel for the onboarding (`#onboarding-[who]-[team]-[month]-[year]-[where]`) add everyone who’s going 
+-   You can request budget for the team lead +1 more team member as an onboarding budget using the Slack command `/offsite`. Any other team members joining can use their working together budget (be mindful that onboardings are distracting so the more team members you have join, the less productive the team will be that week, you also have offsites for the team to all get together).
 -   The new team member already has their own onboarding budget to book their flights and accommodation, so do not include them in the budget.
 -   See if there are any other onboardings at the same time you could pair up with
 
-Aim to keep things sensible and cheap. As always, use your best judgement when [spending money](/handbook/people/spending-money). Request a budget in Brex in USD for any onboardings you are doing. There will of course be some exceptions to this, please just include the reasoning in your brex budget request, and ensure to list who the budget request is for.
+Aim to keep things sensible and cheap. As always, use your best judgement when [spending money](/handbook/people/spending-money). There will of course be some exceptions to this, please just include the reasoning in your Brex budget request, and ensure to list who the budget request is for.
 
 > You should by default avoid combining in-person onboarding with [small team offsites](/handbook/company/offsites#small-team-offsites) as they serve different purposes. The focus of onboarding is generally on making the new team member successful, but offsites feature things like hackathons and 360 feedback which aren't usually helpful for this and detract from useful onboarding time. However, it may occasionally make sense to combine the two - just use your judgement.
 
@@ -83,7 +80,7 @@ Your first week can definitely be a bit overwhelming at any new company, so here
 - You will get all your equipment set up and get access to all the accounts you need
 - You will receive your new hire kit (which includes [No Rules Rules](https://www.penguin.co.uk/books/439530/no-rules-rules-by-meyer-reed-hastings-and-erin/9780753560969) which we encourage everyone to read as it gives you a great insight into how we work as a company)
 - You should try and set up a few calls with a range of people to introduce yourself
-- You should try and speak to some actual users of your product. Your manager or PM will help you set these up, and this can be a great source of things to work on in your first week.
+- You should try and speak to some actual users of your product. Your team lead or PM will help you set these up, and this can be a great source of things to work on in your first week.
 - You should dive straight in, fix a typo in the handbook, ship a tiny bug fix, anything to get you going! 
 
 > **If your laptop is delayed:** In rare cases your PostHog-issued laptop may not arrive until several days after your start date. If that happens, you can begin non-sensitive onboarding tasks (reading the handbook, intro calls, etc.) on your personal laptop in the meantime. Treat a personal laptop as less trusted:
@@ -130,6 +127,7 @@ We use a number of different tools to organise our work and communicate at PostH
 
 ### Everyone
 
+-   PostHog ops platform (ops.posthog.dev) - onboarding, employee profiles and people ops
 -   Google Suite - Gmail, Google Apps such as Docs, Sheets, Slides
 -   GitHub - most comms and product work
 -   Slack - we have an internal workspace and a users Slack as well

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -24,7 +24,7 @@ The onboarding email is sent by the People team directly. We want to strike a ba
 
 ## Onboarding checklist
 
-Everything you need to do, including the role-specific tasks your team adds, is tracked in one place in our [Ops Platform](https://ops.posthog.dev/welcome). When you first log in, you'll land on a welcome page with a short set of preboarding tasks, and your full checklist lives on your employee profile.
+Once your accounts are set up, you'll get a welcome message in your onboarding channel with a link to the [Ops Platform](https://ops.posthog.dev/welcome) to get started. Everything you need to do, including the role-specific tasks your team adds, is tracked there in one place. When you first log in, you'll land on a welcome page with a short set of preboarding tasks, and your full checklist lives on your employee profile.
 
 ## Onboarding buddy
 


### PR DESCRIPTION
Updates the onboarding page to match how onboarding actually runs today. Built on top of the current live page, so the recent buddy-responsibilities, laptop-delay note, PostHog Support rename, and 30/60/90 rewrite are all preserved.

What changed:
- **Onboarding checklist** now points to the ops platform (retired the GitHub issue template)
- **Onboarding email** reordered to come before the checklist; opening updated
- **Onboarding buddy** is the team lead by default, with a description of the dedicated onboarding Slack channel and what gets provisioned after the contract is signed
- **Guidance for buddies**: say hi in the onboarding channel and request budget via `/offsite`; dropped the stale 'find a buddy', 'intro via email', and Brex/Revolut travel steps
- **In-person onboarding**: defaults to Hogpatch / Hedge House, budget via `/offsite`, Hedge House room booking via Slack; removed the old manual Google account / Brex-card provisioning steps
- **Your first week**: 'manager' -> 'team lead'
- **Tools we use**: added the ops platform