### PR TITLE
docs(mcp): call MCP functions "MCP tools" throughout MCP docs

### DIFF
--- a/contents/docs/integrations/lovable.mdx
+++ b/contents/docs/integrations/lovable.mdx
@@ -92,7 +92,7 @@ The agent will modify the existing flag and confirm the new rollout percentage.
 
 The agent will set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
 
-See [all available MCP tools](/docs/model-context-protocol#available-tools) for the complete list.
+See [all available MCP tools](/docs/model-context-protocol/tools#available-mcp-tools) for the complete list.
 
 ## Troubleshooting
 
@@ -110,7 +110,7 @@ Try disconnecting and reconnecting the PostHog MCP server. Make sure you're logg
 
 ## Next steps
 
-- [MCP tools reference](/docs/model-context-protocol#available-tools) - All available MCP tools
+- [MCP tools reference](/docs/model-context-protocol/tools#available-mcp-tools) - All available MCP tools
 - [Error tracking docs](/docs/error-tracking) - Learn more about error tracking features
 - [Feature flags](/docs/feature-flags) - Set up feature flags in your code
 

--- a/contents/docs/integrations/replit.mdx
+++ b/contents/docs/integrations/replit.mdx
@@ -106,7 +106,7 @@ The agent will modify the existing flag and confirm the new rollout percentage.
 
 The agent will set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
 
-See [all available MCP tools](/docs/model-context-protocol#available-tools) for the complete list.
+See [all available MCP tools](/docs/model-context-protocol/tools#available-mcp-tools) for the complete list.
 
 ## Troubleshooting
 
@@ -127,6 +127,6 @@ Try disconnecting and reconnecting the PostHog MCP server. Make sure you're logg
 - [Error tracking docs](/docs/error-tracking) - Learn more about error tracking features
 - [Source maps guide](/docs/error-tracking/upload-source-maps) - Detailed source map configuration
 - [Feature flags](/docs/feature-flags) - Set up feature flags in your code
-- [MCP tools reference](/docs/model-context-protocol#available-tools) - All available MCP tools
+- [MCP tools reference](/docs/model-context-protocol/tools#available-mcp-tools) - All available MCP tools
 
 Have feedback or questions? Let us know on [GitHub](https://github.com/PostHog/posthog/issues) or [ask a question](/questions).

--- a/contents/docs/integrations/v0.mdx
+++ b/contents/docs/integrations/v0.mdx
@@ -92,7 +92,7 @@ The agent will modify the existing flag and confirm the new rollout percentage.
 
 The agent will set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
 
-See [all available MCP tools](/docs/model-context-protocol#available-tools) for the complete list.
+See [all available MCP tools](/docs/model-context-protocol/tools#available-mcp-tools) for the complete list.
 
 ## Troubleshooting
 
@@ -111,7 +111,7 @@ Try disconnecting and reconnecting the PostHog MCP server. Make sure you're logg
 ## Next steps
 
 - [Vercel Flags SDK docs](/docs/libraries/vercel) - Full Vercel Flags SDK setup guide
-- [MCP tools reference](/docs/model-context-protocol#available-tools) - All available MCP tools
+- [MCP tools reference](/docs/model-context-protocol/tools#available-mcp-tools) - All available MCP tools
 - [Feature flags](/docs/feature-flags) - Set up feature flags in your code
 
 Have feedback or questions? Let us know on [GitHub](https://github.com/PostHog/posthog/issues) or [ask a question](/questions).

--- a/contents/docs/model-context-protocol/enterprise-managed-authorization.mdx
+++ b/contents/docs/model-context-protocol/enterprise-managed-authorization.mdx
@@ -50,7 +50,7 @@ sequenceDiagram
     Note over AS: Validate ID-JAG signature,<br/>audience, resource, scopes
     AS-->>Client: PostHog access token
 
-    loop Tool calls
+    loop MCP tool calls
         Client->>MCP: Call MCP tool with access token
         MCP-->>Client: Result
     end
@@ -115,7 +115,7 @@ Configure your IdP to include these scopes when it issues ID-JAGs, at minimum:
 
 - `user:read` — required for all MCP connections
 - `organization:read` and `project:read` — required for the MCP server to bootstrap (list your orgs and projects)
-- Any additional scopes for the tools you want to use (for example, `feature_flag:write` to manage flags)
+- Any additional scopes for the MCP tools you want to use (for example, `feature_flag:write` to manage flags)
 
 PostHog issues the access token with the **intersection** of the scopes your IdP granted and the scopes the client requested. Tokens missing the bootstrap scopes are rejected at the MCP server with an `insufficient_scope` error.
 

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -7,25 +7,25 @@ showTitle: true
 
 Everything you need to know about authentication, scoping, filtering, safety, and billing for the PostHog MCP server. If you're just getting started, head to the [overview](/docs/model-context-protocol) or the [use cases](/docs/model-context-protocol/use-cases) page first.
 
-> Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review tool calls before executing them.
+> Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review MCP tool calls before executing them.
 
 ## Frequently asked questions
 
 ### What is the PostHog MCP server?
 
-The PostHog MCP server is a hosted [Model Context Protocol](https://modelcontextprotocol.io/introduction) endpoint that exposes PostHog's products – feature flags, product analytics, error tracking, experiments, SQL queries, CDP, surveys, and more – as function-calling tools to any MCP-compatible AI agent.
+The PostHog MCP server is a hosted [Model Context Protocol](https://modelcontextprotocol.io/introduction) endpoint that exposes PostHog's products – feature flags, product analytics, error tracking, experiments, SQL queries, CDP, surveys, and more – as function-calling MCP tools to any MCP-compatible AI agent.
 
 ### How much does it cost?
 
-Connecting to the MCP server and calling its tools is free. Standard PostHog [usage and billing](/docs/billing) still apply to the underlying data your queries consume.
+Connecting to the MCP server and calling its MCP tools is free. Standard PostHog [usage and billing](/docs/billing) still apply to the underlying data your queries consume.
 
-Note that some tools use LLMs internally, and usage of these tools may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
+Note that some MCP tools use LLMs internally, and usage of these MCP tools may be billed as PostHog AI spend. These AI-powered MCP tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
 
 ### Are there rate limits?
 
 MCP tool calls execute against the PostHog API, so they're subject to the same [API rate limits](/docs/api#rate-limiting) – there's no separate MCP limit layered on top. These limits apply per team, across all users and keys in your organization.
 
-Some [AI-powered tools](#how-much-does-it-cost) (for example, sentiment analysis and trace summarization) have their own additional, lower limits because they run LLMs internally.
+Some [AI-powered MCP tools](#how-much-does-it-cost) (for example, sentiment analysis and trace summarization) have their own additional, lower limits because they run LLMs internally.
 
 If you regularly hit these limits, consider pulling data through [batch exports](/docs/cdp/batch-exports) or [endpoints](/docs/endpoints) instead.
 
@@ -47,7 +47,7 @@ The MCP server acts as a proxy to your PostHog instance and is automatically rou
 
 ### Is it safe to let an agent write to my project?
 
-Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review tool calls before executing them. You can also restrict the session to [read-only tools](#restricting-to-read-only-tools), limit it to specific tools or feature categories using [tool filtering](#filtering-available-tools), and pin the agent to a specific organization or project to limit blast radius.
+Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review MCP tool calls before executing them. You can also restrict the session to [read-only MCP tools](#restricting-to-read-only-mcp-tools), limit it to specific MCP tools or feature categories using [MCP tool filtering](#filtering-available-mcp-tools), and pin the agent to a specific organization or project to limit blast radius.
 
 ## Advanced configuration
 
@@ -77,7 +77,7 @@ Example for Cursor (add to `.cursor/mcp.json`):
 
 If you're building a programmatic integration or want to restrict the MCP session to a specific organization or project, you can pin the context using headers or query parameters.
 
-When you pin the context, the `switch-organization` and `switch-project` tools are automatically excluded from the available tool list:
+When you pin the context, the `switch-organization` and `switch-project` MCP tools are automatically excluded from the available MCP tool list:
 
 - When `projectId` is provided: both `switch-organization` and `switch-project` are excluded
 - When only `organizationId` is provided: only `switch-organization` is excluded
@@ -111,12 +111,12 @@ Example for Cursor (add to `.cursor/mcp.json`):
 
 ### Choosing a tool mode
 
-The MCP server exposes its tools in one of two modes:
+The MCP server exposes its MCP tools in one of two modes:
 
-- **CLI mode** ships a single, token-optimized `exec` tool. Instead of loading every tool's schema upfront, the agent uses `exec` to list, search, inspect, and call PostHog tools on demand. Because the server has hundreds of tools, this saves a large amount of context, so it's the mode we typically recommend. On clients that support MCP apps, CLI mode also ships a `render-ui` tool that renders interactive visualizations on demand.
-- **Tools mode** registers every PostHog tool individually – the standard MCP behavior. Each tool's name and schema is loaded into context when the agent connects.
+- **CLI mode** ships a single, token-optimized `exec` MCP tool. Instead of loading every MCP tool's schema upfront, the agent uses `exec` to list, search, inspect, and call PostHog MCP tools on demand. Because the server has hundreds of MCP tools, this saves a large amount of context, so it's the mode we typically recommend. On clients that support MCP apps, CLI mode also ships a `render-ui` MCP tool that renders interactive visualizations on demand.
+- **Tools mode** registers every PostHog MCP tool individually – the standard MCP behavior. Each MCP tool's name and schema is loaded into context when the agent connects.
 
-The mode is auto-detected from your client. The majority of clients default to CLI mode – including Claude, Claude Code, Cowork, and Codex – while a few, such as Cursor, default to tools mode because they handle large tool lists natively.
+The mode is auto-detected from your client. The majority of clients default to CLI mode – including Claude, Claude Code, Cowork, and Codex – while a few, such as Cursor, default to tools mode because they handle large MCP tool lists natively.
 
 You can override the default with a header or query parameter:
 
@@ -129,9 +129,9 @@ Both accept `cli` or `tools`. The header takes precedence if you set both.
 https://mcp.posthog.com/mcp?mode=cli
 ```
 
-### Restricting to read-only tools
+### Restricting to read-only MCP tools
 
-To stop the agent from writing to your project, you can restrict the session to read-only tools using a header or query parameter. Tools that create, update, or delete data are excluded from the available tool list, leaving only the ones that read.
+To stop the agent from writing to your project, you can restrict the session to read-only MCP tools using a header or query parameter. MCP tools that create, update, or delete data are excluded from the available MCP tool list, leaving only the ones that read.
 
 - **Header:** `x-posthog-read-only`
 - **Query parameter:** `readonly`
@@ -158,13 +158,13 @@ Example for Cursor (add to `.cursor/mcp.json`):
 }
 ```
 
-### Filtering available tools
+### Filtering available MCP tools
 
-You can limit which tools are available using two query parameters, individually or together.
+You can limit which MCP tools are available using two query parameters, individually or together.
 
 #### Filter by feature category
 
-The `features` parameter exposes all tools belonging to one or more feature categories:
+The `features` parameter exposes all MCP tools belonging to one or more feature categories:
 
 ```text
 https://mcp.posthog.com/mcp?features=flags,dashboards,insights
@@ -184,7 +184,7 @@ Available features:
 | `dashboards`             | [Dashboard creation and management](/docs/product-analytics/dashboards)                |
 | `data_schema`            | Data schema exploration                                                                |
 | `data_warehouse`         | [Data warehouse management](/docs/data-warehouse)                                      |
-| `debug`                  | Debug and diagnostic tools                                                             |
+| `debug`                  | Debug and diagnostic MCP tools                                                         |
 | `docs`                   | PostHog documentation search                                                           |
 | `early_access_features`  | [Early access feature management](/docs/feature-flags/early-access-feature-management) |
 | `error_tracking`         | [Error monitoring and debugging](/docs/error-tracking)                                 |
@@ -208,9 +208,9 @@ Available features:
 
 > **Note:** Hyphens and underscores are treated as equivalent in feature names (e.g., `error-tracking` and `error_tracking` both work).
 
-#### Filter by tool name
+#### Filter by MCP tool name
 
-The `tools` parameter exposes specific tools by their exact name. Use the [tools reference](/docs/model-context-protocol/tools) to find the names you need:
+The `tools` parameter exposes specific MCP tools by their exact name. Use the [MCP tools reference](/docs/model-context-protocol/tools) to find the names you need:
 
 ```text
 https://mcp.posthog.com/mcp?tools=dashboard-get,feature-flag-get-all,execute-sql
@@ -218,13 +218,13 @@ https://mcp.posthog.com/mcp?tools=dashboard-get,feature-flag-get-all,execute-sql
 
 #### Combining both parameters
 
-When both `features` and `tools` are provided, they act as a union — a tool is exposed if it matches a feature category **or** is listed by name. This lets you select a whole feature group and surgically add individual tools from other categories:
+When both `features` and `tools` are provided, they act as a union — an MCP tool is exposed if it matches a feature category **or** is listed by name. This lets you select a whole feature group and surgically add individual MCP tools from other categories:
 
 ```text
 https://mcp.posthog.com/mcp?features=flags&tools=dashboard-get
 ```
 
-If neither parameter is specified, all tools are available.
+If neither parameter is specified, all MCP tools are available.
 
 Example for Cursor (add to `.cursor/mcp.json`):
 
@@ -258,5 +258,5 @@ The MCP server acts as a proxy to your PostHog instance. It does not store your 
 ## Keep exploring
 
 - [Use cases](/docs/model-context-protocol/use-cases) – example prompts and multi-step recipes
-- [Tools reference](/docs/model-context-protocol/tools) – every tool the MCP server exposes
+- [MCP tools reference](/docs/model-context-protocol/tools) – every MCP tool the server exposes
 - [Overview](/docs/model-context-protocol) – back to the MCP overview and install instructions

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -13,7 +13,7 @@ The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/intro
 
 It works with any MCP-compatible client, including [PostHog Desktop](/desktop), Claude Code, Claude Desktop, Cursor, Codex, VS Code, Windsurf, and Zed.
 
-> Connecting to the MCP server and calling its tools is free, but some tools use LLMs internally and may be billed as PostHog AI spend. These AI-powered tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings.
+> Connecting to the MCP server and calling its MCP tools is free, but some MCP tools use LLMs internally and may be billed as PostHog AI spend. These AI-powered MCP tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings.
 
 ## Get started in 30 seconds
 
@@ -60,7 +60,7 @@ There's a lot more – analytics queries, feature flag and experiment management
 ## Go deeper
 
 - **[Use cases](/docs/model-context-protocol/use-cases)** – 20+ example prompts and multi-step recipes for the most useful MCP workflows
-- **[Tools reference](/docs/model-context-protocol/tools)** – every tool the MCP server exposes, grouped by category
+- **[MCP tools reference](/docs/model-context-protocol/tools)** – every MCP tool the server exposes, grouped by category
 - **[FAQ and advanced setup](/docs/model-context-protocol/faq)** – auth, scoping, filtering, safety, and other operational details
 
 ## Next steps

--- a/contents/docs/model-context-protocol/tools.mdx
+++ b/contents/docs/model-context-protocol/tools.mdx
@@ -1,25 +1,25 @@
 ---
 title: PostHog MCP tools reference
-sidebarTitle: Tools
+sidebarTitle: MCP tools
 sidebar: Docs
 showTitle: true
 ---
 
 import MCPTools from "../../../src/components/Docs/MCPTools";
 
-The PostHog MCP server exposes function-calling tools across every PostHog product – from feature flags and experiments to error tracking, logs, surveys, and SQL. Your agent picks the right tool based on the goals and context already in the conversation.
+The PostHog MCP server exposes function-calling MCP tools across every PostHog product – from feature flags and experiments to error tracking, logs, surveys, and SQL. Your agent picks the right MCP tool based on the goals and context already in the conversation.
 
-Tool names are stable and can be used with the [`tools` query parameter](/docs/model-context-protocol/faq#filtering-available-tools) to scope a session to a specific subset.
+MCP tool names are stable and can be used with the [`tools` query parameter](/docs/model-context-protocol/faq#filtering-available-mcp-tools) to scope a session to a specific subset.
 
-> **Tip:** Browse the [example prompts](/docs/model-context-protocol/use-cases) to see what each tool is good for in practice.
+> **Tip:** Browse the [example prompts](/docs/model-context-protocol/use-cases) to see what each MCP tool is good for in practice.
 
-## Available tools
+## Available MCP tools
 
-Click any category to expand the full list of tools it contains.
+Click any category to expand the full list of MCP tools it contains.
 
 <MCPTools />
 
-> **Note:** Some tools are in alpha behind a feature flag and don't appear here yet – like the [semantic layer tools](/docs/semantic-layer/mcp-tools) for governed metrics, table certifications, and relationships.
+> **Note:** Some MCP tools are in alpha behind a feature flag and don't appear here yet – like the [semantic layer MCP tools](/docs/semantic-layer/mcp-tools) for governed metrics, table certifications, and relationships.
 
 ## Keep exploring
 

--- a/contents/docs/model-context-protocol/use-cases.mdx
+++ b/contents/docs/model-context-protocol/use-cases.mdx
@@ -260,7 +260,7 @@ Set one-off or recurring reminders that fire as in-app notifications. Optionally
 
 ## Multi-step recipes
 
-Single prompts get you a long way, but the real value of MCP comes from chaining tool calls into end-to-end workflows. Drop these sequences into your agent one step at a time – each prompt builds on the context the previous one returned.
+Single prompts get you a long way, but the real value of MCP comes from chaining MCP tool calls into end-to-end workflows. Drop these sequences into your agent one step at a time – each prompt builds on the context the previous one returned.
 
 ### Investigate and contain a regression
 
@@ -339,6 +339,6 @@ Conversion is down – use MCP to figure out where users are dropping off, why, 
 
 ## Keep exploring
 
-- [Tools reference](/docs/model-context-protocol/tools) – every tool the MCP server exposes, grouped by category
+- [MCP tools reference](/docs/model-context-protocol/tools) – every MCP tool the server exposes, grouped by category
 - [FAQ and advanced setup](/docs/model-context-protocol/faq) – auth, scoping, filtering, and other operational details
 - [Overview](/docs/model-context-protocol) – back to the MCP overview and install instructions

--- a/src/components/Docs/MCPTools.tsx
+++ b/src/components/Docs/MCPTools.tsx
@@ -23,7 +23,7 @@ const MCPTools: React.FC = () => {
         return (
             <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded">
                 <p className="text-red-800 dark:text-red-200">
-                    Tools unavailable. Please view the repo{' '}
+                    MCP tools unavailable. Please view the repo{' '}
                     <a
                         href="https://github.com/PostHog/posthog/tree/master/services/mcp"
                         className="underline font-semibold"
@@ -32,7 +32,7 @@ const MCPTools: React.FC = () => {
                     >
                         https://github.com/PostHog/posthog/tree/master/services/mcp
                     </a>{' '}
-                    to see tools.
+                    to see MCP tools.
                 </p>
             </div>
         )
@@ -41,7 +41,7 @@ const MCPTools: React.FC = () => {
     if (!toolCategories || toolCategories.length === 0) {
         return (
             <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded">
-                <p className="text-gray-600 dark:text-gray-400">Loading tools...</p>
+                <p className="text-gray-600 dark:text-gray-400">Loading MCP tools...</p>
             </div>
         )
     }
@@ -53,7 +53,7 @@ const MCPTools: React.FC = () => {
                 return (
                     <details key={category.name} className="mb-2">
                         <summary>
-                            <strong>{category.name}</strong> ({toolCount} {toolCount === 1 ? 'tool' : 'tools'})
+                            <strong>{category.name}</strong> ({toolCount} MCP {toolCount === 1 ? 'tool' : 'tools'})
                         </summary>
                         <div className="not-prose px-3 pt-2 pb-1">
                             <dl className="m-0 grid grid-cols-[minmax(0,auto)_1fr] gap-x-4">

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3641,7 +3641,7 @@ export const docsMenu = {
                                     url: '/docs/model-context-protocol/use-cases',
                                 },
                                 {
-                                    name: 'Tools reference',
+                                    name: 'MCP tools reference',
                                     url: '/docs/model-context-protocol/tools',
                                 },
                                 {


### PR DESCRIPTION
## Changes

Disambiguates terminology across the [Model Context Protocol docs](https://posthog.com/docs/model-context-protocol) so the function-calling capabilities the MCP server exposes (e.g. `action-create`, `dashboard-get`) are consistently called **"MCP tools"** rather than just "tools". This keeps them distinct from PostHog's **products/features** ("Tools" like product analytics, session replay, feature flags) and from **surfaces** (PostHog MCP, Web, CLI).

Scope:
- Prose + headings on the overview, use cases, tools reference, FAQ/advanced setup, and enterprise-auth pages.
- The "Tools reference" nav label → "MCP tools reference" and the tools page `sidebarTitle`.
- `MCPTools` component copy (empty/error/loading states and the per-category count).
- Renamed the section anchors that changed as a result (`available-mcp-tools`, `filtering-available-mcp-tools`, `restricting-to-read-only-mcp-tools`, `filter-by-mcp-tool-name`) and updated every internal reference. The Lovable/Replit/v0 integration pages linked to a now-stale `#available-tools` anchor on the overview page; repointed them to the correct tools-page anchor.

Left intentionally unchanged: the literal `tools`/`features` query params and header values, the "CLI mode"/"Tools mode" proper names, and third-party UI labels (e.g. Cursor's "Tools & Integrations").

**Why:** The word "tools" was overloaded in these docs — sometimes meaning PostHog products, sometimes the MCP functions — which made the copy ambiguous. Standardizing on "MCP tools" for the functions makes the docs clearer.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1785408281822479)*