### PR TITLE
Redirect /why to /about

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -150,6 +150,11 @@
     ],
     "redirects": [
         {
+            "source": "/why",
+            "destination": "/about",
+            "statusCode": 301
+        },
+        {
             "source": "/docs/web-analytics/getting-started",
             "destination": "/docs/web-analytics/start-here",
             "statusCode": 301


### PR DESCRIPTION
## Changes

Adds a 301 redirect from `/why` to `/about` in `vercel.json`.

**Why:** the `/why` URL was flagged as surfacing in search as an outdated page. This consolidates it into the maintained `/about` company page. Raised in a Slack thread.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BH6R0RDFX/p1785336351913199)*
