### PR TITLE
Rename Brand foundations page title to "Overview"

### DIFF
--- a/contents/handbook/brand/foundations.md
+++ b/contents/handbook/brand/foundations.md
@@ -1,5 +1,5 @@
 ---
-title: Brand foundations
+title: Overview
 sidebar: Handbook
 showTitle: true
 ---

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -529,7 +529,7 @@ export const handbookSidebar = [
                 name: 'Brandbook',
             },
             {
-                name: 'Brand foundations',
+                name: 'Overview',
                 url: '/handbook/brand/foundations',
             },
             {


### PR DESCRIPTION
## Changes

Updates the `/handbook/brand/foundations` page title from "Brand foundations" to "Overview", both in the page frontmatter and in the handbook sidebar nav (`src/navs/index.js`). The URL is unchanged, so no redirect is needed.

**Why:** Requested via Slack to have this page read as "Overview" in the title and sidebar.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AR8V7V1D4/p1785251287645249)*
