### PR TITLE
Fix featured image on 10k PRs a month blog post

### DIFF
--- a/contents/blog/10k-prs-a-month.md
+++ b/contents/blog/10k-prs-a-month.md
@@ -6,7 +6,7 @@ author:
 rootPage: /blog
 sidebar: Blog
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/v1783662227/stop_being_the_code_review_bottleneck_hero_a734a37558.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/stop_being_the_code_review_bottleneck_hero_a734a37558.png
 featuredImageType: full
 showTitle: true
 hideAnchor: true


### PR DESCRIPTION
Removes the `v1783662227/` version segment from the `featuredImage` Cloudinary URL on the [10k PRs a month](https://posthog.com/blog/10k-prs-a-month) blog post.

The site derives the Cloudinary public ID from everything after `/upload/` (`gatsby/onCreateNode.ts`). The version prefix got baked into that ID, so it no longer matched the real image and the featured image failed to render. Every other blog post uses a version-less URL.

**Why:** The featured image wasn't displaying on the post, which is going out as an X article.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1785425092166709?thread_ts=1785425092.166709&cid=C09GU689J1X)*
