### PR TITLE
Update homepage hero CTA

### DIFF
--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -132,6 +132,7 @@ export const CTAs = () => {
 }
 
 function Hero(): JSX.Element {
+    const [showIntegrationPrompt, setShowIntegrationPrompt] = useState(false)
     return (
         <>
             <div className="text-center @xl:text-left min-w-0">
@@ -204,7 +205,36 @@ function Hero(): JSX.Element {
                     </div>
 
                     <div className="mt-6 flex flex-col items-center min-w-0 w-full">
-                        <PlatformInstall schema={wizardInstallSchema} selfDriving />
+                        <div className="@container">
+                            <div className="flex flex-col @xs:flex-row gap-3 @sm:gap-2">
+                                <CallToAction
+                                    to="https://app.posthog.com/signup"
+                                    size="lg"
+                                    state={{ newWindow: true, initialTab: 'signup' }}
+                                >
+                                    Get started - free
+                                </CallToAction>
+                                <CallToAction
+                                    type="secondary"
+                                    size="lg"
+                                    onClick={() => setShowIntegrationPrompt((current) => !current)}
+                                >
+                                    Install with AI
+                                </CallToAction>
+                            </div>
+                        </div>
+                        <motion.div
+                            className="overflow-hidden"
+                            initial={{ height: 0 }}
+                            animate={{ height: showIntegrationPrompt ? 'auto' : 0 }}
+                        >
+                            <div
+                                data-scheme="secondary"
+                                className="mt-4 p-4 border border-primary rounded-md bg-primary [&_h3]:mt-0 [&_ul]:mb-0 [&_ul]:p-0"
+                            >
+                                <IntegrationPrompt />
+                            </div>
+                        </motion.div>
                         <SecondaryActions />
                     </div>
                 </div>

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -228,11 +228,8 @@ function Hero(): JSX.Element {
                             initial={{ height: 0 }}
                             animate={{ height: showIntegrationPrompt ? 'auto' : 0 }}
                         >
-                            <div
-                                data-scheme="secondary"
-                                className="mt-4 p-4 border border-primary rounded-md bg-primary [&_h3]:mt-0 [&_ul]:mb-0 [&_ul]:p-0"
-                            >
-                                <IntegrationPrompt />
+                            <div className="mt-4">
+                                <PlatformInstall schema={wizardInstallSchema} selfDriving />
                             </div>
                         </motion.div>
                         <SecondaryActions />

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -205,8 +205,8 @@ function Hero(): JSX.Element {
                     </div>
 
                     <div className="mt-6 flex flex-col items-center min-w-0 w-full">
-                        <div className="@container">
-                            <div className="flex flex-col @xs:flex-row gap-3 @sm:gap-2">
+                        <div className="@container w-full">
+                            <div className="flex flex-col items-center @xs:flex-row @xs:justify-center gap-3 @sm:gap-2">
                                 <CallToAction
                                     to="https://app.posthog.com/signup"
                                     size="lg"
@@ -224,11 +224,11 @@ function Hero(): JSX.Element {
                             </div>
                         </div>
                         <motion.div
-                            className="overflow-hidden"
+                            className="overflow-hidden w-full"
                             initial={{ height: 0 }}
                             animate={{ height: showIntegrationPrompt ? 'auto' : 0 }}
                         >
-                            <div className="mt-4">
+                            <div className="mt-4 flex justify-center">
                                 <PlatformInstall schema={wizardInstallSchema} selfDriving />
                             </div>
                         </motion.div>


### PR DESCRIPTION
OBVIOUSLY NEEDS FINESSING

Updating the main CTA to be sign up via the web UI, as we now have wizard cloud runs, so we can send folks there instead of local wizard. 

--------------------- 

## Changes

Changes the homepage hero's main CTA to match the `/product-analytics` page. The inline install wizard is replaced with the same two CTAs used there: **Get started - free** and **Install with AI** (which expands the AI install prompt inline). Copied exactly from the product analytics implementation.

The MCP / watch a demo / talk to a human links underneath are left exactly as they were.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AR8V7V1D4/p1785696081661149)*
