### PR TITLE
docs: document setPersonProperties as a flag property override

### DIFF
--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -99,6 +99,64 @@ final showFeature = await Posthog().isFeatureEnabled('beta-feature');
 
 </MultiLanguage>
 
+#### From `setPersonProperties` calls
+
+`setPersonProperties()` persists the property on the person profile and caches it for flag evaluation. This means a flag can target the property right after you set it, without waiting for the property to be ingested.
+
+<MultiLanguage>
+
+```js file=Web
+// The property is persisted on the person and cached for flag evaluation
+posthog.setPersonProperties({ is_beta_user: true })
+
+// This flag check can use 'is_beta_user' immediately
+const showFeature = posthog.isFeatureEnabled('beta-feature')
+```
+
+```react-native
+// The property is persisted on the person and cached for flag evaluation
+posthog.setPersonProperties({ is_beta_user: true })
+
+// This flag check can use 'is_beta_user' immediately
+const showFeature = posthog.isFeatureEnabled('beta-feature')
+```
+
+```swift file=iOS
+// The property is persisted on the person and cached for flag evaluation
+PostHogSDK.shared.setPersonProperties(userPropertiesToSet: ["is_beta_user": true])
+
+// On iOS, reload flags yourself before checking
+PostHogSDK.shared.reloadFeatureFlags()
+```
+
+```kotlin file=Android
+// The property is persisted on the person and cached for flag evaluation
+PostHog.setPersonProperties(userPropertiesToSet = mapOf("is_beta_user" to true))
+
+// On Android, reload flags yourself before checking
+PostHog.reloadFeatureFlags()
+```
+
+```dart
+// The property is persisted on the person and cached for flag evaluation
+await Posthog().setPersonProperties(
+  userPropertiesToSet: {'is_beta_user': true},
+);
+
+// On iOS and Android, reload flags yourself before checking
+await Posthog().reloadFeatureFlags();
+```
+
+</MultiLanguage>
+
+On web and React Native, `setPersonProperties()` also reloads feature flags. On iOS, Android, and Flutter it doesn't, so call `reloadFeatureFlags()` yourself.
+
+The reload is async, so a flag check on the line straight after `setPersonProperties()` can still return the value cached before the property was set. It's usually fast, but reading the flag in an `onFeatureFlags()` callback avoids the race.
+
+Identical calls are ignored. If you set the same properties for the same distinct ID twice in a row, the second call does nothing: no `$set` event and no flag reload.
+
+> **Note:** `setPersonProperties()` creates a [person profile](/docs/data/persons) if one doesn't exist yet, so subsequent events for that user are captured as [identified events](/docs/data/anonymous-vs-identified-events). If you only need the property for flag evaluation, use [`setPersonPropertiesForFlags()`](#manual-overrides-with-setpersonpropertiesforflags) instead.
+
 #### From group calls
 
 Similarly, when you call `group()` with group properties, those properties are cached for flag evaluation:
@@ -320,6 +378,8 @@ final showFeature = await Posthog().isFeatureEnabled('beta-feature');
 </MultiLanguage>
 
 > **Note:** Properties set with `setPersonPropertiesForFlags()` are additive. Each call merges new properties with existing ones rather than replacing them.
+
+Unlike `setPersonProperties()`, this doesn't create a person profile and doesn't send a `$set` event. The properties stay in the SDK and are sent with each flag evaluation request, so you can target flags on person properties for users who are still anonymous. They aren't saved on the person either, so they're not available anywhere else, like server-side evaluation or the same user on another device.
 
 ### Controlling automatic flag reload
 

--- a/contents/docs/feature-flags/troubleshooting.mdx
+++ b/contents/docs/feature-flags/troubleshooting.mdx
@@ -127,6 +127,8 @@ posthog.setPersonPropertiesForFlags({
 })
 ```
 
+[`setPersonProperties()`](/docs/feature-flags/property-overrides#from-setpersonproperties-calls) does both in one call: it persists the property on the person and caches it for flag evaluation. Use `setPersonPropertiesForFlags()` when you don't want to create a person profile for the user.
+
 
 
 ## Why can't I create a new feature flag?

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
@@ -4,9 +4,10 @@ If you've set the [`personProfiles` config](/docs/libraries/js/config) to `IDENT
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
 - [`group()`](/docs/product-analytics/group-analytics)
 - [`setPersonProperties()`](/docs/product-analytics/person-properties)
-- [`setPersonPropertiesForFlags()`](/docs/libraries/js/features#overriding-server-properties)
 - [`setGroupPropertiesForFlags()`](/docs/libraries/js/features#overriding-server-properties)
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
+
+[`setPersonPropertiesForFlags()`](/docs/feature-flags/property-overrides#manual-overrides-with-setpersonpropertiesforflags) is the exception. It doesn't create a person profile, so you can use it to target feature flags on person properties while the user is still anonymous.
 
 Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.


### PR DESCRIPTION
Our docs and the SDK code disagreed in two places about setting a person property and targeting a flag on it straight away. Thanks @gustavohstrassburger for confirming both in [this thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1785156832090279).

### 1. `setPersonProperties` also skips ingestion lag

`property-overrides.mdx` only documented `setPersonPropertiesForFlags` for this, but `setPersonProperties` persists the property *and* writes the flag override, so one call is enough. Added it as a subsection alongside the existing "From identify calls" and "From group calls".

Two things I found while checking the code that weren't written down anywhere:

- **The reload isn't consistent across SDKs.** Web and React Native reload flags automatically. iOS, Android and Flutter don't: both native impls call `setPersonPropertiesForFlags(..., reloadFeatureFlags: false)`, so mobile users have to call `reloadFeatureFlags()` themselves. Without this, the pattern silently doesn't work on mobile.
- **Identical calls are a no-op.** The dedup hash means setting the same properties for the same distinct ID twice in a row sends no `$set` and triggers no reload.

### 2. `setPersonPropertiesForFlags` doesn't create a person profile

It was on the list of calls that create a profile in `how-to-capture-identified-events-frontend.mdx` (which feeds the anonymous-vs-identified page plus two others). It doesn't enable person processing and doesn't send a `$set` event, so it can be used to target flags on person properties while the user is still anonymous. Removed it from the list and noted the exception.

:warning: I left `setGroupPropertiesForFlags` **on** the list. It does call `_requirePersonProcessing`, so it really does create a profile. The natural fix here is to delete both lines, and that would be wrong.

### Verified against

`posthog-js` `posthog-core.ts:2748-2774` and `posthog-featureflags.ts:1323-1354`, `posthog-ios` `PostHogSDK.swift:945-995`, `posthog-android` `PostHog.kt:1394-1437`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

