### PR TITLE
docs: semantic layer now has a Data Catalog UI

### DIFF
--- a/contents/docs/semantic-layer/_snippets/alpha-callout.mdx
+++ b/contents/docs/semantic-layer/_snippets/alpha-callout.mdx
@@ -2,6 +2,6 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="The semantic layer is in alpha" type="action">
 
-The semantic layer is in alpha, enabled per organization for a small group of customers. There's no dedicated UI yet – you work with it through MCP tools and SQL. Tool names and behavior may change between releases. Found a bug, or want access? [Contact support](https://app.posthog.com/home#supportModal) and mention the semantic layer alpha.
+The semantic layer is in alpha, enabled per organization for a small group of customers. You can manage it from the **Data Catalog** UI in PostHog (press `Cmd/Ctrl + K` and search for "Data Catalog"), or through MCP tools and SQL. Tool names and behavior may change between releases. Found a bug, or want access? [Contact support](https://app.posthog.com/home#supportModal) and mention the semantic layer alpha.
 
 </CalloutBox>

--- a/contents/docs/semantic-layer/index.mdx
+++ b/contents/docs/semantic-layer/index.mdx
@@ -34,9 +34,11 @@ A [relationship](/docs/semantic-layer/certifications-and-relationships#relations
 
 ## How you use it
 
-There's no UI during the alpha. You work with the semantic layer through two surfaces:
+You work with the semantic layer through three surfaces:
 
-**From an AI agent (the main surface).** Connect the [PostHog MCP server](/docs/model-context-protocol) to Claude Code, Cursor, Claude Desktop, or any other MCP client. When the semantic layer is enabled, agents route metric questions through the catalog first: ask `What was our MRR last quarter?` and the agent runs the governed `mrr` metric instead of writing its own SQL. See [MCP tools](/docs/semantic-layer/mcp-tools).
+**From the Data Catalog UI.** Open the command palette (`Cmd/Ctrl + K`) and search for **Data Catalog** to manage your metrics, certifications, and relationships from the app: browse the catalog, review what agents have proposed, and approve, certify, or accept them by hand.
+
+**From an AI agent.** Connect the [PostHog MCP server](/docs/model-context-protocol) to Claude Code, Cursor, Claude Desktop, or any other MCP client. When the semantic layer is enabled, agents route metric questions through the catalog first: ask `What was our MRR last quarter?` and the agent runs the governed `mrr` metric instead of writing its own SQL. See [MCP tools](/docs/semantic-layer/mcp-tools).
 
 **From SQL.** The catalog is queryable from the [SQL editor](/docs/data-warehouse/query) or the `execute-sql` MCP tool:
 

--- a/contents/docs/semantic-layer/troubleshooting.mdx
+++ b/contents/docs/semantic-layer/troubleshooting.mdx
@@ -51,7 +51,7 @@ The flip side: **rejection has no undo** in the alpha. If you rejected a proposa
 
 ## Where's the UI?
 
-There isn't one yet. During the alpha the semantic layer is MCP tools and SQL only – no catalog page in the app. Also worth knowing:
+Open the command palette with `Cmd/Ctrl + K` and search for **Data Catalog**. From there you can browse and manage your metrics, certifications, and relationships – reviewing and promoting what agents have proposed without leaving PostHog. You can still do everything through MCP tools and SQL if you prefer. Also worth knowing:
 
 - Tool names and behavior may change between releases
 - The alpha is enabled per organization, not per user or project


### PR DESCRIPTION
## Changes

The semantic layer docs said repeatedly that there's "no UI during the alpha" and that you work with it through MCP tools and SQL only. That's no longer true — there's now a **Data Catalog** UI in the app (open the command palette with `Cmd/Ctrl + K` and search for "Data Catalog") for managing metrics, certifications, and relationships.

Updated three places:
- The shared alpha callout snippet (rendered on every semantic layer page)
- The "How you use it" section in the index — now three surfaces (UI, agent, SQL) instead of two
- The "Where's the UI?" troubleshooting entry

**Why:** The semantic layer is no longer MCP-only; users can now manage their metrics, certifications, etc. from the Data Catalog UI, and the docs needed to reflect that.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A9BSVSE72/p1785420112804309)*