### PR TITLE
feat: `/events` auto-populate from Luma and Mapbox for GPS locations

### DIFF
--- a/api/luma-events.js
+++ b/api/luma-events.js
@@ -1,0 +1,72 @@
+const LUMA_LIST_EVENTS_URL = 'https://public-api.luma.com/v1/calendar/list-events'
+// Safety bound so a runaway cursor can't loop forever (5 pages × 100 events)
+const MAX_PAGES = 5
+
+// Luma's API sends no CORS headers, so the browser can't call it directly.
+// This proxy fetches upcoming events from the PostHog Luma calendar and
+// returns a trimmed payload for the event form's auto-suggest.
+const handler = async (req, res) => {
+    const token = process.env.GATSBY_LUMA_TOKEN
+    if (!token) {
+        return res.status(500).json({ error: 'Missing Luma API token' })
+    }
+
+    try {
+        const events = []
+        let cursor = null
+
+        for (let page = 0; page < MAX_PAGES; page++) {
+            const url = new URL(LUMA_LIST_EVENTS_URL)
+            url.searchParams.set('after', new Date().toISOString())
+            url.searchParams.set('pagination_limit', '100')
+            if (cursor) {
+                url.searchParams.set('pagination_cursor', cursor)
+            }
+
+            const response = await fetch(url.toString(), {
+                headers: { 'x-luma-api-key': token },
+            })
+            if (!response.ok) {
+                throw new Error(`Luma API request failed: ${response.status}`)
+            }
+
+            const json = await response.json()
+            const entries = Array.isArray(json?.entries) ? json.entries : []
+
+            for (const entry of entries) {
+                const event = entry?.event || entry
+                if (!event?.name) continue
+                const geo = event.geo_address_json || {}
+                events.push({
+                    id: event.api_id || event.id,
+                    name: event.name,
+                    startAt: event.start_at || null,
+                    endAt: event.end_at || null,
+                    timezone: event.timezone || null,
+                    url: event.url || null,
+                    lat: event.coordinate?.latitude ?? (event.geo_latitude ? Number(event.geo_latitude) : null),
+                    lng: event.coordinate?.longitude ?? (event.geo_longitude ? Number(event.geo_longitude) : null),
+                    city: geo.city || null,
+                    cityState: geo.city_state || null,
+                    country: geo.country || null,
+                    venue: geo.address || null,
+                    fullAddress: geo.full_address || null,
+                    online: event.location_type !== 'offline',
+                })
+            }
+
+            if (!json?.has_more || !json?.next_cursor) break
+            cursor = json.next_cursor
+        }
+
+        res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate')
+        return res.status(200).json({ events })
+    } catch (error) {
+        console.error('Error fetching Luma events:', error)
+        return res.status(500).json({ error: 'Failed to fetch Luma events' })
+    }
+}
+
+// CommonJS (not `export default`) so the Gatsby dev middleware can require() this
+// file directly with plain Node; Vercel's runtime supports CJS handlers natively.
+module.exports = handler

