### PR TITLE
docs: clarify first-touch vs latest-touch campaign person properties

### DIFF
--- a/contents/docs/data/utm-segmentation.mdx
+++ b/contents/docs/data/utm-segmentation.mdx
@@ -30,7 +30,12 @@ PostHog automatically captures any UTM parameters that are present when a user v
 
 <CalloutBox icon="IconInfo" title="Setting person properties" type="fyi">
 
-Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. By default, only identified users have person profiles. See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) and [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
+Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. By default, only identified users have person profiles, and this affects the two kinds of campaign person properties differently:
+
+- **Initial** (first-touch) properties like `$initial_utm_source` are backfilled when the user is identified. The SDK stores first-touch values in a cookie and attaches them to later events, so they survive the transition from anonymous to identified.
+- **Latest** properties like `utm_source` are not backfilled. They only reflect campaign parameters seen on events captured while the user has a person profile, in the same browser tab and on the same domain. If a user lands from a campaign anonymously and identifies later, the campaign parameters from that landing won't appear as latest person properties.
+
+If you need latest-touch attribution for users who arrive anonymously, set the values yourself with [`setPersonProperties()`](/docs/product-analytics/person-properties#how-to-set-person-properties) when you identify the user, or use [`person_profiles: 'always'`](/docs/data/anonymous-vs-identified-events) (note that identified events cost more than anonymous ones). See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) and [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
 
 </CalloutBox>
 

--- a/contents/docs/web-analytics/campaign-attribution-troubleshooting.mdx
+++ b/contents/docs/web-analytics/campaign-attribution-troubleshooting.mdx
@@ -57,6 +57,41 @@ limit 100
 
 If you see different `distinct_id` or `person_id` values for pageviews and conversions from the same user, you have identity fragmentation.
 
+## Why are UTMs or click IDs on my events but not on person profiles?
+
+If campaign parameters like `utm_source` or `gclid` appear correctly on `$pageview` events but never show up as person properties, the usual cause is that those events aren't updating a person profile.
+
+Campaign parameters are copied from events to person properties server-side, and only for events that create or update a person profile. With the default [`person_profiles: 'identified_only'`](/docs/data/anonymous-vs-identified-events) configuration, events from anonymous users don't update person profiles, so the campaign parameters on those events never reach a person. This is expected behavior, but it surprises people because the event-level values look fine.
+
+What happens when the user identifies later differs between the two kinds of campaign person properties:
+
+- **Initial** (first-touch) properties like `$initial_utm_source` and `$initial_gclid` are backfilled on identification. The SDK stores first-touch values in a cookie and attaches them to later events.
+- **Latest** properties like `utm_source` and `gclid` are not backfilled. They only reflect campaign parameters seen on events captured while the user has a person profile, in the same browser tab and on the same domain. A campaign landing that happened before the user identified won't appear as a latest person property.
+
+To check whether this is affecting you, run this query and replace `gclid` with the parameter you care about:
+
+```sql
+select
+    person_mode,
+    count() as pageviews
+from events
+where event = '$pageview'
+and timestamp >= now() - interval 7 day
+and isNotNull(properties.gclid)
+group by person_mode
+order by pageviews desc
+```
+
+Rows where `person_mode` is not `full` are events that didn't update person properties.
+
+One thing to watch out for when querying: the JavaScript SDK sends every campaign parameter it tracks whenever at least one is present in the URL, using a JSON null for the missing ones. Use `isNotNull(properties.gclid)` to test for a real value, because `properties.gclid != ''` doesn't exclude JSON nulls.
+
+To fix it:
+
+1. Identify users as early as possible, so more of their events update the person profile
+2. If you need latest-touch attribution from before identification, capture the values yourself and set them with [`setPersonProperties()`](/docs/product-analytics/person-properties#how-to-set-person-properties) when you identify the user
+3. Or switch to [`person_profiles: 'always'`](/docs/data/anonymous-vs-identified-events), which makes anonymous events update person profiles too (note that identified events cost more than anonymous ones)
+
 ## Why are users from LinkedIn/Meta ads not being attributed?
 
 This is a common issue when running ads on social media platforms that open links in their native in-app browsers. Here's a typical scenario:


### PR DESCRIPTION
## Changes

The [UTM segmentation](https://posthog.com/docs/data/utm-segmentation#capturing-utm-parameters) page promises campaign parameters "as **latest** and **initial** properties on the person profile", with only a generic note that person profiles require identified users. That reads as "identify and both work", which isn't true: under the default `person_profiles: 'identified_only'`, **initial** values are backfilled when the user identifies (the SDK carries first-touch values in a cookie), but **latest** values are not, because they live in per-tab, per-origin sessionStorage and only apply to person-processed events.

This is a recurring support confusion ([internal ticket](https://us.posthog.com/project/2/support/tickets/019fa334-91b6-0000-08d9-cdfe723cf2f5) is the latest instance): campaign params or click IDs like `gclid` are visibly correct on events but never appear on the person, and the affected user reads it as a bug.

Two changes:

- `contents/docs/data/utm-segmentation.mdx`: the "Setting person properties" callout now spells out the initial vs latest asymmetry and what to do if you need latest-touch attribution for anonymous arrivals.
- `contents/docs/web-analytics/campaign-attribution-troubleshooting.mdx`: new section "Why are UTMs or click IDs on my events but not on person profiles?" covering the mechanism, a `person_mode` check query, the JSON-null query trap (the JS SDK sends absent campaign params as explicit nulls, so `!= ''` doesn't filter them out), and the three fixes.

Companion to a behavior fix in PostHog/posthog#74742 that stops null campaign params from permanently claiming `$initial_*` slots.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

Note: written by Claude (PostHog Code) during a support investigation, directed by @christiaan-ph. Preview build not checked by the agent, please eyeball both pages in the Vercel preview before marking ready.
