### PR TITLE
feat(templates): emit a machine-readable self-driving scout catalog

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -17,6 +17,7 @@ import {
     generatePricingMd,
     generatePlatformMd,
     generateProductPagesMarkdown,
+    generateSelfDrivingTemplatesCatalog,
 } from './rawMarkdownUtils'
 import { MARKDOWN_CONTENT_PATHS } from '../src/constants'
 import { SdkReferenceData } from '../src/templates/sdk/SdkReference.js'
@@ -590,6 +591,28 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
                         filters {
                             type
                         }
+                        subtitle
+                        question
+                        premise
+                        discriminator {
+                            speaksUp
+                            staysQuiet
+                            why
+                        }
+                        watches {
+                            name
+                            detail
+                        }
+                        requires {
+                            label
+                            level
+                        }
+                        scout {
+                            name
+                            description
+                            body
+                            schedule
+                        }
                     }
                 }
             }
@@ -610,11 +633,14 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
     // Self-driving scout templates are written as agent context as much as marketing pages, so
     // they belong in the index an agent reads. The dashboard/survey templates stay out — they'd
     // be noise. See components/SelfDrivingInbox/README.md.
-    const selfDrivingTemplateSlugs = new Set(
-        docsQuery.data.allMdx.nodes
-            .filter((node) => node.frontmatter?.filters?.type?.some((t) => t?.toLowerCase() === 'self-driving'))
-            .map((node) => node.fields.slug)
+    const selfDrivingTemplateNodes = docsQuery.data.allMdx.nodes.filter((node) =>
+        node.frontmatter?.filters?.type?.some((t) => t?.toLowerCase() === 'self-driving')
     )
+    const selfDrivingTemplateSlugs = new Set(selfDrivingTemplateNodes.map((node) => node.fields.slug))
+
+    // The same templates, as a single machine-readable catalog the wizard's `template` command
+    // reads to create a scout. Shares the filter above so the two can't drift apart.
+    generateSelfDrivingTemplatesCatalog(selfDrivingTemplateNodes)
 
     // Docs pages plus self-driving templates in llms.txt (not handbook, not blog)
     const docsPages = filteredPages.filter(

--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -537,6 +537,162 @@ For features, screenshots, and details, see ${pageLinkFor(item)}.
     }
 }
 
