### PR TITLE
website(nav): expand docs nav submenus in place on mobile

### DIFF
--- a/src/components/Korean/KoreanTaskBarMenu/menuData.tsx
+++ b/src/components/Korean/KoreanTaskBarMenu/menuData.tsx
@@ -414,6 +414,8 @@ export function useMenuData(): MenuType[] {
         },
         {
             trigger: 'Docs',
+            // Mobile skips the menu — the docs homepage covers the same ground with more room
+            mobileLink: '/docs',
             items: mergedDocsMenu(allProducts),
         },
         {

--- a/src/components/Korean/KoreanTaskBarMenu/menuData.tsx
+++ b/src/components/Korean/KoreanTaskBarMenu/menuData.tsx
@@ -804,25 +804,8 @@ export function useMenuData(): MenuType[] {
                         continue
                     }
 
-                    // Convert submenus with mobileDestination to simple items
-                    if (item.type === 'submenu' && item.mobileDestination) {
-                        filteredItems.push({
-                            ...item,
-                            type: 'item' as const,
-                            link: item.mobileDestination,
-                            items: undefined,
-                        })
-                    }
-                    // Convert submenus with links to simple items
-                    else if (item.type === 'submenu' && item.link) {
-                        filteredItems.push({
-                            ...item,
-                            type: 'item' as const,
-                            items: undefined,
-                        })
-                    } else {
-                        filteredItems.push(item)
-                    }
+                    // Submenus keep their children — MenuBar expands them in place on mobile
+                    filteredItems.push(item)
                 }
 
                 const processedItems = filteredItems

--- a/src/components/RadixUI/MenuBar.tsx
+++ b/src/components/RadixUI/MenuBar.tsx
@@ -63,64 +63,10 @@ const MenuItemContent = (item: MenuItemType, forceIconIndent?: boolean) => {
     )
 }
 
