### PR TITLE
Update PostHog Desktop availability to Summer 2026

### DIFF
--- a/contents/docs/posthog-desktop/download-posthog-desktop.mdx
+++ b/contents/docs/posthog-desktop/download-posthog-desktop.mdx
@@ -5,7 +5,7 @@ title: Download PostHog Desktop
 import { DownloadButton } from '../../../src/pages/desktop'
 import List from 'components/List'
 
-PostHog Desktop will be available for download in Spring 2026.
+PostHog Desktop will be available for download in Summer 2026.
 
 <div className="max-w-lg @container bg-blue/10 border border-blue rounded-md pb-8 pt-0 px-8 shadow-xl">
   <DownloadButton />

--- a/contents/docs/posthog-desktop/index.mdx
+++ b/contents/docs/posthog-desktop/index.mdx
@@ -191,7 +191,7 @@ subtitle="Next step"
 icon="IconDownload"
 >
 
-Ready to take it for a spin? Download PostHog Desktop and connect your first repo. PostHog Desktop will be available for download in Spring 2026. 
+Ready to take it for a spin? Download PostHog Desktop and connect your first repo. PostHog Desktop will be available for download in Summer 2026. 
 
 <div className="@container bg-blue/10 border border-blue rounded-md pb-8 pt-0 px-8 shadow-xl">
   <DownloadButton />


### PR DESCRIPTION
## Changes

Updates the PostHog Desktop availability copy from **Spring 2026** to **Summer 2026** on both the download page and the product landing page (they share the same sentence).

**Why:** The Spring 2026 date is no longer accurate — availability has slipped to Summer 2026, so the docs need to reflect the new timeline.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785333163161779?thread_ts=1785333163.161779&cid=C09G8Q32R6F)*