### PR TITLE
Make /changelog readable by crawlers and AI agents

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -390,6 +390,70 @@ module.exports = {
                         // current page satisfied this regular expression;
                         // if not provided or `undefined`, all pages will have feed reference inserted
                     },
+                    {
+                        serialize: ({ query: { site, allRoadmap } }) => {
+                            const { siteUrl } = site.siteMetadata
+
+                            return allRoadmap.nodes.map((node) => {
+                                const team = node.teams?.data?.[0]?.attributes?.name
+                                const topic = node.topic?.data?.attributes?.label
+                                const description = (node.description || '')
+                                    .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // strip images
+                                    .replace(/\]\(\//g, `](${siteUrl}/`) // absolutize relative links
+                                    .trim()
+
+                                return {
+                                    title: node.title,
+                                    description,
+                                    date: node.date,
+                                    url: `${siteUrl}/changelog?id=${node.strapiID}`,
+                                    guid: `posthog-changelog-${node.strapiID}`,
+                                    categories: [team && `${team} Team`, topic].filter(Boolean),
+                                    custom_elements: [
+                                        {
+                                            'content:encoded': {
+                                                _cdata: description,
+                                            },
+                                        },
+                                    ],
+                                }
+                            })
+                        },
+                        query: `
+                        {
+                            allRoadmap(
+                                filter: { complete: { eq: true }, date: { ne: null } }
+                                sort: { fields: date, order: DESC }
+                                limit: 50
+                            ) {
+                                nodes {
+                                    strapiID
+                                    title
+                                    description
+                                    date
+                                    teams {
+                                        data {
+                                            attributes {
+                                                name
+                                            }
+                                        }
+                                    }
+                                    topic {
+                                        data {
+                                            attributes {
+                                                label
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        `,
+                        output: '/changelog.rss',
+                        title: 'PostHog Changelog',
+                        // inserts <link rel="alternate" type="application/rss+xml"> on /changelog pages
+                        match: '^/changelog',
+                    },
                 ],
             },
         },

--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -12,6 +12,7 @@ import { docsMenu, handbookSidebar } from '../src/navs/index.js'
 import {
     generateRawMarkdownPages,
     generateApiSpecMarkdown,
+    generateChangelogMd,
     generateLlmsTxt,
     generateSdkReferencesMarkdown,
     generatePricingMd,
@@ -601,6 +602,59 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
     // Generate the self-driving platform overview + per-product markdown for LLMs/agents
     generatePlatformMd()
     generateProductPagesMarkdown()
+
+    // Generate changelog.md (+ per-year archives) from build-time Roadmap nodes for LLMs/agents.
+    // The /changelog page renders a virtualized UI, so the HTML-scrape path can't cover it.
+    try {
+        const changelogQuery = (await graphql(`
+            query {
+                allRoadmap(filter: { complete: { eq: true }, date: { ne: null } }, sort: { fields: date, order: DESC }) {
+                    nodes {
+                        strapiID
+                        title
+                        description
+                        date
+                        cta {
+                            label
+                            url
+                        }
+                        teams {
+                            data {
+                                attributes {
+                                    name
+                                }
+                            }
+                        }
+                        topic {
+                            data {
+                                attributes {
+                                    label
+                                }
+                            }
+                        }
+                    }
+                }
+                allChangelogVideo(sort: { fields: publishedAt, order: DESC }) {
+                    nodes {
+                        videoId
+                        publishedAt
+                        title
+                    }
+                }
+            }
+        `)) as {
+            data?: {
+                allRoadmap?: { nodes: any[] }
+                allChangelogVideo?: { nodes: any[] }
+            }
+        }
+        generateChangelogMd(
+            changelogQuery.data?.allRoadmap?.nodes || [],
+            changelogQuery.data?.allChangelogVideo?.nodes || []
+        )
+    } catch (error) {
+        console.error('Failed to generate changelog markdown:', error)
+    }
 
     // Publish/update Standard.site document records for blog posts.
     // Self-gates on env (AWS_CODEPIPELINE / STANDARD_SITE_SYNC) and BSKY_APP_PASSWORD; safe no-op otherwise.

--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -537,6 +537,119 @@ For features, screenshots, and details, see ${pageLinkFor(item)}.
     }
 }
 
