### PR TITLE
docs: mark project secret API keys as beta

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -20,7 +20,7 @@ The API is available for all users and instances. It contains two types of endpo
 Private endpoints require authentication. There are three ways to authenticate, and which one you should use depends on who the integration is for:
 
 - **[Personal API keys](/docs/api/personal-api-keys)** – Use these when you're using PostHog from your own scripts, automations, or any integration tied to your own account. This is the right choice if you're just building something for your own project.
-- **[Project secret API keys](/docs/api/project-secret-api-keys)** – Use these for server-to-server access that isn't tied to a user, such as a backend service executing [Endpoints](/docs/endpoints). They're scoped to a single project and only have the scopes you grant them.
+- **[Project secret API keys](/docs/api/project-secret-api-keys)** (beta) – Use these for server-to-server access that isn't tied to a user, such as a backend service executing [Endpoints](/docs/endpoints). They're scoped to a single project and only have the scopes you grant them. They're rolling out gradually, so they may not be available in your organization yet.
 - **[OAuth](/docs/api/oauth)** – Use this when you're building an app that other PostHog users will install or connect to. OAuth lets users grant your app scoped access without sharing their personal API key.
 
 ## Rate limiting

--- a/contents/docs/api/project-secret-api-keys/overview.mdx
+++ b/contents/docs/api/project-secret-api-keys/overview.mdx
@@ -1,3 +1,9 @@
+<CalloutBox icon="IconFlask" title="Project secret API keys are in beta" type="action">
+
+Project secret API keys are in beta and rolling out gradually, so the settings page may not be available in your organization yet. If you'd like access, [reach out to us](https://app.posthog.com#panel=support%3Afeedback%3A%3Alow%3Atrue) in app.
+
+</CalloutBox>
+
 Project secret API keys are server-to-server credentials scoped to a single project. They're the right choice when a backend service needs scoped, project-level access without being tied to anyone's user account.
 
 Unlike a [personal API key](/docs/api/personal-api-keys), a project secret API key doesn't represent a user—it isn't affected when a teammate leaves, and it only has the scopes you grant it. 

--- a/contents/docs/endpoints/start-here/retrieve-data/index.mdx
+++ b/contents/docs/endpoints/start-here/retrieve-data/index.mdx
@@ -13,7 +13,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 Endpoints support two kinds of keys, both with the `endpoint:read` scope.
 
-- **[Project secret API key](/docs/api/project-secret-api-keys)** (recommended for backend services): a project-scoped, server-to-server credential that isn't tied to a user. Create one in [Project secret API keys](https://app.posthog.com/settings/project-secret-api-keys).
+- **[Project secret API key](/docs/api/project-secret-api-keys)** (beta, recommended for backend services): a project-scoped, server-to-server credential that isn't tied to a user. Create one in [Project secret API keys](https://app.posthog.com/settings/project-secret-api-keys). This is in beta and rolling out gradually – if the settings page isn't available in your organization yet, use a personal API key.
 - **[Personal API key](/docs/api/personal-api-keys)**: scoped to your user account, useful for interactive or one-off scripts. Create one in [Personal API keys](https://app.posthog.com/settings/user-api-keys).
 
 To create a key:

--- a/contents/docs/endpoints/surfaces/api.mdx
+++ b/contents/docs/endpoints/surfaces/api.mdx
@@ -34,7 +34,7 @@ curl -X POST \
 
 ## Authentication
 
-Requests use either a [project secret API key](/docs/api/project-secret-api-keys) or a [personal API key](/docs/api/personal-api-keys), both scoped to `endpoint:read`. Project secret keys are the right choice for backend services since they aren't tied to a user account.
+Requests use either a [project secret API key](/docs/api/project-secret-api-keys) or a [personal API key](/docs/api/personal-api-keys), both scoped to `endpoint:read`. Project secret keys are the right choice for backend services since they aren't tied to a user account, but they're in beta and rolling out gradually – if they aren't available in your organization yet, use a personal API key.
 
 Never ship either key in client-side code. For [customer-facing analytics](/docs/endpoints/customer-facing-analytics), proxy the request through your own backend and pass the customer identifier as a variable.
 


### PR DESCRIPTION
## Changes

**Why:** Project secret API keys are still behind a gradual rollout, but the docs describe them as if they're generally available — so readers who don't have the feature yet hit a settings page that isn't there.

- Adds a beta callout to the [project secret API keys overview](https://posthog.com/docs/api/project-secret-api-keys), noting the gradual rollout and how to request access.
- Notes the beta status inline on the API overview and the two Endpoints pages that recommend these keys, pointing at personal API keys as the fallback.

No behaviour or nav changes. Worth a follow-up: adding a `Beta` badge to the sidebar entry in `src/navs/index.js` — AGENTS.md asks for a human decision on that file, so it's left out here.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1785889714472759)*
