### PR TITLE
docs(session-replay): document Flutter web canvas masking

### DIFF
--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -197,6 +197,8 @@ To set up [session replay web](/docs/session-replay) or [mobile session replay](
 If you're using Flutter Web, also enable the [Canvas capture](/docs/session-replay/canvas-recording) in [your project settings](https://us.posthog.com/settings/project-replay).
 This is needed as Flutter renders your app using a browser canvas element.
 
+On Flutter Web, masking (`maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`) applies inside that canvas too — declare `session_recording.canvasCapture.maskRegionsFn` in the `posthog.init` call in your `web/index.html` to enable it. See [masking on Flutter Web](/docs/session-replay/privacy) under the Flutter tab.
+
 ## Surveys
 
 > **Note:** Surveys are supported in Flutter for **Web**, **iOS**, and **Android** platforms.

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -197,7 +197,7 @@ To set up [session replay web](/docs/session-replay) or [mobile session replay](
 If you're using Flutter Web, also enable the [Canvas capture](/docs/session-replay/canvas-recording) in [your project settings](https://us.posthog.com/settings/project-replay).
 This is needed as Flutter renders your app using a browser canvas element.
 
-On Flutter Web, masking (`maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`) applies inside that canvas too — declare `session_recording.canvasCapture.maskRegionsFn` in the `posthog.init` call in your `web/index.html` to enable it. See [masking on Flutter Web](/docs/session-replay/privacy) under the Flutter tab.
+On Flutter Web, masking (`maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`) applies inside that canvas too — declare `session_recording.canvasCapture.maskRegionsFn` in the `posthog.init` call in your `web/index.html` to enable it (requires PostHog Flutter SDK 5.34.0+ and posthog-js 1.408.0+). See [masking on Flutter Web](/docs/session-replay/privacy) under the Flutter tab.
 
 ## Surveys
 

--- a/contents/docs/session-replay/_snippets/flutter-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-privacy.mdx
@@ -13,6 +13,8 @@ config.sessionReplayConfig.maskAllTexts = false;
 config.sessionReplayConfig.maskAllImages = false;
 ```
 
+These settings apply on iOS, Android, and — with [canvas masking](#masking-on-flutter-web) enabled — Flutter Web.
+
 ### Masking in Flutter
 
 - You can manually mark a Widget for masking using the `PostHogMaskWidget` Widget:
@@ -22,6 +24,43 @@ config.sessionReplayConfig.maskAllImages = false;
     const PostHogMaskWidget(child: Text('Sensitive!'))
 ...
 ```
+
+### Masking on Flutter Web
+
+> Requires PostHog Flutter SDK version >= [5.34.0](https://github.com/PostHog/posthog-flutter/releases) and posthog-js version >= [1.408.0](https://github.com/PostHog/posthog-js/releases) in your `web/index.html`.
+
+On Flutter web, session replay records your app as pixels inside the CanvasKit canvas, where DOM-based masking cannot see your widgets. Canvas masking applies the same rules inside the canvas: `maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`, and obscured text fields (like passwords) are honored with the same semantics as iOS and Android.
+
+To enable it, declare a mask-region provider in the `posthog.init` call in your `web/index.html`, alongside enabling canvas capture:
+
+```html file=web/index.html
+<script>
+  posthog.init('<ph_project_token>', {
+    api_host: '<ph_client_api_host>',
+    session_recording: {
+      captureCanvas: {
+        recordCanvas: true,
+      },
+      canvasCapture: {
+        // The PostHog Flutter plugin replaces this once your app starts.
+        // Until then, canvas frames are skipped rather than recorded unmasked.
+        maskRegionsFn: () => null,
+      },
+    },
+  })
+</script>
+```
+
+Mounting a `PostHogMaskWidget` also switches canvas masking on by itself, without the `posthog.init` declaration. Prefer the declaration when you can edit `web/index.html`: it covers the frames captured before Flutter boots (they are skipped instead of recorded unmasked), and it avoids a one-time recording restart at the moment masking switches on.
+
+Things to know:
+
+- Your app must be wrapped in `PostHogWidget`. Without it, canvas frames are skipped rather than recorded unmasked, and a console warning explains the fix.
+- On a posthog-js older than 1.408.0, canvas frames are **not** masked — a console warning tells you to upgrade.
+- If your project configures a `blockSelector` in the replay project settings, list it in `posthog.init` too: the client-side value (which the plugin extends to exclude Flutter's accessibility DOM) takes precedence over the project-level one.
+- Platform views (`HtmlElementView`) are DOM elements, not canvas pixels — they follow posthog-js's DOM masking rules, and `PostHogMaskWidget` does not mask them on web.
+- Text painted by a custom `CustomPainter` is not in the widget tree, so `maskAllTexts` cannot find it — wrap it in `PostHogMaskWidget`.
+- On a page embedding multiple Flutter views, canvases belonging to other Flutter views are skipped entirely (not recorded).
 
 ### Masking platform views
 

--- a/contents/docs/session-replay/canvas-recording.mdx
+++ b/contents/docs/session-replay/canvas-recording.mdx
@@ -22,7 +22,7 @@ Canvas elements are recorded at a rate of **4 frames per second** which may lead
 
 An application that knows where sensitive content sits inside its canvas can supply mask regions via `session_recording.canvasCapture.maskRegionsFn` in `posthog.init`. The returned regions (CSS pixels, relative to the canvas) are painted black inside the capture pipeline before frames are encoded — masked pixels never leave the browser. Returning `null` skips that canvas's frame entirely rather than recording it unmasked.
 
-**Flutter web** uses this to apply its full masking configuration (`maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`) inside the CanvasKit canvas — see [masking in session replay](/docs/session-replay/privacy) under the Flutter tab for setup.
+**Flutter web** (PostHog Flutter SDK 5.34.0+) uses this to apply its full masking configuration (`maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`) inside the CanvasKit canvas — see [masking in session replay](/docs/session-replay/privacy) under the Flutter tab for setup.
 
 <ProductScreenshot
     imageLight={ImgReplayCanvasLight} 

--- a/contents/docs/session-replay/canvas-recording.mdx
+++ b/contents/docs/session-replay/canvas-recording.mdx
@@ -12,9 +12,17 @@ export const ImgReplayCanvasLight = "https://res.cloudinary.com/dmukukwp6/image/
 
 PostHog can capture canvas elements from your application. It works in both 2D and WebGL environments. 
 
-As canvas elements can contain sensitive information and there is **no way to mask canvas elements right now**, we do not capture these automatically. Once you are sure they are free of PII, you can enable this feature globally from your [replay settings](https://us.posthog.com/settings/project-replay#replay).
+As canvas elements can contain sensitive information and are **not covered by DOM-based masking**, we do not capture these automatically. Once you are sure they are free of PII (or you have set up [canvas masking](#masking-canvas-content)), you can enable this feature globally from your [replay settings](https://us.posthog.com/settings/project-replay#replay).
 
 Canvas elements are recorded at a rate of **4 frames per second** which may lead to some perceptual differences during playback.
+
+## Masking canvas content
+
+> Requires posthog-js version >= [1.408.0](https://github.com/PostHog/posthog-js/releases).
+
+An application that knows where sensitive content sits inside its canvas can supply mask regions via `session_recording.canvasCapture.maskRegionsFn` in `posthog.init`. The returned regions (CSS pixels, relative to the canvas) are painted black inside the capture pipeline before frames are encoded — masked pixels never leave the browser. Returning `null` skips that canvas's frame entirely rather than recording it unmasked.
+
+**Flutter web** uses this to apply its full masking configuration (`maskAllTexts`, `maskAllImages`, `PostHogMaskWidget`) inside the CanvasKit canvas — see [masking in session replay](/docs/session-replay/privacy) under the Flutter tab for setup.
 
 <ProductScreenshot
     imageLight={ImgReplayCanvasLight} 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -294,7 +294,7 @@ If you use [canvas masking on Flutter Web](/docs/session-replay/privacy) and con
 
 - Check your app is wrapped in `PostHogWidget` — without it, canvas frames are skipped entirely (blank canvas) rather than recorded unmasked, and a console warning explains the fix.
 - Frames captured between page load and Flutter booting are only covered when `session_recording.canvasCapture.maskRegionsFn` is declared in `posthog.init` — without the declaration, masking starts at the first `PostHogMaskWidget` mount and the recording restarts once at that point (the replay shows a split).
-- Canvas masking requires posthog-js 1.408.0+ — on older versions frames record unmasked and the plugin logs a console warning telling you to upgrade.
+- Canvas masking requires PostHog Flutter SDK 5.34.0+ and posthog-js 1.408.0+ — on an older posthog-js, frames record unmasked and the plugin logs a console warning telling you to upgrade.
 
 ## Angular performance
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -288,6 +288,14 @@ Due to the complexity of browser rendering and replay, some web resources are un
 - **Heavy animations** – Some heavier animations such as SVG or Lottie animations may be _throttled_ or ignored entirely due to the performance overhead in recording and replaying
 - **Iframes** – iframes from the origins under your control **can** be recorded and played back. Third-party embeds you don't control (Typeform, YouTube, Stripe Checkout, Calendly, etc.) **cannot** be recorded – PostHog can't run inside a foreign domain and the same-origin policy blocks DOM access, so the iframe appears as an empty element. There is no per-domain allowlist for this. See [iframe recording](/docs/session-replay/iframes#third-party-embeds-typeform-youtube-stripe-etc) for more info.
 
+## Flutter Web canvas masking not applied
+
+If you use [canvas masking on Flutter Web](/docs/session-replay/privacy) and content appears unmasked or the canvas stays blank:
+
+- Check your app is wrapped in `PostHogWidget` — without it, canvas frames are skipped entirely (blank canvas) rather than recorded unmasked, and a console warning explains the fix.
+- Frames captured between page load and Flutter booting are only covered when `session_recording.canvasCapture.maskRegionsFn` is declared in `posthog.init` — without the declaration, masking starts at the first `PostHogMaskWidget` mount and the recording restarts once at that point (the replay shows a split).
+- Canvas masking requires posthog-js 1.408.0+ — on older versions frames record unmasked and the plugin logs a console warning telling you to upgrade.
+
 ## Angular performance
 
 It is sometimes necessary to run Session Replay outside of the Angular zone. See the [PostHog Angular docs for more detail](/docs/libraries/angular#session-replay)


### PR DESCRIPTION
## Changes

Documents session replay canvas masking on Flutter Web — shipped in posthog-js [1.408.0](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.408.0) (PostHog/posthog-js#4270) and landing in posthog-flutter via PostHog/posthog-flutter#499 + PostHog/posthog-flutter#501.

Flutter Web renders the whole app into a canvas, so DOM masking couldn't see any of it. Masking now happens inside the canvas, and these docs tell users how to turn it on:

- **`session-replay/_snippets/flutter-privacy.mdx`** — new "Masking on Flutter Web" section (the Flutter tab of the privacy page): what gets masked, the `web/index.html` opt-in snippet, the `PostHogMaskWidget` alternative, and the caveats (restart-once, pre-boot window, `PostHogWidget` required, `blockSelector` precedence, platform views, multi-view).
- **`session-replay/canvas-recording.mdx`** — corrects "there is no way to mask canvas elements right now" (no longer true) and adds a short "Masking canvas content" section for `canvasCapture.maskRegionsFn`.
- **`libraries/flutter/index.mdx`** — the session replay section now points at canvas masking next to the existing Canvas capture note.
- **`session-replay/troubleshooting.mdx`** — "Flutter Web canvas masking not applied" entry.

**Draft until the posthog-flutter release ships:** the version callout currently says Flutter SDK `>= 5.34.0` — pin to the actual release number before marking ready.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)
