### PR TITLE
ci: render SDK reference pages in minimal preview builds

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -81,7 +81,8 @@ jobs:
               env:
                   # Previews build minimal by default (fast; skips API-sourced pages such as SDK
                   # references, so those 404 in the preview). Add the `full-preview` label to a PR
-                  # to build the full site and render those pages. Re-labeling re-triggers this job.
+                  # to build the full site and render those pages. Adding (or re-adding) the label
+                  # re-triggers this job; removing it does not (there's no `unlabeled` trigger).
                   GATSBY_MINIMAL: ${{ contains(github.event.pull_request.labels.*.name, 'full-preview') && 'false' || 'true' }}
                   # Emit the static/dynamic module graph so the eager-graph check below can
                   # measure the app shell. Reuses this single PR build — no second build.

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -79,7 +79,10 @@ jobs:
             - name: Build site
               run: pnpm build
               env:
-                  GATSBY_MINIMAL: 'true'
+                  # Previews build minimal by default (fast; skips API-sourced pages such as SDK
+                  # references, so those 404 in the preview). Add the `full-preview` label to a PR
+                  # to build the full site and render those pages. Re-labeling re-triggers this job.
+                  GATSBY_MINIMAL: ${{ contains(github.event.pull_request.labels.*.name, 'full-preview') && 'false' || 'true' }}
                   # Emit the static/dynamic module graph so the eager-graph check below can
                   # measure the app shell. Reuses this single PR build — no second build.
                   EMIT_WEBPACK_STATS: 'true'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -79,11 +79,7 @@ jobs:
             - name: Build site
               run: pnpm build
               env:
-                  # Previews build minimal by default (fast; skips API-sourced pages such as SDK
-                  # references, so those 404 in the preview). Add the `full-preview` label to a PR
-                  # to build the full site and render those pages. Adding (or re-adding) the label
-                  # re-triggers this job; removing it does not (there's no `unlabeled` trigger).
-                  GATSBY_MINIMAL: ${{ contains(github.event.pull_request.labels.*.name, 'full-preview') && 'false' || 'true' }}
+                  GATSBY_MINIMAL: 'true'
                   # Emit the static/dynamic module graph so the eager-graph check below can
                   # measure the app shell. Reuses this single PR build — no second build.
                   EMIT_WEBPACK_STATS: 'true'

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -41,8 +41,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
 
     const DataPipeline = path.resolve(`src/templates/DataPipeline.tsx`)
     const DataWarehouseSource = path.resolve(`src/templates/DataWarehouseSource.tsx`)
