### PR TITLE
Remove outdated multiplayer PR-attribution note on Slack app page

### DIFF
--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -557,18 +557,11 @@ const faqItems = [
     {
         trigger: 'Can multiple people drive the same task?',
         content: (
-            <>
-                <p>
-                    Yes. Anyone in the thread can send follow-ups to the running agent. Every message in the thread is
-                    forwarded as a new turn in the same conversation, so teammates can steer mid-run, drop in extra
-                    context, or answer a question the agent asked.
-                </p>
-                <p>
-                    Heads up: the resulting PR is still authored under whoever started the task – their personal GitHub
-                    integration is the one wired up – so a teammate's follow-up edits land under the original
-                    requester's name. If you want the PR credited to you, start your own task.
-                </p>
-            </>
+            <p>
+                Yes. Anyone in the thread can send follow-ups to the running agent. Every message in the thread is
+                forwarded as a new turn in the same conversation, so teammates can steer mid-run, drop in extra context,
+                or answer a question the agent asked. Each person's follow-up is attributed to their own identity.
+            </p>
         ),
     },
     {


### PR DESCRIPTION
## Changes

Removes the "Heads up" caveat in the *Can multiple people drive the same task?* FAQ on the Slack app page. It previously warned that a teammate's follow-up edits land under the original requester's name — that's no longer true now that each person's follow-up is attributed to their own identity.

## Why

The multiplayer limitation this note described has been fixed: follow-ups are now authored under the identity of the person who sent them, so the caveat was misleading.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0351B1DMUY/p1785925553168679?thread_ts=1785925553.168679&cid=C0351B1DMUY)*