### PR TITLE
docs(support): document unknown login and billing default tags

### DIFF
--- a/contents/handbook/support/posthog-support.md
+++ b/contents/handbook/support/posthog-support.md
@@ -66,6 +66,8 @@ Tickets are tagged automatically to tell us who the customer is, what plan they'
 - **`goodwill_enterprise`** — there's a sales/CS person assigned to the account, so we treat them as enterprise.
 - **`unknown_slack_default_enterprise`** — applied when we know a ticket came from a Slack channel but we can't identify the organization associated with the individual's account. This usually happens when the email isn't present in someone's Slack account, or the email in their Slack account doesn't match the email they use for PostHog. We default these tickets to `plan_enterprise`.
 - **`unknown_msteams_default_enterprise`** — the same as above, but for MS Teams. These are also defaulted to `plan_enterprise`.
+- **`unknown_login_default`** — applied to widget tickets from someone we can't identify (no matching organization or plan) who submitted from a `/login` or `/signup` page, usually a logged-out user. We don't default these to a plan. They get a default SLA so they aren't left without one before falling back to a `#alerts-support` alert.
+- **`unknown_billing_default`** — applied to email tickets sent to `billing@posthog.com` from someone we can't identify (no matching organization or plan). We don't default these to a plan. They get a default SLA matching our pay-as-you-go (`plan_paid`) customers, again before falling back to a `#alerts-support` alert.
 - **`ae_*`** and **`csm_*`** — applied if the account can be identified in customer analytics and has an AE and/or CSM assigned to it.
 
 ### Categorization tags


### PR DESCRIPTION
## Changes

Documents two support tags in the "Customer and account tags" list, alongside the existing Slack/Teams unknown-default tags:

- **`unknown_login_default`** — unidentified widget tickets from a `/login` or `/signup` page (usually logged-out users).
- **`unknown_billing_default`** — unidentified email tickets sent to `billing@posthog.com`.

Both are applied by the FRT/NRT SLA workflows as a fallback when a ticket can't be matched to an organization or plan, so these tickets get a default SLA rather than slipping through with none. Unlike the Slack/Teams defaults, they're not assigned a plan.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
