### PR TITLE
fix: MCP Analytics is beta, not alpha, and wizard install has shipped

### DIFF
--- a/src/hooks/productData/mcp_analytics.tsx
+++ b/src/hooks/productData/mcp_analytics.tsx
@@ -11,7 +11,7 @@ import {
 import OSButton from 'components/OSButton'
 import { getTool } from '../../data/tools'
 
-// MCP Analytics is an alpha product (@posthog/mcp on npm) with a dedicated scene in the app
+// MCP Analytics is a beta product (@posthog/mcp on npm) with a dedicated scene in the app
 // gated behind the `mcp-analytics` early access feature. Copy here is sourced from the docs in
 // contents/docs/mcp-analytics/. There are no marketing screenshots yet, so the slides are
 // text/icon-driven — drop Cloudinary image URLs into `screenshots.overview` and the per-feature
@@ -24,9 +24,7 @@ export const mcpAnalytics = {
     type: 'mcp_analytics',
     color: 'blue',
     colorSecondary: 'sky-blue',
-    // Wizard install (`npx @posthog/wizard mcp-analytics`) ships via a context-mill
-    // release. Flip to `true` once that release is live; 'In development' until then.
-    wizardSupport: 'In development',
+    wizardSupport: true,
     seo: {
         title: 'MCP Analytics – See how agents use your MCP server in PostHog',
         description:
@@ -226,7 +224,7 @@ export const mcpAnalytics = {
     ],
     presenterNotes: {
         overview:
-            'MCP Analytics is alpha (<code>@posthog/mcp</code> on npm). Lead with the one-line wrap and "it\'s all just PostHog events." No new tooling to learn.',
+            'MCP Analytics is beta (<code>@posthog/mcp</code> on npm). Lead with the one-line wrap and "it\'s all just PostHog events." No new tooling to learn.',
     },
 }
 


### PR DESCRIPTION
Two pieces of stale MCP Analytics metadata in `src/hooks/productData/mcp_analytics.tsx`.

**Still said alpha.** The product moved to beta in June — `src/data/tools.ts` sets `status: 'beta'`, the dotcom manifest carries `tags: ['beta']`, and every page under `contents/docs/mcp-analytics/` says beta. But this file still said alpha in two places: the module doc-comment and the `presenterNotes.overview` string a presenter would read aloud. Fixed both; only the one word changed, so the surrounding voice is untouched.

**`wizardSupport` never flipped.** It read `'In development'` with a comment saying to flip it once the context-mill release was live. That release is live — `wizard mcp-analytics` shipped in wizard v2.32.0 and the skill has been released since context-mill v1.24.0 — so this understated a shipped feature on the wizard page. Now `true`, matching how `product_analytics`, `error_tracking`, `session_replay`, and `web_analytics` mark full support (the type is `boolean | string | {value, color}`; a plain `true` renders as full support, strings render as a coloured "in development"/"coming soon" badge). Removed the now-satisfied comment.

`status` itself was left alone: it lives in `src/data/tools.ts` and is spread in via `getTool('mcp_analytics')`, so it was already correct.

## Testing

- `prettier --check` and `eslint` clean on the changed file.
- Did not run a full `gatsby build` — far too slow for a copy/metadata change, and not a meaningful gate here.
- `codex review --base master`: no findings.

## Deliberately not touched

The remaining "alpha" mentions in `contents/docs/semantic-layer/mcp-tools.mdx` and `contents/docs/model-context-protocol/tools.mdx` are about the semantic-layer MCP tools, a different feature that really is still alpha.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*