### PR TITLE
docs(mcp-analytics): name surfaces as PostHog Web, PostHog MCP, PostHog CLI

### DIFF
--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -29,11 +29,11 @@ You explore MCP usage in the PostHog web app. The other surfaces let you query t
 
 <SurfaceCards columns={2}>
 
-<SurfaceCard icon="IconLaptop" color="blue" title="Web app" badge="Beta" url="/docs/mcp-analytics/surfaces/web-app" cta="Explore MCP usage">
+<SurfaceCard icon="IconLaptop" color="blue" title="PostHog Web" badge="Beta" url="/docs/mcp-analytics/surfaces/web-app" cta="Explore MCP usage">
 Dashboards, session replay for agents, per-tool quality, and intent clustering.
 </SurfaceCard>
 
-<SurfaceCard icon="IconPlug" color="purple" title="MCP" url="/docs/mcp-analytics/surfaces/mcp" cta="Query over MCP">
+<SurfaceCard icon="IconPlug" color="purple" title="PostHog MCP" url="/docs/mcp-analytics/surfaces/mcp" cta="Query over PostHog MCP">
 Query sessions, tool stats, failures, and intent clusters from any MCP client.
 </SurfaceCard>
 

--- a/contents/docs/mcp-analytics/surfaces/mcp.mdx
+++ b/contents/docs/mcp-analytics/surfaces/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Query MCP Analytics over MCP
+title: Query MCP Analytics over PostHog MCP
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: MCP Analytics in the web app
+title: MCP Analytics in PostHog Web
 sidebar: Docs
 showTitle: true
 ---

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6653,14 +6653,14 @@ export const docsMenu = {
                     name: 'Surfaces',
                 },
                 {
-                    name: 'Web app',
+                    name: 'PostHog Web',
                     url: '/docs/mcp-analytics/surfaces/web-app',
                     icon: 'IconLaptop',
                     color: 'blue',
                     featured: true,
                 },
                 {
-                    name: 'MCP',
+                    name: 'PostHog MCP',
                     url: '/docs/mcp-analytics/surfaces/mcp',
                     icon: 'IconPlug',
                     color: 'purple',


### PR DESCRIPTION
Follow-up to the docs IA migration. Both IA PRs merged before the surface naming convention was settled, so this brings them in line with the rest of the batch.

## What changed

Surface labels now match the product naming used in the PostHog nav:

| Was | Now |
| --- | --- |
| Web app | **PostHog Web** |
| MCP | **PostHog MCP** |
| CLI | **PostHog CLI** |
| Desktop | **PostHog Desktop** (already correct) |
| API | **API** – deliberately unchanged |

Applied to the **sidebar, overview cards, and CTAs** only. Body prose is untouched, and generic references like "any MCP client" are left alone since those mean the protocol, not PostHog's server.

## Blast radius

Nav changes are scoped to this tool's block. **No URLs change and no pages move**, so no redirects are needed – this is label text only.

One deliberate exception: the `CLI` entry under **Upload source maps** keeps its name. It sits alongside Vite, Webpack, and Next.js as an upload method rather than a surface, so renaming it would break that parallel list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
