### PR TITLE
docs: update Klaviyo source docs: scope list and webhooks Advanced KDP requirement

### DIFF
--- a/contents/docs/cdp/sources/klaviyo.md
+++ b/contents/docs/cdp/sources/klaviyo.md
@@ -17,7 +17,7 @@ The Klaviyo connector syncs your marketing data – campaigns, profiles, events,
 
 ## Prerequisites
 
-You need a Klaviyo account and a private API key. Create one in your [Klaviyo account settings](https://www.klaviyo.com/settings/account/api-keys) by clicking **Create Private API Key**, giving it a name, and selecting a **Read-Only Key**. Grant read permissions for the following: Accounts, Campaigns, Events, Flows, Lists, Metrics, and Profiles.
+You need a Klaviyo account and a private API key. Create one in your [Klaviyo account settings](https://www.klaviyo.com/settings/account/api-keys) by clicking **Create Private API Key**, giving it a name, and selecting a **Read-Only Key**. Grant read permissions for the data you want to sync: Accounts, Campaigns, Catalogs, Coupon codes, Coupons, Custom objects, Events, Flows, Forms, Images, Lists, Metrics, Profiles, Push tokens, Reviews, Segments, Tags, Templates, Web feeds, and Webhooks. Tables you haven't granted access to are skipped.
 
 ## Adding a data source
 
@@ -55,6 +55,10 @@ JOIN klaviyo_list_profiles lp ON lp.profile_id = p.id
 WHERE lp.list_id = 'your_list_id'
   AND arrayExists(x -> x = 'email', JSONExtractArrayRaw(p.properties, '$consent'))
 ```
+
+## Webhooks
+
+The `webhooks` table is only available to Klaviyo accounts with the [Advanced KDP add-on](https://help.klaviyo.com/hc/en-us/articles/17655007276059). Without it, Klaviyo returns a `403 permission_denied` error saying "You must have Advanced KDP enabled to use this endpoint," even when your API key has the Webhooks read scope. This table is disabled by default. Only enable it if your Klaviyo account includes Advanced KDP.
 
 ## Configuration
 


### PR DESCRIPTION
## Changes

Updates the Klaviyo source page to match the current connector:

- Expands the private API key permissions list in Prerequisites. The connector now syncs many more tables than the seven scopes originally listed, and tables without granted access are skipped.
- Adds a "Webhooks" section: the `webhooks` table requires Klaviyo's [Advanced KDP add-on](https://help.klaviyo.com/hc/en-us/articles/17655007276059). Klaviyo returns `403 permission_denied` without it even when the Webhooks read scope is granted, which reads like a scope problem but isn't.
- Companion connector fix (clearer sync error, webhooks now opt-in): [PostHog/posthog#78134](https://github.com/PostHog/posthog/pull/78134)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
