### PR TITLE
Relabel 'Tools' tab to 'MCP tools' in AI prompts section

### DIFF
--- a/src/components/Products/ReaderViewProduct/templates/AskAnything.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/AskAnything.tsx
@@ -79,7 +79,7 @@ const AskAnything = ({ id, productData }: SectionComponentProps) => {
                 }}
                 options={[
                     { label: 'Example prompts', value: 'prompts', default: true },
-                    { label: 'Tools', value: 'tools' },
+                    { label: 'MCP tools', value: 'tools' },
                 ]}
                 className="mb-4 max-w-sm"
             />

--- a/src/components/ReplayVision/AIPromptsSection.tsx
+++ b/src/components/ReplayVision/AIPromptsSection.tsx
@@ -111,7 +111,7 @@ const AIPromptsSection = ({ id }: SectionComponentProps) => {
                 }}
                 options={[
                     { label: 'Example prompts', value: 'prompts', default: true },
-                    { label: 'Tools', value: 'tools' },
+                    { label: 'MCP tools', value: 'tools' },
                 ]}
                 className="mb-4 max-w-sm"
             />


### PR DESCRIPTION
## Changes

Renames the `Tools` tab to `MCP tools` in the "AI prompts" section on product pages (`/product-analytics` etc.), plus the equivalent section on the Replay Vision page.

**Why:** "Tools" on its own is ambiguous — the tab lists MCP tools, so the label should say so.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1785767476345949)*