### PR TITLE
Drop closed beta framing for Replay Vision outside docs

### DIFF
--- a/contents/blog/session-replays-opening-pull-requests.md
+++ b/contents/blog/session-replays-opening-pull-requests.md
@@ -59,4 +59,4 @@ Both of the other PRs landed on the same surface – the taxonomic filter and pr
 
 To be clear about what "opens a PR on its own" means: the pipeline opens drafts, not merges. [A human reviews before anything ships](/blog/10k-prs-a-month#humans-dont-need-to-review-every-pr) – at the time of writing, one of these three PRs is already merged, the other two are waiting. But everything up to that point, like noticing the struggle, grouping it across sessions, finding the exact line of code, and writing the fix, happened without a human interfering.
 
-Replay Vision is currently in closed beta. Point a scanner at a flow you care about, and let it read the sessions you'd never have time to watch. Join the [Replay Vision waitlist](/replay-vision) and be among the first to know when it's out.
+[Replay Vision](/replay-vision) is available to everyone now. Point a scanner at a flow you care about, and let it read the sessions you'd never have time to watch.

--- a/contents/handbook/growth/sales/customer-industry-segments.md
+++ b/contents/handbook/growth/sales/customer-industry-segments.md
@@ -156,7 +156,7 @@ Lead with AI Observability. It's the one product built for how these customers m
 - **Feature Flags and Experiments** – gate new models behind flags, run A/B tests on prompt changes, hold out high-value users from risky rollouts.
 - **Surveys** – trigger feedback prompts after a generation, collect CSAT on AI features, run PMF surveys against power users.
 - **Session Replay** – filter to recordings of users hitting prompt failures or specific `$ai_generation` errors.
-  - **Replay Vision** (closed beta) – run scanners over those recordings to auto-flag dead ends and prompt failures, then query the results back as PostHog events.
+  - **Replay Vision** – run scanners over those recordings to auto-flag dead ends and prompt failures, then query the results back as PostHog events.
 - **Error Tracking** – group exceptions by plan, model, or role to see which segment hits a bug.
 - **Data Warehouse** – sync events for joins against billing or model cost tables, then pipe insights back.
 - **Self-driving** – point the self-driving loop at these signals: agents investigate the reports, open pull requests for fixes, and measure whether they worked.

--- a/contents/handbook/growth/use-case-selling/customer-experience.md
+++ b/contents/handbook/growth/use-case-selling/customer-experience.md
@@ -34,7 +34,7 @@ Most companies don't have a customer experience system. They have tickets in one
 - **[AI Observability](/docs/ai-observability)** — See prompts, outputs, latency, and token usage for AI-powered workflows. When an AI feature misbehaves, trace it back to the specific generation.
 - **[Surveys](/docs/surveys)** — Capture frustration signals (NPS, CSAT) and tie them directly to broken flows. When someone leaves a low score, you can click through to their session and see what went wrong.
 - **[Experiments](/docs/experiments)** — Validate that fixes actually improved the experience. After resolving a class of issues, measure whether user satisfaction and completion rates improved.
-- **[Replay Vision](/docs/replay-vision)** *closed beta* — The support-scale version of session replay. Instead of a human watching recordings one at a time, a scanner reads all of them and tags what happened: task completed, abandoned, blocked by an error. For a support team, that turns "we think a few customers hit this" into a number. Findings land as queryable events. [Waitlist](/replay-vision).
+- **[Replay Vision](/docs/replay-vision)** — The support-scale version of session replay. Instead of a human watching recordings one at a time, a scanner reads all of them and tags what happened: task completed, abandoned, blocked by an error. For a support team, that turns "we think a few customers hit this" into a number. Findings land as queryable events.
 - **[self-driving](/docs/self-driving)** — Support conversations, error tracking, session replay, and logs are all [signal sources](/docs/self-driving/inbox/sources), and external helpdesks (Zendesk, Front, Intercom-likes, Gorgias, Plain) can feed the same inbox. A recurring ticket theme becomes an investigated report with a pull request, so the fix happens instead of the ticket being closed with a workaround.
 
 ## Adoption path and expansion path
@@ -293,7 +293,7 @@ This expansion happens naturally because each step removes a layer of uncertaint
 | Session Replay + Error Tracking | Product Intelligence (for the product team) | Support and engineering are in PostHog for debugging. The product team would benefit from the same analytics for feature development. | "Your support team is using PostHog to debug issues. Has your product team seen what they can do with funnels and retention in the same platform?" |
 | Replay + Errors + Analytics | Surveys (NPS/CSAT) | They're debugging reactively. Surveys let them detect frustration proactively and tie it to specific sessions. | "You're great at debugging reported issues. But how do you find the frustrated users who never file a ticket?" |
 | Replay + Errors (debugging AI features) | AI Observability | Traditional debugging misses AI-specific issues: prompt quality, hallucinations, latency. | "You're catching errors in your AI features. But are you seeing when the model gives a bad answer that isn't technically an error?" |
-| High ticket volume, support watching replays by hand | Replay Vision *closed beta* | Support can only watch a sample; a scanner reads every session | "How many tickets say 'it didn't work' with no detail? A scanner can read those sessions and tell you what actually happened in each one." |
+| High ticket volume, support watching replays by hand | Replay Vision | Support can only watch a sample; a scanner reads every session | "How many tickets say 'it didn't work' with no detail? A scanner can read those sessions and tell you what actually happened in each one." |
 | Zendesk/Front/Jira alongside PostHog | self-driving | Their helpdesk is already a supported signal source; recurring tickets can become PRs | "Your recurring tickets are a to-do list nobody has time for. What if each one arrived investigated, with a fix attached?" |
 | Support with the same issues recurring | self-driving | Tickets are resolved fast but the underlying bugs never make the roadmap | "How many of your tickets are the same handful of problems? Those can come back investigated, with a PR you review — so they stop coming back." |
 | Replay + Errors (engineering in PostHog) | Release Engineering (Feature Flags) | Engineering is in PostHog for debugging. Feature flags for safe releases is a natural add. | "You're tracking bugs after releases. What if you could gate features behind flags and roll back without a deploy?" |
@@ -311,7 +311,7 @@ This expansion happens naturally because each step removes a layer of uncertaint
 - **Surveys docs:** [Surveys](/docs/surveys)
 - **AI Observability docs:** [AI Observability](/docs/ai-observability)
 - **Logs docs:** [Start here](/docs/logs/start-here) · [Link to session replay](/docs/logs/link-session-replay)
-- **Replay Vision docs:** [Overview](/docs/replay-vision) · [Waitlist](/replay-vision)
+- **Replay Vision docs:** [Overview](/docs/replay-vision) · [Quota and limits](/docs/replay-vision/quota-and-limits)
 - **self-driving:** [How to pitch self-driving](/handbook/growth/sales/how-to-pitch-self-driving) · [Signal sources](/docs/self-driving/inbox/sources)
 - **Privacy controls:** [Session Replay Privacy](/docs/session-replay/privacy)
 - **PostHog AI docs:** [Enable PostHog AI](/docs/posthog-ai/allow-access) · [Example prompts](/docs/posthog-ai/example-prompts)

--- a/contents/handbook/growth/use-case-selling/product-intelligence.md
+++ b/contents/handbook/growth/use-case-selling/product-intelligence.md
@@ -28,7 +28,7 @@ This is our bread and butter. Most accounts start here. The risk is they *stay* 
 - **[Workflows](/docs/workflows/start-here)** — Onboarding sequences, activation nudges, lifecycle engagement. The action layer: once you've identified a drop-off in analytics, Workflows lets you do something about it automatically. ([Email drip campaigns](/docs/workflows/email-drip-campaign))
 - **AI Evals** — For products with AI features: proactively surface where users are struggling based on AI output quality. This is product intelligence driven by AI observability. A bridge product to the [AI/LLM Observability](/handbook/growth/use-case-selling/ai-llm-observability) use case.
 - **[PostHog AI](/docs/posthog-ai/allow-access)** — Natural language querying and insight discovery. Lowers the bar for non-technical product stakeholders to self-serve. A PM asks "why did retention drop last week?" instead of building a custom query. ([Example prompts](/docs/posthog-ai/example-prompts))
-- **[Replay Vision](/docs/replay-vision)** *closed beta* — AI scanners that watch session recordings for you and turn what they see into queryable events. Point a scanner at a set of recordings and it flags dead ends, scores frustration, tags intent, or summarizes what happened — with citations that jump to the exact moment. The output lands as a `$recording_observed` event, so a finding becomes a funnel breakdown or a cohort, not a note in a vendor's AI panel. Requires [joining the waitlist](/replay-vision); see the caveats under pain points before promising it. ([Scanner types](/docs/replay-vision/scanner-types) · [Observations](/docs/replay-vision/observations))
+- **[Replay Vision](/docs/replay-vision)** — AI scanners that watch session recordings for you and turn what they see into queryable events. Point a scanner at a set of recordings and it flags dead ends, scores frustration, tags intent, or summarizes what happened — with citations that jump to the exact moment. The output lands as a `$recording_observed` event, so a finding becomes a funnel breakdown or a cohort, not a note in a vendor's AI panel. See the caveats under pain points before promising it. ([Scanner types](/docs/replay-vision/scanner-types) · [Observations](/docs/replay-vision/observations))
 - **[Heatmaps](/docs/toolbar/heatmaps)** — Clickmaps, scrollmaps, and rageclick detection via the [toolbar](/docs/toolbar). Available on every plan. The thing UX teams ask for by name when comparing us to Hotjar.
 - **[self-driving](/docs/self-driving)** — Session replay and product analytics are [signal sources](/docs/self-driving/inbox/sources) for the self-driving loop, so a friction pattern can arrive as an investigated report with a pull request attached rather than a ticket for someone to write. Be careful how you frame this one for a product audience — see the self-driving section below.
 
@@ -178,13 +178,13 @@ Usually **Product Analytics**. Customer starts tracking events, builds dashboard
 | Hotjar | Session replay, heatmaps, basic surveys | Engineering-grade analytics alongside replay; experiments; flags; we ship heatmaps too | Simpler UX for non-technical users; purpose-built for UX research |
 | Heap | Auto-capture product analytics, session replay | Also auto-capture, plus flags, experiments, surveys, workflows | Retroactive analytics (virtual events) is a strong pitch |
 | Pendo | Product analytics + in-app guides | Deeper analytics; experiments; open source; better pricing | More mature in-app guides; stronger enterprise PM workflow features |
-| Fullstory | Autocapture, replay, StoryAI (session summaries, friction "Opportunities") | AI findings become queryable events, not panel-only insights; flags and experiments in the same tool | More mature enterprise DXA motion; StoryAI is GA where Replay Vision is closed beta |
+| Fullstory | Autocapture, replay, StoryAI (session summaries, friction "Opportunities") | AI findings become queryable events, not panel-only insights; flags and experiments in the same tool | More mature enterprise DXA motion; StoryAI has been GA longer and is more established in enterprise deals |
 | Contentsquare / Heap | Behavioral analytics, Sense Analyst (autonomous analysis agent) | One platform through to shipping the fix; better pricing | Sense Analyst is further along than our replay AI; deep enterprise CX tooling |
 | LogRocket | Replay, product analytics, Galileo AI (issue severity, Ask Galileo) | Broader platform; our signals feed an agent that opens PRs in your repo | Galileo is GA and dispatches Cursor agents today; strong frontend debugging |
 
 **Where PostHog stands:** Our strongest position is the breadth of the platform. No competitor offers analytics + replay + heatmaps + surveys + experiments + workflows in one tool. We're weaker against Amplitude in very large enterprises where their ML features and enterprise sales motion are more mature. We're weaker against Hotjar/Pendo for non-technical product teams who want a simpler, more opinionated UX.
 
-On AI specifically, be careful not to oversell: nearly every competitor shipped an AI analyst in the last year, several are GA while Replay Vision is still closed beta, and a customer who has seen Fullstory's or LogRocket's demo will not be impressed by "we have AI too." The defensible claims are narrower and better: the AI output is a first-class event you can join to the rest of your data, and the loop doesn't stop at an insight — it continues into a pull request. Our sweet spot is technical product teams at companies with engineers who value depth, flexibility, and not paying for 5 separate tools.
+On AI specifically, be careful not to oversell: nearly every competitor shipped an AI analyst in the last year, several of them GA for longer than Replay Vision, and a customer who has seen Fullstory's or LogRocket's demo will not be impressed by "we have AI too." The defensible claims are narrower and better: the AI output is a first-class event you can join to the rest of your data, and the loop doesn't stop at an insight — it continues into a pull request. Our sweet spot is technical product teams at companies with engineers who value depth, flexibility, and not paying for 5 separate tools.
 
 ## Pain points & known limitations
 
@@ -192,7 +192,7 @@ On AI specifically, be careful not to oversell: nearly every competitor shipped 
 |---|---|---|
 | No native in-app guides or tooltips | Teams with complex in-app onboarding needs may hit walls | For tooltip/modal UX, keep a dedicated tool (Appcues, Pendo) and use PostHog for analytics + experimentation. |
 | Workflows is new, less mature than dedicated engagement tools | Teams expecting Braze-level email sequencing will find gaps | Position as behavior-driven automation, not a full lifecycle marketing replacement. Complement with existing tools via [Data Pipelines](/docs/cdp/destinations). |
-| Replay Vision is closed beta and quota-limited | You can't promise it on a timeline, and a broad scanner can burn the monthly allowance fast | [Join the waitlist](/replay-vision) rather than committing to access. During beta there's a fixed monthly observation cap per organization (an explicit placeholder — pricing isn't set), scanners sample by default, and it's Gemini-only. Scope scanners narrowly to one flow while tuning. |
+| Replay Vision is quota-limited | A broad scanner can burn the monthly credit budget fast | Usage is metered in credits against a monthly budget per organization, scanners sample by default, and it's Gemini-only. Scope scanners narrowly to one flow while tuning — see [quota and limits](/docs/replay-vision/quota-and-limits). |
 | Replay Vision output is a model's judgment, not ground truth | A PM who treats one observation as fact will get burned | Every observation carries a confidence score and citations that link to the exact moment — coach customers to spot-check before acting, and to look for a pattern across sessions rather than trusting a single scan. |
 | Learning curve for non-technical PMs | PMs used to Amplitude's guided UX may find PostHog's flexibility overwhelming initially | Lead with [PostHog AI](/docs/posthog-ai/allow-access) for querying. Build pre-configured dashboards during onboarding. Start with simple funnels and retention, not HogQL. |
 
@@ -218,7 +218,7 @@ On AI specifically, be careful not to oversell: nearly every competitor shipped 
 - [ ] Set up one [Survey](/docs/surveys/creating-surveys) at a key friction point (post-signup NPS, feature feedback)
 - [ ] Plan first [Experiment](/docs/experiments) targeting a known drop-off point
 - [ ] Show [heatmaps](/docs/toolbar/heatmaps) on their highest-traffic page
-- [ ] If they're a fit for [Replay Vision](/replay-vision), get them on the waitlist early rather than at the point of need
+- [ ] If they're a fit for [Replay Vision](/docs/replay-vision), get a first scanner running on a flow they care about
 
 ## Cross-sell pathways from this use case
 
@@ -226,7 +226,7 @@ On AI specifically, be careful not to oversell: nearly every competitor shipped 
 |---|---|---|---|
 | Product Analytics only | Session Replay | They see the numbers but not the *why* | "You can see 40% drop off at step 3. Want to watch what's actually happening?" |
 | Product Analytics + Session Replay | Surveys | They're forming hypotheses from replays and want direct user input | "You're watching sessions and seeing confusion. Want to ask users directly what's tripping them up?" |
-| High Session Replay volume, low viewing rate | Replay Vision *closed beta* | They're paying to record sessions nobody has time to watch | "You recorded 40,000 sessions last month. How many did anyone actually watch? What if a scanner read all of them and tagged the ones where people got stuck?" |
+| High Session Replay volume, low viewing rate | Replay Vision | They're paying to record sessions nobody has time to watch | "You recorded 40,000 sessions last month. How many did anyone actually watch? What if a scanner read all of them and tagged the ones where people got stuck?" |
 | Watching replays and filing tickets manually | self-driving | The triage between "we saw the problem" and "someone fixed it" is all manual | "You've found the friction. Who writes the fix, and how long does it sit in the backlog first?" |
 | Product Analytics + Surveys | Experiments | They've identified problems and want to validate fixes | "You know the problem. Let's test whether your proposed fix actually works before building it fully." |
 | Analytics + Experiments mature | Workflows | They know what works and want to operationalize it | "You proved the new onboarding flow works. Now let's automatically nudge every new user toward it." |
@@ -245,7 +245,7 @@ On AI specifically, be careful not to oversell: nearly every competitor shipped 
 - **PostHog AI docs:** [Enable PostHog AI](/docs/posthog-ai/allow-access) · [Example prompts](/docs/posthog-ai/example-prompts)
 - **Group Analytics docs:** [Group Analytics](/docs/product-analytics/group-analytics)
 - **Heatmaps docs:** [Heatmaps](/docs/toolbar/heatmaps)
-- **Replay Vision docs:** [Overview](/docs/replay-vision) · [Scanner types](/docs/replay-vision/scanner-types) · [Creating scanners](/docs/replay-vision/creating-scanners) · [Observations](/docs/replay-vision/observations) · [Waitlist](/replay-vision)
+- **Replay Vision docs:** [Overview](/docs/replay-vision) · [Scanner types](/docs/replay-vision/scanner-types) · [Creating scanners](/docs/replay-vision/creating-scanners) · [Observations](/docs/replay-vision/observations) · [Quota and limits](/docs/replay-vision/quota-and-limits)
 - **self-driving:** [How to pitch self-driving](/handbook/growth/sales/how-to-pitch-self-driving) · [Docs](/docs/self-driving) · [Pricing](/docs/self-driving/pricing)
 
 ## Appendix: Company archetype considerations

--- a/contents/handbook/growth/use-case-selling/use-case-selling.md
+++ b/contents/handbook/growth/use-case-selling/use-case-selling.md
@@ -51,13 +51,13 @@ Each use case has a full playbook with discovery questions, competitive position
 | Distributed tracing *alpha* | Observability | Release Engineering |
 | Metrics *alpha* | Observability | |
 | Health checks *beta* | Observability | Data Infrastructure |
-| Replay Vision *closed beta* | Product Intelligence | Customer Experience, Observability |
+| Replay Vision | Product Intelligence | Customer Experience, Observability |
 | PostHog AI | Horizontal (all) | |
 | self-driving | Horizontal (all) | Converts fastest in Observability, Release Engineering, and Customer Experience |
 
-**Maturity matters when you're pitching.** Anything marked *alpha*, *beta*, or *closed beta* above needs a caveat in the room, and each playbook carries the specific one. Two are worth knowing before any call:
+**Maturity matters when you're pitching.** Anything marked *alpha* or *beta* above needs a caveat in the room, and each playbook carries the specific one. Two are worth knowing before any call:
 
-- **[Replay Vision](/docs/replay-vision) is closed beta** — waitlist only, quota-limited, and you cannot promise a date.
+- **[Replay Vision](/docs/replay-vision) is generally available** — no waitlist, but usage is metered in credits against a monthly budget, so scope scanners narrowly. See [quota and limits](/docs/replay-vision/quota-and-limits).
 - **[self-driving](/docs/self-driving) is a capability, not a SKU.** Write it lowercase and hyphenated, and keep the customer's product as the subject: we make *their* product self-driving. Never "PostHog is a self-driving product." See [brand foundations](/handbook/brand/foundations#how-we-describe-posthog) and [how to pitch self-driving](/handbook/growth/sales/how-to-pitch-self-driving).
 
 **Products vs tools.** In brand terms, most rows above are *tools* — the capabilities you access through the five *products* (PostHog Web, Slack, MCP, CLI, and [Desktop](/handbook/marketing/positioning/desktop)). That distinction doesn't change how you sell a use case, but it does change the words: don't call PostHog Desktop a tool, and don't call product analytics a product.

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -303,7 +303,6 @@ export const tools = [
         description: 'AI-powered session replay analysis that watches recordings for you',
         slug: 'replay-vision',
         category: 'product_engineering',
-        status: 'beta',
     },
     {
         handle: 'api',


### PR DESCRIPTION
## Changes

[#19191](https://github.com/PostHog/posthog.com/pull/19191) cleared the closed beta callouts out of `contents/docs/replay-vision/`, but the same framing was still live everywhere else on the site. This picks up the leftovers:

- **Blog** — the closing CTA on the Replay Vision launch post said it was in closed beta and pointed at the waitlist; it now says it's available.
- **Handbook** — dropped the *closed beta* qualifiers and waitlist links from the use-case selling pages (product intelligence, customer experience, the maturity table) and the sales industry-segments page. The quota caveat stays, reframed around the monthly credit budget with a link to [quota and limits](https://posthog.com/docs/replay-vision/quota-and-limits) instead of "pricing isn't set".
- **Competitor notes** — reworded the two lines that leaned on "they're GA, we're closed beta".
- **`src/data/tools.ts`** — removed `status: 'beta'` from the `replay_vision` entry so the Beta badge stops rendering.

## Why

Launch week: the product is generally available, but a CSE spotted stale beta/waitlist copy while getting ready to tell customers about it, and sales guidance still told people they couldn't promise access.

One thing left alone deliberately: `src/components/WaitlistForm/README.md` points at `src/pages/replay-vision.tsx` as its example caller, which no longer exists and no longer uses a waitlist form — worth a separate tidy-up.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — content-only)

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1785740422599779?thread_ts=1785740422.599779&cid=C0B7TE4R8GH)*
