### PR TITLE
Add cta variants

### DIFF
--- a/src/components/Home/HeroCTA/index.tsx
+++ b/src/components/Home/HeroCTA/index.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useLayoutEffect, useState } from 'react'
+import usePostHog from '../../../hooks/usePostHog'
+import { DEFAULT_HERO_CTA_VARIANT, resolveHeroCtaVariant, type HeroCtaVariant } from './variants'
+
+export const HERO_CTA_FLAG = 'homepage-cta'
+
+const HeroCtaContext = React.createContext<HeroCtaVariant>(DEFAULT_HERO_CTA_VARIANT)
+
+export function useHeroCtaVariant(): HeroCtaVariant {
+    return React.useContext(HeroCtaContext)
+}
+
+let hasHydrated = false
+
+/** `useLayoutEffect` warns when it runs during SSR, so fall back to `useEffect` there. */
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+export function HeroCtaProvider({ children }: { children: React.ReactNode }): JSX.Element {
+    const posthog = usePostHog()
+
+    const [variant, setVariant] = useState<HeroCtaVariant>(() => {
+        if (!hasHydrated) return DEFAULT_HERO_CTA_VARIANT
+        return resolveHeroCtaVariant(posthog?.getFeatureFlag?.(HERO_CTA_FLAG)) ?? DEFAULT_HERO_CTA_VARIANT
+    })
+
+    // Layout effect, not a passive one: on a cold load the control has to render for hydration, but
+    // if the flag is already cached this applies the real variant in the same commit, before the
+    // browser paints, so there's no visible swap. When the flag isn't cached yet it changes nothing
+    // and the `onFeatureFlags` subscription below picks it up whenever it lands.
+    useIsomorphicLayoutEffect(() => {
+        hasHydrated = true
+        if (!posthog) return
+        const assigned = resolveHeroCtaVariant(posthog.getFeatureFlag?.(HERO_CTA_FLAG))
+        if (assigned) setVariant(assigned)
+    }, [posthog])
+
+    useEffect(() => {
+        if (!posthog) return
+        const unsubscribe = posthog.onFeatureFlags?.(() => {
+            const assigned = resolveHeroCtaVariant(posthog.getFeatureFlag?.(HERO_CTA_FLAG))
+            if (assigned) setVariant(assigned)
+        }) as unknown
+        return typeof unsubscribe === 'function' ? (unsubscribe as () => void) : undefined
+    }, [posthog])
+
+    return <HeroCtaContext.Provider value={variant}>{children}</HeroCtaContext.Provider>
+}
+
+/** The CTA slot itself. Must be rendered inside `HeroCtaProvider`. */
+export default function HeroCTA(): JSX.Element {
+    const { Component } = useHeroCtaVariant()
+
+    return (
+        <div className="w-full flex flex-col items-center min-w-0">
+            <Component />
+        </div>
+    )
+}
+
+export { HERO_CTA_VARIANTS, DEFAULT_HERO_CTA_VARIANT, resolveHeroCtaVariant } from './variants'
+export type { HeroCtaVariant } from './variants'

--- a/src/components/Home/HeroCTA/index.tsx
+++ b/src/components/Home/HeroCTA/index.tsx
@@ -1,60 +1,28 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react'
+import React from 'react'
+import { RenderInClient } from 'components/RenderInClient'
 import usePostHog from '../../../hooks/usePostHog'
-import { DEFAULT_HERO_CTA_VARIANT, resolveHeroCtaVariant, type HeroCtaVariant } from './variants'
+import { DEFAULT_HERO_CTA_VARIANT, resolveHeroCtaVariant } from './variants'
 
 export const HERO_CTA_FLAG = 'homepage-cta'
 
