### PR TITLE
Delete cross-sell timeline for annual contracts

### DIFF
--- a/contents/handbook/growth/cross-selling/cross-sell-motions.md
+++ b/contents/handbook/growth/cross-selling/cross-sell-motions.md
@@ -85,13 +85,6 @@ Why Now? All good opportunities have this and are timeline driven.
 - Key champion leaves company
 - Data Engineer takes over ownership of PostHog
 
-**Optimal timeline if a customer is on an annual contract:**
-
-- **Months 1-2**: Pure adoption focus, no cross-sell
-- **Months 3-6**: Prime cross-sell window
-- **Months 7-9**: Reinforce value of expanded stack if adopted
-- **Months 10-12**: Focus on "Why stay with PostHog" rather than expansion/cross-sell (it's too late)
-
 ## Hypothetical approach
 
 One way of approaching this that we have seen work is a research -> QBR -> recommended cross-sell 


### PR DESCRIPTION
Removed optimal timeline for cross-selling on annual contracts.

## Changes
I don't think this reflects how TAMs sell.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
