### PR TITLE
Update AI observability pricing across blog and docs

### DIFF
--- a/contents/blog/best-ai-observability-tools.mdx
+++ b/contents/blog/best-ai-observability-tools.mdx
@@ -271,7 +271,7 @@ Let's see how much this would cost, across different platforms:
 
 - **LangSmith (per seat + per trace):** one trace typically represents an entire user request, regardless of how many spans or model calls happen inside it. In this example, 100,000 requests produce 100,000 billable traces. With five seats at $39/month (Plus plan), that's $195 in seat costs. After the 10,000 included traces (Plus plan), the remaining 90,000 traces cost about $225 in overages ($0.0025/trace), bringing the total to roughly $420/month. The important thing is that the bill grows with request volume, not with the number of spans inside each request.
 
-- **Braintrust (flat fee, no seats):** the free Starter tier includes 1GB of processed data (roughly 1 million spans at typical payload sizes), so this ~700,000-span workload still fits inside the free tier at $0. If you outgrow it, Pro is a flat $249 a month with unlimited users and data-based overages. Adding engineers costs nothing.
+- **Braintrust (flat fee, no seats):** the free Starter tier includes 1GB of processed data (roughly 70,000 spans at typical payload sizes), so this ~700,000-span workload runs about $38 a month in overages. Pro is a flat $249 a month with unlimited users and 5GB included, plus ~$17 in overages, for about $266 a month. Adding engineers costs nothing.
 
 - **Langfuse cloud (per observation):** a note on terminology first – Langfuse's billable unit is anything you send it: traces, observations (spans, generations), and scores. If 100,000 user requests create 100,000 traces and about 700,000 observations, the workload is about 800,000 billable units. On the Core plan, that means $29 for the first 100,000 units, plus $56 for the remaining 700,000 units, or about $85/month.
 

--- a/contents/blog/best-ai-observability-tools.mdx
+++ b/contents/blog/best-ai-observability-tools.mdx
@@ -267,7 +267,7 @@ The exception is **per-trace pricing** (LangSmith): one trace covers a whole req
 
 Let's see how much this would cost, across different platforms:
 
-- **PostHog (usage-based per event):** the first 100,000 LLM analytics events each month are free, then you pay a $0.00006 per-event rate with no seat fees. Each generation and span is an event, so this workload is roughly 700,000 events; you'd pay for the ~600,000 above the free tier = ~$36.
+- **PostHog (usage-based per event):** the first 100,000 LLM analytics events each month are free, then you pay a volume-tiered rate that starts at $35 per 100,000 events and falls to $6 per 100,000 at the highest volumes, with no seat fees. Each generation and span is an event, so this workload is roughly 700,000 events; the ~600,000 above the free tier works out to ~$76.
 
 - **LangSmith (per seat + per trace):** one trace typically represents an entire user request, regardless of how many spans or model calls happen inside it. In this example, 100,000 requests produce 100,000 billable traces. With five seats at $39/month (Plus plan), that's $195 in seat costs. After the 10,000 included traces (Plus plan), the remaining 90,000 traces cost about $225 in overages ($0.0025/trace), bringing the total to roughly $420/month. The important thing is that the bill grows with request volume, not with the number of spans inside each request.
 

--- a/contents/blog/best-braintrust-alternatives.mdx
+++ b/contents/blog/best-braintrust-alternatives.mdx
@@ -796,7 +796,7 @@ Every tool on this list bills differently, which makes price comparisons slipper
 | Tool | Bills by | Free tier | First paid step | Watch out for |
 | --- | --- | --- | --- | --- |
 | **Braintrust** | GB of processed data | 1 GB (~1M spans), 14-day retention | $249/month Pro (5 GB) | No middle tier between free and $249; $3/GB overages |
-| **PostHog** | Events | 100K AI events/month | Usage-based, no base fee ($6 per 100K) | Event count scales with instrumentation depth |
+| **PostHog** | Events | 100K AI events/month | Usage-based, no base fee (from $35 per 100K, dropping to $6 per 100K at high volume) | Event count scales with instrumentation depth |
 | **Langfuse** | Units (traces + observations + scores) | 50K units/month, hard cap | $29/month Core + $8 per 100K units | Eval scores count as billable units |
 | **LangSmith** | Seats + traces | 5K traces, 1 seat | $39/seat/month + $2.50 per 1K traces | Costs grow with headcount; base retention is 14 days |
 | **Arize Phoenix** | Free self-host; cloud by spans | 25K spans/month (cloud) | Cloud paid tiers vary | Self-hosting is free but you run the infrastructure |

