### PR TITLE
docs(session-replay): document lazy_loading and config statuses, URL trigger anchoring

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -68,10 +68,22 @@ The client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger
   classes="rounded"
 />
 
+URL trigger patterns are regular expressions and are automatically anchored: PostHog wraps your pattern in `^` and `$`, so it must match the full URL including the path. A bare domain like `https://example.com` won't match `https://example.com/` or any subpage.
+
+To record on a domain, all of its subdomains, and every path:
+
+```
+https://([a-zA-Z0-9-]+\.)?example\.com(/.*)?
+```
+
+Use the URL tester in the settings panel to check your pattern against real URLs before saving.
+
 ## With Event trigger conditions
 
 You can opt to only start recordings once your user emits a particular event. After the event is captured, the recording continues for the rest of the session.
 On the web, the client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see activity leading up to that event.
+
+> **Note:** Event triggers match on the event name only. Property filters are not applied, so an event trigger can't be scoped to a specific domain or page. Use a URL trigger for that.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/event_trigger_light_21a531edbb.png"

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -64,7 +64,7 @@ These three properties together describe replay status. Read them as a set, not 
 | Property                          | What it tells you                                                                                                   |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `$has_recording`                  | `true` once PostHog has confirmed a recording exists for the session. The strongest positive signal.                |
-| `$recording_status`               | The SDK's current state: `active`, `buffering`, `disabled`, `sampled`, or `paused`.                                 |
+| `$recording_status`               | The SDK's current state. See the [full list of values](#recording_status-values) below.                             |
 | `$session_recording_start_reason` | Why recording started (or didn't). Useful for distinguishing "we chose not to record" from "we tried but couldn't". |
 
 #### `$recording_status` values
@@ -76,6 +76,10 @@ These three properties together describe replay status. Read them as a set, not 
 | `disabled`  | Recording is turned off – either in [your project replay settings](https://app.posthog.com/settings/project-replay) or via SDK config at runtime. |
 | `sampled`   | This session was included by the configured replay sample rate – recording started.                                                               |
 | `paused`    | Recording is temporarily paused for this session (consent gate, programmatic `pause()`, or a max-duration cap).                                   |
+| `lazy_loading`    | Recording is enabled and the SDK is still fetching the recorder script. Normal on the first events of a pageload (including the initial `$pageview`). If it persists across a whole session, the script never finished loading (check `$sdk_debug_recording_script_not_loaded`). |
+| `awaiting_config` | The SDK is waiting for fresh remote config before starting the recorder.                                                                                                                                                                                                        |
+| `missing_config`  | The remote config fetch failed. Recording will not start until the page is reloaded.                                                                                                                                                                                            |
+| `rrweb_error`     | The recorder failed to start. `$sdk_debug_replay_rrweb_error` contains the error message.                                                                                                                                                                                       |
 
 #### `$session_recording_start_reason` values
 
@@ -93,6 +97,7 @@ These three properties together describe replay status. Read them as a set, not 
 | `true`           | any                   | any                                                                 | A recording exists. If you can't find it, the issue is UI filtering, retention, or it's still processing.                                                    |
 | `null` / `false` | `active` or `sampled` | `recording_initialized` / `sampling_override` / `linked_flag_match` | Recording is running but PostHog hasn't confirmed ingestion yet, check a later event.                                                                        |
 | `null` / `false` | `buffering`           | any                                                                 | The SDK is waiting on a [trigger](/docs/session-replay/how-to-control-which-sessions-you-record) or duration threshold, check the trigger status properties. |
+| `null` / `false` | `lazy_loading`        | any                                                                 | The recorder script was still loading when this event fired. Normal on early events in a session, check a later event.                                       |
 | `null` / `false` | `disabled`            | any                                                                 | Replay is off, either in [project settings](https://app.posthog.com/settings/project-replay) or via SDK config like `disable_session_recording: true`.       |
 | `null` / `false` | any                   | `sampled_out`                                                       | Your sample rate excluded this session – increase the sample rate or use a trigger to guarantee capture for important flows.                                 |
 | `null` / `false` | `paused`              | any                                                                 | Recording was paused mid-session – usually a consent flow or a programmatic `posthog.sessionRecording.pause()` call.                                         |
@@ -104,11 +109,11 @@ A normal session's `$recording_status` typically progresses like this:
 ```text
 disabled ──── (config or setting turns replay off)
 
-buffering ──► active ──► (recording captured, $has_recording flips to true on later events)
-    │            │
-    │            └──► paused ──► active   (consent flow, programmatic control)
-    │
-    └──► (session ends before a trigger matches, buffer discarded, no recording stored)
+lazy_loading ──► buffering ──► active ──► (recording captured, $has_recording flips to true on later events)
+                     │            │
+                     │            └──► paused ──► active   (consent flow, programmatic control)
+                     │
+                     └──► (session ends before a trigger matches, buffer discarded, no recording stored)
 ```
 
 `sampled` is an alternative entry point meaning "this session was rolled into the sample" and it behaves like `active` from a capture standpoint.


### PR DESCRIPTION
## Changes

Follow-up to support ticket #64981, where a customer hit two documentation gaps while debugging missing recordings.

**`troubleshooting.mdx`**
- Adds the missing `$recording_status` values to the table: `lazy_loading`, `awaiting_config`, `missing_config`, `rrweb_error`. `lazy_loading` is the second most common status in real traffic (it's set while the recorder script is being fetched, so the first events of every pageload carry it) but wasn't documented, which the customer explicitly flagged.
- Adds a `lazy_loading` row to the "Reading the combination" table and to the lifecycle diagram.
- All meanings verified against posthog-js source (`session-recording.ts`, `triggerMatching.ts`).

**`how-to-control-which-sessions-you-record.mdx`**
- Documents that URL trigger patterns are auto-anchored with `^` and `$` (a bare domain matches nothing with a path or trailing slash), with a copy-paste recipe for "this domain plus all subdomains".
- Notes that event triggers match on event name only, since property filters silently don't apply.

## Why

In the ticket, the customer was given a bare-domain regex that the auto-anchoring silently broke, fell back to an event trigger with a (non-functional) property filter, and then couldn't self-serve the debug because `lazy_loading` wasn't in the docs. Each of these three additions removes one step of that failure chain.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
