### PR TITLE
docs(web-analytics): document Bots tab and expand AI traffic tracking guide

### DIFF
--- a/contents/docs/web-analytics/managing-bot-traffic.mdx
+++ b/contents/docs/web-analytics/managing-bot-traffic.mdx
@@ -33,7 +33,7 @@ The **Bots** tab in [Web Analytics](/docs/web-analytics/dashboard) is a dedicate
 - **Crawlers** – every bot that hit you in the selected period, with its category, request count, and when it was last seen.
 - **Most crawled paths** – the pages bots request most, and how many different crawlers hit each one.
 
-The tab reads `$pageview`, `$screen`, and [`$http_log`](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) events, so forwarded server logs show up alongside anything the JavaScript SDK captured. Classification is based on the user agent, so events without one are excluded from this tab – another reason to forward server logs, which always carry it.
+The tab reads `$pageview`, `$screen`, and [`$http_log`](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) events, so forwarded server logs show up alongside anything the JavaScript SDK captured. Classification is based on the user agent, and events without one are excluded from this tab – so when forwarding logs, make sure each event sets `$raw_user_agent`.
 
 > **Note:** The Bots tab is in alpha and rolling out gradually – it may not be enabled for your project yet. The `$virt_*` properties and classification functions are available to everyone today.
 
@@ -59,10 +59,10 @@ AI traffic is worth measuring on its own: these visits are how AI tools discover
 To track them:
 
 1. **Capture the traffic.** Most AI bots don't run JavaScript, so the SDK never sees them. Forward your server or CDN logs as [`$http_log` events](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) – without this, you only measure the small slice of AI traffic that executes your snippet.
-2. **See who's reading your site.** Open the [Bots tab](#see-bots-in-the-bots-tab) and switch the trend to the **Category** breakdown, or build a trend filtered to `$virt_traffic_type` equals `AI Agent` and broken down by `$virt_bot_name` or `$virt_bot_operator` to compare OpenAI, Anthropic, Perplexity, and others.
+2. **See who's reading your site.** Open the [Bots tab](#see-bots-in-the-bots-tab) and switch the trend to the **Category** breakdown, or build a trend on the `$pageview` and `$http_log` events (a `$pageview`-only trend misses the server-side traffic you set up in step 1), filtered to `$virt_traffic_type` equals `AI Agent` and broken down by `$virt_bot_name` or `$virt_bot_operator` to compare OpenAI, Anthropic, Perplexity, and others.
 3. **See what they're reading.** Check **Most crawled paths** in the Bots tab, or break the same trend down by `$pathname`, to find which content AI tools hit most.
 
-Assistant traffic deserves particular attention: each `ai_assistant` request has a person on the other end asking about your content right now, even though the request itself is automated. A rise in assistant traffic to a page is a signal that AI tools are citing it.
+Assistant traffic deserves particular attention: each `ai_assistant` request has a person on the other end asking about your content right now, even though the request itself is automated. A rise in assistant traffic to a page means AI tools are reading it on users' behalf.
 
 ## Related
 

--- a/contents/docs/web-analytics/managing-bot-traffic.mdx
+++ b/contents/docs/web-analytics/managing-bot-traffic.mdx
@@ -2,7 +2,7 @@
 title: Managing bot and AI traffic
 ---
 
