### PR TITLE
Fix seven more newsletter heroes broken by Cloudinary URL prefixes

### DIFF
--- a/contents/newsletter/engineers-do-support.md
+++ b/contents/newsletter/engineers-do-support.md
@@ -4,7 +4,7 @@ date: 2024-08-29
 author:
  - ian-vanagas
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1713888662/posthog.com/contents/images/newsletter/talk-to-users/talk-to-users-big.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/newsletter/talk-to-users/talk-to-users-big.png
 featuredImageType: full
 tags:
   - Engineering

--- a/contents/newsletter/first-time-founders.md
+++ b/contents/newsletter/first-time-founders.md
@@ -4,7 +4,7 @@ date: 2024-04-19
 author:
   - andy-vandervell
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1713521535/posthog.com/contents/blog/evolution-of-founders.jpg
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/blog/evolution-of-founders.jpg
 featuredImageType: full
 tags:
   - Founders

--- a/contents/newsletter/inside-bolt-dot-new.md
+++ b/contents/newsletter/inside-bolt-dot-new.md
@@ -4,7 +4,7 @@ date: 2025-09-16
 author:
   - lior-neu-ner
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/bolt_c70d0ec00f.jpg
+  https://res.cloudinary.com/dmukukwp6/image/upload/bolt_c70d0ec00f.jpg
 featuredImageType: full
 tags:
   - Product

--- a/contents/newsletter/misconceptions-about-analytics.md
+++ b/contents/newsletter/misconceptions-about-analytics.md
@@ -4,7 +4,7 @@ date: 2024-03-11
 author:
   - ian-vanagas
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1711412696/posthog.com/contents/images/blog/misconceptions-about-analytics/analytics.webp
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/misconceptions-about-analytics/analytics.webp
 featuredImageType: full
 tags:
   - Product engineers

--- a/contents/newsletter/pivot-your-startup.md
+++ b/contents/newsletter/pivot-your-startup.md
@@ -4,7 +4,7 @@ date: 2024-03-25
 author:
   - james-temperton
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1710126230/posthog.com/contents/images/blog/story-about-pivots.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/story-about-pivots.png
 featuredImageType: full
 tags:
   - Product-market fit

--- a/contents/newsletter/remote-working.md
+++ b/contents/newsletter/remote-working.md
@@ -4,7 +4,7 @@ date: 2024-05-16
 author:
   - james-temperton
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1711656184/posthog.com/contents/images/newsletter/remote-work/remote_hog.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/newsletter/remote-work/remote_hog.png
 featuredImageType: full
 tags:
   - Culture

--- a/contents/newsletter/talk-to-users.md
+++ b/contents/newsletter/talk-to-users.md
@@ -4,7 +4,7 @@ date: 2024-04-25
 author:
   - ian-vanagas
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1713888662/posthog.com/contents/images/newsletter/talk-to-users/talk-to-users-big.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/newsletter/talk-to-users/talk-to-users-big.png
 featuredImageType: full
 tags:
   - Engineering


### PR DESCRIPTION
## Changes

Seven newsletters are rendering with no hero image on the live site. Each one's `featuredImage` URL carries a prefix between `/upload/` and the filename — six a version segment, one a pair of transformation params:

| Newsletter | Prefix |
|---|---|
| [engineers-do-support](https://posthog.com/newsletter/engineers-do-support) | `v1713888662/` |
| [first-time-founders](https://posthog.com/newsletter/first-time-founders) | `v1713521535/` |
| [misconceptions-about-analytics](https://posthog.com/newsletter/misconceptions-about-analytics) | `v1711412696/` |
| [pivot-your-startup](https://posthog.com/newsletter/pivot-your-startup) | `v1710126230/` |
| [remote-working](https://posthog.com/newsletter/remote-working) | `v1711656184/` |
| [talk-to-users](https://posthog.com/newsletter/talk-to-users) | `v1713888662/` |
| [inside-bolt-dot-new](https://posthog.com/newsletter/inside-bolt-dot-new) | `q_auto,f_auto/` |

`getPublicID` (`gatsby/onCreateNode.ts`) derives the Cloudinary public ID by taking everything after `/upload/`, so the prefix ends up baked into the ID. That misses the metadata cache, `gatsbyImageData` resolves to `null`, and `ReaderView` renders an empty `<GatsbyImage>` — silently, because `featuredImage` is still truthy and there is no `publicURL` fallback.

This is the same root cause as #18799, which fixed the three newsletters the `post-newsletter` skill had produced. These seven predate that work and were outside its scope.

**Why:** seven newsletter pages have been publishing without their hero image.

Only the prefix is removed. No new uploads — every image already exists in Cloudinary and each shortened URL returns 200. Folder paths inside the public ID are kept, which is the shape working newsletters already use (e.g. `beyond-the-10x-engineer` renders fine with `posthog.com/contents/images/...`). Body images are untouched; they are plain `<img>` tags and render either way.

### Verifying

A working hero emits its filename ~14 times into the HTML (one per responsive `srcset` entry). Before this change all seven emit zero. Worth spot-checking a couple in the preview against [code-review-tips](https://posthog.com/newsletter/code-review-tips), which is already correct.

### One thing to decide separately

`engineers-do-support` and `talk-to-users` point at the same image (`talk-to-users-big.png`). Correct for the latter; likely a copy-paste on the former. This PR only makes it render — swapping in a distinct image is a content call, not a build fix.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` — n/a, no pages moved

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*