### PR TITLE
Add MCP wizard install to semantic layer getting started

### DIFF
--- a/contents/docs/semantic-layer/_snippets/alpha-callout.mdx
+++ b/contents/docs/semantic-layer/_snippets/alpha-callout.mdx
@@ -2,6 +2,10 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="The semantic layer is in alpha" type="action">
 
-The semantic layer is in alpha, enabled per organization for a small group of customers. You can manage it from the **Data Catalog** UI in PostHog (press `Cmd/Ctrl + K` and search for "Data Catalog"), or through MCP tools and SQL. Tool names and behavior may change between releases. Found a bug, or want access? [Contact support](https://app.posthog.com/home#supportModal) and mention the semantic layer alpha.
+The semantic layer is in alpha, enabled per organization for a small group of customers.
+
+You can manage it from the **Data Catalog** UI in PostHog (press `Cmd/Ctrl + K` and search for "Data Catalog"), or through MCP tools and SQL. Tool names and behavior may change between releases.
+
+Found a bug, or want access? [Contact support](https://app.posthog.com/home#supportModal) and mention the semantic layer alpha.
 
 </CalloutBox>

--- a/contents/docs/semantic-layer/start-here.mdx
+++ b/contents/docs/semantic-layer/start-here.mdx
@@ -6,6 +6,7 @@ contentMaxWidthClass: max-w-5xl
 
 import AlphaCallout from './_snippets/alpha-callout'
 import { CalloutBox } from 'components/Docs/CalloutBox'
+import PlatformInstall from 'components/PlatformInstall'
 
 In this guide you'll take a metric that only exists in people's heads – MRR – and turn it into a governed definition every AI session agrees on. The whole thing is one agent conversation: the agent proposes, you approve, and from then on every client that asks about MRR gets the same number.
 
@@ -14,9 +15,11 @@ In this guide you'll take a metric that only exists in people's heads – MRR �
 ## Prerequisites
 
 - The semantic layer alpha enabled for your organization
-- The [PostHog MCP server](/docs/model-context-protocol) connected to your agent (Claude Code, Cursor, Claude Desktop, or any MCP client)
 - An API key with the `data_catalog` scope – add `data_catalog_approval` too, since you'll approve a metric in this guide (see [governance](/docs/semantic-layer/governance#api-scopes) for why they're separate)
 - Some revenue-ish data in your [data warehouse](/docs/data-warehouse), like a synced `stripe_subscriptions` table
+- The [PostHog MCP server](/docs/model-context-protocol) connected to your agent (Claude Code, Cursor, Claude Desktop, or any MCP client)
+
+<PlatformInstall />
 
 ## Step 1: See the problem
 


### PR DESCRIPTION
## Changes

On [`/docs/semantic-layer/start-here`](https://posthog.com/docs/semantic-layer/start-here):

- Moved the *PostHog MCP server connected to your agent* bullet to the bottom of the prerequisites list.
- Added the standard `<PlatformInstall />` wizard install component below the list.
- Split the alpha callout snippet into three paragraphs for readability.

**Why:** Requested via Slack — make it easier to install the MCP right from the getting-started guide, and improve the readability of the alpha callout.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C078QBEET1S/p1785492027688099?thread_ts=1785492027.688099&cid=C078QBEET1S)*