### PR TITLE
Add Shopify 1Password login steps to merch store handbook

### DIFF
--- a/contents/handbook/company/merch-store.md
+++ b/contents/handbook/company/merch-store.md
@@ -39,6 +39,16 @@ Shipping is also done through Micromerch (in partnership with Shiphero) - they c
 
 Create a discount code in <PrivateLink url="https://admin.shopify.com/store/posthog/discounts">Shopify admin</PrivateLink>. You don't need to be invited to Shopify, instead the login details are stored in [1Password](https://start.1password.com/signin?l=en).
 
+To log into Shopify using 1Password:
+
+1. Sign in with the email from 1Password
+2. Ignore the saved passkey pop-up
+3. Click "Log in using a different method"
+4. Click "Continue with password"
+5. Use the password from 1Password and click "Log in"
+6. On the "Use your passkey" screen, click "Use the authentication app" — you can then use 1Password to enter the authentication code
+7. You're logged in!
+
 When creating the discount, select "amount off products" then choose if it is a percentage off or a fixed amount - usually we do fixed amounts of $30, $50, or $100 depending on the purpose. The you can choose "specific collections" and choose "All Products". 
 
 > Limit the use to one use only (_not_ one use per customer), otherwise it's unlimited free stuff for them, unlimited high cost for us! 


### PR DESCRIPTION
## Changes

Adds a step-by-step guide to the merch store handbook for logging into Shopify with 1Password, covering the passkey-to-authentication-app flow that recently tripped people up.

**Why:** The current login flow (with the passkey pop-up) is confusing when you only have the 1Password credentials and aren't the passkey holder, so documenting the exact steps saves people from getting stuck.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1779907429896599?thread_ts=1779907429.896599&cid=C09G8Q32R6F)*