-    const SdkReferenceTemplate = path.resolve(`src/templates/sdk/SdkReference.tsx`)
-    const SdkTypeTemplate = path.resolve(`src/templates/sdk/SdkType.tsx`)
 
     const result = (await graphql(`
         {
@@ -1088,76 +1086,85 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
         })
     })
 
+    // Build every SDK reference page (latest + versioned) from the sourced nodes.
+    createSdkReferencePages({
+        createPage,
+        referenceNodes: result.data.allSdkReferences.nodes,
+        typeNodes: result.data.allSdkTypes.nodes,
+    })
+}
+
+// Create SDK reference pages and their type sub-pages from already-sourced `SdkReferences`
+// nodes. Shared by the full build and the minimal (preview) build. `latestOnly` restricts
+// output to the `latest` rows, keeping the minimal preview deploy small (Cloudflare Pages caps
+// deployments at 20k files) while still rendering /docs/references/* for review.
+function createSdkReferencePages({
+    createPage,
+    referenceNodes,
+    typeNodes,
+    latestOnly = false,
+}: {
+    createPage: Parameters<GatsbyNode['createPages']>[0]['actions']['createPage']
+    referenceNodes: any[]
+    typeNodes: any[]
+    latestOnly?: boolean
+}) {
+    const SdkReferenceTemplate = path.resolve(`src/templates/sdk/SdkReference.tsx`)
+    const SdkTypeTemplate = path.resolve(`src/templates/sdk/SdkType.tsx`)
+
     // Grab types available for each SDK and version
-    const sdkTypesByReference = result.data.allSdkTypes.nodes.reduce((acc, node) => {
+    const sdkTypesByReference = typeNodes.reduce((acc, node) => {
         const { referenceId, version, ...types } = node
 
         if (!acc[referenceId]) {
             acc[referenceId] = {}
         }
 
-        acc[referenceId][version] = types.types.map(({ name }) => name)
+        acc[referenceId][version] = types.types.map(({ name }: { name: string }) => name)
 
         return acc
     }, {} as Record<string, Record<string, any>>)
 
-    result.data.allSdkReferences.nodes.forEach((node) => {
-        if (node.version.includes('latest')) {
-            createPage({
-                path: `/docs/references/${node.referenceId}`,
-                component: SdkReferenceTemplate,
-                context: {
-                    name: node.info.title,
-                    description: node.info.description,
-                    fullReference: node,
-                    regex: `/docs/references/${node.referenceId}`,
-                    types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
-                },
-            })
-        } else {
-            createPage({
-                path: `/docs/references/${node.id}`,
-                component: SdkReferenceTemplate,
-                context: {
-                    name: node.info.title,
-                    description: node.info.description,
-                    fullReference: node,
-                    regex: `/docs/references/${node.id}`,
-                    // Null checks, only affects type crosslinking, won't break build
-                    types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
-                },
-            })
+    referenceNodes.forEach((node) => {
+        const isLatest = node.version.includes('latest')
+        if (latestOnly && !isLatest) {
+            return
         }
+        // latest → referenceId (no version in URL); versioned → id (embeds the version)
+        const pagePath = isLatest ? `/docs/references/${node.referenceId}` : `/docs/references/${node.id}`
+        createPage({
+            path: pagePath,
+            component: SdkReferenceTemplate,
+            context: {
+                name: node.info.title,
+                description: node.info.description,
+                fullReference: node,
+                regex: pagePath,
+                // Null checks, only affects type crosslinking, won't break build
+                types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
+            },
+        })
     })
 
-    result.data.allSdkTypes.nodes.forEach((node) => {
-        node.types?.forEach((type) => {
+    typeNodes.forEach((node) => {
+        const isLatest = node.version.includes('latest')
+        if (latestOnly && !isLatest) {
+            return
+        }
+        node.types?.forEach((type: any) => {
             if (type.id && (type.properties || type.example)) {
-                if (node.version.includes('latest')) {
-                    createPage({
-                        path: `/docs/references/${node.referenceId}/types/${type.id}`,
-                        component: SdkTypeTemplate,
-                        context: {
-                            typeData: type,
-                            version: node.version,
-                            id: node.id,
-                            types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
-                            slugPrefix: node.referenceId,
-                        },
-                    })
-                } else {
-                    createPage({
-                        path: `/docs/references/${node.id}/types/${type.id}`,
-                        component: SdkTypeTemplate,
-                        context: {
-                            typeData: type,
-                            version: node.version,
-                            id: node.id,
-                            types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
-                            slugPrefix: node.id,
-                        },
-                    })
-                }
+                const slugPrefix = isLatest ? node.referenceId : node.id
+                createPage({
+                    path: `/docs/references/${slugPrefix}/types/${type.id}`,
+                    component: SdkTypeTemplate,
+                    context: {
+                        typeData: type,
+                        version: node.version,
+                        id: node.id,
+                        types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
+                        slugPrefix,
+                    },
+                })
             }
         })
     })
@@ -1252,6 +1259,81 @@ async function createMinimalPages({
                     }
                 }
             }
+            allSdkReferences {
+                nodes {
+                    info {
+                        description
+                        id
+                        specUrl
+                        slugPrefix
+                        title
+                        version
+                    }
+                    referenceId
+                    hogRef
+                    id
+                    categories
+                    classes {
+                        description
+                        functions {
+                            category
+                            description
+                            details
+                            examples {
+                                code
+                                name
+                                id
+                            }
+                            id
+                            params {
+                                description
+                                isOptional
+                                name
+                                type
+                            }
+                            path
+                            releaseTag
+                            showDocs
+                            returnType {
+                                id
+                                name
+                            }
+                            title
+                        }
+                        id
+                        title
+                    }
+                    version
+                }
+            }
+            allSdkTypes: allSdkReferences {
+                nodes {
+                    id
+                    version
+                    referenceId
+                    info {
+                        description
+                        id
+                        slugPrefix
+                        specUrl
+                        title
+                        version
+                    }
+                    hogRef
+                    categories
+                    types {
+                        example
+                        id
+                        name
+                        path
+                        properties {
+                            description
+                            name
+                            type
+                        }
+                    }
+                }
+            }
         }
     `)
 
@@ -1336,6 +1418,8 @@ async function createMinimalPages({
         productEngineerHandbook: { nodes: any[] }
         posts: { nodes: any[] }
         localizedNewsletter: { nodes: any[] }
+        allSdkReferences: { nodes: any[] }
+        allSdkTypes: { nodes: any[] }
     }
 
     createHandbookPreviewPosts(data.docs.nodes, 'docs', { name: 'Docs', url: '/docs' })
@@ -1362,5 +1446,14 @@ async function createMinimalPages({
                 localizedRoot: 'newsletter',
             },
         })
+    })
+
+    // Render SDK reference pages (latest only) so /docs/references/* is reviewable in previews
+    // without the full site's file count exceeding Cloudflare Pages' 20k-file deploy limit.
+    createSdkReferencePages({
+        createPage,
+        referenceNodes: data.allSdkReferences.nodes,
+        typeNodes: data.allSdkTypes.nodes,
+        latestOnly: true,
     })
 }

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -10,6 +10,87 @@ const markdownLinkExtractor = require('markdown-link-extractor')
 
 const isMinimalBuild = process.env.GATSBY_MINIMAL === 'true'
 
