### PR TITLE
Handbook: explain how to structure contract buyouts

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -139,9 +139,8 @@ There are three ways we structure free credits, and it's important to be clear w
 
 2. **Coverage for a specific number of months.** The free credits are *not* part of the contract term. We add enough free credits to cover the promised period (for example, up to the contract start date), top up if the customer comes up short before then, and add the prepaid credits only when the contract actually starts. Any free-credit balance still remaining at contract start is removed at that point. These credits can be added via billing admin as a one time credit and don't need to be called out as part of the term.
 
-3. **Fixed amount included in an extended term (contract buyouts).** The free credits are part of the contract term, but the term itself is longer than standard because it absorbs the buyout period — 12 months of paid usage plus a 6 month buyout becomes an 18 month term. Use this whenever we're buying a customer out of a competitor contract. See [contract buyouts](#contract-buyouts) for how to build the order form.
+3. **Fixed amount included in an extended term (contract buyouts).** The free credits are part of the contract term, but the term itself is longer than standard because it absorbs the buyout period: 12 months of paid usage plus a 6 month buyout becomes an 18 month term. Use this whenever we're buying a customer out of a competitor contract. See [contract buyouts](#contract-buyouts) for how to build the order form. **Note that this means you won't be able to top up free credits if customer uses them faster than originally planned. If you think this may be the case, default to option 2.**
 
-Prefer option 3 over option 2 for customers who are already paying us, so the free period doesn't show up as a gap in retention.
 
 ### Margin negative deals
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -133,11 +133,15 @@ For contracting purposes, these free credits should either be applied before the
 
 #### How to structure free credits in special terms
 
-There are two ways we structure free credits, and it's important to be clear which one applies, because they're added at different times and treated differently at contract start:
+There are three ways we structure free credits, and it's important to be clear which one applies, because they're added at different times and treated differently at contract start:
 
 1. **Fixed amount included in the 12 month term.** The free credits are part of the contract term and are added to the customer's balance alongside the purchased (prepaid) credits at contract start. Use this when a specific dollar amount of free credit is explicitly called out under Special Terms as part of the term.
 
 2. **Coverage for a specific number of months.** The free credits are *not* part of the contract term. We add enough free credits to cover the promised period (for example, up to the contract start date), top up if the customer comes up short before then, and add the prepaid credits only when the contract actually starts. Any free-credit balance still remaining at contract start is removed at that point. These credits can be added via billing admin as a one time credit and don't need to be called out as part of the term.
+
+3. **Fixed amount included in an extended term (contract buyouts).** The free credits are part of the contract term, but the term itself is longer than standard because it absorbs the buyout period — 12 months of paid usage plus a 6 month buyout becomes an 18 month term. Use this whenever we're buying a customer out of a competitor contract. See [contract buyouts](#contract-buyouts) for how to build the order form.
+
+Prefer option 3 over option 2 for customers who are already paying us, so the free period doesn't show up as a gap in retention.
 
 ### Margin negative deals
 
@@ -224,7 +228,7 @@ When considering a contract buyout, the goal is to pay a little up front to make
 Some rules:
 
 -   They need to share a copy of their current contract/pricing/bank statement as proof.
--   They sign up to an annual contract worth $20k+/year, paid up front. Their PostHog contract starts when their current one expires.
+-   They sign up to an annual contract worth $20k+/year, paid up front.
 -   Their usage in the overlap period needs to be proportionate to the contract they've signed, ie. if they sign a $50k contract and have 6 months to run, they get $25k of PostHog credit for free.
 -   The competitor they're using has to be 'real', ie. not some random side project. As a general rule, anyone we have written a [comparison article](/blog/tags/comparisons) about counts.
 -   Any buyout is subject to team lead approval before it goes on an order form.
@@ -232,6 +236,23 @@ Some rules:
 -   We can still provide a standard free trial period of 2-4 weeks before they sign the contract, as they will likely need to figure out whether PostHog is right for them before committing.
 
 > Normal commission rules apply here - commission is paid in the quarter in which the customer pays their invoice.
+
+### How to structure a buyout on the order form
+
+Buyouts used to get papered in one of two ways: future-dating the order form so the term began when the incumbent contract expired, or sprinkling extra free credits onto an otherwise normal order. Both cost us — the first is effectively extended payment terms and delays when the deal counts, the second cuts order value hard enough to flirt with margin negative. Neither is how we do it now.
+
+Instead, fold the buyout period into the contract term:
+
+-   **Contract term = standard term + buyout period.** A 12 month deal with a 6 month buyout is an 18 month term. A 2 year deal with a 6 month buyout is a 30 month term.
+-   **Credits are calculated as usual** — 12 months of estimated usage, multiplied by the number of years — and then the pro-rated buyout credit is added on top.
+-   **Exclude the buyout credits when calculating the discount** we offer the customer. The buyout credit is not a lever for a bigger discount.
+-   **Show the contracted discount on the order form, not the effective discount.** The effective discount (total paid ÷ total credit) will always look larger than the contracted one because of the free buyout credit. Quoting the effective number sets a false floor for the renewal.
+-   **Everything else is standard** — term start date, payment terms, and signature dates all follow our normal rules. There is no future-dating and no separate payment schedule.
+-   Call out the buyout credit in Special Terms: _"In consideration of Customer migrating to PostHog from its incumbent provider prior to the expiration of Customer's existing agreement with that provider, PostHog will provide a one-time credit in the amount of $NNNNN."_
+
+As a worked example: a customer expected to use ~$100k of credit a year, with 6 months left on their incumbent contract, at a 30% discount. They buy $100k of credit for $70k, we add $50k of buyout credit on top, and the order form is an 18 month term for $150k of total credit at a 30% discount. The effective discount lands north of 50%, which is expected and stays off the order form.
+
+This is also structure 3 in [how to structure free credits in special terms](#how-to-structure-free-credits-in-special-terms).
 
 ## New business renewal credits
 


### PR DESCRIPTION
## Why

Contract buyouts were getting papered two different ways across the sales team — future-dating the order form, or sprinkling extra free credits onto a normal one — and neither is what we actually want. The handbook only documented the standard 12 month term case, so this writes down the agreed structure.

## Changes

- Adds a third free-credit structure to *How to structure free credits in special terms*: a fixed amount inside an extended term that absorbs the buyout period.
- Adds a *How to structure a buyout on the order form* subsection under **Contract buyouts** covering term length (standard term + buyout period), how credits are calculated, excluding buyout credits from the discount calculation, showing the contracted rather than effective discount to protect the renewal, and the Special Terms wording.
- Removes the line saying the PostHog contract starts when the incumbent one expires, which contradicts the new structure.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09677WV1GW/p1785763246288029?thread_ts=1785763246.288029&cid=C09677WV1GW)*