### PR TITLE
docs: document when posthog.group() sends $groupidentify

### DIFF
--- a/contents/docs/product-analytics/cutting-costs.mdx
+++ b/contents/docs/product-analytics/cutting-costs.mdx
@@ -27,13 +27,17 @@ Alternatively, you can [disable autocapture](/docs/product-analytics/autocapture
 
 It's only necessary to [identify](/docs/product-analytics/identify) a user once per session, and you don't need to add your own checks to prevent duplicate calls. If the user is already identified, calling `identify()` again with the same distinct ID doesn't capture another `$identify` event. Instead, it captures a `$set` event only when the person properties you pass have changed. 
 
-## Only call `group()` once per session
+## Only pass group properties when they change
 
 In client-side SDKs, it's only necessary to call [`group()`](/docs/product-analytics/group-analytics) once per session. Prevent calling it multiple times to send fewer events and reduce costs.
 
+The JavaScript Web SDK already deduplicates for you, but only if you don't pass properties. `posthog.group('company', id)` captures a `$groupidentify` the first time the browser sees that key and nothing afterwards, while `posthog.group('company', id, { plan: 'pro' })` captures one on every call — even when the group is already identified and the properties haven't changed. An empty object counts as properties too, so `posthog.group('company', id, {})` sends an event every call.
+
+So pass properties only where they're loaded or updated, and use the bare `posthog.group(type, key)` form everywhere else. Server-side SDKs always send the event, so call their group identify methods only when something changes.
+
 To see where duplicate `$groupidentify` events are being generated, you can use the following SQL:
 
-```
+```sql
 SELECT properties.$lib AS lib, count() AS groupidentify_event_count
 FROM events
 WHERE event = '$groupidentify'
@@ -41,21 +45,8 @@ WHERE event = '$groupidentify'
     SELECT $session_id
     FROM events
     WHERE event = '$groupidentify'
-      ```
-SELECT properties.$lib AS lib, count() AS groupidentify_event_count
-FROM events
-WHERE event = '$groupidentify'
-  AND $session_id IN (
-    SELECT $session_id
-    FROM events
-    WHERE event = '$groupidentify'
-      AND timestamp &gt;= now() - INTERVAL 30 DAY
-      AND timestamp &lt; now()
-    GROUP BY $session_id
-    HAVING count() &gt; 1
-  )
-GROUP BY lib
-ORDER BY groupidentify_event_count DESC
+      AND timestamp >= now() - INTERVAL 30 DAY
+      AND timestamp < now()
     GROUP BY $session_id
     HAVING count() > 1
   )

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -134,6 +134,37 @@ import SettingGroupPropertiesSnippet from "../_snippets/setting-group-properties
 
 <SettingGroupPropertiesSnippet />
 
+### When `$groupidentify` is sent
+
+In the JavaScript Web SDK, `posthog.group()` doesn't always capture a `$groupidentify` event. It captures one when either:
+
+- the group key is new or has changed compared to the key stored in the browser, or
+- you pass properties in the call.
+
+This means the two forms behave differently on repeat calls:
+
+```js-web
+// Sends $groupidentify only the first time this key is seen in the browser.
+// Later calls with the same key send nothing.
+posthog.group('company', 'company_id_in_your_db')
+
+// Sends $groupidentify every time, even if the group is already
+// identified and the properties haven't changed.
+posthog.group('company', 'company_id_in_your_db', { plan: 'pro' })
+```
+
+An empty object counts as properties, so `posthog.group('company', id, {})` also captures a `$groupidentify` on every call. Use the bare two-argument form instead.
+
+To keep your event volume down, pass properties only where they're actually loaded or updated — for example, after fetching the organization or when the user changes a setting — and call `posthog.group(type, key)` without properties everywhere else. See [cutting costs](/docs/product-analytics/cutting-costs) for more.
+
+<CalloutBox icon="IconWarning" title="Older versions of posthog-js" type="caution">
+
+Before posthog-js 1.364.7, `posthog.group()` without properties never captured a `$groupidentify`, so a group called this way was never created in PostHog. If you're on an older version, upgrade before switching to the bare two-argument form.
+
+</CalloutBox>
+
+Server-side SDKs have no browser state to compare against, so their group identify methods always send the event. Call them only when the group or its properties change.
+
 ### Link events to groups
 
 How you link events to individual groups depends on your SDK:

--- a/contents/handbook/cs-and-onboarding/health-checks.md
+++ b/contents/handbook/cs-and-onboarding/health-checks.md
@@ -67,6 +67,15 @@ As with `identify()` above users may also end up calling `posthog.group()` more 
 
 You should get in touch and let them know that they only need to call `posthog.group()` [once per group per session](/docs/product-analytics/group-analytics#how-to-create-groups), or when the group changes.
 
+Before you reach out, work out *why* the volume is high — the fix differs:
+
+- **Which library are the events coming from?**  Server-side SDKs have no browser state to deduplicate against, so their group identify methods always send an event.  Only the JavaScript Web SDK deduplicates.
+- **Are the calls passing properties?**  In the Web SDK, `posthog.group()` only captures a `$groupidentify` when the group key is new or changed *or* when properties are passed.  So `group('company', id)` on a key the browser has already stored sends nothing, but `group('company', id, { plan: 'pro' })` sends one every single time — even if the group was already identified and `plan` was already `pro`.  An empty object counts as properties, so `group('company', id, {})` also sends on every call.
+- **Are those properties actually changing?**  If they aren't changing meaningfully, recommend passing properties only where they're loaded or updated, and calling bare `group(type, key)` everywhere else.
+- **What posthog-js version are they on?**  This deduplication behavior is new.  Before posthog-js 1.364.7, `posthog.group()` *without* properties sent nothing at all, so the group was never created in PostHog.  A customer on an older version passing `{}` may be deliberately working around that — they need to upgrade before dropping the properties argument.
+
+There's also a [skill for investigating identify and groupidentify volume](https://us.posthog.com/project/2/skills/investigating-identify-and-groupidentify-volume) you can use to dig into this.
+
 To see where duplicate groupidentify calls are being generated, you can use the following SQL:
 
 ```


### PR DESCRIPTION
## Changes

Documents the JavaScript Web SDK's `$groupidentify` deduplication semantics, which weren't written down anywhere:

- **`docs/product-analytics/group-analytics.mdx`** — new "When `$groupidentify` is sent" subsection. `posthog.group(type, key)` only captures an event when the key is new/changed; passing properties captures one on *every* call, and an empty object counts as properties. Includes the pre-1.364.7 caveat, where the bare form sent nothing at all and so never created the group.
- **`docs/product-analytics/cutting-costs.mdx`** — the "Only call `group()` once per session" section was incomplete advice, since calling once per session with properties still sends every time. Retitled and rewritten. Also fixes a corrupted code block in that section: the SQL example had a duplicate, HTML-escaped copy nested inside itself.
- **`handbook/cs-and-onboarding/health-checks.md`** — expands the "Calling groupidentify too often" triage with what to actually check (source library, whether properties are passed, whether they change, posthog-js version) and links the existing investigation skill.

## Why

Came out of customer deep dives where high `$groupidentify` volume traced back to properties being passed on every call — in one case an empty object, likely as a deliberate workaround for the old pre-1.364.7 behavior. The docs gave no way to know either of those things, so the guidance is being seeded properly rather than living only in a skill.

Behavior verified against `packages/browser/src/posthog-core.ts` (the `isNewGroup || groupPropertiesToSet` branch), and the 1.364.7 boundary against the browser changelog entry for PostHog/posthog-js#3319.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08M011SBCM/p1785507831827969?thread_ts=1785507831.827969&cid=C08M011SBCM)*