### PR TITLE
Fix light + dark hero images both showing on the Experiments page

### DIFF
--- a/src/components/CloudinaryImage/index.tsx
+++ b/src/components/CloudinaryImage/index.tsx
@@ -45,6 +45,8 @@ export default function CloudinaryImage({
             </Image>
         </div>
     ) : (
-        <img src={src} width={width} className={`inline-block ${imgClassName}`} {...other} />
+        // No wrapper here, so `className` goes on the image itself – otherwise
+        // classes like `dark:hidden` are silently dropped on this branch.
+        <img src={src} width={width} className={`inline-block ${className} ${imgClassName}`} {...other} />
     )
 }

--- a/src/components/CloudinaryImage/index.tsx
+++ b/src/components/CloudinaryImage/index.tsx
@@ -45,8 +45,6 @@ export default function CloudinaryImage({
             </Image>
         </div>
     ) : (
-        // No wrapper here, so `className` goes on the image itself – otherwise
-        // classes like `dark:hidden` are silently dropped on this branch.
-        <img src={src} width={width} className={`inline-block ${className} ${imgClassName}`} {...other} />
+        <img src={src} width={width} className={`inline-block ${imgClassName}`} {...other} />
     )
 }

--- a/src/hooks/productData/experiments.tsx
+++ b/src/hooks/productData/experiments.tsx
@@ -140,9 +140,9 @@ export const experiments = {
             imgClasses: 'rounded-t-md shadow-2xl',
         },
         home: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2026_04_01_at_14_21_27_96d1375a92.png',
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_04_01_at_14_21_27_96d1375a92.png',
             srcDark:
-                'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2026_04_01_at_14_24_58_04e669df5a.png',
+                'https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_04_01_at_14_24_58_04e669df5a.png',
             alt: 'Experiment results',
             classes: 'justify-center items-end px-4 @lg:px-6',
             imgClasses: 'rounded-t-md shadow-2xl',


### PR DESCRIPTION
## Changes

The Experiments product page rendered both the light and dark hero screenshots stacked on top of each other in every theme.

**Why:** reported in Slack — the hero image on the experiments page displays the dark and light version at once.

The reader-view product header renders two `<CloudinaryImage>` elements and toggles them with `dark:hidden` / `hidden dark:block` passed via `className`. `CloudinaryImage` falls through to a raw `<img>` whenever the source URL contains a comma (a Cloudinary transformation segment like `q_auto,f_auto/` breaks its public-ID parsing), and that branch doesn't apply `className` — so the theme-toggle classes were dropped and both images rendered.

Experiments was the only product whose hero `src` **and** `srcDark` carried that transformation segment. Dropping it puts the page on the same code path as product analytics, feature flags, and session replay, whose hero URLs are all plain `upload/<public_id>.png`. Two lines, no component change.

The raw-`<img>` branch silently dropping `className` is still a latent trap for any future screenshot that needs transformation params, but fixing it there means editing a line CodeQL already has an open alert on — better as its own change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1785942251711829)*