-const HeroCtaContext = React.createContext<HeroCtaVariant>(DEFAULT_HERO_CTA_VARIANT)
-
-export function useHeroCtaVariant(): HeroCtaVariant {
-    return React.useContext(HeroCtaContext)
-}
-
-let hasHydrated = false
-
-/** `useLayoutEffect` warns when it runs during SSR, so fall back to `useEffect` there. */
-const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect
-
-export function HeroCtaProvider({ children }: { children: React.ReactNode }): JSX.Element {
+function VariantSlot(): JSX.Element {
     const posthog = usePostHog()
-
-    const [variant, setVariant] = useState<HeroCtaVariant>(() => {
-        if (!hasHydrated) return DEFAULT_HERO_CTA_VARIANT
-        return resolveHeroCtaVariant(posthog?.getFeatureFlag?.(HERO_CTA_FLAG)) ?? DEFAULT_HERO_CTA_VARIANT
-    })
-
-    // Layout effect, not a passive one: on a cold load the control has to render for hydration, but
-    // if the flag is already cached this applies the real variant in the same commit, before the
-    // browser paints, so there's no visible swap. When the flag isn't cached yet it changes nothing
-    // and the `onFeatureFlags` subscription below picks it up whenever it lands.
-    useIsomorphicLayoutEffect(() => {
-        hasHydrated = true
-        if (!posthog) return
-        const assigned = resolveHeroCtaVariant(posthog.getFeatureFlag?.(HERO_CTA_FLAG))
-        if (assigned) setVariant(assigned)
-    }, [posthog])
-
-    useEffect(() => {
-        if (!posthog) return
-        const unsubscribe = posthog.onFeatureFlags?.(() => {
-            const assigned = resolveHeroCtaVariant(posthog.getFeatureFlag?.(HERO_CTA_FLAG))
-            if (assigned) setVariant(assigned)
-        }) as unknown
-        return typeof unsubscribe === 'function' ? (unsubscribe as () => void) : undefined
-    }, [posthog])
-
-    return <HeroCtaContext.Provider value={variant}>{children}</HeroCtaContext.Provider>
-}
-
-/** The CTA slot itself. Must be rendered inside `HeroCtaProvider`. */
-export default function HeroCTA(): JSX.Element {
-    const { Component } = useHeroCtaVariant()
+    const { Component, alignsWithHeadline } =
+        resolveHeroCtaVariant(posthog?.getFeatureFlag?.(HERO_CTA_FLAG)) ?? DEFAULT_HERO_CTA_VARIANT
 
     return (
-        <div className="w-full flex flex-col items-center min-w-0">
+        <div
+            {...(alignsWithHeadline ? { 'data-cta-aligned': '' } : {})}
+            className="w-full flex flex-col items-center min-w-0"
+        >
             <Component />
         </div>
     )
+}
+
+/** The CTA slot. Renders nothing until flags resolve, so the hero never shows the wrong variant. */
+export default function HeroCTA(): JSX.Element {
+    return <RenderInClient render={() => <VariantSlot />} />
 }
 
 export { HERO_CTA_VARIANTS, DEFAULT_HERO_CTA_VARIANT, resolveHeroCtaVariant } from './variants'

--- a/src/components/Home/HeroCTA/variants.tsx
+++ b/src/components/Home/HeroCTA/variants.tsx
@@ -179,7 +179,7 @@ const SignupCard = ({ actions, footer }: { actions: React.ReactNode; footer?: Re
 
 const CommandPanel = () => (
     <div className="border-t border-primary bg-accent px-4 py-3 rounded-b space-y-1.5">
-        <p className="!text-xs text-secondary m-0">Already know what you want? Skip the browser:</p>
+        <p className="!text-xs text-secondary m-0">Happier in the terminal? Skip the browser:</p>
         <ClickableCommand />
     </div>
 )

--- a/src/components/Home/HeroCTA/variants.tsx
+++ b/src/components/Home/HeroCTA/variants.tsx
@@ -1,15 +1,19 @@
 import React, { useRef, useState } from 'react'
 import { IconCheck } from '@posthog/icons'
 import { Logo } from '@posthog/brand/logo'
-import { CallToAction } from 'components/CallToAction'
+import { CallToAction, TrackedCTA } from 'components/CallToAction'
 import PlatformInstall, { CopyableCommand, wizardInstallSchema } from 'components/PlatformInstall'
 import { buildWizardCommand } from 'components/PlatformInstall/buildCommand'
 import { RoughAnnotation } from 'components/Code/RoughAnnotation'
 import { usePrefersReducedMotion } from 'components/Code/usePrefersReducedMotion'
+import usePostHog from '../../../hooks/usePostHog'
 import { cn } from '../../../utils'
 
 const SIGNUP_URL = 'https://app.posthog.com/signup'
 const SIGNUP_STATE = { newWindow: true, initialTab: 'signup' }
+
+const COPY_EVENT = 'homepagecta-copy-clicked'
+const WEB_SIGNUP_EVENT = 'homepagecta-websignup-clicked'
 
 function useWindowEntrance(): string {
     return usePrefersReducedMotion() ? '' : 'animate-window-pop-in'
@@ -40,9 +44,16 @@ const SignupButton = ({
     width?: string
     childClassName?: string
 }) => (
-    <CallToAction to={SIGNUP_URL} size={size} width={width} state={SIGNUP_STATE} childClassName={childClassName}>
+    <TrackedCTA
+        to={SIGNUP_URL}
+        size={size}
+        width={width}
+        state={SIGNUP_STATE}
+        childClassName={childClassName}
+        event={{ name: WEB_SIGNUP_EVENT }}
+    >
         <>{children}</>
-    </CallToAction>
+    </TrackedCTA>
 )
 
 const CheckList = ({ items }: { items: React.ReactNode[] }) => (
@@ -66,10 +77,17 @@ const ClickableCommand = ({
     animate?: boolean
 }) => {
     const fieldRef = useRef<HTMLDivElement>(null)
+    const posthog = usePostHog()
     const { displayCommand, copyCommand } = buildWizardCommand({ subcommand: 'self-driving' })
 
     const copyFromAnywhere = (event: React.MouseEvent) => {
-        if ((event.target as HTMLElement).closest('button')) return
+        // Every copy passes through the button – either clicked directly, or via the forwarded click
+        // below, which bubbles back into this handler with the button as its target. Counting only
+        // that case means one event per copy, however it was triggered.
+        if ((event.target as HTMLElement).closest('button')) {
+            posthog?.capture(COPY_EVENT)
+            return
+        }
         fieldRef.current?.querySelector('button')?.click()
     }
 
@@ -108,7 +126,18 @@ const CommandOrSignup = () => (
  * small secondary link in the card header.
  * ---------------------------------------------------------------------------------------------- */
 
-const VariantControl = () => <PlatformInstall schema={wizardInstallSchema} selfDriving />
+const VariantControl = () => {
+    const posthog = usePostHog()
+
+    return (
+        <PlatformInstall
+            schema={wizardInstallSchema}
+            selfDriving
+            onCopy={() => posthog?.capture(COPY_EVENT)}
+            onSecondaryAction={() => posthog?.capture(WEB_SIGNUP_EVENT)}
+        />
+    )
+}
 
 const SIGNUP_CARD_POINTS = [
     '97% of users pay us $0',

--- a/src/components/Home/HeroCTA/variants.tsx
+++ b/src/components/Home/HeroCTA/variants.tsx
@@ -1,0 +1,322 @@
+import React, { useRef, useState } from 'react'
+import { IconCheck } from '@posthog/icons'
+import { Logo } from '@posthog/brand/logo'
+import { CallToAction } from 'components/CallToAction'
+import PlatformInstall, { CopyableCommand, wizardInstallSchema } from 'components/PlatformInstall'
+import { buildWizardCommand } from 'components/PlatformInstall/buildCommand'
+import { RoughAnnotation } from 'components/Code/RoughAnnotation'
+import { usePrefersReducedMotion } from 'components/Code/usePrefersReducedMotion'
+import { cn } from '../../../utils'
+
+const SIGNUP_URL = 'https://app.posthog.com/signup'
+const SIGNUP_STATE = { newWindow: true, initialTab: 'signup' }
+
+function useWindowEntrance(): string {
+    return usePrefersReducedMotion() ? '' : 'animate-window-pop-in'
+}
+
+const PostHogMark = ({ size, className }: { size: number; className?: string }) => (
+    <>
+        <Logo layout="logomark" size={size} title="PostHog" className={cn(className, 'dark:hidden')} />
+        <Logo
+            layout="logomark"
+            variant="mono"
+            color="white"
+            size={size}
+            title="PostHog"
+            className={cn(className, 'hidden dark:block')}
+        />
+    </>
+)
+
+const SignupButton = ({
+    children,
+    size = 'lg',
+    width = 'auto',
+    childClassName,
+}: {
+    children: React.ReactNode
+    size?: 'md' | 'lg' | 'absurd'
+    width?: string
+    childClassName?: string
+}) => (
+    <CallToAction to={SIGNUP_URL} size={size} width={width} state={SIGNUP_STATE} childClassName={childClassName}>
+        <>{children}</>
+    </CallToAction>
+)
+
+const CheckList = ({ items }: { items: React.ReactNode[] }) => (
+    <ul className="not-prose list-none p-0 m-0 space-y-1.5 text-sm text-primary">
+        {items.map((item, index) => (
+            <li key={index} className="flex items-start gap-1.5">
+                <IconCheck className="size-4 shrink-0 text-green relative top-0.5" />
+                <span>{item}</span>
+            </li>
+        ))}
+    </ul>
+)
+
+const ClickableCommand = ({
+    className,
+    commandClassName,
+    animate,
+}: {
+    className?: string
+    commandClassName?: string
+    animate?: boolean
+}) => {
+    const fieldRef = useRef<HTMLDivElement>(null)
+    const { displayCommand, copyCommand } = buildWizardCommand({ subcommand: 'self-driving' })
+
+    const copyFromAnywhere = (event: React.MouseEvent) => {
+        if ((event.target as HTMLElement).closest('button')) return
+        fieldRef.current?.querySelector('button')?.click()
+    }
+
+    return (
+        <div ref={fieldRef} onClick={copyFromAnywhere} className={cn('cursor-pointer [&>div]:h-full', className)}>
+            <CopyableCommand
+                className={commandClassName}
+                command={displayCommand}
+                copyCommand={copyCommand}
+                animate={animate}
+            />
+        </div>
+    )
+}
+
+const CommandOrSignup = () => (
+    <div className="@container border-t border-primary bg-accent px-2 py-2.5">
+        <div className="flex flex-col @[380px]:flex-row @[380px]:items-center gap-1.5">
+            <ClickableCommand
+                className="flex-1 min-w-0"
+                commandClassName="items-center bg-primary px-1.5 [&_pre]:text-xs [&_pre]:[mask-image:none] [&_pre]:[-webkit-mask-image:none]"
+                animate
+            />
+            <span className="shrink-0 text-center text-xs font-bold uppercase text-secondary">or</span>
+            <div className="shrink-0">
+                <SignupButton size="md" childClassName="whitespace-nowrap">
+                    Get started
+                </SignupButton>
+            </div>
+        </div>
+    </div>
+)
+
+/* -------------------------------------------------------------------------------------------------
+ * A — Control. The CTA exactly as it ships today: the wizard command card, with web signup as a
+ * small secondary link in the card header.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantControl = () => <PlatformInstall schema={wizardInstallSchema} selfDriving />
+
+const SIGNUP_CARD_POINTS = [
+    '97% of users pay us $0',
+    'No credit card required',
+    'Setup wizard installs PostHog for you',
+]
+
+const SignupCard = ({ actions, footer }: { actions: React.ReactNode; footer?: React.ReactNode }) => {
+    const entrance = useWindowEntrance()
+
+    return (
+        <div
+            className={cn(
+                'not-prose w-full max-w-md min-w-0 text-left border border-primary rounded-md bg-primary shadow-2xl',
+                entrance
+            )}
+        >
+            <div className="p-4 space-y-3">
+                <h3 className="!text-lg font-bold text-primary m-0 flex items-center gap-2">
+                    Set up
+                    <PostHogMark size={30} />
+                    <RoughAnnotation
+                        type="highlight"
+                        color="rgba(247, 165, 1, 0.15)"
+                        strokeWidth={1}
+                        padding={2}
+                        delay={280}
+                    >
+                        for free
+                    </RoughAnnotation>
+                </h3>
+                <CheckList items={SIGNUP_CARD_POINTS} />
+                <div className="pt-1">{actions}</div>
+            </div>
+            {footer}
+        </div>
+    )
+}
+
+const CommandPanel = () => (
+    <div className="border-t border-primary bg-accent px-4 py-3 rounded-b space-y-1.5">
+        <p className="!text-xs text-secondary m-0">Already know what you want? Skip the browser:</p>
+        <ClickableCommand />
+    </div>
+)
+
+/* -------------------------------------------------------------------------------------------------
+ * B — Dual CTA. C's card, but signup shares the row with "Install with AI", and the command starts
+ * hidden behind it. Tests whether making the terminal path opt-in – rather than always on show –
+ * pushes more people down the signup route, without removing the option.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantDualCta = () => {
+    const [showCommand, setShowCommand] = useState(false)
+
+    return (
+        <SignupCard
+            actions={
+                /* Own container so the pair splits on the card's own width, not the page's. */
+                <div className="@container">
+                    {/* flex-1 wrappers rather than `width="full"` alone: CallToAction's own w-full
+                       sizes against the flex container, which leaves the pair visibly uneven. */}
+                    <div className="flex flex-col @[340px]:flex-row gap-2">
+                        <div className="flex-1 min-w-0">
+                            <SignupButton width="full" childClassName="whitespace-nowrap">
+                                Get started
+                            </SignupButton>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <CallToAction
+                                type="secondary"
+                                size="lg"
+                                width="full"
+                                onClick={() => setShowCommand((current) => !current)}
+                            >
+                                <span className="whitespace-nowrap">Install with AI</span>
+                            </CallToAction>
+                        </div>
+                    </div>
+                </div>
+            }
+            footer={
+                <div
+                    className={cn(
+                        'grid transition-[grid-template-rows] duration-300 ease-in-out',
+                        showCommand ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                    )}
+                >
+                    <div className="overflow-hidden min-h-0">
+                        <CommandPanel />
+                    </div>
+                </div>
+            }
+        />
+    )
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * C — Signup card. Same card chrome as the control, but the contents are signup-led: full-width
+ * button, three concrete reasons to click it, command relegated to the footer.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantSignupCard = () => (
+    <SignupCard actions={<SignupButton width="full">Get started – free</SignupButton>} footer={<CommandPanel />} />
+)
+
+/* -------------------------------------------------------------------------------------------------
+ * D — Install dialog. The CTA as a system dialog, borrowing the desktop OS paradigm the rest of the
+ * site already runs on. Framing signup as a routine "Install? [OK] [Cancel]" decision is meant to
+ * make it read as low-stakes rather than as a commitment.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantInstallDialog = () => {
+    const entrance = useWindowEntrance()
+
+    return (
+        <div
+            className={cn(
+                'not-prose w-full max-w-md min-w-0 text-left border border-primary rounded-md bg-primary shadow-2xl overflow-hidden',
+                entrance
+            )}
+        >
+            {/* Title bar, echoing the window chrome the rest of the desktop uses. */}
+            <div className="flex items-center justify-between gap-2 bg-accent border-b border-primary px-3 py-1.5">
+                <span className="text-xs font-bold text-primary">Install PostHog</span>
+                <div className="flex items-center gap-1" aria-hidden="true">
+                    <span className="block size-2.5 rounded-full border border-primary" />
+                    <span className="block size-2.5 rounded-full border border-primary" />
+                </div>
+            </div>
+
+            <div className="p-4 flex gap-3">
+                {/* Gradient logomark reads on both light and dark, so no per-scheme swap needed. */}
+                <div className="shrink-0 pt-0.5">
+                    <PostHogMark size={32} />
+                </div>
+                <div className="min-w-0 space-y-1">
+                    <p className="!text-[15px] font-bold text-primary m-0">Set up PostHog on your product?</p>
+                    <p className="!text-sm text-secondary m-0">
+                        No card required – 97% of users pay us $0. The wizard installs and configures PostHog for you.
+                    </p>
+                </div>
+            </div>
+
+            <CommandOrSignup />
+        </div>
+    )
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * E — Minimal. A primary button, then the terminal route on its own line below it: a bare "or"
+ * followed by the copyable command. No card, no border around the group, no reassurance stack – just
+ * the two routes and the space between them. Tests whether the supporting copy in `b`/`c` is doing
+ * work or just adding weight.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantMinimal = () => (
+    <div className="not-prose w-full max-w-sm min-w-0 text-left">
+        <SignupButton width="full">Get started – free</SignupButton>
+
+        {/* "or" sits outside the copy field so the field itself stays a clean, obvious click target. */}
+        <div className="mt-4 flex items-center gap-2">
+            <span className="shrink-0 text-[11px] font-bold uppercase tracking-wide text-secondary">or</span>
+            <ClickableCommand
+                className="min-w-0 flex-1 bg-accent rounded-md"
+                commandClassName="items-center [&_pre]:text-xs [&_pre]:[mask-image:none] [&_pre]:[-webkit-mask-image:none]"
+            />
+        </div>
+    </div>
+)
+
+/* ---------------------------------------------------------------------------------------------- */
+
+export type HeroCtaVariant = {
+    id: string
+    alignsWithHeadline?: boolean
+    Component: () => JSX.Element
+}
+
+export const HERO_CTA_VARIANTS: HeroCtaVariant[] = [
+    {
+        id: 'control',
+        Component: VariantControl,
+    },
+    {
+        id: 'card-no-command',
+        alignsWithHeadline: true,
+        Component: VariantDualCta,
+    },
+    {
+        id: 'card',
+        alignsWithHeadline: true,
+        Component: VariantSignupCard,
+    },
+    {
+        id: 'window',
+        Component: VariantInstallDialog,
+    },
+    {
+        id: 'minimal',
+        Component: VariantMinimal,
+    },
+]
+
+export const DEFAULT_HERO_CTA_VARIANT = HERO_CTA_VARIANTS[0]
+
+export function resolveHeroCtaVariant(value: string | null | undefined): HeroCtaVariant | null {
+    if (!value) return null
+    const normalized = value.trim().toLowerCase()
+    return HERO_CTA_VARIANTS.find(({ id }) => id === normalized) ?? null
+}

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -209,7 +209,7 @@ function Hero(): JSX.Element {
                         </p>
                     </div>
 
-                    <div className="mt-6 flex flex-col items-center min-w-0 w-full @xl:row-start-2 @xl:col-start-2 @xl:group-has-[[data-cta-aligned]]:row-start-1 @xl:group-has-[[data-cta-aligned]]:row-span-2 @xl:group-has-[[data-cta-aligned]]:mt-0">
+                    <div className="mt-6 flex flex-col items-center min-w-0 w-full @xl:row-start-2 @xl:col-start-2 @xl:mt-0 @xl:justify-center @xl:group-has-[[data-cta-aligned]]:row-start-1 @xl:group-has-[[data-cta-aligned]]:row-span-2 @xl:group-has-[[data-cta-aligned]]:justify-start">
                         <HeroCTA />
                     </div>
                 </div>

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -24,8 +24,10 @@ import ToolsTicker from 'components/Home/ToolsTicker'
 // 9000; tweak the install UI via the schema prop instead. This homepage integration (Tagline,
 // GetStarted, the carousel) is the only PostHog.com-side glue and is not present on 9000.
 import PlatformInstall, { wizardInstallSchema } from 'components/PlatformInstall'
+import HeroCTA, { HeroCtaProvider, useHeroCtaVariant } from 'components/Home/HeroCTA'
 import Customers from '../Customers'
 import { RoughAnnotation } from 'components/Code/RoughAnnotation'
+import { cn } from '../../../utils'
 
 /** Loads HeroCarousel + Typecaast slides only in the browser so SSR/Helmet aren't affected. */
 function LazyHeroCarousel({ className }: { className?: string }) {
@@ -132,6 +134,20 @@ export const CTAs = () => {
 }
 
 function Hero(): JSX.Element {
+    // Some CTA variants start at the top of the layout, level with the headline rather than below it.
+    // For those, the headline moves into the left grid column so the CTA column can begin alongside it
+    // – matching `pt-4` on both keeps their text tops on the same line. The logo stays put either way.
+    const { alignsWithHeadline } = useHeroCtaVariant()
+
+    const headline = (
+        <h1 className="!text-3xl @xl:!text-4xl pt-4 mt-0">
+            Shift your product into{' '}
+            <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1 @xl:whitespace-nowrap">
+                self-driving mode
+            </span>
+        </h1>
+    )
+
     return (
         <>
             <div className="text-center @xl:text-left min-w-0">
@@ -140,15 +156,11 @@ function Hero(): JSX.Element {
                     <Logo className="hidden max-w-[157px] dark:block" variant="mono" color="white" width="auto" />
                 </h1>
 
-                <h1 className="!text-3xl @xl:!text-4xl pt-4">
-                    Shift your product into{' '}
-                    <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1 @xl:whitespace-nowrap">
-                        self-driving mode
-                    </span>
-                </h1>
+                {alignsWithHeadline ? null : headline}
 
                 <div className="grid @xl:grid-cols-2 @xl:gap-8 min-w-0">
                     <div className="min-w-0">
+                        {alignsWithHeadline ? headline : null}
                         <p className="text-balance @xl:text-wrap text-[17px]">
                             PostHog already knows your customers, which features they use, and the issues they have.
                         </p>
@@ -203,9 +215,19 @@ function Hero(): JSX.Element {
                         </p>
                     </div>
 
-                    <div className="mt-6 flex flex-col items-center min-w-0 w-full">
-                        <PlatformInstall schema={wizardInstallSchema} selfDriving />
-                        <SecondaryActions />
+                    {/* CTA variant comes from the `homepage-cta` experiment – see
+                        components/Home/HeroCTA/README.md. Falls back to the control (the wizard
+                        install card) until flags resolve. The MCP / demo / talk-to-a-human row that
+                        used to sit under this was removed from the hero; `SecondaryActions` is still
+                        used by `GetStarted` and `CTAs`. */}
+                    <div
+                        className={cn(
+                            'flex flex-col items-center min-w-0 w-full',
+                            // pt-4 mirrors the headline's own top padding so the two line up exactly.
+                            alignsWithHeadline ? '@xl:pt-4 mt-6 @xl:mt-0' : 'mt-6'
+                        )}
+                    >
+                        <HeroCTA />
                     </div>
                 </div>
             </div>
@@ -229,7 +251,9 @@ export default function HomeTest() {
     return (
         <ReaderView proseSize="lg" hideLeftSidebar showQuestions={false}>
             <div className="space-y-12">
-                <Hero />
+                <HeroCtaProvider>
+                    <Hero />
+                </HeroCtaProvider>
                 <Customers />
                 <DataStackSection />
                 <PricingSection />

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -133,34 +133,34 @@ export const CTAs = () => {
     )
 }
 
+const Headline = ({ className }: { className?: string }) => (
+    <h1 className={cn('!text-3xl @xl:!text-4xl pt-4 mt-0', className)}>
+        Shift your product into{' '}
+        <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1 @xl:whitespace-nowrap">
+            self-driving mode
+        </span>
+    </h1>
+)
+
 function Hero(): JSX.Element {
     // Some CTA variants start at the top of the layout, level with the headline rather than below it.
     // For those, the headline moves into the left grid column so the CTA column can begin alongside it
     // – matching `pt-4` on both keeps their text tops on the same line. The logo stays put either way.
     const { alignsWithHeadline } = useHeroCtaVariant()
 
-    const headline = (
-        <h1 className="!text-3xl @xl:!text-4xl pt-4 mt-0">
-            Shift your product into{' '}
-            <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1 @xl:whitespace-nowrap">
-                self-driving mode
-            </span>
-        </h1>
-    )
-
     return (
         <>
             <div className="text-center @xl:text-left min-w-0">
-                <h1 className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-8 pt-2">
+                <div className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-8 pt-2">
                     <Logo className="max-w-[157px] dark:hidden" width="auto" />
                     <Logo className="hidden max-w-[157px] dark:block" variant="mono" color="white" width="auto" />
-                </h1>
+                </div>
 
-                {alignsWithHeadline ? null : headline}
+                {alignsWithHeadline ? null : <Headline />}
 
                 <div className="grid @xl:grid-cols-2 @xl:gap-8 min-w-0">
                     <div className="min-w-0">
-                        {alignsWithHeadline ? headline : null}
+                        {alignsWithHeadline ? <Headline /> : null}
                         <p className="text-balance @xl:text-wrap text-[17px]">
                             PostHog already knows your customers, which features they use, and the issues they have.
                         </p>

--- a/src/components/Home/Test/index.tsx
+++ b/src/components/Home/Test/index.tsx
@@ -24,7 +24,7 @@ import ToolsTicker from 'components/Home/ToolsTicker'
 // 9000; tweak the install UI via the schema prop instead. This homepage integration (Tagline,
 // GetStarted, the carousel) is the only PostHog.com-side glue and is not present on 9000.
 import PlatformInstall, { wizardInstallSchema } from 'components/PlatformInstall'
-import HeroCTA, { HeroCtaProvider, useHeroCtaVariant } from 'components/Home/HeroCTA'
+import HeroCTA from 'components/Home/HeroCTA'
 import Customers from '../Customers'
 import { RoughAnnotation } from 'components/Code/RoughAnnotation'
 import { cn } from '../../../utils'
@@ -134,7 +134,7 @@ export const CTAs = () => {
 }
 
 const Headline = ({ className }: { className?: string }) => (
-    <h1 className={cn('!text-3xl @xl:!text-4xl pt-4 mt-0', className)}>
+    <h1 className={cn('!text-3xl @xl:!text-4xl mt-0', className)}>
         Shift your product into{' '}
         <span className="bg-blue/10 dark:bg-blue/20 text-blue rounded-md px-1 @xl:whitespace-nowrap">
             self-driving mode
@@ -143,24 +143,18 @@ const Headline = ({ className }: { className?: string }) => (
 )
 
 function Hero(): JSX.Element {
-    // Some CTA variants start at the top of the layout, level with the headline rather than below it.
-    // For those, the headline moves into the left grid column so the CTA column can begin alongside it
-    // – matching `pt-4` on both keeps their text tops on the same line. The logo stays put either way.
-    const { alignsWithHeadline } = useHeroCtaVariant()
-
     return (
         <>
             <div className="text-center @xl:text-left min-w-0">
-                <div className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-8 pt-2">
+                <div className="[&_p]:m-0 flex gap-1 flex-wrap justify-center @xl:justify-start !text-2xl mb-12 pt-2">
                     <Logo className="max-w-[157px] dark:hidden" width="auto" />
                     <Logo className="hidden max-w-[157px] dark:block" variant="mono" color="white" width="auto" />
                 </div>
 
-                {alignsWithHeadline ? null : <Headline />}
+                <div className="group grid @xl:grid-cols-2 @xl:gap-x-8 min-w-0">
+                    <Headline className="@xl:row-start-1 @xl:col-start-1 @xl:col-span-2 @xl:group-has-[[data-cta-aligned]]:col-span-1" />
 
-                <div className="grid @xl:grid-cols-2 @xl:gap-8 min-w-0">
-                    <div className="min-w-0">
-                        {alignsWithHeadline ? <Headline /> : null}
+                    <div className="min-w-0 @xl:row-start-2 @xl:col-start-1">
                         <p className="text-balance @xl:text-wrap text-[17px]">
                             PostHog already knows your customers, which features they use, and the issues they have.
                         </p>
@@ -215,18 +209,7 @@ function Hero(): JSX.Element {
                         </p>
                     </div>
 
-                    {/* CTA variant comes from the `homepage-cta` experiment – see
-                        components/Home/HeroCTA/README.md. Falls back to the control (the wizard
-                        install card) until flags resolve. The MCP / demo / talk-to-a-human row that
-                        used to sit under this was removed from the hero; `SecondaryActions` is still
-                        used by `GetStarted` and `CTAs`. */}
-                    <div
-                        className={cn(
-                            'flex flex-col items-center min-w-0 w-full',
-                            // pt-4 mirrors the headline's own top padding so the two line up exactly.
-                            alignsWithHeadline ? '@xl:pt-4 mt-6 @xl:mt-0' : 'mt-6'
-                        )}
-                    >
+                    <div className="mt-6 flex flex-col items-center min-w-0 w-full @xl:row-start-2 @xl:col-start-2 @xl:group-has-[[data-cta-aligned]]:row-start-1 @xl:group-has-[[data-cta-aligned]]:row-span-2 @xl:group-has-[[data-cta-aligned]]:mt-0">
                         <HeroCTA />
                     </div>
                 </div>
@@ -251,9 +234,7 @@ export default function HomeTest() {
     return (
         <ReaderView proseSize="lg" hideLeftSidebar showQuestions={false}>
             <div className="space-y-12">
-                <HeroCtaProvider>
-                    <Hero />
-                </HeroCtaProvider>
+                <Hero />
                 <Customers />
                 <DataStackSection />
                 <PricingSection />

--- a/src/components/PlatformInstall/CopyableCommand.tsx
+++ b/src/components/PlatformInstall/CopyableCommand.tsx
@@ -11,6 +11,8 @@ export type CopyableCommandProps = {
     className?: string
     /** Apply the wizard gradient text effect to the command */
     animate?: boolean
+    /** Fired after the command reaches the clipboard, for callers that want to react to a copy. */
+    onCopy?: () => void
 }
 
 export function CopyableCommand({
@@ -18,6 +20,7 @@ export function CopyableCommand({
     copyCommand,
     className = '',
     animate = false,
+    onCopy,
 }: CopyableCommandProps): JSX.Element {
     const { addToast } = useToast()
     const confettiZIndex = useCopyConfettiZIndex()
@@ -28,6 +31,7 @@ export function CopyableCommand({
         navigator.clipboard.writeText(copyCommand ?? command)
         setCopied(true)
         fireCopyConfetti(copyButtonRef.current, confettiZIndex)
+        onCopy?.()
         window.setTimeout(() => setCopied(false), 1500)
         addToast({
             description: (

--- a/src/components/PlatformInstall/index.tsx
+++ b/src/components/PlatformInstall/index.tsx
@@ -147,8 +147,10 @@ export interface PlatformInstallProps {
     bordered?: boolean
     /** Inline only: "Learn more" link target (default `/wizard`). */
     secondaryTo?: string
-    /** Copy callback (inline). */
+    /** Fired when the main command is copied, in either variant. */
     onCopy?: () => void
+    /** Fired when the schema's `secondaryAction` link is clicked. Card only. */
+    onSecondaryAction?: () => void
 }
 
 export default function PlatformInstall({
@@ -161,6 +163,7 @@ export default function PlatformInstall({
     bordered = false,
     secondaryTo,
     onCopy,
+    onSecondaryAction,
 }: PlatformInstallProps): JSX.Element {
     const [selectedId, setSelectedId] = useState<string | null>(null)
     const [lastSelected, setLastSelected] = useState<Platform | null>(null)
@@ -251,6 +254,7 @@ export default function PlatformInstall({
                         <Link
                             to={schema.secondaryAction.to}
                             state={schema.secondaryAction.state}
+                            onClick={onSecondaryAction}
                             className="inline-flex items-center gap-0.5 text-sm text-secondary hover:text-primary whitespace-nowrap"
                         >
                             {schema.secondaryAction.label}
@@ -259,7 +263,7 @@ export default function PlatformInstall({
                     ) : null}
                 </div>
 
-                <CopyableCommand command={displayCommand} copyCommand={copyCommand} animate />
+                <CopyableCommand command={displayCommand} copyCommand={copyCommand} animate onCopy={onCopy} />
 
                 {schema.supports ? <div className="text-sm text-secondary">{schema.supports}</div> : null}
             </div>


### PR DESCRIPTION
## Changes

Adds homepage CTA variants associated with the following experiment:  
https://us.posthog.com/project/2/experiments/399989  
  
Options shown below:

### Default

### ![image.png](https://app.graphite.com/user-attachments/assets/20639f82-5dae-4469-a7cd-c256ad1b8dbe.png)

### Card

### ![image.png](https://app.graphite.com/user-attachments/assets/becae068-9df7-4186-a61f-d7ce5a5f90e8.png)

### Card (no command)

### ![image.png](https://app.graphite.com/user-attachments/assets/924b201f-c168-488d-81ae-5dd122f50f5e.png)

### Window

### ![image.png](https://app.graphite.com/user-attachments/assets/626a9e7c-b87b-45a5-8341-0c665e367d44.png)

### Minimal

### ![image.png](https://app.graphite.com/user-attachments/assets/0e6959af-8236-4196-a8b5-de4de20a9778.png)





## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`