### PR TITLE
docs: highlight identifying users in loaded callback

### DIFF
--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -25,6 +25,27 @@ import JSIdentifyCrossPlatform from "../_snippets/identify-cross-platform.mdx"
 
 <JSIdentifyWhenToCall/>
 
+#### Identify users when the web SDK loads
+
+If your app already knows the signed-in user when you initialize the JavaScript web SDK, the [`loaded` callback](/docs/libraries/js/config) is a convenient place to call `identify`. This identifies the user as soon as the SDK has loaded:
+
+```js-web
+posthog.init('<ph_project_token>', {
+    api_host: '<ph_client_api_host>',
+    defaults: '<ph_posthog_js_defaults>',
+    loaded: (posthog) => {
+        if (currentUser?.id) {
+            posthog.identify(currentUser.id, {
+                email: currentUser.email,
+                name: currentUser.name,
+            })
+        }
+    },
+})
+```
+
+In this example, `currentUser` represents user data already available from your authentication system. If your app loads the user asynchronously, call `posthog.identify()` as soon as that data becomes available instead.
+
 ### 2. Use unique strings for distinct IDs
 
 <JSIdentifyUseUniqueIds/>

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -32,6 +32,8 @@ import IdentifyFrontendCallout from '../../_snippets/identify-frontend-callout.m
 
 <IdentifyFrontendCallout />
 
+If your app already knows the signed-in user when PostHog initializes, you can [call `identify` from the `loaded` callback](/docs/getting-started/identify-users#identify-users-when-the-web-sdk-loads) to identify them as soon as the web SDK loads.
+
 Once you've installed PostHog, see our [features doc](/docs/libraries/js/features) for more information about what you can do with it. You can also install the [PostHog VS Code extension](/docs/vscode-extension) to see live analytics, flag status, and session replay links inline in your code.
 
 ### Track across marketing website &amp; app


### PR DESCRIPTION
## Problem

Developers who already know the signed-in user when initializing the JavaScript web SDK can identify them from the `loaded` callback, but this approach is difficult to discover in the current identification guidance.

## Changes

- Document how to call `posthog.identify()` from the web SDK's `loaded` callback.
- Explain when to identify asynchronously loaded users instead.
- Link directly to this guidance from the JavaScript web SDK's **Identifying users** section.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
