### PR TITLE
Extra community info for mods

### DIFF
--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -436,7 +436,7 @@ const Details = ({ profile, isEditing, setFieldValue, values, errors, isTeamMemb
                             Only visible to moderators
                         </Tooltip>
                     </span>
-                    <a href={`mailto:${email}`} className="truncate text-right">
+                    <a href={`mailto:${email}`} className="truncate text-right underline font-medium">
                         {email}
                     </a>
                 </p>

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -413,8 +413,9 @@ const AvatarBlock = ({
     )
 }
 
-const Details = ({ profile, isEditing, setFieldValue, values, errors, isTeamMember }) => {
+const Details = ({ profile, isEditing, setFieldValue, values, errors, isTeamMember, isModerator }) => {
     const [showPronounsInput, setShowPronounsInput] = useState(!!values.pronouns)
+    const email = profile?.user?.data?.attributes?.email
 
     // Update showPronounsInput when values.pronouns changes
     useEffect(() => {
@@ -422,6 +423,14 @@ const Details = ({ profile, isEditing, setFieldValue, values, errors, isTeamMemb
     }, [values.pronouns])
     return (
         <div className="text-sm space-y-3">
+            {isModerator && email && (
+                <p className="flex justify-between m-0 gap-2">
+                    <span className="font-semibold">Email</span>
+                    <a href={`mailto:${email}`} className="truncate text-right">
+                        {email}
+                    </a>
+                </p>
+            )}
             {!isEditing && profile.reputation != null && (
                 <p className="flex justify-between items-center m-0">
                     <span className="font-semibold">Reputation</span>
@@ -1501,7 +1510,8 @@ export default function ProfilePage({ params }: PageProps) {
                                 profile.reputation != null ||
                                 profile.pineappleOnPizza !== null ||
                                 profile.pronouns ||
-                                profile.location) && (
+                                profile.location ||
+                                (isModerator && profile?.user?.data?.attributes?.email)) && (
                                 <Block title="Details">
                                     <Details
                                         profile={profile}
@@ -1510,6 +1520,7 @@ export default function ProfilePage({ params }: PageProps) {
                                         values={values}
                                         errors={errors}
                                         isTeamMember={isTeamMember}
+                                        isModerator={isModerator}
                                     />
                                 </Block>
                             )}

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -35,6 +35,7 @@ import {
     IconExternal,
     IconPresent,
     IconSparkles,
+    IconShieldLock,
 } from '@posthog/icons'
 import { Fieldset } from 'components/OSFieldset'
 import { useFormik } from 'formik'
@@ -424,8 +425,17 @@ const Details = ({ profile, isEditing, setFieldValue, values, errors, isTeamMemb
     return (
         <div className="text-sm space-y-3">
             {isModerator && email && (
-                <p className="flex justify-between m-0 gap-2">
-                    <span className="font-semibold">Email</span>
+                <p className="flex justify-between m-0 gap-2 items-center">
+                    <span className="font-semibold inline-flex items-center gap-1 leading-none">
+                        Email
+                        <Tooltip
+                            delay={0}
+                            className="inline-flex items-center text-secondary"
+                            trigger={<IconShieldLock className="size-4" />}
+                        >
+                            Only visible to moderators
+                        </Tooltip>
+                    </span>
                     <a href={`mailto:${email}`} className="truncate text-right">
                         {email}
                     </a>


### PR DESCRIPTION
## Changes

- Surface a community user's email in the profile Details section
- Visible only to logged-in moderators (uses existing moderator `user` populate)