### PR TITLE
chore(replay-vision): drop the beta label for GA

### DIFF
--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -11,9 +11,6 @@ export const replayVision = {
     colorSecondary: 'yellow',
     category: 'product_engineering',
     slug: 'replay-vision',
-    // TODO: drop this on GA launch day (2026-08-03). Pricing stays hidden until billing serves the
-    // product, but this label doesn't, so it stops the product reading as GA in the meantime.
-    status: 'beta',
     slider: {
         // Values in credits. min doubles as the "first N credits free" copy, so it tracks the free allocation.
         marks: [2500, 10000, 50000, 100000],


### PR DESCRIPTION
## Changes

Replay Vision goes GA, so its product data no longer marks it beta. This drops `status: 'beta'` and the TODO that flagged it from `src/hooks/productData/replay_vision.tsx`.

The label was added deliberately in [#19000](https://github.com/PostHog/posthog.com/pull/19000) so the pricing calculator entry could merge early without the product reading as GA.

**Do not merge before launch day (2026-08-03).** Merging early makes the product read as GA on the site while access is still allowlisted.

### No screenshots, because nothing renders differently yet

`status` feeds two surfaces: the Beta chip on the product overview and slide templates, and the status dot in the `/products` list. Replay Vision has neither a reader-view product page nor a row in that list, so the label is currently inert.

The Beta badge on a pricing calculator tab comes from `pricingBadge` (Inbox is the only product setting it), which Replay Vision never set. So the calculator tab renders the same before and after, and it stays hidden entirely until billing serves the product.

Checked on the [deploy preview](https://4287dceb.posthog-preview.pages.dev): `/pricing` is byte-for-byte the same story as production (Inbox is still the only Beta badge, Replay Vision is absent until billing serves it) and `/replay-vision` renders fine without the field.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
