### PR TITLE
Fix: support fullscreen scaling for demo video

### DIFF
--- a/src/components/MediaPlayer/index.tsx
+++ b/src/components/MediaPlayer/index.tsx
@@ -286,6 +286,10 @@ export default function MediaPlayer({
     }
 
     const toggleFullscreen = () => {
+        if (source === 'wistia' && typeof playerState.player?.requestFullscreen === 'function') {
+            playerState.player.requestFullscreen()
+            return
+        }
         const iframe = document.getElementById(`video-player-iframe-${videoId}`) as any
         if (iframe?.requestFullscreen) {
             iframe.requestFullscreen()


### PR DESCRIPTION
## Changes

This PR fixes an issue where the demo video player doesn't enter fullscreen correctly. When fullscreen is clicked, the demo video player does not resize, resulting in a video at the corner of a black screen:

<img height="300" alt="Screenshot 2026-07-29 at 11 52 54 AM" src="https://github.com/user-attachments/assets/4a9d9ac2-c32a-4cf9-8af1-35b01a7c2447" />

The demo is a Wistia video embedded in a `MediaPlayer` component. This PR changes how `MediaPlayer` invokes fullscreen for Wistia videos. Instead of calling `requestFullscreen` on the Wistia container div, this PR switches to using Wistia's fullscreen API. 

This fix is only relevant for instances of `MediaPlayer` which use Wistia embeds. Other instances of `MediaPlayer` on the website (such as [this page](https://posthog.com/changelog-video)) do not use Wistia and are not affected by this bug.

### Validation

I validated the component in Storybook, which confirms the demo video player behavior in isolation. I couldn't run the full Gatsby build locally due to memory constraints.

**Therefore, this PR should be sanity checked through the preview build before merging.**

In Storybook, I confirmed that the demo video now enters fullscreen correctly:

<img height="300" alt="Screenshot 2026-07-29 at 11 52 37 AM" src="https://github.com/user-attachments/assets/a155f078-667e-4a8e-b9d4-5f5907a0dd98" />






**Notes**
- The control bar is not visible in fullscreen. This is true both for the current implementation and for this PR. Users currently need to use Esc to exit fullscreen. A follow-up PR could also fullscreen the control bar, but this is larger scope.
- This fix is mainly aimed at desktop users. In a browser on mobile, the fullscreen button currently does nothing at all. Delegating to Wistia's fullscreen API may improve this failure mode as well, but mobile testing is needed to confirm this.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links --> N/A
- [ ] I've checked the pages added or changed in the Vercel preview build --> PENDING
- [x] If I moved a page, I added a redirect in `vercel.json` --> N/A