### PR TITLE
Team path rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -132,6 +132,10 @@
             "destination": "/community/profiles/[id]/index.html"
         },
         {
+            "source": "/teams/:path*",
+            "destination": "/teams/[slug]/index.html"
+        },
+        {
             "source": "/next-steps/(.*)",
             "destination": "/next-steps/index.html"
         },


### PR DESCRIPTION
## Changes

- Rewrites `/teams/:path*` to the client-only `/teams/[slug]` shell so production stops serving `404.html` before hydration