### PR TITLE
docs(self-driving): explain the trade between signal sources and scouts

### DIFF
--- a/contents/docs/self-driving/faq.mdx
+++ b/contents/docs/self-driving/faq.mdx
@@ -43,7 +43,7 @@ Nothing reaches production without a human clicking merge.
 
 ## Do you use this on PostHog itself?
 
-Yes, heavily. A troop of 35 scouts watches the PostHog app, and reports about posthog.com become pull requests on [the public repo that builds this site](https://github.com/PostHog/posthog.com/pulls), where you can read them. We're the first customer of every part of the loop, and the first to feel it when something's off.
+Yes, heavily. A troop of more than 90 scouts – the canonical fleet plus dozens our own teams have written – watches the PostHog app, and reports about posthog.com become pull requests on [the public repo that builds this site](https://github.com/PostHog/posthog.com/pulls), where you can read them. We're the first customer of every part of the loop, and the first to feel it when something's off.
 
 ## What happens when it gets something wrong?
 
@@ -62,6 +62,22 @@ The scouts themselves aren't a black box either: every canonical scout is a read
 ## How is this different from alerts and monitoring?
 
 Monitoring tells you something broke, then the work begins: triage the alert, reproduce the bug, find the owner, write the fix. Self-driving does that pipeline for you. A signal is investigated, grouped with related evidence, root-caused against your code, and handed to you as a reviewed-and-ready pull request. The [anatomy of a pull request](/docs/self-driving/anatomy-of-a-pr) walks through the difference on a single bug.
+
+## Do I need scouts or signal sources?
+
+Usually both, and they're not competing – they make a trade against each other.
+
+A [signal source](/docs/self-driving/inbox/sources) is deterministic and exhaustive: turn one on and every qualifying item in that stream is processed, continuously, with no bar to clear and nothing skipped because an agent judged it uninteresting. A [scout](/docs/self-driving/scouts) trades some of that for judgement: it runs on a schedule, explores rather than following a fixed stream, and decides what's worth surfacing, so it can weigh and rank and stay quiet – but it's selective by design rather than exhaustive.
+
+Use a source when the stream is well-defined and missing an item would be unacceptable. Use a scout when everything in the stream is technically "something" and you need judgement applied, when what you care about spans several surfaces, or when "worth knowing" is a matter of opinion only your team can define. They stack, too: a scout can sit on top of an existing detector, bundling related items and flagging what nobody actioned, while the source keeps its guaranteed coverage.
+
+[Sources or scouts?](/docs/self-driving/signals#sources-or-scouts) has the side-by-side breakdown.
+
+## Will a scout miss things?
+
+By design, yes – that's the difference between a scout and a source, and it's the point rather than a bug. A scout holds a bar, so most runs close out having found nothing worth your attention, and it deliberately stays quiet on a quiet day. If it talked every day you'd stop reading it.
+
+If you need guaranteed handling of a specific stream, use a [signal source](/docs/self-driving/inbox/sources) for that stream, and let scouts cover the questions nobody is holding. If a scout is holding back things you *do* want, you don't have to edit it: dismiss a report with a note explaining why, or leave a [scout note](/docs/self-driving/scouts#steering-a-scout-with-a-note) in plain English, and later runs read both.
 
 ## How do I control what it watches, and what it costs?
 

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -37,7 +37,7 @@ Self-driving works because the signals that drive the loop live in your product 
 
 A general-purpose coding agent has your code, but not your context. PostHog ties everything together into a [context warehouse](/docs/self-driving/context): your product usage data, your data warehouse, and the context your agents need, in one place. That's what helps your agents do their best work.
 
-We don't just sell this loop, we run it. A troop of 35 scouts watches the PostHog app, and reports about posthog.com become pull requests on [the public repo that builds it](https://github.com/PostHog/posthog.com/pulls). If self-driving ever stops being worth it, we'll be the first to know.
+We don't just sell this loop, we run it. A troop of more than 90 scouts – the canonical fleet plus dozens our own teams have written – watches the PostHog app, and reports about posthog.com become pull requests on [the public repo that builds it](https://github.com/PostHog/posthog.com/pulls). If self-driving ever stops being worth it, we'll be the first to know.
 
 To see the loop play out on a single bug, from first signal to measured fix, read the [anatomy of a pull request](/docs/self-driving/anatomy-of-a-pr).
 
@@ -55,13 +55,14 @@ Once data is flowing, PostHog continuously monitors your product and reports beg
 
 </QuestLogItem>
 
-<QuestLogItem title="Learn the concepts" subtitle="Context, scouts, signals, reports, inbox" icon="IconCode2">
+<QuestLogItem title="Learn the concepts" subtitle="Context, signals, sources, scouts, reports, inbox" icon="IconCode2">
 
 There's a small set of terms worth knowing. Here's a breakdown:
 
 - **[Context](/docs/self-driving/context)** – everything your agents need to know about your product, tied together in your context warehouse. The context a general-purpose agent doesn't have.
-- **[Scouts](/docs/self-driving/scouts)** – scheduled agents that watch a slice of your data and raise a hand when something's worth knowing.
-- **[Signals](/docs/self-driving/signals)** – what a scout emits: a structured finding, with the evidence behind it and a suggested action. Error tracking, session replay, and tools like Zendesk and Linear emit signals too.
+- **[Signals](/docs/self-driving/signals)** – a structured finding: what's happening, the evidence behind it, and a suggested action. Everything the loop does starts from one.
+- **[Signal sources](/docs/self-driving/inbox/sources)** – built-in pipelines that watch one stream continuously and turn every qualifying item into a signal. Error tracking, session replay, and logs inside PostHog, plus tools like Zendesk, Linear, and Sentry.
+- **[Scouts](/docs/self-driving/scouts)** – scheduled agents that watch a slice of your data and raise a hand when something's worth knowing. Where a source is exhaustive, a scout uses judgement about what to surface – [when to use which](/docs/self-driving/signals#sources-or-scouts).
 - **[Reports](/docs/self-driving/reports)** – related signals grouped into one item of work, so you deal with the real problem instead of a noisy stream of findings.
 - **[Inbox](/docs/self-driving/inbox)** – where reports and pull requests land for you to review, steer, and merge.
 

--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -24,6 +24,8 @@ A scout runs on a schedule. Each run, it looks at one slice of your data, decide
 
 Either way, the bar is the same: a structured finding with the evidence behind it and a suggested action. The difference is whether the scout has already done enough research to stand behind the finding as a single inbox item, or whether the pipeline should consolidate it with others first.
 
+A scout is **selective by design**. Holding something back is a decision it makes on purpose, not a gap – most runs close out having found nothing worth your attention, and that's the scout working. If you need every item in a stream handled with no judgement call in between, that's what a [signal source](/docs/self-driving/inbox/sources) is for, and the two are often best run together.
+
 A scout reads your data through the same [PostHog MCP](/docs/model-context-protocol) you can connect to Claude Code or Cursor, so it can see anything in PostHog out of the box – events, [data warehouse](/docs/data-warehouse) tables, insights, dashboards – with nothing to wire up per scout. Because any source you land in PostHog becomes queryable, a scout isn't limited to product analytics: a Slack channel, a billing system, or a support inbox synced to your warehouse is fair game too.
 
 A scout also keeps a durable memory between runs. Each run, it reads back what earlier runs learned and recorded – what's normal, what it's already surfaced, what it decided to hold – so it dedupes against itself and gets sharper over time instead of starting cold. That memory is what makes a scout a long-running agent rather than a one-shot check.
@@ -119,7 +121,9 @@ Built-in scouts don't do this. Their instructions are maintained by PostHog and 
 
 Scouts aren't the only thing that emits [signals](/docs/self-driving/signals). PostHog also has **signal sources**: built-in pipelines that watch one specific stream continuously, like error tracking, session replay, Zendesk, GitHub Issues, and Linear.
 
-The difference is how they look. A signal source watches a single stream in real time; a scout runs on a schedule and explores your product data more holistically. You turn them on independently, and both feed the same pipeline, where their signals are deduplicated and grouped into reports. The more data you capture, the more both have to work with.
+The difference is how they look, and what you get for it. A signal source watches a single stream continuously and processes every qualifying item in it – deterministic and exhaustive, with no bar to clear. A scout runs on a schedule, explores more holistically, and decides what's worth surfacing – judgement and steerability, at the cost of being selective rather than exhaustive.
+
+Neither is the upgrade from the other and most projects run both. You turn them on independently, and both feed the same pipeline, where their signals are deduplicated and grouped into reports. The more data you capture, the more both have to work with. For a side-by-side breakdown and when to reach for which, see [sources or scouts?](/docs/self-driving/signals#sources-or-scouts).
 
 ## Next step
 

--- a/contents/docs/self-driving/self-improving-loop.mdx
+++ b/contents/docs/self-driving/self-improving-loop.mdx
@@ -20,7 +20,7 @@ The self-improving loop is how PostHog turns product data into shipped changes, 
 
 ## Collect signals
 
-The loop starts with [signals](/docs/self-driving/signals), which come from two kinds of source you can turn on independently. **Signal sources** are built-in pipelines that watch one stream continuously, like error tracking, session replay, health checks, Zendesk, GitHub Issues, and Linear. **[Scouts](/docs/self-driving/scouts)** run on a schedule and explore your product data more holistically. A single problem usually shows up as several signals at once.
+The loop starts with [signals](/docs/self-driving/signals), which come from two kinds of source you can turn on independently. **Signal sources** are built-in pipelines that watch one stream continuously and process every qualifying item in it, like error tracking, session replay, health checks, Zendesk, GitHub Issues, and Linear. **[Scouts](/docs/self-driving/scouts)** run on a schedule, explore your product data more holistically, and use judgement about what's worth surfacing. Sources trade judgement for exhaustive coverage and scouts trade coverage for judgement, so most projects run both – [sources or scouts?](/docs/self-driving/signals#sources-or-scouts) covers when to reach for which. A single problem usually shows up as several signals at once.
 
 ## Group into reports
 

--- a/contents/docs/self-driving/signals.mdx
+++ b/contents/docs/self-driving/signals.mdx
@@ -34,6 +34,27 @@ Signals come from two kinds of source, which you can turn on independently:
 
 Both feed signals into the same pipeline. A single problem usually shows up as several signals from several sources, so the loop deduplicates and groups them, and you act on the problem, not the noise. (A scout that finishes its research with a complete finding can also skip the grouping step and file a [report](/docs/self-driving/reports) directly – its evidence still lands as signals backing the report.)
 
+## Sources or scouts?
+
+Neither is the upgrade from the other, and most projects run both. They make a real trade against each other, and knowing which way it runs is what tells you where to point each one.
+
+**A signal source is deterministic and exhaustive.** Turn on error tracking as a source and every qualifying signal in that stream gets processed, continuously, as it happens. Nothing is skipped because an agent weighed it and decided it wasn't interesting. You can reason about coverage: the behavior is the same today and next month, and there's no bar for something to clear.
+
+**A scout trades some of that determinism for judgement.** It runs on a schedule rather than continuously, explores rather than following a fixed stream, and decides what clears the bar you set – so it can weigh, rank, cluster, and stay quiet on a quiet day, but it isn't exhaustive by design and it's making a call each run.
+
+| | **Signal sources** | **Scouts** |
+|---|---|---|
+| **Coverage** | Exhaustive – every qualifying item in the stream | Selective – what clears the bar, holding the rest |
+| **Timing** | Continuous, as events arrive | Scheduled, from every 30 minutes to every 30 days |
+| **Behavior** | Predictable and repeatable | Uses judgement each run; ranks, clusters, and weighs |
+| **Scope** | One stream, deeply | Across surfaces, or any slice you point it at |
+| **Setup** | Toggle it on | Authored – you describe what's worth your attention |
+| **Tuning** | Configuration | Steerable in plain English, and it learns between runs |
+
+So: reach for a **source** when the stream is well-defined and missing an item would be unacceptable. Reach for a **scout** when everything in the stream is technically "something" and you need judgement applied, when the interesting thing spans several surfaces, or when "worth knowing" is a matter of opinion only your team can define.
+
+They also compose. If a detector already exists, a scout can sit on top of it rather than replace it – the source keeps its deterministic coverage while the scout bundles related items, weighs who's affected, and flags what nobody actioned.
+
 ## From signals to reports
 
 On their own, signals are just a stream of findings. Grouped into a [report](/docs/self-driving/reports), they become a single thing you can act on.


### PR DESCRIPTION
## Why

The docs explain how signal sources and scouts differ *mechanically* — one watches a stream continuously, the other runs on a schedule — in four separate places (`signals`, `scouts`, `self-improving-loop`, `index`). None of them says **which to choose, or why**.

The decision-useful fact was missing entirely: sources are deterministic and exhaustive, scouts trade that for judgement and steerability, and most projects want both. Without it, a reader who has just learned both terms still can't tell where to point each one, and "scouts are the newer, better thing" is an easy wrong conclusion to draw.

## What changed

**`signals.mdx` — new "Sources or scouts?" section.** The anchor for this concept, since it's the page the nav points at and it was the thinnest at 47 lines. States the trade in both directions, with a side-by-side table (coverage, timing, behavior, scope, setup, tuning) and guidance on when to reach for which. Also notes they compose — a scout can sit on top of an existing detector while the source keeps its guaranteed coverage.

**The other three mentions now link to it** rather than restating a partial version of the difference.

**`scouts.mdx`** — says plainly that a scout is selective by design, so a run that finds nothing reads as the scout working rather than a gap. This is expectation-setting we were leaving to inference.

**`index.mdx`** — signal sources get their own bullet in the concepts list (they had none, despite being one of the core parts), and signals are no longer defined as "what a scout emits" with sources bolted on afterwards, since sources emit them too.

**`faq.mdx`** — two new entries: "Do I need scouts or signal sources?" and "Will a scout miss things?" The second one is the honest answer to the most likely objection, and the FAQ is already written skeptic-first, so it fits.

## One factual fix

Both the overview and the FAQ said *"A troop of 35 scouts watches the PostHog app."* On the PostHog App + Website project that's now **96 configured, 92 enabled** — 28 canonical plus 68 our own teams have written. The old number understated it considerably. Reworded to "more than 90 … the canonical fleet plus dozens our own teams have written" so it degrades gracefully, but worth a sanity check from someone closer to the fleet — I verified against one project.

## Not done here

Signal sources live at `/docs/self-driving/inbox/sources`, as a sub-page of Inbox, while Scouts is a top-level section with its own Overview and Examples. The information architecture reinforces the same imbalance this PR fixes in the prose. Moving it would mean touching `src/navs/index.js`, which is shared with the live site, so flagging it rather than doing it — happy to follow up if people agree it should move.

## Notes

- All new links and the `#sources-or-scouts` anchor verified to resolve; prettier clean.
- Companion handbook PR for the sales side: #19063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)