### PR TITLE
Fix unreachable submit button on modal windows on small screens

### DIFF
--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -737,7 +737,10 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             : ''
                     } ${
                         item.appSettings?.size?.fixed
-                            ? '!absolute top-2 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-1rem)]'
+                            ? // The max height keeps auto-height modals inside the desktop area on short
+                              // screens — without it they grow past the bottom edge and get clipped by the
+                              // desktop's `overflow-clip` with nothing left to scroll.
+                              '!absolute top-2 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-1rem)] max-h-[calc(100%-1rem)]'
                             : item.windowed
                             ? 'h-[95%] w-[80%]'
                             : 'size-full'
@@ -832,7 +835,14 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                         ref={contentRef}
                         className={`size-full flex-grow ${
                             chrome
-                                ? `overflow-hidden rounded-lg ${hasToolbar ? 'rounded-t-none' : ''} ${
+                                ? `${
+                                      // A modal's auto height makes percentage heights inside it resolve to
+                                      // `auto`, so its own ScrollAreas never overflow and can't scroll. Scroll
+                                      // the content here instead of clipping whatever doesn't fit.
+                                      item.appSettings?.size?.fixed
+                                          ? 'overflow-x-hidden overflow-y-auto'
+                                          : 'overflow-hidden'
+                                  } rounded-lg ${hasToolbar ? 'rounded-t-none' : ''} ${
                                       item.expanded
                                           ? 'rounded-tr-none rounded-tl-none'
                                           : item.snapped === 'left'


### PR DESCRIPTION
## Changes

On short viewports, `/talk-to-a-human` (the "book a demo" form) rendered with its message field and **Send** button below the bottom of the screen and nothing would scroll — every scroll container on the page reported `scrollHeight === clientHeight`, so the form could not be submitted on a phone.

Cause: fixed-size windows with `autoHeight` were given no max height, so the window grew taller than the desktop area and got clipped by its `overflow-clip`. Because the window's height is `auto`, percentage heights inside it resolve to `auto` too, so the form's own ScrollAreas never overflowed and had nothing to scroll either.

Two small changes in `AppWindow`, both scoped to fixed-size (modal) windows:

- Cap the window at `max-h-[calc(100%-1rem)]`, mirroring its `top-2` offset, so it always fits the desktop area.
- Scroll the window's content area (`overflow-y-auto`) instead of clipping whatever doesn't fit.

This is a general fix, so other auto-height modals stop getting clipped on small screens too.

**Why:** raised in Slack — the book a demo form couldn't be submitted on mobile because you couldn't scroll down to the Send button.

Verified against the local dev server at a 390×664 (iPhone 13) viewport: before, the Send button sat at y≈675 with zero scrollable containers; after, the modal is capped to 592px, gains 76px of scroll, and Send scrolls fully into view. Desktop (1440×900) geometry is unchanged from production — same 500×668 modal, no content overflow.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AR8V7V1D4/p1785875444799519)*