### PR TITLE
Fix white rectangle behind name pills on the product team page and stale posthog-code team slug

### DIFF
--- a/contents/handbook/engineering/ai/products.md
+++ b/contents/handbook/engineering/ai/products.md
@@ -329,7 +329,7 @@ Even inspiration-driven features (not from user data) benefit from PostHog Deskt
 
 ### Current status
 
-Right now we're focused on dogfooding — getting the <SmallTeam slug="posthog-code" /> to build everything using PostHog Desktop itself. This lets us refine product quality and identify friction fast.
+Right now we're focused on dogfooding — getting the <SmallTeam slug="posthog-desktop" /> to build everything using PostHog Desktop itself. This lets us refine product quality and identify friction fast.
 
 ### For engineers not using PostHog Desktop
 
@@ -337,7 +337,7 @@ When PostHog Desktop isn't the right fit (maybe you don't trust AI to ship code 
 
 ### Ownership
 
-The dedicated <SmallTeam slug="posthog-code" /> owns the product. The <SmallTeam slug="posthog-ai" /> owns the background sandboxed agents. See [Team Structure](/handbook/engineering/ai/team-structure) for collaboration details.
+The dedicated <SmallTeam slug="posthog-desktop" /> owns the product. The <SmallTeam slug="posthog-ai" /> owns the background sandboxed agents. See [Team Structure](/handbook/engineering/ai/team-structure) for collaboration details.
 
 ## Wizard: AI-powered onboarding [General availability]
 

--- a/contents/handbook/engineering/ai/team-structure.md
+++ b/contents/handbook/engineering/ai/team-structure.md
@@ -14,7 +14,7 @@ This page explains how teams collaborate on AI features at PostHog. For a high-l
 
 ### The PostHog Desktop team
 
-<SmallTeam slug="posthog-code" /> builds PostHog Desktop, an agent-powered product workspace. Everything you and your team need to build and manage your self-driving product. The product is organized around channels that create a multiplayer experience around working with agents, then augment the agent sessions with PostHog's data and channel context that learns over time
+<SmallTeam slug="posthog-desktop" /> builds PostHog Desktop, an agent-powered product workspace. Everything you and your team need to build and manage your self-driving product. The product is organized around channels that create a multiplayer experience around working with agents, then augment the agent sessions with PostHog's data and channel context that learns over time
 
 The PostHog Desktop team owns the desktop app and the task execution pipeline.
 

--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -27,7 +27,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 <div className="grid @md:grid-cols-2 gap-4">
 
 <fieldset>
-<legend><TeamMember name="Anna Szell" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Anna Szell" photo /></legend>
 
 -   <SmallTeam slug="data-modeling" />
 -   <SmallTeam slug="data-tools" />
@@ -37,7 +37,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend><TeamMember name="Annika Schmid" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Annika Schmid" photo /></legend>
 
 -   <SmallTeam slug="posthog-desktop" />
 -   <SmallTeam slug="self-driving" />
@@ -45,7 +45,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend><TeamMember name="Cory Slater" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Cory Slater" photo /></legend>
 
 -   <SmallTeam slug="error-tracking" />
 -   <SmallTeam slug="replay" />
@@ -57,7 +57,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend><TeamMember name="Abe Basu" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Abe Basu" photo /></legend>
 
 -   <SmallTeam slug="batch-exports" />
 -   <SmallTeam slug="apm" />
@@ -67,7 +67,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend><TeamMember name="Mike Warren" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Mike Warren" photo /></legend>
 
 -   <SmallTeam slug="analytics-platform" />
 -   <SmallTeam slug="mcp-analytics" />
@@ -78,7 +78,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend><TeamMember name="Marco Gancitano" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Marco Gancitano" photo /></legend>
 
 -   <SmallTeam slug="ai-observability" />
 -   <SmallTeam slug="ai-gateway" />
@@ -87,7 +87,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend><TeamMember name="Ruby Childs" photo /></legend>
+<legend className="bg-transparent"><TeamMember name="Ruby Childs" photo /></legend>
 
 -   <SmallTeam slug="experiments" />
 -   <SmallTeam slug="feature-flags" />
@@ -95,7 +95,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 </fieldset>
 
 <fieldset>
-<legend>Product teams with no PM currently</legend>
+<legend className="bg-transparent">Product teams with no PM currently</legend>
 
 -   <SmallTeam slug="conversations" />
 

--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -39,7 +39,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 <fieldset>
 <legend><TeamMember name="Annika Schmid" photo /></legend>
 
--   <SmallTeam slug="posthog-code" />
+-   <SmallTeam slug="posthog-desktop" />
 -   <SmallTeam slug="self-driving" />
 
 </fieldset>

--- a/contents/teams/ai-gateway/index.mdx
+++ b/contents/teams/ai-gateway/index.mdx
@@ -10,7 +10,7 @@ The AI gateway is PostHog's internal routing layer for calling LLM providers. It
 
 ## Working with other teams
 
