### PR TITLE
Prefer passkey for Shopify login in merch store handbook

### DIFF
--- a/contents/handbook/company/merch-store.md
+++ b/contents/handbook/company/merch-store.md
@@ -42,16 +42,14 @@ Create a discount code in <PrivateLink url="https://admin.shopify.com/store/post
 To log into Shopify using 1Password:
 
 1. Sign in with the email from 1Password
-2. When the saved passkey pop-up appears, use the passkey — this is the preferred way to log in
-3. You're logged in!
+2. Ignore the saved passkey pop-up — you'll use the passkey later, after entering the password
+3. Click "Log in using a different method"
+4. Click "Continue with password"
+5. Use the password from 1Password and click "Log in"
+6. On the "Use your passkey" screen, use the passkey from 1Password — this is the preferred way to log in
+7. You're logged in!
 
-Only if the passkey doesn't work (for example, you don't have access to it) fall back to the password and authentication code:
-
-1. Click "Log in using a different method"
-2. Click "Continue with password"
-3. Use the password from 1Password and click "Log in"
-4. On the "Use your passkey" screen, click "Use the authentication app" — you can then use 1Password to enter the authentication code
-5. You're logged in!
+If you aren't prompted to use the passkey, click "Use the authentication app" instead — you can then use 1Password to enter the authentication code.
 
 When creating the discount, select "amount off products" then choose if it is a percentage off or a fixed amount - usually we do fixed amounts of $30, $50, or $100 depending on the purpose. The you can choose "specific collections" and choose "All Products". 
 

--- a/contents/handbook/company/merch-store.md
+++ b/contents/handbook/company/merch-store.md
@@ -42,12 +42,16 @@ Create a discount code in <PrivateLink url="https://admin.shopify.com/store/post
 To log into Shopify using 1Password:
 
 1. Sign in with the email from 1Password
-2. Ignore the saved passkey pop-up
-3. Click "Log in using a different method"
-4. Click "Continue with password"
-5. Use the password from 1Password and click "Log in"
-6. On the "Use your passkey" screen, click "Use the authentication app" — you can then use 1Password to enter the authentication code
-7. You're logged in!
+2. When the saved passkey pop-up appears, use the passkey — this is the preferred way to log in
+3. You're logged in!
+
+Only if the passkey doesn't work (for example, you don't have access to it) fall back to the password and authentication code:
+
+1. Click "Log in using a different method"
+2. Click "Continue with password"
+3. Use the password from 1Password and click "Log in"
+4. On the "Use your passkey" screen, click "Use the authentication app" — you can then use 1Password to enter the authentication code
+5. You're logged in!
 
 When creating the discount, select "amount off products" then choose if it is a percentage off or a fixed amount - usually we do fixed amounts of $30, $50, or $100 depending on the purpose. The you can choose "specific collections" and choose "All Products". 
 

--- a/contents/handbook/company/merch-store.md
+++ b/contents/handbook/company/merch-store.md
@@ -42,14 +42,16 @@ Create a discount code in <PrivateLink url="https://admin.shopify.com/store/post
 To log into Shopify using 1Password:
 
 1. Sign in with the email from 1Password
-2. Ignore the saved passkey pop-up — you'll use the passkey later, after entering the password
-3. Click "Log in using a different method"
-4. Click "Continue with password"
-5. Use the password from 1Password and click "Log in"
-6. On the "Use your passkey" screen, use the passkey from 1Password — this is the preferred way to log in
-7. You're logged in!
+2. Log in with the saved passkey when the pop-up appears — this is the preferred way to log in
+3. You're logged in!
 
-If you aren't prompted to use the passkey, click "Use the authentication app" instead — you can then use 1Password to enter the authentication code.
+If you aren't prompted for the passkey, use the password and authentication code instead:
+
+1. Click "Log in using a different method"
+2. Click "Continue with password"
+3. Use the password from 1Password and click "Log in"
+4. On the "Use your passkey" screen, click "Use the authentication app" — you can then use 1Password to enter the authentication code
+5. You're logged in!
 
 When creating the discount, select "amount off products" then choose if it is a percentage off or a fixed amount - usually we do fixed amounts of $30, $50, or $100 depending on the purpose. The you can choose "specific collections" and choose "All Products". 
 


### PR DESCRIPTION
## Changes

Reworks the Shopify login steps in the merch store handbook so the saved passkey is the primary path, and demotes the password + authentication app flow to an explicit fallback for when the passkey isn't available.

**Why:** The steps added in #18984 told everyone to ignore the passkey pop-up, but the passkey is the preferred login method and the authenticator code should only be used as a fallback.

Refs #18984

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0351B1DMUY/p1785754854868929?thread_ts=1785754854.868929&cid=C0351B1DMUY)*