### PR TITLE
docs(replay-vision): rename the quality docs to calibration

### DIFF
--- a/contents/docs/replay-vision/calibration.mdx
+++ b/contents/docs/replay-vision/calibration.mdx
@@ -1,5 +1,5 @@
 ---
-title: Improving scanner accuracy
+title: Calibration
 ---
 
 import { ProductScreenshot } from "components/ProductScreenshot";
@@ -10,13 +10,13 @@ Not yet available to everyone – <a href="/replay-vision">join the waitlist</a>
 
 </CalloutBox>
 
-Replay Vision scanners are only as good as their configuration. The **Quality** tab on each scanner turns your team's judgment into a better configuration: rate the scanner's results, see accuracy trend across versions, and let PostHog AI recommend (and safely test) improvements to the prompt and every other behavior setting.
+Replay Vision scanners are only as good as their configuration. The **Calibration** tab on each scanner turns your team's judgment into a better configuration: rate the scanner's results, see accuracy trend across versions, and let PostHog AI recommend (and safely test) improvements to the prompt and every other behavior setting.
 
-Open any scanner and select the **Quality** tab.
+Open any scanner and select the **Calibration** tab.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quality_tab_overview_fbe89921b9.png"
-  alt="The quality tab of a Replay Vision scanner"
+  alt="The calibration tab of a Replay Vision scanner"
   classes="rounded"
 />
 
@@ -54,7 +54,7 @@ Once your team leaves written feedback, PostHog AI summarizes it into recurring 
   classes="rounded"
 />
 
-## Track quality over time
+## Track accuracy over time
 
 The **Ratings over time** chart shows thumbs up and thumbs down per day, with markers for when each configuration version went live. As the configuration improves, thumbs down should trend down.
 
@@ -121,7 +121,7 @@ Applying never rewrites history: every observation keeps a snapshot of the scann
 
 ## The improvement loop
 
-Putting it together, the quality tab supports a simple loop your team can run continuously:
+Putting it together, the calibration tab supports a simple loop your team can run continuously:
 
 1. Rate new results as they come in, leaving feedback on the wrong ones.
 2. Watch the feedback themes to see which failure modes recur.

--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -82,7 +82,7 @@ A prompt that reads beautifully on its own can still misfire. The fastest feedba
 
 Hold off on the automatic background sweep until you trust the scanner's on-demand results – every sweep observation spends [credits](/docs/replay-vision/quota-and-limits), and a poorly tuned scanner can burn through your budget fast on results you'd throw away anyway.
 
-Once the scanner is running, the tuning loop moves to its [quality tab](/docs/replay-vision/quality): rate results with a thumbs up or down, and PostHog AI turns your team's ratings and feedback into configuration recommendations you can test against the rated sessions before applying.
+Once the scanner is running, the tuning loop moves to its [calibration tab](/docs/replay-vision/calibration): rate results with a thumbs up or down, and PostHog AI turns your team's ratings and feedback into configuration recommendations you can test against the rated sessions before applying.
 
 ### Drafting prompts with PostHog AI
 
