### PR TITLE
docs: Decagon data warehouse source docs

### DIFF
--- a/contents/docs/cdp/sources/decagon.md
+++ b/contents/docs/cdp/sources/decagon.md
@@ -1,0 +1,51 @@
+---
+title: Linking Decagon as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Decagon
+---
+
+import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
+import SyncModes from "../_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Decagon connector syncs conversations between your users and your [Decagon](https://decagon.ai/) AI agents into the PostHog Data warehouse, including every message, customer satisfaction (CSAT) ratings, tags, and metadata. Use it to analyze support quality alongside your product data.
+
+## Prerequisites
+
+You need a Decagon account with API access and a Decagon API key.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Decagon, you'll need:
+
+- **API key** – find or generate one on the **Developer** page of your Decagon dashboard.
+
+## Sync modes
+
+<SyncModes />
+
+The conversations table syncs as a full refresh. Decagon's export returns conversations oldest first, and a conversation reappears in the export whenever it receives new messages, so each sync picks up the latest version of every conversation.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+Decagon rate limits its API to 1 request per second, and each request returns up to 100 conversations, so accounts with a large conversation history can take a while to complete a sync.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the missing docs page for the Decagon data warehouse source at `/docs/cdp/sources/decagon`. The source is live in-app (alpha) and its **docsUrl** already points at this path, which currently 404s.

The page follows the standard source-doc structure (same snippets and sections as `elevenlabs.md`): alpha callout, prerequisites, setup, sync modes, auto-rendered configuration and tables, and a troubleshooting note about Decagon's 1 request/second rate limit.

Companion connector fix: [PostHog/posthog#78129](https://github.com/PostHog/posthog/pull/78129)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
