### PR TITLE
Fix post-newsletter skill auth flow and source fetching

### DIFF
--- a/.claude/skills/post-newsletter/SKILL.md
+++ b/.claude/skills/post-newsletter/SKILL.md
@@ -171,11 +171,24 @@ Name each image descriptively: `{slug}-tip{N}-{description}` (e.g. `how-to-demo-
 The upload response returns a Cloudinary URL in the format:
 `https://res.cloudinary.com/dmukukwp6/image/upload/v1783662227/filename.png`
 
-**Strip the `/v<number>` version segment from the `featuredImage` URL before writing it to frontmatter.** The build derives a Cloudinary public ID from this URL by taking everything after `/upload/` (`gatsby/onCreateNode.ts` → `getPublicID`). If the version segment is left in (`.../upload/v1783662227/filename.png`), the derived public ID becomes `v1783662227/filename` instead of `filename`, which misses the Cloudinary metadata cache — so `gatsbyImageData` resolves to `null` and the hero image silently fails to render (while the direct image URL itself still returns 200). Always write the featured image as `https://res.cloudinary.com/dmukukwp6/image/upload/filename.png` — no `v.../` segment. (This only matters for `featuredImage`, which goes through the image transformer; body images are plain `<img>` tags and render fine with or without the version.)
+**Nothing may sit between `/upload/` and the filename in the `featuredImage` URL.** The build derives a Cloudinary public ID by taking *everything* after `/upload/` (`gatsby/onCreateNode.ts` → `getPublicID`), so any prefix gets baked into the ID, misses the Cloudinary metadata cache, and makes `gatsbyImageData` resolve to `null`. The hero then fails **silently** — `ReaderView` renders an empty `<GatsbyImage>` because `featuredImage` is still truthy, and there's no `publicURL` fallback. The direct image URL still returns 200, so you cannot catch this by checking the link.
+
+Two prefixes cause it, and the upload response hands you the first one:
+
+- **Version segment.** Uploads return `.../upload/v1783662227/filename.png` → ID becomes `v1783662227/filename`. Strip `v<digits>/`.
+- **Transformation params.** A URL copied from elsewhere on the site may carry them: `.../upload/q_auto,f_auto/filename.jpg` → ID becomes `q_auto,f_auto/filename`. Strip those too.
+
+A **missing file extension** breaks it differently but just as silently: `getPublicID` does `substring(0, lastIndexOf('.'))`, and with no dot that yields an empty string.
+
+Write it as `https://res.cloudinary.com/dmukukwp6/image/upload/<public-id>.<ext>`. Folder paths *inside* the public ID are fine and common (`.../upload/posthog.com/contents/images/foo/bar.png` works) — it's only a leading version or transform segment that breaks.
+
+This applies to `featuredImage` (and the other transformed frontmatter fields: `thumbnail`, `logo`, `logoDark`, `icon`). Body images are plain `<img>` tags and render fine either way.
+
+One false alarm to know about: PR previews restore a Cloudinary metadata cache that is only refreshed daily at 06:00 UTC (`.github/workflows/cache-warmup.yml`). An image uploaded after the last refresh is absent from that cache, so its hero can look blank **in the preview** even with a correct URL. Production builds crawl Cloudinary fresh and are unaffected. If the URL has no prefix and the hero is still blank in preview, suspect this before rewriting the URL.
 
 ### 3d: Update the markdown
 
-Replace all `[PLACEHOLDER_...]` and `![PLACEHOLDER: ...](PLACEHOLDER)` entries with the real Cloudinary URLs and descriptive alt text. Remember to strip the `/v<number>` version segment from the `featuredImage` URL (see 3c). Match each uploaded image to its placeholder using the quoted anchor text from step 3b — find that exact sentence or heading in the file and insert the image there — never by list position or order. Before moving on, re-read the finished file and confirm each image's description actually matches the paragraph it now sits next to.
+Replace all `[PLACEHOLDER_...]` and `![PLACEHOLDER: ...](PLACEHOLDER)` entries with the real Cloudinary URLs and descriptive alt text. Remember that the `featuredImage` URL must have nothing between `/upload/` and the filename (see 3c). Match each uploaded image to its placeholder using the quoted anchor text from step 3b — find that exact sentence or heading in the file and insert the image there — never by list position or order. Before moving on, re-read the finished file and confirm each image's description actually matches the paragraph it now sits next to.
 
 **Indentation rule:** Example paragraphs and images that follow a numbered tip and illustrate it should be indented as list continuations (3 spaces for tips 1–9, 4 spaces for tips 10+). Checklists inside a tip should be wrapped in a blockquote (`>`).
 

--- a/.claude/skills/post-newsletter/SKILL.md
+++ b/.claude/skills/post-newsletter/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: post-newsletter
-description: Convert a Substack newsletter post into a native posthog.com newsletter file. Fetches the content from a Substack URL, formats it with correct frontmatter and markdown, applies internal links, and writes image placeholders. Omits Substack-specific sections (byline, related texts, job posts). Use when the user provides a newsletter.posthog.com URL and asks to post it natively.
+description: Convert a Substack newsletter post into a native posthog.com newsletter file. Fetches the content from a Substack URL, formats it with correct frontmatter and markdown, applies internal links, and re-hosts its images on Cloudinary. Omits Substack-specific sections (byline, related texts, job posts). Use when the user provides a newsletter.posthog.com URL and asks to post it natively.
 ---
 
 # Post Newsletter Natively
-
-> **Model:** Sonnet is fine for this skill. The steps are fairly programmatic — copy verbatim, apply mechanical link/image transformations, run scripted uploads — and don't require the nuanced judgment that `/suggest-links` (invoked in Step 4) needs, which should still be run on Opus or higher.
 
 Convert a Substack newsletter post into a native posthog.com markdown file under `contents/newsletter/`.
 
@@ -65,7 +63,7 @@ seo:
 - Format section headers as `##` and subsections as `###`. **Do not modify header text** — copy it exactly as it appears in the source, including any numbering format (e.g. `1.`, `2.`, not `Rule 1:`, `Rule 2:`).
 - For quote blocks: Substack sometimes renders pull quotes or highlighted excerpts as italicized text in quotation marks (e.g. `*"Quote text here."*`). Convert these to markdown blockquotes: `> Quote text here.` — drop the surrounding quotation marks and italics.
 - Place `<NewsletterForm />` once mid-article (after the first major section) and once at the very end.
-- For images: write a placeholder in the format `![PLACEHOLDER: description of image](PLACEHOLDER)` so the user knows where to upload. **Detection tip:** a sentence that ends with a colon (`:`) followed by a blank line almost always precedes an inline image in the Substack source — treat those as image locations even if the scraper didn't return an `<img>` tag.
+- For images: write a placeholder in the format `![PLACEHOLDER: description of image](PLACEHOLDER)` to mark the position. Step 3 replaces each one with a real Cloudinary URL, so none should survive into the finished file. **Detection tip:** a sentence that ends with a colon (`:`) followed by a blank line almost always precedes an inline image in the Substack source — treat those as image locations even if the scraper didn't return an `<img>` tag.
 - For image captions (italicized text directly below an image in Substack): use the `<Caption>` component instead of plain markdown italics, e.g. `<Caption>Caption text here</Caption>` — see `contents/newsletter/building-ai-agents.md` for examples. It renders centered by default, unlike bare `*italic*` text. If the caption contains a link, keep it as an inline `<a href="...">` tag inside the component (per "Preserve original links" below) rather than dropping it — this is easy to miss since the caption reads like a quote at first glance.
 - For code blocks: preserve the language and exact content.
 - For footnotes: use markdown footnote syntax — `[^1]` inline, and `[^1]: text` at the bottom.
@@ -217,6 +215,7 @@ Ask the subagent to go section by section and return a clear verdict (match / di
 
 After all edits, report:
 
-1. **Image placeholders** — list each one so the user knows what to upload.
+1. **Images** — confirm every image resolves, and name any still left as a placeholder (e.g. a hero the user never supplied) so it's clear what's outstanding. Flag any text error rendered into an image, since that needs the asset regenerated.
 2. **Sections omitted** — confirm what Substack-only content was removed.
 3. **Author slug** — flag if the author slug may not exist yet in the codebase (check with Grep for the slug in `contents/`).
+4. **Deliberate divergences from the source** — call out anything that intentionally doesn't match Substack (a typo fixed at the author's request, a regenerated image). A reviewer comparing the two versions will otherwise read these as conversion errors.

--- a/.claude/skills/post-newsletter/SKILL.md
+++ b/.claude/skills/post-newsletter/SKILL.md
@@ -15,12 +15,19 @@ The user will provide a Substack URL: $ARGUMENTS
 
 Run these in parallel:
 
-1. **Fetch the newsletter content** using WebFetch with this prompt:
-   > "Extract the complete text of this newsletter. Include: title, subtitle, all body text verbatim, all links with their href URLs, all image alt text/descriptions, all section headers, and footnotes. Do not summarize — give full verbatim text."
+1. **Fetch the newsletter content from Substack's API**, not with WebFetch. WebFetch routes the page through a summarizing model that will usually refuse to reproduce a full article verbatim ("I can't reproduce the full text verbatim…") and hand back a summary instead — useless when the whole job is copying text exactly. Substack exposes the post as JSON with no auth:
+
+   ```bash
+   curl -sL "https://newsletter.posthog.com/api/v1/posts/{substack-slug}" -o /tmp/post.json
+   ```
+
+   The response includes `title`, `subtitle`, `post_date`, `cover_image`, and `body_html` — the article body as HTML. Write `body_html` to a file and convert it to markdown with a script (unwrap Substack's `<span>` soup, turn `<figure>` blocks into image markers carrying both the `src` and the `<figcaption>`, and convert `<a>` to `[text](href)`). This gives you exact text, exact links, and image positions in one pass, and it doubles as the ground truth for Step 5.
+
+   Keep the JSON and the converted markdown around — Step 3b and Step 5 both reuse them.
 
 2. **Read an existing newsletter** for frontmatter reference. Use a recent one, e.g. `contents/newsletter/building-ai-agents.md` or `contents/newsletter/vibe-designing.md`.
 
-3. **Check for an existing file** at the expected path. The filename should be a kebab-case slug of the article title under `contents/newsletter/`. Use Glob to check.
+3. **Check for an existing file** at the expected path. The filename is **the Substack post's own slug** (the last path segment of the URL), not a slug derived from the article title — the two often differ, e.g. `code-review-tips.md` holds "Stop being the code review bottleneck". Getting this wrong breaks the inbound `/newsletter/{slug}` links other posts already point at. Use Glob to confirm the file doesn't exist yet, and grep `contents/` for `/newsletter/{slug}` to see which posts already link to it.
 
 4. **Check for a suggested-links file** at the repo root — it follows the pattern `suggested-links-{slug}.md`. Read it if it exists.
 
@@ -92,27 +99,47 @@ Ask the user two things:
 
 ### 3b: Get images from Substack
 
-Fetch the Substack URL **once** for images — do not split this into a separate "descriptions" fetch and a separate "raw URLs" fetch. Two independent fetches can disagree on count or order (an image dropped from one but not the other), and zipping them back together by position silently shifts every image after the mismatch onto the wrong caption. This has happened before (PR #18012) and produced a missing image plus a run of wrong images for the rest of the post.
+Read the images out of the `body_html` you already fetched in Step 1 — you do not need another network fetch, and you should not use one. Deriving images from a second, independent fetch can disagree with the first on count or order (an image dropped from one but not the other), and zipping the two back together by position silently shifts every image after the mismatch onto the wrong caption. This has happened before (PR #18012) and produced a missing image plus a run of wrong images for the rest of the post. Taking the `src`, the preceding text, and the `<figcaption>` from a single parse of one `body_html` makes that class of bug impossible.
 
-Use one prompt that returns the URL and its anchor text together, per image:
-> "List every image in the article body, in order of appearance. For each one, give: (1) its exact `src` URL, (2) the sentence or heading immediately before it, quoted verbatim, and (3) a brief description of what it shows. Include only article body images, not avatar or profile images."
+For each `<figure>` in document order, pull: (1) the original image URL — prefer the `<a class="image-link" href="...">` wrapper, which points at the full-size `substack-post-media.s3.amazonaws.com` original, over the resized `substackcdn.com/image/fetch/...` `<img src>`; (2) the text immediately before it; (3) the `<figcaption>`, if any.
 
-Count the images returned against the number of `![PLACEHOLDER: ...]` entries already written in step 2. If the counts don't match, stop and tell the user which section appears to be missing an image instead of guessing.
+Count the images found against the number of `![PLACEHOLDER: ...]` entries already written in step 2. If the counts don't match, stop and tell the user which section appears to be missing an image instead of guessing.
+
+**Look at the images before you place them.** Download each one and Read it — the images are diagrams, and a caption-less diagram is easy to attach to the wrong section. Confirm what each one actually depicts matches the section it's going into. This is also the moment you'll catch text errors rendered into the image itself (a misspelled label, a stale product name); flag those to the user, since they can only be fixed by regenerating the asset.
 
 ### 3c: Authenticate and upload
 
-Ask the user for their **PostHog community credentials** (the account used to sign in at posthog.com/community — not their PostHog app login):
+Uploads go through the posthog.com Strapi backend, which needs a bearer token.
 
-> Please run: `! export SQUEAK_EMAIL=you@posthog.com SQUEAK_PASSWORD=yourpassword`
+**PostHog staff cannot use email/password — ask for a browser token instead.** Strapi refuses the password grant for any `@posthog.com` account, because staff accounts are SSO-only:
 
-Once credentials are set, authenticate and upload all images with a shell script:
+```
+400 BadRequestError: "PostHog employees must log in with PostHog"
+```
+
+There is no password to send, so don't ask for one. Ask the user to hand you the session token the site is already using:
+
+> While logged in to posthog.com, open your browser console and run `localStorage.getItem('jwt')`, then paste the result here.
+
+That's the same token every authenticated request from the site carries — `src/hooks/useUser.tsx` reads and writes it under the `jwt` key. It's valid for about 30 days, so a token from an earlier session in the same conversation is usually still good.
+
+**Only for non-staff accounts** (an external contributor signing in at posthog.com/community with a password) does the credential grant work:
+
+> Please run: `! export SQUEAK_EMAIL=you@example.com SQUEAK_PASSWORD=yourpassword`
+
+Note that `!`-prefixed commands run in the **user's** shell, not yours — the exported variables will NOT be visible to your Bash tool, and `${SQUEAK_EMAIL}` will expand to an empty string. Read the values out of the user's message and pass them inline instead.
+
+Then upload all images with a shell script:
 
 ```bash
-# Authenticate
-JWT=$(curl -s -X POST "https://better-animal-d658c56969.strapiapp.com/api/auth/local" \
-  -H "Content-Type: application/json" \
-  -d "{\"identifier\":\"${SQUEAK_EMAIL}\",\"password\":\"${SQUEAK_PASSWORD}\"}" \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['jwt'])")
+# Staff: use the JWT the user pasted.
+JWT='eyJhbGciOi...'
+
+# Non-staff only: exchange credentials for a JWT.
+# JWT=$(curl -s -X POST "https://better-animal-d658c56969.strapiapp.com/api/auth/local" \
+#   -H "Content-Type: application/json" \
+#   -d "{\"identifier\":\"${SQUEAK_EMAIL}\",\"password\":\"${SQUEAK_PASSWORD}\"}" \
+#   | python3 -c "import sys,json; print(json.load(sys.stdin)['jwt'])")
 
 # Upload hero (if local file provided)
 # curl -s -X POST "https://better-animal-d658c56969.strapiapp.com/api/upload" \
@@ -128,10 +155,18 @@ upload() {
   curl -s -X POST "https://better-animal-d658c56969.strapiapp.com/api/upload" \
     -H "Authorization: Bearer $JWT" \
     -F "files=@${tmpfile};filename=${name}.png" \
-    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['url'])"
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+# A failed upload returns an error object, not a list — surface it instead of
+# crashing on d[0], which hides the real cause (usually an expired token).
+print(d[0]['url'] if isinstance(d, list) else 'ERROR ' + json.dumps(d)[:400])
+"
   rm -f "$tmpfile"
 }
 ```
+
+If an upload returns `401 Unauthorized`, the token has expired — ask for a fresh one rather than retrying.
 
 Name each image descriptively: `{slug}-tip{N}-{description}` (e.g. `how-to-demo-tip4-phone-number`).
 
@@ -163,8 +198,9 @@ Before reporting to the user, spawn a subagent (via the Agent tool, `subagent_ty
 
 **Ground truth, in order of preference:**
 
-1. If the user provided a saved HTML export of the Substack page (rather than just the URL), use that as ground truth. It's large and mostly boilerplate — instruct the subagent to locate the article body (typically inside a `<div class="body markup">`-style container) and strip tags with a quick script rather than reading the whole file.
-2. Otherwise, have the subagent WebFetch the newsletter URL fresh. Note: WebFetch may refuse to reproduce full verbatim text for a copyrighted article and return only a summary with short quotes — if so, the subagent should say so explicitly and verify what it can (structure, links, image count and placement, footnote count) rather than silently downgrading to a shallow check.
+1. **The `body_html` you saved in Step 1.** This is the preferred ground truth: it comes from Substack's own API, so it's the authoritative source text rather than a model's rendering of the page. Point the subagent at the saved file and tell it to strip tags with a script rather than eyeballing raw HTML. Pass along the API JSON too, so it can check `title` and `post_date` against the frontmatter.
+2. A saved HTML export of the Substack page, if the user provided one. Large and mostly boilerplate — instruct the subagent to locate the article body (typically inside a `<div class="body markup">`-style container) and strip tags with a quick script rather than reading the whole file.
+3. Last resort: have the subagent WebFetch the newsletter URL fresh. Expect this to be weak — WebFetch will usually refuse to reproduce full verbatim text and return only a summary with short quotes. If that happens the subagent should say so explicitly and verify what it can (structure, links, image count and placement, footnote count) rather than silently downgrading to a shallow check.
 
 **Tell the subagent what's allowed to differ** so it doesn't flag intentional transformations as bugs:
 


### PR DESCRIPTION
## Changes

The `post-newsletter` skill's image upload step is unusable for PostHog staff. It instructs the agent to authenticate with an email and password, but Strapi refuses the password grant for any `@posthog.com` account:

```
400 BadRequestError: "PostHog employees must log in with PostHog"
```

Staff accounts are SSO-only, so there is no password to send — the skill dead-ends on its own instructions. It now asks for the session token the site already keeps in `localStorage` (the `jwt` key, per `src/hooks/useUser.tsx`), and keeps the credential grant documented for non-staff contributors only.

**Why:** hit while posting a newsletter with this skill (#19002). The documented auth step failed outright, and several other steps were wrong in ways that cost real time, so they are fixed here too.

Beyond auth:

- **Step 1 used WebFetch to get the article text.** WebFetch routes the page through a summarizing model that refuses to reproduce a full article verbatim, which is fatal for a skill whose entire job is copying text exactly. Now uses Substack's public post API, which returns `body_html` plus the title and date. That also gives Step 5 authoritative ground truth to verify against instead of a second lossy fetch.
- **Step 1 said the filename should be a slug of the article title.** It's actually the Substack post slug, and the two often differ — `code-review-tips.md` holds "Stop being the code review bottleneck". Deriving it from the title would break the inbound `/newsletter/{slug}` links other posts already point at.
- **The `featuredImage` rule was too narrow.** It said to strip the `/v<number>` version segment, but *any* prefix between `/upload/` and the filename breaks identically — inline transformation params do it too (one newsletter is broken in production that way, see #19034), and a missing file extension fails via a related path. Restated as "nothing may sit between `/upload/` and the filename", with a note that folder paths inside the public ID are fine. Also documents a false alarm: PR previews restore a Cloudinary metadata cache refreshed only daily, so a freshly uploaded image can look blank in preview while being correct in production.
- Step 3b now reads images from the already-fetched `body_html` rather than a second network call, which structurally removes the image/caption misalignment that PR #18012 hit, and tells the agent to actually look at each diagram before placing it.
- The upload snippet reported errors as a Python traceback on `d[0]`; it now surfaces the API's error body, which is what tells you the token expired.
- Dropped the "Sonnet is fine for this skill" note, and fixed wording that predated the skill's own upload step and still implied the user uploads images by hand.

Docs-only change to a skill file — no site content or build behavior touched.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — n/a, not a site page
- [ ] If I moved a page, I added a redirect in `vercel.json` — n/a, no pages moved

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*