### PR TITLE
Remove prestart hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "build": "gatsby build",
         "prebuild:minimal": "pnpm generate-brand-assets",
         "build:minimal": "GATSBY_MINIMAL=true gatsby build",
-        "prestart": "pnpm generate-brand-assets",
         "start": "./bin/start",
         "serve": "gatsby serve",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",

--- a/scripts/generate-brand-assets.mjs
+++ b/scripts/generate-brand-assets.mjs
@@ -7,7 +7,7 @@ import sharp from 'sharp'
 import { Logo } from '@posthog/brand/logo'
 
 // Materialize stable /brand URLs from the canonical package before Gatsby copies static/ to public/.
-// package.json lifecycle hooks run this automatically for the standard start and build commands.
+// package.json lifecycle hooks run this automatically for the standard build commands.
 const outputDirectory = fileURLToPath(new URL('../static/brand/', import.meta.url))
 
 const scaleDimensions = ([width, height], scale) => [width * scale, height * scale]

--- a/src/components/BrandLogos/README.md
+++ b/src/components/BrandLogos/README.md
@@ -7,7 +7,7 @@ can't drift from the library.
 
 Stable public `/brand/*` URLs are maintained separately for external consumers. The
 `scripts/generate-brand-assets.mjs` script materializes those compatibility files from the same
-package and runs automatically before the standard Gatsby start and build commands.
+package and runs automatically before the standard Gatsby build commands.
 
 ## Usage
 


### PR DESCRIPTION
When `generate-brand-assets` runs, it rewrites the logo files under `static/brand/`, which shows up in the git diff even when nothing brand-related changed.

## Changes

- Removes the `prestart` hook so this only runs on production builds, not every `pnpm start`