### PR TITLE
Generate docs/handbook OG images for pages without contributors

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -180,8 +180,10 @@ const createOGImages = async (data) => {
         const { title } = post.frontmatter
         const { timeToRead, excerpt, fields, parent } = post
         const lastUpdated = parent && parent.fields && parent.fields.lastUpdated
-        if (!title || !timeToRead || !excerpt || !lastUpdated || !fields?.contributors) continue
-        const contributors = fields?.contributors.map((contributor) => {
+        // Contributors are optional – pages missing them still get an OG image, just without the
+        // contributors column (the template already handles an empty list).
+        if (!title || !timeToRead || !excerpt || !lastUpdated) continue
+        const contributors = (fields?.contributors || []).map((contributor) => {
             const { avatar, username } = contributor
             return {
                 username,


### PR DESCRIPTION
## Changes

`/docs/mcp-analytics` (and a lot of other docs pages) have no OpenGraph image — the CDN URL in the `og:image` tag returns `AccessDenied` because the file was never generated.

Root cause is in `gatsby/onPostBuild.ts`: the docs/handbook OG loop required `fields.contributors` to be non-null, and `continue`d otherwise. That field comes from the Strapi `markdowns` collection, so any page without a record there is skipped entirely and never gets an image. Spot-checking docs pages, presence of contributors lines up exactly with whether the OG image exists on the CDN.

The OG template already renders the contributors column conditionally, so contributors don't need to be required. This drops them from the guard and defaults to an empty list — affected pages now get a normal OG image, just without the contributors column.

**Why:** raised in Slack — the OG image for the MCP Analytics docs page won't generate, so shared links preview blank.

Note: this fixes generation. Pages will pick up images on the next OG build; a broader question is why so many docs files are missing from the Strapi `markdowns` collection in the first place (that also makes their "last updated" date fall back to the build date).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1785884379901929)*