### PR TITLE
Handbook: always send contract templates from Drive, not local copies

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -285,15 +285,9 @@ We also sometimes receive unsolicited requests to vary our terms. In these insta
 
 ### How customers should suggest requested terms
 
-The customer should redline the current .docx version of the document in question. Always pull that copy fresh from the master template in Google Drive at the moment you send it:
+The customer should redline the current .docx version of the document in question. You can find the latest versions of the templates in the Legal Documents tab in the <PrivateLink url="https://posthog.slack.com/archives/C090RCG671C">#group-cs-sales-support</PrivateLink> Slack channel, or here — <PrivateLink url="https://docs.google.com/document/d/155w70ZAHecVZcDqTq2_415dvaq2Bk-8QlEOozjq1hG8/edit">MSA</PrivateLink>, <PrivateLink url="https://docs.google.com/document/d/1z1so_nF9f6GS0uOtf-q_Mt7LZFQCukht/edit">DPA</PrivateLink>, <PrivateLink url="https://docs.google.com/document/d/1K-1ErUrHbvNs8ed8CXSQIuA0xJdg55sC/edit">NDA</PrivateLink> (do not save versions locally).
 
--   <PrivateLink url="https://docs.google.com/document/d/155w70ZAHecVZcDqTq2_415dvaq2Bk-8QlEOozjq1hG8/edit">MSA</PrivateLink>
--   <PrivateLink url="https://docs.google.com/document/d/1K-1ErUrHbvNs8ed8CXSQIuA0xJdg55sC/edit">NDA</PrivateLink>
--   [DPA](/dpa) (generated from the site, so it's always current)
-
-These are also pinned to the canvas at the top of the #team-sales Slack channel.
-
-> **Never send a template from a local copy, a previous deal, or a forwarded thread.** The templates are revised regularly and sometimes materially — most recently the MSA changed substantially at the end of June 2026. Sending a stale template means negotiating from terms we no longer offer, and it's a lot of wasted legal time to unwind.
+> **Never send a template from a local copy, a previous deal, or a forwarded thread.** The templates are revised regularly and sometimes materially. Sending a stale template means negotiating from terms we no longer offer, and it's a lot of wasted legal time to unwind.
 
 > We don't accept redlines on our standard terms of service and if a customer has proposed this you should share the correct templates with them before involving legal.
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -285,7 +285,15 @@ We also sometimes receive unsolicited requests to vary our terms. In these insta
 
 ### How customers should suggest requested terms
 
-The customer should redline the current .docx version of the document in question. You can find the latest versions of the templates in the Team Internal Info tab in the #team-sales Slack channel (do not save versions locally).
+The customer should redline the current .docx version of the document in question. Always pull that copy fresh from the master template in Google Drive at the moment you send it:
+
+-   <PrivateLink url="https://docs.google.com/document/d/155w70ZAHecVZcDqTq2_415dvaq2Bk-8QlEOozjq1hG8/edit">MSA</PrivateLink>
+-   <PrivateLink url="https://docs.google.com/document/d/1K-1ErUrHbvNs8ed8CXSQIuA0xJdg55sC/edit">NDA</PrivateLink>
+-   [DPA](/dpa) (generated from the site, so it's always current)
+
+These are also pinned to the canvas at the top of the #team-sales Slack channel.
+
+> **Never send a template from a local copy, a previous deal, or a forwarded thread.** The templates are revised regularly and sometimes materially — most recently the MSA changed substantially at the end of June 2026. Sending a stale template means negotiating from terms we no longer offer, and it's a lot of wasted legal time to unwind.
 
 > We don't accept redlines on our standard terms of service and if a customer has proposed this you should share the correct templates with them before involving legal.
 

--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -169,8 +169,6 @@ Occasionally, customers will want to sign an MSA instead of referencing our term
 
 Sometimes large customers will ask for changes to our MSA. We have a list of the kinds of changes we will/won't consider in a private repo in the [company-internal sales contract changes directory](https://github.com/PostHog/company-internal/blob/master/finance/sales%20contract%20changes) that you can generally agree to without the Ops team reviewing. However, if you are ever in doubt, ask in `#legal` in Slack
 
-> **The MSA was materially revised at the end of June 2026** to add a license covering model training on customer data. Customers signed onto an earlier version of the MSA don't have that license at all — so they can't be opted in to AI training, and the option should be disabled on their account rather than left available for them to switch on. Check which version of the template a customer signed before answering questions about AI training.
-
 ## Business Associate Agreement (BAA)
 
 We offer HIPAA Compliance on PostHog Cloud and as such health companies will require us to sign a Business Associate Agreement with them. As this means we take on increased financial risk in case of a breach we ask them as a minimum to subscribe to one of the platform packages which is a guaranteed monthly payment. A maximum of one BAA per organization will be signed. Under most circumstances, it should be the company that owns the org/pays us.

--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -158,7 +158,7 @@ For newly purchased credits to cover the intended invoice automatically, both of
 
 Occasionally, customers will want to sign an MSA instead of referencing our terms in an order form. 
 
-1. Download a copy of the [PostHog Cloud MSA](https://docs.google.com/document/d/155w70ZAHecVZcDqTq2_415dvaq2Bk-8QlEOozjq1hG8/edit#heading=h.y38xfjgcg4xm) as a Word Document (legal teams prefer this format) and share it with your Customer contact.
+1. Download a fresh copy of the <PrivateLink url="https://docs.google.com/document/d/155w70ZAHecVZcDqTq2_415dvaq2Bk-8QlEOozjq1hG8/edit">PostHog Cloud MSA</PrivateLink> as a Word Document (legal teams prefer this format) and share it with your Customer contact. Download it from Drive every time — never reuse a copy saved locally or one from a previous deal, as the template is revised regularly.
 2. They may want to propose changes (also known as 'redlines'). Work with Hector or Fraser to get these agreed.
 3. Create a new document in PandaDoc, you can choose to either import from Google Drive or upload from your local machine. This should be the clean, non-redlined document as agreed by both parties.
 4. Change the name to be `PostHog Cloud MSA - CUSTOMER LEGAL NAME`.
@@ -168,6 +168,8 @@ Occasionally, customers will want to sign an MSA instead of referencing our term
 8. Send for signature - so long as any proposed changes have been reviewed and approved by Hector or Fraser, you are free to sign on behalf of PostHog
 
 Sometimes large customers will ask for changes to our MSA. We have a list of the kinds of changes we will/won't consider in a private repo in the [company-internal sales contract changes directory](https://github.com/PostHog/company-internal/blob/master/finance/sales%20contract%20changes) that you can generally agree to without the Ops team reviewing. However, if you are ever in doubt, ask in `#legal` in Slack
+
+> **The MSA was materially revised at the end of June 2026** to add a license covering model training on customer data. Customers signed onto an earlier version of the MSA don't have that license at all — so they can't be opted in to AI training, and the option should be disabled on their account rather than left available for them to switch on. Check which version of the template a customer signed before answering questions about AI training.
 
 ## Business Associate Agreement (BAA)
 
@@ -185,7 +187,7 @@ We offer HIPAA Compliance on PostHog Cloud and as such health companies will req
 In some cases, prospective or current customers require a mutual Non-disclosure Agreement (MNDA) in place before conversastion or product activity can proceed. Terms already specify Confidentiality and if there is still a situation where a documented agreement is requested this can be easily accommodated. 
 
 - Access PandaDoc and Create a New Document
-- Use the current PostHog - NDA template
+- Use the current PostHog - NDA template, which is kept in <PrivateLink url="https://docs.google.com/document/d/1K-1ErUrHbvNs8ed8CXSQIuA0xJdg55sC/edit">Google Drive</PrivateLink> — pull it fresh rather than reusing a copy from a previous deal
 - Add your desired contact as a recipient and follow the usual PandaDoc process
 - When document is complete, it will be stored in the Document library and can also be attached to the Salesforce account for future reference
 


### PR DESCRIPTION
## Changes

Updates the two sales contract handbook pages so it is unambiguous that customer-facing templates must come from the current master copy, never from a local or previously-used file.

- `contract-rules.md` — "How customers should suggest requested terms" now points at the Legal Documents tab in `#group-cs-sales-support` (previously the Team Internal Info tab in `#team-sales`) and links the MSA, DPA, and NDA templates inline. Adds a callout not to send a template from a local copy, a previous deal, or a forwarded thread.
- `contracts.md` — the MSA and NDA links now point at the current templates with a download-fresh-every-time instruction.

All template and Slack links use `<PrivateLink>`, so they are only accessible to PostHog org members while the handbook pages themselves stay public.

## Why

Templates get revised periodically, sometimes materially, so a stale copy can mean negotiating from terms we no longer offer. The handbook did not previously link the current templates or state the "pull it fresh" rule clearly, and the channel reference was out of date.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090RCG671C/p1785778063931169?thread_ts=1785778063.931169&cid=C090RCG671C)*