### PR TITLE
Host Replay Vision quality docs images on Cloudinary

### DIFF
--- a/contents/docs/replay-vision/quality.mdx
+++ b/contents/docs/replay-vision/quality.mdx
@@ -15,7 +15,7 @@ Replay Vision scanners are only as good as their configuration. The **Quality** 
 Open any scanner and select the **Quality** tab.
 
 <ProductScreenshot
-  imageLight="https://raw.githubusercontent.com/PostHog/pr-assets/5898ffd45f6dde976c631bc94dcb9c2164591950/2026/07/acc7283c-5bb7-4454-8478-b1f42c180df4.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quality_tab_overview_fbe89921b9.png"
   alt="The quality tab of a Replay Vision scanner"
   classes="rounded"
 />
@@ -31,7 +31,7 @@ The **Rate results** table lists the scanner's successful [observations](/docs/r
 Click a session ID to open the full observation in a new tab, or use **View recording** to watch the recording itself before deciding.
 
 <ProductScreenshot
-  imageLight="https://raw.githubusercontent.com/PostHog/pr-assets/531e4ec376a9cfb5a6cedbc13cbb5ae0cae570c2/2026/07/87df6938-f547-400a-b7c8-81961b415bef.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quality_tab_rate_results_764dc45c5d.png"
   alt="Rating scanner results with a thumbs up or down"
   classes="rounded"
 />
@@ -49,7 +49,7 @@ Rating requires edit access on the scanner.
 Once your team leaves written feedback, PostHog AI summarizes it into recurring failure modes, shown as **Feedback themes** chips above the table. They tell raters what to look out for, and they steer the configuration recommendation. Click a theme to filter the table to the sessions behind it.
 
 <ProductScreenshot
-  imageLight="https://raw.githubusercontent.com/PostHog/pr-assets/5f79b72376d26f9d0d7c7b5c29ed31386431f831/2026/07/1350bdeb-91e7-4d57-b061-9e3e3865cae2.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quality_tab_rated_feedback_22039bce91.png"
   alt="Rated results with written feedback and feedback themes"
   classes="rounded"
 />
@@ -59,7 +59,7 @@ Once your team leaves written feedback, PostHog AI summarizes it into recurring 
 The **Ratings over time** chart shows thumbs up and thumbs down per day, with markers for when each configuration version went live. As the configuration improves, thumbs down should trend down.
 
 <ProductScreenshot
-  imageLight="https://raw.githubusercontent.com/PostHog/pr-assets/f2bee36dcd12d40d94c19e10bdc85c1295813218/2026/07/f709e575-f562-4b3a-adf6-884a118e3986.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quality_tab_ratings_over_time_b258018c68.png"
   alt="Ratings over time with version markers"
   classes="rounded"
 />
@@ -88,7 +88,7 @@ Each recommendation comes with:
 - The ratings it was based on, when it was generated, and against which version.
 
 <ProductScreenshot
-  imageLight="https://raw.githubusercontent.com/PostHog/pr-assets/b746e708d0a92dc0a55e3e6d3d3ef1ff87b5bfd0/2026/07/ade37c9e-07fb-472a-b356-0379fea0318b.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quality_tab_recommendation_f29bd4eb96.png"
   alt="A configuration recommendation with a diff and rationale"
   classes="rounded"
 />


### PR DESCRIPTION
## Changes

Follow-up to #18803: swaps the five screenshots on `/docs/replay-vision/quality` from temporary `PostHog/pr-assets` URLs to Cloudinary (`orig (optimized)` variants), matching how every other docs image is hosted. No content changes, five URL swaps only.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the preview build ([preview](https://fb12ff25.posthog-preview.pages.dev/docs/replay-vision/quality), all five images load from Cloudinary)
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a, no page moved)

