### PR TITLE
docs(workflows): batch audience conditions combine with AND, not OR

### DIFF
--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -88,7 +88,7 @@ A batch trigger combines two things:
 
 #### Audience filters
 
-You define the audience using person properties, cohorts, or distinct IDs. Multiple conditions are combined with **OR** logic, so a person matches if they meet any of them.
+You define the audience using person properties, cohorts, or distinct IDs. Multiple conditions are combined with **AND** logic, so a person matches only if they meet all of them.
 
 The trigger shows a real-time estimate of how many persons will be affected (e.g. "approximately 1,200 of 50,000 persons") before you enable the workflow. If the audience is too large, you'll see a warning prompting you to add filters to narrow it down.
 


### PR DESCRIPTION
## Changes

One sentence in the batch trigger audience filters section: conditions combine with **AND**, not OR.

The product has combined flat audience conditions with AND since batch triggers shipped (PostHog/posthog#41486, Dec 2025), and the audience builder renders an AND divider between condition rows. The OR claim entered in #17884's restructure six months later and matched neither the backend nor the UI.

PostHog/posthog#72663, which tried to change the backend to match this sentence, is closed in favor of correcting the sentence.