### PR TITLE
Remove $100k minimum for AWS Marketplace deals

### DIFF
--- a/contents/handbook/growth/sales/selling-via-aws.md
+++ b/contents/handbook/growth/sales/selling-via-aws.md
@@ -20,7 +20,7 @@ AWS Marketplace lets vendors use their own terms and MSA. For now, PostHog team 
 
 For now, we're keeping it simple:
 - **Annual contracts only** (upfront payment)
-- **Minimum $100k deal size** (this is flexible, but let's start here)
+- **No minimum deal size beyond our usual [sales-assist threshold](/handbook/growth/sales/new-sales#leads-below-the-sales-assist-threshold-less-than-20k-arr)** – there's no extra overhead in selling this way, so if a customer wants to procure via AWS Marketplace, go ahead
 
 ## Using Clazar for private offers
 


### PR DESCRIPTION
## Changes

Drops the $100k minimum deal size from the [Procuring and selling via AWS](https://posthog.com/handbook/growth/sales/selling-via-aws) handbook page. AWS Marketplace deals now just need to clear our standard sales-assist threshold.

**Why:** Selling through AWS Marketplace doesn't add overhead on our side, so there's no reason to gate it behind a higher deal size than any other deal — the $100k floor was turning away customers who wanted to procure this way.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09677WV1GW/p1785780337094149?thread_ts=1785780337.094149&cid=C09677WV1GW)*