### PR TITLE
Fix logs pricing calculator: slider dead zone and 30-day retention cost model

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
@@ -171,13 +171,21 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
 
     const totalCost = mainCost + addonData.reduce((sum, addon) => sum + addon.cost, 0)
 
+    // Add-ons like logs 30-day retention meter their volume through the main product's tiers too
+    // (the add-on price is only the premium), so the main product is billed on the combined volume.
+    const parentMeteredAddonVolume = addonBillingData.reduce(
+        (sum, addon, index) => (addon.countsTowardParentVolume ? sum + (addonData[index]?.volume || 0) : sum),
+        0
+    )
+    const billedMainVolume = mainVolume + parentMeteredAddonVolume
+
     useEffect(() => {
         if (mainBillingTiers) {
-            const { total, costByTier } = calculatePrice(mainVolume, mainBillingTiers)
+            const { total, costByTier } = calculatePrice(billedMainVolume, mainBillingTiers)
             setMainCost(total)
             setMainCostByTier(costByTier)
         }
-    }, [mainVolume, mainBillingTiers])
+    }, [billedMainVolume, mainBillingTiers])
 
     useEffect(() => {
         const updatedAddonData = addonData.map((addon, index) => {
@@ -193,18 +201,19 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
 
     useEffect(() => {
         if (mainBillingTiers) {
-            const { costByTier } = calculatePrice(mainVolume, mainBillingTiers)
+            const { costByTier } = calculatePrice(billedMainVolume, mainBillingTiers)
             setProduct(activeProduct.handle, {
                 cost: totalCost,
                 volume: mainVolume,
                 costByTier,
             })
         }
-    }, [totalCost, mainVolume, mainBillingTiers, activeProduct.handle, setProduct])
+    }, [totalCost, mainVolume, billedMainVolume, mainBillingTiers, activeProduct.handle, setProduct])
 
-    const handleMainVolumeChange = (volume, cost) => {
+    // Cost is derived from billedMainVolume in the effect above — the cost SliderRow reports only
+    // covers its own volume, which undercounts when an add-on meters through the main product.
+    const handleMainVolumeChange = (volume) => {
         setMainVolume(volume)
-        setMainCost(cost)
     }
 
     const handleAddonVolumeChange = (index) => (volume, cost) => {
@@ -247,7 +256,8 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                 (addon, index) =>
                     addon.billingTiers && (
                         <div key={addon.key} className="mb-4">
-                            <h4 className="mb-3 text-base font-semibold">{addon.label}</h4>
+                            <h4 className={`${addon.note ? 'mb-1' : 'mb-3'} text-base font-semibold`}>{addon.label}</h4>
+                            {addon.note && <p className="text-sm opacity-70 mb-3">{addon.note}</p>}
                             <SliderRow
                                 label={addon.unit}
                                 sliderConfig={addon.sliderConfig}
@@ -303,8 +313,22 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
                                     {activeProduct.productVariantName || activeProduct.name}
                                 </h4>
                                 <p className="opacity-70 m-0 text-sm mb-2">
-                                    <strong>{mainVolume.toLocaleString()}</strong>{' '}
-                                    {pluralizeUnit(activeProduct.billingData.unit, mainVolume)}
+                                    <strong>{billedMainVolume.toLocaleString()}</strong>{' '}
+                                    {pluralizeUnit(activeProduct.billingData.unit, billedMainVolume)}
+                                    {parentMeteredAddonVolume > 0 && (
+                                        <>
+                                            {' '}
+                                            (includes{' '}
+                                            {addonBillingData
+                                                .filter(
+                                                    (addon, index) =>
+                                                        addon.countsTowardParentVolume && addonData[index]?.volume > 0
+                                                )
+                                                .map((addon) => addon.label.toLowerCase())
+                                                .join(', ')}{' '}
+                                            volume)
+                                        </>
+                                    )}
                                 </p>
                                 <div className="overflow-auto -mx-4 px-4 md:mx-0 md:px-0">
                                     <div className="p-1 min-w-[500px] md:min-w-auto border border-input rounded-md mt-2">

--- a/src/hooks/productData/logs.tsx
+++ b/src/hooks/productData/logs.tsx
@@ -13,15 +13,20 @@ export const logs = {
     slider: {
         // Values in GB (display_friendly=true converts MB to GB)
         marks: [0, 10, 50, 100, 500, 1000, 5000],
-        min: 10,
+        min: 0,
         scaleMin: 1,
         max: 5000,
     },
     volume: 10,
+    freeAllocationText: 'First 10 GB free – every month!',
     addonSliders: [
         {
             key: 'logs_retention_30d',
             label: '30-day retention',
+            // Billing meters all ingested GB (any retention) on the base logs product, then bills
+            // 30-day GB again at the add-on rate as a storage premium.
+            countsTowardParentVolume: true,
+            note: 'These GB also count toward logs ingestion above – this price is just the added cost of storing them longer.',
             sliderConfig: {
                 marks: [0, 10, 50, 100, 500, 1000, 5000],
                 min: 0,


### PR DESCRIPTION
## Changes

Two fixes to the logs section of the pricing calculator:

**1. The 14-day retention slider couldn't be dragged back below 10 GB.** The slider config had `min: 10` with `scaleMin: 1`, so the track rendered down to the 0 mark but the change handler clamped every value back to 10 — a dead zone you could see but never select. Now `min: 0` (matching the 30-day addon slider), with the "First 10 GB free" note driven by `freeAllocationText`. This also fixes the same stuck slider on `/docs/logs/pricing`, which shares the config.

**2. The 30-day retention slider understated real costs.** Billing meters **all** ingested GB (any retention) on the base logs product (`logs_mb_ingested` is fed by `logs_mb_in_period`, which includes every retention tier), and 30-day GB are billed **again** at the addon rate as a storage premium. The calculator treated the two sliders as independent products, so e.g. 10 GB (14-day) + 100 GB (30-day) showed ~$5 when the real invoice is ~$30 (110 GB through the ingestion tiers + 100 × $0.05).

The addon slider config now supports `countsTowardParentVolume` — when set, the main product is billed on the combined volume. The 30-day slider also gets an explanatory note ("These GB also count toward logs ingestion above…"), and the cost breakdown shows the combined GB with "(includes 30-day retention volume)". Other products using `StandaloneAddonsTab` (Data pipelines, Workflows, etc.) don't set the flag and are unchanged.

Verified locally: slider drags back to 0 and stays; 10 GB + 100 GB shows $25 ingestion + $5 retention = $30; Data pipelines tab unaffected.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)