### PR TITLE
docs: add a "Before you start" install block to every surfaces page

### DIFF
--- a/contents/docs/ai-observability/surfaces/api.mdx
+++ b/contents/docs/ai-observability/surfaces/api.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 The API is both how trace data gets into PostHog and how you drive AI Observability from your own code. Your app sends LLM events through the [capture API](/docs/api/capture), and the [PostHog API](/docs/api) exposes the rest of the product – evaluations, datasets, review queues, clustering, summarization, and provider keys – so you can wire scoring and review into CI or your own tooling instead of clicking through the app.
 
+## Before you start
+
+1. **Set up AI Observability** – [install a PostHog LLM SDK or provider integration](/docs/ai-observability/installation) so traces are captured.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What you can do here
 
 **Send traces in**

--- a/contents/docs/ai-observability/surfaces/desktop.mdx
+++ b/contents/docs/ai-observability/surfaces/desktop.mdx
@@ -14,6 +14,11 @@ PostHog Desktop is in beta.
 
 Unlike [error tracking](/docs/error-tracking), this scout stops at the report. It does not open a draft pull request – see [why](#why-there-is-no-automatic-pull-request) below.
 
+## Before you start
+
+1. **Set up AI Observability** – [install a PostHog LLM SDK or provider integration](/docs/ai-observability/installation) so traces are captured.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## How a regression becomes a report
 
 The scout looks for five kinds of change, sliced by the dimensions it finds in your data – model, provider, feature, product area, and any custom properties you attach:

--- a/contents/docs/ai-observability/surfaces/mcp.mdx
+++ b/contents/docs/ai-observability/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) lets your AI coding agent
 
 This works in any MCP client – Cursor, Codex, Claude Code, Windsurf, VS Code, and others.
 
+## Before you start
+
+1. **Set up AI Observability** – [install a PostHog LLM SDK or provider integration](/docs/ai-observability/installation) so traces are captured.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 With MCP, your coding agent can:

--- a/contents/docs/ai-observability/surfaces/web-app.mdx
+++ b/contents/docs/ai-observability/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is where you actually read your A
 
 From there you can open any trace to see the full conversation – every [generation](/docs/ai-observability/generations) and [span](/docs/ai-observability/spans) in order, with inputs, outputs, model, tokens, and cost on each one. Traces carry the person who triggered them, so you can jump straight to their [session replay](/docs/ai-observability/link-session-replay) or any [exception](/docs/ai-observability/link-error-tracking) the request threw.
 
+## Before you start
+
+1. **Set up AI Observability** – [install a PostHog LLM SDK or provider integration](/docs/ai-observability/installation) so traces are captured.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Analyze LLM performance](/docs/ai-observability/dashboard)** – track cost, latency, tokens, and error rate across models, features, and users.

--- a/contents/docs/cdp/surfaces/api.mdx
+++ b/contents/docs/cdp/surfaces/api.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 Use the API when you want pipelines to live in your own configuration rather than being clicked together in the UI – provisioning the same destinations across projects, keeping function definitions in version control, or wiring pipeline changes into your deploy process.
 
+## Before you start
+
+1. **Set up a pipeline** – [create a source, destination, or transformation](/docs/cdp/start-here) so there's something to manage.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What's available
 
 **Hog functions**

--- a/contents/docs/cdp/surfaces/desktop.mdx
+++ b/contents/docs/cdp/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta. This page is a work in progress.
 
 [PostHog Desktop](/docs/posthog-desktop) is where you review the [Self-driving](/docs/self-driving) work that data pipelines generates. Pipeline failures are quiet – events keep ingesting and your dashboards stay green while a destination silently stops delivering – so a [scout](/docs/self-driving/scouts) watches delivery for you and files what it finds as a report.
 
+## Before you start
+
+1. **Set up a pipeline** – [create a source, destination, or transformation](/docs/cdp/start-here) so there's something to manage.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## How a delivery problem becomes a report
 
 A dedicated data pipelines scout runs on a schedule across your destinations, transformations, batch exports, and hog flows. It only cares about the gap between what a pipeline is configured to do and what it's actually doing:

--- a/contents/docs/cdp/surfaces/mcp.mdx
+++ b/contents/docs/cdp/surfaces/mcp.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 The [PostHog MCP server](/docs/model-context-protocol) gives AI agents and MCP clients direct access to your pipelines. Because pipeline functions are just code plus configuration, this is one of the places MCP pays off most – an agent can write a transformation, test it against a real event, read the failure, and fix it, all without you opening the web app.
 
+## Before you start
+
+1. **Set up a pipeline** – [create a source, destination, or transformation](/docs/cdp/start-here) so there's something to manage.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 **Build and edit functions.** Create a destination, transformation, source webhook, or web script from scratch or from a template, then update it in place. Agents can generate the Hog code, the input schema, and the event filters together.

