### PR TITLE
Update the label for the 'Why PostHog' icon on the desktop page

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -91,7 +91,7 @@ export const useProductLinks = () => {
 
 export const apps: AppItem[] = [
     {
-        label: 'Why PostHog?',
+        label: 'About us',
         Icon: <GlassIcon path={WHY_POSTHOG_SILHOUETTE} />,
         url: '/about',
         source: 'desktop',


### PR DESCRIPTION
## Changes

Update the label for the 'Why PostHog' icon on the desktop page

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