+// GraphQL selection shared by the full and minimal builds so the fields
+// createSdkReferencePages() reads stay in sync across both query sites. Interpolated into the
+// runtime graphql() template literals below (not a statically extracted page query).
+const SDK_REFERENCE_QUERY_FIELDS = `
+    allSdkReferences {
+        nodes {
+            info {
+                description
+                id
+                specUrl
+                slugPrefix
+                title
+                version
+            }
+            referenceId
+            hogRef
+            id
+            categories
+            classes {
+                description
+                functions {
+                    category
+                    description
+                    details
+                    examples {
+                        code
+                        name
+                        id
+                    }
+                    id
+                    params {
+                        description
+                        isOptional
+                        name
+                        type
+                    }
+                    path
+                    releaseTag
+                    showDocs
+                    returnType {
+                        id
+                        name
+                    }
+                    title
+                }
+                id
+                title
+            }
+            version
+        }
+    }
+    allSdkTypes: allSdkReferences {
+        nodes {
+            id
+            version
+            referenceId
+            info {
+                description
+                id
+                slugPrefix
+                specUrl
+                title
+                version
+            }
+            hogRef
+            categories
+            types {
+                example
+                id
+                name
+                path
+                properties {
+                    description
+                    name
+                    type
+                }
+            }
+        }
+    }
+`
+
 export const createPages: GatsbyNode['createPages'] = async ({ actions: { createPage }, graphql }) => {
     if (isMinimalBuild) {
         return createMinimalPages({ createPage, graphql })
@@ -429,81 +510,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                     }
                 }
             }
