### PR TITLE
Update identify() usage explanation in cutting-costs.mdx

### DIFF
--- a/contents/docs/product-analytics/cutting-costs.mdx
+++ b/contents/docs/product-analytics/cutting-costs.mdx
@@ -25,13 +25,7 @@ Alternatively, you can [disable autocapture](/docs/product-analytics/autocapture
 
 ## Only call `identify()` once per session
 
-It's only necessary to [identify](/docs/product-analytics/identify) a user once per session. To prevent sending unnecessary events, check `posthog._isIdentified()` before calling `identify()`:
-
-```js
-if (!posthog._isIdentified()) {
-    posthog.identify('distinct_id') // Replace 'distinct_id' with your user's unique identifier
-}
-```
+It's only necessary to [identify](/docs/product-analytics/identify) a user once per session, and you don't need to add your own checks to prevent duplicate calls. If the user is already identified, calling `identify()` again with the same distinct ID doesn't capture another `$identify` event. Instead it captures a `$set` event when the person properties you pass have changed.
 
 ## Only call `group()` once per session
 

--- a/contents/docs/product-analytics/cutting-costs.mdx
+++ b/contents/docs/product-analytics/cutting-costs.mdx
@@ -25,7 +25,7 @@ Alternatively, you can [disable autocapture](/docs/product-analytics/autocapture
 
 ## Only call `identify()` once per session
 
-It's only necessary to [identify](/docs/product-analytics/identify) a user once per session, and you don't need to add your own checks to prevent duplicate calls. If the user is already identified, calling `identify()` again with the same distinct ID doesn't capture another `$identify` event. Instead it captures a `$set` event when the person properties you pass have changed.
+It's only necessary to [identify](/docs/product-analytics/identify) a user once per session, and you don't need to add your own checks to prevent duplicate calls. If the user is already identified, calling `identify()` again with the same distinct ID doesn't capture another `$identify` event. Instead, it captures a `$set` event only when the person properties you pass have changed. 
 
 ## Only call `group()` once per session
 


### PR DESCRIPTION
Clarified the usage of identify() to explain that duplicate calls do not capture additional events and provided details on the behavior of the identify() function, based on @marandaneto 's comment here: https://github.com/PostHog/posthog-js/pull/4337#issuecomment-5134564190

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links