### PR TITLE
docs(replay-vision): document webhook delivery payload

### DIFF
--- a/contents/docs/replay-vision/webhooks.mdx
+++ b/contents/docs/replay-vision/webhooks.mdx
@@ -1,0 +1,71 @@
+---
+title: Webhooks
+---
+
+<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
+
+Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
+
+</CalloutBox>
+
+Replay Vision can deliver a scanner's digests and alerts to a webhook instead of, or alongside, Slack. When a digest or alert fires, PostHog sends an HTTP `POST` with a JSON body to the URL you set on the action.
+
+## Setting up a webhook
+
+1. Open a scanner and create or edit a digest or an alert.
+2. Under **Delivery**, choose **Webhook**.
+3. Paste the URL of the endpoint that should receive the payload.
+4. Save.
+
+The action still appears on the scanner page and in its run history whether or not a webhook is set, so an unreachable endpoint never hides the result.
+
+## Request
+
+- **Method:** `POST`
+- **Headers:**
+  - `Content-Type: application/json`
+  - `X-PostHog-Webhook-Version: 1` – the payload version. New fields may be added to the body without changing this, so ignore unknown fields rather than rejecting the payload. A breaking change would ship under a new version.
+
+## Payload
+
+The body is a JSON envelope. `type` tells you what happened; `data` carries the report and links.
+
+```json
+{
+  "id": "0192f3a4-...",
+  "type": "replay_vision.digest",
+  "timestamp": "2026-07-27T12:00:00+00:00",
+  "data": {
+    "vision_action_id": "0192f3a4-...",
+    "run_id": "0192f3a4-...",
+    "scanner_id": "0192f3a4-...",
+    "action_name": "Daily checkout digest",
+    "scanner_name": "Checkout funnel scanner",
+    "observation_count": 12,
+    "report": "**Checkout digest**\n\n12 sessions showed ...",
+    "run_url": "https://us.posthog.com/project/1/replay-vision/actions/.../runs/..."
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | Unique ID for this delivery. Equal to `data.run_id`; use it to dedupe retries. |
+| `type` | string | One of `replay_vision.digest`, `replay_vision.alert_fired`, or `replay_vision.alert_recovered`. Route on this. |
+| `timestamp` | string | ISO 8601 time the run was scheduled. |
+| `data.vision_action_id` | string | ID of the digest or alert. |
+| `data.run_id` | string | ID of this specific run. |
+| `data.scanner_id` | string \| null | ID of the scanner the action belongs to. |
+| `data.action_name` | string | Name of the digest or alert. |
+| `data.scanner_name` | string \| null | Name of the scanner. |
+| `data.observation_count` | number | How many observations this run matched. |
+| `data.report` | string | The report as Markdown. |
+| `data.run_url` | string | Link to the run in PostHog, showing every matching observation. |
+
+### Event types
+
+- `replay_vision.digest` – a scheduled digest produced its summary.
+- `replay_vision.alert_fired` – an alert's condition was met.
+- `replay_vision.alert_recovered` – an alert that was firing has cleared.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4483,6 +4483,12 @@ export const docsMenu = {
                     color: 'yellow',
                 },
                 {
+                    name: 'Webhooks',
+                    url: '/docs/replay-vision/webhooks',
+                    icon: 'IconWebhooks',
+                    color: 'yellow',
+                },
+                {
                     name: 'Improving accuracy',
                     url: '/docs/replay-vision/quality',
                     icon: 'IconThumbsUp',


### PR DESCRIPTION
## Changes

Adds a **Webhooks** page under Replay Vision docs documenting the JSON payload PostHog POSTs when a scanner digest or alert is delivered to a webhook.

Covers:
- how to configure a webhook on a digest or alert
- the request method and headers, including `X-PostHog-Webhook-Version: 1`
- the `{id, type, timestamp, data}` envelope with a full field table
- the three event types (`replay_vision.digest`, `replay_vision.alert_fired`, `replay_vision.alert_recovered`)

Registers the page in the Replay Vision sidebar after Observations.

Companion to the product PRs adding webhook delivery (PostHog/posthog#74077, #74078, #74079). The frontend PR links to this page from the webhook URL field, so this should land so that link resolves.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

The page content matches the payload the backend actually emits. I (Claude, via Claude Code) wrote this under @ksvat's direction. I haven't checked the Vercel preview build.