### PR TITLE
Add Pip-Boy image to do more weird slider

### DIFF
--- a/contents/handbook/company/do-more-weird.mdx
+++ b/contents/handbook/company/do-more-weird.mdx
@@ -44,6 +44,8 @@ Weird ideas are fragile, so the most important feedback you can give if you see 
 
 ![Candle](https://res.cloudinary.com/dmukukwp6/image/upload/candle_76d58f66cc.jpeg)
 
+![Pip-Boy](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pipboy2_b67d57b183.jpeg)
+
 </ImageSlider>
 
 ## What do more weird isn’t


### PR DESCRIPTION
## Changes

Added the Pip-Boy image to the `<ImageSlider />` on the [do more weird](/handbook/company/do-more-weird) handbook page.

**Why:** Requested so the slider includes the Pip-Boy alongside the other examples of weird things we've shipped.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BMKTE4NG5/p1785875756789359)*