-            allSdkReferences {
-                nodes {
-                    info {
-                        description
-                        id
-                        specUrl
-                        slugPrefix
-                        title
-                        version
-                    }
-                    referenceId
-                    hogRef
-                    id
-                    categories
-                    classes {
-                        description
-                        functions {
-                            category
-                            description
-                            details
-                            examples {
-                                code
-                                name
-                                id
-                            }
-                            id
-                            params {
-                                description
-                                isOptional
-                                name
-                                type
-                            }
-                            path
-                            releaseTag
-                            showDocs
-                            returnType {
-                                id
-                                name
-                            }
-                            title
-                        }
-                        id
-                        title
-                    }
-                    version
-                }
-            }
-            allSdkTypes: allSdkReferences {
-                nodes {
-                    id
-                    version
-                    referenceId
-                    info {
-                        description
-                        id
-                        slugPrefix
-                        specUrl
-                        title
-                        version
-                    }
-                    hogRef
-                    categories
-                    types {
-                        example
-                        id
-                        name
-                        path
-                        properties {
-                            description
-                            name
-                            type
-                        }
-                    }
-                }
-            }
+            ${SDK_REFERENCE_QUERY_FIELDS}
         }
     `)) as GatsbyContentResponse
 
@@ -1114,24 +1121,31 @@ function createSdkReferencePages({
 
     // Grab types available for each SDK and version
     const sdkTypesByReference = typeNodes.reduce((acc, node) => {
-        const { referenceId, version, ...types } = node
+        const { referenceId, version, types } = node
 
         if (!acc[referenceId]) {
             acc[referenceId] = {}
         }
 
-        acc[referenceId][version] = types.types.map(({ name }: { name: string }) => name)
+        acc[referenceId][version] = types.map(({ name }: { name: string }) => name)
 
         return acc
     }, {} as Record<string, Record<string, any>>)
 
+    // In latest-only (minimal preview) builds, the reference template's version picker still reads
+    // every sourced version from the node store, but only `latest` pages exist here — so choosing
+    // another version 404s in the preview. Accepted preview-only limitation; the full build emits
+    // every version.
     referenceNodes.forEach((node) => {
         const isLatest = node.version.includes('latest')
         if (latestOnly && !isLatest) {
             return
         }
-        // latest → referenceId (no version in URL); versioned → id (embeds the version)
-        const pagePath = isLatest ? `/docs/references/${node.referenceId}` : `/docs/references/${node.id}`
+        // latest → referenceId (no version in URL); versioned → id (embeds the version). The
+        // template links type cross-references under this same prefix (passed via page context),
+        // so both sides derive routing from one place.
+        const slugPrefix = isLatest ? node.referenceId : node.id
+        const pagePath = `/docs/references/${slugPrefix}`
         createPage({
             path: pagePath,
             component: SdkReferenceTemplate,
@@ -1140,6 +1154,7 @@ function createSdkReferencePages({
                 description: node.info.description,
                 fullReference: node,
                 regex: pagePath,
+                slugPrefix,
                 // Null checks, only affects type crosslinking, won't break build
                 types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
             },
@@ -1259,81 +1274,7 @@ async function createMinimalPages({
                     }
                 }
             }
-            allSdkReferences {
-                nodes {
-                    info {
-                        description
-                        id
-                        specUrl
-                        slugPrefix
-                        title
-                        version
-                    }
-                    referenceId
-                    hogRef
-                    id
-                    categories
-                    classes {
-                        description
-                        functions {
-                            category
-                            description
-                            details
-                            examples {
-                                code
-                                name
-                                id
-                            }
-                            id
-                            params {
-                                description
-                                isOptional
-                                name
-                                type
-                            }
-                            path
-                            releaseTag
-                            showDocs
-                            returnType {
-                                id
-                                name
-                            }
-                            title
-                        }
-                        id
-                        title
-                    }
-                    version
-                }
-            }
-            allSdkTypes: allSdkReferences {
-                nodes {
-                    id
-                    version
-                    referenceId
-                    info {
-                        description
-                        id
-                        slugPrefix
-                        specUrl
-                        title
-                        version
-                    }
-                    hogRef
-                    categories
-                    types {
-                        example
-                        id
-                        name
-                        path
-                        properties {
-                            description
-                            name
-                            type
-                        }
-                    }
-                }
-            }
+            ${SDK_REFERENCE_QUERY_FIELDS}
         }
     `)
 

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -11,6 +11,87 @@ const markdownLinkExtractor = require('markdown-link-extractor')
 
 const isMinimalBuild = process.env.GATSBY_MINIMAL === 'true'
 