--- a/api/luma-events.js
+++ b/api/luma-events.js
@@ -6,7 +6,7 @@ const MAX_PAGES = 5
 // This proxy fetches upcoming events from the PostHog Luma calendar and
 // returns a trimmed payload for the event form's auto-suggest.
 const handler = async (req, res) => {
-    const token = process.env.GATSBY_LUMA_TOKEN
+    const token = process.env.LUMA_TOKEN
     if (!token) {
         return res.status(500).json({ error: 'Missing Luma API token' })
     }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -53,6 +53,19 @@ const getQuestionPages = async (base) => {
 }
 
 module.exports = {
+    // Luma's API blocks browser CORS, so the events form fetches /api/luma-events.
+    // In production Vercel serves api/luma-events.js; mirror that route here so
+    // the form also works under `gatsby develop`. Dev server only — no effect on builds.
+    developMiddleware: (app) => {
+        app.use('/api/luma-events', async (req, res) => {
+            try {
+                await require('./api/luma-events')(req, res)
+            } catch (error) {
+                console.error('luma-events dev middleware error:', error)
+                res.status(500).json({ error: 'Failed to fetch Luma events' })
+            }
+        })
+    },
     flags: {
         DEV_SSR: false,
     },

--- a/src/components/EventForm/SuggestionDropdown.tsx
+++ b/src/components/EventForm/SuggestionDropdown.tsx
@@ -14,8 +14,9 @@ type SuggestionDropdownProps = {
     onSelect: (index: number) => void
 }
 
-// Absolutely-positioned listbox rendered inside a `relative` wrapper around an
-// input. Keyboard navigation stays with the input that owns the dropdown.
+// Exported so the owning input can point aria-activedescendant at the highlighted row
+export const suggestionOptionId = (listId: string, index: number): string => `${listId}-option-${index}`
+
 export default function SuggestionDropdown({
     id,
     items,
@@ -29,16 +30,16 @@ export default function SuggestionDropdown({
         <ul
             id={id}
             role="listbox"
-            className="absolute mt-1 max-h-72 w-full overflow-auto rounded border border-primary bg-primary shadow-2xl z-20"
+            className="absolute top-full mt-1 max-h-72 w-full overflow-auto rounded border border-primary bg-primary shadow-2xl z-20"
         >
             {items.map((item, idx) => (
                 <li
                     key={item.id}
+                    id={suggestionOptionId(id, idx)}
                     role="option"
                     aria-selected={highlightIndex === idx}
                     className={`px-3 py-2 cursor-pointer ${highlightIndex === idx ? 'bg-accent' : ''}`}
                     onMouseEnter={() => onHighlight(idx)}
-                    onMouseLeave={() => onHighlight(-1)}
                     onClick={() => onSelect(idx)}
                     title={item.sublabel || item.label}
                 >

--- a/src/components/EventForm/SuggestionDropdown.tsx
+++ b/src/components/EventForm/SuggestionDropdown.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+
+export type SuggestionItem = {
+    id: string
+    label: string
+    sublabel?: string
+}
+
+type SuggestionDropdownProps = {
+    id: string
+    items: SuggestionItem[]
+    highlightIndex: number
+    onHighlight: (index: number) => void
+    onSelect: (index: number) => void
+}
+
+// Absolutely-positioned listbox rendered inside a `relative` wrapper around an
+// input. Keyboard navigation stays with the input that owns the dropdown.
+export default function SuggestionDropdown({
+    id,
+    items,
+    highlightIndex,
+    onHighlight,
+    onSelect,
+}: SuggestionDropdownProps): React.ReactElement | null {
+    if (items.length === 0) return null
+
+    return (
+        <ul
+            id={id}
+            role="listbox"
+            className="absolute mt-1 max-h-72 w-full overflow-auto rounded border border-primary bg-primary shadow-2xl z-20"
+        >
+            {items.map((item, idx) => (
+                <li
+                    key={item.id}
+                    role="option"
+                    aria-selected={highlightIndex === idx}
+                    className={`px-3 py-2 cursor-pointer ${highlightIndex === idx ? 'bg-accent' : ''}`}
+                    onMouseEnter={() => onHighlight(idx)}
+                    onMouseLeave={() => onHighlight(-1)}
+                    onClick={() => onSelect(idx)}
+                    title={item.sublabel || item.label}
+                >
+                    <div className="text-sm font-semibold text-primary">{item.label}</div>
+                    {item.sublabel && <div className="text-xs text-secondary mt-0.5">{item.sublabel}</div>}
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/src/components/EventForm/index.tsx
+++ b/src/components/EventForm/index.tsx
@@ -5,6 +5,8 @@ import { OSInput, OSTextarea } from 'components/OSForm'
 import OSButton from 'components/OSButton'
 import { graphql, useStaticQuery } from 'gatsby'
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
 import { useUser } from 'hooks/useUser'
 import { IconSpinner } from '@posthog/icons'
 import Toggle from 'components/Toggle'
@@ -15,6 +17,10 @@ import EventGraphic, { type EventGraphicSpeaker } from 'components/EventGraphic'
 import { useToast } from '../../context/Toast'
 import { Event } from '../../pages/events'
 import CreatableMultiSelect from 'components/CreatableMultiSelect'
+import SuggestionDropdown from './SuggestionDropdown'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 type EventFormValues = {
     name: string
@@ -44,6 +50,35 @@ type SelectOption = {
     label: string
     value: any
 }
+
+type LumaEvent = {
+    id: string
+    name: string
+    startAt: string | null
+    endAt: string | null
+    timezone: string | null
+    url: string | null
+    lat: number | null
+    lng: number | null
+    city: string | null
+    cityState: string | null
+    country: string | null
+    venue: string | null
+    fullAddress: string | null
+    online: boolean
+}
+
+type CitySuggestion = {
+    id: string
+    name: string
+    placeFormatted: string
+}
+
+// Session token for Mapbox Search Box API billing semantics
+const newSessionToken = (): string =>
+    typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2) + Date.now().toString(36)
 
 const validationSchema = Yup.object().shape({
     name: Yup.string().max(60, 'Max 60 characters').required('Name is required'),
@@ -320,6 +355,197 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
         }
     }
 
+    // Luma event auto-suggest (create mode only) — events are fetched once
+    // through /api/luma-events since Luma's API blocks browser CORS
+    const [lumaEvents, setLumaEvents] = React.useState<LumaEvent[]>([])
+    const [lumaOpen, setLumaOpen] = React.useState(false)
+    const [lumaHighlight, setLumaHighlight] = React.useState(-1)
+    const lumaContainerRef = React.useRef<HTMLDivElement>(null)
+
+    // Mapbox city autocomplete on the location field
+    const [cityQuery, setCityQuery] = React.useState('')
+    const [citySuggestions, setCitySuggestions] = React.useState<CitySuggestion[]>([])
+    const [cityOpen, setCityOpen] = React.useState(false)
+    const [cityHighlight, setCityHighlight] = React.useState(-1)
+    const [citySessionToken, setCitySessionToken] = React.useState(newSessionToken)
+    const cityAbortRef = React.useRef<AbortController | null>(null)
+    const cityContainerRef = React.useRef<HTMLDivElement>(null)
+
+    React.useEffect(() => {
+        if (event) return
+        const controller = new AbortController()
+        fetch('/api/luma-events', { signal: controller.signal })
+            .then((response) => (response.ok ? response.json() : null))
+            .then((json) => {
+                if (json && Array.isArray(json.events)) {
+                    setLumaEvents(json.events)
+                }
+            })
+            .catch(() => {
+                // Proxy unavailable (e.g. plain gatsby dev) — suggestions just don't appear
+            })
+        return () => controller.abort()
+    }, [event])
+
+    const lumaMatches = React.useMemo(() => {
+        const query = formik.values.name.trim().toLowerCase()
+        if (event || query.length < 3 || lumaEvents.length === 0) return []
+        return lumaEvents.filter((lumaEvent) => lumaEvent.name.toLowerCase().includes(query)).slice(0, 5)
+    }, [lumaEvents, formik.values.name, event])
+
+    const handleLumaSelect = (lumaEvent: LumaEvent) => {
+        let start: dayjs.Dayjs | null = null
+        if (lumaEvent.startAt) {
+            try {
+                start = lumaEvent.timezone ? dayjs(lumaEvent.startAt).tz(lumaEvent.timezone) : dayjs(lumaEvent.startAt)
+            } catch {
+                start = dayjs(lumaEvent.startAt)
+            }
+        }
+        formik.setValues({
+            ...formik.values,
+            name: lumaEvent.name,
+            date: start?.isValid() ? start.format('YYYY-MM-DD') : formik.values.date,
+            startTime: start?.isValid() ? start.format('HH:mm') : formik.values.startTime,
+            link: lumaEvent.url || formik.values.link,
+            online: lumaEvent.online,
+            ...(lumaEvent.online
+                ? { locationLabel: '', locationLat: undefined, locationLng: undefined, venueName: '' }
+                : {
+                      locationLabel:
+                          lumaEvent.cityState ||
+                          [lumaEvent.city, lumaEvent.country].filter(Boolean).join(', ') ||
+                          formik.values.locationLabel,
+                      venueName: lumaEvent.venue || '',
+                      locationLat: lumaEvent.lat ?? undefined,
+                      locationLng: lumaEvent.lng ?? undefined,
+                  }),
+        })
+        setLumaOpen(false)
+        setLumaHighlight(-1)
+    }
+
+    // Debounced Mapbox suggest — only fires while the user is typing (cityQuery
+    // is set in onChange, not when the field is populated programmatically)
+    React.useEffect(() => {
+        const token = process.env.GATSBY_MAPBOX_TOKEN
+        const query = cityQuery.trim()
+        if (typeof window === 'undefined' || !token || query.length <= 3) {
+            cityAbortRef.current?.abort()
+            cityAbortRef.current = null
+            setCitySuggestions([])
+            setCityOpen(false)
+            setCityHighlight(-1)
+            return
+        }
+        const controller = new AbortController()
+        cityAbortRef.current = controller
+        const handle = setTimeout(async () => {
+            try {
+                const url = new URL('https://api.mapbox.com/search/searchbox/v1/suggest')
+                url.searchParams.set('q', query)
+                url.searchParams.set('limit', '2')
+                url.searchParams.set('types', 'place')
+                url.searchParams.set('language', 'en')
+                url.searchParams.set('session_token', citySessionToken)
+                url.searchParams.set('access_token', token)
+                const response = await fetch(url.toString(), { signal: controller.signal })
+                const json = await response.json()
+                const suggestions = Array.isArray(json?.suggestions) ? json.suggestions : []
+                setCitySuggestions(
+                    suggestions.map((s: { mapbox_id: string; name: string; place_formatted?: string }) => ({
+                        id: s.mapbox_id,
+                        name: s.name,
+                        placeFormatted: s.place_formatted || '',
+                    }))
+                )
+                setCityOpen(suggestions.length > 0)
+                setCityHighlight(-1)
+            } catch {
+                // Aborted or network error — ignore
+            }
+        }, 200)
+        return () => {
+            clearTimeout(handle)
+            controller.abort()
+        }
+    }, [cityQuery, citySessionToken])
+
+    const handleCitySelect = async (item: CitySuggestion) => {
+        setCityOpen(false)
+        setCityHighlight(-1)
+        setCityQuery('')
+        formik.setFieldValue('locationLabel', [item.name, item.placeFormatted].filter(Boolean).join(', '))
+        const token = process.env.GATSBY_MAPBOX_TOKEN
+        try {
+            if (!token || !item.id) return
+            const url = new URL(`https://api.mapbox.com/search/searchbox/v1/retrieve/${encodeURIComponent(item.id)}`)
+            url.searchParams.set('session_token', citySessionToken)
+            url.searchParams.set('access_token', token)
+            const response = await fetch(url.toString())
+            const json = await response.json()
+            const feature = (Array.isArray(json?.features) && json.features[0]) || null
+            const coords = feature?.geometry?.coordinates || feature?.properties?.coordinates || null
+            let longitude: number | null = null
+            let latitude: number | null = null
+            if (Array.isArray(coords) && coords.length >= 2) {
+                longitude = coords[0]
+                latitude = coords[1]
+            } else if (typeof coords?.longitude === 'number' && typeof coords?.latitude === 'number') {
+                longitude = coords.longitude
+                latitude = coords.latitude
+            }
+            if (longitude != null && latitude != null) {
+                formik.setFieldValue('locationLat', latitude)
+                formik.setFieldValue('locationLng', longitude)
+            }
+        } catch (error) {
+            console.error('Error retrieving city coordinates:', error)
+        } finally {
+            // Start a new session token after selection as per Mapbox session semantics
+            setCitySessionToken(newSessionToken())
+        }
+    }
+
+    // Close suggestion dropdowns on outside click
+    React.useEffect(() => {
+        const onClick = (e: MouseEvent) => {
+            if (lumaContainerRef.current && !lumaContainerRef.current.contains(e.target as Node)) {
+                setLumaOpen(false)
+            }
+            if (cityContainerRef.current && !cityContainerRef.current.contains(e.target as Node)) {
+                setCityOpen(false)
+            }
+        }
+        window.addEventListener('click', onClick)
+        return () => window.removeEventListener('click', onClick)
+    }, [])
+
+    const suggestionKeyDown =
+        (
+            isOpen: boolean,
+            count: number,
+            highlight: number,
+            setHighlight: React.Dispatch<React.SetStateAction<number>>,
+            selectAt: (index: number) => void,
+            close: () => void
+        ) =>
+        (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (!isOpen || count === 0) return
+            if (e.key === 'ArrowDown') {
+                e.preventDefault()
+                setHighlight((idx) => (idx + 1) % count)
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault()
+                setHighlight((idx) => (idx - 1 + count) % count)
+            } else if (e.key === 'Enter') {
+                e.preventDefault()
+                selectAt(highlight >= 0 ? highlight : 0)
+            } else if (e.key === 'Escape') {
+                close()
+            }
+        }
+
     const baseOptions = React.useMemo(
         () => ({
             format,
@@ -368,14 +594,53 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
         <div>
             <h2 className="text-xl font-bold mb-1">Add a new event</h2>
             <form onSubmit={formik.handleSubmit} className="space-y-3">
-                <OSInput
-                    label="Name"
-                    required
-                    direction="column"
-                    touched={formik.touched.name}
-                    error={formik.errors.name}
-                    {...formik.getFieldProps('name')}
-                />
+                <div ref={lumaContainerRef} className="relative">
+                    <OSInput
+                        label="Name"
+                        required
+                        direction="column"
+                        autoComplete="off"
+                        touched={formik.touched.name}
+                        error={formik.errors.name}
+                        aria-autocomplete={event ? undefined : 'list'}
+                        aria-expanded={lumaOpen && lumaMatches.length > 0}
+                        aria-controls="luma-event-suggestions"
+                        {...formik.getFieldProps('name')}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                            formik.handleChange(e)
+                            if (!event) {
+                                setLumaOpen(e.target.value.trim().length >= 3)
+                                setLumaHighlight(-1)
+                            }
+                        }}
+                        onKeyDown={suggestionKeyDown(
+                            lumaOpen,
+                            lumaMatches.length,
+                            lumaHighlight,
+                            setLumaHighlight,
+                            (idx) => lumaMatches[idx] && handleLumaSelect(lumaMatches[idx]),
+                            () => setLumaOpen(false)
+                        )}
+                    />
+                    {!event && lumaOpen && (
+                        <SuggestionDropdown
+                            id="luma-event-suggestions"
+                            items={lumaMatches.map((lumaEvent) => ({
+                                id: lumaEvent.id,
+                                label: lumaEvent.name,
+                                sublabel: [
+                                    lumaEvent.startAt ? dayjs(lumaEvent.startAt).format('MMM D, YYYY') : null,
+                                    lumaEvent.online ? 'Online' : lumaEvent.cityState || lumaEvent.city,
+                                ]
+                                    .filter(Boolean)
+                                    .join(' · '),
+                            }))}
+                            highlightIndex={lumaHighlight}
+                            onHighlight={setLumaHighlight}
+                            onSelect={(idx) => lumaMatches[idx] && handleLumaSelect(lumaMatches[idx])}
+                        />
+                    )}
+                </div>
                 <div className="grid grid-cols-2 gap-3">
                     <OSInput
                         label="Date"
@@ -413,15 +678,46 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                 </div>
                 {!formik.values.online && (
                     <>
-                        <OSInput
-                            label="Location"
-                            required
-                            direction="column"
-                            placeholder="e.g. Dublin, Ireland"
-                            touched={formik.touched.locationLabel}
-                            error={formik.errors.locationLabel}
-                            {...formik.getFieldProps('locationLabel')}
-                        />
+                        <div ref={cityContainerRef} className="relative">
+                            <OSInput
+                                label="Location"
+                                required
+                                direction="column"
+                                placeholder="e.g. Dublin, Ireland"
+                                autoComplete="off"
+                                touched={formik.touched.locationLabel}
+                                error={formik.errors.locationLabel}
+                                aria-autocomplete="list"
+                                aria-expanded={cityOpen && citySuggestions.length > 0}
+                                aria-controls="city-suggestions"
+                                {...formik.getFieldProps('locationLabel')}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    formik.handleChange(e)
+                                    setCityQuery(e.target.value)
+                                }}
+                                onKeyDown={suggestionKeyDown(
+                                    cityOpen,
+                                    citySuggestions.length,
+                                    cityHighlight,
+                                    setCityHighlight,
+                                    (idx) => citySuggestions[idx] && handleCitySelect(citySuggestions[idx]),
+                                    () => setCityOpen(false)
+                                )}
+                            />
+                            {cityOpen && (
+                                <SuggestionDropdown
+                                    id="city-suggestions"
+                                    items={citySuggestions.map((city) => ({
+                                        id: city.id,
+                                        label: city.name,
+                                        sublabel: city.placeFormatted,
+                                    }))}
+                                    highlightIndex={cityHighlight}
+                                    onHighlight={setCityHighlight}
+                                    onSelect={(idx) => citySuggestions[idx] && handleCitySelect(citySuggestions[idx])}
+                                />
+                            )}
+                        </div>
                         <div className="grid grid-cols-2 gap-3">
                             <OSInput
                                 label="Latitude"

--- a/src/components/EventForm/index.tsx
+++ b/src/components/EventForm/index.tsx
@@ -17,7 +17,7 @@ import EventGraphic, { type EventGraphicSpeaker } from 'components/EventGraphic'
 import { useToast } from '../../context/Toast'
 import { Event } from '../../pages/events'
 import CreatableMultiSelect from 'components/CreatableMultiSelect'
-import SuggestionDropdown from './SuggestionDropdown'
+import SuggestionDropdown, { suggestionOptionId } from './SuggestionDropdown'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -605,6 +605,11 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                         aria-autocomplete={event ? undefined : 'list'}
                         aria-expanded={lumaOpen && lumaMatches.length > 0}
                         aria-controls="luma-event-suggestions"
+                        aria-activedescendant={
+                            lumaOpen && lumaHighlight >= 0
+                                ? suggestionOptionId('luma-event-suggestions', lumaHighlight)
+                                : undefined
+                        }
                         {...formik.getFieldProps('name')}
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                             formik.handleChange(e)
@@ -690,6 +695,11 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                                 aria-autocomplete="list"
                                 aria-expanded={cityOpen && citySuggestions.length > 0}
                                 aria-controls="city-suggestions"
+                                aria-activedescendant={
+                                    cityOpen && cityHighlight >= 0
+                                        ? suggestionOptionId('city-suggestions', cityHighlight)
+                                        : undefined
+                                }
                                 {...formik.getFieldProps('locationLabel')}
                                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                                     formik.handleChange(e)


### PR DESCRIPTION
## Changes

Auto-populate the moderator "Add event" form so events don't have to be typed by hand:
<img width="370" height="194" alt="image" src="https://github.com/user-attachments/assets/2488d564-9f1f-4b1e-8116-a1081a0979c5" />

- **Luma suggest** — typing 3+ chars in **Name** suggests upcoming events from the luma.com/PostHog calendar (proxied via `api/luma-events.js` since Luma blocks browser CORS); accepting one prefills date, start time (in the event's timezone), link, location, venue, lat/lng, and the online toggle. Also mounted into the Gatsby dev server via `developMiddleware` so it works under `pnpm start`.
- **City autocomplete** — typing 4+ chars in **Location** suggests the top 2 Mapbox cities and fills lat/lng on accept (`GATSBY_MAPBOX_TOKEN`, browser-side).

New shared `SuggestionDropdown` listbox powers both fields (arrow/Enter/Escape, outside-click close). Uses existing `GATSBY_LUMA_TOKEN` + `GATSBY_MAPBOX_TOKEN`.

## Caveat

- This needs to be tested in prod unfortunately since it runs a vercel function to call the Luma API

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links — N/A (no content links)
- [ ] I've checked the pages added or changed in the Vercel preview build — verify Luma + city autocomplete on `/events` → Add event in the preview
- [x] If I moved a page, I added a redirect in `vercel.json` — N/A (no page moved)
