### PR TITLE
Update CLI ownership and add MCP store feature entry

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -98,7 +98,13 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     cli: {
         feature: 'CLI',
-        owner: ['error-tracking'],
+        owner: ['error-tracking', 'self-driving'],
+        notes: (
+            <>
+                <TeamMember name="Chris Volzer" /> is the point owner for agentic use cases. Error tracking owns the
+                symbolication/upload pipeline and symbol/sourcemap upload internals.
+            </>
+        ),
     },
     'client-libraries': {
         feature: 'Client libraries',
@@ -274,6 +280,16 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
             </>
         ),
         label: 'feature/mcp',
+    },
+    'mcp-store': {
+        feature: 'MCP store',
+        owner: ['self-driving'],
+        notes: (
+            <>
+                <TeamMember name="Chris Volzer" /> is the point owner.
+            </>
+        ),
+        label: false,
     },
     notebooks: {
         feature: 'Notebooks',


### PR DESCRIPTION
## Changes

Updates `src/hooks/useFeatureOwnership.tsx`:

- CLI is now shared between error tracking and self-driving. Error tracking owns the symbolication/upload pipeline and symbol/sourcemap upload internals; self-driving (Chris Volzer) is the point owner for agentic use cases.
- Adds an MCP store entry owned by self-driving, with Chris Volzer as point owner — following the same point-owner note pattern introduced in #18391.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links (N/A, no links added)
- [ ] I've checked the pages added or changed in the Vercel preview build (N/A, not a docs page)
- [ ] If I moved a page, I added a redirect in `vercel.json` (N/A)