### PR TITLE
Render Caption as a single block box

### DIFF
--- a/src/components/Caption/index.js
+++ b/src/components/Caption/index.js
@@ -2,10 +2,8 @@ import React from 'react'
 
 export const Caption = ({ children }) => {
     return (
-        <div className="caption text-center mb-4">
-            <caption className="inline text-sm">
-                <span className="px-2 py-2 rounded-sm bg-accent text-secondary">{children}</span>
-            </caption>
+        <div className="caption mb-4">
+            <div className="px-2 py-1.5 rounded-sm bg-accent text-secondary text-sm text-center">{children}</div>
         </div>
     )
 }


### PR DESCRIPTION
## Changes

The `<Caption>` component put its background on an inline `<span>`, so a multi-line caption got one background fragment per line — the second line's background overlapped the first, and it stopped short of the container edges. It now renders as one block-level box with centered text, so the background is a single consistent rectangle regardless of caption length. Also removes the invalid `<caption>` element (only valid inside a table).

**Why:** long captions looked broken on the site — text on the first line was visually clipped by the line below it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BMKTE4NG5/p1785939671211009)*