### PR TITLE
Make self-driving page heading bold

### DIFF
--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -946,7 +946,7 @@ export default function SelfDrivingPage({
                     <div className="not-prose mb-8 pt-2 @lg/reader-content:pt-6 @3xl:mb-12">
                         <section className="relative mx-auto max-w-5xl overflow-hidden rounded-md border border-primary bg-primary shadow-2xl">
                             <div className="relative z-20 p-5 pb-6 @md/reader-content:p-7 @xl/reader-content:p-10">
-                                <h1 className="m-0 mb-5 text-3xl !leading-[1.2] @md/reader-content:text-4xl @3xl/reader-content:text-5xl">
+                                <h1 className="m-0 mb-5 text-3xl font-bold !leading-[1.2] @md/reader-content:text-4xl @3xl/reader-content:text-5xl">
                                     Shift your product into <Highlight>self-driving</Highlight> mode
                                 </h1>
                                 <p className="m-0 text-[15px] text-secondary @xl/reader-content:text-[17px]">


### PR DESCRIPTION
## Changes

Makes the "Shift your product into self-driving mode" heading on the [/self-driving](https://posthog.com/self-driving) page bold by adding `font-bold` to the `<h1>` class.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AU440KS6P/p1785333840380799)*
