### PR TITLE
Remove handbook references to archived #coming-soon channel

### DIFF
--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -158,12 +158,9 @@ Also keep in mind that, as an open source platform, PostHog has contributors who
 
 **Keeping up with what we ship**
 
-We recommend everyone at PostHog joins these two channels to stay current on what's shipped and what's coming:
+We recommend everyone at PostHog joins [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) to stay current on what's shipped. It's owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updates constantly as PRs merge.
 
-- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) — what's just shipped. Owned by the [Wizard & Docs team](/teams/wizard-and-docs). Updates constantly as PRs merge.
-- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) — what's shipping soon. Owned by the [Marketing team](/teams/marketing). Posts a daily digest.
-
-Both channels are powered by agentic workflows that scan merged PRs and feature flag changes and summarize them into the relevant channel. PR authors can opt in or out manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for more detail.
+The channel is powered by agentic workflows that scan merged PRs and feature flag changes and summarize them into it. PR authors can opt in or out manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for more detail.
 
 **Slack etiquette**
 

--- a/contents/handbook/engineering/customer-comms.md
+++ b/contents/handbook/engineering/customer-comms.md
@@ -15,11 +15,8 @@ Prior art to mirror: the feature-flags quota-limit rollout in [`product-internal
 
 For the underlying email infrastructure (Customer.io tags, categories, unsubscribe behavior), see the [email comms handbook page](/handbook/marketing/email-comms). For incidents specifically, see [engineering incidents](/handbook/engineering/operations/incidents) — Marketing handles those comms too.
 
-## Staying ahead of what's about to ship
+## Staying on top of what ships
 
-If you write or coordinate customer comms, join these two internal Slack channels — they're the lowest-friction way to know what's just shipped and what's about to land:
+If you write or coordinate customer comms, join the [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) internal Slack channel — it's the lowest-friction way to know what's just shipped. It's owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
 
-- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
-- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. Owned by the [Marketing team](/teams/marketing) and posted as a daily digest.
-
-Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in `posthog/posthog` and summarize them into the channel. You can opt a PR in or out via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for the full flow.
+The channel is populated by agentic workflows that scan merged PRs and feature flag changes in `posthog/posthog` and summarize them into it. You can opt a PR in or out via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for the full flow.

--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -94,9 +94,6 @@ Our people are spread across the [teams above](#our-teams), each with its own sm
 
 ## Staying current with what we ship
 
-Being a [power user of PostHog](#our-vision) means knowing what just shipped and what's about to land. Two internal Slack channels make this easy, and we recommend everyone on the Sales, CS & Onboarding teams joins both:
+Being a [power user of PostHog](#our-vision) means knowing what just shipped. The [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) Slack channel makes this easy, and we recommend everyone on the Sales, CS & Onboarding teams joins it. It's owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
 
-- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
-- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. Owned by the [Marketing team](/teams/marketing) and posted as a daily digest.
-
-Both channels are populated by agentic workflows that scan merged PRs and feature flag changes and summarize them into the channel. Authors can also opt in or out using the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog).
+The channel is populated by agentic workflows that scan merged PRs and feature flag changes and summarize them into it. Authors can also opt in or out using the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the `posthog/posthog` PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog).

--- a/contents/handbook/growth/sales/sales-and-cs-tools.md
+++ b/contents/handbook/growth/sales/sales-and-cs-tools.md
@@ -96,4 +96,3 @@ Unless otherwise indicated, you can self-serve access requests to the following 
 - <PrivateLink url='https://posthog.slack.com/archives/C0975UEGHT5'>#today-i-learned</PrivateLink> - where we share our learnings.
 - <PrivateLink url='https://posthog.slack.com/archives/C07TQR0V16U'>#ask-max</PrivateLink> - bot focused on internal processes and questions.
 - <PrivateLink url='https://posthog.slack.com/archives/C0AP5NXF8D7'>#demo-posthog-anything</PrivateLink> - show off something cool or see how others are demoing things.
-- <PrivateLink url='https://posthog.slack.com/archives/C0B5QBS29QU'>#coming-soon</PrivateLink> - see what's coming soon - a schedule of upcoming product launches.

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -19,12 +19,9 @@ If you're not sure who to talk to, check [Who can help me?](/handbook/marketing/
 
 ## Slack channels to know
 
-To keep up with what's shipped and what's about to ship across the company, join:
+To keep up with what's shipped across the company, join [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
 
-- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
-- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. **Owned by the Marketing team** and posted as a daily digest.
-
-Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the relevant channel. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for the full flow.
+The channel is populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into it. Engineers can also opt their PR in (or out) manually via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for the full flow.
 
 > **Tip:** The [`@posthog` Slack app](/docs/slack-app) can also answer questions about our own product data. `@PostHog` it in any channel to pull metrics or PR something to the website.
 

--- a/contents/handbook/support/support-team.md
+++ b/contents/handbook/support/support-team.md
@@ -23,9 +23,6 @@ We're not a ticket-routing operation. We genuinely care about making our users' 
 
 ## Slack channels to stay current
 
-To answer customer questions well we need to know what's just shipped and what's about to land. Two internal channels keep this in front of you — every member of the Support team should join both:
+To answer customer questions well we need to know what's just shipped. The [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) internal channel keeps this in front of you — every member of the Support team should join it. It's owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
 
-- [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) – what's just shipped. Owned by the [Wizard & Docs team](/teams/wizard-and-docs) and updated constantly as PRs merge.
-- [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) – what's shipping soon. Owned by the [Marketing team](/teams/marketing) and posted as a daily digest.
-
-Both channels are populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into the channel. Engineers can opt a PR in or out via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for the full flow.
+The channel is populated by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo and summarize them into it. Engineers can opt a PR in or out via the *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes on the PR template, or via the `@posthog` Slack app. See [how to publish changelog](/handbook/wizard-and-docs/how-to-publish-changelog) for the full flow.

--- a/contents/handbook/wizard-and-docs/how-to-publish-changelog.mdx
+++ b/contents/handbook/wizard-and-docs/how-to-publish-changelog.mdx
@@ -9,18 +9,17 @@ We have one of the coolest [changelogs](/changelog) on the internet. It's also o
 
 As a company that ships weirdly fast, it's important to share what we're working on with as many people as possible, as often as possible. The changelog is a great way to do that.
 
-## Internal Slack channels
+## Internal Slack channel
 
-We run two internal Slack channels that surface what we ship and what's about to ship. We recommend that everyone at PostHog joins both.
+We run an internal Slack channel that surfaces what we ship. We recommend that everyone at PostHog joins it.
 
 | Channel | Use it for | Cadence | Owner |
 |---------|------------|---------|-------|
 | [`#changelog`](https://posthog.slack.com/archives/C099B0YCULT) | What's just shipped | Updates constantly as PRs merge | <SmallTeam slug="wizard-and-docs" /> |
-| [`#coming-soon`](https://posthog.slack.com/archives/C0B5QBS29QU) | What's shipping soon | Daily digest | <SmallTeam slug="marketing" /> |
 
-Both channels are powered by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo, classify them, and summarize them into the relevant channel. The `#changelog` channel posts each impactful change as it lands; the `#coming-soon` channel rolls up upcoming work into a single daily digest.
+The channel is powered by agentic workflows that scan merged PRs and feature flag changes in the `posthog/posthog` repo, classify them, and summarize them into it, posting each impactful change as it lands.
 
-You can also opt a PR into either workflow manually:
+You can also opt a PR into the workflow manually:
 
 - **PR template checkboxes** — the `posthog/posthog` PR template has *Publish to changelog?* and *Alert Sales and Marketing teams?* checkboxes under **Automatic notifications**. Tick them when you want to override the automated classification.
 - **`@posthog` Slack app** — you can also include or exclude PRs from these workflows via the `@posthog` Slack app, which is handy after the fact (e.g. once a change is in production).


### PR DESCRIPTION
## Changes

The `#coming-soon` Slack channel has been archived, but seven handbook pages still pointed people at it. This removes those references.

Most pages framed `#changelog` and `#coming-soon` as a pair ("two channels", "both channels"), so the surrounding copy is rewritten rather than just deleted — each section now reads naturally as being about `#changelog` alone. The `#coming-soon` row is also dropped from the channel table on the how-to-publish-changelog page.

**Why:** the channel is archived, so the handbook was pointing people at a dead link.

**Open question:** the *Alert Sales and Marketing teams?* checkbox on the `posthog/posthog` PR template fed the `#coming-soon` digest. It is left documented as-is here since it still exists on the template, but whoever owns that workflow may want to retire it separately.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*