@@ -103,7 +103,7 @@ Each scanner type has a few extra knobs. The full reference is on the [scanner t
 - **Summarizer** – pick a summary length (short / medium / long). The core summarizer prompt is built in, so the prompt field becomes **Additional context**: use it for product context or steering, like what the ideal user flow looks like.
 - **Monitor** – choose whether the model can return `inconclusive` rather than forcing a yes/no answer.
 
-The editor also has a **model** picker, which sets the price of every observation the scanner makes: 2 credits on Gemini 3.5 Flash Lite, 5 on Gemini 3 Flash (the default), and 15 on Gemini 3.6 Flash. Newer models tend to produce higher-quality observations, but the top tier costs over seven times as much per session as the cheapest. Start on the default. If results are close but not quite right, tune the prompt before reaching for a pricier model, since a sharper prompt is free and the [quality tab](/docs/replay-vision/quality) will tell you whether it worked. See [quota and limits](/docs/replay-vision/quota-and-limits) for how credits are metered.
+The editor also has a **model** picker, which sets the price of every observation the scanner makes: 2 credits on Gemini 3.5 Flash Lite, 5 on Gemini 3 Flash (the default), and 15 on Gemini 3.6 Flash. Newer models tend to produce higher-quality observations, but the top tier costs over seven times as much per session as the cheapest. Start on the default. If results are close but not quite right, tune the prompt before reaching for a pricier model, since a sharper prompt is free and the [calibration tab](/docs/replay-vision/calibration) will tell you whether it worked. See [quota and limits](/docs/replay-vision/quota-and-limits) for how credits are metered.
 
 ## Filters: scoping the scanner
 

--- a/contents/docs/replay-vision/index.mdx
+++ b/contents/docs/replay-vision/index.mdx
@@ -56,7 +56,7 @@ Each of these maps to a [scanner type](/docs/replay-vision/scanner-types).
 - **Picking the right scanner type?** Read the [scanner types reference](/docs/replay-vision/scanner-types).
 - **Authoring a scanner?** See [creating scanners](/docs/replay-vision/creating-scanners) for prompt patterns, filters, and sampling.
 - **Already have observations?** Learn how to [read them and query them as events](/docs/replay-vision/observations) to build insights, dashboards, and alerts.
-- **Is the scanner getting it right?** Rate results and apply AI configuration recommendations on the [quality tab](/docs/replay-vision/quality).
+- **Is the scanner getting it right?** Rate results and apply AI configuration recommendations on the [calibration tab](/docs/replay-vision/calibration).
 - **Want to be notified?** Set up scheduled [digests and alerts](/docs/replay-vision/actions) that push a scanner's findings to Slack or a webhook.
 - **Hit a snag?** Check [troubleshooting](/docs/replay-vision/troubleshooting).
 

--- a/contents/docs/replay-vision/mcp.mdx
+++ b/contents/docs/replay-vision/mcp.mdx
@@ -62,9 +62,9 @@ Aggregate stats, rather than the rows themselves:
 
 ### Rating results and improving the scanner
 
-The [quality tab](/docs/replay-vision/quality)'s loop is fully drivable over MCP:
+The [calibration tab](/docs/replay-vision/calibration)'s loop is fully drivable over MCP:
 
-- `vision-observations-label-create` – rate an observation with a thumbs up or down, optionally with written feedback. Same rating the Quality tab records.
+- `vision-observations-label-create` – rate an observation with a thumbs up or down, optionally with written feedback. Same rating the calibration tab records.
 - `vision-observations-label-destroy` – remove a rating.
 - `vision-scanners-prompt-suggestions-current` – read the newest recommendation, whether it's gone stale since new ratings arrived, and how many rated observations back it.
 - `vision-scanners-prompt-suggestions-generate` – generate a fresh recommendation from the current ratings. The model call runs inline, so the request takes a while.

--- a/contents/docs/replay-vision/observations.mdx
+++ b/contents/docs/replay-vision/observations.mdx
@@ -14,7 +14,7 @@ Each scanner has an **Observations** tab listing every observation it's produced
 
 Observations also surface in the replay player: the **observations dock** at the bottom of the player lists everything scanners have found about the session you're watching, and is where the **Scan this recording** action lives.
 
-To judge whether the results are right – and improve the scanner from that judgment – rate observations on the scanner's [quality tab](/docs/replay-vision/quality).
+To judge whether the results are right – and improve the scanner from that judgment – rate observations on the scanner's [calibration tab](/docs/replay-vision/calibration).
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/observations_dock_0301561e5d.png"

--- a/contents/docs/replay-vision/quota-and-limits.mdx
+++ b/contents/docs/replay-vision/quota-and-limits.mdx
@@ -54,7 +54,7 @@ You can also fetch the budget programmatically – the `vision-quota-retrieve` M
 
 Pending and running observations reserve budget so a burst of concurrent on-demand triggers can't blow past the cap before any of them complete. Once an observation reaches a terminal failed or ineligible state, its reservation is released.
 
-Testing a configuration recommendation on the [quality tab](/docs/replay-vision/quality#test-before-applying) re-runs the scanner against rated sessions, and each tested session is charged like a normal observation of the scanner's model. The test controls show the planned cost before you run it.
+Testing a configuration recommendation on the [calibration tab](/docs/replay-vision/calibration#test-before-applying) re-runs the scanner against rated sessions, and each tested session is charged like a normal observation of the scanner's model. The test controls show the planned cost before you run it.
 
 ## What happens when the budget is reached
 

--- a/contents/docs/replay-vision/scanner-types.mdx
+++ b/contents/docs/replay-vision/scanner-types.mdx
@@ -198,6 +198,6 @@ If you find yourself encoding a number range as classifier tags ("low / medium /
 
 ## Confidence and citations
 
-Confidence is the model's self-reported certainty. It's useful as a filter (e.g. "only alert when confidence > 0.7") but not as ground truth – treat it as a signal, not a guarantee. For actual ground truth, rate results on the scanner's [quality tab](/docs/replay-vision/quality) – your team's ratings measure accuracy per configuration version and power AI configuration recommendations.
+Confidence is the model's self-reported certainty. It's useful as a filter (e.g. "only alert when confidence > 0.7") but not as ground truth – treat it as a signal, not a guarantee. For actual ground truth, rate results on the scanner's [calibration tab](/docs/replay-vision/calibration) – your team's ratings measure accuracy per configuration version and power AI configuration recommendations.
 
 Citations are emitted inline in the model's free-text output (the `reasoning` field for monitors, classifiers, and scorers; the `summary` field for summarizers) and rendered as clickable links in the observation detail view. They jump the embedded player to the timestamp the model points at. They're the single best tool for understanding _why_ a model returned what it did.

--- a/contents/docs/replay-vision/start-here.mdx
+++ b/contents/docs/replay-vision/start-here.mdx
@@ -119,4 +119,4 @@ You'll see a count over time of sessions the scanner flagged. From here you can 
 - [Scanner types](/docs/replay-vision/scanner-types) – understand monitor vs. classifier vs. scorer vs. summarizer before authoring your second one.
 - [Creating scanners](/docs/replay-vision/creating-scanners) – prompt patterns that actually work, plus how filters and sampling interact.
 - [Running scanners](/docs/replay-vision/running-scanners) – automatic background sweeps vs. on-demand triggers, and what happens to ineligible sessions.
-- [Improving scanner accuracy](/docs/replay-vision/quality) – once observations flow, rate them on the scanner's Quality tab and let PostHog AI recommend configuration improvements.
+- [Calibration](/docs/replay-vision/calibration) – once observations flow, rate them on the scanner's calibration tab and let PostHog AI recommend configuration improvements.

--- a/contents/docs/replay-vision/troubleshooting.mdx
+++ b/contents/docs/replay-vision/troubleshooting.mdx
@@ -65,7 +65,7 @@ One caveat: sessions from the over-limit window are permanently unscannable. Dro
 
 ## The model is making bad calls
 
-Start on the scanner's [quality tab](/docs/replay-vision/quality): rate the wrong results with a thumbs down and say why in the feedback field. PostHog AI turns those ratings into a configuration recommendation you can test against the rated sessions before applying – that loop fixes most systematic errors without hand-tuning.
+Start on the scanner's [calibration tab](/docs/replay-vision/calibration): rate the wrong results with a thumbs down and say why in the feedback field. PostHog AI turns those ratings into a configuration recommendation you can test against the rated sessions before applying – that loop fixes most systematic errors without hand-tuning.
 
 To understand *why* the model got something wrong, the reasoning + citations on each observation are your debugging tool. Open three or four observations the scanner got wrong and read them.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4826,8 +4826,8 @@ export const docsMenu = {
                     color: 'yellow',
                 },
                 {
-                    name: 'Improving accuracy',
-                    url: '/docs/replay-vision/quality',
+                    name: 'Calibration',
+                    url: '/docs/replay-vision/calibration',
                     icon: 'IconThumbsUp',
                     color: 'yellow',
                 },

--- a/vercel.json
+++ b/vercel.json
@@ -150,6 +150,11 @@
     ],
     "redirects": [
         {
+            "source": "/docs/replay-vision/quality",
+            "destination": "/docs/replay-vision/calibration",
+            "statusCode": 301
+        },
+        {
             "source": "/activity",
             "destination": "/docs/activity",
             "statusCode": 301


### PR DESCRIPTION
## Summary

Renames the Replay Vision **Quality** tab docs to **Calibration**, catching the docs up to the in-app rename that already shipped in [PostHog/posthog#75460](https://github.com/PostHog/posthog/pull/75460).

## Changes

- `contents/docs/replay-vision/quality.mdx` → `calibration.mdx`, so the URL is now `/docs/replay-vision/calibration`. Page title is now "Calibration".
- 301 redirect from `/docs/replay-vision/quality` in `vercel.json`.
- Docs sidebar entry renamed from "Improving accuracy" to "Calibration" (`src/navs/index.js`).
- Updated the 9 inbound links across 8 replay-vision pages, plus prose that named the tab ("the **Quality** tab" → "the **Calibration** tab").
- Renamed the "Track quality over time" section to "Track accuracy over time", since "quality" there read as the old tab name.

Left alone on purpose: the unrelated uses of the word quality (the session-coverage recording-quality filter, "higher-quality observations" in the model picker copy) and the Cloudinary screenshot filenames, which still contain `quality_tab_*` but are just asset URLs.

## How did you test this code?

No automated tests here. I verified by inspection:

- `python3 -c "import json; json.load(open('vercel.json'))"` passes, and the new redirect is the first entry in the array.
- `grep -rn "replay-vision/quality" contents/ src/` returns only the redirect's `source`, so no link points at the old path.
- `grep -rni "quality" contents/docs/replay-vision/` returns only the intentional leftovers listed above.

I did not run a Gatsby build or `pnpm test-redirects` (no `node_modules` in this worktree), and I did not view the rendered page.

## Sequencing

The tab is already called Calibration in the app, so this can merge on its own. [PostHog/posthog#75713](https://github.com/PostHog/posthog/pull/75713) cleans up the last stale "Quality tab" strings left in the monorepo, including the MCP tool description.
