### PR TITLE
docs(metrics): document the metrics agent Docker path, sharding, and durability

### DIFF
--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -6,10 +6,11 @@ title: Metrics
 
 PostHog Metrics lets you send application and infrastructure metrics (request counts, latencies, queue depths, resource usage) to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
 
-There are two ways to send metrics:
+There are three ways to send metrics:
 
 1. **Already have PostHog installed?** Record metrics directly with the [`posthog.metrics` API](#already-have-posthog-installed-use-posthogmetrics) built into the PostHog SDK, with no extra packages.
 2. **Using OpenTelemetry?** Point any standard OpenTelemetry library or Collector at [PostHog's OTLP endpoint](#set-up-metrics-with-opentelemetry), with no PostHog-specific packages.
+3. **Already exposing Prometheus metrics?** Run the metrics agent with [Docker](/docs/metrics/installation/docker) or [Kubernetes](/docs/metrics/installation/kubernetes) to scrape your existing `/metrics` endpoints, with no code changes.
 
 ## Already have PostHog installed? Use posthog.metrics
 
@@ -162,6 +163,17 @@ service:
     metrics:
       receivers: [otlp]
       exporters: [otlphttp/posthog]
+```
+
+### Already exposing Prometheus metrics?
+
+If your services expose Prometheus `/metrics` endpoints, you don't need to change any code or run your own Collector. Deploy the PostHog metrics agent with [Docker](/docs/metrics/installation/docker) or the [Kubernetes Helm chart](/docs/metrics/installation/kubernetes) and it scrapes your existing endpoints and forwards them to PostHog, exemplars included:
+
+```bash
+docker run -d \
+  -e POSTHOG_API_KEY=<ph_project_token> \
+  -e SCRAPE_TARGETS=your-app:9090 \
+  posthog/metrics-agent:latest
 ```
 
 ## Supported metric types

--- a/contents/docs/metrics/installation/docker.mdx
+++ b/contents/docs/metrics/installation/docker.mdx
@@ -1,0 +1,120 @@
+---
+title: Docker metrics installation
+platformLogo: docker
+showStepsToc: true
+---
+
+import { Steps, Step } from "components/Docs/Steps";
+import MetricsNextSteps from "./_snippets/metrics-next-steps.mdx";
+
+> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+
+If your services already expose Prometheus-format `/metrics` endpoints, the PostHog metrics agent scrapes them and forwards everything to PostHog. One `docker run`, no application changes.
+
+Running Kubernetes? Use the [Helm chart](/docs/metrics/installation/kubernetes) instead, which also discovers annotated pods automatically.
+
+<Steps>
+
+<Step title="Get your project token" badge="required">
+
+You'll need your PostHog project token to authenticate metrics requests. This is the same token you use for capturing events with the PostHog SDK.
+
+> **Important:** Use your **project token**, which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project token in [Project Settings](https://app.posthog.com/settings).
+
+</Step>
+
+<Step title="Run the agent" badge="required">
+
+Point the agent at one or more `host:port` targets that expose `/metrics`:
+
+```bash
+docker run -d --name posthog-metrics-agent \
+  -e POSTHOG_API_KEY=<ph_project_token> \
+  -e POSTHOG_HOST=<ph_client_api_host> \
+  -e SCRAPE_TARGETS=your-app:9090,your-worker:9091 \
+  posthog/metrics-agent:latest
+```
+
+The agent scrapes each target every 15 seconds by default. Two common adjustments:
+
+```bash
+  -e SCRAPE_INTERVAL=30s \
+  -e SCRAPE_METRICS_PATH=/custom/metrics \
+```
+
+Set `SCRAPE_JOB_NAME` to control the `service_name` your metrics arrive under. It defaults to `posthog-metrics-agent`.
+
+</Step>
+
+<Step title="Verify metrics are flowing" badge="recommended">
+
+1. Check the agent started cleanly:
+
+```bash
+docker logs posthog-metrics-agent
+```
+
+You should see `Everything is ready. Begin running and processing data.` Scrape or export errors appear in the same log.
+
+2. Open [**Metrics**](https://app.posthog.com/metrics) in PostHog and pick a metric from the name picker. Data points should appear within a minute.
+
+The agent also exposes its own health: `:13133` answers health probes, and `:8888/metrics` serves the agent's own metrics, including scrape successes, queue depth, and points sent or dropped.
+
+<CallToAction type="primary" to="https://app.posthog.com/metrics">
+  View your metrics in PostHog
+</CallToAction>
+
+</Step>
+
+<Step title="Keep data through restarts" badge="optional">
+
+By default, if PostHog is briefly unreachable the agent retries from memory, and a restart during that window drops whatever was buffered. To keep those samples, back the queue with disk:
+
+```bash
+docker run -d --name posthog-metrics-agent \
+  -e POSTHOG_API_KEY=<ph_project_token> \
+  -e SCRAPE_TARGETS=your-app:9090 \
+  -e PERSIST_QUEUE=1 \
+  -v posthog-agent-queue:/var/lib/posthog-agent \
+  posthog/metrics-agent:latest
+```
+
+Samples scraped during an outage then survive restarts and deliver when PostHog is reachable again.
+
+</Step>
+
+<Step title="Scale out with shards" badge="optional">
+
+One agent scrapes every target itself, which is enough for most setups. For a large target set, run a fleet: set `SHARD_COUNT` on every instance and give each one a distinct `SHARD_INDEX` from `0` to `SHARD_COUNT - 1`. Each instance then scrapes only the targets whose address hashes to its shard, so nothing is scraped twice and nothing is missed.
+
+Don't scale with plain copies of one agent: two unsharded agents scraping the same targets record every metric twice.
+
+</Step>
+
+<MetricsNextSteps />
+
+</Steps>
+
+## Configuration reference
+
+| Variable              | Default                    | Description                                                                  |
+| --------------------- | -------------------------- | ---------------------------------------------------------------------------- |
+| `POSTHOG_API_KEY`     | required                   | Project token (`phc_...`), sent as a bearer token                            |
+| `POSTHOG_HOST`        | `https://us.i.posthog.com` | PostHog ingestion origin. Set to `https://eu.i.posthog.com` for EU Cloud     |
+| `SCRAPE_TARGETS`      | required                   | Comma-separated `host:port` list to scrape                                   |
+| `SCRAPE_INTERVAL`     | `15s`                      | How often to scrape each target                                              |
+| `SCRAPE_METRICS_PATH` | `/metrics`                 | Metrics path on the targets                                                  |
+| `SCRAPE_JOB_NAME`     | `posthog-metrics-agent`    | Becomes `service_name` on every metric                                       |
+| `SHARD_COUNT`         | `1`                        | Fleet size. Above 1, each instance scrapes only its share of the targets     |
+| `SHARD_INDEX`         | from hostname ordinal      | This instance's shard, `0` to `SHARD_COUNT - 1`                              |
+| `PERSIST_QUEUE`       | off                        | Set to `1` to buffer undelivered batches on disk                             |
+| `QUEUE_DIR`           | `/var/lib/posthog-agent`   | Where the persistent queue is stored                                         |
+| `POSTHOG_DEBUG`       | off                        | Set to `1` to also log exported batches to stdout                            |
+
+For custom Prometheus `scrape_configs` or a full OpenTelemetry Collector config, mount them into the container. The [agent README](https://github.com/PostHog/posthog/tree/master/products/metrics/agent) documents both escape hatches.
+
+## Exemplars: link metrics to traces
+
+If your Prometheus client attaches exemplars (trace and span IDs on counters and histograms), the agent preserves them, and the metrics viewer links those data points to the matching [traces](/docs/distributed-tracing). The agent requests the OpenMetrics format automatically, because it's the only Prometheus format that carries exemplars. If your endpoint only serves classic Prometheus text, metrics still flow, only without trace links.

--- a/contents/docs/metrics/installation/index.mdx
+++ b/contents/docs/metrics/installation/index.mdx
@@ -8,7 +8,7 @@ There are three ways to get metrics into PostHog:
 
 - **PostHog SDKs**: if a PostHog SDK is already in your app, record metrics with the `posthog.metrics` API. No new packages, no extra authentication.
 - **OpenTelemetry (OTLP)**: if you use OpenTelemetry anywhere else, point your OTLP metrics exporter at PostHog. No PostHog packages required.
-- **Kubernetes Helm chart**: if you run Kubernetes and already have pods exposing Prometheus metrics, install the PostHog metrics agent to scrape and forward them automatically.
+- **Metrics agent**: if your services already expose Prometheus `/metrics` endpoints, run the PostHog metrics agent with [Docker](/docs/metrics/installation/docker) or the [Kubernetes Helm chart](/docs/metrics/installation/kubernetes) to scrape and forward them, with no code changes.
 
 Already capturing metrics with Prometheus, StatsD, or Datadog? You don't need to replace anything: add the PostHog call next to your existing instrumentation, using the same metric name and attributes, and migrate at your own pace.
 
@@ -20,6 +20,7 @@ Already capturing metrics with Prometheus, StatsD, or Datadog? You don't need to
 | [Node.js](/docs/metrics/installation/nodejs)              | `posthog.metrics` API in [posthog-node](/docs/libraries/node)     |
 | [Python](/docs/metrics/installation/python)               | `posthog.metrics` API in [posthog-python](/docs/libraries/python) |
 | [Other languages](/docs/metrics/installation/other)       | Any OpenTelemetry-compatible OTLP metrics exporter                |
+| [Docker](/docs/metrics/installation/docker)               | Metrics agent container that scrapes Prometheus `/metrics` targets |
 | [Kubernetes](/docs/metrics/installation/kubernetes)       | Helm chart that scrapes `prometheus.io/scrape` annotated pods     |
 
 > **Note:** Metrics uses the OpenTelemetry Protocol (OTLP) standard. If your language isn't listed, check the [OpenTelemetry documentation](https://opentelemetry.io/docs/) for compatible libraries and see [other languages](/docs/metrics/installation/other).

--- a/contents/docs/metrics/installation/kubernetes.mdx
+++ b/contents/docs/metrics/installation/kubernetes.mdx
@@ -11,7 +11,7 @@ import MetricsNextSteps from "./_snippets/metrics-next-steps.mdx";
 
 If your Kubernetes workloads already expose Prometheus-format `/metrics` endpoints, the PostHog metrics agent scrapes them and forwards everything to PostHog. One `helm install`, no application changes.
 
-The agent runs as a single-replica Deployment by design – two replicas would double-scrape every target and double-count all metrics.
+The agent runs as a single instance by default. To scale beyond one pod, use [shards](#scale-out-with-shards) rather than replicas: two plain replicas would scrape every target twice and double-count all metrics.
 
 <Steps>
 
@@ -120,9 +120,35 @@ If nothing shows up, check the agent logs for connection or authentication error
 kubectl logs -l app.kubernetes.io/name=posthog-metrics-agent
 ```
 
+The agent also exposes its own metrics (scrape successes, queue depth, points sent or dropped) on port `8888`, so you can monitor the monitor.
+
 <CallToAction type="primary" to="https://app.posthog.com/metrics">
   View your metrics in PostHog
 </CallToAction>
+
+</Step>
+
+<Step title="Keep data through restarts" badge="optional">
+
+By default, if PostHog is briefly unreachable the agent retries from memory, and a pod restart during that window drops whatever was buffered. To keep those samples, back the queue with a persistent volume:
+
+```bash
+--set persistence.enabled=true
+```
+
+The chart provisions a volume per agent (using `persistence.size` and `persistence.storageClass`), and samples scraped during an outage survive restarts and deliver when PostHog is reachable again.
+
+</Step>
+
+<Step title="Scale out with shards" badge="optional">
+
+One agent scrapes every target itself, which is enough for most clusters. For a large target set, run a fleet:
+
+```bash
+--set shards=4
+```
+
+The chart switches to a StatefulSet, each pod works out its own shard from its name, and every target is scraped by exactly one pod: nothing is scraped twice, nothing is missed. Combine with `persistence.enabled=true` to give each shard its own durable queue.
 
 </Step>
 
@@ -141,6 +167,11 @@ kubectl logs -l app.kubernetes.io/name=posthog-metrics-agent
 | `scrape.annotationDiscovery` | `true`                     | Discover pods via `prometheus.io/scrape` annotations                                    |
 | `scrape.staticTargets`       | `[]`                       | Fixed `host:port` targets, e.g. `['my-svc:9090']`                                       |
 | `scrape.extraScrapeConfigs`  | `''`                       | Raw Prometheus `scrape_configs` YAML appended verbatim                                  |
+| `shards`                     | `1`                        | Agent fleet size. Above 1, a StatefulSet partitions targets so each is scraped once     |
+| `persistence.enabled`        | `false`                    | Buffer undelivered batches on a persistent volume so restarts lose nothing              |
+| `persistence.size`           | `10Gi`                     | Size of each agent's queue volume                                                       |
+| `persistence.storageClass`   | `''`                       | StorageClass for the queue volume. Empty uses the cluster default                       |
+| `podEnv`                     | `{}`                       | Extra environment variables for the agent container                                     |
 | `resources.requests.cpu`     | `100m`                     | CPU request                                                                             |
 | `resources.requests.memory`  | `256Mi`                    | Memory request                                                                          |
 | `resources.limits.memory`    | `512Mi`                    | Memory limit                                                                            |

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -8032,6 +8032,8 @@ export const docsMenu = {
                         { name: 'Node.js', url: '/docs/metrics/installation/nodejs' },
                         { name: 'Python', url: '/docs/metrics/installation/python' },
                         { name: 'Other languages', url: '/docs/metrics/installation/other' },
+                        { name: 'Docker', url: '/docs/metrics/installation/docker' },
+                        { name: 'Kubernetes', url: '/docs/metrics/installation/kubernetes' },
                     ],
                 },
                 {


### PR DESCRIPTION
## Changes

Completes the metrics agent onboarding docs, matching what ships in the agent today plus [PostHog/posthog#75087](https://github.com/PostHog/posthog/pull/75087):

- **New page: `/docs/metrics/installation/docker`** - the missing non-Kubernetes onboarding for the metrics agent (`posthog/metrics-agent`). Steps format matching the other installation pages: run, verify, keep data through restarts, scale out with shards, full env reference, exemplars.
- **`/docs/metrics/installation/kubernetes`** - extended with the agent's new capabilities: `shards` (StatefulSet fleet, each target scraped exactly once), `persistence.enabled` (disk-backed queue so restarts lose nothing), the agent's own `:8888` metrics endpoint in the verify step, and the new chart values in the reference table. Also reworded the "single replica by design" line since sharding is now the sanctioned way to scale.
- **Nav fix**: the installation section now lists Docker and Kubernetes - the Kubernetes page existed but was never added to the sidebar.
- **`/docs/metrics` + `/docs/metrics/installation`**: the "ways to send metrics" lists now include the scrape path with working links, and a short "Already exposing Prometheus metrics?" section sits next to the existing Collector section.

## Merge timing

The sharding and persistence sections document chart `0.2.0`, which publishes when [PostHog/posthog#75087](https://github.com/PostHog/posthog/pull/75087) merges. Everything else on these pages is live today (`0.1.0`). Suggest merging this after that PR lands so the docs never describe values the published chart doesn't have.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