--- a/contents/blog/best-langsmith-alternatives.mdx
+++ b/contents/blog/best-langsmith-alternatives.mdx
@@ -622,7 +622,7 @@ If you want [open-source](/blog/best-open-source-llm-observability-tools), [lowe
 
 The two bill differently: LangSmith charges per trace (one per user request, regardless of internal steps) plus $39 per seat on its Plus plan. PostHog charges per event – roughly 6 events per request for a typical multi-step app (each LLM call, span, and embedding is one event) – with no seat fees.
 
-Here's what monthly volumes cost, assuming a 5-person team (LangSmith Plus at $195/month in seats, 10K traces included, $2.50 per 1K base trace overage) versus PostHog ($6 per 100K events after 100K free):
+Here's what monthly volumes cost, assuming a 5-person team (LangSmith Plus at $195/month in seats, 10K traces included, $2.50 per 1K base trace overage) versus PostHog (volume-tiered from $35 per 100K events after the first 100K free, falling to $6 per 100K at high volume):
 
 This table is great, but broken for me. You might need to use HTML components to get it working.  
 
@@ -630,16 +630,16 @@ This table is great, but broken for me. You might need to use HTML components to
 
 | Requests/month | LangSmith (5 seats, base retention) | PostHog (~6 events/request) |
 | --- | --- | --- |
-| 100K | ~$420 | ~$30 |
-| 500K | ~$1,420 | ~$174 |
-| 1M | ~$2,670 | ~$354 |
-| 5M | ~$12,670 | ~$1,794 |
+| 100K | ~$420 | ~$68 |
+| 500K | ~$1,420 | ~$240 |
+| 1M | ~$2,670 | ~$450 |
+| 5M | ~$12,670 | ~$2,030 |
 
-Three things drive the gap. LangSmith's per-request rate is higher ($2.50 per 1K traces versus roughly $0.36 per 1K requests' worth of PostHog events). Seats add a fixed floor that grows with your team – a 10-person team starts at $390/month before a single trace. And LangSmith's base rate only buys 14-day retention; extended retention (400 days) doubles the trace rate to $5 per 1K, while PostHog's free plan retains data for a year.
+Three things drive the gap. LangSmith's per-request rate is higher ($2.50 per 1K traces versus roughly $0.39-$0.48 per 1K requests' worth of PostHog events, depending on volume). Seats add a fixed floor that grows with your team – a 10-person team starts at $390/month before a single trace. And LangSmith's base rate only buys 14-day retention; extended retention (400 days) doubles the trace rate to $5 per 1K, while PostHog's free plan retains data for a year.
 
 The honest caveats: PostHog's event count scales with instrumentation depth, so a simple one-call-per-request app emits fewer events (cheaper), while a complex agent emits more (the gap narrows but doesn't close – even at 40 events per request, PostHog is ~$12K at 5M requests, comparable to LangSmith *before* extended retention or extra seats). And LangSmith's included traces (10K on Plus) matter at very low volumes, where both tools are effectively free.
 
-Pricing current as of July 2026. For other alternatives, see our guide to the [cheapest AI observability tools](/blog/cheapest-ai-observability-tools).
+Pricing current as of August 2026. For other alternatives, see our guide to the [cheapest AI observability tools](/blog/cheapest-ai-observability-tools).
 
 </details>
 

--- a/contents/blog/best-langsmith-alternatives.mdx
+++ b/contents/blog/best-langsmith-alternatives.mdx
@@ -635,7 +635,7 @@ This table is great, but broken for me. You might need to use HTML components to
 | 1M | ~$2,670 | ~$450 |
 | 5M | ~$12,670 | ~$2,030 |
 
-Three things drive the gap. LangSmith's per-request rate is higher ($2.50 per 1K traces versus roughly $0.39-$0.48 per 1K requests' worth of PostHog events, depending on volume). Seats add a fixed floor that grows with your team – a 10-person team starts at $390/month before a single trace. And LangSmith's base rate only buys 14-day retention; extended retention (400 days) doubles the trace rate to $5 per 1K, while PostHog's free plan retains data for a year.
+Three things drive the gap. LangSmith's per-request rate is higher ($2.50 per 1K traces versus roughly $0.39-$0.48 per 1K requests' worth of PostHog events). Seats add a fixed floor that grows with your team – a 10-person team starts at $390/month before a single trace. And LangSmith's base rate only buys 14-day retention; extended retention (400 days) doubles the trace rate to $5 per 1K, while PostHog's free plan retains data for a year.
 
 The honest caveats: PostHog's event count scales with instrumentation depth, so a simple one-call-per-request app emits fewer events (cheaper), while a complex agent emits more (the gap narrows but doesn't close – even at 40 events per request, PostHog is ~$12K at 5M requests, comparable to LangSmith *before* extended retention or extra seats). And LangSmith's included traces (10K on Plus) matter at very low volumes, where both tools are effectively free.
 

