### PR TITLE
feat: add Eve AI observability installation guide

### DIFF
--- a/contents/docs/ai-observability/installation/eve.mdx
+++ b/contents/docs/ai-observability/installation/eve.mdx
@@ -1,0 +1,43 @@
+---
+title: Eve AI observability installation
+platformLabel: Eve
+platformLogo: vercel
+showStepsToc: true
+tableOfContents: [
+    {
+        url: 'install-dependencies',
+        value: 'Install dependencies',
+        depth: 1,
+    },
+    {
+        url: 'set-environment-variables',
+        value: 'Set environment variables',
+        depth: 1,
+    },
+    {
+        url: 'add-eve-instrumentation',
+        value: 'Add Eve instrumentation',
+        depth: 1,
+    },
+    {
+        url: 'verify-traces-and-generations',
+        value: 'Verify traces and generations',
+        depth: 1,
+    },
+]
+---
+
+<!--
+This page imports shared onboarding content from the main PostHog repo.
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/eve.tsx
+See the docs runbook for more info: https://posthog.com/handbook/wizard-and-docs/onboarding-docs
+-->
+
+import { EveInstallation } from 'onboarding/ai-observability/eve.tsx'
+import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
+import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
+import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
+
+<OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
+    <EveInstallation modifySteps={addNextStepsStep} />
+</OnboardingContentWrapper>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6129,6 +6129,11 @@ export const docsMenu = {
                             platformLogo: 'vercel',
                         },
                         {
+                            name: 'Eve',
+                            url: '/docs/ai-observability/installation/eve',
+                            platformLogo: 'vercel',
+                        },
+                        {
                             name: 'LangChain',
                             url: '/docs/ai-observability/installation/langchain',
                             icon: 'IconLangChain',


### PR DESCRIPTION
## Changes

- Adds the public Eve AI observability installation page using the shared onboarding content from [PostHog/posthog#74229](https://github.com/PostHog/posthog/pull/74229).
- Adds Eve to the AI Observability installation navigation and platform picker.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Internal links use relative URLs
- [ ] I've checked the page in the preview build
- [x] No page was moved, so no redirect is needed
