### PR TITLE
docs: tax on credits and uncollectible invoice handling

### DIFF
--- a/contents/handbook/growth/sales/refunds.md
+++ b/contents/handbook/growth/sales/refunds.md
@@ -116,15 +116,12 @@ If you want more precision when a single event type is inflated, use the 'Event 
 
 ### Invoice status and what you can do
 
-What you can do depends on the invoice's status in Stripe:
+You don't void invoices or create Stripe credit notes by hand. Both refunds and corrections to unpaid invoices go through the same Billing Admin refund flow, which issues the Stripe credit note for you automatically. What that flow can do depends on the invoice's status in Stripe:
 
--   **We no longer void invoices.** Voiding has been replaced entirely by credit notes.
--   **Credit notes apply to `paid`, `open`, and `uncollectible` invoices.** They can't be applied to `draft` or `void` invoices. The Billing Admin refund flow works on `open` invoices too, not only `paid` ones.
--   **If Stripe rejects a credit note because the invoice still has a pending payment attempt,** wait for the attempt to resolve, or mark the invoice `uncollectible` in Stripe and retry.
--   **Marking an invoice `uncollectible` is itself the act of forgiving it.** It stops showing as open, so there's usually nothing left to fix on an uncollectible invoice.
--   **Subscriptions are auto-cancelled after repeated failed payment attempts** on a small unpaid invoice, which is also when that invoice is marked `uncollectible`. RevOps can cancel manually earlier if needed. Separately, a customer who accumulates two or more `uncollectible` invoices is blocked from subscribing again.
--   **Churn status in Vitally is not driven by invoice status.** It's set when the Stripe subscription status becomes `canceled` ([config](https://posthog.vitally-eu.io/settings/customer-management/churn)).
--   Customers can re-subscribe as long as they aren't blocked from doing so.
+-   **It works on `paid`, `open`, and `uncollectible` invoices**, but not on `draft` or `void` ones. For a `paid` invoice the refund goes back to the payment method and/or customer balance; for an `open` or `uncollectible` invoice it reduces the amount still due.
+-   **If the flow errors that the invoice has a pending payment attempt,** wait for that attempt to resolve and retry, or mark the invoice `uncollectible` in Stripe first. The refund flow won't mark invoices uncollectible for you.
+-   **Small unpaid invoices are handled automatically.** After Stripe's repeated failed payment attempts on a small invoice (below the threshold where CS steps in, and for customers without a high trust score), billing marks it `uncollectible` and cancels the subscription. RevOps can cancel earlier if needed.
+-   **Two or more `uncollectible` invoices block a customer from subscribing again.** They're unblocked automatically once they no longer have any uncollectible invoices, so clearing those invoices is what lets them re-subscribe.
 
 ## How to issue refunds or credits
 

--- a/contents/handbook/growth/sales/refunds.md
+++ b/contents/handbook/growth/sales/refunds.md
@@ -116,12 +116,12 @@ If you want more precision when a single event type is inflated, use the 'Event 
 
 ### Invoice status and what you can do
 
-You don't void invoices or create Stripe credit notes by hand. Both refunds and corrections to unpaid invoices go through the same Billing Admin refund flow, which issues the Stripe credit note for you automatically. What that flow can do depends on the invoice's status in Stripe:
+You don't void invoices or create credit notes by hand. Every refund and correction to an unpaid invoice goes through one place — the Billing Admin refund flow — and it creates the underlying Stripe credit note for you. What you can do just depends on the invoice's status:
 
--   **It works on `paid`, `open`, and `uncollectible` invoices**, but not on `draft` or `void` ones. For a `paid` invoice the refund goes back to the payment method and/or customer balance; for an `open` or `uncollectible` invoice it reduces the amount still due.
--   **If the flow errors that the invoice has a pending payment attempt,** wait for that attempt to resolve and retry, or mark the invoice `uncollectible` in Stripe first. The refund flow won't mark invoices uncollectible for you.
--   **Small unpaid invoices are handled automatically.** After Stripe's repeated failed payment attempts on a small invoice (below the threshold where CS steps in, and for customers without a high trust score), billing marks it `uncollectible` and cancels the subscription. RevOps can cancel earlier if needed.
--   **Two or more `uncollectible` invoices block a customer from subscribing again.** They're unblocked automatically once they no longer have any uncollectible invoices, so clearing those invoices is what lets them re-subscribe.
+-   **`paid`, `open`, and `uncollectible` invoices can be refunded; `draft` and `void` ones can't.** A refund on a `paid` invoice goes back to the payment method and/or customer balance. On an `open` or `uncollectible` invoice, it reduces the amount still owed.
+-   **Hit a "pending payment" error?** The invoice has a payment in flight. Wait for it to resolve and try again, or mark the invoice `uncollectible` in Stripe first — the refund flow won't do that for you.
+-   **Small unpaid invoices resolve themselves.** Once Stripe exhausts its retries on a small invoice (below the amount where CS gets involved, and for customers without a high trust score), billing marks it `uncollectible` and cancels the subscription automatically. RevOps can cancel sooner if needed.
+-   **Two or more `uncollectible` invoices block a customer from re-subscribing.** The block lifts automatically once they have none left, so clearing those invoices is what frees them to subscribe again.
 
 ## How to issue refunds or credits
 
