### PR TITLE
Add redirect for /teams/product-led-sales

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -228,6 +228,14 @@
             "statusCode": 301
         },
         {
+            "source": "/teams/product-led-sales",
+            "destination": "/teams/sales-product-led"
+        },
+        {
+            "source": "/teams/product-led-sales/:path*",
+            "destination": "/teams/sales-product-led/:path*"
+        },
+        {
             "source": "/teams/customer-success",
             "destination": "/teams/customer-success-eu"
         },


### PR DESCRIPTION
## Changes

`/teams/product-led-sales` has no matching team record, so it rendered an empty page (document title `undefined - PostHog`, "No data available") rather than a 404 or a real team page. Added a redirect to `/teams/sales-product-led`, following the existing pattern for renamed team slugs (e.g. `/teams/customer-success` → `/teams/customer-success-eu`), plus a matching `:path*` rule for sub-pages.

**Why:** a new hire hit this as a broken link from the onboarding checklist (raised in Slack).

Note: the checklist itself lives outside this repo, so this fixes the destination rather than the link.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A8JG753A5/p1785859369924089?thread_ts=1785859369.924089&cid=C0A8JG753A5)*