+// GraphQL selection shared by the full and minimal builds so the fields
+// createSdkReferencePages() reads stay in sync across both query sites. Interpolated into the
+// runtime graphql() template literals below (not a statically extracted page query).
+const SDK_REFERENCE_QUERY_FIELDS = `
+    allSdkReferences {
+        nodes {
+            info {
+                description
+                id
+                specUrl
+                slugPrefix
+                title
+                version
+            }
+            referenceId
+            hogRef
+            id
+            categories
+            classes {
+                description
+                functions {
+                    category
+                    description
+                    details
+                    examples {
+                        code
+                        name
+                        id
+                    }
+                    id
+                    params {
+                        description
+                        isOptional
+                        name
+                        type
+                    }
+                    path
+                    releaseTag
+                    showDocs
+                    returnType {
+                        id
+                        name
+                    }
+                    title
+                }
+                id
+                title
+            }
+            version
+        }
+    }
+    allSdkTypes: allSdkReferences {
+        nodes {
+            id
+            version
+            referenceId
+            info {
+                description
+                id
+                slugPrefix
+                specUrl
+                title
+                version
+            }
+            hogRef
+            categories
+            types {
+                example
+                id
+                name
+                path
+                properties {
+                    description
+                    name
+                    type
+                }
+            }
+        }
+    }
+`
+
 export const createPages: GatsbyNode['createPages'] = async ({ actions: { createPage }, graphql }) => {
     if (isMinimalBuild) {
         return createMinimalPages({ createPage, graphql })
@@ -42,8 +123,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
 
     const DataPipeline = path.resolve(`src/templates/DataPipeline.tsx`)
     const DataWarehouseSource = path.resolve(`src/templates/DataWarehouseSource.tsx`)
-    const SdkReferenceTemplate = path.resolve(`src/templates/sdk/SdkReference.tsx`)
-    const SdkTypeTemplate = path.resolve(`src/templates/sdk/SdkType.tsx`)
 
     const result = (await graphql(`
         {
@@ -432,81 +511,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                     }
                 }
             }
-            allSdkReferences {
-                nodes {
-                    info {
-                        description
-                        id
-                        specUrl
-                        slugPrefix
-                        title
-                        version
-                    }
-                    referenceId
-                    hogRef
-                    id
-                    categories
-                    classes {
-                        description
-                        functions {
-                            category
-                            description
-                            details
-                            examples {
-                                code
-                                name
-                                id
-                            }
-                            id
-                            params {
-                                description
-                                isOptional
-                                name
-                                type
-                            }
-                            path
-                            releaseTag
-                            showDocs
-                            returnType {
-                                id
-                                name
-                            }
-                            title
-                        }
-                        id
-                        title
-                    }
-                    version
-                }
-            }
-            allSdkTypes: allSdkReferences {
-                nodes {
-                    id
-                    version
-                    referenceId
-                    info {
-                        description
-                        id
-                        slugPrefix
-                        specUrl
-                        title
-                        version
-                    }
-                    hogRef
-                    categories
-                    types {
-                        example
-                        id
-                        name
-                        path
-                        properties {
-                            description
-                            name
-                            type
-                        }
-                    }
-                }
-            }
+            ${SDK_REFERENCE_QUERY_FIELDS}
         }
     `)) as GatsbyContentResponse
 
@@ -1099,35 +1104,66 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
         })
     })
 
