### PR TITLE
Fix CTA secondary action alignment

### DIFF
--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -52,9 +52,9 @@ function LazyHeroCarousel({ className }: { className?: string }) {
 
 const SecondaryActions = ({ justify = 'center' }: { className?: string; justify?: 'center' | 'start' }) => (
     <p
-        className={`!text-sm flex flex-wrap items-center gap-2 ${
+        className={`!text-sm mt-4 mb-0 flex w-full max-w-md flex-wrap items-center gap-2 ${
             justify === 'start' ? 'justify-start' : 'justify-center'
-        } @xl:min-w-96 @xl:max-w-md`}
+        }`}
     >
         <Link
             to="/docs/model-context-protocol"


### PR DESCRIPTION
## Changes

- Match the secondary action row width to the install CTA card
- Add consistent spacing and center the links beneath the card

**Why**

The MCP, demo, and contact links sat too close to the CTA and appeared off-center on the self-driving page.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*