### PR TITLE
Refresh Replay Vision docs for current product state

### DIFF
--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -79,7 +79,9 @@ A prompt that reads beautifully on its own can still misfire. The fastest feedba
 4. Adjust the prompt where the model misread something obvious.
 5. Scan another batch of recordings and repeat until the results look right.
 
-Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation counts against your [monthly quota](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through it fast on results you'd throw away anyway.
+Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation costs [budget](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through it fast on results you'd throw away anyway.
+
+Once the scanner is running, the tuning loop moves to its [quality tab](/docs/replay-vision/quality): rate results with a thumbs up or down, and PostHog AI turns your team's ratings and feedback into configuration recommendations you can test against the rated sessions before applying.
 
 ### Drafting prompts with PostHog AI
 
@@ -95,10 +97,12 @@ Inside the scanner editor, you can ask [PostHog AI](/docs/posthog-ai) to draft a
 
 Each scanner type has a few extra knobs. The full reference is on the [scanner types](/docs/replay-vision/scanner-types) page; the highlights:
 
-- **Classifier** – define your tag vocabulary, choose whether multiple tags per session are allowed, and whether the model can invent tags outside the vocabulary.
+- **Classifier** – define your tag vocabulary (or have PostHog AI suggest tags based on your prompt and what's been seen in recordings), choose whether multiple tags per session are allowed, and whether the model can invent tags outside the vocabulary.
 - **Scorer** – set the numeric scale (min, max) and an optional label describing what the scale means.
-- **Summarizer** – pick a summary length (short / medium / long).
+- **Summarizer** – pick a summary length (short / medium / long). The core summarizer prompt is built in, so the prompt field becomes **Additional context**: use it for product context or steering, like what the ideal user flow looks like.
 - **Monitor** – choose whether the model can return `inconclusive` rather than forcing a yes/no answer.
+
+The editor also has a **model** picker. Newer models tend to produce higher-quality observations but cost more per observation – each option shows its price, and the [budget](/docs/replay-vision/quota-and-limits) page explains how costs add up.
 
 ## Filters: scoping the scanner
 
@@ -111,35 +115,35 @@ Recording filters use the same query builder as the rest of [Session Replay](/do
 
 A scanner with no filters matches every eligible session in your project. A scanner with narrow filters – e.g. "sessions on `/checkout` longer than 30 seconds for users on the trial plan" – is much cheaper, much faster to iterate on, and usually more useful.
 
+One limit applies regardless of filters: recordings with more than 1 hour of active interaction take too long to analyze well, so Vision always skips them.
+
 A good default discipline: start with a narrow filter while you're tuning the prompt, then widen the filter once you trust the results.
 
 ## Session coverage: filtering by quality
 
-The **Session coverage** toggle pre-filters recordings by their predicted quality before sampling is applied. It uses an internally-computed surfacing score that estimates how much meaningful activity a recording contains – engagement, errors, navigation – versus idle or empty sessions.
+The **Session coverage** setting pre-filters recordings by their activity level before sampling is applied. It uses an internally-computed relevance score that estimates how much meaningful activity a recording contains – engagement, errors, navigation – versus idle or empty sessions.
 
-| Mode              | What it keeps                                    |
-| ----------------- | ------------------------------------------------ |
-| **Focused**       | Roughly the top 25% of sessions by quality score |
-| **Balanced**      | Roughly the top 65% of sessions by quality score |
-| **Comprehensive** | All sessions – no quality filtering (default)    |
+| Mode                      | What it keeps                                      |
+| ------------------------- | -------------------------------------------------- |
+| **Highest activity only** | Roughly the top 25% of sessions by activity score  |
+| **Skip lowest activity**  | Roughly the top 65% of sessions by activity score  |
+| **All recordings**        | Every session matching your filters (default)      |
 
-Sessions without a score are skipped by Focused and Balanced modes.
+Sessions without a score are skipped by the two filtered modes.
 
 The three-step filtering process is:
 
 1. **Recording filters** pick sessions matching your criteria.
-2. **Session coverage** drops low-quality sessions by surfacing score.
+2. **Session coverage** drops low-activity sessions by relevance score.
 3. **Sampling rate** randomly keeps a fraction of what's left.
 
-Existing scanners default to Comprehensive, so they behave the same as before.
-
-Use a tighter coverage mode when you want to spend your observation budget on sessions where something actually happened, rather than idle or empty recordings.
+Use a tighter coverage mode when you want to spend your budget on sessions where something actually happened, rather than idle or empty recordings.
 
 ## Sampling rate: controlling volume
 
 The sampling rate (0–100%) is applied **after** the filters match. A scanner with filter "sessions over 30 seconds" and sampling 25% scans roughly one in four of those sessions.
 
-The scanner editor shows a **per-month estimate** of how many observations the scanner will produce, based on your project's recent recording volume, the filters you've set, the session coverage mode, and the sampling rate. Use this to size the scanner against your [quota](/docs/replay-vision/quota-and-limits) _before_ saving.
+The scanner editor shows an **estimated cost** – roughly how many observations the scanner will produce per month and what they'll cost at the selected model's price – based on your project's recent recording volume, the filters you've set, the session coverage mode, and the sampling rate. Use this to size the scanner against your [budget](/docs/replay-vision/quota-and-limits) _before_ saving.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/estimate_callout_2d954ec2cb.png"
@@ -147,11 +151,12 @@ The scanner editor shows a **per-month estimate** of how many observations the s
   classes="rounded"
 />
 
-If the estimate looks too high, you have three knobs:
+If the estimate looks too high, you have four knobs:
 
 - Narrow the filters.
-- Tighten the session coverage mode (Comprehensive → Balanced → Focused).
+- Tighten the session coverage mode (All recordings → Skip lowest activity → Highest activity only).
 - Lower the sampling rate.
+- Pick a cheaper model.
 
 ## Enabling and disabling
 
@@ -163,7 +168,7 @@ To stop a scanner entirely, delete it. Deleting a scanner also removes all of it
 
 ## Handing off to Responder agents
 
-Each scanner has a **Hand off to Responder agents** toggle in the configuration step. When enabled, the scanner gains a side mission: during each scan, the model looks for clear, actionable product issues – bugs, broken or confusing flows, errors, or significant UX friction – and reports them as findings.
+Each scanner has an **Emit findings as Signals** toggle in the editor's self-driving step. When enabled, the scanner gains a side mission: during each scan, the model looks for clear, actionable product issues – bugs, broken or confusing flows, errors, or significant UX friction – and reports them as findings.
 
 The scanner's primary task (monitoring, classifying, scoring, or summarizing) is unaffected. The side mission runs alongside it, and most scans produce no finding at all. The bar is deliberately high: a finding must be self-contained and concrete enough for someone with no session context to act on it.
 

--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -10,13 +10,14 @@ Not yet available to everyone – <a href="/replay-vision">join the waitlist</a>
 
 </CalloutBox>
 
-A scanner is made up of five things you author:
+A scanner is made up of six things you author:
 
 1. A **prompt** describing what to look for.
 2. A **scanner type** that determines the output shape – see [scanner types](/docs/replay-vision/scanner-types).
 3. **Recording filters** that select which sessions the scanner applies to.
 4. A **session coverage** mode that pre-filters by recording quality.
 5. A **sampling rate** that controls how many matching sessions get scanned.
+6. A **model**, which sets what each observation costs.
 
 ## Start from a template
 
@@ -79,7 +80,7 @@ A prompt that reads beautifully on its own can still misfire. The fastest feedba
 4. Adjust the prompt where the model misread something obvious.
 5. Scan another batch of recordings and repeat until the results look right.
 
-Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation costs [budget](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through it fast on results you'd throw away anyway.
+Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation spends [credits](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through your budget fast on results you'd throw away anyway.
 
 Once the scanner is running, the tuning loop moves to its [quality tab](/docs/replay-vision/quality): rate results with a thumbs up or down, and PostHog AI turns your team's ratings and feedback into configuration recommendations you can test against the rated sessions before applying.
 
@@ -102,7 +103,7 @@ Each scanner type has a few extra knobs. The full reference is on the [scanner t
 - **Summarizer** – pick a summary length (short / medium / long). The core summarizer prompt is built in, so the prompt field becomes **Additional context**: use it for product context or steering, like what the ideal user flow looks like.
 - **Monitor** – choose whether the model can return `inconclusive` rather than forcing a yes/no answer.
 
-The editor also has a **model** picker. Newer models tend to produce higher-quality observations but cost more per observation – each option shows its price, and the [budget](/docs/replay-vision/quota-and-limits) page explains how costs add up.
+The editor also has a **model** picker, which sets the price of every observation the scanner makes: 2 credits on Gemini 3.5 Flash Lite, 5 on Gemini 3 Flash (the default), and 15 on Gemini 3.6 Flash. Newer models tend to produce higher-quality observations, but the top tier costs over seven times as much per session as the cheapest. Start on the default. If results are close but not quite right, tune the prompt before reaching for a pricier model, since a sharper prompt is free and the [quality tab](/docs/replay-vision/quality) will tell you whether it worked. See [quota and limits](/docs/replay-vision/quota-and-limits) for how credits are metered.
 
 ## Filters: scoping the scanner
 
@@ -143,7 +144,7 @@ Use a tighter coverage mode when you want to spend your budget on sessions where
 
 The sampling rate (0–100%) is applied **after** the filters match. A scanner with filter "sessions over 30 seconds" and sampling 25% scans roughly one in four of those sessions.
 
-The scanner editor shows an **estimated cost** – roughly how many observations the scanner will produce per month and what they'll cost at the selected model's price – based on your project's recent recording volume, the filters you've set, the session coverage mode, and the sampling rate. Use this to size the scanner against your [budget](/docs/replay-vision/quota-and-limits) _before_ saving.
+The scanner editor shows an **estimated cost** – roughly how many observations the scanner will produce per month and the credits they'll spend at the selected model's price – based on your project's recent recording volume, the filters you've set, the session coverage mode, and the sampling rate. Use this to size the scanner against your [budget](/docs/replay-vision/quota-and-limits) _before_ saving.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/estimate_callout_2d954ec2cb.png"

--- a/contents/docs/replay-vision/index.mdx
+++ b/contents/docs/replay-vision/index.mdx
@@ -56,6 +56,7 @@ Each of these maps to a [scanner type](/docs/replay-vision/scanner-types).
 - **Picking the right scanner type?** Read the [scanner types reference](/docs/replay-vision/scanner-types).
 - **Authoring a scanner?** See [creating scanners](/docs/replay-vision/creating-scanners) for prompt patterns, filters, and sampling.
 - **Already have observations?** Learn how to [read them and query them as events](/docs/replay-vision/observations) to build insights, dashboards, and alerts.
+- **Is the scanner getting it right?** Rate results and apply AI configuration recommendations on the [quality tab](/docs/replay-vision/quality).
 - **Hit a snag?** Check [troubleshooting](/docs/replay-vision/troubleshooting).
 
 ## Further reading

--- a/contents/docs/replay-vision/mcp.mdx
+++ b/contents/docs/replay-vision/mcp.mdx
@@ -33,8 +33,8 @@ Replay Vision's MCP tools are all prefixed `vision-`. They fall into a few group
 
 ### Sizing before you create
 
-- `vision-scanners-estimate-create` – project the per-month observation volume of a hypothetical scanner before you commit to it.
-- `vision-quota-retrieve` – check the remaining monthly quota.
+- `vision-scanners-estimate-create` – project the per-month observation volume and cost of a hypothetical scanner before you commit to it.
+- `vision-quota-retrieve` – check the remaining monthly budget.
 
 Pair these two before calling `vision-scanners-create` to avoid creating a scanner that would immediately blow the budget.
 
@@ -56,6 +56,18 @@ For one scanner (across sessions):
 - `vision-scanners-observations-list` – paginated list of a scanner's observations.
 - `vision-scanners-observations-get` – fetch one of that scanner's observations by ID.
 
+### Rating results and improving the scanner
+
+The [quality tab](/docs/replay-vision/quality)'s loop is fully drivable over MCP:
+
+- `vision-observations-label-create` – rate an observation with a thumbs up or down, optionally with written feedback. Same rating the Quality tab records.
+- `vision-observations-label-destroy` – remove a rating.
+- `vision-scanners-observations-stats` – rating counts over time and per configuration version.
+- `vision-scanners-prompt-suggestions-generate` – generate a configuration recommendation from the team's ratings.
+- `vision-scanners-prompt-suggestions-current` – read the current recommendation.
+- `vision-scanners-prompt-suggestions-apply` – apply it to the scanner as a new version.
+- `vision-scanners-prompt-suggestions-dismiss` – dismiss it.
+
 ### Impact and cohorts
 
 - `vision-scanners-impact-retrieve` – get affected sessions and users for a scanner over a trailing window. Monitors count verdict-yes observations. Classifiers require a `tag` parameter. Scorers require `min_score` and/or `max_score`.
@@ -71,7 +83,9 @@ Try these with your MCP-enabled agent:
 - `Scan session abc123 with the "Dead-end pages" scanner and tell me what it found, including the reasoning.`
 - `List the last 20 observations from my "Frustration score" scanner and summarize what's driving high scores.`
 - `Find every Replay Vision observation for session abc123 and give me a one-line summary of each.`
-- `How much Replay Vision quota do we have left this month?`
+- `How much Replay Vision budget do we have left this month?`
 - `How many users did my "Dead-end pages" monitor affect in the last 14 days? Save them as a cohort.`
+- `Look at the last 10 observations from my "Dead-end pages" scanner, rate each one right or wrong based on the reasoning, and leave feedback on the wrong ones.`
+- `Generate a configuration recommendation for my "User intent" classifier from the team's ratings and show me what it would change.`
 
 See the [MCP server docs](/docs/model-context-protocol) for client setup, and the [Replay Vision overview](/docs/replay-vision) for product concepts.

--- a/contents/docs/replay-vision/mcp.mdx
+++ b/contents/docs/replay-vision/mcp.mdx
@@ -33,10 +33,10 @@ Replay Vision's MCP tools are all prefixed `vision-`. They fall into a few group
 
 ### Sizing before you create
 
-- `vision-scanners-estimate-create` – project the per-month observation volume and cost of a hypothetical scanner before you commit to it.
-- `vision-quota-retrieve` – check the remaining monthly budget.
+- `vision-scanners-estimate-create` – project a hypothetical scanner's monthly observation volume and credit spend before you commit to it.
+- `vision-quota-retrieve` – check the organization's remaining [credit budget](/docs/replay-vision/quota-and-limits).
 
-Pair these two before calling `vision-scanners-create` to avoid creating a scanner that would immediately blow the budget.
+Pair these two before calling `vision-scanners-create` to avoid creating a scanner that would immediately blow the budget. Compare credits with credits: the estimate returns `estimated_credits_per_month`, and the quota tool returns `remaining`.
 
 ### Triggering an observation on demand
 
@@ -56,17 +56,29 @@ For one scanner (across sessions):
 - `vision-scanners-observations-list` – paginated list of a scanner's observations.
 - `vision-scanners-observations-get` – fetch one of that scanner's observations by ID.
 
+Aggregate stats, rather than the rows themselves:
+
+- `vision-scanners-observations-stats` – one scanner's status mix and success rate, distinct sessions covered, rating totals, and the per-type distributions (monitor verdict counts, classifier tag rankings, scorer score summary and histogram).
+
 ### Rating results and improving the scanner
 
 The [quality tab](/docs/replay-vision/quality)'s loop is fully drivable over MCP:
 
 - `vision-observations-label-create` – rate an observation with a thumbs up or down, optionally with written feedback. Same rating the Quality tab records.
 - `vision-observations-label-destroy` – remove a rating.
-- `vision-scanners-observations-stats` – rating counts over time and per configuration version.
-- `vision-scanners-prompt-suggestions-generate` – generate a configuration recommendation from the team's ratings.
-- `vision-scanners-prompt-suggestions-current` – read the current recommendation.
+- `vision-scanners-prompt-suggestions-current` – read the newest recommendation, whether it's gone stale since new ratings arrived, and how many rated observations back it.
+- `vision-scanners-prompt-suggestions-generate` – generate a fresh recommendation from the current ratings. The model call runs inline, so the request takes a while.
 - `vision-scanners-prompt-suggestions-apply` – apply it to the scanner as a new version.
-- `vision-scanners-prompt-suggestions-dismiss` – dismiss it.
+- `vision-scanners-prompt-suggestions-dismiss` – dismiss it without changing the scanner.
+
+### Digests and alerts
+
+For scanners with digests or alerts attached:
+
+- `vision-actions-list` – the actions bound to a scanner: digests, group summaries, and alerts.
+- `vision-actions-retrieve` – one action's configuration, including which observations it selects and on what cadence.
+- `vision-actions-runs-list` – that action's run history.
+- `vision-actions-runs-retrieve` – a run's synthesized report, plus the observations it cited. The report references its sources inline as `[obs N]`, so you can check each claim against the observation behind it.
 
 ### Impact and cohorts
 
@@ -83,7 +95,7 @@ Try these with your MCP-enabled agent:
 - `Scan session abc123 with the "Dead-end pages" scanner and tell me what it found, including the reasoning.`
 - `List the last 20 observations from my "Frustration score" scanner and summarize what's driving high scores.`
 - `Find every Replay Vision observation for session abc123 and give me a one-line summary of each.`
-- `How much Replay Vision budget do we have left this month?`
+- `How many Replay Vision credits do we have left this period, and which scanner is spending the most?`
 - `How many users did my "Dead-end pages" monitor affect in the last 14 days? Save them as a cohort.`
 - `Look at the last 10 observations from my "Dead-end pages" scanner, rate each one right or wrong based on the reasoning, and leave feedback on the wrong ones.`
 - `Generate a configuration recommendation for my "User intent" classifier from the team's ratings and show me what it would change.`

--- a/contents/docs/replay-vision/observations.mdx
+++ b/contents/docs/replay-vision/observations.mdx
@@ -30,7 +30,7 @@ Observations move through a small state machine:
 - **`failed`** – terminal. The detail view shows an error reason. See [troubleshooting](/docs/replay-vision/troubleshooting#failed-observations) for what each failure kind means.
 - **`ineligible`** – terminal. The session can't be analyzed (no recording, too short, no events, etc.). Doesn't count against your quota. See [running scanners](/docs/replay-vision/running-scanners#ineligible-sessions).
 
-Succeeded, pending, and running observations count against your monthly [budget](/docs/replay-vision/quota-and-limits); failed and ineligible ones don't.
+Succeeded, pending, and running observations spend [credits](/docs/replay-vision/quota-and-limits); failed and ineligible ones don't. A failed observation can be retried from its detail page (or from its card in the replay player), which replaces it with a fresh scan of the same recording.
 
 ## Querying observations as events
 
@@ -45,11 +45,14 @@ Every successful observation is captured as a `$recording_observed` event in you
 | `scanner_type`                   | `monitor`, `classifier`, `scorer`, or `summarizer`                                                                                                  |
 | `scanner_version`                | Version of the scanner config that produced this observation                                                                                        |
 | `session_id`                     | The recording that was observed                                                                                                                     |
-| `triggered_by`                   | `schedule` (background sweep) or `on_demand`                                                                                                        |
-| `triggered_by_user_id`           | The user who triggered an on-demand observation; null for background sweeps                                                                         |
+| `recording_distinct_id`          | Distinct ID of the person in the recorded session (the subject, not whoever triggered the scan)                                                     |
+| `recording_subject_email`        | Email of the recording subject at scan time, when known                                                                                             |
+| `triggered_by`                   | `schedule` (background sweep), `on_demand`, or `retry` (a re-run of a failed observation)                                                           |
+| `triggered_by_user_id`           | The user who triggered an on-demand observation or retry; null for background sweeps                                                                |
 | `model_used`                     | The model that produced the result                                                                                                                  |
 | `provider_used`                  | The LLM provider behind `model_used`                                                                                                                |
-| `credits`                        | What this observation cost, in credits (100 credits = $1), frozen at the price when it ran                                                          |
+| `credits`                        | What this observation cost, in credits (1 credit = $0.01), frozen at the price when it ran                                                          |
+| `emits_signals`                  | Whether the scanner was feeding findings into PostHog Signals when it ran                                                                           |
 | `scanner_output_confidence`      | The model's confidence (0.0 to 1.0)                                                                                                                 |
 | `scanner_output_reasoning`       | **Monitor, classifier, and scorer** – the model's reasoning text, including any inline citations. Summarizers don't have a separate reasoning field |
 | `scanner_output_verdict`         | **Monitor only** – `"yes"`, `"no"`, or `"inconclusive"`                                                                                             |
@@ -181,17 +184,17 @@ ORDER BY sessions DESC
 
 ### Cross-scanner: spend by scanner
 
-Each event carries a `credits` property with the observation's cost (100 credits = $1), so spend is just another query. This is the same data behind the **Usage** tab on the Replay Vision home:
+Each event carries a `credits` property with the observation's cost (1 credit = $0.01), so spend is just another query. This is the same data behind the **Usage** tab on the Replay Vision home:
 
 ```sql
 SELECT
     properties.scanner_name AS scanner,
-    sum(toFloat64(properties.credits)) / 100 AS dollars
+    sum(toFloat64(properties.credits)) AS credits
 FROM events
 WHERE event = '$recording_observed'
   AND timestamp > now() - INTERVAL 30 DAY
 GROUP BY scanner
-ORDER BY dollars DESC
+ORDER BY credits DESC
 ```
 
 ### Cross-scanner: filter only high-confidence verdicts

--- a/contents/docs/replay-vision/observations.mdx
+++ b/contents/docs/replay-vision/observations.mdx
@@ -14,6 +14,8 @@ Each scanner has an **Observations** tab listing every observation it's produced
 
 Observations also surface in the replay player: the **observations dock** at the bottom of the player lists everything scanners have found about the session you're watching, and is where the **Scan this recording** action lives.
 
+To judge whether the results are right – and improve the scanner from that judgment – rate observations on the scanner's [quality tab](/docs/replay-vision/quality).
+
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/observations_dock_0301561e5d.png"
   alt="The replay player with the observations dock expanded, listing observation cards from several scanners and the Scan this recording action"
@@ -28,7 +30,7 @@ Observations move through a small state machine:
 - **`failed`** – terminal. The detail view shows an error reason. See [troubleshooting](/docs/replay-vision/troubleshooting#failed-observations) for what each failure kind means.
 - **`ineligible`** – terminal. The session can't be analyzed (no recording, too short, no events, etc.). Doesn't count against your quota. See [running scanners](/docs/replay-vision/running-scanners#ineligible-sessions).
 
-Succeeded, pending, and running observations count against your monthly [quota](/docs/replay-vision/quota-and-limits); failed and ineligible ones don't.
+Succeeded, pending, and running observations count against your monthly [budget](/docs/replay-vision/quota-and-limits); failed and ineligible ones don't.
 
 ## Querying observations as events
 
@@ -47,6 +49,7 @@ Every successful observation is captured as a `$recording_observed` event in you
 | `triggered_by_user_id`           | The user who triggered an on-demand observation; null for background sweeps                                                                         |
 | `model_used`                     | The model that produced the result                                                                                                                  |
 | `provider_used`                  | The LLM provider behind `model_used`                                                                                                                |
+| `credits`                        | What this observation cost, in credits (100 credits = $1), frozen at the price when it ran                                                          |
 | `scanner_output_confidence`      | The model's confidence (0.0 to 1.0)                                                                                                                 |
 | `scanner_output_reasoning`       | **Monitor, classifier, and scorer** – the model's reasoning text, including any inline citations. Summarizers don't have a separate reasoning field |
 | `scanner_output_verdict`         | **Monitor only** – `"yes"`, `"no"`, or `"inconclusive"`                                                                                             |
@@ -176,6 +179,21 @@ GROUP BY friction_point
 ORDER BY sessions DESC
 ```
 
+### Cross-scanner: spend by scanner
+
+Each event carries a `credits` property with the observation's cost (100 credits = $1), so spend is just another query. This is the same data behind the **Usage** tab on the Replay Vision home:
+
+```sql
+SELECT
+    properties.scanner_name AS scanner,
+    sum(toFloat64(properties.credits)) / 100 AS dollars
+FROM events
+WHERE event = '$recording_observed'
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY scanner
+ORDER BY dollars DESC
+```
+
 ### Cross-scanner: filter only high-confidence verdicts
 
 ```sql
@@ -190,7 +208,7 @@ Confidence is self-reported, so this is a heuristic, not a guarantee – but it'
 
 ## Scanner impact and cohorts
 
-Each scanner tracks its impact: how many sessions and users its findings affected over a trailing window (default 30 days). These counts appear in the scanner overview panel.
+Each scanner tracks its impact: how many sessions and users its findings affected over a trailing window (default 30 days). These counts appear on the scanner's **Overview** tab.
 
 What counts as "affected" depends on the scanner type:
 

--- a/contents/docs/replay-vision/quota-and-limits.mdx
+++ b/contents/docs/replay-vision/quota-and-limits.mdx
@@ -2,88 +2,94 @@
 title: Quota and limits
 ---
 
-import { ProductScreenshot } from "components/ProductScreenshot";
-
 <CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
 
 Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
 
 </CalloutBox>
 
-Replay Vision usage is metered per organization, on a monthly cycle. This page covers what the cap is, what counts against it, and what to do when you're approaching it.
+Replay Vision usage is metered per organization as **estimated spend**, on a monthly billing cycle. This page covers how observations are priced, what the budget is, what counts against it, and what to do when you're approaching it.
 
-<CalloutBox icon="IconFlask" title="Closed beta quota will change" type="action">
+<CalloutBox icon="IconFlask" title="No charges during the closed beta" type="action">
 
-The current cap of 3,000 observations per organization per month is a placeholder for the beta period and will change before general availability. The in-app usage meter is the authoritative current number for your organization.
+The spend meter shows what your usage *would* cost – you won't be billed during the closed beta, and the default budget will change before general availability. The in-app meter is the authoritative number for your organization.
 
 </CalloutBox>
 
-## Monthly observation cap
+## How usage is priced
 
-During the closed beta, each organization gets **3,000 observations per calendar month**. The counter resets at the start of each calendar month (UTC).
+Every successful observation has a fixed price that depends on the **model** the scanner uses – newer models tend to produce higher-quality observations but cost more per observation. The model picker in the scanner editor shows each option's price, and the current lineup is:
 
-The current month's usage is shown in the Replay Vision app:
+| Model                       | Price per observation |
+| --------------------------- | --------------------- |
+| Gemini 3.5 Flash Lite       | $0.02                 |
+| Gemini 3 Flash (default)    | $0.05                 |
+| Gemini 3.6 Flash            | $0.15                 |
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quota_meter_ddcc762a43.png"
-  alt="The monthly usage meter: observations used this month against the organization's cap"
-  classes="rounded"
-/>
+Prices are frozen when the observation runs: editing a scanner's model later doesn't change what past observations cost, and each [`$recording_observed` event](/docs/replay-vision/observations#querying-observations-as-events) carries a `credits` property (100 credits = $1) with its price.
 
-You can also fetch it programmatically – see the `vision-quota-retrieve` MCP tool.
+## The monthly budget
 
-## What counts against the cap
+Each organization gets a monthly spend budget – during the closed beta this defaults to **$150 per month**. Current usage and the projection for the rest of the period are shown on the **Spend this period** tile on the Replay Vision home.
 
-| Observation outcome | Counts against cap? |
-| ------------------- | ------------------- |
-| **Succeeded**       | Yes                 |
-| **Pending**         | Yes                 |
-| **Running**         | Yes                 |
-| **Failed**          | No                  |
-| **Ineligible**      | No                  |
+You can also fetch the remaining budget programmatically – see the `vision-quota-retrieve` MCP tool.
 
-Pending and running observations count so a burst of concurrent on-demand triggers can't blow past the cap before any of them complete. Once an observation reaches a terminal failed or ineligible state, it stops counting toward the month's usage.
+## What counts against the budget
 
-In practice this means: **every observation that produces a `$recording_observed` event uses one unit of quota.** Ineligibles and failures don't consume any.
+| Observation outcome | Counts against budget?                                |
+| ------------------- | ----------------------------------------------------- |
+| **Succeeded**       | Yes – charged at the scanner's per-observation price  |
+| **Pending**         | Reserved while in flight                              |
+| **Running**         | Reserved while in flight                              |
+| **Failed**          | No                                                    |
+| **Ineligible**      | No                                                    |
 
-## What happens when the cap is reached
+Pending and running observations reserve budget so a burst of concurrent on-demand triggers can't blow past the cap before any of them complete. Once an observation reaches a terminal failed or ineligible state, its reservation is released.
+
+Testing a configuration recommendation on the [quality tab](/docs/replay-vision/quality#test-before-applying) re-runs the scanner against rated sessions, and each tested session is charged like a normal observation of the scanner's model. The test controls show the planned cost before you run it.
+
+## What happens when the budget is reached
 
 Both enforcement paths use the same check:
 
-- **Background sweeps** – new observations queued by the automatic schedule are silently skipped. The scanner stays enabled, the sweep keeps running, but no work gets queued until quota frees up (next month, or as in-flight observations resolve to ineligible/failed).
-- **On-demand triggers** – the player action and the `vision-scanners-scan-session` MCP tool return a `402 Payment Required` response with a `quota_limit_exceeded` code.
+- **Background sweeps** – new observations queued by the automatic schedule are silently skipped. The scanner stays enabled, the sweep keeps running, but no work gets queued until budget frees up. A banner on the Replay Vision pages shows "Monthly spend limit reached" with the reset date.
+- **On-demand triggers** – the player action and the `vision-scanners-scan-session` MCP tool return a `402 Payment Required` response.
 
-A scanner that's been silenced by the cap will resume producing observations automatically once usage drops below the cap (e.g. at the start of the next month).
+A scanner that's been paused by the budget resumes producing observations automatically once the period resets.
 
-## Sizing scanners against the cap
+## Tracking where spend goes
 
-The scanner editor shows a **projected per-month observation count** for the scanner you're configuring, based on:
+The Replay Vision home has a **Usage** tab with:
+
+- **Spend over time** – a chart of your spend (daily, weekly, monthly, or yearly), with a forecast warning when the current pace would hit the budget before the period ends.
+- **A per-scanner breakdown** – each scanner's successful observations this period, its price per observation (which model it uses), its sampling rate, and its share of total spend.
+
+A scanner dominating the spend table is the first place to look when the budget runs down faster than expected – its sampling rate is the main cost lever.
+
+## Sizing scanners against the budget
+
+The scanner editor shows an **estimated cost** for the scanner you're configuring – roughly how many observations per month and what they'll cost – based on:
 
 - Your project's recent recording volume.
 - The filters you've set.
 - The session coverage mode.
 - The sampling rate.
+- The selected model's price.
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/estimate_callout_2d954ec2cb.png"
-  alt="The scan conditions step of the scanner editor: sampling rate, recording filters, and the estimated per-month impact against the remaining quota"
-  classes="rounded"
-/>
-
-If the projection is uncomfortably close to your remaining cap, the cheapest knobs are:
+If the projection is uncomfortably close to your remaining budget, the cheapest knobs are:
 
 - **Narrow the filters** – e.g. require a specific URL pattern, exclude bots, restrict to a cohort.
-- **Tighten session coverage** – switching from Comprehensive to Balanced or Focused mode filters out low-quality sessions before sampling, so your budget goes toward recordings with meaningful activity.
-- **Lower the sampling rate** – samples are random, so a 10% rate gives you a representative slice of matching sessions for one-tenth the volume.
-- **Combine all three** – a tight filter on the sessions you care most about, plus Focused or Balanced coverage, plus a higher sampling rate, often yields better signal-per-observation than a loose filter with Comprehensive coverage and low sampling.
+- **Tighten session coverage** – switching from "All recordings" to "Skip lowest activity" or "Highest activity only" filters out low-activity sessions before sampling, so your budget goes toward recordings with meaningful activity.
+- **Lower the sampling rate** – samples are random, so a 10% rate gives you a representative slice of matching sessions for one-tenth the cost.
+- **Pick a cheaper model** – the price difference per observation is up to 7x across the lineup.
 
 To project a hypothetical scanner _before_ creating it (e.g. from a script or agent), use the `vision-scanners-estimate-create` MCP tool. It runs the same projection the editor shows.
 
-## What to do if you're hitting the cap
+## What to do if you're hitting the budget
 
 Try these, in order:
 
-1. **Look at which scanner is consuming the most quota.** The Observations tab makes this easy – a scanner producing thousands of observations a month is probably broader than it needs to be.
-2. **Tighten its filters, session coverage, or sampling rate.** Use the editor's projection to find a setting that gives you enough signal without dominating the cap.
+1. **Open the Usage tab and look at which scanner is consuming the most spend.** A scanner dominating the share-of-spend column is probably broader (or on a pricier model) than it needs to be.
+2. **Tighten its filters, session coverage, or sampling rate, or move it to a cheaper model.** Use the editor's estimate to find a setting that gives you enough signal without dominating the budget.
 3. **Disable scanners you're not actively using.** A disabled scanner produces zero new background observations.
-4. **Wait for the cap to reset.** Caps reset at the start of each calendar month in UTC.
+4. **Wait for the period to reset.** The reset date is shown on the spend tile and in the budget banner.

--- a/contents/docs/replay-vision/quota-and-limits.mdx
+++ b/contents/docs/replay-vision/quota-and-limits.mdx
@@ -2,13 +2,15 @@
 title: Quota and limits
 ---
 
+import { ProductScreenshot } from "components/ProductScreenshot";
+
 <CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
 
 Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
 
 </CalloutBox>
 
-Replay Vision usage is metered per organization as **estimated spend**, on a monthly billing cycle. This page covers how observations are priced, what the budget is, what counts against it, and what to do when you're approaching it.
+Replay Vision usage is metered per organization in **credits**, on a monthly billing cycle. This page covers how observations are priced, what the budget is, what counts against it, and what to do when you're approaching it.
 
 <CalloutBox icon="IconFlask" title="No charges during the closed beta" type="action">
 
@@ -18,27 +20,33 @@ The spend meter shows what your usage *would* cost – you won't be billed durin
 
 ## How usage is priced
 
-Every successful observation has a fixed price that depends on the **model** the scanner uses – newer models tend to produce higher-quality observations but cost more per observation. The model picker in the scanner editor shows each option's price, and the current lineup is:
+One credit is $0.01. Every successful observation costs a fixed number of credits that depends on the **model** the scanner uses – newer models tend to produce higher-quality observations but cost more per observation. The model picker in the scanner editor shows each option's price, and the current lineup is:
 
-| Model                       | Price per observation |
-| --------------------------- | --------------------- |
-| Gemini 3.5 Flash Lite       | $0.02                 |
-| Gemini 3 Flash (default)    | $0.05                 |
-| Gemini 3.6 Flash            | $0.15                 |
+| Model                       | Credits per observation |
+| --------------------------- | ----------------------- |
+| Gemini 3.5 Flash Lite       | 2                       |
+| Gemini 3 Flash (default)    | 5                       |
+| Gemini 3.6 Flash            | 15                      |
 
-Prices are frozen when the observation runs: editing a scanner's model later doesn't change what past observations cost, and each [`$recording_observed` event](/docs/replay-vision/observations#querying-observations-as-events) carries a `credits` property (100 credits = $1) with its price.
+Prices are frozen when the observation runs: editing a scanner's model later doesn't change what past observations cost, and each [`$recording_observed` event](/docs/replay-vision/observations#querying-observations-as-events) carries a `credits` property with its price.
 
 ## The monthly budget
 
-Each organization gets a monthly spend budget – during the closed beta this defaults to **$150 per month**. Current usage and the projection for the rest of the period are shown on the **Spend this period** tile on the Replay Vision home.
+Each organization gets a monthly credit budget – during the closed beta this defaults to **15,000 credits per month** (about $150). Current usage and the projection for the rest of the period are shown on the **Spend this period** tile on the Replay Vision home, in credits with the dollar equivalent alongside.
 
-You can also fetch the remaining budget programmatically – see the `vision-quota-retrieve` MCP tool.
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quota_meter_ddcc762a43.png"
+  alt="The Replay Vision usage meter: credits used this period against the organization's budget"
+  classes="rounded"
+/>
+
+You can also fetch the budget programmatically – the `vision-quota-retrieve` MCP tool returns `credit_limit` (null when uncapped), `credits_used`, `remaining`, `exhausted`, `projected_monthly_credits`, and the current period's start and end.
 
 ## What counts against the budget
 
-| Observation outcome | Counts against budget?                                |
-| ------------------- | ----------------------------------------------------- |
-| **Succeeded**       | Yes – charged at the scanner's per-observation price  |
+| Observation outcome | Counts against budget?                                 |
+| ------------------- | ------------------------------------------------------ |
+| **Succeeded**       | Yes – charged the scanner's credits per observation    |
 | **Pending**         | Reserved while in flight                              |
 | **Running**         | Reserved while in flight                              |
 | **Failed**          | No                                                    |
@@ -68,13 +76,19 @@ A scanner dominating the spend table is the first place to look when the budget 
 
 ## Sizing scanners against the budget
 
-The scanner editor shows an **estimated cost** for the scanner you're configuring – roughly how many observations per month and what they'll cost – based on:
+The scanner editor shows an **estimated cost** for the scanner you're configuring – roughly how many observations per month and the credits they'll spend – based on:
 
 - Your project's recent recording volume.
 - The filters you've set.
 - The session coverage mode.
 - The sampling rate.
 - The selected model's price.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/estimate_callout_2d954ec2cb.png"
+  alt="The scan conditions step of the scanner editor: sampling rate, recording filters, and the estimated per-month credits against the remaining budget"
+  classes="rounded"
+/>
 
 If the projection is uncomfortably close to your remaining budget, the cheapest knobs are:
 
@@ -83,7 +97,7 @@ If the projection is uncomfortably close to your remaining budget, the cheapest 
 - **Lower the sampling rate** – samples are random, so a 10% rate gives you a representative slice of matching sessions for one-tenth the cost.
 - **Pick a cheaper model** – the price difference per observation is up to 7x across the lineup.
 
-To project a hypothetical scanner _before_ creating it (e.g. from a script or agent), use the `vision-scanners-estimate-create` MCP tool. It runs the same projection the editor shows.
+To project a hypothetical scanner _before_ creating it (e.g. from a script or agent), use the `vision-scanners-estimate-create` MCP tool. It runs the same projection the editor shows, returning both the observation count and the credits it would cost (`estimated_credits_per_month`).
 
 ## What to do if you're hitting the budget
 

--- a/contents/docs/replay-vision/running-scanners.mdx
+++ b/contents/docs/replay-vision/running-scanners.mdx
@@ -17,7 +17,7 @@ There are two ways a scanner produces observations: automatically in the backgro
 Once a scanner is **enabled**, PostHog runs a background sweep every few minutes. The sweep:
 
 1. Looks for new recordings that match the scanner's filters and that the scanner hasn't already observed.
-2. Applies the [session coverage](/docs/replay-vision/creating-scanners#session-coverage-quality-pre-filter) mode to drop low-quality sessions (Focused and Balanced modes filter by surfacing score; Comprehensive keeps all).
+2. Applies the [session coverage](/docs/replay-vision/creating-scanners#session-coverage-filtering-by-quality) mode to drop low-activity sessions ("Highest activity only" and "Skip lowest activity" filter by relevance score; "All recordings" keeps everything).
 3. Applies the sampling rate to what's left (so a 10% rate means roughly one in ten remaining sessions get queued).
 4. Queues an observation per session for the model to process.
 5. Records the result – success, failure, or [ineligible](#ineligible-sessions) – and emits a `$recording_observed` event for successes.
@@ -43,6 +43,13 @@ Changing a scanner's filters affects which **new** sessions match going forward.
 Disabling stops the background sweep. Existing in-flight observations finish; no new ones get queued. On-demand triggers continue to work.
 
 ## On-demand on recordings you pick
+
+### From the scanner's On-demand tab
+
+Every scanner has an **On-demand** tab with two ways to trigger a scan:
+
+- **Scan a session by ID** – paste a recording's session ID and run the scanner against it right now.
+- **Pick from your recordings** – filter your session recordings inline and scan one at a time, or select several and scan them together. Sessions the scanner has already observed show their status instead of a scan button, so you can't double-scan.
 
 ### From the replay player
 
@@ -82,13 +89,14 @@ Some sessions can't be analyzed – there's no recording data, the recording is 
 
 The taxonomy:
 
-| Ineligible reason | What it means                                                           |
-| ----------------- | ----------------------------------------------------------------------- |
-| `no_recording`    | The session referenced doesn't have replay data in storage              |
-| `too_short`       | The recording is below the minimum duration we'll scan                  |
-| `too_inactive`    | The recording is long enough but the user was idle for almost all of it |
-| `too_long`        | The recording is above the maximum duration we'll scan                  |
-| `no_events`       | The recording has no analytics events at all                            |
+| Ineligible reason | What it means                                                                 |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `no_recording`    | The session referenced doesn't have replay data in storage                    |
+| `too_short`       | The recording is below the minimum duration we'll scan                        |
+| `too_inactive`    | The recording is long enough but the user was idle for almost all of it       |
+| `too_long`        | The recording is above the maximum duration we'll scan                        |
+| `no_events`       | The recording has no analytics events at all                                  |
+| `no_ai_consent`   | AI data processing is turned off for your organization, so nothing is scanned |
 
 Ineligible observations:
 

--- a/contents/docs/replay-vision/scanner-types.mdx
+++ b/contents/docs/replay-vision/scanner-types.mdx
@@ -62,7 +62,7 @@ A monitor returns a yes/no verdict for whether the condition in your prompt occu
 
 ### Impact and cohorts
 
-Monitors track how many sessions and users matched the verdict-yes condition over a trailing window (default 30 days). The scanner overview shows these impact counts, and you can save the affected users as a static [cohort](/docs/data/cohorts) with one click.
+Monitors track how many sessions and users matched the verdict-yes condition over a trailing window (default 30 days). The scanner's **Overview** tab shows these impact counts alongside the verdict mix, and you can save the affected users as a static [cohort](/docs/data/cohorts) with one click.
 
 The cohort is a snapshot at creation time and doesn't live-update. Use it anywhere cohorts work: funnel breakdowns, retention analysis, survey targeting, or experiment exclusion.
 
@@ -78,7 +78,7 @@ A classifier assigns one or more **tags** from a vocabulary you define. You can 
 
 **Type-specific config**
 
-- **Tag vocabulary** – the set of allowed tag names. The vocabulary itself is just names – put a short definition of each tag in the prompt so the model knows what it means (see the example below).
+- **Tag vocabulary** – the set of allowed tag names. The vocabulary itself is just names – put a short definition of each tag in the prompt so the model knows what it means (see the example below). The editor can also **suggest tags with PostHog AI** based on your prompt, your product, and what's been seen in recordings.
 - **Allow multiple tags** – whether the model can pick more than one per session.
 - **Allow freeform tags** – whether the model can invent new tags outside the vocabulary.
 
@@ -107,7 +107,7 @@ A classifier assigns one or more **tags** from a vocabulary you define. You can 
 
 ### Impact and cohorts
 
-Classifiers track impact per tag: how many sessions and users were assigned each tag in the trailing window. Each tag panel in the scanner overview has a button to save that tag's affected users as a static [cohort](/docs/data/cohorts).
+Classifiers track impact per tag: how many sessions and users were assigned each tag in the trailing window. Each tag panel on the scanner's **Overview** tab has a button to save that tag's affected users as a static [cohort](/docs/data/cohorts).
 
 The cohort is a snapshot at creation time and doesn't live-update. Use it anywhere cohorts work: funnel breakdowns, retention analysis, survey targeting, or experiment exclusion.
 
@@ -162,7 +162,8 @@ A summarizer produces a short prose summary of what happened in the session, plu
 
 **Type-specific config**
 
-- **Summary length** – short, medium, or long. Controls roughly how many sentences the model writes.
+- **Additional context** – the core summarizer prompt is built in, so instead of a full prompt you add product context or steering – for example, what the ideal user flow looks like.
+- **Summary length** – short (1-2 sentences), medium (1 paragraph), or long (3-5 paragraphs).
 
 **When to use it**
 
@@ -170,9 +171,9 @@ A summarizer produces a short prose summary of what happened in the session, plu
 - Triage queues where humans need a one-line preview before clicking in
 - Feeding into a downstream analytics or retrieval pipeline
 
-**Example prompt**
+**Example context**
 
-> _Summarize what the user did in this session: which pages they visited, what they tried to accomplish, and any notable moments like errors, confusion, or successful completions. Be concrete and don't speculate._
+> _Our product is a B2B file-sharing app. The happy path is signing up, creating a workspace, then uploading a first file. Call out where sessions deviate from that flow, and name the exact page where any error appears._
 
 **On `$recording_observed`** – `scanner_output_title` and `scanner_output_summary` carry the title and summary; the facets land as `scanner_output_intent`, `scanner_output_outcome`, `scanner_output_friction_points`, and `scanner_output_keywords`. See [observations](/docs/replay-vision/observations#querying-observations-as-events).
 
@@ -197,6 +198,6 @@ If you find yourself encoding a number range as classifier tags ("low / medium /
 
 ## Confidence and citations
 
-Confidence is the model's self-reported certainty. It's useful as a filter (e.g. "only alert when confidence > 0.7") but not as ground truth – treat it as a signal, not a guarantee.
+Confidence is the model's self-reported certainty. It's useful as a filter (e.g. "only alert when confidence > 0.7") but not as ground truth – treat it as a signal, not a guarantee. For actual ground truth, rate results on the scanner's [quality tab](/docs/replay-vision/quality) – your team's ratings measure accuracy per configuration version and power AI configuration recommendations.
 
 Citations are emitted inline in the model's free-text output (the `reasoning` field for monitors, classifiers, and scorers; the `summary` field for summarizers) and rendered as clickable links in the observation detail view. They jump the embedded player to the timestamp the model points at. They're the single best tool for understanding _why_ a model returned what it did.

--- a/contents/docs/replay-vision/scanner-types.mdx
+++ b/contents/docs/replay-vision/scanner-types.mdx
@@ -123,7 +123,7 @@ A scorer assigns a **numeric score** on a scale you define – e.g. 0 to 10 for 
 
 **Type-specific config**
 
-- **Scale** – minimum and maximum values (integers).
+- **Scale** – minimum and maximum values. Any numbers will do (decimals included) as long as the minimum is lower, though whole numbers are easier to reason about when you're reading scores later.
 - **Scale label** – optional short description of what the scale represents (e.g. "0 = no friction, 10 = severe friction").
 
 **When to use it**

--- a/contents/docs/replay-vision/start-here.mdx
+++ b/contents/docs/replay-vision/start-here.mdx
@@ -53,7 +53,7 @@ For a first run, leave the prompt and model alone. To keep volume low while you 
 
 <CalloutBox type="fyi" title="Estimate your usage first">
 
-The form shows a projected per-month observation count based on your project's recent recording volume, the filters you set, and the sampling rate. Use that to size against your [quota](/docs/replay-vision/quota-and-limits) before saving.
+The form shows an estimated monthly cost and observation count based on your project's recent recording volume, the filters you set, and the sampling rate. Use that to size against your [budget](/docs/replay-vision/quota-and-limits) before saving.
 
 </CalloutBox>
 
@@ -119,3 +119,4 @@ You'll see a count over time of sessions the scanner flagged. From here you can 
 - [Scanner types](/docs/replay-vision/scanner-types) – understand monitor vs. classifier vs. scorer vs. summarizer before authoring your second one.
 - [Creating scanners](/docs/replay-vision/creating-scanners) – prompt patterns that actually work, plus how filters and sampling interact.
 - [Running scanners](/docs/replay-vision/running-scanners) – automatic background sweeps vs. on-demand triggers, and what happens to ineligible sessions.
+- [Improving scanner accuracy](/docs/replay-vision/quality) – once observations flow, rate them on the scanner's Quality tab and let PostHog AI recommend configuration improvements.

--- a/contents/docs/replay-vision/troubleshooting.mdx
+++ b/contents/docs/replay-vision/troubleshooting.mdx
@@ -19,7 +19,7 @@ Check, in order:
 1. **Is the scanner enabled?** Disabled scanners don't sweep. The toggle is on the scanner list and on the scanner detail page.
 2. **Are the filters too narrow?** Try removing all filters and see whether observations start showing up. If they do, re-add filters one at a time to find the culprit.
 3. **Is the sampling rate 0%?** A common oversight – 0% means every matching session gets skipped.
-4. **Is the budget exhausted?** Check the spend tile on the Replay Vision home (the Usage tab breaks spend down per scanner). A scanner whose background sweep is paused by the budget will silently produce nothing until it frees up. See [quota and limits](/docs/replay-vision/quota-and-limits).
+4. **Is the credit budget exhausted?** Check the spend tile on the Replay Vision home (the Usage tab breaks spend down per scanner). A scanner whose background sweep is paused by the budget will silently produce nothing until credits free up. See [quota and limits](/docs/replay-vision/quota-and-limits).
 5. **Is your project recording sessions at all?** Replay Vision only sees sessions [Session Replay](/docs/session-replay) has captured. No recordings, no observations. See [events or recordings aren't coming in](#events-or-recordings-arent-coming-in).
 6. **Is your organization over a usage limit?** If Product analytics or Session replay is over its billing limit, new events or recordings are dropped at ingestion and scanners have nothing usable to scan. See [usage limits stop scanning](#usage-limits-stop-scanning).
 7. **Are all the matched sessions ineligible?** If your filters happen to match only very short or no-event sessions, the scanner will produce ineligible observations but no successful ones. See [running scanners – ineligible sessions](/docs/replay-vision/running-scanners#ineligible-sessions).
@@ -94,9 +94,9 @@ Failed observations show an **error reason** on the detail page in the form `kin
 
 ### `provider_transient`
 
-A transient Gemini error – network hiccup, rate limit, model overloaded. This is the one failure kind PostHog retries automatically, on the scanner's next scheduled run.
+A transient Gemini error – network hiccup, rate limit, model overloaded. PostHog retries the provider call automatically during the scan (up to three attempts). An observation only lands here once those retries are exhausted.
 
-**What to do:** a single failure isn't actionable. If you're seeing a burst across many sessions, the upstream model is likely having availability issues – wait it out before triggering more on-demand work.
+**What to do:** retry the observation from its detail page. If you're seeing a burst across many sessions, the upstream model is likely having availability issues – wait it out before triggering more on-demand work.
 
 ### `provider_rejected`
 
@@ -120,7 +120,7 @@ The model returned a response that didn't match the scanner's expected output sh
 
 The analysis was interrupted before finishing – for example by a deploy or a worker restart – and was cleaned up.
 
-**What to do:** run the scanner on that recording again if you still want the result. Interrupted observations don't cost budget.
+**What to do:** retry the observation from its detail page. The retry replaces the failed row with a fresh scan of the same recording. Interrupted observations don't spend credits. If the same session orphans repeatedly, [contact support](/questions) with the observation ID.
 
 ### `internal_error`
 

--- a/contents/docs/replay-vision/troubleshooting.mdx
+++ b/contents/docs/replay-vision/troubleshooting.mdx
@@ -19,7 +19,7 @@ Check, in order:
 1. **Is the scanner enabled?** Disabled scanners don't sweep. The toggle is on the scanner list and on the scanner detail page.
 2. **Are the filters too narrow?** Try removing all filters and see whether observations start showing up. If they do, re-add filters one at a time to find the culprit.
 3. **Is the sampling rate 0%?** A common oversight – 0% means every matching session gets skipped.
-4. **Is the quota exhausted?** Check the usage meter in the Replay Vision header. A scanner whose background sweep is silenced by the cap will silently produce nothing until quota frees up. See [quota and limits](/docs/replay-vision/quota-and-limits).
+4. **Is the budget exhausted?** Check the spend tile on the Replay Vision home (the Usage tab breaks spend down per scanner). A scanner whose background sweep is paused by the budget will silently produce nothing until it frees up. See [quota and limits](/docs/replay-vision/quota-and-limits).
 5. **Is your project recording sessions at all?** Replay Vision only sees sessions [Session Replay](/docs/session-replay) has captured. No recordings, no observations. See [events or recordings aren't coming in](#events-or-recordings-arent-coming-in).
 6. **Is your organization over a usage limit?** If Product analytics or Session replay is over its billing limit, new events or recordings are dropped at ingestion and scanners have nothing usable to scan. See [usage limits stop scanning](#usage-limits-stop-scanning).
 7. **Are all the matched sessions ineligible?** If your filters happen to match only very short or no-event sessions, the scanner will produce ineligible observations but no successful ones. See [running scanners – ineligible sessions](/docs/replay-vision/running-scanners#ineligible-sessions).
@@ -37,6 +37,7 @@ Ineligibles don't cost you quota, but a high ineligibility rate usually means th
 | `too_inactive` | Add an event-presence filter (e.g. require at least one `$pageview` or `$autocapture`) so silent sessions are skipped earlier. |
 | `too_long` | Add an upper duration filter. |
 | `no_events` | Require at least one event, as with `too_inactive`. If nearly every recent scan is `no_events`, check whether your organization is over its Product analytics limit – see [usage limits stop scanning](#usage-limits-stop-scanning). |
+| `no_ai_consent` | AI data processing is turned off for your organization, so nothing gets scanned. An organization admin needs to approve AI data processing in the organization settings. |
 
 Once you've added the filter, the ineligibility rate should drop. The Observations tab is the source of truth – check it after the next sweep.
 
@@ -64,7 +65,9 @@ One caveat: sessions from the over-limit window are permanently unscannable. Dro
 
 ## The model is making bad calls
 
-The reasoning + citations on each observation are your debugging tool here. Open three or four observations the scanner got wrong and read them.
+Start on the scanner's [quality tab](/docs/replay-vision/quality): rate the wrong results with a thumbs down and say why in the feedback field. PostHog AI turns those ratings into a configuration recommendation you can test against the rated sessions before applying – that loop fixes most systematic errors without hand-tuning.
+
+To understand *why* the model got something wrong, the reasoning + citations on each observation are your debugging tool. Open three or four observations the scanner got wrong and read them.
 
 Common patterns and fixes:
 
@@ -91,7 +94,7 @@ Failed observations show an **error reason** on the detail page in the form `kin
 
 ### `provider_transient`
 
-A transient Gemini error – network hiccup, rate limit, model overloaded.
+A transient Gemini error – network hiccup, rate limit, model overloaded. This is the one failure kind PostHog retries automatically, on the scanner's next scheduled run.
 
 **What to do:** a single failure isn't actionable. If you're seeing a burst across many sessions, the upstream model is likely having availability issues – wait it out before triggering more on-demand work.
 
@@ -112,6 +115,12 @@ PostHog couldn't render the recording to video. Usually a sign of corrupted snap
 The model returned a response that didn't match the scanner's expected output shape (e.g. a classifier returned a tag not in the vocabulary, or a scorer returned a non-numeric value).
 
 **What to do:** tighten the prompt to spell out the allowed responses. For classifiers, restate the vocabulary inside the prompt body, not just in the config. For scorers, repeat the scale.
+
+### `orphaned`
+
+The analysis was interrupted before finishing – for example by a deploy or a worker restart – and was cleaned up.
+
+**What to do:** run the scanner on that recording again if you still want the result. Interrupted observations don't cost budget.
 
 ### `internal_error`
 


### PR DESCRIPTION
## Changes

Re-opens #18992 for review (it was merged before team review and reverted in #18995 – the content here is identical).

Audit and refresh of the whole Replay Vision docs section against the product as it is on `PostHog/posthog` master today. Verified every claim against the code (frontend scenes, backend quota/billing, error kinds, MCP `tools.yaml`).

The substantive updates:

- **Quota and limits rewritten for the spend model**: usage is metered as estimated spend with per-model observation prices (shown in the model picker), a monthly budget with the "Spend this period" tile, in-flight reservations, 402 on-demand behavior, the new home **Usage** tab (spend over time, forecast, per-scanner share of spend), and quality-tab prompt tests being charged like normal observations. The old page described a retired 3,000-observations/month cap and its stale meter screenshot is removed.
- **Session coverage renames**: "Focused / Balanced / Comprehensive" became "Highest activity only / Skip lowest activity / All recordings" throughout, and the fourth cost knob (cheaper model) is documented.
- **Quality tab cross-linked everywhere it's relevant**: overview, getting started, creating scanners (the tuning loop now hands off to the quality tab), scanner types (confidence vs ground truth), observations, and troubleshooting ("the model is making bad calls" starts with rating + recommendations now).
- **New facts**: the summarizer's prompt field is now "Additional context" with a built-in core prompt, classifier tag suggestions via PostHog AI, the model picker and pricing note, the 1-hour active-time hard limit, the scanner's On-demand tab (scan by ID + pick from recordings with bulk select), the `credits` event property with a spend-by-scanner SQL recipe, and impact panels living on the new **Overview** tab.
- **New error kinds documented**: `no_ai_consent` (ineligible) and `orphaned` (failed, interrupted), plus the note that `provider_transient` auto-retries.
- **MCP page**: added the quality-loop tools (observation labels, rating stats, prompt suggestions generate/current/apply/dismiss) and rating/recommendation example prompts.

Intentionally not documented: the "Digests and alerts" tab (still feature-flagged), so nothing here advertises gated functionality.

Known follow-up: two screenshots (the scanner-editor estimate and the templates picker) predate the pricing display and could be refreshed, and a screenshot of the new Usage tab would be a nice addition.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the preview build (verified on the #18992 preview, content identical)
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)
