### PR TITLE
Swap in higher-res AI observability screenshots

### DIFF
--- a/src/hooks/productData/ai_observability/features.tsx
+++ b/src/hooks/productData/ai_observability/features.tsx
@@ -30,7 +30,7 @@ export const features = {
         color: 'purple',
         images: [
             {
-                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/dashboard_screenshot_ce72bbf715.png',
+                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Dashboardscreenshot_36ce056f2d.png',
                 alt: 'AI Observability dashboard',
             },
         ],
@@ -44,7 +44,7 @@ export const features = {
         color: 'yellow',
         images: [
             {
-                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/generations_screenshot_56f0f313ae.png',
+                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Generationsscreenshot_cc4d4f107e.png',
                 alt: 'AI Observability generations',
             },
         ],
@@ -190,7 +190,7 @@ export const features = {
         color: 'red',
         images: [
             {
-                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/users_screenshot_2_d93795cbdc.png',
+                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Userscreenshot_0b8d02a617.png',
                 alt: 'AI Observability users',
             },
         ],
@@ -204,7 +204,7 @@ export const features = {
         color: 'yellow',
         images: [
             {
-                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/errors_screenshot_e413f3f20b.png',
+                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/errorscreenshot_6b30e34a4e.png',
                 alt: 'AI Observability errors',
             },
         ],
@@ -232,7 +232,7 @@ export const features = {
         color: 'purple',
         images: [
             {
-                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/playground_screenshot_2_3364a67436.png',
+                src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/playgroundscreenshot_29797c78d6.png',
                 alt: 'AI Observability playground',
             },
         ],


### PR DESCRIPTION
## Changes

Swaps in higher-resolution captures for five product screenshots on `/ai-observability` that were rendering blurry on large / high-DPI screens. The old assets were only ~800px wide but displayed at full container width; the replacements are ~2× (1586–1748px wide), so they stay crisp when the reader window is stretched.

Updated in `src/hooks/productData/ai_observability/features.tsx`:
- **Dashboard**, **Errors**, **Playground** — the "How do I use it?" section
- **Generations**, **Users** — the "Top features" section

**Why:** The screenshots looked blurry on a 27" display. Reported in Slack.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1785441356612879?thread_ts=1785441356.612879&cid=C01V9AT7DK4)*
