### PR TITLE
docs: refresh Replay Vision docs against shipped behavior

### DIFF
--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -10,13 +10,14 @@ Not yet available to everyone – <a href="/replay-vision">join the waitlist</a>
 
 </CalloutBox>
 
-A scanner is made up of five things you author:
+A scanner is made up of six things you author:
 
 1. A **prompt** describing what to look for.
 2. A **scanner type** that determines the output shape – see [scanner types](/docs/replay-vision/scanner-types).
 3. **Recording filters** that select which sessions the scanner applies to.
 4. A **session coverage** mode that pre-filters by recording quality.
 5. A **sampling rate** that controls how many matching sessions get scanned.
+6. A **model**, which sets what each observation costs.
 
 ## Start from a template
 
@@ -79,7 +80,7 @@ A prompt that reads beautifully on its own can still misfire. The fastest feedba
 4. Adjust the prompt where the model misread something obvious.
 5. Scan another batch of recordings and repeat until the results look right.
 
-Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation counts against your [monthly quota](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through it fast on results you'd throw away anyway.
+Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation spends [credits](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through your budget fast on results you'd throw away anyway.
 
 ### Drafting prompts with PostHog AI
 
@@ -147,11 +148,18 @@ The scanner editor shows a **per-month estimate** of how many observations the s
   classes="rounded"
 />
 
-If the estimate looks too high, you have three knobs:
+If the estimate looks too high, you have four knobs:
 
 - Narrow the filters.
 - Tighten the session coverage mode (Comprehensive → Balanced → Focused).
 - Lower the sampling rate.
+- Pick a cheaper model.
+
+## Model: quality against cost
+
+The **Model** selector in the configure step picks which Gemini model reads each recording, and it sets the price of every observation the scanner makes: 2 credits on `gemini-3.5-flash-lite`, 5 on `gemini-3-flash-preview` (the default), and 15 on `gemini-3.6-flash`. Newer models tend to produce higher-quality observations, but the top tier costs over seven times as much per session as the cheapest.
+
+Start on the default. If results are close but not quite right, tune the prompt before reaching for a pricier model – a sharper prompt is free, and the [Quality tab](/docs/replay-vision/quality) will tell you whether it worked. See [quota and limits](/docs/replay-vision/quota-and-limits) for how credits are metered.
 
 ## Enabling and disabling
 
@@ -161,12 +169,12 @@ Toggling a scanner to **disabled** stops the background sweep. On-demand trigger
 
 To stop a scanner entirely, delete it. Deleting a scanner also removes all of its observations from the Observations tab. The `$recording_observed` events the scanner produced are ordinary PostHog events in your project's event stream and aren't affected – they stay queryable.
 
-## Handing off to Responder agents
+## Feeding the self-driving loop
 
-Each scanner has a **Hand off to Responder agents** toggle in the configuration step. When enabled, the scanner gains a side mission: during each scan, the model looks for clear, actionable product issues – bugs, broken or confusing flows, errors, or significant UX friction – and reports them as findings.
+The last step of the editor is **Self-driving**, with an **Emit findings as Signals** toggle. When enabled, the scanner gains a side mission: during each scan, the model looks for clear, actionable product issues – bugs, broken or confusing flows, errors, or significant UX friction – and reports them as findings.
 
 The scanner's primary task (monitoring, classifying, scoring, or summarizing) is unaffected. The side mission runs alongside it, and most scans produce no finding at all. The bar is deliberately high: a finding must be self-contained and concrete enough for someone with no session context to act on it.
 
-Findings are emitted as signals to the [self-driving inbox](/docs/self-driving/inbox/sources), where Responder agents can pick them up, research the issue against your codebase and product data, and potentially open a PR.
+Findings are emitted as signals to the [self-driving inbox](/docs/self-driving/inbox/sources), where an agent can pick them up, research the issue against your codebase and product data, and potentially open a PR.
 
-The toggle is the only setup required – there's no additional configuration in PostHog Desktop Inbox for this source.
+The toggle is the only setup required – there's no additional configuration in the inbox for this source.

--- a/contents/docs/replay-vision/index.mdx
+++ b/contents/docs/replay-vision/index.mdx
@@ -25,7 +25,7 @@ The key idea is that Replay Vision actually *watches the video* of each recordin
 
 Replay Vision is built around two concepts:
 
-- **Scanner** – a configured AI probe scoped to your project. A scanner has a natural-language prompt describing what to look for, a [scanner type](/docs/replay-vision/scanner-types) that determines what kind of output it produces, a set of recording filters that select which sessions it applies to, and a sampling rate.
+- **Scanner** – a configured AI probe scoped to your project. A scanner has a natural-language prompt describing what to look for, a [scanner type](/docs/replay-vision/scanner-types) that determines what kind of output it produces, recording filters that select which sessions it applies to, a session coverage mode and sampling rate that control how many of those get scanned, and a model that sets what each scan [costs](/docs/replay-vision/quota-and-limits).
 - **Observation** – one application of a scanner to a single recording. Each observation runs the scanner against that session and produces a structured result that's persisted and emitted as a queryable [`$recording_observed` event](/docs/replay-vision/observations#querying-observations-as-events).
 
 When a scanner runs against a recording, PostHog:

--- a/contents/docs/replay-vision/mcp.mdx
+++ b/contents/docs/replay-vision/mcp.mdx
@@ -18,6 +18,7 @@ This works in any MCP client – Cursor, Codex, Claude Code, Windsurf, VS Code, 
 - **Trigger an observation on demand** – scan a specific session you're investigating without switching to the app.
 - **Read observations as part of a coding task** – pull the structured result and the model's reasoning into context as the agent works.
 - **Audit a scanner** – list its recent observations to decide whether the prompt or filters need tuning.
+- **Improve a scanner** – rate results, then generate and apply a prompt recommendation from those ratings.
 
 ## The tools, by job
 
@@ -33,10 +34,10 @@ Replay Vision's MCP tools are all prefixed `vision-`. They fall into a few group
 
 ### Sizing before you create
 
-- `vision-scanners-estimate-create` – project the per-month observation volume of a hypothetical scanner before you commit to it.
-- `vision-quota-retrieve` – check the remaining monthly quota.
+- `vision-scanners-estimate-create` – project a hypothetical scanner's monthly observation volume and credit spend before you commit to it.
+- `vision-quota-retrieve` – check the organization's remaining [credit budget](/docs/replay-vision/quota-and-limits).
 
-Pair these two before calling `vision-scanners-create` to avoid creating a scanner that would immediately blow the budget.
+Pair these two before calling `vision-scanners-create` to avoid creating a scanner that would immediately blow the budget. Compare credits with credits: the estimate returns `estimated_credits_per_month`, and the quota tool returns `remaining`.
 
 ### Triggering an observation on demand
 
@@ -56,10 +57,34 @@ For one scanner (across sessions):
 - `vision-scanners-observations-list` – paginated list of a scanner's observations.
 - `vision-scanners-observations-get` – fetch one of that scanner's observations by ID.
 
+Aggregate stats, rather than the rows themselves:
+
+- `vision-scanners-observations-stats` – one scanner's status mix and success rate, distinct sessions covered, rating totals, and the per-type distributions (monitor verdict counts, classifier tag rankings, scorer score summary and histogram).
+
 ### Impact and cohorts
 
 - `vision-scanners-impact-retrieve` – get affected sessions and users for a scanner over a trailing window. Monitors count verdict-yes observations. Classifiers require a `tag` parameter. Scorers require `min_score` and/or `max_score`.
 - `vision-scanners-affected-cohort-create` – save the affected users as a static cohort. Same qualifiers as the impact endpoint. The cohort is a dated snapshot and doesn't live-update.
+
+### Improving a scanner
+
+The same rate-and-recommend loop as the [Quality tab](/docs/replay-vision/quality), from your editor:
+
+- `vision-observations-label-create` – rate an observation thumbs up or down, with optional written feedback. Ratings are shared across the team.
+- `vision-observations-label-destroy` – clear a rating.
+- `vision-scanners-prompt-suggestions-current` – read the newest recommendation, whether it's gone stale since new ratings arrived, and how many rated observations back it.
+- `vision-scanners-prompt-suggestions-generate` – generate a fresh recommendation from the current ratings. The model call runs inline, so the request takes a while.
+- `vision-scanners-prompt-suggestions-apply` – write the suggested prompt to the scanner as a new version.
+- `vision-scanners-prompt-suggestions-dismiss` – reject it without changing the scanner.
+
+### Digests and alerts
+
+For scanners with digests or alerts attached:
+
+- `vision-actions-list` – the actions bound to a scanner: digests, group summaries, and alerts.
+- `vision-actions-retrieve` – one action's configuration, including which observations it selects and on what cadence.
+- `vision-actions-runs-list` – that action's run history.
+- `vision-actions-runs-retrieve` – a run's synthesized report, plus the observations it cited. The report references its sources inline as `[obs N]`, so you can check each claim against the observation behind it.
 
 ## Example prompts
 
@@ -71,7 +96,8 @@ Try these with your MCP-enabled agent:
 - `Scan session abc123 with the "Dead-end pages" scanner and tell me what it found, including the reasoning.`
 - `List the last 20 observations from my "Frustration score" scanner and summarize what's driving high scores.`
 - `Find every Replay Vision observation for session abc123 and give me a one-line summary of each.`
-- `How much Replay Vision quota do we have left this month?`
+- `How many Replay Vision credits do we have left this period, and which scanner is spending the most?`
+- `Rate the last 10 observations from my "User intent" classifier against what I tell you, then generate a prompt recommendation.`
 - `How many users did my "Dead-end pages" monitor affect in the last 14 days? Save them as a cohort.`
 
 See the [MCP server docs](/docs/model-context-protocol) for client setup, and the [Replay Vision overview](/docs/replay-vision) for product concepts.

--- a/contents/docs/replay-vision/observations.mdx
+++ b/contents/docs/replay-vision/observations.mdx
@@ -26,9 +26,9 @@ Observations move through a small state machine:
 
 - **`succeeded`** – terminal. The structured result is saved and a [`$recording_observed` event](#querying-observations-as-events) is emitted.
 - **`failed`** – terminal. The detail view shows an error reason. See [troubleshooting](/docs/replay-vision/troubleshooting#failed-observations) for what each failure kind means.
-- **`ineligible`** – terminal. The session can't be analyzed (no recording, too short, no events, etc.). Doesn't count against your quota. See [running scanners](/docs/replay-vision/running-scanners#ineligible-sessions).
+- **`ineligible`** – terminal. The session can't be analyzed (no recording, too short, no events, etc.). Doesn't cost anything. See [running scanners](/docs/replay-vision/running-scanners#ineligible-sessions).
 
-Succeeded, pending, and running observations count against your monthly [quota](/docs/replay-vision/quota-and-limits); failed and ineligible ones don't.
+Succeeded, pending, and running observations spend [credits](/docs/replay-vision/quota-and-limits); failed and ineligible ones don't. A failed observation can be retried from its detail page, which replaces it with a fresh scan of the same recording.
 
 ## Querying observations as events
 
@@ -43,10 +43,14 @@ Every successful observation is captured as a `$recording_observed` event in you
 | `scanner_type`                   | `monitor`, `classifier`, `scorer`, or `summarizer`                                                                                                  |
 | `scanner_version`                | Version of the scanner config that produced this observation                                                                                        |
 | `session_id`                     | The recording that was observed                                                                                                                     |
-| `triggered_by`                   | `schedule` (background sweep) or `on_demand`                                                                                                        |
-| `triggered_by_user_id`           | The user who triggered an on-demand observation; null for background sweeps                                                                         |
+| `triggered_by`                   | `schedule` (background sweep), `on_demand`, or `retry` (a re-run of a failed observation)                                                           |
+| `triggered_by_user_id`           | The user who triggered an on-demand observation or retry; null for background sweeps                                                                |
+| `recording_distinct_id`          | Distinct ID of the person in the recorded session, which is the subject, not whoever triggered the scan                                             |
+| `recording_subject_email`        | Email of the recording subject at scan time, when known                                                                                             |
 | `model_used`                     | The model that produced the result                                                                                                                  |
 | `provider_used`                  | The LLM provider behind `model_used`                                                                                                                |
+| `credits`                        | What this observation cost, priced at emit time (1 credit = $0.01). Use it to chart [spend](/docs/replay-vision/quota-and-limits) in SQL            |
+| `emits_signals`                  | Whether the scanner was feeding findings into PostHog Signals when it ran                                                                           |
 | `scanner_output_confidence`      | The model's confidence (0.0 to 1.0)                                                                                                                 |
 | `scanner_output_reasoning`       | **Monitor, classifier, and scorer** – the model's reasoning text, including any inline citations. Summarizers don't have a separate reasoning field |
 | `scanner_output_verdict`         | **Monitor only** – `"yes"`, `"no"`, or `"inconclusive"`                                                                                             |

--- a/contents/docs/replay-vision/quota-and-limits.mdx
+++ b/contents/docs/replay-vision/quota-and-limits.mdx
@@ -10,59 +10,70 @@ Not yet available to everyone – <a href="/replay-vision">join the waitlist</a>
 
 </CalloutBox>
 
-Replay Vision usage is metered per organization, on a monthly cycle. This page covers what the cap is, what counts against it, and what to do when you're approaching it.
+Replay Vision usage is metered per organization in **credits**. This page covers what an observation costs, what counts against your budget, and what to do when you're approaching it.
 
-<CalloutBox icon="IconFlask" title="Closed beta quota will change" type="action">
+## Credits and what an observation costs
 
-The current cap of 3,000 observations per organization per month is a placeholder for the beta period and will change before general availability. The in-app usage meter is the authoritative current number for your organization.
+One credit is $0.01. Each observation spends credits according to the model the scanner runs, so the model you pick is a cost lever as much as a quality one:
 
-</CalloutBox>
+| Model                    | Credits per observation |
+| ------------------------ | ----------------------- |
+| `gemini-3.5-flash-lite`  | 2                       |
+| `gemini-3-flash-preview` | 5 (default)             |
+| `gemini-3.6-flash`       | 15                      |
 
-## Monthly observation cap
+Newer models tend to produce higher-quality observations, but a scanner on the most capable model costs over seven times as much per session as one on the cheapest. Start on the default and move up only when the cheaper tiers demonstrably miss what you're looking for.
 
-During the closed beta, each organization gets **3,000 observations per calendar month**. The counter resets at the start of each calendar month (UTC).
+## Your budget
 
-The current month's usage is shown in the Replay Vision app:
+Budgets are set per organization and reset each billing period. Rather than repeat a number here that may not match your plan, check the in-app meter, which is always authoritative:
+
+- The **Usage** tab in Replay Vision shows your organization's spend over time, daily through yearly.
+- Each scanner's page shows what that scanner has spent this period, so you can see which one is consuming the budget.
+- The scanner editor shows a projected monthly spend for the scanner you're configuring, against what's left.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quota_meter_ddcc762a43.png"
-  alt="The monthly usage meter: observations used this month against the organization's cap"
+  alt="The Replay Vision usage meter: credits used this period against the organization's budget"
   classes="rounded"
 />
 
-You can also fetch it programmatically – see the `vision-quota-retrieve` MCP tool.
+You can also fetch it programmatically – see the `vision-quota-retrieve` MCP tool, which returns `credit_limit`, `credits_used`, `remaining`, `exhausted`, and the current period's start and end.
 
-## What counts against the cap
+## What counts against your budget
 
-| Observation outcome | Counts against cap? |
-| ------------------- | ------------------- |
-| **Succeeded**       | Yes                 |
-| **Pending**         | Yes                 |
-| **Running**         | Yes                 |
-| **Failed**          | No                  |
-| **Ineligible**      | No                  |
+| Observation outcome     | Counts? |
+| ----------------------- | ------- |
+| **Succeeded**           | Yes     |
+| **Pending**             | Yes     |
+| **Running**             | Yes     |
+| **Failed**              | No      |
+| **Ineligible**          | No      |
 
-Pending and running observations count so a burst of concurrent on-demand triggers can't blow past the cap before any of them complete. Once an observation reaches a terminal failed or ineligible state, it stops counting toward the month's usage.
+Pending and running observations are reserved at their model's price so a burst of concurrent on-demand triggers can't blow past the budget before any of them complete. Once an observation reaches a terminal failed or ineligible state, it stops counting.
 
-In practice this means: **every observation that produces a `$recording_observed` event uses one unit of quota.** Ineligibles and failures don't consume any.
+In practice this means: **every observation that produces a `$recording_observed` event spends its model's credits.** Ineligibles and failures don't cost anything.
 
-## What happens when the cap is reached
+Prompt tests count too. Testing a configuration recommendation on the [Quality tab](/docs/replay-vision/quality#test-before-applying) re-runs the scanner against rated sessions, and each of those is charged like a normal observation. The panel shows the cost before you run it.
+
+## What happens when the budget runs out
 
 Both enforcement paths use the same check:
 
-- **Background sweeps** – new observations queued by the automatic schedule are silently skipped. The scanner stays enabled, the sweep keeps running, but no work gets queued until quota frees up (next month, or as in-flight observations resolve to ineligible/failed).
+- **Background sweeps** – new observations queued by the automatic schedule are silently skipped. The scanner stays enabled, the sweep keeps running, but no work gets queued until budget frees up (the next period, or as in-flight observations resolve to ineligible/failed).
 - **On-demand triggers** – the player action and the `vision-scanners-scan-session` MCP tool return a `402 Payment Required` response with a `quota_limit_exceeded` code.
 
-A scanner that's been silenced by the cap will resume producing observations automatically once usage drops below the cap (e.g. at the start of the next month).
+A scanner that's been silenced this way resumes producing observations automatically once usage drops below the budget, for example at the start of the next period.
 
-## Sizing scanners against the cap
+## Sizing scanners against your budget
 
-The scanner editor shows a **projected per-month observation count** for the scanner you're configuring, based on:
+The scanner editor shows a **projected monthly spend** for the scanner you're configuring, based on:
 
 - Your project's recent recording volume.
 - The filters you've set.
 - The session coverage mode.
 - The sampling rate.
+- The model, which sets the per-observation price.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/estimate_callout_2d954ec2cb.png"
@@ -70,20 +81,21 @@ The scanner editor shows a **projected per-month observation count** for the sca
   classes="rounded"
 />
 
-If the projection is uncomfortably close to your remaining cap, the cheapest knobs are:
+If the projection is uncomfortably close to what's left, the cheapest knobs are:
 
 - **Narrow the filters** – e.g. require a specific URL pattern, exclude bots, restrict to a cohort.
 - **Tighten session coverage** – switching from Comprehensive to Balanced or Focused mode filters out low-quality sessions before sampling, so your budget goes toward recordings with meaningful activity.
 - **Lower the sampling rate** – samples are random, so a 10% rate gives you a representative slice of matching sessions for one-tenth the volume.
-- **Combine all three** – a tight filter on the sessions you care most about, plus Focused or Balanced coverage, plus a higher sampling rate, often yields better signal-per-observation than a loose filter with Comprehensive coverage and low sampling.
+- **Pick a cheaper model** – dropping from `gemini-3.6-flash` to the default cuts the per-observation price by two thirds, and to `gemini-3.5-flash-lite` by almost 90%.
+- **Combine them** – a tight filter on the sessions you care most about, plus Focused or Balanced coverage, often yields better signal-per-credit than a loose filter with Comprehensive coverage and low sampling.
 
-To project a hypothetical scanner _before_ creating it (e.g. from a script or agent), use the `vision-scanners-estimate-create` MCP tool. It runs the same projection the editor shows.
+To project a hypothetical scanner _before_ creating it (e.g. from a script or agent), use the `vision-scanners-estimate-create` MCP tool. It runs the same projection the editor shows, returning both the observation count and the credits it would cost.
 
-## What to do if you're hitting the cap
+## What to do if you're running out
 
 Try these, in order:
 
-1. **Look at which scanner is consuming the most quota.** The Observations tab makes this easy – a scanner producing thousands of observations a month is probably broader than it needs to be.
-2. **Tighten its filters, session coverage, or sampling rate.** Use the editor's projection to find a setting that gives you enough signal without dominating the cap.
+1. **Find the scanner spending the most.** Each scanner shows its spend for the current period, and the Usage tab charts spend over time. A scanner costing far more than the rest is usually broader, or on a pricier model, than it needs to be.
+2. **Tighten its filters, session coverage, sampling rate, or model.** Use the editor's projection to find a setting that gives you enough signal without dominating the budget.
 3. **Disable scanners you're not actively using.** A disabled scanner produces zero new background observations.
-4. **Wait for the cap to reset.** Caps reset at the start of each calendar month in UTC.
+4. **Wait for the period to reset.** Usage resets at the start of each billing period.

--- a/contents/docs/replay-vision/scanner-types.mdx
+++ b/contents/docs/replay-vision/scanner-types.mdx
@@ -123,7 +123,7 @@ A scorer assigns a **numeric score** on a scale you define – e.g. 0 to 10 for 
 
 **Type-specific config**
 
-- **Scale** – minimum and maximum values (integers).
+- **Scale** – minimum and maximum values. Any numbers will do as long as the minimum is lower, though whole numbers are easier to reason about when you're reading scores later.
 - **Scale label** – optional short description of what the scale represents (e.g. "0 = no friction, 10 = severe friction").
 
 **When to use it**

--- a/contents/docs/replay-vision/troubleshooting.mdx
+++ b/contents/docs/replay-vision/troubleshooting.mdx
@@ -19,7 +19,7 @@ Check, in order:
 1. **Is the scanner enabled?** Disabled scanners don't sweep. The toggle is on the scanner list and on the scanner detail page.
 2. **Are the filters too narrow?** Try removing all filters and see whether observations start showing up. If they do, re-add filters one at a time to find the culprit.
 3. **Is the sampling rate 0%?** A common oversight – 0% means every matching session gets skipped.
-4. **Is the quota exhausted?** Check the usage meter in the Replay Vision header. A scanner whose background sweep is silenced by the cap will silently produce nothing until quota frees up. See [quota and limits](/docs/replay-vision/quota-and-limits).
+4. **Is the credit budget exhausted?** Check the usage meter in the Replay Vision header. A scanner whose background sweep is silenced by an exhausted budget will silently produce nothing until credits free up. See [quota and limits](/docs/replay-vision/quota-and-limits).
 5. **Is your project recording sessions at all?** Replay Vision only sees sessions [Session Replay](/docs/session-replay) has captured. No recordings, no observations. See [events or recordings aren't coming in](#events-or-recordings-arent-coming-in).
 6. **Is your organization over a usage limit?** If Product analytics or Session replay is over its billing limit, new events or recordings are dropped at ingestion and scanners have nothing usable to scan. See [usage limits stop scanning](#usage-limits-stop-scanning).
 7. **Are all the matched sessions ineligible?** If your filters happen to match only very short or no-event sessions, the scanner will produce ineligible observations but no successful ones. See [running scanners – ineligible sessions](/docs/replay-vision/running-scanners#ineligible-sessions).
@@ -118,6 +118,12 @@ The model returned a response that didn't match the scanner's expected output sh
 Something else went wrong on PostHog's side. These should be rare.
 
 **What to do:** if you see it more than once, [contact support](/questions) with the observation ID.
+
+### `orphaned`
+
+The scan started but never reached a result – the job died partway through, so PostHog marked the observation failed rather than leaving it stuck as pending or running forever.
+
+**What to do:** retry the observation from its detail page. The retry replaces the failed row with a fresh scan of the same recording. If the same session orphans repeatedly, [contact support](/questions) with the observation ID.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/failed_observation_detail_d3da59138d.png"


### PR DESCRIPTION
## What and why

I swept every Replay Vision docs page against the product code on `PostHog/posthog` master and fixed what had drifted. Most of the drift comes from the move to credits-based metering, which the docs never picked up.

The one that actually misleads people is **quota and limits**. The page is built on "3,000 observations per organization per calendar month, one unit per observation". Usage is now metered in credits (1 credit = $0.01) priced per model at 2, 5, or 15 credits per observation, over the org's billing period. A reader following the old page would size a scanner against a budget that doesn't exist, and would miss that switching models changes cost by more than 7x.

Since credit budgets are billing-driven, the rewritten page deliberately publishes no org-level number. It explains the model and points at the in-app meter, the Usage tab, and per-scanner spend as authoritative. Happy to add a figure if someone who owns pricing messaging wants one there.

## Page by page

| Page | Change |
| --- | --- |
| `quota-and-limits` | Rewritten around credits: per-model price table, billing period rather than calendar month, prompt tests count as spend, per-scanner spend and the Usage tab as the way to find the expensive scanner, model added as a cost lever. |
| `creating-scanners` | The self-driving toggle is in its own **Self-driving** step and is labelled **Emit findings as Signals**, not "Hand off to Responder agents" in the configure step. Added a section on model choice, which was missing entirely despite being the biggest cost lever. Dropped "Responder agents" and "PostHog Desktop Inbox", neither of which appears in the self-driving docs. |
| `observations` | `triggered_by` can also be `retry`. Added the `credits`, `emits_signals`, `recording_distinct_id`, and `recording_subject_email` event properties. `credits` matters most: it's how you chart spend in SQL. |
| `mcp` | Listed the nine enabled tools the page was missing: observation stats, ratings, the four prompt-suggestion tools, and the four digest/alert tools. Estimate and quota tools now described in credits. |
| `troubleshooting` | Added the `orphaned` failure kind, which users can see and the failure reference didn't cover. |
| `scanner-types` | Scorer scales aren't restricted to integers. |
| `index` | The scanner definition was missing session coverage and the model. |

## How I verified

Every claim I changed was checked against a specific file on `PostHog/posthog` master rather than against the running app:

- Credit prices and the billing period: `products/replay_vision/backend/billing.py` and `backend/quota.py`.
- The self-driving step and its toggle label: `frontend/replay_scanners/ScannerEditorScene.tsx`.
- Event properties: `backend/temporal/activities/emit_observation_event.py`.
- Triggers and failure kinds: `backend/models/replay_observation.py` and `backend/error_kinds.py`.
- Enabled MCP tools: parsed `products/replay_vision/mcp/tools.yaml` and diffed the tool names against what each page mentions.
- Retry behavior: the `retry` action in `backend/api/observations.py` plus the "Retry scan" button in `frontend/observations/ReplayObservation.tsx`.

I also confirmed a good chunk of the docs is already correct, so this PR leaves it alone: the five templates, the session-coverage thresholds including the top 25% / 65% calibration, the ineligible taxonomy, the dock and bulk-scan flows, the 10,000-user cohort cap, the 402 `quota_limit_exceeded` response, and the scorer and summarizer impact limitations. `quality.mdx` was already credit-aware and is untouched.

No screenshots were re-taken. The existing images still match the flows they illustrate, though the usage-meter screenshot on the quota page shows observations rather than credits and is worth refreshing when someone has the app open.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus 5, Claude Code) did the sweep and wrote the changes, as a follow-on to the same exercise over the in-repo docs in PostHog/posthog#73994 (product README, agent skills, MCP tool descriptions). Working across both repos is what surfaced how far the credits model had spread through the product without reaching either set of docs.

Two judgment calls for a reviewer to sanity check: publishing the per-model credit prices while deliberately omitting any org-level budget number, and dropping the "Responder agents" term because no other self-driving page uses it.
