### PR TITLE
Fix uneven blockquote vertical spacing

### DIFF
--- a/src/components/BlockQuote/index.js
+++ b/src/components/BlockQuote/index.js
@@ -4,6 +4,6 @@ export const Blockquote = (props) => (
     <blockquote
         {...props}
         data-scheme="secondary"
-        className="not-prose pt-2 px-4 my-4 rounded bg-primary border border-primary [&>p:first-child]:mt-1 [&_a]:font-semibold [&_a]:underline [&>*:last-child]:mb-4 [&_ul>li]:list-disc [&_ol>li]:list-decimal [&_ul]:pl-6 [&_ol]:pl-6"
+        className="not-prose py-2 px-4 my-4 rounded bg-primary border border-primary [&>p:first-child]:mt-1 [&_a]:font-semibold [&_a]:underline [&>*:last-child]:mb-4 [&_ul>li]:list-disc [&_ol>li]:list-decimal [&_ul]:pl-6 [&_ol]:pl-6"
     />
 )


### PR DESCRIPTION
## Changes

- Give shared blockquotes equal top and bottom padding.

**Why:** The reusable About PostHog blurb had visibly less space below its text than above it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
