### PR TITLE
docs: document experimental iOS session replay background screenshot capture

### DIFF
--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -74,6 +74,14 @@ config.sessionReplayConfig.captureNetworkTelemetry = true
 // The screenshot may contain sensitive information, so use with caution
 config.sessionReplayConfig.screenshotMode = true
 
+// Experimental. Only has an effect when `screenshotMode` is enabled.
+// Moves screenshot capture off the main thread to a background queue, reducing
+// jank on high-refresh-rate (120Hz ProMotion) displays.
+// May trigger Xcode's Main Thread Checker warnings and briefly freeze the app
+// on the first captured screenshot. Default is false.
+// Requires SDK version 3.58.1 or higher.
+config.sessionReplayConfig.screenshotModeBackgroundCapture = false
+
 // Sets the minimum time interval (in seconds) between session replay snapshots.
 // A higher value reduces performance impact but decreases replay smoothness. Default is 1.0s.
 // Note: Previously known as `debouncerDelay` before version 3.21.0
@@ -100,3 +108,4 @@ config.sessionReplayConfig.sampleRate = nil
 - If you have enabled session replay using feature flags, the flags are evaluated on the device once the PostHog SDK starts as early as possible. The SDK might be using the cached flags from the previous SDK start. If you have changed the flag or its condition, kill and reopen the app to force a new SDK start at least once.
     - This will also happen in production, and you might experience some delay for the new flag/conditions to take effect on your users. We're tracking this bug in [issue #263](https://github.com/PostHog/posthog-ios/issues/263).
     - Session replay feature flag evaluation does not capture `$feature_flag_called` events, so the `Usage` tab on the feature flag page won't show anything. We're tracking this feature request in [issue #250](https://github.com/PostHog/posthog-android/issues/250).
+- If session replay looks janky or drops frames on high-refresh-rate (120Hz ProMotion) iPhones when `screenshotMode` is enabled, turn on `config.sessionReplayConfig.screenshotModeBackgroundCapture` (experimental, requires SDK 3.58.1 or higher) to move screenshot capture off the main thread. This can trigger Xcode's Main Thread Checker warnings, so disable it in your scheme's Run diagnostics if that happens.

--- a/contents/docs/session-replay/installation/react-native.mdx
+++ b/contents/docs/session-replay/installation/react-native.mdx
@@ -27,3 +27,7 @@ If your iOS project uses Swift Package Manager for native dependencies, you can 
 ```
 
 This path requires `use_frameworks! :linkage => :dynamic` in your `ios/Podfile`. Without `posthog.useSpm`, the default CocoaPods resolution path is unchanged.
+
+## Troubleshooting
+
+- If session replay looks janky or drops frames on high-refresh-rate (120Hz ProMotion) iPhones, turn on the experimental `sessionReplayConfig.screenshotModeBackgroundCapture` option (iOS only, requires `posthog-react-native` 4.45.0 or higher) to move screenshot capture off the main thread. This can trigger Xcode's Main Thread Checker warnings, so disable it in your scheme's Run diagnostics if that happens.


### PR DESCRIPTION
## Problem

The iOS SDK ships an experimental `screenshotModeBackgroundCapture` option that moves session replay screenshot capture off the main thread to cut jank on 120Hz ProMotion displays, but it's undocumented. Users hitting frame drops on high-refresh-rate iPhones have no documented fix.

## Changes

- Documents `config.sessionReplayConfig.screenshotModeBackgroundCapture` in the iOS installation snippet, with the caveats: experimental, only affects `screenshotMode`, may trigger Xcode's Main Thread Checker warnings, requires posthog-ios `3.58.1+`.
- Adds a troubleshooting bullet to both the iOS snippet and the React Native session replay install page pointing janky-replay users at the option. RN requires posthog-react-native `4.45.0+`.

## Testing

Docs-only. I verified both version gates against source: `screenshotModeBackgroundCapture` landed in posthog-ios `3.58.1`, and RN support landed in posthog-react-native `4.45.0` (posthog-js#3552).

DRI: @ioannisj
Autonomy: Human-driven (agent-assisted)
