### PR TITLE
docs: clarify keeper tests don't replace direct feedback

### DIFF
--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -12,7 +12,7 @@ This includes giving feedback [to each other](/handbook/values#youre-the-driver)
 
 'Open and honest' doesn't mean 'being an asshole' – we expect feedback to be direct, but shared with good intentions and in the spirit of genuinely helping that person and PostHog as a whole to improve. Please make sure your feedback is constructive and based on observations, not _emotions_. If possible, share examples to help the feedback receiver understand the context of the feedback. 
 
-## Keeper tests are not a substitute for direct feedback
+### Keeper tests are not a substitute for direct feedback
 
 [Keeper tests](/handbook/company/management#the-keeper-test) are not designed to replace direct feedback, and the responses are not made visible to the person being assessed in the ops platform. We've always wanted people to give direct feedback to each other, across teams and in all directions – keeper tests do not replace the art and process of giving continual, direct, and 360 feedback.
 

--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -12,6 +12,17 @@ This includes giving feedback [to each other](/handbook/values#youre-the-driver)
 
 'Open and honest' doesn't mean 'being an asshole' – we expect feedback to be direct, but shared with good intentions and in the spirit of genuinely helping that person and PostHog as a whole to improve. Please make sure your feedback is constructive and based on observations, not _emotions_. If possible, share examples to help the feedback receiver understand the context of the feedback. 
 
+## Keeper tests are not a substitute for direct feedback
+
+[Keeper tests](/handbook/company/management#the-keeper-test) are not designed to replace direct feedback, and the responses are not made visible to the person being assessed in the ops platform. We've always wanted people to give direct feedback to each other, across teams and in all directions – keeper tests do not replace the art and process of giving continual, direct, and 360 feedback.
+
+The keeper test forms exist for a few specific reasons:
+
+- To surface feedback to the relevant Blitzscale team member so they can help where necessary.
+- To keep a record of feedback given, in case the person moves team or the team lead changes.
+
+We also want people to fill these forms out totally unfiltered, rather than through the lens of "will this person see this feedback". If you have feedback for someone, give it to them directly – don't rely on the keeper test to do it for you.
+
 ## Full team feedback sessions
 
 We run full team 360-degree feedback session as part of every offsite. Some teams will do them during their own small team offsite, while others choose to do them as part of the whole company offsite. The session gives everyone the opportunity to give and receive feedback to everyone else. If your team works closely with another or is very small, you may combine with another team (but keep attendees to <8 if you can).


### PR DESCRIPTION
## Changes

Adds a "Keeper tests are not a substitute for direct feedback" section to the People feedback handbook page. It clarifies that keeper test responses aren't surfaced to the person in the ops platform, explains the two reasons the forms exist (surfacing feedback to the relevant Blitzscale member, and keeping a record if someone changes team/lead), and reinforces that people should give feedback directly rather than relying on the form.

**Why:** Came up in a Slack thread where people expected to be able to read their own keeper test feedback. The decision was that this feedback stays unfiltered and isn't a replacement for direct feedback, so the handbook should call that out explicitly.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09HPV5GTPG/p1783947563444859?thread_ts=1783947563.444859&cid=C09HPV5GTPG)*
