### PR TITLE
Clarify how PostHog proposes fixes

### DIFF
--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -807,6 +807,11 @@ export default function SelfDrivingPage({
                                     While you slept, PostHog dug through your product data, found what was worth fixing,
                                     and had agents do the work. <Highlight>All you need to do is hit merge.</Highlight>
                                 </p>
+                                <p className="mb-0 mt-4 max-w-3xl text-[15px] text-secondary @xl/reader-content:text-[17px]">
+                                    The Wizard instruments your codebase, then PostHog combines that context with
+                                    product data – like usage, errors, and recordings – to understand problems and
+                                    propose fixes.
+                                </p>
                                 <GetStarted selfDriving />
                             </div>
 

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -808,8 +808,8 @@ export default function SelfDrivingPage({
                                     and had agents do the work. <Highlight>All you need to do is hit merge.</Highlight>
                                 </p>
                                 <p className="mb-0 mt-4 max-w-3xl text-[15px] text-secondary @xl/reader-content:text-[17px]">
-                                    The Wizard instruments your codebase, then PostHog combines that context with
-                                    product data – like usage, errors, and recordings – to understand problems and
+                                    PostHog instruments your codebase, then combines that context with
+                                    product data like analytics events, errors, and recordings to understand problems and
                                     propose fixes.
                                 </p>
                                 <GetStarted selfDriving />


### PR DESCRIPTION
## Changes

Adds a short explanation to the self-driving page connecting Wizard instrumentation, code context, and product data.

**Why:** New readers should understand how PostHog gets enough context to identify problems and propose fixes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*