### PR TITLE
Trim Slack blurb on marketing team page

### DIFF
--- a/contents/teams/marketing/index.mdx
+++ b/contents/teams/marketing/index.mdx
@@ -6,7 +6,7 @@ hideAnchor: false
 template: team
 ---
 
-You can find out more about what the marketing team does in the handbook. On Slack we use [the #team-marketing channel](https://posthog.slack.com/archives/C08CG24E3SR) for most things, while the illustration group uses [#design-fish-tank](https://posthog.slack.com/archives/C09ARM6LBLZ) for collecting feedback and sharing work. We also recommend joining [#hoglife](https://posthog.slack.com/archives/C033D5NTA22) for irregular doses of hedgehog related joy. 
+You can find out more about what the marketing team does in the handbook. On Slack we use [the #team-marketing channel](https://posthog.slack.com/archives/C08CG24E3SR) for most things.
 
 If something needs marketing attention, there are several group handles you can use on Slack.
 


### PR DESCRIPTION
Removes the `#design-fish-tank` illustration-group pointer and the `#hoglife` recommendation from the marketing team page intro, leaving just the `#team-marketing` channel.

**Before:**
> On Slack we use [the #team-marketing channel](...) for most things, while the illustration group uses [#design-fish-tank](...) for collecting feedback and sharing work. We also recommend joining [#hoglife](...) for irregular doses of hedgehog related joy.

**After:**
> On Slack we use [the #team-marketing channel](...) for most things.

One-line content change in `contents/teams/marketing/index.mdx`. The `#hoglife` mention in the onboarding handbook's social-channels list is untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*