### PR TITLE
docs: note Twilio API key type and region requirements

### DIFF
--- a/contents/docs/cdp/sources/twilio.md
+++ b/contents/docs/cdp/sources/twilio.md
@@ -27,6 +27,14 @@ Enter your Twilio credentials to pull your Twilio data into the PostHog data war
 4. Back in PostHog, enter your Account SID, pick the authentication method, fill in the matching credentials, and click **Next**.
 5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
 
+<CalloutBox icon="IconWarning" title="Key type and region requirements" type="caution">
+
+- Create the key in the same Twilio account or subaccount as the Account SID you enter. A key from another account can't authenticate against it.
+- PostHog connects to `api.twilio.com`, so the account must be in Twilio's default `us1` region. Keys created in another region don't work.
+- A Standard API key can read every table except `keys`. Twilio restricts the [Keys resource](https://www.twilio.com/docs/iam/api-keys) to your Auth token and to Main API keys, so choose one of those if you want to sync `keys`.
+
+</CalloutBox>
+
 Once the syncs are complete, you can start using Twilio data in PostHog.
 
 ## Available tables
@@ -40,7 +48,7 @@ Once the syncs are complete, you can start using Twilio data in PostHog.
 | `addresses` | Addresses on the account | Full refresh |
 | `applications` | TwiML applications | Full refresh |
 | `incoming_phone_numbers` | Phone numbers owned by the account | Full refresh |
-| `keys` | API keys on the account | Full refresh |
+| `keys` | API keys on the account. Needs your Auth token or a Main API key | Full refresh |
 | `outgoing_caller_ids` | Verified outgoing caller IDs | Full refresh |
 | `queues` | Call queues | Full refresh |
 | `transcriptions` | Recording transcriptions | Full refresh |

--- a/contents/docs/cdp/sources/twilio.md
+++ b/contents/docs/cdp/sources/twilio.md
@@ -22,14 +22,14 @@ Enter your Twilio credentials to pull your Twilio data into the PostHog data war
 1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
 2. Click **+ New source** and then click **Link** next to Twilio.
 3. Find your **Account SID** on the [Twilio Console dashboard](https://console.twilio.com). For the remaining credentials, choose an authentication method:
-   - **API key (SID + secret)** — recommended, since it can be revoked independently. Create a [Standard API key](https://console.twilio.com/us1/account/keys-credentials/api-keys) and copy its `API key SID` and `API key secret`.
-   - **Auth token** — alternatively, use the `Auth token` shown alongside your Account SID in the console.
+   - **API key (SID + secret)** – recommended, since it can be revoked independently. Create a [Standard API key](https://console.twilio.com/us1/account/keys-credentials/api-keys) and copy its `API key SID` and `API key secret`.
+   - **Auth token** – alternatively, use the `Auth token` shown alongside your Account SID in the console.
 4. Back in PostHog, enter your Account SID, pick the authentication method, fill in the matching credentials, and click **Next**.
 5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
 
 <CalloutBox icon="IconWarning" title="Key type and region requirements" type="caution">
 
-- Create the key in the same Twilio account or subaccount as the Account SID you enter. A key from another account can't authenticate against it.
+- Create the key in the same Twilio account as the Account SID you enter. A key from a parent or sibling account can't authenticate against it.
 - PostHog connects to `api.twilio.com`, so the account must be in Twilio's default `us1` region. Keys created in another region don't work.
 - A Standard API key can read every table except `keys`. Twilio restricts the [Keys resource](https://www.twilio.com/docs/iam/api-keys) to your Auth token and to Main API keys, so choose one of those if you want to sync `keys`.
 


### PR DESCRIPTION
## Changes

The Twilio source page recommends creating a Standard API key, but doesn't mention the constraints that come with one. A user following the page can enter correct-looking credentials and still fail, with nothing on the page explaining why.

Added a caution callout after the setup steps covering three things a user can't infer:

- The key must be created in the same Twilio account or subaccount as the Account SID they enter.
- The account must be in Twilio's default `us1` region, because PostHog connects to `api.twilio.com`.
- A Standard API key can read every table except `keys`. Twilio [restricts the Keys resource](https://www.twilio.com/docs/iam/api-keys) to the Auth token and to Main API keys.

Also annotated the `keys` row in the "Available tables" list with the same requirement.

Pairs with [PostHog/posthog#78033](https://github.com/PostHog/posthog/pull/78033), which fixes the backend so a Standard key passes credential validation at all, and disables the `keys` table in the schema picker when the credential can't read it. The Standard key recommendation on this page becomes correct once that ships. This PR adds the caveats around it.

No screenshots: text-only change to one markdown file.

### Pre-existing fixes included

Two lines I didn't otherwise need to touch:

- Swapped the em dashes on the two credential bullets for spaced en dashes. Vale flags em dashes as errors, and these sit directly above the new callout.
- Vale now reports 0 errors on this file, down from 2.

One warning remains, on the page intro: `PostHogBase.ProductNames` wants "Data Warehouse" capitalized. That line is unrelated to this change, and the docs use all three casings ("data warehouse", "Data warehouse", "Data Warehouse") in roughly comparable numbers, so I left it rather than picking a side here. Happy to drop either drive-by if you'd rather keep the diff to just the callout.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

I (actually Claude) have not checked the Vercel preview. The change uses `CalloutBox` with `icon="IconWarning"` and `type="caution"`, matching the 24 existing uses of that pairing under `contents/docs/cdp/sources/`, so it should render like the callouts already on sibling source pages. Worth a glance at the preview before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

