### PR TITLE
docs: add Rust logs installation page

### DIFF
--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -37,7 +37,7 @@ You can find your project token in [Project Settings](https://app.posthog.com/se
 
 <Step title="Configure the SDK" badge="required">
 
-Set up the OpenTelemetry SDK to send logs to PostHog. This reads the token from the environment rather than hardcoding it, so the value stays out of your source tree.
+Set up the OpenTelemetry SDK to send logs to PostHog. This reads the token from the environment rather than embedding it in source, so the value stays out of your repository.
 
 ```rust
 use std::collections::HashMap;

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -56,7 +56,7 @@ fn init_logs() -> SdkLoggerProvider {
         .with_protocol(Protocol::HttpBinary)
         .with_headers(HashMap::from([(
             "Authorization".to_string(),
-            format!("Bearer {token}"),
+            format!("Bearer <ph_project_token>"),
         )]))
         .build()
         .expect("failed to build the OTLP log exporter");

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -14,10 +14,12 @@ import LogsNextSteps from './_snippets/logs-next-steps.mdx'
 ```bash
 cargo add opentelemetry opentelemetry_sdk opentelemetry-appender-tracing tracing
 cargo add tracing-subscriber --features env-filter
-cargo add opentelemetry-otlp --no-default-features --features logs,http-proto,reqwest-blocking-client,reqwest-rustls
+cargo add opentelemetry-otlp --features reqwest-rustls
 ```
 
-> **Important:** `opentelemetry-otlp` doesn't enable a TLS backend by default, so `reqwest-rustls` is required to reach an `https` endpoint. Without it, every export fails immediately with `HTTP export failed: network error`.
+> **Important:** `opentelemetry-otlp` enables no TLS backend by default, so `reqwest-rustls` is required to reach an `https` endpoint. Without it, every export fails immediately with `HTTP export failed: network error`.
+
+This guide targets `opentelemetry*` 0.32 and needs 0.28 or later. Earlier releases use `LoggerProvider` rather than `SdkLoggerProvider`, and a different `Resource` API.
 
 `opentelemetry-appender-tracing` bridges the [`tracing`](https://docs.rs/tracing) ecosystem into OpenTelemetry. If your application uses the [`log`](https://docs.rs/log) crate instead, swap it for `opentelemetry-appender-log`.
 
@@ -35,7 +37,7 @@ You can find your project token in [Project Settings](https://app.posthog.com/se
 
 <Step title="Configure the SDK" badge="required">
 
-Set up the OpenTelemetry SDK to send logs to PostHog.
+Set up the OpenTelemetry SDK to send logs to PostHog. This reads the token from the environment rather than hardcoding it, so the value stays out of your source tree.
 
 ```rust
 use std::collections::HashMap;
@@ -45,14 +47,16 @@ use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig, WithHttpConfig
 use opentelemetry_sdk::{logs::SdkLoggerProvider, Resource};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
-fn main() {
+fn init_logs() -> SdkLoggerProvider {
+    let token = std::env::var("POSTHOG_PROJECT_TOKEN").expect("POSTHOG_PROJECT_TOKEN not set");
+
     let exporter = LogExporter::builder()
         .with_http()
         .with_endpoint("<ph_client_api_host>/i/v1/logs")
         .with_protocol(Protocol::HttpBinary)
         .with_headers(HashMap::from([(
             "Authorization".to_string(),
-            "Bearer <ph_project_token>".to_string(),
+            format!("Bearer {token}"),
         )]))
         .build()
         .expect("failed to build the OTLP log exporter");
@@ -62,25 +66,45 @@ fn main() {
         .with_batch_exporter(exporter)
         .build();
 
-    // Without these directives the SDK exports its own diagnostics as log lines,
-    // which produce further diagnostics on the next export.
-    let filter = EnvFilter::new("info")
+    // hyper, h2, and reqwest don't propagate OpenTelemetry's suppression context, so
+    // their own logs would loop back through the exporter. opentelemetry=off keeps the
+    // SDK's diagnostics out of your PostHog log volume if you raise this above info.
+    let export_filter = EnvFilter::new("info")
         .add_directive("opentelemetry=off".parse().unwrap())
         .add_directive("hyper=off".parse().unwrap())
+        .add_directive("h2=off".parse().unwrap())
         .add_directive("reqwest=off".parse().unwrap());
 
     tracing_subscriber::registry()
-        .with(OpenTelemetryTracingBridge::new(&provider).with_filter(filter))
-        // Optional, also log to stdout
-        .with(tracing_subscriber::fmt::layer())
+        .with(OpenTelemetryTracingBridge::new(&provider).with_filter(export_filter))
+        // Export failures are only ever reported here, so keep this layer.
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap()),
+            ),
+        )
         .init();
+
+    provider
+}
+
+fn main() {
+    let provider = init_logs();
 
     tracing::info!("Service started");
 
-    // Batched logs are dropped if the process exits without flushing.
-    provider.shutdown().expect("failed to flush logs");
+    // ... run your application here ...
+
+    // Flush on graceful exit. Logs emitted after this are silently dropped.
+    if let Err(err) = provider.shutdown() {
+        eprintln!("failed to flush logs: {err}");
+    }
 }
 ```
+
+Keep `provider` alive for the lifetime of the process and call `shutdown()` only on graceful exit, not at the end of your setup function. Anything logged after `shutdown()` is dropped without an error.
+
+The service name is what you filter on in PostHog, so set it to something you'll recognize. To set it outside your application instead, drop `with_service_name()` and export the standard `OTEL_SERVICE_NAME` environment variable, which `Resource::builder()` picks up on its own.
 
 Alternatively, you can pass the project token as a query parameter instead of a header:
 
@@ -88,9 +112,11 @@ Alternatively, you can pass the project token as a query parameter instead of a 
 .with_endpoint("<ph_client_api_host>/i/v1/logs?token=<ph_project_token>")
 ```
 
