### PR TITLE
Update contract buyouts

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -219,16 +219,16 @@ If your customer must pay via credit card, you absolutely _need_ to let Mine (Si
 
 > **Are you a potential customer who wants to speak to us about a contract buyout?** Get in touch with the Sales team via your shared Slack channel, or [reach out directly](/talk-to-a-human).
 
-Sometimes customers will be locked into a contract with a competitor, but want to switch to PostHog when their contract is up. In this case, we are willing to let them use PostHog for free for up to 6 months. This is beneficial to PostHog as well, as we can get them set up and using PostHog sooner, capitalizing on the momentum of their interest today, and giving them more time to get comfortable with the platform.
+Sometimes customers will be locked into a contract with a competitor, but want to switch to PostHog when their contract is up. In this case, we are willing to give them free PostHog credits for up to 6 months of their total PostHog contract value. This is beneficial to PostHog as well, as we can get them set up and using PostHog sooner, capitalizing on the momentum of their interest today, and giving them more time or resources to get comfortable with the platform.
 
 ### The guiding principle: The buyout amount needs to make financial sense
-When considering a contract buyout, the goal is to pay a little up front to make more money over the long term. It doesn't make sense to buy out a contract for $60k if the customer is only planning on spending $20k annually with PostHog.
+When considering a contract buyout, the goal is for PostHog to pay a little up front to make more money over a long-term customer relationship. It doesn't make sense to buy out a contract for $60k if the customer is only planning on spending $20k annually with PostHog.
 
 Some rules:
 
 -   They need to share a copy of their current contract/pricing/bank statement as proof.
 -   They sign up to an annual contract worth $20k+/year, paid up front.
--   Their usage in the overlap period needs to be proportionate to the contract they've signed, ie. if they sign a $50k contract and have 6 months to run, they get $25k of PostHog credit for free.
+-   Their usage in the overlap period needs to be proportionate to the contract they've signed with PostHog, ie. if they sign a $50k PostHog contract and have 6 months to run, they get $25k of PostHog credit for free.
 -   The competitor they're using has to be 'real', ie. not some random side project. As a general rule, anyone we have written a [comparison article](/blog/tags/comparisons) about counts.
 -   Any buyout is subject to team lead approval before it goes on an order form.
 -   We have final discretion on deciding who gets the deal.


### PR DESCRIPTION
Clarifying the Contract Buyout section a bit. Specifically:

- We give them free credits for up to 6 months of their PostHog contract value (not just 6 months free)
- We do this for the long-term customer relationship

## Relationship to #19204

#19204 (now merged) documents the agreed structure for buyouts — contract term = standard term + buyout period, how credits and the discount are treated, and the Special Terms wording. This branch has been rebased on top of it and no longer conflicts.

The one change dropped from this PR is the note that customers do not receive contracted credits until their invoice comes into effect, so they should pick a start date accordingly. Under the structure in #19204 the term starts as normal at signature and absorbs the buyout period, so there is no floating start date left to advise on. Everything else here still stands and is not covered by #19204.