### PR TITLE
Add link to evaluating growth potential doc in sales handover

### DIFF
--- a/contents/handbook/onboarding/sales-handover.md
+++ b/contents/handbook/onboarding/sales-handover.md
@@ -11,7 +11,7 @@ If you see that a customer is spending **more than $1,000 monthly**, evaluate wh
 
 If that's the case, you can pass the account to Sales even **without speaking with the customer first**, as long as you’ve confirmed that the high spend is intentional. The goal is to react quickly to healthy, high-spend accounts—but avoid passing through problematic ones.
 
-Before you hand off, also consider month-over-month growth. A flat $1.2k account is a very different lead from a $1k account that doubled organically last month. Growth rate matters to the Sales person deciding whether to prioritise the lead, so call it out.
+Before you hand off, also consider month-over-month growth. A flat $1.2k account is a very different lead from a $1k account that doubled organically last month. Growth rate matters to the Sales person deciding whether to prioritise the lead, so call it out. Here is a [useful doc](/handbook/growth/sales/evaluating-growth-potential) on evaluating growth potential.
 
 Be courteous and **leave a note in Vitally** with context on the account before handing off. Include what you spotted in Metabase, any relevant billing patterns, and your read on why the spend is legitimate. The Sales person receiving the lead should be able to pick it up without having to dig.
 


### PR DESCRIPTION
Adds a sentence linking to the [evaluating growth potential](/handbook/growth/sales/evaluating-growth-potential) doc in the sales handover onboarding page, right after the paragraph about month-over-month growth.

**Why:** Give people handing off leads a reference for how to evaluate an account's growth potential.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BE0AVBDRR/p1785918489823119)*