### PR TITLE
docs(surveys): wait for feature flags before matching API surveys

### DIFF
--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -121,6 +121,8 @@ function App() {
 export default App;
 ```
 
+> **Note:** With `ignoreConditions: false`, this checks the survey's display conditions, which can depend on feature flags. See [waiting for feature flags](#wait-for-feature-flags-before-checking-which-surveys-match) if your survey is targeted with a flag.
+
 #### Pre-filling survey responses
 
 You can pre-fill survey answers programmatically by passing `initialResponses` to `displaySurvey`. This works with single choice, multiple choice, and rating questions, and is only supported for **popover** surveys.
@@ -282,7 +284,7 @@ For more control over your surveys, you can use API surveys. When implementing a
 
 1. To get all surveys, call `getSurveys(callback, forceReload)`. This means you still need to handle display conditions yourself.
 
-2. To get surveys enabled for the current user, call `getActiveMatchingSurveys(callback, forceReload)`. This always returns an active survey if the user meets the display conditions, as long as the user (determined by their distinct ID) has not already dismissed or responded the survey.
+2. To get surveys enabled for the current user, call `getActiveMatchingSurveys(callback, forceReload)`. This returns the active surveys the user matches the display conditions for, as long as the user (determined by their distinct ID) has not already dismissed or responded to the survey.
 
 Surveys are requested on first load and then cached by default by the JavaScript SDK. If you want to force an API call to get an updated list of surveys, pass `true` to the `forceReload` parameter. You only need to do this if you want changed surveys to appear mid-session for users.
 
@@ -315,6 +317,26 @@ Both methods return a callback with an array of surveys in this format:
 }]
 ```
 
+### Wait for feature flags before checking which surveys match
+
+Display conditions often depend on feature flags. Targeting a survey at a set of users creates a flag behind the scenes, and linking a survey to a flag uses one directly. Flags are fetched after the page loads, so they are not available immediately.
+
+`getActiveMatchingSurveys` reports what the SDK knows at the moment you call it, and it calls your callback once. If you call it before flag values arrive, you can get an empty list for a user who does match, and you won't be called again when the flags land.
+
+Call it inside `posthog.onFeatureFlags()` to avoid this. That callback runs as soon as flag values are available, and runs right away if they already are. It also returns a function you can call to unsubscribe.
+
+```js-web
+posthog.onFeatureFlags(() => {
+  posthog.getActiveMatchingSurveys((surveys) => {
+    // Flag values are available here, so display conditions are evaluated against them
+  });
+});
+```
+
+This applies to `displaySurvey` with `ignoreConditions: false` too, since it checks the same display conditions. If none of your surveys use flag targeting or a linked flag, you can call `getActiveMatchingSurveys` directly.
+
+### Example: a dynamic feedback form
+
 As an example, we can use `getActiveMatchingSurveys()` to make our Next.js feedback survey more dynamic:
 
 ```js-web
@@ -327,11 +349,14 @@ export default function Feedback() {
   const posthog = usePostHog()
 
   useEffect(() => {
-    posthog.getActiveMatchingSurveys((surveys) => {
-      if (surveys.length > 0) {
-        const survey = surveys[0];
-        setSurvey(survey)
-      }
+    // Wait for feature flags so surveys targeted with a flag are evaluated against real values
+    return posthog.onFeatureFlags(() => {
+      posthog.getActiveMatchingSurveys((surveys) => {
+        if (surveys.length > 0) {
+          const survey = surveys[0];
+          setSurvey(survey)
+        }
+      });
     });
   }, [posthog]);
 


### PR DESCRIPTION
## Changes

Companion to [PostHog/posthog-js#4304](https://github.com/PostHog/posthog-js/pull/4304).

The API-survey example here called `getActiveMatchingSurveys` once on mount with nothing waiting for feature flags. Survey display conditions usually depend on a flag (targeting a survey at a set of users generates one behind the scenes, and a linked flag uses one directly), and flags are fetched after page load. So that example can report no matching survey for a user who does match, and because the callback runs once, it is never corrected when the flags land.

This came out of a support investigation where a customer's API survey lost most of its impressions. Their integration followed this example.

- Wrap the example in `posthog.onFeatureFlags()`, returned from the `useEffect` so it unsubscribes.
- Add "Wait for feature flags before checking which surveys match" explaining the timing, placed just before the example.
- Note that `displaySurvey` with `ignoreConditions: false` depends on the same values, with a pointer from that example.
- Soften the claim that `getActiveMatchingSurveys` "always returns an active survey if the user meets the display conditions". That is not true before flags load. Also fixed "responded the survey" to "responded to the survey" on the same line.

Verified against posthog-js rather than assumed: `isFeatureEnabled` returns the default (`undefined`) while flags are unloaded and nothing is cached, so a first-time visitor fails flag-gated conditions until `/flags` responds. `onFeatureFlags` fires immediately when flags are already loaded and returns an unsubscribe function, so it is correct as a `useEffect` return value.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)

On the unchecked box: I did not run or view the site build, so the new anchor link and heading rendering are unverified in a preview. The anchor follows the lowercase-hyphenated heading convention already used in this directory, but it is worth a glance in the Vercel preview before merging.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
