### PR TITLE
Default to Stripe over AWS Marketplace for billing

### DIFF
--- a/contents/handbook/growth/sales/selling-via-aws.md
+++ b/contents/handbook/growth/sales/selling-via-aws.md
@@ -9,6 +9,14 @@ PostHog is now available on AWS Marketplace for SaaS products. The way we've cho
 
 AWS Marketplace lets vendors use their own terms and MSA. For now, PostHog team members set the price as a lump sum credit purchase for **annual pre-payment only**. Down the road, if we change our listing to public on the marketplace, we could set up usage-based billing through AWS (but that's future state).
 
+## Default to Stripe
+
+**Stripe is our default billing method. Only use AWS Marketplace when the customer specifically asks for it.**
+
+Stripe charges a flat fee per bank transfer regardless of deal size, and the cash lands with us straight away. AWS Marketplace takes a percentage cut on new contracts and disburses on its own schedule, so we get paid less and later, with more admin along the way.
+
+That said, we don't want to block customers from buying the way that's easiest for them. If procuring through their existing AWS spend is what unblocks the deal, use AWS Marketplace — it's available, we're just not promoting it. Don't offer it unprompted.
+
 ## Why this matters
 
 1. **Our ICP lives in AWS** - Product engineers already have AWS access and budget. Adding PostHog to their AWS bill just makes sense since we're part of their product infrastructure stack


### PR DESCRIPTION
## Changes

Adds a "Default to Stripe" section to the [Procuring and selling via AWS](https://posthog.com/handbook/growth/sales/selling-via-aws) handbook page: Stripe is the default billing method, and AWS Marketplace is used only when a customer specifically asks for it. Also makes explicit that we don't offer it unprompted, but won't block a customer who wants it.

**Why:** Stripe charges a flat fee per bank transfer and the cash arrives immediately, while AWS Marketplace takes a percentage on new contracts, pays out on a slower schedule, and adds admin overhead. The page previously read as neutral between the two.

Stacked conceptually with [#19208](https://github.com/PostHog/posthog.com/pull/19208) (removing the deal-size floor) but branched off master and touches a different part of the page, so the two can merge in either order.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09677WV1GW/p1785780337094149?thread_ts=1785780337.094149&cid=C09677WV1GW)*