### PR TITLE
Reorder homepage carousel around web-first flows

### DIFF
--- a/src/components/Home/HeroCarousel/homeSlides.tsx
+++ b/src/components/Home/HeroCarousel/homeSlides.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { IconArrowRight, IconAtSign, IconCheck, IconCoffee, IconSparkles } from '@posthog/icons'
 import { IconSlack } from 'components/OSIcons'
 import OSButton from 'components/OSButton'
+import { SignupCTA } from 'components/SignupCTA'
 import CloudinaryImage from 'components/CloudinaryImage'
 import useProduct from 'hooks/useProduct'
 import { useApp } from '../../../context/App'
@@ -78,7 +79,7 @@ export const PullRequestSlide = () => {
                 />
             </div>
             */}
-            <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-center">
+            <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-start">
                 <CarouselTypecaast
                     config={slackBrokenLink}
                     height={CAROUSEL_EMBED_HEIGHT}
@@ -96,7 +97,7 @@ export const PullRequestSlide = () => {
                         ever leaving Slack. Triage and build with your team in the tools you already use.
                     </p>
                     <OSButton to="/slack" state={{ newWindow: true }} variant="secondary" size="md" asLink>
-                        Learn more
+                        Explore PostHog Slack
                     </OSButton>
                 </div>
                 {/* Web view — re-add alongside the toggle when multi-player supports web:
@@ -146,13 +147,14 @@ export const FixBugsSlide = () => {
                     onValueChange={(v) => v && setView(v as 'web' | 'code' | 'slack')}
                 />
             </div>
-            <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-center">
+            <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-start">
                 {view === 'web' ? (
-                    <div className="flex overflow-hidden rounded border border-primary">
+                    <div className={`flex overflow-hidden rounded border border-primary ${CAROUSEL_EMBED_HEIGHT}`}>
                         <CloudinaryImage
                             src={INBOX_IMAGE}
                             alt="The PostHog Inbox showing prioritized reports and pull requests"
-                            imgClassName="w-full"
+                            className="h-full w-full"
+                            imgClassName="h-full w-full object-cover object-top"
                         />
                     </div>
                 ) : view === 'slack' ? (
@@ -208,8 +210,8 @@ export const FixBugsSlide = () => {
                             PostHog Signals runs analysis on errors, logs, and summarized session recordings to detect
                             and fix bugs without any human prompting.
                         </p>
-                        <OSButton to="/self-driving" state={{ newWindow: true }} variant="secondary" size="md" asLink>
-                            Learn more
+                        <OSButton to="/slack" state={{ newWindow: true }} variant="secondary" size="md" asLink>
+                            Explore PostHog Slack
                         </OSButton>
                     </div>
                 ) : (
@@ -266,7 +268,7 @@ export const AskAnythingSlide = () => {
                     onValueChange={(v) => v && setView(v as 'slack' | 'web')}
                 />
             </div>
-            <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-center">
+            <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-start">
                 {view === 'slack' ? (
                     <CarouselTypecaast
                         config={slackAskPostHog}
@@ -300,8 +302,8 @@ export const AskAnythingSlide = () => {
                             Pipe in third party data to analyze alongside customer usage data for a more complete
                             picture of product usage.
                         </p>
-                        <OSButton to="/ai" state={{ newWindow: true }} size="md" variant="secondary" asLink>
-                            Explore PostHog AI
+                        <OSButton to="/slack" state={{ newWindow: true }} size="md" variant="secondary" asLink>
+                            Explore PostHog Slack
                         </OSButton>
                     </div>
                 ) : (
@@ -320,9 +322,7 @@ export const AskAnythingSlide = () => {
                             Pipe in third party data to analyze alongside customer usage data for a more complete
                             picture of product usage.
                         </p>
-                        <OSButton to="/ai" state={{ newWindow: true }} size="md" variant="secondary" asLink>
-                            Explore PostHog AI
-                        </OSButton>
+                        <SignupCTA size="md" state={{ initialTab: 'signup' }} />
                     </div>
                 )}
             </div>

--- a/src/components/Home/HeroCarousel/homeSlides.tsx
+++ b/src/components/Home/HeroCarousel/homeSlides.tsx
@@ -24,6 +24,7 @@ const MAX_CAROUSEL_HOLD_MS = 30000
 // Shared height for every Typecaast embed in the hero carousel — one value so all slides
 // match and the carousel doesn't jump in height between tabs.
 const CAROUSEL_EMBED_HEIGHT = 'h-[400px]'
+const INBOX_IMAGE = 'https://res.cloudinary.com/dmukukwp6/image/upload/inbox_prs_cloud_f44f8ba69b.png'
 
 const CarouselTypecaast = ({ onEnded, ...props }: TypecaastPlayerProps): JSX.Element => {
     const [ended, setEnded] = useState(false)
@@ -121,7 +122,7 @@ export const PullRequestSlide = () => {
 }
 
 export const FixBugsSlide = () => {
-    const [view, setView] = useState<'slack' | 'code'>('slack')
+    const [view, setView] = useState<'web' | 'code' | 'slack'>('web')
     const allProducts = useProduct() as any[]
     const codeProduct = Array.isArray(allProducts)
         ? allProducts.find((p: any) => p.handle === 'posthog_code')
@@ -137,15 +138,24 @@ export const FixBugsSlide = () => {
                     title="View"
                     hideTitle
                     options={[
+                        { label: <span className="whitespace-nowrap">Web</span>, value: 'web' },
+                        { label: <span className="whitespace-nowrap">Desktop</span>, value: 'code' },
                         { label: <span className="whitespace-nowrap">Slack</span>, value: 'slack' },
-                        { label: <span className="whitespace-nowrap">PostHog Desktop</span>, value: 'code' },
                     ]}
                     value={view}
-                    onValueChange={(v) => v && setView(v as 'slack' | 'code')}
+                    onValueChange={(v) => v && setView(v as 'web' | 'code' | 'slack')}
                 />
             </div>
             <div className="grid grid-cols-1 @2xl:grid-cols-[1.4fr_1fr] gap-6 @2xl:gap-8 items-center">
-                {view === 'slack' ? (
+                {view === 'web' ? (
+                    <div className="flex overflow-hidden rounded border border-primary">
+                        <CloudinaryImage
+                            src={INBOX_IMAGE}
+                            alt="The PostHog Inbox showing prioritized reports and pull requests"
+                            imgClassName="w-full"
+                        />
+                    </div>
+                ) : view === 'slack' ? (
                     <CarouselTypecaast
                         config={slackSignalsLoading}
                         height={CAROUSEL_EMBED_HEIGHT}
@@ -164,7 +174,29 @@ export const FixBugsSlide = () => {
                 ) : (
                     <div />
                 )}
-                {view === 'slack' ? (
+                {view === 'web' ? (
+                    <div className="flex flex-col gap-3">
+                        <div className="space-y-2">
+                            <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
+                                <IconSparkles className="size-4" /> PostHog Inbox
+                            </p>
+                            <h2 className="text-2xl font-bold m-0">Improvements, ready for review</h2>
+                        </div>
+                        <p className="text-secondary m-0">
+                            Your Inbox clusters related findings into researched reports, ranked by priority. Review
+                            proposed improvements and pull requests, then decide what ships.
+                        </p>
+                        <OSButton
+                            to="/docs/self-driving/inbox"
+                            state={{ newWindow: true }}
+                            variant="secondary"
+                            size="md"
+                            asLink
+                        >
+                            Explore Inbox
+                        </OSButton>
+                    </div>
+                ) : view === 'slack' ? (
                     <div className="flex flex-col gap-3">
                         <div className="space-y-2">
                             <p className="flex items-center gap-1.5 text-secondary text-sm font-semibold m-0">
@@ -213,7 +245,7 @@ export const FixBugsSlide = () => {
 }
 
 export const AskAnythingSlide = () => {
-    const [view, setView] = useState<'slack' | 'web'>('slack')
+    const [view, setView] = useState<'slack' | 'web'>('web')
     const allProducts = useProduct() as any[]
     const aiProduct = Array.isArray(allProducts) ? allProducts.find((p: any) => p.handle === 'posthog_ai') : undefined
     const { siteSettings } = useApp()
@@ -227,8 +259,8 @@ export const AskAnythingSlide = () => {
                     title="View"
                     hideTitle
                     options={[
-                        { label: <span className="whitespace-nowrap">Slack</span>, value: 'slack' },
                         { label: <span className="whitespace-nowrap">Web</span>, value: 'web' },
+                        { label: <span className="whitespace-nowrap">Slack</span>, value: 'slack' },
                     ]}
                     value={view}
                     onValueChange={(v) => v && setView(v as 'slack' | 'web')}

--- a/src/components/Home/HeroCarousel/tabs.tsx
+++ b/src/components/Home/HeroCarousel/tabs.tsx
@@ -47,8 +47,16 @@ export const productUsageTabs: Tab[] = [
     },
 ]
 
-// Agentic "@PostHog" carousel — lives on the homepage (Slack-first).
+// Agentic "@PostHog" carousel — lives on the homepage (lowest-friction entry points first).
 export const buildTabs: Tab[] = [
+    {
+        value: 'ask-anything',
+        label: 'Ask PostHog anything',
+        content: <AskAnythingSlide />,
+        color: 'bg-purple',
+        activeText: 'text-white',
+        progressBar: 'bg-white shadow-[0_0_6px_2px_rgba(255,255,255,0.4)]',
+    },
     {
         value: 'slack',
         label: 'Fix bugs from Slack',
@@ -64,13 +72,5 @@ export const buildTabs: Tab[] = [
         color: 'bg-blue',
         activeText: 'text-white',
         progressBar: 'bg-white shadow-[0_0_6px_2px_rgba(0,0,0,0.2)]',
-    },
-    {
-        value: 'ask-anything',
-        label: 'Ask PostHog anything',
-        content: <AskAnythingSlide />,
-        color: 'bg-purple',
-        activeText: 'text-white',
-        progressBar: 'bg-white shadow-[0_0_6px_2px_rgba(255,255,255,0.4)]',
     },
 ]


### PR DESCRIPTION
## Changes

- Reorders the homepage carousel to lead with Ask PostHog anything, followed by Slack bug fixes and automatic improvements.
- Makes Web the default Ask surface and adds a Web-first Inbox view to automatic improvements, followed by Desktop and Slack.

**Why:** Lead with the capabilities visitors can use today with the least onboarding friction.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*