### PR TITLE
feat: add Replay Vision to the pricing calculator

### DIFF
--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -22,8 +22,8 @@ export const replayVision = {
         <div data-scheme="secondary" className="prose prose-sm text-lg mt-8 mb-12 leading-normal text-primary">
             <h3 className="text-xl font-bold text-primary mb-4">How credits work</h3>
             <p>
-                You pay per observation. One observation is one session recording watched by one scanner, so the
-                credits you use depend on how many sessions your scanners pick up.
+                You pay per observation. One observation is one session recording watched by one scanner, so the credits
+                you use depend on how many sessions your scanners pick up.
             </p>
             <ul>
                 <li>

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -11,6 +11,9 @@ export const replayVision = {
     colorSecondary: 'yellow',
     category: 'product_engineering',
     slug: 'replay-vision',
+    // Drop on GA launch day. Pricing itself stays hidden until billing serves the product,
+    // but this label doesn't, so it keeps the product from reading as GA in the meantime.
+    status: 'beta',
     slider: {
         // Values in credits. min doubles as the "first N credits free" copy, so it tracks the free allocation.
         marks: [2500, 10000, 50000, 100000],

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -11,8 +11,8 @@ export const replayVision = {
     colorSecondary: 'yellow',
     category: 'product_engineering',
     slug: 'replay-vision',
-    // Drop on GA launch day. Pricing itself stays hidden until billing serves the product,
-    // but this label doesn't, so it keeps the product from reading as GA in the meantime.
+    // TODO: drop this on GA launch day (2026-08-03). Pricing stays hidden until billing serves the
+    // product, but this label doesn't, so it stops the product reading as GA in the meantime.
     status: 'beta',
     slider: {
         // Values in credits. min doubles as the "first N credits free" copy, so it tracks the free allocation.

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -1,0 +1,20 @@
+import { IconLlmPromptEvaluation } from '@posthog/icons'
+
+export const replayVision = {
+    name: 'Replay Vision',
+    Icon: IconLlmPromptEvaluation,
+    description: 'AI-powered session replay analysis that watches recordings for you',
+    handle: 'replay_vision',
+    type: 'replay_vision',
+    color: 'yellow',
+    colorSecondary: 'yellow',
+    category: 'product_engineering',
+    slug: 'replay-vision',
+    slider: {
+        // Values in credits. min doubles as the "first N credits free" copy, so it tracks the free allocation.
+        marks: [2500, 10000, 50000, 100000],
+        min: 2500,
+        max: 100000,
+    },
+    volume: 2500,
+}

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -1,8 +1,9 @@
-import { IconLlmPromptEvaluation } from '@posthog/icons'
+import React from 'react'
+import { IconEye } from '@posthog/icons'
 
 export const replayVision = {
     name: 'Replay Vision',
-    Icon: IconLlmPromptEvaluation,
+    Icon: IconEye,
     description: 'AI-powered session replay analysis that watches recordings for you',
     handle: 'replay_vision',
     type: 'replay_vision',
@@ -17,4 +18,28 @@ export const replayVision = {
         max: 100000,
     },
     volume: 2500,
+    customPricingContent: (
+        <div data-scheme="secondary" className="prose prose-sm text-lg mt-8 mb-12 leading-normal text-primary">
+            <h3 className="text-xl font-bold text-primary mb-4">How credits work</h3>
+            <p>
+                You pay per observation. One observation is one session recording watched by one scanner, so the
+                credits you use depend on how many sessions your scanners pick up.
+            </p>
+            <ul>
+                <li>
+                    <strong className="text-primary">An observation costs 2, 5, or 15 credits</strong> depending on
+                    which model the scanner runs. You choose the model per scanner and see its price next to each
+                    option.
+                </li>
+                <li>
+                    <strong className="text-primary">1 credit is $0.01</strong>, so 100 credits cost $1. The first 2,500
+                    credits each month are free, which covers 500 sessions on the default model.
+                </li>
+            </ul>
+            <p>
+                Before you turn a scanner on, PostHog estimates how many sessions it will match each month and what that
+                costs. Set a billing limit if you want a hard cap on spend.
+            </p>
+        </div>
+    ),
 }

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -29,7 +29,6 @@ import {
     IconCursorClick,
     IconChat,
     IconAtSign,
-    IconLlmPromptEvaluation,
 } from '@posthog/icons'
 import useProducts from './useProducts'
 import { mcpAnalytics } from './productData/mcp_analytics'
@@ -1753,17 +1752,6 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
                 },
             ],
             worksWith: ['feature_flags', 'surveys', 'product_analytics', 'session_replay'],
-        },
-        {
-            name: 'Replay Vision',
-            Icon: IconLlmPromptEvaluation,
-            description: 'AI-powered session replay analysis that watches recordings for you',
-            handle: 'replay_vision',
-            color: 'yellow',
-            colorSecondary: 'yellow',
-            category: 'product_engineering',
-            slug: 'replay-vision',
-            status: 'beta',
         },
         mcpAnalytics,
         {

--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -21,6 +21,7 @@ import { logs } from './productData/logs'
 import { realtimeDestinations } from './productData/realtime_destinations'
 import { endpoints } from './productData/endpoints'
 import { inbox } from './productData/inbox'
+import { replayVision } from './productData/replay_vision'
 
 const initialProducts = [
     productAnalytics,
@@ -39,6 +40,7 @@ const initialProducts = [
     workflows,
     inbox,
     endpoints,
+    replayVision,
 ]
 
 export default function useProducts() {


### PR DESCRIPTION
## Changes

Adds Replay Vision to the pricing page and pricing calculator for GA launch. This is the "Pricing calculator (site)" item on the [Replay Vision launch plan](https://github.com/PostHog/marketing/issues/179), and the last unfinished one of the four billing checklist items.

Replay Vision only existed in `src/hooks/useProduct.ts` as a `status: 'beta'` entry. That file's own header comment describes that list as the bucket for alpha/beta products and things that aren't really products, and says a released product should move to `useProducts.tsx`. Until it moves, it can't appear on any pricing surface, because those read `initialProducts` from `useProducts.tsx`.

So:

- New `src/hooks/productData/replay_vision.tsx`, carrying over every field from the old beta entry plus the three the pricing surfaces need: `type`, `slider`, and `volume`. Also adds a "How credits work" explainer, since a credit price says nothing about how many sessions you get (PostHog AI solves the same problem the same way).
- Imported and appended to `initialProducts` in `useProducts.tsx`.
- Removed the beta entry from `useProduct.ts` (and its now-unused icon import).

Both had to happen together. `useProduct` dedupes by `name` with its hand-written entries first, so leaving the beta entry in place would have shadowed the new one and kept billing data off the product.

Everything else (price tiers, free allocation, unit) comes from the billing API at build time, matched on `handle` — the same wiring every other product uses. Nothing about pricing is hardcoded here.

### Why the slider values

| Field | Value | Why |
| --- | --- | --- |
| `min` | 2,500 | The free allocation. `Tabbed.tsx` renders "First {`slider.min`} credits free", so this has to track the plan's `free_allocation`, not just be a nice starting point. |
| `volume` | 2,500 | Calculator opens at the free tier, so it starts at $0. Same as PostHog AI (`volume` 500, `free_allocation` 500). |
| `marks` / `max` | up to 100,000 | Mirrors PostHog AI, the sibling credits product on the same $0.01/credit rate, so the two calculators feel consistent. 100,000 credits is roughly $975/month after the free tier. |

The credit costs in the explainer (2 / 5 / 15 per observation, default 5) match `OBSERVATION_CREDITS_BY_MODEL` in `products/replay_vision/backend/billing.py`. 2,500 free credits covering 500 sessions follows from the 5-credit default.

### Safe to merge before launch

Pricing can't render until [billing#2018](https://github.com/PostHog/billing/pull/2018) is merged and deployed, and that gate is server-side: `Tabbed.tsx` filters on `!!product.unit` and `PricingAccordion.tsx` on `item.billedWith || item.billingData`, both of which come from the billing API at build time. So Replay Vision is simply absent from the calculator and pricing table until then — no broken tab, no empty row, no build failure. (The two places that dereference `billingData` unguarded, `Pricing/Pricing.tsx`'s `AllAddons` and `PricingCalculator/SingleProduct.tsx`, both have zero importers.)

Two surfaces do list products without a billing filter, so they pick it up on merge: `AppsList` on the `/docs` index (links to `/docs/replay-vision`) and `ProductSwitcher` in ReaderView sidebars (links to `/replay-vision`). Both pages are already public and already in the docs nav, so this is consistent with what's live today.

The beta label isn't gated by billing, so `status: 'beta'` is kept for now to stop the product reading as GA early. **Launch day: drop that one line** (`src/hooks/productData/replay_vision.tsx`), and optionally rebuild once billing is deployed so the calculator picks up the tiers.

### Screenshots

Not meaningful yet: the product's pricing comes from the billing API at build time, and that API won't return `replay_vision` until billing#2018 deploys, so a preview build today renders the current pricing page unchanged. Worth grabbing one after billing is live.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — no visible change until billing#2018 deploys, see above
- [x] If I moved a page, I added a redirect in `vercel.json` — n/a

## 🤖 Agent context

Kept the display name as `Replay Vision` rather than switching to sentence case `Replay vision` (which is what the docs and billing config use). Renaming would change the nav label, the product page, and the `dedupe` key across the site, which is a marketing call and not this PR's job. Worth settling separately.
