### PR TITLE
Add Replay Vision to the pricing page free tier grid

### DIFF
--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -122,6 +122,12 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
                 icon={<Icons.IconTerminal className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
                 size={size}
             />
+            <FreeTierItem
+                name="Replay Vision"
+                allocation="2500 credits (worth $25)"
+                icon={<Icons.IconEye className={`text-yellow size-5 ${size === 'large' && 'size-7'}`} />}
+                size={size}
+            />
         </>
     )
 }


### PR DESCRIPTION
Replay Vision launched today but was missing from the "Free tier on all plans" grid on /pricing.

This adds it after Logs, matching the conventions already used on the Replay Vision product page and in billing:

- Name and icon: Replay Vision with `IconEye` in yellow, same as `src/hooks/productData/replay_vision.tsx`
- Allocation: 2500 credits (worth $25) per month, matching the free plan in billing (`replay_vision/free-20260706.yml`, usage key `replay_vision_credits`) and the pricing section on the product page
- Format follows the existing PostHog AI entry ("500 credits (worth $5)")

`FreeTier` is shared, so the item also shows up in the other places that render the free tier grid (pricing hero, plan content, home board).

## Before

![Free tier grid before (Replay Vision missing)](https://raw.githubusercontent.com/PostHog/pr-assets/6651cc336ec2729430472a4cd3257ee94a127079/2026/08/321c9ddf-14f5-4128-9d63-a5716a4b9727.png)

## After (from the [deploy preview](https://ef3b6d23.posthog-preview.pages.dev/pricing))

![Free tier grid after (Replay Vision added)](https://raw.githubusercontent.com/PostHog/pr-assets/8034a1a6b1a0ef6554d65d76ec53cb3715fee856/2026/08/1a9542ed-e653-48b8-9b17-cd9ce8e42e50.png)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
