### PR TITLE
Remove beta callout from prompt management

### DIFF
--- a/contents/docs/prompt-management/_snippets/prompts-alpha.mdx
+++ b/contents/docs/prompt-management/_snippets/prompts-alpha.mdx
@@ -1,9 +1,0 @@
-import CalloutBox from 'components/Docs/CalloutBox'
-
-<CalloutBox icon="IconFlask" title="Prompt management is in beta" type="action">
-
-Prompt management is currently in beta.
-
-We'd love to [hear your feedback](https://app.posthog.com/home#panel=support%3Afeedback%3A%3Alow%3Atrue) as we develop this feature.
-
-</CalloutBox>

--- a/contents/docs/prompt-management/index.mdx
+++ b/contents/docs/prompt-management/index.mdx
@@ -2,10 +2,7 @@
 title: Prompt management
 ---
 
-import PromptsAlpha from "./_snippets/prompts-alpha.mdx"
 import { ProductScreenshot } from "components/ProductScreenshot"
-
-<PromptsAlpha />
 
 Prompt management lets you create and update LLM prompts directly in PostHog. When you use prompts through the SDK, they're fetched at runtime with caching and fallback support—so you can iterate on prompts without deploying code.
 

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -549,8 +549,7 @@ const products: Product[] = [
         Icon: IconLlmPromptManagement,
         color: 'yellow',
         types: ['AI'],
-        status: 'Roadmap',
-        roadmapID: 2168,
+        status: 'Production',
     },
     {
         name: 'Support',


### PR DESCRIPTION
## Changes

Prompt management is leaving beta.

- Removed the "Prompt management is in beta" callout from /docs/prompt-management and deleted the unused snippet.
- Homepage product board: Prompt management moved from Roadmap to Production.
- Removed the beta markers from prompt management in the competitor comparison data (`src/hooks/competitorData/posthog.tsx`), which feeds the comparison tables.
- Removed "(beta)" from prompt management and prompt experiments mentions across blog posts (langfuse/langsmith/braintrust/helicone alternatives, posthog-vs-langfuse, what-is-ai-observability, and more).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`