@@ -137,7 +137,7 @@ You don't void invoices or create Stripe credit notes by hand. Both refunds and 
 8. Click 'Save and view'
 9. After saving, you'll land on the customer view in Billing Admin — confirm the credit now appears on the customer's balance there. You don't need to check Stripe.
 
-**A note on tax:** tax is applied automatically by Anrok through Stripe. It is not managed in billing and is not part of billing limits, and it applies to US customers only, which is why internationally credited accounts show no tax line and the credit lands cleanly. Tax is also calculated on the full invoice amount before credits are applied. So if a US customer has hit a billing limit and you issue credits equal to that limit expecting a zero bill, they will still be charged the tax on the pre-credit amount. Before issuing the credit, check Stripe for the applied tax amount, and gross the credit up to cover it if the goal is a zero bill.
+**A note on tax:** Tax is added automatically by Anrok through Stripe. It applies to US customers only, isn't managed in billing, and doesn't count toward billing limits — so for customers outside the US there's no tax line and a credit lands cleanly. Tax is also calculated on the full invoice amount *before* credits are applied. That trips people up: if a US customer has hit a billing limit and you credit them exactly that amount expecting a $0 bill, they'll still owe the tax on the pre-credit total. To land a true zero bill, check the applied tax in Stripe and gross the credit up to cover it.
 
 ### Issuing a refund
 Refunds are now initiated through Billing Admin and finalized in Stripe via a credit note. 

--- a/contents/handbook/growth/sales/refunds.md
+++ b/contents/handbook/growth/sales/refunds.md
@@ -112,7 +112,19 @@ If you want more precision when a single event type is inflated, use the 'Event 
 
 -   Issue credits if the customer's period hasn't ended yet and the invoice isn't finalized. It is much easier and better for users and us to avoid payment if we can!
 -   If invoice is finalized and this is a first time request, issue a refund via a credit note (do not use the refund button, this is important for correct revenue attribution).
