### PR TITLE
feat: /events auto-populate also from Notion

### DIFF
--- a/api/notion-events.js
+++ b/api/notion-events.js
@@ -1,0 +1,207 @@
+const NOTION_QUERY_URL = (databaseId) => `https://api.notion.com/v1/databases/${databaseId}/query`
+// Pinned: 2025-09-03 replaced database queries with data sources
+const NOTION_API_VERSION = '2022-06-28'
+// Safety bound so a runaway cursor can't loop forever (5 pages × 100 rows)
+const MAX_PAGES = 5
+// Include recently-finished events so they can still be backfilled
+const PAST_WINDOW_DAYS = 90
+
+const plainText = (rich) =>
+    Array.isArray(rich)
+        ? rich
+              .map((chunk) => chunk?.plain_text || '')
+              .join('')
+              .trim()
+        : ''
+
+// The database is hand-maintained, so a field like Location may be rich_text in one
+// workspace and select in another. Read the common shapes rather than assuming one.
+const readProp = (prop) => {
+    if (!prop) return null
+    switch (prop.type) {
+        case 'title':
+            return plainText(prop.title) || null
+        case 'rich_text':
+            return plainText(prop.rich_text) || null
+        case 'select':
+            return prop.select?.name || null
+        case 'status':
+            return prop.status?.name || null
+        case 'multi_select':
+            return (
+                prop.multi_select
+                    ?.map((o) => o.name)
+                    .filter(Boolean)
+                    .join(', ') || null
+            )
+        case 'number':
+            return typeof prop.number === 'number' ? prop.number : null
+        case 'url':
+            return prop.url || null
+        case 'email':
+            return prop.email || null
+        case 'date':
+            return prop.date?.start || null
+        case 'people':
+            return (
+                prop.people
+                    ?.map((p) => p.name)
+                    .filter(Boolean)
+                    .join(', ') || null
+            )
+        case 'formula':
+            return prop.formula?.string ?? prop.formula?.number ?? prop.formula?.date?.start ?? null
+        default:
+            return null
+    }
+}
+
+// Case-insensitive with aliases, so a renamed column degrades to a missing field
+const findKey = (properties, name) => Object.keys(properties).find((key) => key.toLowerCase() === name.toLowerCase())
+
+const pick = (properties, ...names) => {
+    for (const name of names) {
+        const key = findKey(properties, name)
+        if (!key) continue
+        const value = readProp(properties[key])
+        if (value !== null && value !== '') return value
+    }
+    return null
+}
+
+const pickDate = (properties, ...names) => {
+    for (const name of names) {
+        const key = findKey(properties, name)
+        if (key && properties[key]?.type === 'date' && properties[key].date?.start) return properties[key].date
+    }
+    return null
+}
+
+const titleKey = (properties) => Object.keys(properties).find((key) => properties[key]?.type === 'title')
+
+// Role words mixed in with names ("Xander attending"). Excludes "team" on purpose —
+// stripping it would leave "PostHog", which then matches the "PostHog AI" profile.
+const ROLE_WORDS =
+    /\b(speaking|speakers?|attending|attended|attends|attendee|hosting|hosts?|presenting|presenter|moderating|moderator|mc|panel(?:ist)?|talk|workshop|demo|booth|travel*ing|travelled|visiting|joining|joined|going|organi[sz]ing|organi[sz]er|sponsoring|sponsor|exhibiting|tbc|tbd|maybe)\b/gi
+
+// Free text like "Meikel Ratz (PostHog) speaking; Daniel Z hosting w/ Peppe Silletti" —
+// split into candidate names, dropping annotations. The client resolves them to profiles.
+const parseSpeakerNames = (raw) =>
+    (raw || '')
+        .replace(/\([^)]*\)/g, ' ')
+        .split(/,|;|&|\+|\bw\/|\band\b|\//i)
+        .map((part) => part.replace(ROLE_WORDS, ' ').replace(/\s+/g, ' ').trim())
+        // Keep name-shaped fragments only — no digits, URLs, or leftover notes
+        .filter((part) => part.length > 1 && /^[\p{L}][\p{L}'’.\- ]*$/u.test(part))
+
+const toEvent = (page) => {
+    const properties = page.properties || {}
+    const nameKey = titleKey(properties)
+    const name = pick(properties, 'Name', 'Event', 'Title') || (nameKey ? readProp(properties[nameKey]) : null)
+    if (!name) return null
+
+    const date = pickDate(properties, 'Date', 'Event date', 'Start')
+    const start = date?.start || null
+    const category = pick(properties, 'Category', 'Type', 'Format')
+    const location = pick(properties, 'Location', 'City')
+    const venue = pick(properties, 'Venue')
+
+    return {
+        id: page.id,
+        source: 'notion',
+        name,
+        // Raw: date-only or offset-bearing. The client reads the wall clock as authored.
+        startAt: start,
+        endAt: date?.end || null,
+        allDay: Boolean(start) && !start.includes('T'),
+        timezone: date?.time_zone || null,
+        url: pick(properties, 'Event URL', 'URL', 'Link'),
+        // Notion stores no coordinates; the client geocodes venue + location
+        lat: null,
+        lng: null,
+        city: location,
+        cityState: location,
+        country: null,
+        venue,
+        fullAddress: [venue, location].filter(Boolean).join(', ') || null,
+        // Heuristic: only the virtual categories imply no physical location
+        online: /webinar|virtual|online/i.test(category || ''),
+        description: pick(properties, 'Event Description', 'Description'),
+        category,
+        primaryPurpose: pick(properties, 'Primary purpose', 'Purpose'),
+        attendees: pick(properties, 'Attended') ?? pick(properties, 'Registered'),
+        status: pick(properties, 'Status'),
+        // The "Speakers" relation is redacted unless the integration can also read the
+        // related database, so names come from the free-text column instead.
+        speakerNames: parseSpeakerNames(pick(properties, 'Speaking, Attending', 'Speakers', 'Speaker')),
+    }
+}
+
+// Notion sends no CORS headers, and the token grants read access to the whole database,
+// so the browser can't call it directly. Returns a trimmed payload for the event form.
+const handler = async (req, res) => {
+    const token = process.env.NOTION_TOKEN
+    const databaseId = process.env.NOTION_EVENTS_DATABASE_ID
+    if (!token || !databaseId) {
+        return res.status(500).json({ error: 'Missing Notion token or database ID' })
+    }
+
+    const cutoff = new Date(Date.now() - PAST_WINDOW_DAYS * 86400000).toISOString().slice(0, 10)
+
+    const query = async (body) =>
+        fetch(NOTION_QUERY_URL(databaseId), {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Notion-Version': NOTION_API_VERSION,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+        })
+
+    try {
+        const events = []
+        let cursor = null
+        // Notion rejects the filter if the date property isn't literally named "Date",
+        // so fall back to an unfiltered scan and drop old rows below.
+        let filterByDate = true
+
+        for (let page = 0; page < MAX_PAGES; page++) {
+            const body = { page_size: 100, ...(cursor ? { start_cursor: cursor } : {}) }
+            if (filterByDate) {
+                body.filter = { property: 'Date', date: { on_or_after: cutoff } }
+                body.sorts = [{ property: 'Date', direction: 'ascending' }]
+            }
+
+            let response = await query(body)
+            if (!response.ok && filterByDate && response.status === 400) {
+                console.warn('notion-events: no "Date" property to filter on, falling back to full scan')
+                filterByDate = false
+                delete body.filter
+                delete body.sorts
+                response = await query(body)
+            }
+            if (!response.ok) {
+                throw new Error(`Notion API request failed: ${response.status}`)
+            }
+
+            const json = await response.json()
+            for (const row of json.results || []) {
+                const mapped = toEvent(row)
+                // Rows with no date can't populate the form's required date field
+                if (mapped?.startAt && mapped.startAt.slice(0, 10) >= cutoff) events.push(mapped)
+            }
+
+            if (!json.has_more || !json.next_cursor) break
+            cursor = json.next_cursor
+        }
+
+        res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate')
+        return res.status(200).json({ events })
+    } catch (error) {
+        console.error('Error fetching Notion events:', error)
+        return res.status(500).json({ error: 'Failed to fetch Notion events' })
+    }
+}
+
+module.exports = handler

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,13 +57,17 @@ module.exports = {
     // In production Vercel serves api/luma-events.js; mirror that route here so
     // the form also works under `gatsby develop`. Dev server only — no effect on builds.
     developMiddleware: (app) => {
-        app.use('/api/luma-events', async (req, res) => {
-            try {
-                await require('./api/luma-events')(req, res)
-            } catch (error) {
-                console.error('luma-events dev middleware error:', error)
-                res.status(500).json({ error: 'Failed to fetch Luma events' })
-            }
+        // Vercel serves these from api/*.js in production; mirror them here so the event
+        // form works under `gatsby develop`. Dev only — ignored by `gatsby build`.
+        ;['luma-events', 'notion-events'].forEach((route) => {
+            app.use(`/api/${route}`, async (req, res) => {
+                try {
+                    await require(`./api/${route}`)(req, res)
+                } catch (error) {
+                    console.error(`${route} dev middleware error:`, error)
+                    res.status(500).json({ error: `Failed to fetch ${route}` })
+                }
+            })
         })
     },
     flags: {

--- a/src/components/EventForm/index.tsx
+++ b/src/components/EventForm/index.tsx
@@ -51,11 +51,14 @@ type SelectOption = {
     value: any
 }
 
-type LumaEvent = {
+// Shared shape from both /api proxies: Luma has coordinates, Notion the editorial fields
+type SuggestedEvent = {
     id: string
+    source: string
     name: string
     startAt: string | null
     endAt: string | null
+    allDay?: boolean
     timezone: string | null
     url: string | null
     lat: number | null
@@ -66,12 +69,137 @@ type LumaEvent = {
     venue: string | null
     fullAddress: string | null
     online: boolean
+    description?: string | null
+    category?: string | null
+    primaryPurpose?: string | null
+    attendees?: number | null
+    speakerNames?: string[]
+}
+
+const DEFAULT_AUDIENCE = 'Builders'
+
+// Notion's Category is mostly a format signal and Primary purpose a business goal, so only
+// the values that imply who an event is for are mapped; the rest fall back to the default.
+const AUDIENCE_BY_NOTION_VALUE: Record<string, string> = {
+    students: 'Students',
+    'community building': 'Builders',
+    'brand awareness': 'Builders',
+}
+
+// Reuse an existing option's casing so prefilling can't add near-duplicate values
+const canonicalAudience = (value: string, options: SelectOption[]): string =>
+    options.find((option) => option.label.toLowerCase() === value.toLowerCase())?.value ?? value
+
+const audienceFromNotion = (suggestion: SuggestedEvent, options: SelectOption[]): string[] => {
+    const mapped = [suggestion.category, suggestion.primaryPurpose]
+        .map((value) => (value ? AUDIENCE_BY_NOTION_VALUE[value.trim().toLowerCase()] : undefined))
+        .filter((value): value is string => Boolean(value))
+    return [...new Set((mapped.length > 0 ? mapped : [DEFAULT_AUDIENCE]).map((v) => canonicalAudience(v, options)))]
+}
+
+const normalizeName = (name: string): string => name.toLowerCase().replace(/[.'’]/g, '').replace(/\s+/g, ' ').trim()
+
+// Notion speakers are free text ("Andy M") but the form stores squeakIds. Only an
+// unambiguous single match is accepted — the wrong person is worse than none.
+const matchSpeakerOption = (name: string, options: SelectOption[]): string | null => {
+    const target = normalizeName(name)
+    if (!target) return null
+    const unique = (matches: SelectOption[]) => (matches.length === 1 ? matches[0].value : null)
+
+    const exact = unique(options.filter((option) => normalizeName(option.label) === target))
+    if (exact) return exact
+
+    // "Andy M" — first name plus a last-name initial
+    const initial = target.match(/^(\S+)\s+(\S)$/)
+    if (initial) {
+        const [, first, letter] = initial
+        return unique(
+            options.filter((option) => {
+                const [optionFirst, ...rest] = normalizeName(option.label).split(' ')
+                return optionFirst === first && rest.join(' ').startsWith(letter)
+            })
+        )
+    }
+
+    // Bare first name — only when it's unambiguous across profiles
+    return unique(options.filter((option) => normalizeName(option.label).split(' ')[0] === target))
+}
+
+const SOURCE_LABELS: Record<string, string> = { luma: 'Luma', notion: 'Notion' }
+
+const sourceLabel = (source: string): string =>
+    source
+        .split('+')
+        .map((part) => SOURCE_LABELS[part.trim()] || part.trim())
+        .join(' + ')
+
+// Collapse the same event from both systems on name + day, preferring the copy with coordinates
+const mergeSuggestedEvents = (lists: SuggestedEvent[][]): SuggestedEvent[] => {
+    const byKey = new Map<string, SuggestedEvent>()
+    for (const suggestion of lists.flat()) {
+        const key = `${suggestion.name.trim().toLowerCase()}|${(suggestion.startAt || '').slice(0, 10)}`
+        const existing = byKey.get(key)
+        if (!existing) {
+            byKey.set(key, suggestion)
+            continue
+        }
+        const [primary, secondary] = existing.lat != null ? [existing, suggestion] : [suggestion, existing]
+        byKey.set(key, {
+            ...secondary,
+            ...primary,
+            venue: primary.venue || secondary.venue,
+            url: primary.url || secondary.url,
+            description: primary.description || secondary.description,
+            category: primary.category || secondary.category,
+            // Spelled out so they survive if the other source starts sending the key as null
+            primaryPurpose: primary.primaryPurpose || secondary.primaryPurpose,
+            speakerNames: primary.speakerNames?.length ? primary.speakerNames : secondary.speakerNames,
+            attendees: primary.attendees ?? secondary.attendees,
+            source: [...new Set([existing.source, suggestion.source])].join(' + '),
+        })
+    }
+    return [...byKey.values()]
+}
+
+// Luma sends UTC instants with a timezone; Notion sends the wall clock as typed. Decide
+// from the value's shape so merged suggestions work either way.
+const suggestedDateTime = (suggestion: SuggestedEvent): { date: string; startTime: string } | null => {
+    const { startAt, timezone } = suggestion
+    if (!startAt) return null
+    if (!startAt.includes('T')) return { date: startAt.slice(0, 10), startTime: '' }
+    if (timezone) {
+        try {
+            const zoned = dayjs(startAt).tz(timezone)
+            if (zoned.isValid()) return { date: zoned.format('YYYY-MM-DD'), startTime: zoned.format('HH:mm') }
+        } catch {
+            // Unknown zone — fall through to the literal wall clock
+        }
+    }
+    return { date: startAt.slice(0, 10), startTime: startAt.slice(11, 16) }
 }
 
 type CitySuggestion = {
     id: string
     name: string
     placeFormatted: string
+}
+
+// Notion has no coordinates. Geocoding API rather than Search Box — no interactive session here.
+const geocodeLocation = async (query: string): Promise<{ lat: number; lng: number } | null> => {
+    const token = process.env.GATSBY_MAPBOX_TOKEN
+    if (!token || !query.trim()) return null
+    try {
+        const url = new URL('https://api.mapbox.com/search/geocode/v6/forward')
+        url.searchParams.set('q', query.trim())
+        url.searchParams.set('limit', '1')
+        url.searchParams.set('access_token', token)
+        const response = await fetch(url.toString())
+        const json = await response.json()
+        const coords = json?.features?.[0]?.geometry?.coordinates
+        return Array.isArray(coords) && coords.length >= 2 ? { lng: coords[0], lat: coords[1] } : null
+    } catch {
+        return null
+    }
 }
 
 // Session token for Mapbox Search Box API billing semantics
@@ -355,9 +483,8 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
         }
     }
 
-    // Luma event auto-suggest (create mode only) — events are fetched once
-    // through /api/luma-events since Luma's API blocks browser CORS
-    const [lumaEvents, setLumaEvents] = React.useState<LumaEvent[]>([])
+    // Auto-suggest (create mode only) — via /api proxies; neither API allows browser calls
+    const [lumaEvents, setLumaEvents] = React.useState<SuggestedEvent[]>([])
     const [lumaOpen, setLumaOpen] = React.useState(false)
     const [lumaHighlight, setLumaHighlight] = React.useState(-1)
     const lumaContainerRef = React.useRef<HTMLDivElement>(null)
@@ -374,55 +501,96 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
     React.useEffect(() => {
         if (event) return
         const controller = new AbortController()
-        fetch('/api/luma-events', { signal: controller.signal })
-            .then((response) => (response.ok ? response.json() : null))
-            .then((json) => {
-                if (json && Array.isArray(json.events)) {
-                    setLumaEvents(json.events)
-                }
-            })
-            .catch(() => {
-                // Proxy unavailable (e.g. plain gatsby dev) — suggestions just don't appear
-            })
+        // Sources fail independently — one unavailable proxy doesn't lose the other's results
+        const load = (path: string, source: string): Promise<SuggestedEvent[]> =>
+            fetch(path, { signal: controller.signal })
+                .then((response) => (response.ok ? response.json() : null))
+                .then((json) =>
+                    Array.isArray(json?.events)
+                        ? json.events.map((suggestion: SuggestedEvent) => ({ ...suggestion, source }))
+                        : []
+                )
+                .catch(() => [])
+
+        Promise.all([load('/api/luma-events', 'luma'), load('/api/notion-events', 'notion')]).then((lists) =>
+            setLumaEvents(mergeSuggestedEvents(lists))
+        )
         return () => controller.abort()
     }, [event])
 
     const lumaMatches = React.useMemo(() => {
         const query = formik.values.name.trim().toLowerCase()
         if (event || query.length < 3 || lumaEvents.length === 0) return []
-        return lumaEvents.filter((lumaEvent) => lumaEvent.name.toLowerCase().includes(query)).slice(0, 5)
+        const today = dayjs().format('YYYY-MM-DD')
+        // Upcoming soonest-first, then recent past. Must sort before slicing, or the cap
+        // keeps an arbitrary five.
+        const bucket = (date: string) => (!date ? 2 : date >= today ? 0 : 1)
+        return lumaEvents
+            .filter((suggestion) => suggestion.name.toLowerCase().includes(query))
+            .map((suggestion) => ({ suggestion, date: suggestedDateTime(suggestion)?.date || '' }))
+            .sort((a, b) =>
+                bucket(a.date) !== bucket(b.date)
+                    ? bucket(a.date) - bucket(b.date)
+                    : bucket(a.date) === 1
+                    ? b.date.localeCompare(a.date)
+                    : a.date.localeCompare(b.date)
+            )
+            .slice(0, 5)
+            .map(({ suggestion }) => suggestion)
     }, [lumaEvents, formik.values.name, event])
 
-    const handleLumaSelect = (lumaEvent: LumaEvent) => {
-        let start: dayjs.Dayjs | null = null
-        if (lumaEvent.startAt) {
-            try {
-                start = lumaEvent.timezone ? dayjs(lumaEvent.startAt).tz(lumaEvent.timezone) : dayjs(lumaEvent.startAt)
-            } catch {
-                start = dayjs(lumaEvent.startAt)
-            }
-        }
+    const handleLumaSelect = async (suggestion: SuggestedEvent) => {
+        const when = suggestedDateTime(suggestion)
+        const locationLabel =
+            suggestion.cityState ||
+            [suggestion.city, suggestion.country].filter(Boolean).join(', ') ||
+            formik.values.locationLabel
+
+        // External speakers, and profiles missing a team/avatar, are dropped
+        const matchedSpeakers = [
+            ...new Set(
+                (suggestion.speakerNames || [])
+                    .map((speakerName) => matchSpeakerOption(speakerName, speakers))
+                    .filter((squeakId): squeakId is string => Boolean(squeakId))
+            ),
+        ]
+
         formik.setValues({
             ...formik.values,
-            name: lumaEvent.name,
-            date: start?.isValid() ? start.format('YYYY-MM-DD') : formik.values.date,
-            startTime: start?.isValid() ? start.format('HH:mm') : formik.values.startTime,
-            link: lumaEvent.url || formik.values.link,
-            online: lumaEvent.online,
-            ...(lumaEvent.online
+            name: suggestion.name,
+            date: when?.date || formik.values.date,
+            startTime: when?.startTime || formik.values.startTime,
+            link: suggestion.url || formik.values.link,
+            online: suggestion.online,
+            description: suggestion.description || formik.values.description,
+            // Category maps onto Format; seeded only while empty, never overwriting a selection
+            format:
+                suggestion.category && formik.values.format.length === 0 ? [suggestion.category] : formik.values.format,
+            attendees: suggestion.attendees ?? formik.values.attendees,
+            speakers: formik.values.speakers.length === 0 ? matchedSpeakers : formik.values.speakers,
+            // Required field, so this always resolves to at least the default
+            audience:
+                formik.values.audience.length === 0 ? audienceFromNotion(suggestion, audience) : formik.values.audience,
+            ...(suggestion.online
                 ? { locationLabel: '', locationLat: undefined, locationLng: undefined, venueName: '' }
                 : {
-                      locationLabel:
-                          lumaEvent.cityState ||
-                          [lumaEvent.city, lumaEvent.country].filter(Boolean).join(', ') ||
-                          formik.values.locationLabel,
-                      venueName: lumaEvent.venue || '',
-                      locationLat: lumaEvent.lat ?? undefined,
-                      locationLng: lumaEvent.lng ?? undefined,
+                      locationLabel,
+                      venueName: suggestion.venue || '',
+                      locationLat: suggestion.lat ?? undefined,
+                      locationLng: suggestion.lng ?? undefined,
                   }),
         })
         setLumaOpen(false)
         setLumaHighlight(-1)
+
+        // Notion carries no coordinates — resolve them from the venue/city text
+        if (!suggestion.online && suggestion.lat == null) {
+            const coords = await geocodeLocation([suggestion.venue, locationLabel].filter(Boolean).join(', '))
+            if (coords) {
+                formik.setFieldValue('locationLat', coords.lat)
+                formik.setFieldValue('locationLng', coords.lng)
+            }
+        }
     }
 
     // Debounced Mapbox suggest — only fires while the user is typing (cityQuery
@@ -590,9 +758,35 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
         }
     }
 
+    // resetForm() alone leaves a stale city query that re-opens its dropdown. In edit mode
+    // this reverts to the saved event rather than emptying the form.
+    const clearForm = () => {
+        formik.resetForm()
+        setCityQuery('')
+        setCitySuggestions([])
+        setCityOpen(false)
+        setCityHighlight(-1)
+        setCitySessionToken(newSessionToken())
+        setLumaOpen(false)
+        setLumaHighlight(-1)
+    }
+
     return (
         <div>
-            <h2 className="text-xl font-bold mb-1">Add a new event</h2>
+            {/* pr-10 keeps this clear of the card's absolutely-positioned close button */}
+            <div className="flex items-center justify-between gap-2 mb-1 pr-10">
+                <h2 className="text-xl font-bold mb-0">Add a new event</h2>
+                <OSButton
+                    size="sm"
+                    variant="secondary"
+                    type="button"
+                    disabled={submitting}
+                    tooltip={event ? 'Revert to the saved event' : 'Clear all fields'}
+                    onClick={clearForm}
+                >
+                    {event ? 'Revert' : 'Clear'}
+                </OSButton>
+            </div>
             <form onSubmit={formik.handleSubmit} className="space-y-3">
                 <div ref={lumaContainerRef} className="relative">
                     <OSInput
@@ -630,12 +824,15 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                     {!event && lumaOpen && (
                         <SuggestionDropdown
                             id="luma-event-suggestions"
-                            items={lumaMatches.map((lumaEvent) => ({
-                                id: lumaEvent.id,
-                                label: lumaEvent.name,
+                            items={lumaMatches.map((suggestion) => ({
+                                id: suggestion.id,
+                                label: suggestion.name,
                                 sublabel: [
-                                    lumaEvent.startAt ? dayjs(lumaEvent.startAt).format('MMM D, YYYY') : null,
-                                    lumaEvent.online ? 'Online' : lumaEvent.cityState || lumaEvent.city,
+                                    suggestedDateTime(suggestion)
+                                        ? dayjs(suggestedDateTime(suggestion)!.date).format('MMM D, YYYY')
+                                        : null,
+                                    suggestion.online ? 'Online' : suggestion.cityState || suggestion.city,
+                                    sourceLabel(suggestion.source),
                                 ]
                                     .filter(Boolean)
                                     .join(' · '),
@@ -957,13 +1154,7 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                             'Add event'
                         )}
                     </OSButton>
-                    <OSButton
-                        disabled={submitting}
-                        variant="default"
-                        size="md"
-                        type="button"
-                        onClick={() => formik.resetForm()}
-                    >
+                    <OSButton disabled={submitting} variant="default" size="md" type="button" onClick={clearForm}>
                         Reset
                     </OSButton>
                 </div>


### PR DESCRIPTION
Extending scope from #18978 to include events from our Notion db

## Changes

* Adds our Notion IRL events db as a source for the "Add event" form's auto-suggest.
* Adds a `Clear` form button

→ Note: just like Luma's API, `api/notion-events.js` is a serverless proxy because the `NOTION_TOKEN` and `NOTION_EVENTS_DATABASE_ID` are server-only.

<img width="371" height="408" alt="Add a new event" src="https://github.com/user-attachments/assets/5c999001-78ea-4aa1-95d9-c3f123c8cfc7" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links — N/A (no content links)
- [ ] I've checked the pages added or changed in the Vercel preview build — N/A: previews are static-only Cloudflare Pages, so `/api` routes don't run there. Tested locally via `pnpm start` (the dev middleware in `gatsby-config.js` serves both routes)
- [x] If I moved a page, I added a redirect in `vercel.json` — N/A (no page moved)
