### PR TITLE
Style tweaks to homepage and install component

### DIFF
--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -136,7 +136,7 @@ function Hero(): JSX.Element {
     const isDark = siteSettings.theme === 'dark'
     return (
         <>
-            <div className="text-center @xl:text-left mb-24 min-w-0">
+            <div className="text-center @xl:text-left min-w-0">
                 <h1 className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-8 pt-2">
                     <Logo
                         className="max-w-[157px]"

--- a/src/components/PlatformInstall/CopyableCommand.tsx
+++ b/src/components/PlatformInstall/CopyableCommand.tsx
@@ -45,7 +45,7 @@ export function CopyableCommand({
     return (
         <div
             className={cn(
-                'group flex items-start gap-2 bg-primary border border-primary rounded px-2 py-1.5',
+                'group flex items-start gap-2 bg-accent/30 border border-primary rounded-md px-2 py-1.5',
                 className
             )}
         >

--- a/src/components/PlatformInstall/index.tsx
+++ b/src/components/PlatformInstall/index.tsx
@@ -213,7 +213,7 @@ export default function PlatformInstall({
 
     return (
         <div
-            className={`not-prose w-full max-w-md min-w-0 border border-primary rounded bg-accent/40 shadow-2xl mb-2 ${className}`}
+            className={`not-prose w-full max-w-md min-w-0 border border-primary rounded-md bg-primary shadow-2xl mb-2 ${className}`}
         >
             <div className="p-3 space-y-2">
                 <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Changes

- Adds white background / accented install container for the install command to provide better contrast against the transparent background
- Rounds corners *slightly* more
- Reduces margin between hero and carousel

(Before / After only includes homepage, the install command is also included on a number of other pages)

#### Before
<img width="1141" height="933" alt="image" src="https://github.com/user-attachments/assets/ad4698ac-d01a-4f4e-919b-e6bd6f49af7e" />

#### After
<img width="1141" height="933" alt="image" src="https://github.com/user-attachments/assets/ec7105bd-a056-426d-a0a0-390416c9c6f7" />
