### PR TITLE
Fix grammar in homepage social proof: "7 letters or fewer"

### DIFF
--- a/src/components/Home/Customers.tsx
+++ b/src/components/Home/Customers.tsx
@@ -44,7 +44,7 @@ export const companyBreakdowns = {
         col1: 'Companies you can explain to your parents',
         col2: 'Companies your parents will never understand',
     },
-    shortNames: { col1: 'Names with 7 letters or less', col2: 'Names you can easily mistype' },
+    shortNames: { col1: 'Names with 7 letters or fewer', col2: 'Names you can easily mistype' },
     realWords: { col1: 'Real words', col2: 'Not real words' },
     american: { col1: 'Founded in America', col2: 'Not founded in America' },
     pokemon: { col1: 'Could be a Pokémon', col2: 'Could be a Bond Villain' },

--- a/src/components/Home/Test/Demos.tsx
+++ b/src/components/Home/Test/Demos.tsx
@@ -435,7 +435,7 @@ const companyBreakdowns = {
         col1: 'Companies you can explain to your parents',
         col2: 'Companies your parents will never understand',
     },
-    shortNames: { col1: 'Names with 7 letters or less', col2: 'Names you can easily mistype' },
+    shortNames: { col1: 'Names with 7 letters or fewer', col2: 'Names you can easily mistype' },
     realWords: { col1: 'Real words', col2: 'Not real words' },
     american: { col1: 'Founded in America', col2: 'Not founded in America' },
     pokemon: { col1: 'Could be a Pokémon', col2: 'Could be a Bond Villain' },

--- a/src/pages/ko/_translations.ts
+++ b/src/pages/ko/_translations.ts
@@ -332,7 +332,7 @@ const koTranslations: Record<string, string> = {
     'Could be mistaken for pharmaceuticals': '의약품처럼 들릴 수 있는 이름',
     'Companies you can explain to your parents': '부모님께 설명할 수 있는 회사',
     'Companies your parents will never understand': '부모님이 절대 이해하지 못할 회사',
-    'Names with 7 letters or less': '7글자 이하의 이름',
+    'Names with 7 letters or fewer': '7글자 이하의 이름',
     'Names you can easily mistype': '오타 내기 쉬운 이름',
     'Real words': '실제 단어',
     'Not real words': '실제 단어가 아닌 이름',


### PR DESCRIPTION
## Changes

The homepage social proof section had a column labeled "Names with 7 letters or less." Since letters are countable, the grammatically correct word is "fewer," not "less." Updated the label to "Names with 7 letters or fewer" in the homepage component, the test variant, and the Korean translation key.

**Why:** A grammar nitpick surfaced on Twitter/X — "less" is incorrect for countable nouns like letters.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03C60FT1J7/p1785268160495519?thread_ts=1785268160.495519&cid=C03C60FT1J7)*