### PR TITLE
Update sales contract order form template link to correct PandaDoc template

### DIFF
--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -58,7 +58,7 @@ You will likely need to use <PrivateLink url="https://quote.posthog.com">QuoteHo
 
 We use [PandaDoc](https://app.pandadoc.com/a/#/) to handle document generation, routing and signature. Ask <TeamMember name="Mine Katsu" showOnlyFirstName photo /> or <TeamMember name="Simon Fisher" showOnlyFirstName photo /> for access if you don't have it.
 
-1. The <PrivateLink url="https://app.pandadoc.com/a/#/templates/87jsEEeg8rvYYri9Y8gK5B">order form template</PrivateLink> to use is titled `[Client.Company] PostHog Cloud Order Form - <MMM YYYY>`
+1. The <PrivateLink url="https://app.pandadoc.com/a/#/templates/EKqx7pa5VroDQhkNcHyYzd">order form template</PrivateLink> to use is titled `[Client.Company] PostHog Cloud Order Form - <MMM YYYY>`
 2. When looking at the template, click the link to **Use this template** in the top bar.
 3. In the Add recipients box which pops up:
     1. Replace `<MM YYYY>` with the month and year the contract starts (e.g. March 2023)


### PR DESCRIPTION
Updates the order form template link on the [sales contracts handbook page](https://posthog.com/handbook/growth/sales/contracts) to point at the correct, maintained PandaDoc template.

**Why:** The page linked to an outdated template that's still being used in the sales process. The other template is the current source of truth (it's the one with automations built downstream and the correct "30 days from credit allocation date" payment terms), so the handbook should point people there to avoid the inconsistency.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090RCG671C/p1785514716505799?thread_ts=1785514716.505799&cid=C090RCG671C)*