### PR TITLE
docs(support): name surfaces as PostHog Web, PostHog Slack, PostHog MCP

### DIFF
--- a/contents/docs/support/index.mdx
+++ b/contents/docs/support/index.mdx
@@ -33,7 +33,7 @@ Support does different things depending on where you work. You read and reply to
     <div>
       <p className="m-0 font-bold text-primary">PostHog Slack</p>
       <p className="m-0 mt-0.5 text-sm text-secondary">Ask <code>@PostHog</code> about your support data and review Self-driving reports built from your tickets.</p>
-      <a href="/docs/support/surfaces/slack" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">See the Slack app →</a>
+      <a href="/docs/support/surfaces/slack" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Ask in Slack →</a>
     </div>
   </div>
 
@@ -51,7 +51,7 @@ Support does different things depending on where you work. You read and reply to
     <div>
       <p className="m-0 font-bold text-primary flex items-center gap-1.5">PostHog Desktop <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
       <p className="m-0 mt-0.5 text-sm text-secondary">Review and merge Self-driving reports and PRs built from your tickets, next to the agents improving your product.</p>
-      <a href="/docs/posthog-desktop" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">PostHog Desktop →</a>
+      <a href="/docs/posthog-desktop" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Review reports →</a>
     </div>
   </div>
 

--- a/contents/docs/support/index.mdx
+++ b/contents/docs/support/index.mdx
@@ -22,7 +22,7 @@ Support does different things depending on where you work. You read and reply to
   <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
     <IconLaptop className="size-6 shrink-0 text-blue mt-0.5" />
     <div>
-      <p className="m-0 font-bold text-primary">Web</p>
+      <p className="m-0 font-bold text-primary">PostHog Web</p>
       <p className="m-0 mt-0.5 text-sm text-secondary">Read and reply to customer tickets, each with the sender's replay and events in view.</p>
       <a href="/docs/support/inbox" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">Manage tickets →</a>
     </div>
@@ -31,7 +31,7 @@ Support does different things depending on where you work. You read and reply to
   <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
     <IconMessage className="size-6 shrink-0 text-red mt-0.5" />
     <div>
-      <p className="m-0 font-bold text-primary">Slack</p>
+      <p className="m-0 font-bold text-primary">PostHog Slack</p>
       <p className="m-0 mt-0.5 text-sm text-secondary">Ask <code>@PostHog</code> about your support data and review Self-driving reports built from your tickets.</p>
       <a href="/docs/support/surfaces/slack" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">See the Slack app →</a>
     </div>
@@ -40,7 +40,7 @@ Support does different things depending on where you work. You read and reply to
   <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
     <IconMagic className="size-6 shrink-0 text-purple mt-0.5" />
     <div>
-      <p className="m-0 font-bold text-primary">MCP</p>
+      <p className="m-0 font-bold text-primary">PostHog MCP</p>
       <p className="m-0 mt-0.5 text-sm text-secondary">List and update tickets and manage Self-driving reports from any MCP client.</p>
       <a href="/docs/model-context-protocol/tools" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">MCP tools reference →</a>
     </div>
@@ -49,7 +49,7 @@ Support does different things depending on where you work. You read and reply to
   <div className="flex items-start gap-3 rounded border border-primary p-5 bg-primary">
     <IconCode className="size-6 shrink-0 text-green mt-0.5" />
     <div>
-      <p className="m-0 font-bold text-primary flex items-center gap-1.5">Code <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
+      <p className="m-0 font-bold text-primary flex items-center gap-1.5">PostHog Desktop <span className="text-2xs font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-yellow/20 text-orange">Beta</span></p>
       <p className="m-0 mt-0.5 text-sm text-secondary">Review and merge Self-driving reports and PRs built from your tickets, next to the agents improving your product.</p>
       <a href="/docs/posthog-desktop" className="inline-flex items-center gap-1 mt-1.5 text-sm font-semibold">PostHog Desktop →</a>
     </div>

--- a/contents/docs/support/surfaces/mcp.mdx
+++ b/contents/docs/support/surfaces/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Support over MCP
+title: Use Support over PostHog MCP
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/support/surfaces/slack.mdx
+++ b/contents/docs/support/surfaces/slack.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Support in Slack
+title: Use Support in PostHog Slack
 sidebar: Docs
 showTitle: true
 ---

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5714,19 +5714,19 @@ export const docsMenu = {
                     name: 'Surfaces',
                 },
                 {
-                    name: 'Web app',
+                    name: 'PostHog Web',
                     url: '/docs/support/inbox',
                     icon: 'IconHeadset',
                     color: 'yellow',
                 },
                 {
-                    name: 'Slack',
+                    name: 'PostHog Slack',
                     url: '/docs/support/surfaces/slack',
                     icon: 'IconChat',
                     color: 'purple',
                 },
                 {
-                    name: 'MCP',
+                    name: 'PostHog MCP',
                     url: '/docs/support/surfaces/mcp',
                     icon: 'IconMagic',
                     color: 'blue',


### PR DESCRIPTION
Brings the Support docs in line with the surface naming convention the rest of the tool docs now use. Support is the template the other tools copy, so leaving it on the old labels would drift it away from the 15 tools that follow it.

## What changed

| Was | Now |
| --- | --- |
| Web | **PostHog Web** |
| Slack *(the surface)* | **PostHog Slack** |
| MCP | **PostHog MCP** |
| Code | **PostHog Desktop** – stale label, see below |
| API | **API** – deliberately unchanged |

Applied to the sidebar, the overview surface cards, and surface page titles.

## Two things worth a look

**Slack appears twice in these docs, and only one is renamed.**

- `/docs/support/surfaces/slack` – the `@PostHog` app you *work from*. This is a PostHog surface → **PostHog Slack**.
- `/docs/support/slack` – SupportHog, which turns messages in *your* Slack into tickets. This is a channel, and it names the customer's Slack rather than a PostHog product → stays **Slack**.

The "Slack aka SupportHog" card in the *Where tickets come from* grid is untouched for the same reason.

**Fixes a stale card.** The PostHog Desktop surface card still read "Code", left over from the PostHog Code → PostHog Desktop rename. Its link already pointed at `/docs/posthog-desktop`, so only the label was wrong.

## Blast radius

**No URLs change and no pages move**, so no redirects are needed – label text only. Nav changes are scoped to the Support block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