+interface SelfDrivingTemplateNode {
+    fields: { slug: string }
+    frontmatter: {
+        title?: string
+        subtitle?: string
+        question?: string
+        premise?: string
+        discriminator?: { speaksUp?: string; staysQuiet?: string; why?: string }
+        watches?: Array<{ name?: string; detail?: string }>
+        requires?: Array<{ label?: string; level?: string }>
+        scout?: { name?: string; description?: string; body?: string; schedule?: string }
+    }
+}
+
+// The fields the catalog carries, in a fixed order so the output is stable across builds.
+const CATALOG_FIELDS = [
+    'title',
+    'subtitle',
+    'question',
+    'premise',
+    'discriminator',
+    'watches',
+    'requires',
+    'scout',
+] as const
+
+/**
+ * Minimal YAML scalar emitter for the catalog's known field shapes.
+ *
+ * Single-line strings become double-quoted scalars (YAML accepts JSON's escapes, so
+ * JSON.stringify is a safe encoder). Multi-line strings become literal block scalars, which
+ * preserve `scout.body` — a markdown document — byte for byte. Rolling this by hand rather
+ * than adding a YAML dependency is deliberate: the shapes here are fixed and shallow.
+ */
+const yamlScalar = (value: string, indent: string): string => {
+    // Trailing whitespace on a line inside a block scalar is not round-trippable, and a
+    // trailing newline changes the scalar's chomping. Normalize both before choosing a form.
+    const normalized = value.replace(/[ \t]+$/gm, '').replace(/\n+$/, '')
+    if (!normalized.includes('\n')) return JSON.stringify(normalized)
+
+    const body = normalized
+        .split('\n')
+        .map((line) => (line.length > 0 ? `${indent}  ${line}` : ''))
+        .join('\n')
+    return `|-\n${body}`
+}
+
+const yamlField = (key: string, value: unknown, indent = ''): string | null => {
+    if (value == null) return null
+
+    if (typeof value === 'string') {
+        if (value.trim().length === 0) return null
+        return `${indent}${key}: ${yamlScalar(value, indent)}`
+    }
+
+    if (Array.isArray(value)) {
+        const items = value
+            .map((item) => {
+                const pairs = Object.entries(item as Record<string, unknown>)
+                    .map(([k, v]) => yamlField(k, v, `${indent}    `))
+                    .filter((line): line is string => line !== null)
+                if (pairs.length === 0) return null
+                // First pair joins the `- ` marker; the rest align under it.
+                return `${indent}  - ${pairs[0].trimStart()}\n${pairs.slice(1).join('\n')}`.replace(/\n$/, '')
+            })
+            .filter((item): item is string => item !== null)
+        return items.length > 0 ? `${indent}${key}:\n${items.join('\n')}` : null
+    }
+
+    const pairs = Object.entries(value as Record<string, unknown>)
+        .map(([k, v]) => yamlField(k, v, `${indent}  `))
+        .filter((line): line is string => line !== null)
+    return pairs.length > 0 ? `${indent}${key}:\n${pairs.join('\n')}` : null
+}
+
+const slugFor = (node: SelfDrivingTemplateNode): string =>
+    node.fields.slug.split('/').filter(Boolean).pop() || node.fields.slug
+
+/**
+ * Generate /templates/self-driving-catalog.md — the machine-readable catalog of every
+ * self-driving scout template, one section per template with its frontmatter inline.
+ *
+ * This exists for agents, not people: the PostHog wizard's `template` command reads it to
+ * offer a template, check whether the project emits the events the scout needs, and create
+ * the scout verbatim. Humans get the inbox at /templates/self-driving.
+ *
+ * One aggregate file rather than per-slug files on purpose — the wizard's context-mill
+ * pipeline enumerates explicit URLs with no glob support, so a single stable URL means new
+ * templates flow through without anyone editing a config. Output is deterministic (no
+ * timestamps) because it is fetched into a content-addressed build cache downstream.
+ */
+export const generateSelfDrivingTemplatesCatalog = (nodes: SelfDrivingTemplateNode[]) => {
+    if (nodes.length === 0) {
+        console.log('No self-driving templates found, skipping self-driving-catalog.md')
+        return
+    }
+
+    const publicPath = path.resolve(__dirname, '../public')
+    const outputPath = path.join(publicPath, 'templates', 'self-driving-catalog.md')
+    const templates = [...nodes].sort((a, b) => slugFor(a).localeCompare(slugFor(b)))
+
+    const summaryRows = templates.map((node) => {
+        const requiredCount = (node.frontmatter.requires || []).filter(
+            (r) => (r?.level || 'required').toLowerCase() === 'required'
+        ).length
+        const cells = [
+            slugFor(node),
+            node.frontmatter.title || '',
+            node.frontmatter.scout?.schedule || 'Daily',
+            String(requiredCount),
+        ]
+        return `| ${cells.map((cell) => cell.replace(/\|/g, '\\|')).join(' | ')} |`
+    })
+
+    const sections = templates.map((node) => {
+        const yaml = CATALOG_FIELDS.map((field) => yamlField(field, node.frontmatter[field]))
+            .filter((line): line is string => line !== null)
+            .join('\n')
+
+        return `## ${slugFor(node)}
+
+Page: https://posthog.com/${node.fields.slug.replace(/^\//, '')}
+
+\`\`\`yaml
+${yaml}
+\`\`\``
+    })
+
+    const content = `# Self-driving scout templates
+
+Machine-readable catalog of every self-driving scout template on PostHog. One section per
+template, with that template's frontmatter inline as YAML.
+
+Each template describes a named question a self-driving product watches for. \`scout\` is the
+scout itself — pass \`scout.name\`, \`scout.description\`, and \`scout.body\` to PostHog to create
+it. \`requires\` lists what the scout needs to produce useful findings; a scout whose required
+prerequisites are unmet will run on schedule and find nothing, so check them before creating it.
+
+Fields carried: ${CATALOG_FIELDS.join(', ')}.
+Presentational fields (the example report, images, filters) are deliberately omitted — do not
+look for them here. The human-readable version of each template, including its example report,
+is linked above each section.
+
+| slug | title | schedule | required prerequisites |
+| --- | --- | --- | --- |
+${summaryRows.join('\n')}
+
+${sections.join('\n\n')}
+`
+
+    const dirPath = path.dirname(outputPath)
+    if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true })
+    fs.writeFileSync(outputPath, content, 'utf8')
+    console.log(`Generated: templates/self-driving-catalog.md (${templates.length} templates)`)
+}
+
 export const generateLlmsTxt = (pages) => {
     console.log('Generating llms.txt file...')
 


### PR DESCRIPTION
## Changes

Adds `/templates/self-driving-catalog.md` — one aggregate file listing every self-driving scout
template with its frontmatter inline as YAML. Emitted in `onPostBuild` alongside `llms.txt`, reusing
the same self-driving filter so the two can't drift. No pages, routes, or components change.

**Why:** the wizard is getting a `template` command that sets up a scout from these templates. It
runs in the developer's repo, so unlike the web "Add this scout" button it can check whether the
project actually emits the events the scout reads first. To do that it needs the frontmatter as
*data*, at one stable URL.

Stacked on #19131 and targets that branch.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links *(n/a — the emitted file is fetched out of band, so absolute)*
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` *(n/a — nothing moved)*

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
