### PR TITLE
Copy edits to skills store docs page

### DIFF
--- a/contents/docs/ai-engineering/skills-store.mdx
+++ b/contents/docs/ai-engineering/skills-store.mdx
@@ -2,19 +2,21 @@
 title: Using the PostHog skills store
 ---
 
-Your team's coding agents (Claude Code, Cursor, Codex, Windsurf, and others) all support [MCP](/docs/model-context-protocol). PostHog's skills store gives you a centralized, versioned place to store and share reusable agent skills — following the [Agent Skills specification](https://agentskills.io/specification) — across any tool, for any team member.
+Your team's coding agents (Claude Code, Cursor, Codex, Windsurf, and others) all support [MCP](/docs/model-context-protocol). PostHog's skills store gives you a centralized, versioned place to store and share reusable agent skills – following the [Agent Skills specification](https://agentskills.io/specification) – across any tool, for any team member.
 
-> **Shortcut: install the PostHog AI plugin.** The [PostHog AI plugin](https://github.com/PostHog/ai-plugin) ships an official [`skills-store` skill](https://github.com/PostHog/ai-plugin/tree/main/skills/skills-store) — maintained alongside the [canonical version in the PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/skills/skills/skills-store) — that teaches your agent exactly how to discover, load, create, and update skills via the PostHog MCP tools. Install the plugin in [Claude Code](/docs/model-context-protocol/claude-code), [Codex](/docs/model-context-protocol/codex), Cursor, or Gemini CLI and your agent already knows how to use the store. The rest of this guide covers the same concepts in case you want to understand what's happening under the hood or roll your own bridge.
+> **Shortcut: install the PostHog AI plugin.**
+>
+> The [PostHog AI plugin](https://github.com/PostHog/ai-plugin) ships an official [`skills-store` skill](https://github.com/PostHog/ai-plugin/tree/main/skills/skills-store) – maintained alongside the [canonical version in the PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/skills/skills/skills-store) – that teaches your agent exactly how to discover, load, create, and update skills via the PostHog MCP tools. Install the plugin in [Claude Code](/docs/model-context-protocol/claude-code), [Codex](/docs/model-context-protocol/codex), Cursor, or Gemini CLI and your agent already knows how to use the store.
 
 ## Why use PostHog as your skills store?
 
-- **Works in any MCP-connected agent** — Claude Code, Cursor, Codex, Windsurf, VS Code, and more
-- **Centrally managed** — Update a skill once, every team member gets the latest version on their next fetch
-- **Full version history** — Every edit creates an immutable version, with `base_version` concurrency checks
-- **Bundled files** — Skills can include scripts, references, and assets alongside the instructions
-- **Progressive disclosure** — Agents list skills by description, load bodies on demand, and fetch bundled files only when needed
-- **No vendor lock-in** — Not tied to a specific agent or IDE
-- **Non-engineers can contribute** — Anyone on your team can create and maintain skills through the PostHog UI
+- **Works in any MCP-connected agent** – Claude Code, Cursor, Codex, Windsurf, VS Code, and more
+- **Centrally managed** – Update a skill once, every team member gets the latest version on their next fetch
+- **Full version history** – Every edit creates an immutable version, with `base_version` concurrency checks
+- **Bundled files** – Skills can include scripts, references, and assets alongside the instructions
+- **Progressive disclosure** – Agents list skills by description, load bodies on demand, and fetch bundled files only when needed
+- **No vendor lock-in** – Not tied to a specific agent or IDE
+- **Non-engineers can contribute** – Anyone on your team can create and maintain skills through the PostHog UI
 
 ## How it works
 
@@ -25,16 +27,16 @@ The MCP server exposes the skills store through a dedicated family of tools:
 | Tool                | Purpose                                                                           |
 | ------------------- | --------------------------------------------------------------------------------- |
 | `skill-list`        | List all available skills (name + description only)                               |
-| `skill-get`         | Fetch a skill by name — returns the body and a manifest of bundled files          |
+| `skill-get`         | Fetch a skill by name – returns the body and a manifest of bundled files          |
 | `skill-file-get`    | Fetch a single bundled file by path (on demand)                                   |
 | `skill-create`      | Store a new skill, optionally with bundled files                                  |
-| `skill-update`      | Publish a new version — provide full `body`, incremental `edits`, or `file_edits` |
+| `skill-update`      | Publish a new version – provide full `body`, incremental `edits`, or `file_edits` |
 | `skill-file-create` | Add one bundled file to a skill (publishes a new version)                         |
 | `skill-file-delete` | Remove one bundled file from a skill                                              |
 | `skill-file-rename` | Rename one bundled file (move without rewriting content)                          |
 | `skill-duplicate`   | Duplicate an existing skill under a new name                                      |
 
-Agents use these with progressive disclosure: discover by description, fetch the body only when relevant, and pull individual files on demand — rather than loading everything up front.
+Agents use these with progressive disclosure: discover by description, fetch the body only when relevant, and pull individual files on demand – rather than loading everything up front.
 
 ## Prerequisites
 
@@ -50,7 +52,7 @@ Let's create a skill called `hog-release-notes` that writes release notes in Pos
 1. Navigate to **[Skills](https://app.posthog.com/skills)**
 2. Click **New skill**
 3. Name it `hog-release-notes`
-4. Add a description that explains _when_ to use the skill — this is what agents use to discover it
+4. Add a description that explains _when_ to use the skill – this is what agents use to discover it
 5. Paste your skill body (see example below)
 6. Optionally add bundled files, `allowed_tools`, `license`, `compatibility`, or metadata
 7. Click **Create skill**
@@ -78,7 +80,7 @@ Or call `skill-create` directly:
 
 ### Example skill body
 
-A good skill body gives the agent all the context it needs — where to find information, what format to use, and any project-specific knowledge:
+A good skill body gives the agent all the context it needs – where to find information, what format to use, and any project-specific knowledge:
 
 ```markdown
 # Hog release notes writer
@@ -96,17 +98,17 @@ You write release notes for PostHog. Follow these rules.
 
 ## Voice and tone
 
-- Direct and concise — no marketing fluff
+- Direct and concise – no marketing fluff
 - Technical but approachable
 - Use second person ("you") not third person ("users")
 - Be specific about what changed and why it matters
 
 ## Structure for each entry
 
-1. **One-line summary** — What shipped, in plain language
-2. **What it does** — 2-3 sentences on the feature or fix
-3. **How to use it** — Concrete steps or code snippets
-4. **Why we built it** — The problem this solves (one sentence)
+1. **One-line summary** – What shipped, in plain language
+2. **What it does** – 2-3 sentences on the feature or fix
+3. **How to use it** – Concrete steps or code snippets
+4. **Why we built it** – The problem this solves (one sentence)
 
 ## Rules
 
@@ -151,7 +153,7 @@ You can deep-link directly to a specific bundled file within a skill by adding a
 https://app.posthog.com/skills/hog-release-notes?file=references/changelog.md
 ```
 
-When someone visits this URL, the file viewer automatically expands, loads the file content, and scrolls it into view. Combine it with `version` to link to a file in a specific skill version — e.g. `?file=scripts/run.py&version=3`. This is useful for sharing a specific reference document or script with a teammate.
+When someone visits this URL, the file viewer automatically expands, loads the file content, and scrolls it into view. Combine it with `version` to link to a file in a specific skill version – e.g. `?file=scripts/run.py&version=3`. This is useful for sharing a specific reference document or script with a teammate.
 
 ## Step 2: Use a skill from any agent
 
@@ -163,7 +165,7 @@ Once a skill exists in PostHog, any team member with the MCP server configured c
 Use PostHog MCP to list available skills.
 ```
 
-This calls `skill-list` and returns every skill's name + description — never the body. Agents pick the right skill from the description alone, without loading any bodies.
+This calls `skill-list` and returns every skill's name + description – never the body. Agents pick the right skill from the description alone, without loading any bodies.
 
 You can also filter:
 
@@ -178,13 +180,13 @@ Use PostHog MCP to fetch "hog-release-notes" and follow its
 instructions to write release notes for the changes in my current branch.
 ```
 
-The agent calls `skill-get` with `skill_name: "hog-release-notes"`, receives the body + file manifest, reads the body as its system instructions, and gets to work — fetching any referenced bundled files via `skill-file-get` on demand.
+The agent calls `skill-get` with `skill_name: "hog-release-notes"`, receives the body + file manifest, reads the body as its system instructions, and gets to work – fetching any referenced bundled files via `skill-file-get` on demand.
 
 This works identically in Claude Code, Cursor, Codex, or any other MCP-connected agent. The skill lives in PostHog, not in any particular tool.
 
 ## Step 3: Set up a bridge skill (optional shortcut)
 
-Step 2 is all you need. If you've installed the [PostHog AI plugin](https://github.com/PostHog/ai-plugin), you can skip this step entirely — the plugin's `skills-store` skill already provides the bridge.
+Step 2 is all you need. If you've installed the [PostHog AI plugin](https://github.com/PostHog/ai-plugin), you can skip this step entirely – the plugin's `skills-store` skill already provides the bridge.
 
 Otherwise, if your agent supports local skills (like Claude Code's `.claude/skills/` directory), you can drop in a tiny DIY bridge that bootstraps into the PostHog skills store. You only need **one** generic bridge:
 
@@ -213,13 +215,13 @@ Fetch the full instructions from PostHog:
 2. Follow the instructions in the returned body
 ```
 
-The bridge is intentionally thin — it just points at the canonical `skills-store` skill in PostHog, where the real instructions live. Updates to that remote skill automatically reach everyone on the team.
+The bridge is intentionally thin – it just points at the canonical `skills-store` skill in PostHog, where the real instructions live. Updates to that remote skill automatically reach everyone on the team.
 
-One local file, unlimited remote skills. But again, this is purely a convenience — everything the bridge does, you can do by asking your agent to use PostHog MCP skills directly.
+One local file, unlimited remote skills. But again, this is purely a convenience – everything the bridge does, you can do by asking your agent to use PostHog MCP skills directly.
 
 ## Example: a full session
 
-Here's what using the skills store looks like in practice — from running a skill, to updating it mid-session, to a teammate picking up the changes automatically.
+Here's what using the skills store looks like in practice – from running a skill, to updating it mid-session, to a teammate picking up the changes automatically.
 
 ### Running the skill
 
@@ -238,14 +240,14 @@ the release notes.
   ...
 ```
 
-The agent had everything it needed — the body told it where to find what's already published, how to discover what's new, and how to format the output.
+The agent had everything it needed – the body told it where to find what's already published, how to discover what's new, and how to format the output.
 
 ### Updating the skill mid-session
 
 After reviewing the output, you decide the skill could be better:
 
 ```text
-> Great, but let's update the hog-release-notes skill — add a rule to
+> Great, but let's update the hog-release-notes skill – add a rule to
   always include a fun hedgehog fact at the end of each set of
   release notes.
 
@@ -257,7 +259,7 @@ body and base_version for conflict detection.
   "End each set of release notes with a fun hedgehog fact."
 ```
 
-That's it — the skill is updated in PostHog. You can review the diff in the PostHog UI to see exactly what changed.
+That's it – the skill is updated in PostHog. You can review the diff in the PostHog UI to see exactly what changed.
 
 ### A teammate benefits automatically
 
@@ -267,7 +269,7 @@ The next day, a teammate runs the same skill from their own agent (Claude Code, 
 > Use PostHog MCP to run "hog-release-notes" for this week.
 
 Agent calls skill-get and gets version 2 (the latest), follows the updated
-instructions, and includes a hedgehog fact at the end — without the
+instructions, and includes a hedgehog fact at the end – without the
 teammate needing to know anything changed.
 ```
 
@@ -288,7 +290,7 @@ Update the PostHog skill "hog-release-notes" to also include
 a "Known limitations" section in the release notes structure.
 ```
 
-The agent calls `skill-get` to read the current version, then `skill-update` with the new body and `base_version`. Fields you don't pass are carried forward. Pick the most surgical primitive for what you're changing — the API offers several so you don't have to round-trip the whole skill to tweak one part.
+The agent calls `skill-get` to read the current version, then `skill-update` with the new body and `base_version`. Fields you don't pass are carried forward. Pick the most surgical primitive for what you're changing – the API offers several so you don't have to round-trip the whole skill to tweak one part.
 
 ### Use incremental edits
 
@@ -306,8 +308,8 @@ Instead of rewriting the entire skill body, you can use incremental find/replace
 
 Each edit must have:
 
-- `old` — the exact text to find (must match exactly once in the body)
-- `new` — the replacement text
+- `old` – the exact text to find (must match exactly once in the body)
+- `new` – the replacement text
 
 Edits are applied sequentially. If `old` matches zero times or more than once, the update fails with an error indicating which edit failed.
 
@@ -330,7 +332,7 @@ Use `file_edits` to patch one bundled file without resending every file:
 }
 ```
 
-Non-targeted files carry forward unchanged. `file_edits` cannot add, remove, or rename files — use the per-file tools below for that.
+Non-targeted files carry forward unchanged. `file_edits` cannot add, remove, or rename files – use the per-file tools below for that.
 
 ### Add, remove, or rename a file
 
@@ -373,36 +375,36 @@ Use atomic per-file tools when you need to add, delete, or rename a single bundl
 
 ### Replace the whole bundle (rare)
 
-Passing `files` to `skill-update` replaces ALL bundled files — anything not in the array is dropped. Only use this when you intentionally want to wipe and reseed the bundle. For everything else, prefer `file_edits` or the per-file CRUD tools above.
+Passing `files` to `skill-update` replaces ALL bundled files – anything not in the array is dropped. Only use this when you intentionally want to wipe and reseed the bundle. For everything else, prefer `file_edits` or the per-file CRUD tools above.
 
 ### Review changes
 
-Use the compare view in the PostHog UI to see a diff between any two versions. This is especially useful when an agent has updated a skill — you can review exactly what it changed before the rest of your team picks it up.
+Use the compare view in the PostHog UI to see a diff between any two versions. This is especially useful when an agent has updated a skill – you can review exactly what it changed before the rest of your team picks it up.
 
 ### Automatic propagation
 
-Team members get the latest version on their next `skill-get`. No PRs, no syncing, no manual updates — just one source of truth in PostHog.
+Team members get the latest version on their next `skill-get`. No PRs, no syncing, no manual updates – just one source of truth in PostHog.
 
 ## Porting a local skill
 
 To move a skill from a local `SKILL.md` directory (e.g. `~/.claude/skills/<name>/` with `scripts/`, `references/`, and `assets/` subdirs) into PostHog:
 
-1. Read the local `SKILL.md` — use its frontmatter for `name`, `description`, `license`, `compatibility`, `allowed_tools`, and `metadata`; the body after the frontmatter becomes `body`
+1. Read the local `SKILL.md` – use its frontmatter for `name`, `description`, `license`, `compatibility`, `allowed_tools`, and `metadata`; the body after the frontmatter becomes `body`
 2. Walk the `scripts/`, `references/`, and `assets/` subdirs and collect each file as `{ path, content, content_type }`
-3. Call `skill-create` with everything in one shot — the skill lands at v1 with its full bundle
+3. Call `skill-create` with everything in one shot – the skill lands at v1 with its full bundle
 
 The skill is then available to the whole team via `skill-get`.
 
 ## Skills vs prompts
 
-PostHog also has a separate [prompts](/docs/prompt-management) tool family (`prompt-list`, `prompt-get`, `prompt-create`, `prompt-update`) for plain single-text prompts — LLM system prompts, short reusable text, and anything the SDK fetches at runtime for generations. Skills are the right choice whenever the workflow needs structured metadata, bundled files, or an `allowed_tools` surface. When in doubt, use skills.
+PostHog also has a separate [prompts](/docs/prompt-management) tool family (`prompt-list`, `prompt-get`, `prompt-create`, `prompt-update`) for plain single-text prompts – LLM system prompts, short reusable text, and anything the SDK fetches at runtime for generations. Skills are the right choice whenever the workflow needs structured metadata, bundled files, or an `allowed_tools` surface. When in doubt, use skills.
 
 ## Team workflow tips
 
-- **Use descriptive, kebab-case names** — `review-frontend-pr`, `write-api-docs`, `check-security-headers`
-- **Invest in descriptions** — discovery depends entirely on them; an agent decides whether to load your skill based on its description alone
-- **Discover before you create** — run `skill-list` to see what skills your team already has before creating a duplicate
-- **Port local skills to PostHog** — if you have useful `SKILL.md` files saved locally, move them (with their bundled files) to PostHog so the whole team benefits
-- **Keep skills focused** — one task per skill. A skill that does "everything" is a skill that does nothing well
-- **Don't preload bundled files** — let the agent fetch them on demand via `skill-file-get`; that's the whole point of progressive disclosure
-- **Let agents update skills** — after an agent follows a skill, ask it to suggest improvements, then update via `skill-update`
+- **Use descriptive, kebab-case names** – `review-frontend-pr`, `write-api-docs`, `check-security-headers`
+- **Invest in descriptions** – discovery depends entirely on them; an agent decides whether to load your skill based on its description alone
+- **Discover before you create** – run `skill-list` to see what skills your team already has before creating a duplicate
+- **Port local skills to PostHog** – if you have useful `SKILL.md` files saved locally, move them (with their bundled files) to PostHog so the whole team benefits
+- **Keep skills focused** – one task per skill. A skill that does "everything" is a skill that does nothing well
+- **Don't preload bundled files** – let the agent fetch them on demand via `skill-file-get`; that's the whole point of progressive disclosure
+- **Let agents update skills** – after an agent follows a skill, ask it to suggest improvements, then update via `skill-update`


### PR DESCRIPTION
## Changes

- Removed the trailing sentence "The rest of this guide covers the same concepts…" from the shortcut callout.
- Split the callout so **Shortcut: install the PostHog AI plugin.** sits on its own line.
- Replaced every em dash on the page with an en dash.

**Why:** requested in a docs review of the skills store page – the closing sentence was redundant, and the page should use en dashes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BMKTE4NG5/p1785772787492429)*