### PR TITLE
Rework launch tier framework with "what to market" guidance

### DIFF
--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -40,7 +40,7 @@ It's easy to look at what competitors post on X and feel like we should be slick
 ## Types of announcement
 
 We classify announcements into four tiers, from a full-blown new product launch (tier 1) down to a minor changelog note (tier 4). The tier defines how much we do to market something. It's a guideline, but PMMs have free rein to do something different.
-
+> This framework helps us manage expectations with other teams. When a team lead or PM tells us about a launch, we use the context they give us (plus our own judgement) to decide which tier it falls into. Share that back with the team so they know what marketing will deliver.
 ### Deciding what to market
 
 Before you settle on a launch tier, work through the questions below. They shape how you pitch a launch and who you point it at.

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -39,42 +39,37 @@ It's easy to look at what competitors post on X and feel like we should be slick
 
 ## Types of announcement
 
-We classify announcements using the general guidelines below, with full discretion for doing something different.
+We classify announcements into four tiers, from a full-blown new product launch (tier 1) down to a minor changelog note (tier 4). The tier sets the ceiling for how much we do to market something – but it's a guideline, and we have full discretion to do something different.
 
-### Minor announcements
+### Deciding what to market
 
-Minor announcements involve changes which have no noticeable impact on the experience of most users. They can involve small visual changes, such as UI tweaks, but are more often small bug fixes or back-end changes. They do not require action from users and pose no known risk.
+Before you settle on a tier – or decide whether something is worth marketing at all – work through the questions below. They also shape how you pitch a launch and who you point it at.
 
-We may typically support minor announcements by:
+**Who is this for, and what do we want them to do?** Different audiences need different launches:
 
-- Including them in the weekly changelog update.
-- Writing a short Twitter and/or [LinkedIn post](/handbook/content/linkedin).
+- **Net new** – never heard of PostHog.
+- **Activate** – signed up, but haven't done the thing yet.
+- **Cross-sell** – uses one or two tools, doesn't know about the rest.
+- **Deepen** – uses multiple tools, could use them better.
+- **Defend** – comparing us against someone else.
 
-An example of a minor announcement is the [UUID format change](/changelog?id=1923).
+**Which surface is it for?** Should a user reach for this through MCP, desktop, web, or the Slack app? This is only getting more confusing as we ship across surfaces, so be explicit about where it's most relevant. Related: is this agent-facing or human-facing?
 
-### Medium announcements
+**What can their role actually do with it?** Match the audience to what they're allowed to do. Launches with pricing usually go to owners and admins, since they make the purchase decision. Owners and admins are also the ones who have to turn on integrations – as was the case with the Slack app – unless we build a self-serve flow.
 
-Medium announcements involve changes which have a noticeable impact on the experience of some users, but not the majority. They are likely to involve visual or functional changes, such as adding a chart type, but do not introduce wholly new features. They do not require action from users and pose no known risk.
+**What's the "now what?"** Once someone clicks the email, ad, or notification, what's the one meaningful action we want? Be diligent about setting a goal metric in Customer.io, usually tied to the activation criteria for the tool or thing you launched – the PMM can ask the PM for this. Watch for actions that carry more decision or risk, like connecting a repo, which need more hand-holding.
 
-We may typically support medium announcements by:
+**How does it fit the self-driving story?** Decide how to pitch it:
 
-- Including them in the weekly changelog update and related emails.
-- Creating an in-app changelog notification.
-- Writing a Twitter and LinkedIn post.
+- This tool got better.
+- This helps you **Ship with PostHog**.
+- This makes your product **self-driving**.
 
-An example of a medium announcement includes the [launch of the NPS survey tool](/changelog?id=1787).
+Remember that existing users have fixed notions of what PostHog is and what it's for. As we attract new users with the "ship with PostHog" and self-driving story, that gap will widen – so be deliberate about which story a given audience is hearing.
 
-### Major announcements
+### Tier 1: New product announcements
 
