### PR TITLE
Add Voice of the customer handbook page

### DIFF
--- a/contents/handbook/cs-and-onboarding/voice-of-the-customer.md
+++ b/contents/handbook/cs-and-onboarding/voice-of-the-customer.md
@@ -1,0 +1,37 @@
+---
+title: Voice of the customer
+sidebar: Handbook
+showTitle: true
+---
+
+CSMs are uniquely positioned to gather qualitative insights on top of just customer data trends. The goal of this page is to provide a framework to help CSMs keep track of important customer signals and to create a formal feedback loop with Product, Engineering, and Marketing. Things like how a customer talks about PostHog versus a competitor, where the product confuses them, what made them hesitate on a renewal, phrases they use that don't match how we describe a feature. Feature requests, churn risk, and open support issues are all already tracked - this process provides a place to gather softer, potentially compounding customer sentiment, so product, marketing, and engineering can act on signals gathered from those who are closest to them (CSMs!).
+
+## When to use this vs. other channels
+
+If something is urgent, like a customer is at risk of churn, or something is actively broken, don't wait for the monthly roll-up. Flag it immediately per [handling customer issues](/handbook/cs-and-onboarding/handling-customer-issues) or directly in the relevant team's Slack channel. This process is for slower-moving, pattern-level signal that's valuable precisely because it accumulates across accounts and over time.
+
+## Signal categories
+
+- **Sentiment & relationship health.** Notable shifts in how a customer feels about PostHog, not already flagged as a churn risk.
+- **Competitive intel.** Competitor mentions, comparisons, or reasons a customer evaluated alternatives.
+- **Positioning & messaging.** How customers describe PostHog in their own words, and where they get confused about what something does or is called.
+- **Usage & workflow friction.** Recurring struggle with the product that isn't yet a formal feature request.
+- **Pricing & packaging feedback.** Reactions to plans, billing, or how customers perceive the value they're getting.
+
+## The process
+
+1. Each CSM keeps a running doc through the month covering their book of accounts. These are highlights, standout observations rather than comprehensive notes.
+2. By the end of the month, every CSM submits their roll-up using the template below.
+3. The CS team lead aggregates submissions, clusters repeated signals across accounts, and adds an actionable takeaway that captures the overall customer signal. This is then shared in the relevant team's Slack channel, tagging the associated team lead.
+
+## Template
+
+For each notable signal, capture:
+
+- **Account name**
+- **Category** — one of the five above
+- **What happened** — the observation or a direct quote
+- **Why it matters** — the potential impact if it goes unaddressed
+- **Suggested audience** — product, marketing, or engineering
+
+A CSM with nothing notable for a given category in a given month simply leaves it blank — this isn't a form to pad out, it's a place to put signal that would otherwise get lost.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1462,6 +1462,10 @@ export const handbookSidebar = [
                         name: 'Engaging unengaged customers',
                         url: '/handbook/cs-and-onboarding/engaging-unengaged-customers',
                     },
+                    {
+                        name: 'Voice of the customer',
+                        url: '/handbook/cs-and-onboarding/voice-of-the-customer',
+                    },
                 ],
             },
             {


### PR DESCRIPTION
## Summary
- Adds a new Customer Success handbook page formalizing a monthly process for CSMs to roll up customer signals (sentiment, competitive intel, positioning/messaging, usage friction, pricing feedback) that don't already have a home in feature request tracking or churn/issue handling
- Adds the page to the Customer Success section of the handbook nav

## Test plan
- [ ] Confirm page renders correctly at `/handbook/cs-and-onboarding/voice-of-the-customer`
- [ ] Confirm nav entry appears at the end of the Customer Success section