--- a/contents/docs/cdp/surfaces/web-app.mdx
+++ b/contents/docs/cdp/surfaces/web-app.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 The [PostHog web app](https://app.posthog.com) is where you build pipelines and watch them run. Sources, transformations, destinations, and batch exports each get their own section, and every pipeline you create – whether from a template or written by hand – ends up as a [Hog function](/docs/hog) you can open, edit, and test.
 
+## Before you start
+
+1. **Set up a pipeline** – [create a source, destination, or transformation](/docs/cdp/start-here) so there's something to manage.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 ### Link sources

--- a/contents/docs/data-warehouse/surfaces/api.mdx
+++ b/contents/docs/data-warehouse/surfaces/api.mdx
@@ -8,6 +8,11 @@ The [PostHog API](/docs/api) covers the warehouse end to end – the sources you
 
 Every warehouse endpoint is project-scoped and authenticates with a [personal API key](/docs/api#authentication). See the [API reference](/docs/api) for the exact paths, request shapes, scopes, and rate limits.
 
+## Before you start
+
+1. **Set up the Data Warehouse** – [link a source](/docs/data-warehouse/start-here) so there are tables to query.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need.
+
 ## What you can do here
 
 **Manage sources and schemas**

--- a/contents/docs/data-warehouse/surfaces/desktop.mdx
+++ b/contents/docs/data-warehouse/surfaces/desktop.mdx
@@ -14,6 +14,11 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 [PostHog Desktop](/docs/posthog-desktop) is where you work through the warehouse problems PostHog raises on its own – a materialized view that stopped refreshing, or a source whose sync keeps failing. It's a triage surface, not a place to browse your data.
 
+## Before you start
+
+1. **Set up the Data Warehouse** – [link a source](/docs/data-warehouse/start-here) so there are tables to query.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## What you can do here
 
 - **Pick up warehouse signals** – PostHog watches the import side for the moments a source stops keeping its promise: a connection in error, a table schema that failed or is stuck mid-sync, silent staleness behind a green status, a dead webhook channel, and materialized views that fail to refresh. Each one becomes a [signal](/docs/self-driving/signals) carrying the source or view name and the underlying error, so a stale dashboard lands in your queue instead of going unnoticed. When imports are healthy, it looks for optimization candidates instead – expensive query shapes worth materializing, and materialized views nobody reads.

--- a/contents/docs/data-warehouse/surfaces/mcp.mdx
+++ b/contents/docs/data-warehouse/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) lets your AI coding agent
 
 This works in any MCP client – Cursor, Codex, Claude Code, Windsurf, VS Code, and others.
 
+## Before you start
+
+1. **Set up the Data Warehouse** – [link a source](/docs/data-warehouse/start-here) so there are tables to query.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 With MCP, your coding agent can:

--- a/contents/docs/data-warehouse/surfaces/web-app.mdx
+++ b/contents/docs/data-warehouse/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is home base for the data warehou
 
 Open the [SQL editor](https://us.posthog.com/sql) to see the schema browser: your PostHog tables, every synced source table, and your saved views, all queryable together. It's also the only surface where you can change a view's SQL, because a view's definition lives in PostHog rather than in your repository.
 
+## Before you start
+
+1. **Set up the Data Warehouse** – [link a source](/docs/data-warehouse/start-here) so there are tables to query.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Link sources](/docs/data-warehouse/sources)** – connect Stripe, Postgres, Salesforce, HubSpot, and dozens more, pick which tables to sync, and re-run or reset a table when a sync goes wrong.

--- a/contents/docs/endpoints/surfaces/api.mdx
+++ b/contents/docs/endpoints/surfaces/api.mdx
@@ -20,6 +20,11 @@ curl -X POST \
   "<ph_app_host>/api/environments/{project_id}/endpoints/{endpoint_name}/run"
 ```
 
+## Before you start
+
+1. **Create an endpoint** – [define your data and publish it](/docs/endpoints/start-here) so there's an endpoint to call.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What you can do here
 
 - **Parameterize the query** – pass [variables](/docs/endpoints/variables) so one endpoint serves many customers, date ranges, or breakdowns.

--- a/contents/docs/endpoints/surfaces/desktop.mdx
+++ b/contents/docs/endpoints/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ Both Endpoints and PostHog Desktop are in beta.
 
 [PostHog Desktop](/docs/posthog-desktop) is where endpoints meet the code that calls them. The agent has your repo, your endpoints, and PostHog's [endpoint skills](/docs/posthog-desktop/skills) in one place, so it can build an endpoint and wire it into your app in the same session.
 
+## Before you start
+
+1. **Create an endpoint** – [define your data and publish it](/docs/endpoints/start-here) so there's an endpoint to call.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## What you can do here
 
 - **Build and consume an endpoint in one pass** – the agent creates the endpoint, tests it, then writes the typed client code that calls it.

--- a/contents/docs/endpoints/surfaces/mcp.mdx
+++ b/contents/docs/endpoints/surfaces/mcp.mdx
@@ -12,6 +12,11 @@ Endpoints is in beta and free to use while it is. [Send us feedback](https://app
 
 The PostHog [MCP server](/docs/model-context-protocol) brings endpoints into Claude Code, Cursor, and other AI tools. Because the agent writing the code that calls your endpoint can also create and test that endpoint, you go from "I need this number in my app" to a working request without leaving your editor.
 
+## Before you start
+
+1. **Create an endpoint** – [define your data and publish it](/docs/endpoints/start-here) so there's an endpoint to call.
+2. **Connect the MCP server** – [install it in your AI tool](#set-up) and give it access to your project.
+
 ## What you can do here
 
 Through MCP tools, your agent can:

--- a/contents/docs/endpoints/surfaces/web-app.mdx
+++ b/contents/docs/endpoints/surfaces/web-app.mdx
@@ -14,6 +14,11 @@ The [PostHog web app](https://app.posthog.com/endpoints) is where endpoints get 
 
 Open **Endpoints** in [PostHog](https://app.posthog.com/endpoints) to see every endpoint in the project, with its current version and whether it's materialized. The **New endpoint** menu starts from either a SQL query in the SQL editor or a new or existing insight – see [endpoint types](/docs/endpoints/endpoint-types) for how the two differ once they're live.
 
+## Before you start
+
+1. **Create an endpoint** – [define your data and publish it](/docs/endpoints/start-here) so there's an endpoint to call.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Create a SQL-based endpoint with variables](/docs/endpoints/guide-variables)** – write the query, parameterize it, and publish it.

--- a/contents/docs/error-tracking/surfaces/cli.mdx
+++ b/contents/docs/error-tracking/surfaces/cli.mdx
@@ -8,6 +8,11 @@ The [PostHog CLI](/docs/cli) is how error tracking gets what it needs from your 
 
 This is a build-time and CI surface rather than a place you read issues. You triage and resolve issues in the [web app](/docs/error-tracking/surfaces/web-app) or over [MCP](/docs/error-tracking/surfaces/mcp).
 
+## Before you start
+
+1. **Set up Error Tracking** – [install exception capture in your app](/docs/error-tracking/installation) so exceptions reach PostHog.
+2. **Install the CLI** – [install and authenticate `posthog-cli`](/docs/cli) with a personal API key.
+
 ## What you can do here
 
 - **Upload source maps** – inject and upload JavaScript source maps so minified frames resolve to your real code. See [Upload source maps with the CLI](/docs/error-tracking/upload-source-maps/cli).

--- a/contents/docs/error-tracking/surfaces/desktop.mdx
+++ b/contents/docs/error-tracking/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta. This page is a work in progress.
 
 [PostHog Desktop](/docs/posthog-desktop) is where you review and merge the [Self-driving](/docs/self-driving) work that error tracking generates. When recurring exceptions are grouped into a report and a code fix is possible, Self-driving opens a draft pull request. You review it in PostHog Desktop, next to the agents improving your product, and nothing ships until you merge.
 
+## Before you start
+
+1. **Set up Error Tracking** – [install exception capture in your app](/docs/error-tracking/installation) so exceptions reach PostHog.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## Start at the inbox
 
 Reports don't come looking for you – they queue up in the [Self-driving inbox](/docs/self-driving/inbox), so checking it is the habit that makes this surface worth anything. The inbox holds everything Self-driving has found across every source, error tracking included, with the highest-priority reports first. Open one to see the issue behind it, the evidence, and any pull request it opened.

--- a/contents/docs/error-tracking/surfaces/mcp.mdx
+++ b/contents/docs/error-tracking/surfaces/mcp.mdx
@@ -19,6 +19,11 @@ For example, with MCP, your agents can:
 
 All of this happens directly inside the MCP client, like Cursor, Windsurf, or Claude Code, so you can investigate and resolve product issues without ever leaving the code editor.
 
+## Before you start
+
+1. **Set up Error Tracking** – [install exception capture in your app](/docs/error-tracking/installation) so exceptions reach PostHog.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## How it works
 
 <ProductVideo

--- a/contents/docs/error-tracking/surfaces/web-app.mdx
+++ b/contents/docs/error-tracking/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is home base for error tracking. 
 
 Open **Error tracking** in [PostHog](https://app.posthog.com) to see the issues list: every open issue with its status, assignee, first and last seen, and occurrence count. From there, filter and search to find what matters, then open an issue to dig in.
 
+## Before you start
+
+1. **Set up Error Tracking** – [install exception capture in your app](/docs/error-tracking/installation) so exceptions reach PostHog.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Monitor and search issues](/docs/error-tracking/monitoring)** – filter, search, and save views over your issues so the important ones surface first.

--- a/contents/docs/experiments/surfaces/api.mdx
+++ b/contents/docs/experiments/surfaces/api.mdx
@@ -8,6 +8,11 @@ Use the API when experiments need to be created or read by something other than 
 
 Reading requires the `experiment:read` scope and writing requires `experiment:write`, both on a [personal API key](/docs/api#authentication).
 
+## Before you start
+
+1. **Set up Experiments** – [install a PostHog SDK](/docs/experiments/installation) so your app can serve variants.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What's available
 
 **Experiments**

--- a/contents/docs/experiments/surfaces/desktop.mdx
+++ b/contents/docs/experiments/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta, so some behaviors may still change.
 
 [PostHog Desktop](/docs/posthog-desktop) is where you review the [Self-driving](/docs/self-driving) work your experiments generate. A [scout](/docs/self-driving/scouts) audits your running experiments for problems with the measurement itself – a skewed split, a stalled exposure stream, a flag edited mid-run – and files each confirmed problem as a [report](/docs/self-driving/reports) in your [inbox](/docs/self-driving/inbox). You don't design, launch, or analyze experiments here, that happens in the [web app](/docs/experiments/surfaces/web-app).
 
+## Before you start
+
+1. **Set up Experiments** – [install a PostHog SDK](/docs/experiments/installation) so your app can serve variants.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## What you can do here
 
 - Open a validity report to see the experiment, its [feature flag](/docs/feature-flags) key, and the numbers behind the finding – observed versus expected split, exposure counts, days dormant, and when the problem started.

--- a/contents/docs/experiments/surfaces/mcp.mdx
+++ b/contents/docs/experiments/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) exposes experiments as fu
 
 This is the surface to use when the experiment lives next to the code you're writing. You can scaffold the test in the same session you build the feature, then come back later and ask whether it won.
 
+## Before you start
+
+1. **Set up Experiments** – [install a PostHog SDK](/docs/experiments/installation) so your app can serve variants.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 **Plan and create experiments**

--- a/contents/docs/experiments/surfaces/web-app.mdx
+++ b/contents/docs/experiments/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is where experiments are designed
 
 Because the experiment sits next to the rest of your PostHog data, the results view isn't just a number. You can jump from a variant to the [session replays](/docs/session-replay) of the people who saw it, or break a metric down by any property you already capture.
 
+## Before you start
+
+1. **Set up Experiments** – [install a PostHog SDK](/docs/experiments/installation) so your app can serve variants.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Create an experiment](/docs/experiments/creating-an-experiment)** – define your hypothesis, variants, and metrics, and let PostHog create the backing [feature flag](/docs/feature-flags).

--- a/contents/docs/feature-flags/surfaces/api.mdx
+++ b/contents/docs/feature-flags/surfaces/api.mdx
@@ -8,6 +8,11 @@ There are two APIs for feature flags, and they answer different questions. The [
 
 Use the API when you want flags in a place PostHog doesn't ship an SDK for, or when flag management should be part of a pipeline rather than a person clicking through the app.
 
+## Before you start
+
+1. **Set up Feature Flags** – [install a PostHog SDK](/docs/feature-flags/installation) so your app can evaluate flags.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need.
+
 ## What you can do here
 
 **Evaluate flags** with [`/flags`](/docs/api/flags), using your public project API key and a `distinct_id`. It returns each flag's value for that user, plus any payloads. See the [API installation guide](/docs/feature-flags/installation/api) for the request shape.

--- a/contents/docs/feature-flags/surfaces/desktop.mdx
+++ b/contents/docs/feature-flags/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta.
 
 [PostHog Desktop](/docs/posthog-desktop) is where you review the [Self-driving](/docs/self-driving) work that feature flags generate. A scout reads your flag roster against the `$feature_flag_called` stream, finds places where the flags in your PostHog project no longer match the flag checks in your code, and files what it finds as a report you can act on.
 
+## Before you start
+
+1. **Set up Feature Flags** – [install a PostHog SDK](/docs/feature-flags/installation) so your app can evaluate flags.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## What the flags scout watches for
 
 The scout is auditing the wiring between the flag UI and your code, not judging which features should be on. A flag whose evaluation stream matches its configured state is left alone, however its volume trends. What it looks for instead:

--- a/contents/docs/feature-flags/surfaces/mcp.mdx
+++ b/contents/docs/feature-flags/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) lets your AI coding agent
 
 This works in any MCP client – Cursor, Codex, Claude Code, Windsurf, VS Code, and others.
 
+## Before you start
+
+1. **Set up Feature Flags** – [install a PostHog SDK](/docs/feature-flags/installation) so your app can evaluate flags.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## How it works
 
 With MCP, your coding agent can:

--- a/contents/docs/feature-flags/surfaces/web-app.mdx
+++ b/contents/docs/feature-flags/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is home base for feature flags. I
 
 Open **Feature flags** in [PostHog](https://app.posthog.com) to see every flag in the project with its status, type, and last-modified date. Open a flag to edit its release conditions, inspect which users match, test how it evaluates, and see the activity log of who changed what.
 
+## Before you start
+
+1. **Set up Feature Flags** – [install a PostHog SDK](/docs/feature-flags/installation) so your app can evaluate flags.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Create feature flags](/docs/feature-flags/creating-feature-flags)** – set up boolean, multivariate, or remote config flags and define their release conditions.

--- a/contents/docs/logs/surfaces/api.mdx
+++ b/contents/docs/logs/surfaces/api.mdx
@@ -8,6 +8,11 @@ The Logs API is the surface for anything you want to script or wire into your ow
 
 It's a project-scoped REST API and uses the same [authentication](/docs/api) as the rest of PostHog. Note that this is for reading and managing logs – to *send* logs to PostHog you use an [OpenTelemetry client](/docs/logs/installation), not this API.
 
+## Before you start
+
+1. **Set up Logs** – [send them to PostHog with an OpenTelemetry client](/docs/logs/installation) so there's something to read.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need.
+
 ## What you can do here
 
 | Endpoint | What it's for |

--- a/contents/docs/logs/surfaces/desktop.mdx
+++ b/contents/docs/logs/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta, so some behaviors may still change.
 
 [PostHog Desktop](/docs/posthog-desktop) is the surface for driving parallel agents that improve your product. For Logs, it's where you review the [Self-driving](/docs/self-driving) work that your firing alerts generate, plus the shifts PostHog spots in your logs on its own. You don't browse raw log lines here – that's the [web app](/docs/logs/surfaces/web-app).
 
+## Before you start
+
+1. **Set up Logs** – [send them to PostHog with an OpenTelemetry client](/docs/logs/installation) so there's something to read.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## What you can do here
 
 When a [log alert](/docs/logs/alerts) starts firing, or breaks and auto-disables, it emits a signal into Self-driving. Related signals get grouped into a [report](/docs/self-driving/reports) with the logs behind them, and when there's a code fix, a drafted pull request.

--- a/contents/docs/logs/surfaces/mcp.mdx
+++ b/contents/docs/logs/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) gives coding agents direc
 
 This works in any MCP client – Cursor, Codex, Claude Code, Windsurf, VS Code, and others.
 
+## Before you start
+
+1. **Set up Logs** – [send them to PostHog with an OpenTelemetry client](/docs/logs/installation) so there's something to read.
+2. **Connect the MCP server** – [install it in your AI tool](#set-up) and give it access to your project.
+
 ## What you can do here
 
 Through MCP tools, your agent can:

--- a/contents/docs/logs/surfaces/web-app.mdx
+++ b/contents/docs/logs/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com/logs) is home base for Logs. It's 
 
 Most investigations start the same way: filter to a service and severity, find the log line that matters, then pivot to the [session replay](/docs/logs/link-session-replay), [person](/docs/logs/link-person), or error attached to it.
 
+## Before you start
+
+1. **Set up Logs** – [send them to PostHog with an OpenTelemetry client](/docs/logs/installation) so there's something to read.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Search and filter](/docs/logs/search)** – narrow logs with the facet rail, the filter bar, or free-text search, and save a filter combination as a view you can switch back to.

--- a/contents/docs/mcp-analytics/surfaces/api.mdx
+++ b/contents/docs/mcp-analytics/surfaces/api.mdx
@@ -14,6 +14,11 @@ Use the API to pull MCP Analytics data into your own dashboards, reports, or wor
 
 For the raw event stream, you can also query `$mcp_*` events directly through the [query API](/docs/api/query) – see [sample queries](/docs/mcp-analytics/queries) for HogQL recipes.
 
+## Before you start
+
+1. **Set up MCP Analytics** – [install the SDK in your MCP server](/docs/mcp-analytics/installation) so tool calls are captured.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What's available
 
 **Sessions**

--- a/contents/docs/mcp-analytics/surfaces/desktop.mdx
+++ b/contents/docs/mcp-analytics/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta.
 
 [PostHog Desktop](/docs/posthog-desktop) is where you act on the [Self-driving](/docs/self-driving) reports MCP Analytics generates. A scout reads your tool call telemetry, finds tools that need fixing, and files a report. Whether that report arrives with a pull request attached depends on who owns the server it's about.
 
+## Before you start
+
+1. **Set up MCP Analytics** – [install the SDK in your MCP server](/docs/mcp-analytics/installation) so tool calls are captured.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## Whether you get a pull request depends on who owns the server
 
 The scout can only propose a code fix for code you control, so the same finding takes one of two paths:

--- a/contents/docs/mcp-analytics/surfaces/mcp.mdx
+++ b/contents/docs/mcp-analytics/surfaces/mcp.mdx
@@ -12,9 +12,10 @@ MCP Analytics tools are in beta and require the MCP Analytics feature preview to
 
 PostHog's [MCP server](/docs/model-context-protocol) exposes MCP Analytics as a set of tools, so you can investigate how agents use your server from Claude Code, Cursor, or any other MCP client – without switching to the web app. It's the fastest way to ask "which of my tools is failing, and why?" while you're already in your editor.
 
-## Setup
+## Before you start
 
-Follow the [MCP server setup](/docs/model-context-protocol) to connect PostHog to your client. MCP Analytics tools need the `mcp_analytics:read` scope, and the ones that write data (feedback, missing capabilities, recomputing clusters) need `mcp_analytics:write`.
+1. **Set up MCP Analytics** – [install the SDK in your MCP server](/docs/mcp-analytics/installation) so tool calls are captured.
+2. **Connect the MCP server** – follow the [MCP server setup](/docs/model-context-protocol) to connect PostHog to your client. MCP Analytics tools need the `mcp_analytics:read` scope, and the ones that write data (feedback, missing capabilities, recomputing clusters) need `mcp_analytics:write`.
 
 ## What you can do here
 

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -12,6 +12,11 @@ The MCP Analytics views are behind a feature preview. [Turn on the MCP Analytics
 
 The [PostHog web app](https://app.posthog.com) is where you explore how agents use your MCP tools. Once your server is [sending events](/docs/mcp-analytics/installation), open **MCP Analytics** to get dashboards, session drill-downs, per-tool quality, and clustered intent – all built on the `$mcp_tool_call` stream.
 
+## Before you start
+
+1. **Set up MCP Analytics** – [install the SDK in your MCP server](/docs/mcp-analytics/installation) so tool calls are captured.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 The scene is organized into tabs, each answering a different question.

--- a/contents/docs/posthog-ai/surfaces/slack.mdx
+++ b/contents/docs/posthog-ai/surfaces/slack.mdx
@@ -14,6 +14,11 @@ Most questions about your product get asked in Slack, not in PostHog. The [PostH
 
 It's a real conversation, not an alert feed. PostHog AI replies in the thread, you can follow up in plain English, and it keeps the whole thread as context for the run.
 
+## Before you start
+
+1. **Enable PostHog AI** – [grant it access to your project](/docs/posthog-ai/allow-access), which an org admin does once.
+2. **Install the PostHog Slack app** – [add it to your workspace](/docs/slack/setup) as a project admin, and make sure your Slack email matches your PostHog account.
+
 ## Start a conversation
 
 There are three ways in:

--- a/contents/docs/posthog-ai/surfaces/web-app.mdx
+++ b/contents/docs/posthog-ai/surfaces/web-app.mdx
@@ -10,6 +10,11 @@ The [PostHog web app](https://app.posthog.com) is home base for PostHog AI. It's
 
 Because it runs next to your data, PostHog AI can do more than answer. It reads your events, insights, and warehouse schema, runs queries against them, and then acts – creating dashboards, editing the filters on the page you're on, or writing the SQL you were about to write yourself.
 
+## Before you start
+
+1. **Enable PostHog AI** – [grant it access to your project](/docs/posthog-ai/allow-access), which an org admin does once.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## In-app chat
 
 The primary dedicated interface is an in-app <a href="https://app.posthog.com/#panel=max">AI chat</a> for conventional prompting and conversation-based flows.

--- a/contents/docs/product-analytics/surfaces/api.mdx
+++ b/contents/docs/product-analytics/surfaces/api.mdx
@@ -8,6 +8,11 @@ Use the API to run analytics queries and manage saved insights from your own sys
 
 There are two things worth knowing about. The **query endpoint** runs any analytics query and hands back results, and the **insights endpoints** create, read, update, and delete the insights people see in the web app.
 
+## Before you start
+
+1. **Set up Product Analytics** – [install a PostHog SDK](/docs/product-analytics/installation) so events are captured.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## Run a query
 
 `POST /api/projects/:project_id/query/` takes a query node – trends, funnels, retention, paths, stickiness, lifecycle, or raw [SQL](/docs/data-warehouse/sql) – and returns the results. This is the same endpoint the web app uses, so anything you can build as an insight you can run over the API.

--- a/contents/docs/product-analytics/surfaces/desktop.mdx
+++ b/contents/docs/product-analytics/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta.
 
 [PostHog Desktop](/docs/posthog-desktop) is where you read the [Self-driving](/docs/self-driving) reports your product analytics data generates. Your insights don't just sit on a dashboard – a scout reads them, finds the ones that regressed, and files what it finds for you to act on.
 
+## Before you start
+
+1. **Set up Product Analytics** – [install a PostHog SDK](/docs/product-analytics/installation) so events are captured.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## How a regression becomes a report
 
 A [scout](/docs/self-driving/scouts) watches the funnel, retention, lifecycle, stickiness, and paths insights you've saved, and looks at the rates they produce rather than raw volume. Traffic being down is not a signal. A conversion step that used to convert at 40% and now converts at 22% is.

--- a/contents/docs/product-analytics/surfaces/mcp.mdx
+++ b/contents/docs/product-analytics/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) gives your AI coding agen
 
 This works in any MCP client: Cursor, Codex, Claude Code, Windsurf, VS Code, and others.
 
+## Before you start
+
+1. **Set up Product Analytics** – [install a PostHog SDK](/docs/product-analytics/installation) so events are captured.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 - **Check feature performance** before making code changes – "How many users are using the new search feature this week?"

--- a/contents/docs/product-analytics/surfaces/web-app.mdx
+++ b/contents/docs/product-analytics/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is home base for product analytic
 
 Open **Product analytics** in [PostHog](https://app.posthog.com) to start a new insight, or **Dashboards** to see what your team has already built.
 
+## Before you start
+
+1. **Set up Product Analytics** – [install a PostHog SDK](/docs/product-analytics/installation) so events are captured.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Create insights](/docs/product-analytics/insights)** – start from an insight type, pick your events and filters, and save the result.

--- a/contents/docs/session-replay/surfaces/api.mdx
+++ b/contents/docs/session-replay/surfaces/api.mdx
@@ -8,6 +8,11 @@ PostHog's REST API exposes session recordings and playlists, so you can pull rep
 
 Authenticate with a [personal API key](/docs/api#authentication) scoped to `session_recording` and `session_recording_playlist`. Reads need the `:read` scopes; writes and deletes need `:write`.
 
+## Before you start
+
+1. **Set up Session Replay** – [install and enable recording](/docs/session-replay/installation) so there are sessions to watch.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need.
+
 ## What you can do here
 
 - **List and filter recordings** – page through recordings for a project and filter them the same way the replay list does.

--- a/contents/docs/session-replay/surfaces/desktop.mdx
+++ b/contents/docs/session-replay/surfaces/desktop.mdx
@@ -14,6 +14,11 @@ PostHog Desktop is in beta. This page is a work in progress.
 
 Unlike [error tracking](/docs/error-tracking), this scout stops at the report. It doesn't open a draft pull request – see [why](#why-there-is-no-pull-request) below.
 
+## Before you start
+
+1. **Set up Session Replay** – [install and enable recording](/docs/session-replay/installation) so there are sessions to watch.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## How a session problem becomes a report
 
 The scout watches two things: whether you're still recording, and where recorded users hit a wall.

--- a/contents/docs/session-replay/surfaces/mcp.mdx
+++ b/contents/docs/session-replay/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) exposes session replay to
 
 This works in any MCP client, including Cursor, Claude Code, Codex, Windsurf, and VS Code.
 
+## Before you start
+
+1. **Set up Session Replay** – [install and enable recording](/docs/session-replay/installation) so there are sessions to watch.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 - **Search recordings** – find sessions by events, person properties, replay behaviors like rage clicks and dead clicks, and time range.

--- a/contents/docs/session-replay/surfaces/web-app.mdx
+++ b/contents/docs/session-replay/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is where you watch replays. Open 
 
 That's the difference between a video and a debugging environment. You can jump to the moment an error fired, read the console output from that instant, and inspect the network waterfall around it without asking the user to reproduce anything.
 
+## Before you start
+
+1. **Set up Session Replay** – [install and enable recording](/docs/session-replay/installation) so there are sessions to watch.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Watch recordings](/docs/session-replay/how-to-watch-recordings)** – play back a session with the synced activity, console, and network panels.

--- a/contents/docs/support/surfaces/desktop.mdx
+++ b/contents/docs/support/surfaces/desktop.mdx
@@ -12,6 +12,11 @@ PostHog Desktop is in beta, so some behaviors may still change.
 
 [PostHog Desktop](/docs/posthog-desktop) is the surface for driving parallel agents that improve your product. For Support, it's where you review and merge the [Self-driving](/docs/self-driving) PRs generated from your tickets. You don't reply to customer tickets here, that happens in the [web app](/docs/support/inbox).
 
+## Before you start
+
+1. **Set up Support** – [enable conversations and connect a channel](/docs/support/start-here) so tickets arrive in your inbox.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## Review the fixes your tickets generated
 
 Recurring issues in your support conversations become [Self-driving reports](/docs/self-driving/reports), each with the evidence behind it and, when there's a code fix, a drafted pull request. PostHog Desktop is where you connect those conversations as a signal source and work through the reports they generate.

--- a/contents/docs/support/surfaces/mcp.mdx
+++ b/contents/docs/support/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ import TicketStatuses from '../_snippets/ticket-statuses.mdx'
 
 The PostHog [MCP server](/docs/model-context-protocol) brings Support into Claude Code, Cursor, and other AI tools. If you already work in one of these tools, it keeps ticket context within reach without a trip to the web app.
 
+## Before you start
+
+1. **Set up Support** – [enable conversations and connect a channel](/docs/support/start-here) so tickets arrive in your inbox.
+2. **Connect the MCP server** – [install it in your AI tool](#set-up) and give it access to your project.
+
 ## Debug without leaving your editor
 
 When a ticket is about the bug you're chasing in Cursor or Claude Code, ask your agent to pull it instead of switching to the web app. It reads the customer's message, linked session, events, and exception in your editor, so you go from report to root cause without breaking flow. Fix it, then resolve the ticket from the same place.

--- a/contents/docs/support/surfaces/slack.mdx
+++ b/contents/docs/support/surfaces/slack.mdx
@@ -14,6 +14,11 @@ Mention `@PostHog` in any Slack channel to query your support data and the [Self
 
 This page covers using `@PostHog` for support. For everything the app can do across the rest of PostHog, see the [Slack app docs](/docs/slack).
 
+## Before you start
+
+1. **Set up Support** – [enable conversations and connect a channel](/docs/support/start-here) so tickets arrive in your inbox.
+2. **Install the PostHog Slack app** – [add `@PostHog` to your workspace](/docs/slack/setup) as a project admin, and make sure your Slack email matches your PostHog account. To turn Slack messages into tickets instead, install [SupportHog](/docs/support/slack) – that's a separate app with its own setup.
+
 ## What you can do
 
 Mention `@PostHog` and it works in the thread:

--- a/contents/docs/surveys/surfaces/api.mdx
+++ b/contents/docs/surveys/surfaces/api.mdx
@@ -8,6 +8,11 @@ Use the API when you want surveys managed by your own tooling rather than by han
 
 Reading surveys requires the `survey:read` scope; creating, updating, launching, stopping, and deleting them requires `survey:write`.
 
+## Before you start
+
+1. **Set up Surveys** – [install a PostHog SDK](/docs/surveys/installation) so they can be shown to users.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What you can do here
 
 **Manage surveys**

--- a/contents/docs/surveys/surfaces/desktop.mdx
+++ b/contents/docs/surveys/surfaces/desktop.mdx
@@ -14,6 +14,11 @@ PostHog Desktop is in beta. This page is a work in progress.
 
 Unlike [error tracking](/docs/error-tracking), this scout stops at the report. It doesn't open a draft pull request – see [why](#why-there-is-no-pull-request) below.
 
+## Before you start
+
+1. **Set up Surveys** – [install a PostHog SDK](/docs/surveys/installation) so they can be shown to users.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## How feedback becomes a report
 
 Surveys are direct user voice, so the bar for a report is deliberately high: a handful of converging open-text answers can outweigh a much larger analytics signal, but a wobble in a small NPS sample is not a report.

--- a/contents/docs/surveys/surfaces/mcp.mdx
+++ b/contents/docs/surveys/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) exposes PostHog's API as 
 
 That means you can spin up a survey while you're still writing the feature it asks about, launch it when you ship, and pull the responses back into your editor when they land – without opening the PostHog web app.
 
+## Before you start
+
+1. **Set up Surveys** – [install a PostHog SDK](/docs/surveys/installation) so they can be shown to users.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 - **Create a survey** – describe the questions, type, targeting, and display conditions, and the agent creates it. Surveys are created as drafts by default, so nothing goes live until you say so.

--- a/contents/docs/surveys/surfaces/web-app.mdx
+++ b/contents/docs/surveys/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com) is where surveys are built, targe
 
 Open **Surveys** in [PostHog](https://app.posthog.com/surveys) to see every survey in your project with its status, response count, and schedule. Start from a template – NPS, product-market fit, churn, or open feedback – or write your own from scratch, and preview it before anyone sees it.
 
+## Before you start
+
+1. **Set up Surveys** – [install a PostHog SDK](/docs/surveys/installation) so they can be shown to users.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Create a survey](/docs/surveys/creating-surveys)** – pick a type (popover, widget, hosted form, or headless API), write your questions, style the appearance, and launch it.

--- a/contents/docs/web-analytics/surfaces/api.mdx
+++ b/contents/docs/web-analytics/surfaces/api.mdx
@@ -8,6 +8,11 @@ The API is how traffic data gets into PostHog and how you get it back out. Your 
 
 Use it when you want traffic data somewhere PostHog isn't – a status page, an internal report, a weekly digest of your own – or when you want to script something the dashboard doesn't do.
 
+## Before you start
+
+1. **Set up Web Analytics** – [install PostHog on your site](/docs/web-analytics/installation) so pageviews are captured.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What you can do here
 
 **Send traffic in**

--- a/contents/docs/web-analytics/surfaces/desktop.mdx
+++ b/contents/docs/web-analytics/surfaces/desktop.mdx
@@ -14,6 +14,11 @@ PostHog Desktop is in beta. This page is a work in progress.
 
 Unlike [error tracking](/docs/error-tracking), these scouts stop at the report. They don't open a draft pull request – see [why](#why-there-is-usually-no-pull-request) below.
 
+## Before you start
+
+1. **Set up Web Analytics** – [install PostHog on your site](/docs/web-analytics/installation) so pageviews are captured.
+2. **Install PostHog Desktop** – [download the app](/docs/posthog-desktop/download-posthog-desktop) and connect it to your project.
+
 ## How a traffic change becomes a report
 
 A scout watches your `sessions` data for the changes a site-wide total hides:

--- a/contents/docs/web-analytics/surfaces/mcp.mdx
+++ b/contents/docs/web-analytics/surfaces/mcp.mdx
@@ -8,6 +8,11 @@ The [PostHog MCP server](/docs/model-context-protocol) lets your AI agent query 
 
 This works in any MCP client, including Cursor, Codex, Claude Code, Windsurf, and VS Code.
 
+## Before you start
+
+1. **Set up Web Analytics** – [install PostHog on your site](/docs/web-analytics/installation) so pageviews are captured.
+2. **Connect the MCP server** – [install it in your AI tool](#install-the-mcp-server) and give it access to your project.
+
 ## What you can do here
 
 - **Summarize a site** – `web-analytics-weekly-digest` returns visitors, pageviews, sessions, bounce rate, and average session duration over a 1–90 day window, with period-over-period comparison, plus top pages, top sources, and goal conversions.

--- a/contents/docs/web-analytics/surfaces/web-app.mdx
+++ b/contents/docs/web-analytics/surfaces/web-app.mdx
@@ -8,6 +8,11 @@ The [PostHog web app](https://app.posthog.com/web) is home base for web analytic
 
 Open **Web analytics** in [PostHog](https://app.posthog.com/web) to see the overview: visitors, pageviews, [sessions](/docs/data/sessions), average session duration, and bounce rate, each compared to the previous period. Click any row – a landing page, a referrer, a UTM source – to filter the whole dashboard to it, then jump straight into the [session replays](/docs/session-replay) behind the number.
 
+## Before you start
+
+1. **Set up Web Analytics** – [install PostHog on your site](/docs/web-analytics/installation) so pageviews are captured.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **[Read the dashboard](/docs/web-analytics/dashboard)** – visitors, pageviews, paths, channels, referrers, UTMs, world map, retention, and active hours, all filterable.

--- a/contents/docs/workflows/surfaces/api.mdx
+++ b/contents/docs/workflows/surfaces/api.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 Workflows are stored as **hog flows**, and every one of them is available over the PostHog [REST API](/docs/api). Use it when you want workflows under version control, generated from your own system, or created as part of a deploy.
 
+## Before you start
+
+1. **Set up Workflows** – Workflows are no-code, so there's nothing to install. [Install a PostHog SDK](/docs/workflows/installation) if you want event-based triggers.
+2. **Get API access** – [create a personal API key](/docs/api/personal-api-keys) with the scopes you need. See [authentication](#authentication) below.
+
 ## What you can do here
 
 - **Manage workflows.** `/api/projects/:project_id/hog_flows/` lists, creates, reads, updates, and deletes workflows, including their trigger, graph of actions, and enabled state.

--- a/contents/docs/workflows/surfaces/mcp.mdx
+++ b/contents/docs/workflows/surfaces/mcp.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 The PostHog [MCP server](/docs/model-context-protocol) brings Workflows into Claude Code, Cursor, and other AI tools. It covers the full lifecycle – create a draft, edit its graph, test it, publish it, and read its stats and logs – so you can build and ship a workflow without leaving your editor.
 
+## Before you start
+
+1. **Set up Workflows** – Workflows are no-code, so there's nothing to install. [Install a PostHog SDK](/docs/workflows/installation) if you want event-based triggers.
+2. **Connect the MCP server** – [install it in your AI tool](#set-up) and give it access to your project.
+
 ## What you can do here
 
 Through MCP tools, your agent can:

--- a/contents/docs/workflows/surfaces/web-app.mdx
+++ b/contents/docs/workflows/surfaces/web-app.mdx
@@ -6,6 +6,11 @@ showTitle: true
 
 The [PostHog web app](https://app.posthog.com) is where workflows are built. It's the surface for the drag-and-drop [workflow builder](/docs/workflows/workflow-builder), the [content library](/docs/workflows/library) where message templates live, your [channels](/docs/workflows/configure-channels), and your [opt-out and suppression lists](/docs/workflows/opt-outs).
 
+## Before you start
+
+1. **Set up Workflows** – Workflows are no-code, so there's nothing to install. [Install a PostHog SDK](/docs/workflows/installation) if you want event-based triggers.
+2. **Open the web app** – no install needed, just sign in to [PostHog](https://app.posthog.com).
+
 ## What you can do here
 
 - **Build a workflow.** Start from a trigger – an event, a webhook, a tracking pixel, a schedule, or a manual run – then add delays, audience splits, message dispatches, and PostHog actions until you reach an exit. See the [workflow builder](/docs/workflows/workflow-builder) for every node type.


### PR DESCRIPTION
## Changes

Every `surfaces/*` docs page (60 of them, across 16 products) now opens with a **Before you start** section: two numbered steps covering how to install the product, then how to set up the surface.

The steps link to install docs that already exist rather than restating them — `/docs/<product>/installation` or `start-here` for the product, and `/docs/model-context-protocol`, `/docs/slack/setup`, `/docs/posthog-desktop/download-posthog-desktop`, `/docs/api/personal-api-keys`, `/docs/cli` for the surface. Where a page already documents the surface install further down (most MCP pages), step 2 links to that section's anchor instead of duplicating it. On `mcp-analytics/surfaces/mcp` the existing `## Setup` section was folded into the new block rather than added alongside it.

Two pages get a bit of extra disambiguation: `support/surfaces/slack` now says explicitly that `@PostHog` and SupportHog are separate apps with separate installs, since that's the confusion that prompted this.

## Why

Raised in a Slack thread: someone trying to understand the Support adoption funnel read `support/surfaces/slack` and couldn't find the install → setup → activation journey, because surfaces pages start from "here's what you can do here" and assume both the product and the surface are already set up. That gap is systemic, not specific to Support — none of the 60 surfaces pages told you how to get to the starting line. The two Slack surfaces (SupportHog as a ticket channel vs `@PostHog` as an agent surface) made it worse, since it wasn't obvious which install a reader needed.

Flagging for the docs team, who are actively working in this area — happy for the wording or the block placement to be reshaped.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — not done; instead `markdownlint-cli2` (0 issues) and Vale (0 findings on added lines) were run locally, and every link and in-page anchor in the new blocks was verified to resolve
- [ ] If I moved a page, I added a redirect in `vercel.json` — n/a, no pages moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BKQ4XDCUR/p1785849358792519?thread_ts=1785849358.792519&cid=C0BKQ4XDCUR)*