-Major announcements involve changes which have a noticeable impact on the experience of most users, or require specific action from affected users. They may introduce new features, require product downtime, or include opt-in betas for upcoming work.
-
-We might do anything and everything for a major announcement.
-
-Examples of major announcements include [the surveys beta](/changelog?id=1945) or [the analytics pricing change](/changelog?id=1907).
-
-### New product announcements
-
-New product launches are major announcements. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/meta/issues/new/choose). Product marketers should always create a launch plan for new product announcements.
+New product launches are our biggest tier. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/meta/issues/new/choose). Product marketers should always create a launch plan for new product announcements.
 
 For new product announcements we generally apply the following best practices:
 
@@ -92,6 +87,37 @@ For new product announcements we generally apply the following best practices:
 Comms should also be aware of [the engineering best practices for product launches](/handbook/engineering/development-process#best-practices-for-full-releases), so we can be sure that features launch well.
 
 If the product is moving from free beta to paid general availability (GA) you might also want to choose a reward for beta users. Examples of this include giving PostHog AI beta users 30 extra days of unlimited free usage, or giving Workflows beta users a discount code for merch.
+
+### Tier 2: Major announcements
+
+Major announcements involve changes which have a noticeable impact on the experience of most users, or require specific action from affected users. They may introduce new features, require product downtime, or include opt-in betas for upcoming work.
+
+We might do anything and everything for a major announcement.
+
+Examples of major announcements include [the surveys beta](/changelog?id=1945) or [the analytics pricing change](/changelog?id=1907).
+
+### Tier 3: Medium announcements
+
+Medium announcements involve changes which have a noticeable impact on the experience of some users, but not the majority. They are likely to involve visual or functional changes, such as adding a chart type, but do not introduce wholly new features. They do not require action from users and pose no known risk.
+
+We may typically support medium announcements by:
+
+- Including them in the weekly changelog update and related emails.
+- Creating an in-app changelog notification.
+- Writing a Twitter and LinkedIn post.
+
+An example of a medium announcement includes the [launch of the NPS survey tool](/changelog?id=1787).
+
+### Tier 4: Minor announcements
+
+Minor announcements involve changes which have no noticeable impact on the experience of most users. They can involve small visual changes, such as UI tweaks, but are more often small bug fixes or back-end changes. They do not require action from users and pose no known risk.
+
+We may typically support minor announcements by:
+
+- Including them in the weekly changelog update.
+- Writing a short Twitter and/or [LinkedIn post](/handbook/content/linkedin).
+
+An example of a minor announcement is the [UUID format change](/changelog?id=1923).
 
 ### PR announcements
 

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -59,7 +59,33 @@ Before you settle on a launch tier, work through the questions below. They shape
 
 New product launches are our biggest tier. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/meta/issues/new/choose). Product marketers should always create a launch plan for new product announcements.
 
