### PR TITLE
fix(docs): correct how workflow email link tracking is described

### DIFF
--- a/contents/docs/workflows/library.mdx
+++ b/contents/docs/workflows/library.mdx
@@ -109,7 +109,7 @@ If you type Liquid syntax directly and the Liquid doesn't compile correctly, the
 
 ### Disabling link click tracking
 
-PostHog automatically rewrites every link in an email to route through a click-tracking redirect, which powers the `$workflows_email_link_clicked` [engagement event](/docs/workflows/engagement-events).
+Links in an email are rewritten for click tracking, which powers the `$workflows_email_link_clicked` [engagement event](/docs/workflows/engagement-events).
 
 If you need a link to reach its destination exactly as written, add an HTML block and mark the anchor with either `clicktracking="off"` or `data-ph-no-track`:
 
@@ -117,7 +117,7 @@ If you need a link to reach its destination exactly as written, add an HTML bloc
 <a href="https://example.com/your-link" data-ph-no-track>Open link</a>
 ```
 
-The attribute must be on the `<a>` tag itself, not a child element. Links marked this way won't produce click events.
+The attribute must be on the `<a>` tag itself, not a child element. Links marked this way keep their original URL and won't produce click events. Use this for app deep links and mobile universal links, which stop resolving to the app once they're rewritten.
 
 ### Testing templates
 


### PR DESCRIPTION
## Problem

The workflows library page describes link click tracking in a way that is no longer accurate, and one part of it was never accurate.

It says PostHog "automatically rewrites every link in an email to route through a click-tracking redirect". On the SES send path that stops being true with PostHog/posthog#75097, which leaves hrefs pointing at their real destination and lets the email provider rewrite them for click tracking instead.

It also says links marked `clicktracking="off"` or `data-ph-no-track` "won't produce click events". That was the intent, but SES recognizes only its own `ses:no-track` marker, so those anchors were still being rewritten and still produced clicks. The companion PR fixes that, which makes the documented behavior real.

## Changes

Reworded the section so it describes what happens rather than the specific mechanism, and added the reason someone would actually reach for the opt-out: app deep links and mobile universal links stop resolving to the app once a link is rewritten.

```diff
-PostHog automatically rewrites every link in an email to route through a click-tracking redirect, which powers the `$workflows_email_link_clicked` engagement event.
+Links in an email are rewritten for click tracking, which powers the `$workflows_email_link_clicked` engagement event.
```

```diff
-The attribute must be on the `<a>` tag itself, not a child element. Links marked this way won't produce click events.
+The attribute must be on the `<a>` tag itself, not a child element. Links marked this way keep their original URL and won't produce click events. Use this for app deep links and mobile universal links, which stop resolving to the app once they're rewritten.
```

> [!NOTE]
> This should merge alongside or after PostHog/posthog#75097. On its own it describes behavior that isn't shipped yet.

## How did you test this code?

Docs-only prose change, no build run. I (Claude) did not start the Gatsby dev server; the edit is two paragraphs of MDX with no component or frontmatter changes, and the fenced HTML example is untouched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code, `claude-opus-5`) wrote this while working on the messaging change in PostHog/posthog#75097. Skill invoked: `/writing-user-facing-copy`.

Found by grepping for the opt-out attribute names while tracing the click-tracking path, rather than from a report. The doc turned out to be describing intended behavior that the code did not deliver, which is what led to the `ses:no-track` fix in the companion PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_018cci2CGqACYGKMmjoCNKj8)_