### PR TITLE
Link the Support product page from self-driving and site search

### DIFF
--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -165,7 +165,7 @@ export const tools = [
         handle: 'support',
         name: 'Support',
         description: 'Built-in customer support with chat widget and unified inbox.',
-        slug: 'docs/support',
+        slug: 'support',
         category: 'communication',
         aliases: ['PostHog support', 'Customer support'],
     },

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -29,6 +29,7 @@ import {
     IconShieldLock,
     IconSparkles,
     IconStack,
+    IconSupport,
     IconTerminal,
     IconWarning,
 } from '@posthog/icons'
@@ -133,7 +134,7 @@ const TabPanel = ({
 }
 
 // Signal sources shown on the carousel's first slide, à la the homepage "debug and fix" slide.
-const signalSources: { Icon: IconComponent; color: string; name: string; description: string }[] = [
+const signalSources: { Icon: IconComponent; color: string; name: string; description: string; href?: string }[] = [
     {
         Icon: IconWarning,
         color: 'text-yellow',
@@ -147,10 +148,11 @@ const signalSources: { Icon: IconComponent; color: string; name: string; descrip
         description: 'Dead clicks, quick backs, long stalls',
     },
     {
-        Icon: IconCompass,
+        Icon: IconSupport,
         color: 'text-blue',
-        name: 'Scouts',
-        description: 'Scheduled agents with durable memory',
+        name: 'Support',
+        description: 'Tickets and conversations from your users',
+        href: '/support',
     },
     {
         Icon: IconPlug,
@@ -199,11 +201,23 @@ const loopTabs: TabbedCarouselTab[] = [
             >
                 <p className="m-0">A signal is a single observation about your product.</p>
                 <div className="not-prose mt-4 grid grid-cols-1 gap-x-4 gap-y-3 @sm:grid-cols-2">
-                    {signalSources.map(({ Icon, color, name, description }) => (
+                    {signalSources.map(({ Icon, color, name, description, href }) => (
                         <div key={name} className="flex items-start gap-2">
                             <Icon className={`mt-0.5 size-5 shrink-0 ${color}`} />
                             <div>
-                                <p className="m-0 text-base font-bold text-primary">{name}</p>
+                                <p className="m-0 text-base font-bold text-primary">
+                                    {href ? (
+                                        <Link
+                                            to={href}
+                                            state={{ newWindow: true }}
+                                            className="text-primary hover:underline"
+                                        >
+                                            {name}
+                                        </Link>
+                                    ) : (
+                                        name
+                                    )}
+                                </p>
                                 <p className="m-0 text-sm leading-snug text-secondary">{description}</p>
                             </div>
                         </div>

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -134,18 +134,20 @@ const TabPanel = ({
 }
 
 // Signal sources shown on the carousel's first slide, à la the homepage "debug and fix" slide.
-const signalSources: { Icon: IconComponent; color: string; name: string; description: string; href?: string }[] = [
+const signalSources: { Icon: IconComponent; color: string; name: string; description: string; href: string }[] = [
     {
         Icon: IconWarning,
         color: 'text-yellow',
         name: 'Error tracking',
         description: 'Exceptions and stack traces grouped into issues',
+        href: '/error-tracking',
     },
     {
         Icon: IconRewindPlay,
         color: 'text-orange',
         name: 'Session replay',
         description: 'Dead clicks, quick backs, long stalls',
+        href: '/session-replay',
     },
     {
         Icon: IconSupport,
@@ -159,6 +161,7 @@ const signalSources: { Icon: IconComponent; color: string; name: string; descrip
         color: 'text-purple',
         name: 'External tools',
         description: 'Zendesk, Linear, GitHub issues',
+        href: '/docs/self-driving/signals',
     },
 ]
 
@@ -205,18 +208,14 @@ const loopTabs: TabbedCarouselTab[] = [
                         <div key={name} className="flex items-start gap-2">
                             <Icon className={`mt-0.5 size-5 shrink-0 ${color}`} />
                             <div>
-                                <p className="m-0 text-base font-bold text-primary">
-                                    {href ? (
-                                        <Link
-                                            to={href}
-                                            state={{ newWindow: true }}
-                                            className="text-primary hover:underline"
-                                        >
-                                            {name}
-                                        </Link>
-                                    ) : (
-                                        name
-                                    )}
+                                <p className="m-0 text-base font-bold">
+                                    <Link
+                                        to={href}
+                                        state={{ newWindow: true }}
+                                        className="text-primary underline underline-offset-2 hover:text-red dark:hover:text-yellow"
+                                    >
+                                        {name}
+                                    </Link>
                                 </p>
                                 <p className="m-0 text-sm leading-snug text-secondary">{description}</p>
                             </div>


### PR DESCRIPTION
## Changes

The new [/support](https://posthog.com/support) product page wasn't linked from a couple of key surfaces. This adds two links:

- **Site search (`src/data/tools.ts`)** — the Support tool's slug pointed at `docs/support`, so Algolia treated the docs page as the canonical "tools" result. Now points at `support`, consistent with every other product.
- **/self-driving** — replaces the "Scouts" item in the signals carousel with a "Support" signal source (tickets and conversations from your users), linking to `/support`. Support tickets are a genuine signal source, and Scouts is already covered by its own carousel tab and the canonical/custom scouts section.

Note: the global `components/Footer/Footer.tsx` also omits Support, but that component isn't rendered anywhere on the site, so it was left alone. `/support` is already surfaced via the `/products` page, the homepage products board, and the searchable products menu.

## Why

We shipped a new Support product page and want the important pages that discuss support-related concepts to link to it, and site search to send people to the product page rather than the docs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AR8V7V1D4/p1785694546638759)*
