### PR TITLE
docs(error-tracking): name surfaces as PostHog Web, PostHog MCP, PostHog CLI

### DIFF
--- a/contents/docs/error-tracking/index.mdx
+++ b/contents/docs/error-tracking/index.mdx
@@ -20,11 +20,11 @@ You triage and resolve issues in the PostHog web app. The other surfaces let you
 
 <SurfaceCards columns={2}>
 
-<SurfaceCard icon="IconLaptop" color="blue" title="Web app" url="/docs/error-tracking/monitoring" cta="Monitor issues">
+<SurfaceCard icon="IconLaptop" color="blue" title="PostHog Web" url="/docs/error-tracking/monitoring" cta="Monitor issues">
 Monitor, assign, and resolve issues, each with the affected user's replay and events in view.
 </SurfaceCard>
 
-<SurfaceCard icon="IconMagic" color="purple" title="MCP" url="/docs/error-tracking/surfaces/mcp" cta="Debug over MCP">
+<SurfaceCard icon="IconMagic" color="purple" title="PostHog MCP" url="/docs/error-tracking/surfaces/mcp" cta="Debug over PostHog MCP">
 Pull up issues and stack traces and debug them from any MCP client or AI agent.
 </SurfaceCard>
 
@@ -32,7 +32,7 @@ Pull up issues and stack traces and debug them from any MCP client or AI agent.
 Review and merge the Self-driving fixes opened from your recurring issues.
 </SurfaceCard>
 
-<SurfaceCard icon="IconTerminal" color="seagreen" title="CLI" url="/docs/error-tracking/surfaces/cli" cta="Upload symbols">
+<SurfaceCard icon="IconTerminal" color="seagreen" title="PostHog CLI" url="/docs/error-tracking/surfaces/cli" cta="Upload symbols">
 Upload source maps and debug symbols from your build so stack traces stay readable.
 </SurfaceCard>
 

--- a/contents/docs/error-tracking/surfaces/cli.mdx
+++ b/contents/docs/error-tracking/surfaces/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Error Tracking from the CLI
+title: Use Error Tracking from PostHog CLI
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/error-tracking/surfaces/desktop.mdx
+++ b/contents/docs/error-tracking/surfaces/desktop.mdx
@@ -24,5 +24,5 @@ Reports don't come looking for you – they queue up in the [Self-driving inbox]
 
 ## Related
 
-- [Debug over MCP](/docs/error-tracking/surfaces/mcp) – pull issues and stack traces into any MCP client or AI agent.
+- [Debug over PostHog MCP](/docs/error-tracking/surfaces/mcp) – pull issues and stack traces into any MCP client or AI agent.
 - [How Self-driving works](/docs/self-driving) – the full report-to-merge loop.

--- a/contents/docs/error-tracking/surfaces/mcp.mdx
+++ b/contents/docs/error-tracking/surfaces/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Error Tracking over MCP
+title: Use Error Tracking over PostHog MCP
 ---
 
 The [PostHog MCP server](/docs/model-context-protocol) exposes function calling tools to any MCP client, enabling AI agents to interact with PostHog's API via the MCP protocol.

--- a/contents/docs/error-tracking/surfaces/web-app.mdx
+++ b/contents/docs/error-tracking/surfaces/web-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: Error tracking in the web app
+title: Error tracking in PostHog Web
 sidebar: Docs
 showTitle: true
 ---

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5369,7 +5369,7 @@ export const docsMenu = {
                     name: 'Surfaces',
                 },
                 {
-                    name: 'Web app',
+                    name: 'PostHog Web',
                     url: '/docs/error-tracking/surfaces/web-app',
                     icon: 'IconLaptop',
                     color: 'seagreen',
@@ -5406,7 +5406,7 @@ export const docsMenu = {
                     ],
                 },
                 {
-                    name: 'MCP',
+                    name: 'PostHog MCP',
                     url: '/docs/error-tracking/surfaces/mcp',
                     icon: 'IconLlmPromptEvaluation',
                     color: 'green',
@@ -5420,7 +5420,7 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
-                    name: 'CLI',
+                    name: 'PostHog CLI',
                     url: '/docs/error-tracking/surfaces/cli',
                     icon: 'IconTerminal',
                     color: 'seagreen',


### PR DESCRIPTION
Follow-up to the docs IA migration. Both IA PRs merged before the surface naming convention was settled, so this brings them in line with the rest of the batch.

## What changed

Surface labels now match the product naming used in the PostHog nav:

| Was | Now |
| --- | --- |
| Web app | **PostHog Web** |
| MCP | **PostHog MCP** |
| CLI | **PostHog CLI** |
| Desktop | **PostHog Desktop** (already correct) |
| API | **API** – deliberately unchanged |

Applied to the **sidebar, overview cards, and CTAs** only. Body prose is untouched, and generic references like "any MCP client" are left alone since those mean the protocol, not PostHog's server.

## Blast radius

Nav changes are scoped to this tool's block. **No URLs change and no pages move**, so no redirects are needed – this is label text only.

One deliberate exception: the `CLI` entry under **Upload source maps** keeps its name. It sits alongside Vite, Webpack, and Next.js as an upload method rather than a surface, so renaming it would break that parallel list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