+    // Build every SDK reference page (latest + versioned) from the sourced nodes.
+    createSdkReferencePages({
+        createPage,
+        referenceNodes: result.data.allSdkReferences.nodes,
+        typeNodes: result.data.allSdkTypes.nodes,
+    })
+}
+
+// Create SDK reference pages and their type sub-pages from already-sourced `SdkReferences`
+// nodes. Shared by the full build and the minimal (preview) build. `latestOnly` restricts
+// output to the `latest` rows, keeping the minimal preview deploy small (Cloudflare Pages caps
+// deployments at 20k files) while still rendering /docs/references/* for review.
+function createSdkReferencePages({
+    createPage,
+    referenceNodes,
+    typeNodes,
+    latestOnly = false,
+}: {
+    createPage: Parameters<GatsbyNode['createPages']>[0]['actions']['createPage']
+    referenceNodes: any[]
+    typeNodes: any[]
+    latestOnly?: boolean
+}) {
+    const SdkReferenceTemplate = path.resolve(`src/templates/sdk/SdkReference.tsx`)
+    const SdkTypeTemplate = path.resolve(`src/templates/sdk/SdkType.tsx`)
+
     // The `latest` row is served unversioned; every other row keeps its `<sdk>-<version>` id.
     const slugPrefixFor = (node: { version: string; referenceId: string; id: string }) =>
         isLatestVersion(node.version) ? node.referenceId : node.id
 
     // Each row crosslinks against its own types, so a versioned page describes that version.
-    const typesByRow = result.data.allSdkTypes.nodes.reduce(
+    const typesByRow = typeNodes.reduce(
         (acc, node) => {
             acc[node.id] = (node.types ?? [])
                 .filter(typeHasPage)
-                .map(({ name }) => name)
+                .map(({ name }: { name: string }) => name)
                 // A type with no usable name can't be linked to, so keep it out of the allowlist.
-                .filter((name) => name && name !== 'null')
+                .filter((name: string) => name && name !== 'null')
             return acc
         },
         {} as Record<string, string[]>
     )
 
-    result.data.allSdkReferences.nodes.forEach((node) => {
+    // Latest-only builds leave the version picker pointing at pages that don't exist — see the
+    // note above `sdkVersions` in src/templates/sdk/SdkReference.tsx.
+    referenceNodes.forEach((node) => {
+        if (latestOnly && !isLatestVersion(node.version)) {
+            return
+        }
         const slugPrefix = slugPrefixFor(node)
-        const path = `/docs/references/${slugPrefix}`
+        const pagePath = `/docs/references/${slugPrefix}`
 
         createPage({
-            path,
+            path: pagePath,
             component: SdkReferenceTemplate,
             context: {
                 name: node.info.title,
                 description: node.info.description,
                 fullReference: node,
-                regex: path,
+                regex: pagePath,
                 // Must match the type page paths created below.
                 slugPrefix,
                 // Null checks, only affects type crosslinking, won't break build
@@ -1136,10 +1172,13 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
         })
     })
 
-    result.data.allSdkTypes.nodes.forEach((node) => {
+    typeNodes.forEach((node) => {
+        if (latestOnly && !isLatestVersion(node.version)) {
+            return
+        }
         const slugPrefix = slugPrefixFor(node)
 
-        node.types?.forEach((type) => {
+        node.types?.forEach((type: any) => {
             if (typeHasPage(type)) {
                 createPage({
                     path: `/docs/references/${slugPrefix}/types/${type.id}`,
@@ -1247,6 +1286,7 @@ async function createMinimalPages({
                     }
                 }
             }
+            ${SDK_REFERENCE_QUERY_FIELDS}
             pocketGuides: allMdx(filter: { fields: { slug: { regex: "/^/pocket-guides//" } } }) {
                 nodes {
                     id
@@ -1339,6 +1379,8 @@ async function createMinimalPages({
         productEngineerHandbook: { nodes: any[] }
         posts: { nodes: any[] }
         localizedNewsletter: { nodes: any[] }
+        allSdkReferences: { nodes: any[] }
+        allSdkTypes: { nodes: any[] }
         pocketGuides: { nodes: any[] }
     }
 
@@ -1380,5 +1422,14 @@ async function createMinimalPages({
                 localizedRoot: 'newsletter',
             },
         })
+    })
+
+    // Render SDK reference pages (latest only) so /docs/references/* is reviewable in previews
+    // without the full site's file count exceeding Cloudflare Pages' 20k-file deploy limit.
+    createSdkReferencePages({
+        createPage,
+        referenceNodes: data.allSdkReferences.nodes,
+        typeNodes: data.allSdkTypes.nodes,
+        latestOnly: true,
     })
 }

--- a/src/templates/sdk/SdkReference.tsx
+++ b/src/templates/sdk/SdkReference.tsx
@@ -73,6 +73,9 @@ export interface SdkReferenceData {
 export interface PageContext {
     fullReference: SdkReferenceData
     types: string[]
+    // Slug segment type cross-links resolve under, owned by gatsby/createPages.ts (latest →
+    // referenceId, versioned → id). Passed in so the template never re-derives page routing.
+    slugPrefix: string
 }
 
 export interface VersionsData {
@@ -132,7 +135,7 @@ function groupFunctionsByCategory(functions: SdkFunction[]): { label: string | n
 }
 
 export default function SdkReference({ pageContext, data }: { pageContext: PageContext; data: VersionsData }) {
-    const { fullReference } = pageContext
+    const { fullReference, slugPrefix } = pageContext
     const location = useLocation()
 
     // Get the language for this SDK reference
@@ -360,7 +363,7 @@ export default function SdkReference({ pageContext, data }: { pageContext: PageC
                                                         </Accordion>
                                                     )}
                                                     <Parameters
-                                                        slugPrefix={`${currentReferenceId}-${fullReference.info.version}`}
+                                                        slugPrefix={slugPrefix}
                                                         params={func.params}
                                                         validTypes={validTypes}
                                                     />
@@ -369,7 +372,7 @@ export default function SdkReference({ pageContext, data }: { pageContext: PageC
                                                 <div className="lg:sticky top-[108px] space-y-6">
                                                     <FunctionExamples examples={func.examples} language={sdkLanguage} />
                                                     <FunctionReturn
-                                                        slugPrefix={`${currentReferenceId}-${fullReference.info.version}`}
+                                                        slugPrefix={slugPrefix}
                                                         returnType={func.returnType}
                                                         validTypes={validTypes}
                                                     />

--- a/src/templates/sdk/SdkReference.tsx
+++ b/src/templates/sdk/SdkReference.tsx
@@ -61,6 +61,8 @@ export interface SdkReferenceData {
     info: {
         description: string
         id: string
+        // Always the bare referenceId (`posthog-python`), even on versioned pages. Not the page's
+        // own slug — use PageContext.slugPrefix for anything that builds a URL.
         slugPrefix: string
         specUrl: string
         title: string
@@ -85,7 +87,7 @@ export interface PageContext {
     fullReference: SdkReferenceData
     types: string[]
     // Slug segment type cross-links resolve under, owned by gatsby/createPages.ts (latest →
-    // referenceId, versioned → id). Not `info.slugPrefix`, which is a spec field, unused here.
+    // referenceId, versioned → id). Passed in so the template never re-derives page routing.
     slugPrefix: string
 }
 
@@ -157,6 +159,9 @@ export default function SdkReference({ pageContext, data }: { pageContext: PageC
     const canonicalPath = `/docs/references/${fullReference.referenceId}`
     const hasConcreteVersionLabel = hasConcreteVersion(fullReference.info.version)
 
+    // Every sourced version, not just the ones that got pages. Minimal preview builds create the
+    // `latest` pages only (createSdkReferencePages in gatsby/createPages.ts), so picking any other
+    // version 404s in a preview. The full build emits every version.
     const sdkVersions = data.allSdkReferences.nodes
 
     const currentReferenceId = fullReference.referenceId


### PR DESCRIPTION
## Changes

Preview builds run with `GATSBY_MINIMAL=true`, which skips API-sourced pages — including the SDK reference pages under `/docs/references`. Those pages therefore **404 in every Cloudflare preview**, even though they build fine in production's full build.

A full-site preview build isn't a viable fix: it produces more than 20,000 files and Cloudflare Pages rejects the deploy on the current plan. Instead, this teaches the **minimal** build to also emit the SDK reference pages:

- Extract reference/type page creation into a shared `createSdkReferencePages()` helper in `gatsby/createPages.ts`.
- Full build calls it as before (latest + all versions), so the set of pages it emits is unchanged.
- Reference pages pass `slugPrefix` through page context instead of `SdkReference.tsx` rebuilding `${referenceId}-${info.version}`. #19155 shipped that fix to production, so after the rebase onto current master only explanatory comments remain in `SdkReference.tsx`. The net effect of this PR is the shared `createSdkReferencePages()` extraction plus rendering the `latest` reference pages in minimal previews.
- Minimal (preview) build calls it with `latestOnly: true`, so only the `latest` reference pages and their type sub-pages are generated. That's a small, bounded set that keeps the preview deploy well under the file cap while still rendering `/docs/references/*` for review.

The SDK reference data is already sourced in minimal builds (no `GATSBY_MINIMAL` guard in `sourceNodes.ts`), so no data-sourcing change is needed.

Known preview-only limitation: the version picker on a reference page reads every sourced version from the node store, not just the ones that got pages, so picking a non-latest version 404s in a preview. Noted in a comment above `sdkVersions` in `SdkReference.tsx`.

**Why:** Reviewers can't currently verify changes to SDK reference pages via the preview URL because those pages don't exist in minimal previews.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