-Bots, crawlers, and AI agents make up a growing share of web traffic, and not all of it is noise. PostHog lets you decide – per type of traffic – whether to welcome it, measure it, or keep it out of your numbers. This guide covers those decisions and where to act on them. For the underlying functions and properties, see [bot and traffic detection](/docs/web-analytics/bot-detection).
+Bots, crawlers, and AI agents make up a growing share of web traffic, and not all of it is noise. PostHog lets you decide – per type of traffic – whether to welcome it, measure it, or keep it out of your numbers, and gives you a dedicated [Bots tab](#see-bots-in-the-bots-tab) in Web Analytics to watch it. This guide covers those decisions and where to act on them. For the underlying functions and properties, see [bot and traffic detection](/docs/web-analytics/bot-detection).
 
 ## Decide what to keep
 
@@ -25,6 +25,18 @@ There are three points where you can deal with bots, from most aggressive to mos
 2. **Exclude at query time.** Keep the events and filter them out where you don't want them – add a `$virt_is_bot` is `false` filter to an insight or dashboard. Flexible and reversible: the underlying data stays intact, so you can include or break down bot traffic whenever you want.
 3. **Capture server-side to measure bots.** Most bots and AI agents never run JavaScript, so the SDK never sees them. To measure that traffic, forward your server logs as [`$http_log` events](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) – they carry the user agent and get classified the same way.
 
+## See bots in the Bots tab
+
+The **Bots** tab in [Web Analytics](/docs/web-analytics/dashboard) is a dedicated dashboard for automated traffic, scoped to detected bots so it stays separate from your human metrics. It shows:
+
+- **Bot requests over time** – a trend of bot traffic, with breakdowns by crawler, category, host, and path.
+- **Crawlers** – every bot that hit you in the selected period, with its category, request count, and when it was last seen.
+- **Most crawled paths** – the pages bots request most, and how many different crawlers hit each one.
+
+The tab reads `$pageview`, `$screen`, and [`$http_log`](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) events, so forwarded server logs show up alongside anything the JavaScript SDK captured. Classification is based on the user agent, so events without one are excluded from this tab – another reason to forward server logs, which always carry it.
+
+> **Note:** The Bots tab is in alpha and rolling out gradually – it may not be enabled for your project yet. The `$virt_*` properties and classification functions are available to everyone today.
+
 ## Exclude bots from an insight or dashboard
 
 In any [Product Analytics](/docs/product-analytics) insight or [Web Analytics](/docs/web-analytics/dashboard) view, add a filter where `$virt_is_bot` equals `false`. Your visitor, session, and pageview counts then reflect human traffic only, without changing the stored data.
@@ -34,11 +46,23 @@ To exclude a narrower set – say, only automation and HTTP clients while keepin
 ## See which bots are hitting you
 
 - **Right now** – open the [Live tab](/docs/web-analytics/live#bot-traffic) and check the bot traffic tile to see which bots are crawling you in real time.
-- **Over time** – build a trend filtered to `$virt_is_bot` is `true` and broken down by `$virt_bot_name`. See [example queries](/docs/web-analytics/bot-detection#example-queries) for the SQL equivalent.
+- **Over time** – open the [Bots tab](#see-bots-in-the-bots-tab) for a ready-made dashboard, or build a trend filtered to `$virt_is_bot` is `true` and broken down by `$virt_bot_name`. See [example queries](/docs/web-analytics/bot-detection#example-queries) for the SQL equivalent.
 
-## Measure AI crawler traffic
+## Track AI bot traffic
 
-AI agents are worth watching on their own: they're how assistants and AI search surface your content. To track them, filter to `$virt_traffic_type` equals `AI Agent` and break down by `$virt_bot_name` or `$virt_bot_operator` to see which tools (OpenAI, Anthropic, Perplexity, and others) are reading your site, and which pages they hit most.
+AI traffic is worth measuring on its own: these visits are how AI tools discover, index, and cite your content. PostHog classifies it into three categories:
+
+- **AI crawlers** (`ai_crawler`) – collect training data. Examples: GPTBot, ClaudeBot, Google-Extended.
+- **AI search crawlers** (`ai_search`) – index your site for AI-powered search results. Examples: OAI-SearchBot, Claude-SearchBot.
+- **AI assistants** (`ai_assistant`) – fetch a page because a person asked an assistant about it right then. Examples: ChatGPT-User, Claude-User, Perplexity-User.
+
+To track them:
+
+1. **Capture the traffic.** Most AI bots don't run JavaScript, so the SDK never sees them. Forward your server or CDN logs as [`$http_log` events](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) – without this, you only measure the small slice of AI traffic that executes your snippet.
+2. **See who's reading your site.** Open the [Bots tab](#see-bots-in-the-bots-tab) and switch the trend to the **Category** breakdown, or build a trend filtered to `$virt_traffic_type` equals `AI Agent` and broken down by `$virt_bot_name` or `$virt_bot_operator` to compare OpenAI, Anthropic, Perplexity, and others.
+3. **See what they're reading.** Check **Most crawled paths** in the Bots tab, or break the same trend down by `$pathname`, to find which content AI tools hit most.
+
+Assistant traffic deserves particular attention: each `ai_assistant` request has a person on the other end asking about your content right now, even though the request itself is automated. A rise in assistant traffic to a page is a signal that AI tools are citing it.
 
 ## Related
 


### PR DESCRIPTION
## Changes

Makes `/docs/web-analytics/managing-bot-traffic` the canonical link for "how do I track AI bot traffic?" (context: [Slack thread](https://posthog.slack.com/archives/C05LJK1N3CP/p1785425497184989)).

- Adds a **See bots in the Bots tab** section documenting the alpha Bots tab in Web Analytics (`/web/bots`): bot requests trend with crawler/category/host/path breakdowns, Crawlers table, and Most crawled paths table. Includes an alpha rollout note matching the style used in `live.mdx`.
- Expands **Measure AI crawler traffic** into **Track AI bot traffic**: explains the three AI traffic categories (`ai_crawler`, `ai_search`, `ai_assistant`), then a three-step walkthrough – capture server-side via `$http_log` (most AI bots don't run JS), break down by bot name/operator, find the most-crawled paths.
- Points the intro and "See which bots are hitting you" at the Bots tab.

Kept `/docs/web-analytics/bot-detection` as the separate reference page rather than merging – the guide/reference split works, and that page has been substantially improved since the thread.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case
- [x] Feature names are in sentence case too
- [x] Any UTM parameters are removed from links