### PR TITLE
Add Vitally to Tools we use

### DIFF
--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -104,6 +104,8 @@ The expectation is that this temporary CSM will ensure your customers aren't com
 For longer periods away, Dana may look to reassign some or all of your accounts.
 
 ## Tools we use
+**Vitally:** Vitally is our customer success platform and the system of record for your book of business. Account health scores, usage and billing signals, and indicators for risks and opportunities live here. 
+
 **Gmail**
 We use Gmail for our email and the team uses many different clients from [Superhuman](https://superhuman.com/) to [Spark](https://sparkmailapp.com/) to the default Gmail web interface. Find something that works well for you. To get your own email signature, copy the signature from someone else on the team (like Simon) and then fill in your own details.
 


### PR DESCRIPTION

## Changes

This adds a short Vitally entry at the top of "Tools we use" describing it as
the CS system of record, and covering health scores and indicators.

**For reviewers:** I sourced these details from `how-we-use-automation`, which
may itself be out of date

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
