### PR TITLE
docs: crypto revenue and BTC-only currency support

### DIFF
--- a/contents/docs/revenue-analytics/troubleshooting.mdx
+++ b/contents/docs/revenue-analytics/troubleshooting.mdx
@@ -20,7 +20,23 @@ This ensures that your revenue data is converted using recent exchange rates, ba
 
 ## Which currencies do you support?
 
-PostHog supports a wide range of global currencies for revenue tracking. See our [currencies.py file](https://github.com/PostHog/posthog/blob/master/posthog/models/exchange_rate/currencies.py) for a complete list.
+PostHog supports a wide range of global fiat currencies for revenue tracking. See our [currencies.py file](https://github.com/PostHog/posthog/blob/master/posthog/models/exchange_rate/currencies.py) for the complete, authoritative list.
+
+Bitcoin (BTC) is the only cryptocurrency we support. Ether (ETH), Tether (USDT), and other tokens are not supported, and broader cryptocurrency support is not planned. If you receive revenue in crypto, see [How do I track crypto revenue?](#how-do-i-track-crypto-revenue) below.
+
+## How do I track crypto revenue?
+
+Since Bitcoin is the only supported cryptocurrency, send your crypto revenue events with the value already converted to a supported currency, and set that currency on the event. USD is usually the simplest choice. You already need conversion rates to get a normalized figure, so converting to USD before sending the event costs you nothing extra.
+
+Keep the original transaction details as custom event properties so you can still break revenue down by asset in Trends. For example:
+
+```
+crypto_currency: "ETH"
+crypto_amount: 0.05
+payment_type: "crypto"
+```
+
+This matters because sending a raw crypto ticker as the currency does not fail loudly. As covered in [What if you don't support the currency on my revenue event?](#what-if-you-dont-support-the-currency-on-my-revenue-event), an unsupported currency is tracked as `0` value, so a revenue event sent with a currency like `ETH` silently shows zero revenue instead of raising an error.
 
 ## What "currency's minor unit" means?
 


### PR DESCRIPTION
## Changes

Adds two things to the revenue events / currency conversion troubleshooting page, both framed around revenue events, currency conversion, and managed views (not a "revenue analytics" product surface, which was removed in PostHog/posthog#72984 and reflected in #18877).

- **"Which currencies do you support?"** now states in prose that Bitcoin (BTC) is the only supported cryptocurrency, that ETH, USDT, and other tokens are not, and that broader crypto support is not planned. The `currencies.py` link is kept as the authoritative source. Previously the supported list only existed in a Python file and never in prose, so PostHog AI could not surface it.
- **New "How do I track crypto revenue?" section**: send the USD-converted value with USD as the currency, and keep the original asset details (`crypto_currency`, `crypto_amount`, etc.) as custom event properties for breakdowns in Trends. It also cross-links to the unsupported-currency section and makes the silent-zero behavior explicit: sending a raw crypto ticker does not error, it silently records `0` revenue.

**Why:** A customer wanted to track crypto revenue split by asset with a normalized USD value, and their transactions were rejected/zeroed because we only accept fiat tickers (plus BTC). The gap was that the supported-currency answer lived only in code, and the silent-zero consequence was split across two sections.

### Verification (against current `master`)

Both January findings still hold, nothing moved:

- `posthog/models/exchange_rate/currencies.py`: BTC ("Bitcoin") is the only crypto entry. ETH and USDT are not present (ETH is not even in the `CurrencyCode` enum). Confirmed 152 currency entries, BTC the sole crypto.
- Silent-zero behavior confirmed: `convertCurrency` compiles to ClickHouse `dictGetOrDefault(...)` against the exchange-rate dictionary keyed by `SUPPORTED_CURRENCY_CODES`. An unrecognized ticker misses the key, the rate defaults to `0`, and the `if(from_rate = 0, toDecimal128(0, ...), ...)` branch forces the converted amount to `0`. The event is kept in the `revenue_item` managed view (not dropped, no error), with `amount = 0`. Asserted by `test_currency_conversion` in the HogQL printer tests.

Sources (Slack): https://posthog.slack.com/archives/C08ERRQT41E/p1767774234900409

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BGJ0BD8KH/p1785306684427669)*
