### PR TITLE
Add changelog CTA to release-notes blog tag page

### DIFF
--- a/src/components/ChangelogCTA/index.tsx
+++ b/src/components/ChangelogCTA/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { CallToAction } from 'components/CallToAction'
+
+export default function ChangelogCTA(): JSX.Element {
+    return (
+        <div className="p-6 md:p-8 border border-primary bg-accent rounded mb-8 mt-2">
+            <p className="font-semibold mb-1 opacity-75">Release notes have moved</p>
+            <h3 className="text-2xl mt-0 mb-4">
+                Looking for the latest updates? Check the <span className="text-red dark:text-yellow">changelog</span>.
+            </h3>
+            <p className="mb-6 text-[15px] opacity-75">
+                We don't publish release notes on the blog anymore. The changelog has the most up-to-date list of
+                everything new we've shipped in PostHog.
+            </p>
+            <CallToAction to="/changelog" type="primary" size="sm">
+                View the changelog
+            </CallToAction>
+        </div>
+    )
+}

--- a/src/templates/BlogTag.tsx
+++ b/src/templates/BlogTag.tsx
@@ -7,6 +7,7 @@ import { Posts, PostToggle } from 'components/Blog'
 import Pagination from 'components/Pagination'
 import { NewsletterForm } from 'components/NewsletterForm'
 import CommunityCTA from 'components/CommunityCTA'
+import ChangelogCTA from 'components/ChangelogCTA'
 import { companyMenu } from '../navs'
 
 const BlogTag = ({
@@ -14,7 +15,7 @@ const BlogTag = ({
         allPostsRecent: { edges: allPostsRecent },
         allPostsPopular: { edges: allPostsPopular },
     },
-    pageContext: { tag, numPages, currentPage, base },
+    pageContext: { tag, slug, numPages, currentPage, base },
 }) => {
     const [allPostsFilter, setAllPostsFilter] = useState<'latest' | 'popular'>('latest')
     const handleToggleChange = (checked: boolean) => {
@@ -34,6 +35,7 @@ const BlogTag = ({
             <SEO title={`${tag} - PostHog`} />
 
             <PostLayout article={false} title="Blog" hideSidebar hideSurvey>
+                {slug === 'release-notes' && <ChangelogCTA />}
                 <Posts
                     titleBorder
                     title={tag}


### PR DESCRIPTION
## Changes

The [release-notes tag page](https://posthog.com/blog/tags/release-notes) now shows a CTA directing visitors to the [changelog](https://posthog.com/changelog), since we no longer publish release notes on the blog and the changelog is the most up-to-date source.

- New `ChangelogCTA` component, modeled on the existing `StartupsCTA`
- Rendered in `BlogTag.tsx` only when the tag slug is `release-notes` (same conditional pattern as `StartupsCTA` on the startups category page)

**Why:** Release notes are no longer published on the blog, so visitors landing on that tag page should be pointed to the changelog instead.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1785252572218599)*