-// Process menu items for mobile display - truncate nesting to 2 levels max
-const processMobileMenuItem = (item: MenuItemType): MenuItemType | null => {
-    // Skip items marked for mobile omission
-    if (item.mobileDestination === false) {
-        return null
-    }
-
-    // If item has a mobile destination, convert submenu to simple link
-    if (item.mobileDestination && item.type === 'submenu') {
-        return {
-            ...item,
-            type: 'item' as const,
-            link: item.mobileDestination,
-            items: undefined, // Remove nested items on mobile
-        }
-    }
-
-    // For submenus without explicit mobile destination, limit depth
-    if (item.type === 'submenu' && item.items) {
-        // If the submenu has a link, make it a simple link on mobile
-        if (item.link) {
-            return {
-                ...item,
-                type: 'item' as const,
-                items: undefined,
-            }
-        }
-
-        // Otherwise, process children but make them all leaf nodes
-        if (Array.isArray(item.items)) {
-            const processedItems = item.items
-                .map((subItem: MenuItemType) => {
-                    // Convert all nested submenus to simple items
-                    if (subItem.type === 'submenu') {
-                        return {
-                            ...subItem,
-                            type: 'item' as const,
-                            link:
-                                subItem.link ||
-                                subItem.mobileDestination ||
-                                subItem.items?.find((subItem) => !!subItem?.link)?.link ||
-                                '#',
-                            items: undefined,
-                        }
-                    }
-                    return subItem
-                })
-                .filter(Boolean) as MenuItemType[]
-
-            return {
-                ...item,
-                items: processedItems,
-            }
-        }
-    }
-
-    return item
-}
+// Mobile keeps the full tree — submenus expand in place rather than opening a flyout, so
+// nothing is dropped. Only omission is honoured here.
+const processMobileMenuItem = (item: MenuItemType): MenuItemType | null =>
+    item.mobileDestination === false ? null : item
 
 const processMobileMenuItems = (items: MenuItemType[]): MenuItemType[] => {
     const processedItems: MenuItemType[] = []
@@ -146,17 +92,66 @@ const processMobileMenuItems = (items: MenuItemType[]): MenuItemType[] => {
     return processedItems
 }
 
-// Components
-const MenuItem: React.FC<{
+type MenuItemProps = {
     portalContainer: HTMLElement | null
     appContainer: HTMLElement | null
     item: MenuItemType
     forceIconIndent?: boolean
     menuIndex: number
     onCloseMenu?: () => void
-}> = ({ item, forceIconIndent, menuIndex, portalContainer, appContainer, onCloseMenu }) => {
+}
+
+// Mobile has no room for a sideways flyout, so a submenu expands underneath itself instead.
+// Chevron rotates 90° when open, matching the docs sidebar (TreeMenu).
+const MobileSubmenuItem: React.FC<MenuItemProps> = (props) => {
+    const { item, forceIconIndent } = props
+    const [open, setOpen] = React.useState(false)
+
+    return (
+        <>
+            <RadixMenubar.Item
+                className={ItemClasses}
+                onSelect={(e) => {
+                    // Keep the menu open — this row toggles rather than navigates
+                    e.preventDefault()
+                    setOpen((wasOpen) => !wasOpen)
+                }}
+            >
+                <span className="px-2.5 flex w-full items-center gap-2">
+                    {item.icon ? (
+                        item.icon
+                    ) : forceIconIndent ? (
+                        <span style={{ display: 'inline-block', width: 16, minWidth: 16 }} />
+                    ) : null}
+                    <span className="flex-1 text-left">{item.label}</span>
+                    <IconChevronRight
+                        className={`size-4 shrink-0 transition-transform duration-150 ${open ? 'rotate-90' : ''}`}
+                        aria-hidden
+                    />
+                </span>
+            </RadixMenubar.Item>
+            {open && Array.isArray(item.items) && (
+                <div className="ml-4 border-l border-primary pl-1">
+                    {item.items.map((child, index) => (
+                        <MenuItem {...props} key={index} item={child} forceIconIndent={false} />
+                    ))}
+                </div>
+            )}
+        </>
+    )
+}
+
+// Components
+const MenuItem: React.FC<MenuItemProps> = (props) => {
+    const { item, forceIconIndent, menuIndex, portalContainer, appContainer, onCloseMenu } = props
+    const { isMobile } = useAppSettings()
+
     if (item.type === 'separator') {
         return <RadixMenubar.Separator className={SeparatorClasses} />
+    }
+
+    if (isMobile && item.type === 'submenu' && Array.isArray(item.items) && item.items.length > 0) {
+        return <MobileSubmenuItem {...props} />
     }
 
     if (item.type === 'label') {

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -450,6 +450,8 @@ export function useMenuData(): MenuType[] {
         },
         {
             trigger: 'Docs',
+            // Mobile skips the menu — the docs homepage covers the same ground with more room
+            mobileLink: '/docs',
             items: mergedDocsMenu(allProducts),
         },
         {

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -850,25 +850,8 @@ export function useMenuData(): MenuType[] {
                         continue
                     }
 
-                    // Convert submenus with mobileDestination to simple items
-                    if (item.type === 'submenu' && item.mobileDestination) {
-                        filteredItems.push({
-                            ...item,
-                            type: 'item' as const,
-                            link: item.mobileDestination,
-                            items: undefined,
-                        })
-                    }
-                    // Convert submenus with links to simple items
-                    else if (item.type === 'submenu' && item.link) {
-                        filteredItems.push({
-                            ...item,
-                            type: 'item' as const,
-                            items: undefined,
-                        })
-                    } else {
-                        filteredItems.push(item)
-                    }
+                    // Submenus keep their children — MenuBar expands them in place on mobile
+                    filteredItems.push(item)
                 }
 
                 const processedItems = filteredItems


### PR DESCRIPTION
uh oh spahetti-o, I broke mobile lol

fixes broken nav on mobile for new docs drop down - instead sends them to docs homepage/overview

before:

https://github.com/user-attachments/assets/39235735-c827-490a-a685-08d78bb72361

after:


https://github.com/user-attachments/assets/4c579cb0-ca80-48b4-a969-037741e8ea45



