### PR TITLE
feat(replay-vision) remove beta banners from vision docs

### DIFF
--- a/contents/docs/replay-vision/actions.mdx
+++ b/contents/docs/replay-vision/actions.mdx
@@ -4,12 +4,6 @@ title: Digests and alerts
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 [Observations](/docs/replay-vision/observations) tell you what a scanner found. **Digests and alerts** push those findings to you on a schedule, so you don't have to keep opening the scanner to check. Both are configured on a scanner's **Digests and alerts** tab, and PostHog collectively calls them the scanner's *actions*.
 
 - A **digest** runs on a fixed schedule (say, every weekday at 8am) and produces an AI-written summary of the observations from that period.

--- a/contents/docs/replay-vision/calibration.mdx
+++ b/contents/docs/replay-vision/calibration.mdx
@@ -4,12 +4,6 @@ title: Calibration
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Replay Vision scanners are only as good as their configuration. The **Calibration** tab on each scanner turns your team's judgment into a better configuration: rate the scanner's results, see accuracy trend across versions, and let PostHog AI recommend (and safely test) improvements to the prompt and every other behavior setting.
 
 Open any scanner and select the **Calibration** tab.

--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -4,12 +4,6 @@ title: Creating scanners
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 A scanner is made up of six things you author:
 
 1. A **prompt** describing what to look for.

--- a/contents/docs/replay-vision/index.mdx
+++ b/contents/docs/replay-vision/index.mdx
@@ -4,12 +4,6 @@ title: Replay Vision
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Replay Vision uses AI to automatically watch your [session recordings](/docs/session-replay) and turn what it sees into structured, queryable data. You configure **scanners** – named AI probes that describe what to look for – and PostHog applies them to your recordings, producing **observations** you can query, chart, and alert on.
 
 The key idea is that Replay Vision actually *watches the video* of each recording alongside its events. This lets it pick up on visual and behavioral cues – hesitation, confusion, where a user's attention goes – that aren't captured by clicks and pageviews alone. Instead of manually reviewing hundreds of replays to spot a pattern, you describe what matters once and let it run continuously.

--- a/contents/docs/replay-vision/mcp.mdx
+++ b/contents/docs/replay-vision/mcp.mdx
@@ -2,12 +2,6 @@
 title: MCP
 ---
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 The [PostHog MCP server](/docs/model-context-protocol) exposes Replay Vision through a set of tools your AI coding agent can call directly – author scanners, trigger observations on demand, and read results without leaving your editor.
 
 This works in any MCP client – Cursor, Codex, Claude Code, Windsurf, VS Code, and others.

--- a/contents/docs/replay-vision/observations.mdx
+++ b/contents/docs/replay-vision/observations.mdx
@@ -4,12 +4,6 @@ title: Observations
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Each scanner has an **Observations** tab listing every observation it's produced. Click into one to open the detail view: the structured result, the model's reasoning (with clickable citations that jump the embedded player to the cited moment), and the prompt that produced it – frozen even if you've since edited the scanner.
 
 Observations also surface in the replay player: the **observations dock** at the bottom of the player lists everything scanners have found about the session you're watching, and is where the **Scan this recording** action lives.

--- a/contents/docs/replay-vision/quota-and-limits.mdx
+++ b/contents/docs/replay-vision/quota-and-limits.mdx
@@ -4,12 +4,6 @@ title: Quota and limits
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Replay Vision usage is metered per organization in **credits**, on a monthly billing cycle. This page covers how observations are priced, what the budget is, what counts against it, and what to do when you're approaching it.
 
 <CalloutBox icon="IconFlask" title="No charges during the closed beta" type="action">

--- a/contents/docs/replay-vision/quota-and-limits.mdx
+++ b/contents/docs/replay-vision/quota-and-limits.mdx
@@ -4,19 +4,7 @@ title: Quota and limits
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Replay Vision usage is metered per organization in **credits**, on a monthly billing cycle. This page covers how observations are priced, what the budget is, what counts against it, and what to do when you're approaching it.
-
-<CalloutBox icon="IconFlask" title="No charges during the closed beta" type="action">
-
-The spend meter shows what your usage *would* cost – you won't be billed during the closed beta, and the default budget will change before general availability. The in-app meter is the authoritative number for your organization.
-
-</CalloutBox>
 
 ## How usage is priced
 
@@ -32,7 +20,7 @@ Prices are frozen when the observation runs: editing a scanner's model later doe
 
 ## The monthly budget
 
-Each organization gets a monthly credit budget – during the closed beta this defaults to **15,000 credits per month** (about $150). Current usage and the projection for the rest of the period are shown on the **Spend this period** tile on the Replay Vision home, in credits with the dollar equivalent alongside.
+Each organization gets a monthly credit budget – this defaults to **15,000 credits per month** (about $150). Current usage and the projection for the rest of the period are shown on the **Spend this period** tile on the Replay Vision home, in credits with the dollar equivalent alongside.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/quota_meter_ddcc762a43.png"

--- a/contents/docs/replay-vision/running-scanners.mdx
+++ b/contents/docs/replay-vision/running-scanners.mdx
@@ -4,12 +4,6 @@ title: Running scanners
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 There are two ways a scanner produces observations: automatically in the background as new recordings come in, or on-demand against recordings you pick. Both paths produce the same observation rows and the same `$recording_observed` events – they only differ in how the work gets triggered.
 
 ## Automatically on matching sessions

--- a/contents/docs/replay-vision/scanner-types.mdx
+++ b/contents/docs/replay-vision/scanner-types.mdx
@@ -4,12 +4,6 @@ title: Scanner types
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 The scanner type determines the shape of the structured output the model returns. It's chosen when you create a scanner and **can't be changed afterwards** – to switch types, create a new scanner.
 
 There are four types:

--- a/contents/docs/replay-vision/start-here.mdx
+++ b/contents/docs/replay-vision/start-here.mdx
@@ -4,12 +4,6 @@ title: Getting started with Replay Vision
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 This walkthrough takes you from zero to your first observation in about five minutes. We'll create a scanner from a built-in template, run it on a recording you pick, and then query the result as a regular PostHog event.
 
 You should already have [Session Replay](/docs/session-replay) recording sessions for your project. Replay Vision watches those recordings – without them there's nothing to scan.

--- a/contents/docs/replay-vision/troubleshooting.mdx
+++ b/contents/docs/replay-vision/troubleshooting.mdx
@@ -4,12 +4,6 @@ title: Troubleshooting
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Common things that go wrong with Replay Vision, and what to do about each.
 
 ## My scanner isn't producing any observations
@@ -136,4 +130,4 @@ Something else went wrong on PostHog's side. These should be rare.
 
 ## Something else
 
-If you're hitting something that doesn't fit the above, [reach out](/questions) – Replay Vision is in beta and the team is actively looking for sharp edges.
+If you're hitting something that doesn't fit the above, [reach out](/questions) – the team is actively looking for sharp edges.

--- a/contents/docs/replay-vision/troubleshooting.mdx
+++ b/contents/docs/replay-vision/troubleshooting.mdx
@@ -4,12 +4,6 @@ title: Troubleshooting
 
 import { ProductScreenshot } from "components/ProductScreenshot";
 
-<CalloutBox icon="IconFlask" title="Replay Vision is in closed beta" type="action">
-
-Not yet available to everyone – <a href="/replay-vision">join the waitlist</a> to get updates.
-
-</CalloutBox>
-
 Common things that go wrong with Replay Vision, and what to do about each.
 
 ## My scanner isn't producing any observations


### PR DESCRIPTION
## Changes

replay vision is out of beta, need to remove the beta banners.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