+type ChangelogRoadmapNode = {
+    strapiID?: number | string
+    title: string
+    description?: string
+    date: string
+    cta?: { label?: string; url?: string }
+    teams?: { data?: Array<{ attributes?: { name?: string } }> }
+    topic?: { data?: { attributes?: { label?: string } } }
+}
+
+type ChangelogVideoNode = {
+    videoId: string
+    publishedAt: string
+    title: string
+}
+
+// How many months of entries the top-level changelog.md covers. Full history is
+// available in the per-year archives (public/changelog/{year}.md).
+const CHANGELOG_MD_MONTHS = 12
+
+// Generates /changelog.md (and per-year archives) directly from the build-time Roadmap
+// nodes, like generatePricingMd/generatePlatformMd. The /changelog page itself renders a
+// virtualized UI, so the HTML-scrape path used for docs pages can't produce useful
+// markdown for it — this is the canonical machine-readable changelog for LLMs/agents.
+export const generateChangelogMd = (roadmaps: ChangelogRoadmapNode[], videos: ChangelogVideoNode[] = []) => {
+    console.log('Generating changelog markdown files...')
+
+    const publicPath = path.resolve(__dirname, '../public')
+
+    const monthKey = (date: string) => date.slice(0, 7) // YYYY-MM
+    const monthTitle = (key: string) =>
+        new Date(`${key}-15T00:00:00Z`).toLocaleString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+    const dayTitle = (date: string) =>
+        new Date(date).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC' })
+
+    const cleanDescription = (md?: string) =>
+        (md || '')
+            .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // strip images
+            .replace(/\]\(\//g, '](https://posthog.com/') // absolutize relative links
+            .trim()
+
+    const absoluteUrl = (url?: string) => (url && url.startsWith('/') ? `https://posthog.com${url}` : url)
+
+    const entryMarkdown = (roadmap: ChangelogRoadmapNode) => {
+        const team = roadmap.teams?.data?.[0]?.attributes?.name
+        const topic = roadmap.topic?.data?.attributes?.label
+        const meta = [dayTitle(roadmap.date), team && `${team} Team`, topic].filter(Boolean).join(' · ')
+        const description = cleanDescription(roadmap.description)
+        const cta = roadmap.cta?.url ? `[${roadmap.cta.label || 'Learn more'}](${absoluteUrl(roadmap.cta.url)})` : ''
+
+        return [`### ${roadmap.title}`, `_${meta}_`, description, cta].filter(Boolean).join('\n\n')
+    }
+
+    // Group entries and videos by YYYY-MM, newest first (input is sorted date DESC)
+    const months = new Map<string, { roadmaps: ChangelogRoadmapNode[]; videos: ChangelogVideoNode[] }>()
+    const getMonth = (key: string) => {
+        if (!months.has(key)) months.set(key, { roadmaps: [], videos: [] })
+        return months.get(key) as { roadmaps: ChangelogRoadmapNode[]; videos: ChangelogVideoNode[] }
+    }
+    roadmaps
+        .filter((roadmap) => roadmap?.title && roadmap?.date)
+        .forEach((roadmap) => getMonth(monthKey(roadmap.date)).roadmaps.push(roadmap))
+    videos
+        .filter((video) => video?.videoId && video?.publishedAt)
+        .forEach((video) => getMonth(monthKey(video.publishedAt)).videos.push(video))
+
+    const sortedMonthKeys = [...months.keys()].sort().reverse()
+    if (sortedMonthKeys.length === 0) {
+        console.warn('No changelog entries found; skipping changelog markdown generation')
+        return
+    }
+
+    const monthMarkdown = (key: string) => {
+        const { roadmaps: monthRoadmaps, videos: monthVideos } = getMonth(key)
+        const videoLines = monthVideos
+            .map((video) => `- 📺 [${video.title}](https://www.youtube.com/watch?v=${video.videoId})`)
+            .join('\n')
+        return [`## ${monthTitle(key)}`, videoLines, ...monthRoadmaps.map(entryMarkdown)].filter(Boolean).join('\n\n')
+    }
+
+    const years = [...new Set(sortedMonthKeys.map((key) => key.slice(0, 4)))].sort().reverse()
+    const yearArchiveLinks = years.map((year) => `[${year}](https://posthog.com/changelog/${year}.md)`).join(' · ')
+
+    const header = (scope: string) => `# PostHog changelog
+
+New features, improvements, and fixes shipped in PostHog. ${scope} Regenerated on every deploy.
+
+- Canonical page: https://posthog.com/changelog
+- RSS feed: https://posthog.com/changelog.rss
+- Full history by year: ${yearArchiveLinks}
+
+`
+
+    // Top-level changelog.md: the most recent CHANGELOG_MD_MONTHS months
+    const recentMonthKeys = sortedMonthKeys.slice(0, CHANGELOG_MD_MONTHS)
+    const changelogMd =
+        header(`This file covers the last ${recentMonthKeys.length} months.`) +
+        recentMonthKeys.map(monthMarkdown).join('\n\n') +
+        '\n'
+    fs.writeFileSync(path.join(publicPath, 'changelog.md'), changelogMd, 'utf8')
+    console.log('Generated: changelog.md')
+
+    // Per-year archives: public/changelog/{year}.md
+    const changelogDir = path.join(publicPath, 'changelog')
+    if (!fs.existsSync(changelogDir)) fs.mkdirSync(changelogDir, { recursive: true })
+    for (const year of years) {
+        const yearMonthKeys = sortedMonthKeys.filter((key) => key.startsWith(year))
+        const yearMd = header(`This file covers ${year}.`) + yearMonthKeys.map(monthMarkdown).join('\n\n') + '\n'
+        fs.writeFileSync(path.join(changelogDir, `${year}.md`), yearMd, 'utf8')
+        console.log(`Generated: changelog/${year}.md`)
+    }
+}
+
 export const generateLlmsTxt = (pages) => {
     console.log('Generating llms.txt file...')
 
@@ -682,6 +795,16 @@ ${PLATFORM_ITEMS.filter((i) => i.layer === 'tool')
 **Context** — ${CONTEXT_BLURB}
 
 **Context warehouse** — ${CONTEXT_WAREHOUSE_BLURB}
+
+`
+
+    // Changelog — high-value for agents deciding what PostHog can do today
+    llmsTxtContent += `## Changelog
+
+What's new in PostHog — new features, products, and tools, updated with every deploy. Check this before assuming a capability doesn't exist.
+
+- [Changelog (last 12 months, Markdown)](https://posthog.com/changelog.md)
+- [Changelog RSS feed](https://posthog.com/changelog.rss)
 
 `
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,5 @@
 // Paths that have raw markdown available for copying/downloading
-export const MARKDOWN_CONTENT_PATHS = ['/docs', '/handbook', '/blog', '/newsletter'] as const
+export const MARKDOWN_CONTENT_PATHS = ['/docs', '/handbook', '/blog', '/newsletter', '/changelog'] as const
 export const isMarkdownContentPath = (path: string) =>
     MARKDOWN_CONTENT_PATHS.some((p) => path === p || path.startsWith(`${p}/`))
 

--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -412,8 +412,8 @@ const StaticChangelogList = ({ roadmaps }: { roadmaps: RoadmapNode[] }) => {
         <ScrollArea className="h-full">
             <div className="max-w-3xl mx-auto px-4 pb-8">
                 <p className="text-sm text-secondary">
-                    Also available as <Link to="/changelog.md">Markdown</Link> and{' '}
-                    <Link to="/changelog.rss">RSS</Link>.
+                    Also available as <a href="/changelog.md">Markdown</a> and{' '}
+                    <a href="/changelog.rss">RSS</a>.
                 </p>
                 {byMonth.map(([month, items]) => {
                     const fullDetail = fullDetailCutoff ? !dayjs.utc(month).isBefore(fullDetailCutoff) : true

--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -382,6 +382,78 @@ const Roadmap = ({
     )
 }
 
+// How many months of entries get full descriptions in the server-rendered fallback below.
+// Older entries render titles only to keep the HTML weight bounded.
+const SSR_FULL_DETAIL_MONTHS = 12
+
+// Server-rendered fallback for the virtualized cards view. `RoadmapCards` renders
+// `virtualizer.getVirtualItems()`, which is empty during SSR, so crawlers and agents
+// fetching this page over plain HTTP would otherwise see no entries at all. This list
+// renders until the client mounts, then hands off to the interactive UI.
+const StaticChangelogList = ({ roadmaps }: { roadmaps: RoadmapNode[] }) => {
+    const byMonth = useMemo(() => {
+        const groups = new Map<string, RoadmapNode[]>()
+        ;[...roadmaps]
+            .sort((a, b) => dayjs.utc(b.date).valueOf() - dayjs.utc(a.date).valueOf())
+            .forEach((roadmap) => {
+                const key = dayjs.utc(roadmap.date).format('YYYY-MM')
+                groups.set(key, [...(groups.get(key) || []), roadmap])
+            })
+        return [...groups.entries()]
+    }, [roadmaps])
+
+    // Derived from the data (not the clock) so SSR and hydration always agree
+    const fullDetailCutoff = useMemo(
+        () => (byMonth[0] ? dayjs.utc(byMonth[0][0]).subtract(SSR_FULL_DETAIL_MONTHS, 'month') : null),
+        [byMonth]
+    )
+
+    return (
+        <ScrollArea className="h-full">
+            <div className="max-w-3xl mx-auto px-4 pb-8">
+                <p className="text-sm text-secondary">
+                    Also available as <Link to="/changelog.md">Markdown</Link> and{' '}
+                    <Link to="/changelog.rss">RSS</Link>.
+                </p>
+                {byMonth.map(([month, items]) => {
+                    const fullDetail = fullDetailCutoff ? !dayjs.utc(month).isBefore(fullDetailCutoff) : true
+                    return (
+                        <section key={month}>
+                            <h2>{dayjs.utc(month).format('MMMM YYYY')}</h2>
+                            {items.map((roadmap) => {
+                                const teamName = roadmap.teams?.data?.[0]?.attributes?.name
+                                return (
+                                    <article key={roadmap.id} className="mb-6">
+                                        <Heading
+                                            as="h3"
+                                            id={slugify(roadmap.title, { lower: true })}
+                                            className="m-0"
+                                        >
+                                            {roadmap.title}
+                                        </Heading>
+                                        <p className="m-0 text-sm opacity-60">
+                                            {dayjs.utc(roadmap.date).format('MMMM D, YYYY')}
+                                            {teamName ? ` · ${teamName} Team` : ''}
+                                        </p>
+                                        {fullDetail && roadmap.description && (
+                                            <div className="mt-2">
+                                                <Markdown regularText={true}>{roadmap.description}</Markdown>
+                                            </div>
+                                        )}
+                                        {fullDetail && roadmap.cta?.url && (
+                                            <Link to={roadmap.cta.url}>{roadmap.cta.label || 'Learn more'}</Link>
+                                        )}
+                                    </article>
+                                )
+                            })}
+                        </section>
+                    )
+                })}
+            </div>
+        </ScrollArea>
+    )
+}
+
 interface RoadmapCardsProps {
     roadmaps: RoadmapNode[]
     setPercentageOfScrollInView: (percentage: number) => void
@@ -803,6 +875,13 @@ export default function Changelog({
     const [containerWidth, setContainerWidth] = useState(0)
     const [teamFilter, setTeamFilter] = useState('all')
     const [categoryFilter, setCategoryFilter] = useState('all')
+    // Two-pass render: SSR (and the first client render) show the static, crawlable list;
+    // the virtualized cards UI takes over after mount. Both passes agree, so hydration is safe.
+    const [mounted, setMounted] = useState(false)
+
+    useEffect(() => {
+        setMounted(true)
+    }, [])
     const hideEmpty = useMemo(() => teamFilter !== 'all' || categoryFilter !== 'all', [teamFilter, categoryFilter])
     const playlistVideos = data.allChangelogVideo?.nodes || []
 
@@ -970,7 +1049,10 @@ export default function Changelog({
 
     return (
         <>
-            <SEO title="Changelog - PostHog" />
+            <SEO
+                title="Changelog - PostHog"
+                description="New features, improvements, and fixes shipped in PostHog, updated continuously."
+            />
             <Editor
                 hideToolbar
                 hasTabs
@@ -1016,20 +1098,23 @@ export default function Changelog({
                         </div>
 
                         <div className={`min-h-0 flex-grow pt-2 ${hideEmpty ? 'mb-4' : ''}`}>
-                            <RoadmapCards
-                                startYear={2020}
-                                endYear={2026}
-                                roadmaps={filteredData}
-                                setPercentageOfScrollInView={setPercentageOfScrollInView}
-                                windowPercentageFromLeft={windowPercentageFromLeft}
-                                setRoadmapsPercentageFromLeft={setRoadmapsPercentageFromLeft}
-                                onRoadmapClick={handleRoadmapClick}
-                                containerWidth={containerWidth}
-                                activeRoadmap={activeRoadmap}
-                                hideEmpty={hideEmpty}
-                                initialActiveRoadmap={initialActiveRoadmap}
-                                videos={playlistVideos}
-                            />
+                            {!mounted && <StaticChangelogList roadmaps={filteredData} />}
+                            {mounted && (
+                                <RoadmapCards
+                                    startYear={2020}
+                                    endYear={2026}
+                                    roadmaps={filteredData}
+                                    setPercentageOfScrollInView={setPercentageOfScrollInView}
+                                    windowPercentageFromLeft={windowPercentageFromLeft}
+                                    setRoadmapsPercentageFromLeft={setRoadmapsPercentageFromLeft}
+                                    onRoadmapClick={handleRoadmapClick}
+                                    containerWidth={containerWidth}
+                                    activeRoadmap={activeRoadmap}
+                                    hideEmpty={hideEmpty}
+                                    initialActiveRoadmap={initialActiveRoadmap}
+                                    videos={playlistVideos}
+                                />
+                            )}
                         </div>
                         <AnimatePresence>
                             {!hideEmpty && (

--- a/vercel.json
+++ b/vercel.json
@@ -128,6 +128,28 @@
             "destination": "/newsletter/:path*.md"
         },
         {
+            "source": "/changelog/",
+            "has": [
+                {
+                    "type": "header",
+                    "key": "accept",
+                    "value": "(?:.*text/markdown.*)"
+                }
+            ],
+            "destination": "/changelog.md"
+        },
+        {
+            "source": "/changelog",
+            "has": [
+                {
+                    "type": "header",
+                    "key": "accept",
+                    "value": "(?:.*text/markdown.*)"
+                }
+            ],
+            "destination": "/changelog.md"
+        },
+        {
             "source": "/community/profiles/:path*",
             "destination": "/community/profiles/[id]/index.html"
         },


### PR DESCRIPTION
## Changes

`posthog.com/changelog` serves its entries entirely client-side — the built HTML contains only the nav and year picker, so crawlers and AI agents fetching the page over plain HTTP see no changelog content at all. There's also no `/changelog.md`, no llms.txt entry, and no RSS feed for it.

This PR makes the changelog machine-readable four ways:

- **Prerender**: `/changelog` now server-renders a static, month-grouped list of entries (full descriptions for the last 12 months, titles beyond that). The virtualized interactive UI takes over after hydration — no UX change.
- **`/changelog.md`**: generated at build time from the same Roadmap nodes (like `pricing.md`/`platform.md`), covering the last 12 months, with full per-year archives at `/changelog/{year}.md`. `Accept: text/markdown` content negotiation included.
- **llms.txt**: new `## Changelog` section linking the markdown and RSS.
- **RSS**: new feed at `/changelog.rss` (latest 50 entries), with `<link rel="alternate">` discovery on the page.

## Why

Agents and MCP clients increasingly answer "what can PostHog do?" from posthog.com over plain HTTP — today the changelog is invisible to them, so newly shipped features and tools go undiscovered. Raised in [this Slack thread](https://posthog.slack.com/archives/C0BJRGDSPPC/p1785842406620959).

Note: the `.md`/llms.txt generation runs in `onPostBuild`, which is skipped in `GATSBY_MINIMAL` preview builds — only the SSR fallback and RSS feed are verifiable in the Vercel/Cloudflare preview; the rest lands on the first production build after merge.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved; added content-negotiation rewrites)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BJRGDSPPC/p1785842406620959)*
