### PR TITLE
Sync blog/newsletter filters (category, tag, author) to the URL

### DIFF
--- a/src/templates/PostListing.tsx
+++ b/src/templates/PostListing.tsx
@@ -12,7 +12,7 @@ import CloudinaryImage from 'components/CloudinaryImage'
 import Tooltip from 'components/RadixUI/Tooltip'
 import ProgressBar from 'components/ProgressBar'
 import slugify from 'slugify'
-import { graphql, useStaticQuery } from 'gatsby'
+import { graphql, navigate, useStaticQuery } from 'gatsby'
 import { usePaginatedPosts } from 'components/Edition/hooks/usePaginatedPosts'
 import { IconSpinner } from '@posthog/icons'
 import LikeButton from 'components/Edition/LikeButton'
@@ -73,7 +73,7 @@ export const FeaturedImage = ({ url }: { url: string }) => {
     )
 }
 
-export default function Posts({ pageContext }) {
+export default function Posts({ pageContext, location }) {
     const [loginModalOpen, setLoginModalOpen] = useState(false)
     const { allPostCategory } = useStaticQuery(graphql`
         {
@@ -102,13 +102,28 @@ export default function Posts({ pageContext }) {
         }
     `)
     const articleRef = useRef<HTMLDivElement>(null)
+    const initialFilters = useMemo(() => {
+        const searchParams = new URLSearchParams(location?.search)
+        const category = searchParams.get('category')
+        const tag = searchParams.get('tag')
+        return {
+            root: category ? (category === 'all' ? null : category) : pageContext.root || null,
+            tag: tag ? (tag === 'all' ? null : tag) : pageContext.selectedTag,
+            author: searchParams.get('author') ? Number(searchParams.get('author')) : undefined,
+        }
+    }, [])
     const [authors, setAuthors] = useState<any[]>([])
-    const [selectedTag, setSelectedTag] = useState(pageContext.selectedTag)
-    const [root, setRoot] = useState(pageContext.root || null)
-    const [selectedAuthor, setSelectedAuthor] = useState()
-    const [sort, setSort] = useState(getSortOption(pageContext.root).label)
+    const [selectedTag, setSelectedTag] = useState(initialFilters.tag)
+    const [root, setRoot] = useState(initialFilters.root)
+    const [selectedAuthor, setSelectedAuthor] = useState(initialFilters.author)
+    const [sort, setSort] = useState(getSortOption(initialFilters.root).label)
     const [params, setParams] = useState(
-        getParams(pageContext.root, pageContext.selectedTag, getSortOption(pageContext.root).sort, selectedAuthor)
+        getParams(
+            initialFilters.root,
+            initialFilters.tag,
+            getSortOption(initialFilters.root).sort,
+            initialFilters.author
+        )
     )
     const allTags = useMemo(
         () =>
@@ -199,6 +214,25 @@ export default function Posts({ pageContext }) {
         scrollToTop()
     }, [selectedTag, root, selectedAuthor, sort])
 
+    useEffect(() => {
+        if (typeof window === 'undefined') return
+        const searchParams = new URLSearchParams()
+        if (root !== (pageContext.root || null)) {
+            searchParams.set('category', root ?? 'all')
+        }
+        if ((selectedTag || null) !== (pageContext.selectedTag || null)) {
+            searchParams.set('tag', selectedTag ?? 'all')
+        }
+        if (selectedAuthor) {
+            searchParams.set('author', String(selectedAuthor))
+        }
+        const search = searchParams.toString()
+        const newUrl = `${location.pathname}${search ? `?${search}` : ''}`
+        if (newUrl !== window.location.pathname + window.location.search) {
+            navigate(newUrl, { replace: true })
+        }
+    }, [selectedTag, root, selectedAuthor])
+
     return (
         <PostsContext.Provider value={{ setLoginModalOpen }}>
             <SEO title="Posts - PostHog" />
@@ -276,6 +310,7 @@ export default function Posts({ pageContext }) {
                               {
                                   label: 'author',
                                   value: 'authors',
+                                  initialValue: selectedAuthor,
                                   options: [
                                       {
                                           label: 'All',


### PR DESCRIPTION
## Problem

On post listing pages like [/blog](https://posthog.com/blog) and [/newsletter](https://posthog.com/newsletter), changing the category, tags, or author dropdown only updates local state, so the URL never changes. That means a filtered view (e.g. tag = Experimentation, or everything by one author) can't be shared or bookmarked.

## Changes

All in `src/templates/PostListing.tsx` (the template behind `/blog`, `/newsletter`, `/founders`, etc.):

- Filter changes now write query params in place via `navigate(url, { replace: true })` — e.g. `/newsletter?tag=Experimentation&author=34044`, `/blog?category=newsletter`. Same pattern already used by `TemplatesLibrary`/`IntegrationsLibrary`, and safe within the window system since windows are matched by pathname only (no new window opens).
- Opening a URL with `category`, `tag`, or `author` params hydrates the filter state (and the dropdowns) so the first fetch is already filtered.
- `category`/`tag` only appear in the URL when they differ from the page's own default, with an `all` sentinel for explicitly clearing a prerendered tag page's tag. `replace: true` keeps the history clean.
- Param names (`category`, `tag`, `author`) intentionally differ from `ViewerFilters`' internal keys (`root`, `post_tags`, `authors`) so its existing read-only URL hydration doesn't double-handle them.

<img width="1366" height="583" alt="Screenshot 2026-08-03 at 8 10 53 PM" src="https://github.com/user-attachments/assets/f476f455-fbdc-4d59-8331-daf2aca57cf6" />

Sort is deliberately not synced.

## How I tested

Puppeteer against the local dev server, all passing:
1. Changing tags on `/newsletter` → URL becomes `/newsletter?tag=Product+engineers`, pathname unchanged, no new window.
2. Changing author → `&author=34044` appended.
3. Reloading the shared URL → dropdowns show `tags:Product engineers` / `author:Abe Basu` and the list is filtered on first load.
4. Resetting tag to All → param removed.
5. Changing category on `/blog` → `/blog?category=newsletter`, pathname unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*