### PR TITLE
Clarify pay review process and effective date

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -74,7 +74,7 @@ The reason for less sophistication here is that we have very few executives, and
 
 ## Pay reviews
 
-We review pay proactively 2-3 times a year, and everybody on the team is reviewed at every pay review. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask.
+We review pay proactively 2-3 times a year, and everybody on the team is reviewed at every pay review. Any change to your pay takes effect from the 1st of the month following your review, and isn't backdated. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask.
 
 As we do these much more frequently than regular companies, team members should definitely not expect these to result in a change to their Step or Level each time - mostly they will stay the same. Additionally, team members will find that their Step, or place within a Step's range, will change more frequently than their Level.
 


### PR DESCRIPTION
Added details about pay change effective dates and backdating.

## Changes

Added one sentence to the Pay reviews section clarifying that pay
changes take effect from the 1st of the month following the review,
and aren't backdated.

This came up because team members asked why the payslip they got in
the review month still showed their old amount. The effective date
wasn't documented anywhere, so this should save the question coming
up each cycle.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ x] Words are spelled using American English
- [ x] Use relative URLs for internal links
- [ x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
