### PR TITLE
Use "phase" instead of "stage" in customer journey handbook

### DIFF
--- a/contents/handbook/growth/sales/customer-journey.md
+++ b/contents/handbook/growth/sales/customer-journey.md
@@ -4,24 +4,24 @@ sidebar: Handbook
 showTitle: true
 ---
 
-This is a rough articulation of the stages a paid and "sales sized" customer moves through PostHog, from first signup to steady state, and which role covers them at each stage. The purpose of mapping this out is creating a shared understanding so we can better standardize how we think of and approach accounts, as well as account allocation. When you know a customer's stage and ARR band, you know who should be working with the account. For the operational process (book planning, allocation cadence, handover mechanics), see [Account allocation and handover](/handbook/growth/sales/account-allocation), which holds the allocation rules.
+This is a rough articulation of the phases a paid and "sales sized" customer moves through PostHog, from first signup to steady state, and which role covers them at each phase. The purpose of mapping this out is creating a shared understanding so we can better standardize how we think of and approach accounts, as well as account allocation. When you know a customer's phase and ARR band, you know who should be working with the account. For the operational process (book planning, allocation cadence, handover mechanics), see [Account allocation and handover](/handbook/growth/sales/account-allocation), which holds the allocation rules.
 
-## The stages
+## The phases
 
 ### Presales
 
-| Stage          | Definition                                                               |
+| Phase          | Definition                                                               |
 | -------------- | ------------------------------------------------------------------------ |
 | **Exploring**  | Signed up, sending events, free tier or trivial spend. No buying signal. |
 | **Evaluating** | Actively comparing us against alternatives or against not buying.        |
 | **Proving**    | Running a structured POC with success criteria, ours or theirs.          |
 | **Buying**     | Commercial negotiation. Quote out, annual terms in discussion.           |
 
-> In a PLG motion most customers move through the presales stages invisibly and without contact. Our process and system should be able to capture and identify the right accounts to work with at the right time based on signals and stages. Exploring, Evaluating, and Proving are inferred from product signals unless sales is engaged. The presales stages only need to be as granular as the routing decision they drive, which is binary: automation, or a human from new biz.
+> In a PLG motion most customers move through the presales phases invisibly and without contact. Our process and system should be able to capture and identify the right accounts to work with at the right time based on signals and phases. Exploring, Evaluating, and Proving are inferred from product signals unless sales is engaged. The presales phases only need to be as granular as the routing decision they drive, which is binary: automation, or a human from new biz.
 
 ### Postsales
 
-| Stage            | Definition                                                                                                                                                                                                          |
+| Phase            | Definition                                                                                                                                                                                                          |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Implementing** | Delivering a closed deal. Posthog instrumentation, onboarding and success plan, stakeholder map.                                                                                                                    |
 | **Ramping**      | Usage growing, account below full TAM threshold or still climbing toward committed volume or otherwise just not at fully implemented production volume. Generally takes longer for larger or more traditional orgs. |
@@ -30,17 +30,17 @@ This is a rough articulation of the stages a paid and "sales sized" customer mov
 
 > Edge case worth noting: a pure self-serve account that crosses $20k ARR with no sales involvement skips Implementing entirely.  They enter at whatever their adoption or usage indicates, usually Ramping or Expanding. This is important, though, because an account that's been self-serve and steady state in prod for 2 years doesn't need the same tactic and approach as a sales-driven "implementation" account, and our process shouldn't treat them the same.
 
-### At risk is a status, not a stage
+### At risk is a status, not a phase
 
-An account in any postsales stage can be at risk. At risk does not change the stage or reassign the account. The current owner runs the churn save. 
+An account in any postsales phase can be at risk. At risk does not change the phase or reassign the account. The current owner runs the churn save. 
 
 ## Coverage map
 
-Who covers the account at each stage. Stages run top to bottom in the order a customer moves through them; roles run across.
+Who covers the account at each phase. Phases run top to bottom in the order a customer moves through them; roles run across.
 
 ✅ active coverage &nbsp;·&nbsp; 🟡 conditional (see notes) &nbsp;·&nbsp; blank = not involved
 
-| Stage            | BDR | TAE | CSM | TAM | Growth TAM | FDE | Onboarding |
+| Phase            | BDR | TAE | CSM | TAM | Growth TAM | FDE | Onboarding |
 | ---------------- | :-: | :-: | :-: | :-: | :--------: | :-: | :--------: |
 | **Exploring**    | ✅  |     |     |     |            |     |     🟡     |
 | **Evaluating**   | 🟡  | ✅  |     |     |            |     |     🟡     |


### PR DESCRIPTION
## Changes

Updates the [customer journey and coverage model](https://posthog.com/handbook/growth/sales/customer-journey) handbook page to consistently use "phase" instead of "stage" when referring to the steps a customer moves through. This covers the intro copy, section headings, table column headers, and the notes/ownership sections.

**Why:** Aligns the terminology with how the team refers to the customer journey.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*