-The service name is what you filter on in PostHog, so set it to something you'll recognize. To set it outside your application instead, drop `with_service_name()` and export the standard `OTEL_SERVICE_NAME` environment variable, which `Resource::builder()` picks up on its own.
+Prefer the header where you control the client. Tokens in a URL tend to end up in proxy and CDN access logs.
 
-> **Note:** Use the blocking `reqwest` client even in an async application. The batch log processor exports from its own dedicated thread, so the async client (the `reqwest-client` feature) panics there with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`.
+> **Note:** Use the blocking `reqwest` client even in an async application. The batch log processor exports from its own dedicated thread, so the async client (the `reqwest-client` feature) panics there with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`. Because Cargo unifies features across your dependency graph, and `reqwest-client` takes priority over `reqwest-blocking-client` when both are enabled, another crate turning on `reqwest-client` is enough to trigger this.
+
+> **Note:** On Tokio's current-thread runtime, don't call the blocking `shutdown()` from your main thread, as it can deadlock. Call it from a separate thread or via `tokio::task::spawn_blocking`.
 
 </Step>
 
@@ -104,9 +130,16 @@ tracing::warn!(endpoint = "/old-api", "Deprecated API used");
 tracing::error!(error = "Connection timeout", "Database connection failed");
 ```
 
-`tracing` levels map onto OpenTelemetry severities, so `info!`, `warn!`, and `error!` show up in PostHog as `info`, `warn`, and `error`.
+`tracing` levels map onto OpenTelemetry severities, so `info!`, `warn!`, and `error!` arrive with severity `info`, `warn`, and `error`. `debug!` and `trace!` are excluded by the `info` default in the filter above. Change it to `debug` if you want them in PostHog.
 
-To connect a log line to a person or a session replay, emit `posthogDistinctId` and `sessionId` as fields. See [linking logs to a person](/docs/logs/link-person) and [linking session replay](/docs/logs/link-session-replay).
+To connect a log line to a person or a session replay, emit `posthogDistinctId` and `sessionId` as fields:
+
+```rust
+// These keys are matched exactly. snake_case versions won't link.
+tracing::info!(posthogDistinctId = %user_id, sessionId = %session_id, "Checkout completed");
+```
+
+See [linking logs to a person](/docs/logs/link-person) and [linking session replay](/docs/logs/link-session-replay).
 
 </Step>
 
@@ -117,6 +150,8 @@ Once everything is configured, test that logs are flowing into PostHog:
 1. Send a test log from your application
 2. Check the PostHog Logs interface for your log entries
 3. Verify the logs appear in your project
+
+If nothing arrives, the `fmt` layer above is where the exporter reports itself. A working export logs `HttpClient.ExportStarted` followed by `HttpClient.ExportSucceeded`; a broken one logs `BatchLogProcessor.ExportError`. You can also see a `HttpLogsClient.ResponseParseError` about a Protobuf buffer underflow alongside a successful export, which is harmless: PostHog acknowledges the batch with a JSON body rather than a Protobuf one.
 
 <CallToAction type="primary" to="https://app.posthog.com/logs">
 View your logs in PostHog

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -1,0 +1,129 @@
+---
+title: Rust logs installation
+platformLogo: rust
+showStepsToc: true
+---
+
+import { Steps, Step } from 'components/Docs/Steps'
+import LogsNextSteps from './_snippets/logs-next-steps.mdx'
+
+<Steps>
+
+<Step title="Install OpenTelemetry packages" badge="required">
+
+```bash
+cargo add opentelemetry opentelemetry_sdk opentelemetry-appender-tracing tracing
+cargo add tracing-subscriber --features env-filter
+cargo add opentelemetry-otlp --no-default-features --features logs,http-proto,reqwest-blocking-client,reqwest-rustls
+```
+
+> **Important:** `opentelemetry-otlp` doesn't enable a TLS backend by default, so `reqwest-rustls` is required to reach an `https` endpoint. Without it, every export fails immediately with `HTTP export failed: network error`.
+
+`opentelemetry-appender-tracing` bridges the [`tracing`](https://docs.rs/tracing) ecosystem into OpenTelemetry. If your application uses the [`log`](https://docs.rs/log) crate instead, swap it for `opentelemetry-appender-log`.
+
+</Step>
+
+<Step title="Get your project token" badge="required">
+
+You'll need your PostHog project token to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
+
+> **Important:** Use your **project token** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project token in [Project Settings](https://app.posthog.com/settings).
+
+</Step>
+
+<Step title="Configure the SDK" badge="required">
+
+Set up the OpenTelemetry SDK to send logs to PostHog.
+
+```rust
+use std::collections::HashMap;
+
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::{logs::SdkLoggerProvider, Resource};
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+fn main() {
+    let exporter = LogExporter::builder()
+        .with_http()
+        .with_endpoint("<ph_client_api_host>/i/v1/logs")
+        .with_protocol(Protocol::HttpBinary)
+        .with_headers(HashMap::from([(
+            "Authorization".to_string(),
+            "Bearer <ph_project_token>".to_string(),
+        )]))
+        .build()
+        .expect("failed to build the OTLP log exporter");
+
+    let provider = SdkLoggerProvider::builder()
+        .with_resource(Resource::builder().with_service_name("my-service").build())
+        .with_batch_exporter(exporter)
+        .build();
+
+    // Without these directives the SDK exports its own diagnostics as log lines,
+    // which produce further diagnostics on the next export.
+    let filter = EnvFilter::new("info")
+        .add_directive("opentelemetry=off".parse().unwrap())
+        .add_directive("hyper=off".parse().unwrap())
+        .add_directive("reqwest=off".parse().unwrap());
+
+    tracing_subscriber::registry()
+        .with(OpenTelemetryTracingBridge::new(&provider).with_filter(filter))
+        // Optional, also log to stdout
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    tracing::info!("Service started");
+
+    // Batched logs are dropped if the process exits without flushing.
+    provider.shutdown().expect("failed to flush logs");
+}
+```
+
+Alternatively, you can pass the project token as a query parameter instead of a header:
+
+```rust
+.with_endpoint("<ph_client_api_host>/i/v1/logs?token=<ph_project_token>")
+```
+
+The service name is what you filter on in PostHog, so set it to something you'll recognize. To set it outside your application instead, drop `with_service_name()` and export the standard `OTEL_SERVICE_NAME` environment variable, which `Resource::builder()` picks up on its own.
+
+> **Note:** Use the blocking `reqwest` client even in an async application. The batch log processor exports from its own dedicated thread, so the async client (the `reqwest-client` feature) panics there with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`.
+
+</Step>
+
+<Step title="Use OpenTelemetry logging" badge="required">
+
+Once the subscriber is installed, ordinary `tracing` macros flow to PostHog. The message becomes the log body, and structured fields become searchable attributes:
+
+```rust
+tracing::info!(user_id = "123", action = "login", "User action");
+tracing::warn!(endpoint = "/old-api", "Deprecated API used");
+tracing::error!(error = "Connection timeout", "Database connection failed");
+```
+
+`tracing` levels map onto OpenTelemetry severities, so `info!`, `warn!`, and `error!` show up in PostHog as `info`, `warn`, and `error`.
+
+To connect a log line to a person or a session replay, emit `posthogDistinctId` and `sessionId` as fields. See [linking logs to a person](/docs/logs/link-person) and [linking session replay](/docs/logs/link-session-replay).
+
+</Step>
+
+<Step title="Test your setup" badge="recommended">
+
+Once everything is configured, test that logs are flowing into PostHog:
+
+1. Send a test log from your application
+2. Check the PostHog Logs interface for your log entries
+3. Verify the logs appear in your project
+
+<CallToAction type="primary" to="https://app.posthog.com/logs">
+View your logs in PostHog
+</CallToAction>
+
+</Step>
+
+<LogsNextSteps />
+
+</Steps>

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -19,9 +19,7 @@ cargo add opentelemetry-otlp --features reqwest-rustls
 
 > **Important:** `opentelemetry-otlp` enables no TLS backend by default, so `reqwest-rustls` is required to reach an `https` endpoint. Without it, every export fails immediately with `HTTP export failed: network error`.
 
