### PR TITLE
Fix demo video fullscreen

### DIFF
--- a/src/components/MediaPlayer/index.tsx
+++ b/src/components/MediaPlayer/index.tsx
@@ -286,6 +286,15 @@ export default function MediaPlayer({
     }
 
     const toggleFullscreen = () => {
+        if (source === 'wistia' && playerState.player?.requestFullscreen) {
+            if (playerState.player.inFullscreen?.()) {
+                playerState.player.cancelFullscreen()
+            } else {
+                playerState.player.requestFullscreen()
+            }
+            return
+        }
+
         const iframe = document.getElementById(`video-player-iframe-${videoId}`) as any
         if (iframe?.requestFullscreen) {
             iframe.requestFullscreen()


### PR DESCRIPTION
## Changes

Fixes fullscreen toggling for Wistia-sourced videos in the media player. Previously, the fullscreen logic only handled iframes, which didn't work correctly for Wistia players. Now, when the source is `wistia` and the player supports `requestFullscreen`, it uses the Wistia player's native fullscreen API — calling `cancelFullscreen` if already in fullscreen, or `requestFullscreen` otherwise — before falling through to the existing iframe-based logic for other sources.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`