--- a/contents/blog/best-product-analytics-tools-for-startups.mdx
+++ b/contents/blog/best-product-analytics-tools-for-startups.mdx
@@ -192,7 +192,7 @@ Want to skip the manual setup entirely? You can try out the [PostHog wizard](/do
 | Surveys | 1,500 responses | $0.10/response |
 | Error tracking | 100K exceptions | $0.00037/exception |
 | Data warehouse | 1M synced rows | $0.000015/row |
-| LLM observability | 100K events | $0.00006/event |
+| LLM observability | 100K events | $0.00035/event |
 | Logs | 50GB ingested | $0.25/GB |
 | Workflows | 10K messages/channel | $0.003000/email |
 | PostHog AI | 500 credits | $1 per 100 credits |

--- a/contents/blog/posthog-vs-langfuse.mdx
+++ b/contents/blog/posthog-vs-langfuse.mdx
@@ -191,7 +191,7 @@ When it comes to pricing, Langfuse uses a combination of tier and usage-based pr
 | **Pricing model** | Usage-based | Tiered plans |
 | **Free tier** | Generous limits per product (100,000 events free per month for AI observability) | 50,000 units/month (Units \= Count of Traces \+ Count of Observations \+ Count of Scores) |
 | **Seat limits** | None, as you get unlimited users on every plan | 2 users on the free plan |
-| **Paid plans** | Pay only for usage above free tier (Starts at $0.00006/event) | Starts at $29/month for 100k units (extra at $0.00008/unit) |
+| **Paid plans** | Pay only for usage above free tier (Starts at $0.00035/event, with volume discounts down to $0.00006/event) | Starts at $29/month for 100k units (extra at $0.00008/unit) |
 | **Overages** | Scales with usage | Billed on top of the paid tier |
 | **Startup program** | [$50,000 in free credits](/startups) for 12 months | 50% off the first year |
 | **License** | MIT | MIT |

--- a/contents/blog/posthog-vs-plausible.mdx
+++ b/contents/blog/posthog-vs-plausible.mdx
@@ -189,7 +189,7 @@ PostHog is [entirely usage-based](/pricing). Its free tier includes:
 | Feature flags and A/B testing |    1 million API requests   |  From $0.0001/request    |
 | Surveys                       |    1,500 responses          |  From $0.10/response     |
 | Error tracking                |    100,000 exceptions       |  From $0.00037/exception |
-| LLM observability             |    100,000 events           |  From $0.00006/event     |
+| LLM observability             |    100,000 events           |  From $0.00035/event     |
 | Data warehouse                |    1 million synced rows    |  From $0.000015/row      |
 | Logs                          |    50 GB ingested           |  From $0.25/GB           |
 | Workflows                     |    10,000 messages/channel  |  From $0.003/email       |

--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -146,7 +146,7 @@ PostHog's SDK wrappers handle all the heavy lifting. Use your LLM provider as no
 
   - No credit card required to start
   - First 100K LLM events per month are free with 30-day retention
-  - Above 100k we have usage-based pricing at $0.00006/event
+  - Above 100k we have volume-based pricing, starting at $0.00035/event and falling to $0.00006/event at high volume
   - Set billing limits to avoid surprise charges
   - See our [pricing page](/pricing) for more up-to-date details
 

--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -146,7 +146,7 @@ PostHog's SDK wrappers handle all the heavy lifting. Use your LLM provider as no
 
   - No credit card required to start
   - First 100K LLM events per month are free with 30-day retention
-  - Above 100k we have volume-based pricing, starting at $0.00035/event and falling to $0.00006/event at high volume
+  - Above 100k, we have volume-based pricing starting at $0.00035/event and falling to $0.00006/event as volume grows
   - Set billing limits to avoid surprise charges
   - See our [pricing page](/pricing) for more up-to-date details
 

--- a/src/pages/r/ai-observability.tsx
+++ b/src/pages/r/ai-observability.tsx
@@ -424,7 +424,7 @@ export default function AIObservabilityLanding(): JSX.Element {
                                     <strong>First 100k LLM events/mo are free</strong> with 30-day retention
                                 </li>
                                 <li>
-                                    Above 100k: <strong>$0.00006/event</strong> with volume discounts
+                                    Above 100k: <strong>from $0.00035/event</strong> with volume discounts down to $0.00006/event
                                 </li>
                                 <li>Set billing limits to avoid surprise charges</li>
                                 <li>


### PR DESCRIPTION
## Changes

AI observability pricing moves from a flat `$0.00006`/event above the 100k free tier to a volume-tiered model: `$35` per 100k events at the first paid tier, stepping down to `$6` per 100k at the highest volumes. The free tier (100k events/month, unlimited seats) is unchanged.

- Updated the quoted rate in the pricing and competitor comparison tables (`posthog-vs-langfuse`, `posthog-vs-plausible`, `best-product-analytics-tools-for-startups`, `best-braintrust-alternatives`)
- Recalculated the worked cost examples in `best-ai-observability-tools` (700k-event agent workload) and `best-langsmith-alternatives` (cost-at-volume table and the per-1k-request rate), and refreshed that post's "pricing current as of" date
- Fixed the same claim in the AI observability docs TL;DR and on the `/r/ai-observability` landing page

`cheapest-ai-observability-tools` needed no change — it only compares free tiers.

**Why:** the previous rate dated from launch and has been replaced by the new volume-based tiers, so every published figure was stale and understated what customers actually pay.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BMKTE4NG5/p1785850901879889)*