### PR TITLE
docs: document SendGrid per-table scopes

### DIFF
--- a/contents/docs/cdp/sources/sendgrid.md
+++ b/contents/docs/cdp/sources/sendgrid.md
@@ -9,41 +9,59 @@ availability:
 sourceId: SendGrid
 ---
 
-<CalloutBox icon="IconFlask" title="Alpha release" type="action">
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
 
-This source is currently in **alpha**. The interface and available tables may change.
+<AlphaRelease />
 
-</CalloutBox>
+The SendGrid connector pulls your SendGrid data into the PostHog data warehouse, covering suppressions, unsubscribe groups, marketing lists, and email templates.
 
-Enter your SendGrid API key to pull your SendGrid data into the PostHog data warehouse.
+## Prerequisites
+
+You need a SendGrid account with permission to create API keys. Marketing lists additionally require an account with Marketing Campaigns, which is covered under [required scopes](#required-scopes) below.
 
 ## Adding a data source
 
-1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
-2. Click **+ New source** and then click **Link** next to SendGrid.
-3. You need an API key from SendGrid. Create one in your [SendGrid account settings](https://app.sendgrid.com/settings/api_keys) under **Settings → API Keys**. Grant the following read access (Restricted Access) so the key can reach the data you want to sync:
-   - **Suppressions** — bounces, blocks, invalid emails, spam reports, global unsubscribes, unsubscribe groups
-   - **Marketing** — marketing lists
-   - **Template Engine** — templates
-4. Back in PostHog, paste the key in the `API key` field and click **Next**.
-5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+<SourceSetupIntro />
 
-Once the syncs are complete, you can start using SendGrid data in PostHog.
+The only credential this source needs is a SendGrid API key. Create one in your [SendGrid API keys settings](https://app.sendgrid.com/settings/api_keys) under **Settings > API Keys**. Give it **Restricted Access** and grant read access to the areas you want to sync:
 
-## Available tables
+- **Suppressions** for bounces, blocks, invalid emails, spam reports, global unsubscribes, and unsubscribe groups
+- **Marketing** for marketing lists
+- **Template Engine** for templates
 
-| Table | Description | Sync method |
-| ----- | ----------- | ----------- |
-| `bounces` | Suppressed addresses that hard or soft bounced | Incremental |
-| `blocks` | Addresses blocked from receiving mail | Incremental |
-| `invalid_emails` | Addresses rejected as invalid | Incremental |
-| `spam_reports` | Recipients who marked your mail as spam | Incremental |
-| `global_unsubscribes` | Globally unsubscribed addresses | Incremental |
-| `unsubscribe_groups` | Unsubscribe (suppression) groups | Full refresh |
-| `marketing_lists` | Marketing contact lists | Full refresh |
-| `templates` | Email templates (legacy and dynamic) | Full refresh |
+The key value starts with `SG.` and SendGrid shows it only once, so copy it before closing the dialog.
 
-**Incremental** tables sync only new or updated records on each run. **Full refresh** tables reload all data on each sync.
+### Required scopes
+
+SendGrid grants scopes per endpoint, so a key that reads one table often cannot read another. Each table needs the scope below, spelled as SendGrid's `/v3/scopes` endpoint reports it:
+
+| Table                 | SendGrid scope                      |
+| --------------------- | ----------------------------------- |
+| `bounces`             | `suppression.bounces.read`          |
+| `blocks`              | `suppression.blocks.read`           |
+| `invalid_emails`      | `suppression.invalid_emails.read`   |
+| `spam_reports`        | `suppression.spam_reports.read`     |
+| `global_unsubscribes` | `suppression.unsubscribes.read`     |
+| `unsubscribe_groups`  | `asm.groups.read`                   |
+| `marketing_lists`     | `marketing.read`                    |
+| `templates`           | `templates.read`                    |
+
+You don't have to grant every scope. When you paste the key, PostHog checks each table and flags the ones the key can't read, so you can connect with a narrow key and sync only what you need.
+
+<CalloutBox icon="IconWarning" title="Marketing lists need Marketing Campaigns" type="caution">
+
+`marketing_lists` reads SendGrid's Marketing Campaigns API, so `marketing.read` alone isn't always enough. Accounts without Marketing Campaigns, and accounts still on legacy Marketing Campaigns, return a permission error for this table however the key is scoped. If that's your account, leave `marketing_lists` unselected. Every other table still syncs.
+
+</CalloutBox>
+
+## Sync modes
+
+<SyncModes />
+
+The suppression tables filter server side on their immutable `created` timestamp, so they sync incrementally. The remaining tables have no timestamp filter in the SendGrid API and sync as a full refresh.
 
 ## Configuration
 
@@ -52,3 +70,23 @@ Once the syncs are complete, you can start using SendGrid data in PostHog.
 ## Supported tables
 
 <SourceTables />
+
+## Troubleshooting
+
+### A table is paused with a missing scope error
+
+The key authenticated but isn't allowed to read that table, so adding the scope fixes it. You don't need to generate a new key:
+
+1. In SendGrid, go to **Settings > API Keys** and edit the existing key.
+2. Add read access for the table's area, using the [required scopes](#required-scopes) table above.
+3. In PostHog, re-enable the sync for that table. A paused table stays paused until you turn it back on.
+
+Allow a few minutes after updating a key before retrying, since SendGrid takes a moment to apply new permissions.
+
+If only `marketing_lists` fails while the other tables sync, check whether your account has Marketing Campaigns before changing scopes. Without it, no scope grant will make that table sync.
+
+### The key is rejected when adding the source
+
+A rejected key is invalid or expired rather than under-scoped. Generate a new key in SendGrid and paste the full value, including the `SG.` prefix.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Companion to [PostHog/posthog#78035](https://github.com/PostHog/posthog/pull/78035), which makes the SendGrid source report per-table scope errors. This documents the behavior.

- Add a table mapping each synced table to the SendGrid scope it needs, as `/v3/scopes` spells it.
- State that a narrow key is fine. PostHog flags the tables it cannot read at setup.
- Add a callout for `marketing_lists`: it needs `marketing.read` and an account with Marketing Campaigns. Accounts without it, and accounts on legacy Marketing Campaigns, get a permission error however the key is scoped.
- Add a troubleshooting section for the paused-table case. Editing the existing key is enough, and a paused table stays paused until someone re-enables it.
- Add prerequisites and sync modes, and note which tables sync incrementally and why.
- Replace the inline alpha callout and setup steps with the shared snippets.
- Drop the hand-written "Available tables" list. `<SourceTables />` already renders that from the source config, so the copy was a second source of truth.

The old page told users to "grant the following read access" with no scope names, and said nothing about Marketing Campaigns. That sent people to regenerate keys when the key was never the problem.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

On the conditional item: no page moved, so no redirect is needed.

The preview build passes, so the snippet imports and components resolve and the page builds. I did not view the rendered page myself, so a quick look at the preview is still worth it to confirm the scope table and the callout read well.

I could not run `audit_source_docs` here because it needs Postgres. I checked its invariants by hand instead: the enum value `SendGrid` matches the frontmatter `sourceId`, and the source's `docsUrl` slug still matches the filename. The snippet import paths match the ones in `simfin.md` and `azure-devops.md`.

Written by Claude via PostHog Code, directed by a CSM following up on a customer's paused sync.