-The gateway sits underneath PostHog's AI features, so most internal teams shipping AI functionality call it instead of providers directly — and as we move to general availability, external customers route through the same gateway. We work closely with <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, <SmallTeam slug="self-driving" />, <SmallTeam slug="ai-observability" />, and any small team adding AI features to their product.
+The gateway sits underneath PostHog's AI features, so most internal teams shipping AI functionality call it instead of providers directly — and as we move to general availability, external customers route through the same gateway. We work closely with <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-desktop" />, <SmallTeam slug="agents" />, <SmallTeam slug="self-driving" />, <SmallTeam slug="ai-observability" />, and any small team adding AI features to their product.
 
 Come to us if you:
 

--- a/contents/teams/ai-gateway/objectives.mdx
+++ b/contents/teams/ai-gateway/objectives.mdx
@@ -5,7 +5,7 @@
 *Description*: Carry all of PostHog's internal AI traffic on the gateway, and go live with the first paying customers.
 
 *What we will ship*:
-- **100% internal traffic** – route <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground through the gateway and switch off the old one
+- **100% internal traffic** – route <SmallTeam slug="posthog-ai" />, <SmallTeam slug="posthog-desktop" />, <SmallTeam slug="agents" />, and the <SmallTeam slug="ai-observability" /> Playground through the gateway and switch off the old one
 - **Alpha/beta paying customers** – get the first external orgs live and billed
 - **Accurate, secure billing** – track usage, spend, and balances correctly and securely before we charge real money
 
@@ -20,7 +20,7 @@
 
 #### Goal 3: Auth and attribution
 
-*Description*: Generalize our authentication and attribution solutions for <SmallTeam slug="posthog-code" />, <SmallTeam slug="agents" />, and external customers.
+*Description*: Generalize our authentication and attribution solutions for <SmallTeam slug="posthog-desktop" />, <SmallTeam slug="agents" />, and external customers.
 
 *What we will ship*:
 - **Per-user spend controls** – enforce rate limits, spend caps, overspend, and sub-wallets per user

--- a/src/components/Roadmap/roadmapTeamOverrides.ts
+++ b/src/components/Roadmap/roadmapTeamOverrides.ts
@@ -54,7 +54,7 @@ export const ROADMAP_TEAM_OVERRIDES: Record<string, string> = {
     'b2b-analytics': 'customer-analytics',
     'cookie-banner-product': 'web-analytics',
     'customer-support-product': 'conversations',
-    'code-editor': 'posthog-code',
+    'code-editor': 'posthog-desktop',
     'toolbar-for-mobile': 'growth', // toolbar area
     'ai-api-access': 'ai-gateway',
     'product-tours': 'surveys',

--- a/src/components/TeamMember/index.tsx
+++ b/src/components/TeamMember/index.tsx
@@ -64,7 +64,7 @@ export const TeamMemberLink = ({
                 <span
                     className={`inline-flex items-center ${
                         photo
-                            ? 'absolute top-0 left-0 whitespace-nowrap gap-1.5 p-0.5 pr-1.5 border border-primary rounded-full bg-light text-dark'
+                            ? 'absolute top-0 left-0 whitespace-nowrap gap-1.5 p-0.5 pr-1.5 border border-primary rounded-full text-primary'
                             : 'border-b border-primary border-dashed'
                     } ${className}`}
                 >

--- a/src/components/TeamMember/index.tsx
+++ b/src/components/TeamMember/index.tsx
@@ -64,7 +64,7 @@ export const TeamMemberLink = ({
                 <span
                     className={`inline-flex items-center ${
                         photo
-                            ? 'absolute top-0 left-0 whitespace-nowrap gap-1.5 p-0.5 pr-1.5 border border-primary rounded-full text-primary'
+                            ? 'absolute top-0 left-0 whitespace-nowrap gap-1.5 p-0.5 pr-1.5 border border-primary rounded-full bg-light text-dark'
                             : 'border-b border-primary border-dashed'
                     } ${className}`}
                 >


### PR DESCRIPTION
## Changes

- On `/handbook/product/product-team`, each PM name sits in a `<legend>`. The global `fieldset legend` rule applies `bg-primary`, which paints a white rectangle that extends past the rounded name pill (via `px-1 -mx-1`) and clashes with the page's accent surface. Overrode those legends with `bg-transparent`, matching the existing convention in `credits/index.tsx` and `VideosSlide.tsx`. The pill itself is unchanged. The native legend border gap still keeps the fieldset line from striking through.
- The PostHog Desktop small team's slug is `posthog-desktop`, but a handful of pages still passed `slug="posthog-code"` to `<SmallTeam />`. That slug no longer resolves, so those spots rendered the raw string `posthog-code` as plain text instead of a linked team pill. Updated on `/handbook/product/product-team`, `/handbook/engineering/ai/team-structure`, `/handbook/engineering/ai/products`, and the AI gateway team pages, plus the same stale value in `roadmapTeamOverrides.ts`.

**Why:** raised in Slack — the white box behind names on the product team page looked wrong, and Annika's team showed as `posthog-code` instead of linking to the PostHog Desktop team.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*