### PR TITLE
Frame Replay Vision free tier as a limited-time 5x boost on the product page pricing tab

### DIFF
--- a/src/components/ReplayVision/PricingSections.tsx
+++ b/src/components/ReplayVision/PricingSections.tsx
@@ -16,7 +16,8 @@ import type { SectionComponentProps } from 'components/Products/ReaderViewProduc
  */
 
 const CREDIT_PRICE = 0.01 // USD per credit
-const FREE_CREDITS = 2500 // per org, per month
+const FREE_CREDITS = 2500 // per org, per month – 5x the standard tier for a limited time at launch
+const STANDARD_FREE_CREDITS = 500 // the regular free tier, kept visible (struck through) next to the boosted one
 
 // Observation cost by model, in credits. Names are abstracted from the internal
 // model list for the public page.
@@ -28,8 +29,13 @@ const MODELS: { key: string; label: string; creditsPerObservation: number }[] = 
 
 const pricingDetails: { headline: React.ReactNode; body: React.ReactNode }[] = [
     {
-        headline: `${FREE_CREDITS.toLocaleString()} credits free every month.`,
-        body: 'Worth ~$25 – roughly 500 observations on the standard model. Only add a card when you scan more.',
+        headline: (
+            <>
+                <s className="opacity-60">{STANDARD_FREE_CREDITS.toLocaleString()}</s> {FREE_CREDITS.toLocaleString()}{' '}
+                credits free every month.
+            </>
+        ),
+        body: '5x the free tier for a limited time! Worth ~$25 – roughly 500 observations on the standard model. Only add a card when you scan more.',
     },
     {
         headline: 'Pay per use, not per seat.',
@@ -68,13 +74,16 @@ export const PricingTLDR = ({ id }: SectionComponentProps) => (
     <section id={id} className="scroll-mt-20 not-prose @container">
         <h2 className="text-3xl font-bold text-primary mt-0 mb-6">TL;DR:</h2>
         <p className="text-3xl leading-snug font-normal text-primary mb-3">
-            <strong className="font-bold">{FREE_CREDITS.toLocaleString()} credits free</strong> every month,{' '}
-            <br className="hidden @xl:block" />
+            <strong className="font-bold">
+                <s className="opacity-60">{STANDARD_FREE_CREDITS.toLocaleString()}</s> {FREE_CREDITS.toLocaleString()}{' '}
+                credits free
+            </strong>{' '}
+            every month, <br className="hidden @xl:block" />
             then <strong className="font-bold tabular-nums">${CREDIT_PRICE.toFixed(2)}/credit</strong>
         </p>
         <p className="text-lg text-primary/50 mb-4">
-            1 credit = $0.01. That's ~500 free observations a month on the standard model – you only pay for what your
-            scanners run.
+            5x the free tier for a limited time! 1 credit = $0.01. That's ~500 free observations a month on the standard
+            model – you only pay for what your scanners run.
         </p>
         <div className="flex flex-wrap items-center gap-3 mt-6">
             <OSButton variant="primary" asLink to="https://app.posthog.com/signup" size="lg">
@@ -94,11 +103,18 @@ const ROW_GRID = 'grid grid-cols-2 @xl:grid-cols-[minmax(0,1.5fr)_minmax(0,2fr)_
 const LABEL_CELL = 'col-span-2 @xl:col-span-1'
 const ROW_PADDING = 'py-3'
 
-type PlanValue = string | boolean
+type PlanValue = React.ReactNode
+
+// Rendered in both plan columns: the standard tier struck through next to the launch boost.
+const boostedFreeCredits = (
+    <>
+        <s className="opacity-60">{STANDARD_FREE_CREDITS.toLocaleString()}</s> {FREE_CREDITS.toLocaleString()}
+    </>
+)
 
 const planRows: { label: string; free: PlanValue; paid: PlanValue }[] = [
-    { label: 'Monthly free credits', free: '2,500', paid: '2,500' },
-    { label: 'Monthly volume', free: 'Up to 2,500 credits', paid: 'Unlimited' },
+    { label: 'Monthly free credits', free: boostedFreeCredits, paid: boostedFreeCredits },
+    { label: 'Monthly volume', free: `Up to ${FREE_CREDITS.toLocaleString()} credits`, paid: 'Unlimited' },
     { label: 'All scanner types', free: true, paid: true },
     { label: 'All AI models', free: true, paid: true },
     { label: 'Custom monthly spending limit', free: true, paid: true },

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -330,8 +330,9 @@ export const replayVision = {
                     option.
                 </li>
                 <li>
-                    <strong className="text-primary">1 credit is $0.01</strong>, so 100 credits cost $1. The first 2,500
-                    credits each month are free, which covers 500 sessions on the default model.
+                    <strong className="text-primary">1 credit is $0.01</strong>, so 100 credits cost $1. The first{' '}
+                    <s>500</s> 2,500 credits each month are free (5x the free tier for a limited time), which covers 500
+                    sessions on the default model.
                 </li>
             </ul>
             <p>


### PR DESCRIPTION
## Changes

Implements Cory's proposal from [this Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1785452570154709): frame the Replay Vision Free Plan free tier as

> ~~500 credits~~ 2,500 credits - 5x the free tier for a limited time!

The billing free allocation at launch is 2,500 credits, but presenting it as a limited-time 5x boost of the standard 500 preserves the ability to painlessly lower the tier later. Per the thread, the wording stays open ended ("limited time") rather than naming an end date, for the same reason.

**This PR targets the #18810 branch** (`replay-vision-product-page`) so the change ships with the new product page. It needs to merge into that branch before #18810 merges to master. It covers the first of the two spots Cory listed (the product page Pricing tab); the PostHog pricing page is handled in #19169 against master.

On `/replay-vision/pricing` (`PricingSections.tsx`):

- **TL;DR**: "~~500~~ 2,500 credits free every month, then $0.01/credit", with the subline now leading with "5x the free tier for a limited time!"
- **Plans table**: the "Monthly free credits" cells show "~~500~~ 2,500" in both columns
- **Pricing sidebar**: the first bullet gets the same strikethrough headline and the "5x the free tier for a limited time!" lead

Also applies the same one-line framing to the "How credits work" explainer in this branch's copy of `src/hooks/productData/replay_vision.tsx`, so merging #18810 won't revert the equivalent change made on master in #19169.

## Screenshots (from the deploy preview)

![Replay Vision pricing tab: TL;DR and Plans with the limited-time 5x free tier framing](https://raw.githubusercontent.com/PostHog/pr-assets/10bccb20f54d6a53f6f18513d045d573c0d1fa85/2026/07/d906d115-3e11-4cbd-9466-f691076cd99d.png)

![Pricing sidebar bullet with the limited-time 5x free tier framing](https://raw.githubusercontent.com/PostHog/pr-assets/b67800afd3b766f33b469461d5e7f3dc44e7eb72/2026/07/bc36b985-f050-4fe0-b2d6-ffd92aa78228.png)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links - n/a
- [x] I've checked the pages added or changed in the Vercel preview build - `/replay-vision/pricing` on the deploy preview, screenshots above
- [x] If I moved a page, I added a redirect in `vercel.json` - n/a

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*