### PR TITLE
Fix header contrast in dark mode for blogs

### DIFF
--- a/src/templates/BlogPost.tsx
+++ b/src/templates/BlogPost.tsx
@@ -236,7 +236,7 @@ export const getSortOption = (root?: string) =>
 const Filters = ({ tag, setTag, sort, setSort, activeMenu }) => {
     return activeMenu?.children?.length > 0 ? (
         <div className="mb-1 flex items-center justify-between sticky top-0 z-10 pl-1.5">
-            <h5 className="m-0 text-sm font-semibold">{activeMenu?.name}</h5>
+            <h5 className="m-0 text-sm font-semibold text-muted">{activeMenu?.name}</h5>
             <div className="flex items-center">
                 <MenuBar
                     menus={[


### PR DESCRIPTION
## Changes

Fix bad contrast for blog headers

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