--   If the customer has overdue invoices and needs changes on that, we need to apply credit notes. Escalate such cases to RevOps.
+-   If the customer has overdue (open or uncollectible) invoices that need changes, see [Invoice status and what you can do](#invoice-status-and-what-you-can-do) below before acting, and escalate to RevOps if you're unsure.
+
+### Invoice status and what you can do
+
+What you can do depends on the invoice's status in Stripe:
+
+-   **We no longer void invoices.** Voiding has been replaced entirely by credit notes.
+-   **Credit notes apply to `paid`, `open`, and `uncollectible` invoices.** They can't be applied to `draft` or `void` invoices. The Billing Admin refund flow works on `open` invoices too, not only `paid` ones.
+-   **If Stripe rejects a credit note because the invoice still has a pending payment attempt,** wait for the attempt to resolve, or mark the invoice `uncollectible` in Stripe and retry.
+-   **Marking an invoice `uncollectible` is itself the act of forgiving it.** It stops showing as open, so there's usually nothing left to fix on an uncollectible invoice.
+-   **Subscriptions are auto-cancelled after repeated failed payment attempts** on a small unpaid invoice, which is also when that invoice is marked `uncollectible`. RevOps can cancel manually earlier if needed. Separately, a customer who accumulates two or more `uncollectible` invoices is blocked from subscribing again.
+-   **Churn status in Vitally is not driven by invoice status.** It's set when the Stripe subscription status becomes `canceled` ([config](https://posthog.vitally-eu.io/settings/customer-management/churn)).
+-   Customers can re-subscribe as long as they aren't blocked from doing so.
 
 ## How to issue refunds or credits
 
@@ -127,6 +139,8 @@ If you want more precision when a single event type is inflated, use the 'Event 
 7. Include an optional link in the 'Reference link' field, e.g. support ticket, Slack message link, etc.
 8. Click 'Save and view'
 9. After saving, you'll land on the customer view in Billing Admin — confirm the credit now appears on the customer's balance there. You don't need to check Stripe.
+
+**A note on tax:** tax is applied automatically by Anrok through Stripe. It is not managed in billing and is not part of billing limits, and it applies to US customers only, which is why internationally credited accounts show no tax line and the credit lands cleanly. Tax is also calculated on the full invoice amount before credits are applied. So if a US customer has hit a billing limit and you issue credits equal to that limit expecting a zero bill, they will still be charged the tax on the pre-credit amount. Before issuing the credit, check Stripe for the applied tax amount, and gross the credit up to cover it if the goal is a zero bill.
 
 ### Issuing a refund
 Refunds are now initiated through Billing Admin and finalized in Stripe via a credit note. 


### PR DESCRIPTION
## Changes

Two additions to the refunds handbook page, plus one correction.

- **"Issuing credits"** now has a note that tax (applied automatically by Anrok through Stripe, US customers only) is calculated on the full invoice amount *before* credits are applied and is not part of billing limits. So a credit sized exactly to a billing limit can still leave a taxable balance. Advises checking Stripe for the applied tax and grossing the credit up for a zero bill.
- **New "Invoice status and what you can do" subsection** under "Refund or credit?": credit notes vs invoice status, that we no longer void, that marking an invoice uncollectible is itself forgiving it, subscription auto-cancel behavior, and re-subscribe blocking.
- **Corrected the misleading overdue-invoices line** in place (it pointed vaguely at credit notes + RevOps) to link into the new subsection.

<details>
  <summary>More context </summary>
  
**Why:** Issuing credits equal to a hit billing limit still produced a non-zero bill for a US customer because tax was charged on the pre-credit amount, and the page never mentioned tax. Separately, the single line on overdue invoices was misleading about what's possible per invoice status. Both came out of RevOps threads that never made it into docs.

### ⚠️ Verification: two January findings changed and are NOT documented as originally reported

I verified everything against current `master` of `PostHog/billing`. Two of the source claims no longer hold, so the page reflects **current** behavior, not the January version:

1. **"Credit notes never apply to uncollectible invoices" — REVERSED.** As of `PostHog/billing` (PR #1836, April 2026), `Refund.REFUNDABLE_STATUSES = {"paid", "open", "uncollectible"}`; `draft` and `void` are rejected (dedicated tests exist for each). Marking an invoice `uncollectible` is now the *recommended workaround* when Stripe rejects a credit note due to a pending payment attempt (`PENDING_PAYMENT_CREDIT_NOTE_FRIENDLY_ERROR` in `billing/models/refund.py`). The page documents this current rule rather than "you cannot credit-note an uncollectible invoice."

2. **"Two uncollectible invoices auto-cancels the subscription" — NOT how the code works.** In `billing/webhooks/stripe.py`, cancellation is triggered by the *final failed payment attempt* on a small unpaid invoice (which marks that invoice uncollectible and cancels the subscription). The "two or more uncollectible invoices" threshold (`should_block_customer_from_subscribing` in `billing/utils/stripe_utils.py`) instead **blocks the customer from re-subscribing** — it does not cancel an existing subscription. The page states both mechanisms accurately and separately.

Confirmed unchanged:
- **We still never void invoices.** No production code calls Stripe's void API; there's only a webhook handler reacting to Stripe-initiated voids. `mark_invoice_uncollectible` is used instead.
- **The refund flow works on `open` invoices, not only `paid`** (`open` is in `REFUNDABLE_STATUSES`).
- **Tax is applied by Anrok through Stripe** (`_prorate_tax_amounts` / `has_manual_tax` in `billing/models/refund.py`).

One nuance worth flagging: tax *is* now surfaced (`tax_percent`) in the Billing Admin **Refund / credit-note** flow (`get_invoice_data_view` → `product_amounts_form.html`, ~April–July 2026), but **not** in the flat-dollar **"Add credits"** admin flow, which is the one the "Issuing credits" section documents. So for that flow, the manual Stripe check is still the correct guidance.

Sources (Slack): https://posthog.slack.com/archives/C08ERRQT41E/p1767696984662129 and https://posthog.slack.com/archives/C08ERRQT41E/p1767612206041399
  
  ```

  ```
  
</details>


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BGJ0BD8KH/p1785306684427669)*
