### PR TITLE
Remove broken LinkedIn link from shipping fast newsletter

### DIFF
--- a/contents/newsletter/hidden-danger-of-shipping-fast.md
+++ b/contents/newsletter/hidden-danger-of-shipping-fast.md
@@ -131,7 +131,7 @@ Define a [launch tier framework](https://aakashgupta.medium.com/the-launch-tier-
 2. **Strategic upgrades:** Meaningful product improvements (not redefinitions) that don't require the full machinery of a major campaign. For example, [PostHog Logs launch](/blog/logs-ga).
 3. **Steady improvements:** Standard product development that doesn't require coordination beyond the product team. For example, AI Observability adding [time to first token](/changelog?id=2558).
 
-This is where brand helps. Things like [humor](https://www.youtube.com/playlist?list=PLnOY1RYHjDfxcuWI_L1xwuhoXAsxR59VL), narrative, and deliberate [absurdity](https://www.youtube.com/watch?v=EXisgy6eWJ0) work because they lower the cost of paying attention. [Partnering with influencers](https://www.linkedin.com/feed/update/urn:li:activity:7401713037386379265) that own trust with your ICP is another way to extend mindshare beyond your brand channels.
+This is where brand helps. Things like [humor](https://www.youtube.com/playlist?list=PLnOY1RYHjDfxcuWI_L1xwuhoXAsxR59VL), narrative, and deliberate [absurdity](https://www.youtube.com/watch?v=EXisgy6eWJ0) work because they lower the cost of paying attention. Partnering with influencers that own trust with your ICP is another way to extend mindshare beyond your brand channels.
 
 > **What this looks like:** Notion ships constantly, but markets selectively. Many features land with almost no fanfare, while a small number (AI, databases, templates) get sustained narrative investment over months.
 


### PR DESCRIPTION
## Changes

The LinkedIn post URL on `Partnering with influencers` returned a 404, so I removed the link.

<img width="566" height="377" alt="CleanShot 2026-08-01 at 14 39 36" src="https://github.com/user-attachments/assets/6b08892e-04e9-42e4-bc51-3782363deb7b" />
  
  
I also scrolled through the whole history of [PostHog's LinkedIn posts](https://www.linkedin.com/company/posthog/posts/?feedView=all) but didn't find an alternative by an influencer targeting your ICP. 🥲

If you have an alternative, let me know or directly push it to this PR :)


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] ~I've checked the pages added or changed in the Vercel preview build~ I ran the local dev server and checked the page
- [x] If I moved a page, I added a redirect in `vercel.json`
