### PR TITLE
Point people to #group-cs-sales-support to reach customer owners

### DIFF
--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -34,6 +34,8 @@ We're not one big Sales team. We're several small teams, each owning a different
 
 Each team has its own Slack channel for day-to-day work: [`#team-new-business-sales`](https://posthog.slack.com/archives/C09677WV1GW), [`#team-product-led-sales`](https://posthog.slack.com/archives/C093XHYMGBE), [`#team-customer-success`](https://posthog.slack.com/archives/C08M011SBCM), and [`#team-onboarding`](https://posthog.slack.com/archives/C098D86DZDZ). Anything that spans all of us goes to [`#group-cs-sales-support`](https://posthog.slack.com/archives/C090RCG671C).
 
+> **Not on one of these teams but need to reach the humans who look after a customer?** Post in [`#group-cs-sales-support`](https://posthog.slack.com/archives/C090RCG671C). It's the cross-team channel for everyone who owns customers, so someone will pick it up or point you to the right person.
+
 ## Our vision
 
 ### Things we want to be great at

--- a/contents/handbook/support/customer-support.md
+++ b/contents/handbook/support/customer-support.md
@@ -176,9 +176,9 @@ For bug reports from normal and high priority users (assuming you've confirmed i
 Steps for feature requests from normal and high priority users are pretty much the same, but [use this form](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&projects=&template=feature_request.yml) instead. If you find that there's already a matching feature request open, reply with a link to the feature request, and let them know they can upvote it by adding a "`+1`" comment.
 
 
-#### Handling sales leads
+#### Reaching the sales / CS / onboarding teams
 
-If a support ticket should be handled by one of the sales / CS / onboarding teams, message #group-cs-sales-support to let the teams know.
+If you need to reach the humans who look after a customer — for example, a support ticket should be handled by one of the sales / CS / onboarding teams, or you've spotted a sales lead — message [#group-cs-sales-support](https://posthog.slack.com/archives/C090RCG671C) to let the teams know. It's the cross-team channel for everyone who owns customers.
 
 
 #### How should I handle self-hosted setups?


### PR DESCRIPTION
## Changes

Makes it clear which Slack channel to use to reach the humans who look after a customer, for people outside the Sales / CS / Onboarding teams:

- **Sales overview** — adds a cross-team callout pointing to `#group-cs-sales-support`, right after the per-team channel list.
- **Customer support** — broadens the old "Handling sales leads" section to "Reaching the sales / CS / onboarding teams" so it covers any reason to hand a customer off, not just leads.

**Why:** it wasn't obvious to people outside these teams where to go when they need to reach a customer's owner — `#group-cs-sales-support` is already the de facto channel for this, but the handbook only framed it for people already inside CS/Sales.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090RCG671C/p1785423080166269?thread_ts=1785423080.166269&cid=C090RCG671C)*