### PR TITLE
docs(self-driving): document scout schedules, notes, and output routing

### DIFF
--- a/contents/docs/self-driving/inbox/index.mdx
+++ b/contents/docs/self-driving/inbox/index.mdx
@@ -34,6 +34,8 @@ From the inbox you:
 
 Nothing ships without you. The inbox is where you stay in control of what self-driving does.
 
+Triage is also how you teach the loop. When you dismiss or snooze a report and say why, that note is [forwarded to the scout that filed it](/docs/self-driving/scouts#your-inbox-feedback-steers-scouts-too), so later runs read it before deciding what to surface. Explaining a bad report is the cheapest way to stop getting it.
+
 ## Where to find it
 
 The inbox is available across surfaces – the [web app](/docs/self-driving/web), [PostHog Desktop](/docs/posthog-desktop), and Slack – so you can review and act on work wherever you are. It's the same inbox everywhere; only the way you open it changes.

--- a/contents/docs/self-driving/reports.mdx
+++ b/contents/docs/self-driving/reports.mdx
@@ -26,10 +26,19 @@ A report is enriched and ranked:
 - **Grouped signals** – the related findings, from one or more sources, with the evidence behind them.
 - **Priority** – how urgent it is, so the most important work rises to the top.
 - **State** – whether it's **actionable**, so an agent can open a pull request, or **needs input** before anything can be worked on.
+- **Charts** – where a finding is about something that moved, the report can carry the chart that shows it, so you can see the shape of the problem without rebuilding the query yourself.
+
+A report also accumulates a history as work happens on it: the commits and pull requests opened against it, the code the investigating agent referenced, CI status and review comments on its PR, related reports, and any notes people left while triaging. You're reading the whole trail, not just the original finding.
 
 ## Where reports go
 
 Reports land in your [inbox](/docs/self-driving/inbox), ranked by priority. An agent investigates each one. Actionable reports get a pull request to review and merge – the rest wait in your inbox for your input.
+
+## When a report is done
+
+A report you resolve stays resolved – resolving is terminal, and a resolved report never quietly reopens. If the same problem comes back later, the loop files a **fresh** report for the new occurrence instead of reviving the old one.
+
+That's deliberate: the recurrence is genuinely new information. Reopening would blur two separate incidents into one item and lose the fact that a fix didn't hold, where a new report makes the pattern visible.
 
 ## Next step
 

--- a/contents/docs/self-driving/scout-examples.mdx
+++ b/contents/docs/self-driving/scout-examples.mdx
@@ -24,6 +24,7 @@ PostHog ships a fleet of canonical scouts out of the box, each watching a common
 | [AI observability](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-ai-observability/SKILL.md) | Cost, latency, error, eval, and tool-usage trends and spikes across your AI traffic |
 | [Anomaly detection](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-anomaly-detection/SKILL.md) | Bursts, drops, flat-lines, and trend breaks in your most-viewed dashboards and insights |
 | [APM](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-apm/SKILL.md) | RED-metric regressions (error rate, p95 latency, volume) and new errors per service and operation |
+| [Conversations](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-conversations/SKILL.md) | Support delivery regressions – SLA breach rates, first-response latency, backlog inflow outpacing resolution, and channel or assignment concentration |
 | [CSP violations](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-csp-violations/SKILL.md) | Content Security Policy violation clusters, per-directive bursts, and suspicious third-party domains |
 | [Customer analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-customer-analytics/SKILL.md) | Churn-risk shapes on named accounts – engagement cliffs, dormancy, single-threaded champions |
 | [Data pipelines](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-data-pipelines/SKILL.md) | Delivery failures across CDP destinations, batch exports, and workflows, where config and reality disagree |
@@ -45,6 +46,7 @@ PostHog ships a fleet of canonical scouts out of the box, each watching a common
 | [Session replay](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-session-replay/SKILL.md) | Recording capture integrity, plus rage-click and dead-click friction clusters |
 | [Skills store](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-skills-store/SKILL.md) | Static, verifiable skill-authoring problems such as vague descriptions, stale file links, bloated bodies, and committed secrets |
 | [Surveys](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-surveys/SKILL.md) | NPS and CSAT regressions, plus recurring themes in open-text responses |
+| [Tasks](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-tasks/SKILL.md) | Agent task delivery health – runs failing, clustered by repo and error class, retry storms, and recurring asks that point at a product gap |
 | [Web analytics](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-web-analytics/SKILL.md) | Acquisition channels diverging, attribution breakage, and 404 spikes |
 | [Web vitals](https://github.com/PostHog/posthog/blob/master/products/signals/skills/signals-scout-web-vitals/SKILL.md) | Core Web Vitals regressions and other recent performance shifts in web traffic |
 

--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -30,11 +30,58 @@ A scout also keeps a durable memory between runs. Each run, it reads back what e
 
 Because scouts run on a schedule, the loop keeps noticing problems and opportunities on its own, instead of waiting for someone to file a ticket.
 
+## Setting a scout's schedule
+
+Every scout runs on its own schedule, which you set per scout without touching its instructions. There are two ways to express one:
+
+- **An interval** – how long to wait between runs, from every 30 minutes to every 30 days. This is the default, and a new scout starts at every 24 hours. Use it when you care about frequency rather than timing.
+- **A cron expression** – a standard five-field expression that anchors runs to wall-clock slots, like `30 9 * * *` for every day at 09:30, `0 9,17 * * *` for twice a day, or `0 9 * * 1-5` on weekdays only. Occurrences have to be at least 30 minutes apart, the same floor as the interval.
+
+Cron expressions are evaluated in your project's timezone, so a scout scheduled for 09:00 stays at 09:00 through daylight saving changes. Setting a cron expression takes precedence over the interval.
+
+Interval scheduling drifts – a run that starts late pushes the next one later – so reach for cron when the timing itself matters: a [digest scout](/docs/self-driving/scout-examples) that should land before standup, or a scout that should look at a full day of data rather than a rolling window.
+
+Since every run costs a share of your project's daily run budget, the schedule is also the main dial on what a scout costs. Most scouts close out without finding anything, so a tighter cadence mostly pays to re-confirm that nothing changed. Slow a chatty or expensive scout down before you turn it off.
+
 ## Running a scout on demand
 
 Scouts run themselves on their schedule, but you can also trigger a run on demand – useful to test a scout right after authoring it, or to refresh its findings without waiting for the next scheduled run. A scout that's still disabled can be run this way too, so you can see what it would surface before turning it on.
 
 On-demand runs count against the same daily run budget as scheduled runs, so repeatedly re-running the same scout can use up your project's daily allowance.
+
+### Dry runs
+
+A scout writes its findings to your inbox by default, which is usually what you want – seeing what actually lands is the fastest way to tell whether a scout is calibrated. For a scout you expect to be chatty, expensive, or high-stakes, you can put it in **dry run** instead: it still runs and still records its full reasoning, but writes nothing to your inbox. Read back what it *would* have filed, tune it, then switch it to writing for real.
+
+A dry run consumes a run from your daily budget like any other, so it's a safety net rather than an iteration loop.
+
+## Steering a scout with a note
+
+Sometimes you don't want to change a scout – you want to tell it something. **Scout notes** are short steering messages you leave for the fleet, which every run reads as context alongside its own memory:
+
+- **Feedback on its output** – "the staging traffic spike you keep flagging is known noise, stop reporting it."
+- **A pointer** – "dig into the EU signup funnel this week, we think something regressed."
+- **Context it couldn't know** – "we shipped a new checkout on Tuesday, treat conversion shifts after that as expected."
+
+A note can address one scout by name or the whole fleet, and you can give it an expiry date so time-boxed steering ("watch this closely this week") retires itself.
+
+Notes are advisory. They direct a scout's attention, but they don't lower its evidence bar or force it to file anything – a note saying "report X" still gets an honest investigation. Each run says which notes it acted on and how, and folds anything durable into its memory.
+
+A note is the right tool for steering *this project, right now*, and for trying a nudge before committing to it. Once a steer becomes permanent policy – a threshold, a disqualifier, a change of scope – edit the scout instead. A note you keep re-leaving is a scout edit waiting to happen.
+
+### Your inbox feedback steers scouts too
+
+When you dismiss or snooze a [report](/docs/self-driving/reports) and type a note explaining why, that note is the single most useful thing a scout can learn from: a human saying, in their own words, why what it surfaced wasn't worth surfacing. So it doesn't just sit on the report – it's also forwarded into the steering channel, where later runs read it by name.
+
+Resolving a report doesn't forward anything, because resolving says the report did its job, not that filing it was wrong. Forwarded notes expire after 30 days, so a steady stream of dismissals can't crowd out the steering you leave deliberately.
+
+The practical upshot: triaging your inbox honestly is how scouts get quieter. You don't have to go and edit a scout to stop it repeating itself.
+
+## Sending a scout's output to Slack
+
+Each scout can post what it finds to a Slack channel of your choosing, set per scout. That lets you route scouts to the teams that care – the revenue scout to `#growth`, the APM scout to `#on-call` – instead of sending everything to one firehose channel.
+
+This is per scout and separate from the project-wide **#posthog-inbox** notification you set up when [connecting Slack](/docs/self-driving/setup). Connect your Slack workspace once, then pick a channel on any scout you want routed.
 
 ## Every report is also an event
 


### PR DESCRIPTION
## Changes

Reviewed ~8 weeks of `signals`/`scout` work in the monorepo against the self-driving docs and found several shipped, user-facing capabilities that weren't documented anywhere. This adds them.

**`scouts.mdx`**
- **Setting a scout's schedule** — the interval range (30 min to 30 days, default 24h) and the optional five-field cron expression, evaluated in the project timezone, min 30 min between occurrences, takes precedence over the interval. ([#72731](https://github.com/PostHog/posthog/pull/72731))
- **Dry runs** — running a scout so it logs its reasoning but writes nothing to the inbox, and the fact it still spends a run from the daily budget.
- **Steering a scout with a note** — the notes channel for telling a scout something without editing it: per-scout vs fleet-wide targeting, expiry, and the fact that notes are advisory rather than a way to force a report. ([#73072](https://github.com/PostHog/posthog/pull/73072))
- **Inbox feedback steers scouts too** — dismiss/snooze notes are forwarded into the steering channel, resolving deliberately isn't, and forwarded notes expire after 30 days. ([#73686](https://github.com/PostHog/posthog/pull/73686))
- **Sending a scout's output to Slack** — per-scout Slack destinations, and how that differs from the project-wide #posthog-inbox notification. ([#72937](https://github.com/PostHog/posthog/pull/72937))

**`reports.mdx`**
- Charts on reports ([#73549](https://github.com/PostHog/posthog/pull/73549)), the activity trail a report accumulates (commits, code references, CI status, review comments, related reports, notes), and the terminal `resolved` state — a recurrence spawns a fresh report rather than reopening the old one ([#71981](https://github.com/PostHog/posthog/pull/71981)).

**`scout-examples.mdx`**
- Adds the two canonical scouts missing from the table: **conversations** ([#72716](https://github.com/PostHog/posthog/pull/72716)) and **tasks** ([#73685](https://github.com/PostHog/posthog/pull/73685)).

**`inbox/index.mdx`**
- Short pointer from triage to the steering section, since dismissal feedback is what actually drives the loop.

## How I verified

Every claim is checked against the monorepo rather than inferred from commit titles — `SignalScoutConfig` and `SignalScoutNote` in `products/signals/backend/models.py`, the config serializers' cron/output-destination validation, `dismissal_notes.py`, `SignalReportArtefact`, and the `authoring-scouts` skill. Ranges, defaults, precedence rules, and the resolve-vs-dismiss distinction all come from those sources.

## Not included

Deliberately left out as internal or not yet worth a docs surface: model routing/attribution on scout runs, ai-gateway routing, the MCP tool surface (`scout-create-prepare`/`-execute`, `scout-metadata-get`), CI signal taxonomy, and ranking telemetry. Happy to add any of these if you'd rather they were public.