### PR TITLE
Netlify source: document table scoping and empty-table troubleshooting

### DIFF
--- a/contents/docs/cdp/sources/netlify.md
+++ b/contents/docs/cdp/sources/netlify.md
@@ -28,7 +28,7 @@ You need a Netlify account and a personal access token. The token has full acces
 
 You need a Netlify personal access token. Create one under **User settings > Applications > Personal access tokens** in the [Netlify UI](https://app.netlify.com/user/applications).
 
-> **Note:** Netlify invalidates tokens on password reset. SAML SSO teams must opt tokens in during generation.
+> **Note:** Netlify invalidates tokens on password reset. If your team requires SAML SSO, select **Allow access to my SAML-based Netlify team** when generating the token, otherwise Netlify denies the token access to that team's data.
 
 ## Sync modes
 
@@ -44,8 +44,13 @@ All Netlify tables are full refresh only, since the API exposes no server-side t
 
 <SourceTables />
 
+The `sites` table includes every site the token can access, across all of your teams. The `builds`, `deploys`, `forms`, and `submissions` tables are fetched per site, and `members` is fetched per account.
+
 ## Troubleshooting
 
 - If the connection fails with an access-denied error, your token may be invalid or revoked (Netlify invalidates tokens on password reset). Create a new token and reconnect.
+- If syncs complete but tables stay empty, the token likely can't access the team that owns your sites. For SAML SSO teams, generate a new token with **Allow access to my SAML-based Netlify team** selected, then reconnect.
+- The `builds`, `deploys`, `forms`, and `submissions` tables stay empty until the `sites` table syncs at least one row, since they're fetched per site.
+- The `dns_zones` table is only populated if your team manages DNS through Netlify.
 
 <TroubleshootingLink />


### PR DESCRIPTION
## Changes

Updates the Netlify data warehouse source docs alongside the fix in [PostHog/posthog#78127](https://github.com/PostHog/posthog/pull/78127):

- States that the `sites` table covers every site the token can access across teams, and that `builds`, `deploys`, `forms`, and `submissions` are fetched per site.
- Adds troubleshooting for syncs that complete with empty tables: SAML SSO teams deny non-opted-in tokens, site-scoped tables need `sites` rows first, and `dns_zones` requires Netlify-managed DNS.
- Names the exact token option (**Allow access to my SAML-based Netlify team**) per [Netlify's API docs](https://docs.netlify.com/api-and-cli-guides/api-guides/get-started-with-api/).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
