### PR TITLE
docs: document the 200 character distinct_id limit

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -16,6 +16,8 @@ Here are examples of the types of events you can send:
 
 Every event request must contain an `api_key`, `distinct_id`, and `event` field with the name. Both the `properties` and `timestamp` fields are optional.
 
+`distinct_id` is limited to 200 characters. Longer values are shortened to the first 200 characters and the event is still ingested, with an [ingestion warning](/docs/data/ingestion-warnings#ingested-event-after-shortening-its-distinct-id-to-the-200-character-limit).
+
 > **Note:** By default, events captured via the API are [identified events](/docs/data/anonymous-vs-identified-events). See the section on [how to capture anonymous events](#anonymous-event-capture) for more.
 
 <MultiLanguage>

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -89,7 +89,7 @@ This usually means one distinct ID is shared by many users or machines. See [rat
 
 ## Ingested event after shortening its distinct ID to the 200 character limit
 
-PostHog shortens any `distinct_id` longer than 200 characters to its first 200 characters and ingests the event under the shortened ID.
+PostHog shortens any `distinct_id` longer than 200 characters to its first 200 characters and ingests the event under the shortened ID. The same limit applies to [session replay](/docs/session-replay) events, which are ingested under the shortened ID without a warning.
 
 A distinct ID this long usually means something other than a user ID, like a token or a serialized object, was passed as the distinct ID. Fix the `capture` or `identify` call to send a real user ID. Until then, events keep landing under the shortened ID.
 

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -36,6 +36,7 @@ List of ingestion warnings:
 - [Discarded event exceeding 1MB limit](#discarded-event-exceeding-1mb-limit)
 - [Event ingestion has overflowed capacity](#event-ingestion-has-overflowed-capacity)
 - [Skipped person profile processing for a high-volume distinct ID](#skipped-person-profile-processing-for-a-high-volume-distinct-id)
+- [Ingested event after shortening its distinct ID to the 200 character limit](#ingested-event-after-shortening-its-distinct-id-to-the-200-character-limit)
 - [Replay event timestamp is invalid](#replay-event-timestamp-is-invalid)
 - [Replay event timestamp was too far in the future](#replay-event-timestamp-was-too-far-in-the-future)
 - [$set or $set_once is ignored on exception events and should not be sent](#set-or-set_once-is-ignored-on-exception-events-and-should-not-be-sent)
@@ -85,6 +86,12 @@ This warning indicates PostHog is receiving more events for a single `distinct_i
 One distinct ID sent events much faster than expected, so PostHog skipped [person processing](/docs/how-posthog-works/ingestion-pipeline#2-person-processing) for those events. The events are still ingested. They just don't create or update a person profile while the limit is active.
 
 This usually means one distinct ID is shared by many users or machines. See [rate limiting high-volume distinct IDs](/docs/how-posthog-works/ingestion-pipeline#rate-limiting-high-volume-distinct-ids) for how to fix it.
+
+## Ingested event after shortening its distinct ID to the 200 character limit
+
+PostHog shortens any `distinct_id` longer than 200 characters to its first 200 characters and ingests the event under the shortened ID.
+
+A distinct ID this long usually means something other than a user ID, like a token or a serialized object, was passed as the distinct ID. Fix the `capture` or `identify` call to send a real user ID. Until then, events keep landing under the shortened ID.
 
 ## Replay event timestamp is invalid
 


### PR DESCRIPTION
## Changes

The `distinct_id` length limit was not documented anywhere public: events sent with a `distinct_id` over 200 characters have it shortened to the first 200 characters at ingestion, and since [PostHog/posthog#75812](https://github.com/PostHog/posthog/pull/75812) this now surfaces as the `distinct_id_truncated` ingestion warning in the app. This adds the missing docs, matching the warning's in-app description so the UI can link here:

- `docs/api/capture.mdx`: one line noting the 200 character limit and shortening behavior, next to the event payload requirements (mirrors how the `$group_type`/`$group_key` 400 character limits are documented on the same page).
- `docs/data/ingestion-warnings.mdx`: a new section for the warning, with the heading matching the in-app description text (page convention), covering what happened, the usual cause, and the fix.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)