### PR TITLE
Frame Replay Vision free tier as a limited-time 5x boost on the pricing page

### DIFF
--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -35,8 +35,9 @@ export const replayVision = {
                     option.
                 </li>
                 <li>
-                    <strong className="text-primary">1 credit is $0.01</strong>, so 100 credits cost $1. The first 2,500
-                    credits each month are free, which covers 500 sessions on the default model.
+                    <strong className="text-primary">1 credit is $0.01</strong>, so 100 credits cost $1. The first{' '}
+                    <s>500</s> 2,500 credits each month are free (5x the free tier for a limited time), which covers 500
+                    sessions on the default model.
                 </li>
             </ul>
             <p>


### PR DESCRIPTION
## Changes

Implements Cory's proposal from [this Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1785452570154709): frame the Replay Vision Free Plan free tier as

> ~~500 credits~~ 2,500 credits - 5x the free tier for a limited time!

The billing free allocation at launch is 2,500 credits ([billing#2018](https://github.com/PostHog/billing/pull/2018)), but presenting it as a limited-time 5x boost of the standard 500 preserves the ability to painlessly lower the tier later. Per the thread, the wording stays open ended ("limited time") rather than naming an end date, for the same reason.

This PR covers the second of the two spots Cory listed (the PostHog pricing page): the "How credits work" explainer in `src/hooks/productData/replay_vision.tsx`, which renders with the `/pricing` calculator once billing serves the product, now reads "The first ~~500~~ 2,500 credits each month are free (5x the free tier for a limited time)".

The product page pricing tab (the first spot) lives on the #18810 branch and is handled in #19170 targeting that branch.

**Safe to merge now:** Replay Vision stays hidden on `/pricing` until the billing API serves the product, so nothing renders differently until launch. Verified on the deploy preview: `/pricing` has no Replay Vision mentions and renders the same as production.

## Screenshots

Both are **simulated on the deploy preview**, since Replay Vision won't render on `/pricing` for real until the billing API serves `replay_vision` on launch day.

The updated "How credits work" explainer (this PR's change), rendered with the site's CSS:

![Simulated render of the updated How credits work explainer with the limited-time 5x framing](https://raw.githubusercontent.com/PostHog/pr-assets/4363a6f9cb2bf70ee1508c29e8410718dcaaef43/2026/07/8fca963c-3938-409e-a618-91b86cdc08f5.png)

Where Replay Vision will sit in the `/pricing` rates accordion at launch, with the billing-served 2,500 free credits (not changed by this PR, shown for context):

![Simulated launch state of the /pricing rates accordion: Replay Vision expanded with 2,500 free credits](https://raw.githubusercontent.com/PostHog/pr-assets/ac4833ea5f3aab676883b225dc7bdf25d04892de/2026/07/1512bb29-6d02-424c-9768-1e0efdf0df13.png)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links - n/a
- [x] I've checked the pages added or changed in the Vercel preview build - `/pricing` renders unchanged until billing serves the product, verified on the preview
- [x] If I moved a page, I added a redirect in `vercel.json` - n/a

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*