-This guide targets `opentelemetry*` 0.32 and needs 0.28 or later. Earlier releases use `LoggerProvider` rather than `SdkLoggerProvider`, and a different `Resource` API.
-
-`opentelemetry-appender-tracing` bridges the [`tracing`](https://docs.rs/tracing) ecosystem into OpenTelemetry. If your application uses the [`log`](https://docs.rs/log) crate instead, swap it for `opentelemetry-appender-log`.
+This guide targets `opentelemetry*` 0.32 and needs 0.28 or later. `opentelemetry-appender-tracing` bridges the [`tracing`](https://docs.rs/tracing) ecosystem into OpenTelemetry. If your application uses the [`log`](https://docs.rs/log) crate, swap it for `opentelemetry-appender-log`.
 
 </Step>
 
@@ -37,7 +35,7 @@ You can find your project token in [Project Settings](https://app.posthog.com/se
 
 <Step title="Configure the SDK" badge="required">
 
-Set up the OpenTelemetry SDK to send logs to PostHog. This reads the token from the environment rather than embedding it in source, so the value stays out of your repository.
+Set up the OpenTelemetry SDK to send logs to PostHog.
 
 ```rust
 use std::collections::HashMap;
@@ -66,9 +64,8 @@ fn init_logs() -> SdkLoggerProvider {
         .with_batch_exporter(exporter)
         .build();
 
-    // hyper, h2, and reqwest don't propagate OpenTelemetry's suppression context, so
-    // their own logs would loop back through the exporter. opentelemetry=off keeps the
-    // SDK's diagnostics out of your PostHog log volume if you raise this above info.
+    // The transport crates log through tracing too, so their output would loop
+    // back through the exporter.
     let export_filter = EnvFilter::new("info")
         .add_directive("opentelemetry=off".parse().unwrap())
         .add_directive("hyper=off".parse().unwrap())
@@ -77,7 +74,7 @@ fn init_logs() -> SdkLoggerProvider {
 
     tracing_subscriber::registry()
         .with(OpenTelemetryTracingBridge::new(&provider).with_filter(export_filter))
-        // Export failures are only ever reported here, so keep this layer.
+        // Export failures are only reported here, so keep this layer.
         .with(
             tracing_subscriber::fmt::layer().with_filter(
                 EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap()),
@@ -95,51 +92,41 @@ fn main() {
 
     // ... run your application here ...
 
-    // Flush on graceful exit. Logs emitted after this are silently dropped.
+    // Flush on graceful exit. Logs emitted after this are dropped.
     if let Err(err) = provider.shutdown() {
         eprintln!("failed to flush logs: {err}");
     }
 }
 ```
 
-Keep `provider` alive for the lifetime of the process and call `shutdown()` only on graceful exit, not at the end of your setup function. Anything logged after `shutdown()` is dropped without an error.
+Keep `provider` alive for the lifetime of the process. On Tokio's current-thread runtime, call the blocking `shutdown()` from `tokio::task::spawn_blocking` rather than your main thread, which can deadlock.
 
-The service name is what you filter on in PostHog, so set it to something you'll recognize. To set it outside your application instead, drop `with_service_name()` and export the standard `OTEL_SERVICE_NAME` environment variable, which `Resource::builder()` picks up on its own.
+The service name is what you filter on in PostHog. To set it outside your application, drop `with_service_name()` and export `OTEL_SERVICE_NAME`, which `Resource::builder()` picks up on its own.
 
-Alternatively, you can pass the project token as a query parameter instead of a header:
+Alternatively, you can pass the project token as a query parameter, though it will show up in proxy and CDN access logs:
 
 ```rust
 .with_endpoint("<ph_client_api_host>/i/v1/logs?token=<ph_project_token>")
 ```
 
-Prefer the header where you control the client. Tokens in a URL tend to end up in proxy and CDN access logs.
-
-> **Note:** Use the blocking `reqwest` client even in an async application. The batch log processor exports from its own dedicated thread, so the async client (the `reqwest-client` feature) panics there with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`. Because Cargo unifies features across your dependency graph, and `reqwest-client` takes priority over `reqwest-blocking-client` when both are enabled, another crate turning on `reqwest-client` is enough to trigger this.
-
-> **Note:** On Tokio's current-thread runtime, don't call the blocking `shutdown()` from your main thread, as it can deadlock. Call it from a separate thread or via `tokio::task::spawn_blocking`.
+> **Note:** Use the blocking `reqwest` client even in an async application. The batch log processor exports from its own dedicated thread, so the async `reqwest-client` feature panics there with `there is no reactor running`.
 
 </Step>
 
 <Step title="Use OpenTelemetry logging" badge="required">
 
-Once the subscriber is installed, ordinary `tracing` macros flow to PostHog. The message becomes the log body, and structured fields become searchable attributes:
+Now you can start logging with OpenTelemetry. The message becomes the log body, and structured fields become searchable attributes:
 
 ```rust
 tracing::info!(user_id = "123", action = "login", "User action");
 tracing::warn!(endpoint = "/old-api", "Deprecated API used");
 tracing::error!(error = "Connection timeout", "Database connection failed");
-```
 
-`tracing` levels map onto OpenTelemetry severities, so `info!`, `warn!`, and `error!` arrive with severity `info`, `warn`, and `error`. `debug!` and `trace!` are excluded by the `info` default in the filter above. Change it to `debug` if you want them in PostHog.
-
-To connect a log line to a person or a session replay, emit `posthogDistinctId` and `sessionId` as fields:
-
-```rust
 // These keys are matched exactly. snake_case versions won't link.
 tracing::info!(posthogDistinctId = %user_id, sessionId = %session_id, "Checkout completed");
 ```
 
-See [linking logs to a person](/docs/logs/link-person) and [linking session replay](/docs/logs/link-session-replay).
+`debug!` and `trace!` are excluded by the `info` default in the filter above. Change it to `debug` if you want them in PostHog.
 
 </Step>
 
@@ -151,7 +138,7 @@ Once everything is configured, test that logs are flowing into PostHog:
 2. Check the PostHog Logs interface for your log entries
 3. Verify the logs appear in your project
 
-If nothing arrives, the `fmt` layer above is where the exporter reports itself. A working export logs `HttpClient.ExportStarted` followed by `HttpClient.ExportSucceeded`; a broken one logs `BatchLogProcessor.ExportError`. You can also see a `HttpLogsClient.ResponseParseError` about a Protobuf buffer underflow alongside a successful export, which is harmless: PostHog acknowledges the batch with a JSON body rather than a Protobuf one.
+If nothing arrives, check stdout. A working export logs `HttpClient.ExportSucceeded`, and a broken one logs `BatchLogProcessor.ExportError`.
 
 <CallToAction type="primary" to="https://app.posthog.com/logs">
 View your logs in PostHog

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -19,7 +19,7 @@ cargo add opentelemetry-otlp --features reqwest-rustls
 
 > **Important:** `opentelemetry-otlp` enables no TLS backend by default, so `reqwest-rustls` is required to reach an `https` endpoint. Without it, every export fails immediately with `HTTP export failed: network error`.
 
-This guide targets `opentelemetry*` 0.32 and needs 0.28 or later. `opentelemetry-appender-tracing` bridges the [`tracing`](https://docs.rs/tracing) ecosystem into OpenTelemetry. If your application uses the [`log`](https://docs.rs/log) crate, swap it for `opentelemetry-appender-log`.
+This guide targets `opentelemetry*` 0.32 and needs 0.28 or later. If your application uses the [`log`](https://docs.rs/log) crate rather than [`tracing`](https://docs.rs/tracing), swap `opentelemetry-appender-tracing` for `opentelemetry-appender-log`.
 
 </Step>
 
@@ -48,6 +48,8 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 fn init_logs() -> SdkLoggerProvider {
     let token = std::env::var("POSTHOG_PROJECT_TOKEN").expect("POSTHOG_PROJECT_TOKEN not set");
 
+    // use the blocking client even in an async app, the batch processor exports from
+    // its own thread and the async reqwest-client feature panics there
     let exporter = LogExporter::builder()
         .with_http()
         .with_endpoint("<ph_client_api_host>/i/v1/logs")
@@ -59,13 +61,13 @@ fn init_logs() -> SdkLoggerProvider {
         .build()
         .expect("failed to build the OTLP log exporter");
 
+    // you could also set the service name outside your application, with OTEL_SERVICE_NAME
     let provider = SdkLoggerProvider::builder()
         .with_resource(Resource::builder().with_service_name("my-service").build())
         .with_batch_exporter(exporter)
         .build();
 
-    // The transport crates log through tracing too, so their output would loop
-    // back through the exporter.
+    // the transport crates log through tracing too, so their output would loop back
     let export_filter = EnvFilter::new("info")
         .add_directive("opentelemetry=off".parse().unwrap())
         .add_directive("hyper=off".parse().unwrap())
@@ -74,7 +76,7 @@ fn init_logs() -> SdkLoggerProvider {
 
     tracing_subscriber::registry()
         .with(OpenTelemetryTracingBridge::new(&provider).with_filter(export_filter))
-        // Export failures are only reported here, so keep this layer.
+        // export failures are only reported here, so keep this layer
         .with(
             tracing_subscriber::fmt::layer().with_filter(
                 EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap()),
@@ -86,30 +88,24 @@ fn init_logs() -> SdkLoggerProvider {
 }
 
 fn main() {
+    // keep the provider alive for the lifetime of the process
     let provider = init_logs();
 
-    tracing::info!("Service started");
+    tracing::info!("this is a log line");
 
-    // ... run your application here ...
-
-    // Flush on graceful exit. Logs emitted after this are dropped.
+    // flush on graceful exit, logs emitted after this are dropped. on tokio's
+    // current-thread runtime call this from spawn_blocking, it can deadlock
     if let Err(err) = provider.shutdown() {
         eprintln!("failed to flush logs: {err}");
     }
 }
 ```
 
-Keep `provider` alive for the lifetime of the process. On Tokio's current-thread runtime, call the blocking `shutdown()` from `tokio::task::spawn_blocking` rather than your main thread, which can deadlock.
-
-The service name is what you filter on in PostHog. To set it outside your application, drop `with_service_name()` and export `OTEL_SERVICE_NAME`, which `Resource::builder()` picks up on its own.
-
-Alternatively, you can pass the project token as a query parameter, though it will show up in proxy and CDN access logs:
+Alternatively, you can pass the project token as a query parameter by modifying the URL path, though it will then appear in proxy and CDN access logs:
 
 ```rust
 .with_endpoint("<ph_client_api_host>/i/v1/logs?token=<ph_project_token>")
 ```
-
-> **Note:** Use the blocking `reqwest` client even in an async application. The batch log processor exports from its own dedicated thread, so the async `reqwest-client` feature panics there with `there is no reactor running`.
 
 </Step>
 
@@ -118,15 +114,14 @@ Alternatively, you can pass the project token as a query parameter, though it wi
 Now you can start logging with OpenTelemetry. The message becomes the log body, and structured fields become searchable attributes:
 
 ```rust
+// debug! and trace! are excluded by the info filter above
 tracing::info!(user_id = "123", action = "login", "User action");
 tracing::warn!(endpoint = "/old-api", "Deprecated API used");
 tracing::error!(error = "Connection timeout", "Database connection failed");
 
-// These keys are matched exactly. snake_case versions won't link.
+// these keys are matched exactly, snake_case versions won't link
 tracing::info!(posthogDistinctId = %user_id, sessionId = %session_id, "Checkout completed");
 ```
-
-`debug!` and `trace!` are excluded by the `info` default in the filter above. Change it to `debug` if you want them in PostHog.
 
 </Step>
 
@@ -137,8 +132,6 @@ Once everything is configured, test that logs are flowing into PostHog:
 1. Send a test log from your application
 2. Check the PostHog Logs interface for your log entries
 3. Verify the logs appear in your project
-
-If nothing arrives, check stdout. A working export logs `HttpClient.ExportSucceeded`, and a broken one logs `BatchLogProcessor.ExportError`.
 
 <CallToAction type="primary" to="https://app.posthog.com/logs">
 View your logs in PostHog

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -46,8 +46,6 @@ use opentelemetry_sdk::{logs::SdkLoggerProvider, Resource};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 fn init_logs() -> SdkLoggerProvider {
-    let token = std::env::var("POSTHOG_PROJECT_TOKEN").expect("POSTHOG_PROJECT_TOKEN not set");
-
     // use the blocking client even in an async app, the batch processor exports from
     // its own thread and the async reqwest-client feature panics there
     let exporter = LogExporter::builder()
@@ -56,7 +54,7 @@ fn init_logs() -> SdkLoggerProvider {
         .with_protocol(Protocol::HttpBinary)
         .with_headers(HashMap::from([(
             "Authorization".to_string(),
-            format!("Bearer <ph_project_token>"),
+            "Bearer <ph_project_token>".to_string(),
         )]))
         .build()
         .expect("failed to build the OTLP log exporter");

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7152,6 +7152,7 @@ export const docsMenu = {
                         { name: 'Python', url: '/docs/logs/installation/python' },
                         { name: 'Go', url: '/docs/logs/installation/go' },
                         { name: 'Java', url: '/docs/logs/installation/java' },
+                        { name: 'Rust', url: '/docs/logs/installation/rust' },
                         { name: 'Next.js', url: '/docs/logs/installation/nextjs' },
                         { name: 'JavaScript (web)', url: '/docs/logs/installation/javascript' },
                         { name: 'React Native', url: '/docs/logs/installation/react-native' },


### PR DESCRIPTION
## Changes

Adds a Rust page to Logs installation, plus its sidebar nav entry.

PostHog Logs ingestion is OpenTelemetry-only, so Rust already worked before this PR. What was missing was the page: `contents/docs/logs/installation/` had 11 language pages and zero mentions of Rust, and the platform tile grid on `/docs/logs/installation` is generated from that directory. A Rust user landed there, saw no Rust tile, clicked through to "Other languages", and got "find the OpenTelemetry SDK for your language in the registry" with no snippet.

Prompted by an SDK feedback survey response asking for Logs for Rust so they could instrument their backend more easily.

The page follows the same Steps structure as the Go and Python pages. Things it documents that aren't obvious and cost me a while to work out:

- `opentelemetry-otlp` enables no TLS backend by default. Without the `reqwest-rustls` feature, every export to an `https` endpoint fails instantly with `HTTP export failed: network error`.
- The async `reqwest-client` feature panics with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`, because the batch log processor exports from its own dedicated thread. Use the blocking client even in a Tokio app. Cargo feature unification makes this a live footgun: `reqwest-client` takes priority over `reqwest-blocking-client`, so any other crate in the graph enabling it is enough to break the exporter.
- The `posthogDistinctId` person-linking key is matched exactly. Rust readers are the most likely of any language on this nav list to snake_case it on reflex and silently lose linking, so the page shows it inline with a warning.
- The ingestion endpoint acknowledges batches with a JSON `{}` body rather than a Protobuf `ExportLogsServiceResponse`, so the OTel client logs a `HttpLogsClient.ResponseParseError` buffer underflow at debug alongside every *successful* export. Documented as harmless so it doesn't read as a failure. Happy to raise that separately if we'd rather the endpoint returned Protobuf.

## How I tested this

Built and ran the page's exact commands and code against a test project on Rust 1.90.0, then iterated on what the runs showed:

- The `cargo add` commands were run in a fresh crate and produce the intended `Cargo.toml`. The snippet compiles warning-free.
- Log lines arrived with the expected bodies, severities (`info`/`warn`/`error` mapping to OpenTelemetry 9/13/17), structured fields as searchable attributes, `posthogDistinctId` preserved as-is, and `service.name` driving the service filter.
- Verified the `OTEL_SERVICE_NAME` alternative resolves when `with_service_name()` is omitted.
- Ran the bridge filter both with and without the `opentelemetry` directive at both `info` and `debug` levels to establish what each part actually does. At `debug` without it, the SDK's own `LoggerProvider.ShutdownInvokedByUser` gets exported into your log volume; with it, only application lines are. That's why the directive is there.
- Confirmed the TLS failure mode and the exact error string by removing the feature and running it.

MDX compile-checked against the same `@mdx-js/mdx@1.6.22` the site builds with, using `go.mdx` as a control, since Gatsby silently skips MDX files with syntax errors.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the [deploy preview](https://ed4966d0.posthog-preview.pages.dev/docs/logs/installation/rust) (renders correctly, Rust appears in the sidebar between Java and Next.js, and the `<ph_client_api_host>` placeholder substitutes as expected)
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, new page only)