-For new product announcements we generally apply the following best practices:
+Here are some activities your Tier 1 launch could include:
+
+- New product page 
+- Sales enablement doc
+- Competitive comparison (can be added to the tool page)
+- A case study
+- Blog announcement
+- Social media brief for Liam 
+- Demo video
+- Email announcement (or multiple, if you want to segment users and personalize your message)
+- Custom designs for blog covers, social posts, etc. 
+- [Memes](https://www.figma.com/design/I0VKEEjbkKUDSVzFus2Lpu/Hoglitos?node-id=3962-6)
+
+Some other things we've done for launches: 
+
+- Having a messaging doc is very useful for bigger launches because it can be used by different content-producing teams, and it brings alignment on how we want to communicate the product.
+- Initiate communication with the billing team so you're on top of billing changes and schedule your announcements accordingly.
+- Meet with the related PM regularly to stay informed about changes and get their input on what you're writing. More about collab with PMs [here](/blog/pm-pmm-collaboration).
+- Create a separate Slack channel and communicate all updates there. Add all relevant stakeholders and make sure it's active. Post a weekly/bi-weekly update of the progress.
+- Create a canvas in your Slack channel where you'll be dropping all relevant links to things published, your launch plan, Figma files, etc. This makes it easier for engineers, PMs, and other stakeholders to find what you've been working on. 
+- If the product is moving from free beta to paid general availability (GA) you might also want to choose a reward for beta users. Examples of this include giving PostHog AI beta users 30 extra days of unlimited free usage, or giving Workflows beta users a discount code for merch.
+- If the product has been free for a while and it's becoming paid with the launch, make sure to plan to notify free customers in advance and clearly communicate pricing. 
+
+As an example, here's the issue of the [Tier 1 launch for Replay Vision](https://github.com/PostHog/requests-for-comments-public/issues/562).
+
+_Note: All of these are suggestions, not must-haves. It's likely that not all of these things can be ready for launch. A case study, for example, can follow a few weeks after._
+
 
 - Ensure the product has a product page added to the website.
 - Ensure the product team has implemented [intent](/handbook/growth/growth-engineering/product-intents) and [activation](/handbook/growth/growth-engineering/per-product-activation) signals for the product.
@@ -80,7 +106,13 @@ If the product is moving from free beta to paid general availability (GA) you mi
 
 Major announcements involve changes which have a noticeable impact on the experience of most users, or require specific action from affected users. They may introduce new features, require product downtime, or include opt-in betas for upcoming work.
 
-We might do anything and everything for a major announcement.
+Some examples of stuff you could do: 
+
+- Email announcement
+- Artwork to use for social posts or a blog cover
+- Blog announcement 
+- In-app modal
+
 
 Examples of major announcements include [the surveys beta](/changelog?id=1945) or [the analytics pricing change](/changelog?id=1907).
 

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -76,7 +76,7 @@ Some other things we've done for launches:
 
 - Having a messaging doc is very useful for bigger launches because it can be used by different content-producing teams, and it brings alignment on how we want to communicate the product.
 - Initiate communication with the billing team so you're on top of billing changes and schedule your announcements accordingly.
-- Meet with the related PM regularly to stay informed about changes and get their input on what you're writing. More about collab with PMs [here](/blog/pm-pmm-collaboration).
+- Meet with the related PM regularly to stay informed about changes and get their input on what you're writing. Read more about [how PMs and PMMs collaborate](/blog/pm-pmm-collaboration).
 - Create a separate Slack channel and communicate all updates there. Add all relevant stakeholders and make sure it's active. Post a weekly/bi-weekly update of the progress.
 - Create a canvas in your Slack channel where you'll be dropping all relevant links to things published, your launch plan, Figma files, etc. This makes it easier for engineers, PMs, and other stakeholders to find what you've been working on. 
 - If the product is moving from free beta to paid general availability (GA) you might also want to choose a reward for beta users. Examples of this include giving PostHog AI beta users 30 extra days of unlimited free usage, or giving Workflows beta users a discount code for merch.

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -39,33 +39,21 @@ It's easy to look at what competitors post on X and feel like we should be slick
 
 ## Types of announcement
 
-We classify announcements into four tiers, from a full-blown new product launch (tier 1) down to a minor changelog note (tier 4). The tier sets the ceiling for how much we do to market something – but it's a guideline, and we have full discretion to do something different.
+We classify announcements into four tiers, from a full-blown new product launch (tier 1) down to a minor changelog note (tier 4). The tier defines how much we do to market something. It's a guideline, but PMMs have free rein to do something different.
 
 ### Deciding what to market
 
-Before you settle on a tier – or decide whether something is worth marketing at all – work through the questions below. They also shape how you pitch a launch and who you point it at.
+Before you settle on a launch tier, work through the questions below. They shape how you pitch a launch and who you point it at.
 
-**Who is this for, and what do we want them to do?** Different audiences need different launches:
+- **Who is this for, and what do they expect from us?** Remember that existing users have fixed notions of what PostHog is and what it's for. As we attract new users with the self-driving story, that gap will widen – so be deliberate about which story a given audience is expecting and how this launch relates.
 
-- **Net new** – never heard of PostHog.
-- **Activate** – signed up, but haven't done the thing yet.
-- **Cross-sell** – uses one or two tools, doesn't know about the rest.
-- **Deepen** – uses multiple tools, could use them better.
-- **Defend** – comparing us against someone else.
+**Which surface is it for?** Should a user reach for this new thing through MCP, desktop, web, or the Slack app? Be explicit about where it's most relevant to the user based on the interface(s) they're engaged, or which interface you want them to adopt. 
 
-**Which surface is it for?** Should a user reach for this through MCP, desktop, web, or the Slack app? This is only getting more confusing as we ship across surfaces, so be explicit about where it's most relevant. Related: is this agent-facing or human-facing?
+**What can their role actually do with it?** Match the audience to their permissions. Launches with pricing usually target owners and admins, since they make a purchase decision when enabling the new thing. Owners and admins are also the ones who have to turn on integrations before the rest of the team can use the new tool or feature (as was the case with the Slack app launch). 
 
-**What can their role actually do with it?** Match the audience to what they're allowed to do. Launches with pricing usually go to owners and admins, since they make the purchase decision. Owners and admins are also the ones who have to turn on integrations – as was the case with the Slack app – unless we build a self-serve flow.
+**How does it fit the self-driving story?** Some launches feed the loop by giving the system a new source of context (tickets, conversations). Other launches close the loop by acting on that context (Scouts generating Inbox reports). Both promise the same thing: the user's product gets better. A support product isn't exciting because an agent can read tickets. It's exciting because bugs buried in those tickets get found and fixed without anyone prompting it.
 
-**What's the "now what?"** Once someone clicks the email, ad, or notification, what's the one meaningful action we want? Be diligent about setting a goal metric in Customer.io, usually tied to the activation criteria for the tool or thing you launched – the PMM can ask the PM for this. Watch for actions that carry more decision or risk, like connecting a repo, which need more hand-holding.
-
-**How does it fit the self-driving story?** Decide how to pitch it:
-
-- This tool got better.
-- This helps you **Ship with PostHog**.
-- This makes your product **self-driving**.
-
-Remember that existing users have fixed notions of what PostHog is and what it's for. As we attract new users with the "ship with PostHog" and self-driving story, that gap will widen – so be deliberate about which story a given audience is hearing.
+- **What's the "now what?"** Once someone clicks the email, ad, or notification, what's the one meaningful action we want? Be diligent about setting a goal metric in Customer.io, usually tied to the activation criteria for thing that's launching (the PMM can ask the PM for this). Actions that carry more decision or risk, like connecting a GitHub account to enable self-driving, will typically have lower conversion and need more follow-ups emails and marketing.
 
 ### Tier 1: New product announcements
 
@@ -98,7 +86,7 @@ Examples of major announcements include [the surveys beta](/changelog?id=1945) o
 
 ### Tier 3: Medium announcements
 
-Medium announcements involve changes which have a noticeable impact on the experience of some users, but not the majority. They are likely to involve visual or functional changes, such as adding a chart type, but do not introduce wholly new features. They do not require action from users and pose no known risk.
+Medium announcements involve changes which have a noticeable impact on the experience of some users, but not the majority. They are likely to involve visual or functional changes, but do not introduce wholly new features. They do not require action from users and pose no known risk.
 
 We may typically support medium announcements by:
 


### PR DESCRIPTION
## Changes

Reworks the "Types of announcement" framework on the product announcements handbook page.

- Reframes the four announcement types as **tiers 1–4** (tier 1 = new products, down to tier 4 = minor), keeping the existing names, and reorders them to run top-to-bottom.
- Adds a short **"Deciding what to market"** section with tactical prompts to help decide a tier, whether something is worth marketing at all, and how to pitch it: who it's for (net new / activate / cross-sell / deepen / defend), which surface it's on, what the audience's role can do with it, the "now what?" action + goal metric, and how it fits the self-driving story.

**Why:** The current minor/medium/major/new-products labels are too vague for deciding how (and whether) to market a launch. The tier framing plus the decision prompts give PMMs a more tactical way to make that call.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BK7PZDPK5/p1785276170615029)*
