### PR TITLE
Swap sparks joy to reader view

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -12,6 +12,7 @@ import {
     IconLinkedIn,
     IconGithub,
     IconInstagram,
+    IconDictator,
     IconSparksJoy,
 } from 'components/OSIcons'
 import { useAppSettings } from '../../context/App'
@@ -964,20 +965,20 @@ export const SparksJoyItems = {
         {
             label: 'Hedgehog mode',
             link: '/sparks-joy/hedgehog-mode',
-            iconName: 'games' as AppIconName,
+            iconName: 'hedgehog_mode' as AppIconName,
             customIcon: null,
         },
         {
             label: 'HogWars',
             link: '/sparks-joy/hogwars',
-            iconName: 'games' as AppIconName,
+            iconName: 'hogwars' as AppIconName,
             customIcon: null,
         },
         {
             label: 'Dictator or tech bro?',
             link: '/sparks-joy/dictator-or-tech-bro',
-            iconName: 'games' as AppIconName,
-            customIcon: null,
+            iconName: null,
+            customIcon: <IconDictator />,
         },
         {
             label: 'BrickHog',

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -12,7 +12,6 @@ import {
     IconLinkedIn,
     IconGithub,
     IconInstagram,
-    IconDictator,
     IconSparksJoy,
 } from 'components/OSIcons'
 import { useAppSettings } from '../../context/App'
@@ -965,20 +964,20 @@ export const SparksJoyItems = {
         {
             label: 'Hedgehog mode',
             link: '/sparks-joy/hedgehog-mode',
-            iconName: 'hedgehog_mode' as AppIconName,
+            iconName: 'games' as AppIconName,
             customIcon: null,
         },
         {
             label: 'HogWars',
             link: '/sparks-joy/hogwars',
-            iconName: 'hogwars' as AppIconName,
+            iconName: 'games' as AppIconName,
             customIcon: null,
         },
         {
             label: 'Dictator or tech bro?',
             link: '/sparks-joy/dictator-or-tech-bro',
-            iconName: null,
-            customIcon: <IconDictator />,
+            iconName: 'games' as AppIconName,
+            customIcon: null,
         },
         {
             label: 'BrickHog',

--- a/src/pages/sparks-joy/brickhog/index.tsx
+++ b/src/pages/sparks-joy/brickhog/index.tsx
@@ -10,7 +10,7 @@ export default function BrickHog(): JSX.Element {
                 description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
                 image={`/images/og/default.png`}
             />
-            <Explorer template="generic" slug="brickhog" title="BrickHog" fullScreen>
+            <Explorer template="generic" slug="brickhog" title="BrickHog" showAddressBar={false} fullScreen>
                 <iframe src="https://brickbreak-ebon.vercel.app/" className="w-full h-full border-0" />
             </Explorer>
         </>

--- a/src/pages/sparks-joy/brickhog/index.tsx
+++ b/src/pages/sparks-joy/brickhog/index.tsx
@@ -10,7 +10,14 @@ export default function BrickHog(): JSX.Element {
                 description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
                 image={`/images/og/default.png`}
             />
-            <Explorer template="generic" slug="brickhog" title="BrickHog" showAddressBar={false} fullScreen>
+            <Explorer
+                template="generic"
+                slug="brickhog"
+                title="BrickHog"
+                showAddressBar={false}
+                headerBarOptions={[]}
+                fullScreen
+            >
                 <iframe src="https://brickbreak-ebon.vercel.app/" className="w-full h-full border-0" />
             </Explorer>
         </>

--- a/src/pages/sparks-joy/dictator-or-tech-bro/index.tsx
+++ b/src/pages/sparks-joy/dictator-or-tech-bro/index.tsx
@@ -19,6 +19,7 @@ export default function DictatorOrTechBro(): JSX.Element {
                 // roadmapCategory="product-analytics"
                 // changelogCategory="product-analytics"
                 showAddressBar={false}
+                headerBarOptions={[]}
                 fullScreen
             >
                 <iframe src="https://dictatorortechbro.com" className="w-full h-full border-0" />

--- a/src/pages/sparks-joy/dictator-or-tech-bro/index.tsx
+++ b/src/pages/sparks-joy/dictator-or-tech-bro/index.tsx
@@ -18,6 +18,7 @@ export default function DictatorOrTechBro(): JSX.Element {
                 // teamName="product-analytics"
                 // roadmapCategory="product-analytics"
                 // changelogCategory="product-analytics"
+                showAddressBar={false}
                 fullScreen
             >
                 <iframe src="https://dictatorortechbro.com" className="w-full h-full border-0" />

--- a/src/pages/sparks-joy/hedgehog-mode/index.tsx
+++ b/src/pages/sparks-joy/hedgehog-mode/index.tsx
@@ -18,6 +18,7 @@ export default function HedgehogModeGame(): JSX.Element {
                 // teamName="product-analytics"
                 // roadmapCategory="product-analytics"
                 // changelogCategory="product-analytics"
+                showAddressBar={false}
                 fullScreen
             >
                 <iframe src="https://hedgehog-mode-playground.vercel.app/" className="w-full h-full border-0" />

--- a/src/pages/sparks-joy/hedgehog-mode/index.tsx
+++ b/src/pages/sparks-joy/hedgehog-mode/index.tsx
@@ -19,6 +19,7 @@ export default function HedgehogModeGame(): JSX.Element {
                 // roadmapCategory="product-analytics"
                 // changelogCategory="product-analytics"
                 showAddressBar={false}
+                headerBarOptions={[]}
                 fullScreen
             >
                 <iframe src="https://hedgehog-mode-playground.vercel.app/" className="w-full h-full border-0" />

--- a/src/pages/sparks-joy/hogpatch/index.tsx
+++ b/src/pages/sparks-joy/hogpatch/index.tsx
@@ -10,7 +10,14 @@ export default function HogPatch(): JSX.Element {
                 description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
                 image={`/images/og/default.png`}
             />
-            <Explorer template="generic" slug="hogpatch" showAddressBar={false} title="HogPatch: The Game" fullScreen>
+            <Explorer
+                template="generic"
+                slug="hogpatch"
+                title="HogPatch: The Game"
+                showAddressBar={false}
+                headerBarOptions={[]}
+                fullScreen
+            >
                 <iframe src="https://candidate-rpg.vercel.app/game" className="w-full h-full border-0" />
             </Explorer>
         </>

--- a/src/pages/sparks-joy/hogwars/index.tsx
+++ b/src/pages/sparks-joy/hogwars/index.tsx
@@ -19,6 +19,7 @@ export default function HogWars(): JSX.Element {
                 // roadmapCategory="product-analytics"
                 // changelogCategory="product-analytics"
                 showAddressBar={false}
+                headerBarOptions={[]}
                 fullScreen
             >
                 <iframe src="https://hogwars.vercel.app/" className="w-full h-full border-0" />

--- a/src/pages/sparks-joy/hogwars/index.tsx
+++ b/src/pages/sparks-joy/hogwars/index.tsx
@@ -18,6 +18,7 @@ export default function HogWars(): JSX.Element {
                 // teamName="product-analytics"
                 // roadmapCategory="product-analytics"
                 // changelogCategory="product-analytics"
+                showAddressBar={false}
                 fullScreen
             >
                 <iframe src="https://hogwars.vercel.app/" className="w-full h-full border-0" />

--- a/src/pages/sparks-joy/index.tsx
+++ b/src/pages/sparks-joy/index.tsx
@@ -1,21 +1,13 @@
 import React from 'react'
-import Explorer from 'components/Explorer'
-import { Link } from 'gatsby'
+import ReaderView from 'components/ReaderView'
 import SEO from 'components/seo'
-import { IconSparksJoy } from 'components/OSIcons/Icons'
 import { Accordion } from 'components/RadixUI/Accordion'
 import { explorerGridColumns } from '../../constants'
-import { explorerLayoutOptions } from '../../constants/explorerLayoutOptions'
-import { ToggleGroup } from 'components/RadixUI/ToggleGroup'
-import { useExplorerLayout } from '../../hooks/useExplorerLayout'
-import { SparksJoyItems, useMenuSelectOptions } from '../../components/TaskBarMenu/menuData'
+import { SparksJoyItems } from '../../components/TaskBarMenu/menuData'
 import { AppLink, AppIcon } from 'components/OSIcons/AppIcon'
 import ZoomHover from 'components/ZoomHover'
 
 export default function SparkJoy(): JSX.Element {
-    const { isListLayout, setLayoutValue, currentLayout } = useExplorerLayout('grid')
-    const selectOptions = useMenuSelectOptions()
-
     return (
         <>
             <SEO
@@ -23,66 +15,22 @@ export default function SparkJoy(): JSX.Element {
                 description="Because we're not all work and no play"
                 image={`/images/og/default.png`}
             />
-            <Explorer
-                template="generic"
-                slug="spark-joy"
-                // title="Sparks joy"
-                selectOptions={selectOptions}
-                selectedCategory="sparks-joy"
-                rightActionButtons={
-                    <ToggleGroup
-                        title="Layout"
-                        hideTitle={true}
-                        options={explorerLayoutOptions}
-                        onValueChange={setLayoutValue}
-                        value={currentLayout}
-                        className="-my-1 ml-2"
-                    />
-                }
-                // options below only needed to override matching the slug
-                // teamName="product-analytics"
-                // roadmapCategory="product-analytics"
-                // changelogCategory="product-analytics"
-                leftSidebarContent={
-                    <>
-                        <Accordion
-                            data-scheme="primary"
-                            className=""
-                            defaultValue="item-0"
-                            items={[
-                                {
-                                    trigger: (
-                                        <>
-                                            <IconSparksJoy className={`size-5 inline-block`} />
-                                            <span className="flex-1">Why?</span>
-                                        </>
-                                    ),
-                                    content: (
-                                        <>
-                                            <p className="text-sm mb-0">
-                                                It's a reference to a book by Marie Kondo and is part of the{' '}
-                                                <Link to="/handbook/company/lore" state={{ newWindow: true }}>
-                                                    lore of PostHog
-                                                </Link>
-                                                .
-                                            </p>
-                                        </>
-                                    ),
-                                },
-                            ]}
-                        />
-                    </>
-                }
+            <ReaderView
+                className="border-t border-primary"
+                hideAppOptions
+                hideRightSidebar
+                hideLeftSidebar
+                showQuestions={false}
             >
-                <div className="@container not-prose space-y-2 @md:-ml-3">
+                <div className="@container not-prose space-y-2">
                     {/* Games Section */}
                     <Accordion
-                        triggerClassName="flex-row-reverse [&>svg]:!-rotate-90 [&[data-state=open]>svg]:!rotate-0 [&>span]:relative [&>span]:after:absolute [&>span]:after:right-0 [&>span]:after:top-1/2 [&>span]:after:h-px [&>span]:after:w-full [&>span]:after:bg-border [&>span]:after:content-['']"
+                        triggerClassName="flex-row-reverse [&>svg]:!-rotate-90 [&[data-state=open]>svg]:!rotate-0 [&>span]:gap-2 [&>span]:after:h-0.5 [&>span]:after:flex-1 [&>span]:after:bg-border [&>span]:after:content-['']"
                         items={[
                             {
                                 value: 'games',
                                 trigger: (
-                                    <span className="bg-primary pr-2 relative z-10 select-none">
+                                    <span>
                                         Games (
                                         {SparksJoyItems.games.filter((item) => item.iconName || item.customIcon).length}
                                         )
@@ -90,21 +38,12 @@ export default function SparkJoy(): JSX.Element {
                                 ),
                                 content: (
                                     <div
-                                        className={`@md:pl-4 grid ${
-                                            isListLayout
-                                                ? '@lg:grid-cols-2 @3xl:grid-cols-3'
-                                                : explorerGridColumns + ' gap-y-4 items-start justify-items-center'
-                                        } gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
+                                        className={`@md:pl-4 grid ${explorerGridColumns} gap-y-4 items-start justify-items-center gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
                                     >
                                         {SparksJoyItems.games
                                             .filter((item) => item.iconName || item.customIcon)
                                             .map((item) => (
-                                                <ZoomHover
-                                                    key={item.link}
-                                                    className={
-                                                        isListLayout ? 'w-full justify-start' : 'w-28 justify-center'
-                                                    }
-                                                >
+                                                <ZoomHover key={item.link} className="w-28 justify-center">
                                                     <AppLink
                                                         label={item.label}
                                                         url={item.link}
@@ -115,9 +54,7 @@ export default function SparkJoy(): JSX.Element {
                                                                 item.customIcon
                                                             )
                                                         }
-                                                        background="bg-primary"
                                                         className="size-12"
-                                                        orientation={isListLayout ? 'row' : 'column'}
                                                     />
                                                 </ZoomHover>
                                             ))}
@@ -130,12 +67,12 @@ export default function SparkJoy(): JSX.Element {
 
                     {/* Not games Section */}
                     <Accordion
-                        triggerClassName="flex-row-reverse [&>svg]:!-rotate-90 [&[data-state=open]>svg]:!rotate-0 [&>span]:relative [&>span]:after:absolute [&>span]:after:right-0 [&>span]:after:top-1/2 [&>span]:after:h-px [&>span]:after:w-full [&>span]:after:bg-border [&>span]:after:content-['']"
+                        triggerClassName="flex-row-reverse [&>svg]:!-rotate-90 [&[data-state=open]>svg]:!rotate-0 [&>span]:gap-2 [&>span]:after:h-0.5 [&>span]:after:flex-1 [&>span]:after:bg-border [&>span]:after:content-['']"
                         items={[
                             {
                                 value: 'grab-bag',
                                 trigger: (
-                                    <span className="bg-primary pr-2 relative z-10 select-none">
+                                    <span>
                                         Grab bag (
                                         {
                                             SparksJoyItems.notGames.filter((item) => item.iconName || item.customIcon)
@@ -146,21 +83,12 @@ export default function SparkJoy(): JSX.Element {
                                 ),
                                 content: (
                                     <div
-                                        className={`@md:pl-4 grid ${
-                                            isListLayout
-                                                ? '@lg:grid-cols-2 @3xl:grid-cols-3'
-                                                : explorerGridColumns + ' gap-y-4 items-start justify-items-center'
-                                        } gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
+                                        className={`@md:pl-4 grid ${explorerGridColumns} gap-y-4 items-start justify-items-center gap-x-1 @md:gap-x-4 relative [&>div]:mx-auto [&_figure]:text-center`}
                                     >
                                         {SparksJoyItems.notGames
                                             .filter((item) => item.iconName || item.customIcon)
                                             .map((item) => (
-                                                <ZoomHover
-                                                    key={item.link}
-                                                    className={
-                                                        isListLayout ? 'w-full justify-start' : 'w-28 justify-center'
-                                                    }
-                                                >
+                                                <ZoomHover key={item.link} className="w-28 justify-center">
                                                     <AppLink
                                                         label={item.label}
                                                         url={item.link}
@@ -171,9 +99,7 @@ export default function SparkJoy(): JSX.Element {
                                                                 item.customIcon
                                                             )
                                                         }
-                                                        background="bg-primary"
                                                         className="size-12"
-                                                        orientation={isListLayout ? 'row' : 'column'}
                                                     />
                                                 </ZoomHover>
                                             ))}
@@ -184,7 +110,7 @@ export default function SparkJoy(): JSX.Element {
                         defaultValue="grab-bag"
                     />
                 </div>
-            </Explorer>
+            </ReaderView>
         </>
     )
 }


### PR DESCRIPTION
## Changes

Match the [/sparks-joy](https://posthog.com/sparks-joy) page styling to the [/trash](https://posthog.com/trash) page (updated in #19061):

- Swap `Explorer` for `ReaderView` (hiding app options and sidebars)
- Drop the grid/list layout toggle
- Remove the left sidebar "Why?" note (trash's equivalent sidebar note was dropped in #19061 too)
- Update the accordion trigger + grid styling to match trash

**Why:** Requested so the two pages look stylistically consistent.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AR8V7V1D4/p1785335447067919)*