### PR TITLE
Reorder AI observability page sections

### DIFF
--- a/src/hooks/productData/ai_observability.tsx
+++ b/src/hooks/productData/ai_observability.tsx
@@ -10,7 +10,6 @@ import {
     IconLlmAnalytics,
     IconMagic,
     IconMessage,
-    IconNewspaper,
     IconPieChart,
     IconRocket,
     IconSparkles,
@@ -87,14 +86,13 @@ export const aiObservability = {
             icon: <IconChat className="size-4" />,
         },
         { slug: 'pairs-with', name: 'Pairs with...', hideFromNav: true, icon: <IconConfetti className="size-4" /> },
-        { slug: 'changelog', name: 'Changelog', group: 'divided', icon: <IconNewspaper className="size-4" /> },
-        { slug: 'community', name: 'Questions?', group: 'divided', icon: <IconMessage className="size-4" /> },
         {
             slug: 'feature-comparison',
             name: 'Feature comparison',
             group: 'divided',
             icon: <IconList className="size-4" />,
         },
+        { slug: 'community', name: 'Questions?', group: 'divided', icon: <IconMessage className="size-4" /> },
         // No `installation` section: the shared install taxonomy has no LLM provider
         // category, so it would list generic web/backend SDKs instead of the
         // per-provider guides. The provider grid lives in the Integrations slide of


### PR DESCRIPTION
## Changes

Reorders the sections on the `/ai-observability` product page so the flow is: Overview → How do I use it → Top features → AI prompts → Feature comparison → Questions → Get started. The Changelog section is removed (and its now-unused `IconNewspaper` import dropped).

Install was intentionally left out: the shared install component has no LLM-provider category, so it would surface generic web/backend SDKs rather than the per-provider guides (those already live in the Integrations slide of Top features).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AR8V7V1D4/p1785408052814129)*
