### PR TITLE
fix-react-loop

### DIFF
--- a/patches/@typecaast+react+0.5.5.patch
+++ b/patches/@typecaast+react+0.5.5.patch
@@ -1,0 +1,54 @@
+diff --git a/node_modules/@typecaast/react/dist/index.cjs b/node_modules/@typecaast/react/dist/index.cjs
+index 787cf02..3f36ae2 100644
+--- a/node_modules/@typecaast/react/dist/index.cjs
++++ b/node_modules/@typecaast/react/dist/index.cjs
+@@ -435,12 +435,20 @@ var Player = react.forwardRef(function Player2({
+   const player = tc.player;
+   const fonts = useSkinFonts(skin);
+   react.useEffect(() => {
+-    if (reduced) tc.seek(tc.duration);
++    // PATCHED (posthog.com): `tc` is a fresh object literal on every render
++    // (useTypecaast does not memoize its return), so this effect re-runs constantly.
++    // play() on an already-finished non-looping player synchronously re-ended it and
++    // emitted tick/pause/end -> setState -> re-render -> effect -> play() again: a
++    // CPU-bound loop pinning the main thread at ~99% once the animation completed.
++    // Skipping only those no-op calls fixes the loop while leaving this effect's
++    // dependencies, timing, and every other play()/pause() call untouched.
++    if (reduced && player.currentMs !== player.durationMs) tc.seek(tc.duration);
+   }, [reduced, tc]);
+   react.useEffect(() => {
+     if (paused === void 0 || reduced) return;
++    const finished = !player.loop && player.currentMs >= player.durationMs;
+     if (paused) tc.pause();
+-    else tc.play();
++    else if (!finished) tc.play();
+   }, [paused, reduced, tc]);
+   react.useEffect(() => {
+     const offs = [];
+diff --git a/node_modules/@typecaast/react/dist/index.js b/node_modules/@typecaast/react/dist/index.js
+index 54d7040..73cb744 100644
+--- a/node_modules/@typecaast/react/dist/index.js
++++ b/node_modules/@typecaast/react/dist/index.js
+@@ -434,12 +434,20 @@ var Player = forwardRef(function Player2({
+   const player = tc.player;
+   const fonts = useSkinFonts(skin);
+   useEffect(() => {
+-    if (reduced) tc.seek(tc.duration);
++    // PATCHED (posthog.com): `tc` is a fresh object literal on every render
++    // (useTypecaast does not memoize its return), so this effect re-runs constantly.
++    // play() on an already-finished non-looping player synchronously re-ended it and
++    // emitted tick/pause/end -> setState -> re-render -> effect -> play() again: a
++    // CPU-bound loop pinning the main thread at ~99% once the animation completed.
++    // Skipping only those no-op calls fixes the loop while leaving this effect's
++    // dependencies, timing, and every other play()/pause() call untouched.
++    if (reduced && player.currentMs !== player.durationMs) tc.seek(tc.duration);
+   }, [reduced, tc]);
+   useEffect(() => {
+     if (paused === void 0 || reduced) return;
++    const finished = !player.loop && player.currentMs >= player.durationMs;
+     if (paused) tc.pause();
+-    else tc.play();
++    else if (!finished) tc.play();
+   }, [paused, reduced, tc]);
+   useEffect(() => {
+     const offs = [];

--- a/src/components/Home/HeroCarousel/index.tsx
+++ b/src/components/Home/HeroCarousel/index.tsx
@@ -76,7 +76,7 @@ export default function HeroCarousel({ tabs = productUsageTabs, className }: { t
                                                     key={progressKey}
                                                     className={`h-full rounded-full ${tab.progressBar}`}
                                                     style={{
-                                                        animation: `hero-carousel-progress ${SLIDE_DURATION}ms linear forwards`,
+                                                        animation: `carousel-progress ${SLIDE_DURATION}ms linear forwards`,
                                                         animationPlayState: effectivelyPaused ? 'paused' : 'running',
                                                     }}
                                                     onAnimationEnd={advance}

--- a/src/components/Home/ToolsTicker/README.md
+++ b/src/components/Home/ToolsTicker/README.md
@@ -25,7 +25,7 @@ Handles that don't resolve to a product with a `name` and `slug` are silently sk
 ## How the loop works
 
 - The item list is rendered **twice** inside a `flex w-max` track.
-- The `tools-ticker-marquee` keyframe (defined in `src/styles/global.css`, next to `hero-carousel-progress`) animates the track from `translateX(0)` to `translateX(-50%)` – exactly one copy's width – so the loop is seamless for any number of items.
+- The `tools-ticker-marquee` keyframe (defined in `src/styles/global.css`, next to `carousel-progress`) animates the track from `translateX(0)` to `translateX(-50%)` – exactly one copy's width – so the loop is seamless for any number of items.
 - Each `<ul>` has `pr-6` matching its internal `gap-6`, so the seam between copies is invisible.
 - Duration is `items × 2.5s`, keeping the apparent speed constant when the list changes.
 

--- a/src/components/Korean/KoreanHeroCarousel/index.tsx
+++ b/src/components/Korean/KoreanHeroCarousel/index.tsx
@@ -92,7 +92,7 @@ export default function KoreanHeroCarousel({ translate = translateKo }: { transl
                                                 key={progressKey}
                                                 className={`h-full rounded-full ${tab.progressBar}`}
                                                 style={{
-                                                    animation: `hero-carousel-progress ${SLIDE_DURATION}ms linear forwards`,
+                                                    animation: `carousel-progress ${SLIDE_DURATION}ms linear forwards`,
                                                     animationPlayState: effectivelyPaused ? 'paused' : 'running',
                                                 }}
                                                 onAnimationEnd={advance}


### PR DESCRIPTION
## Changes

Patches latent React effect loop in typecaast and fixes mismatched css animation names. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`