### PR TITLE
docs: fix stale positioning and broken links on agent-retrievable surfaces

### DIFF
--- a/contents/docs/ai-engineering/index.mdx
+++ b/contents/docs/ai-engineering/index.mdx
@@ -15,9 +15,7 @@ You'll find this page and its resources useful if you're:
 - A vibe coder or engineer who uses AI agents and tools
 - Just here to try cool AI features in PostHog
 
-PostHog is all the dev tools you need in one. When you add AI on top of that, and with enough data, your product should be able to build itself. That's our long-term vision for AI at PostHog, so we're building the tools you need to get there. 
-
-It's a bit like the dream of a self-driving car, but for your product.
+PostHog is all the dev tools you need in one. When you add AI on top of that, your product becomes [self-driving](/docs/self-driving): PostHog reads your data, finds what's worth fixing, and ships changes with you — never without you. That's not a long-term vision; you can turn it on today.
 
 ## AI features
 

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -194,9 +194,9 @@ Available features:
 | `hog_functions`          | [CDP function management](/docs/cdp)                                                   |
 | `hog_function_templates` | CDP function template browsing                                                         |
 | `insights`               | [Analytics insights](/docs/product-analytics/insights)                                 |
-| `ai_observability`          | [AI observability evaluations](/docs/ai-engineering)                                      |
-| `prompts`                | [LLM prompt management](/docs/ai-engineering)                                          |
-| `logs`                   | [Log querying](/docs/ai-engineering/observability)                                     |
+| `ai_observability`          | [AI observability evaluations](/docs/ai-observability)                                      |
+| `prompts`                | [LLM prompt management](/docs/prompt-management)                                          |
+| `logs`                   | [Log querying](/docs/logs)                                     |
 | `notebooks`              | [Notebook management](/docs/notebooks)                                                 |
 | `persons`                | [Person and group management](/docs/data/persons)                                      |
 | `reverse_proxy`          | Reverse proxy record management                                                        |
@@ -204,7 +204,16 @@ Available features:
 | `sdk_doctor`             | [SDK health diagnostics](/docs/health-checks/sdk-health)                                             |
 | `sql`                    | SQL query execution                                                                    |
 | `surveys`                | [Survey management](/docs/surveys)                                                     |
-| `workflows`              | [Workflow management](/docs/cdp)                                                       |
+| `workflows`              | [Workflow management](/docs/workflows)                                                 |
+| `endpoints`              | [Endpoint management](/docs/endpoints)                                                 |
+| `replay`                 | [Session replay](/docs/session-replay)                                                 |
+| `replay_vision`          | [Replay Vision scanners](/docs/replay-vision)                                          |
+| `web_analytics`          | [Web analytics](/docs/web-analytics)                                                   |
+| `customer_analytics`     | [Customer analytics](/docs/customer-analytics/start-here)                              |
+| `conversations`          | [Support tickets](/docs/support)                                                       |
+| `signals`                | [Self-driving signals and inbox](/docs/self-driving)                                   |
+| `tasks`                  | [Tasks](/docs/posthog-desktop/tasks)                                                   |
+| `tracing`                | [Distributed tracing](/docs/distributed-tracing/start-here)                            |
 
 > **Note:** Hyphens and underscores are treated as equivalent in feature names (e.g., `error-tracking` and `error_tracking` both work).
 

--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -447,6 +447,24 @@ const PLATFORM_ITEMS: PlatformItem[] = [
         layer: 'tool',
         oneLiner: 'The interface humans and agents use to understand the product.',
     },
+    {
+        name: 'Support',
+        layer: 'tool',
+        link: 'https://posthog.com/docs/support',
+        oneLiner: 'Tickets triaged with full product context — agents draft replies and fixes from the same data.',
+    },
+    {
+        name: 'Customer analytics',
+        layer: 'tool',
+        link: 'https://posthog.com/docs/customer-analytics/start-here',
+        oneLiner: 'Accounts, usage metrics, and customer journeys — the account-level context behind every signal.',
+    },
+    {
+        name: 'Replay Vision',
+        layer: 'tool',
+        link: 'https://posthog.com/docs/replay-vision',
+        oneLiner: 'Agents that watch session recordings at scale and turn what users hit into observations.',
+    },
 ]
 
 const CONTEXT_BLURB =
@@ -494,6 +512,7 @@ ${CONTEXT_WAREHOUSE_BLURB}
 
 ---
 
+Self-driving in depth — signals, Inbox, scouts, and the PR loop: https://posthog.com/docs/self-driving.md
 Pricing: every tool has a generous free tier, then usage-based pricing. Exact numbers: https://posthog.com/pricing.md
 All docs are available as Markdown (append \`.md\` to any docs URL). Full index: https://posthog.com/llms.txt
 `


### PR DESCRIPTION
## Changes

Fixes from an audit of the docs surfaces agents retrieve (llms.txt, platform.md, per-page `.md` exports, MCP docs):

- **`/docs/ai-engineering`**: the intro framed self-driving as "our long-term vision… a bit like the dream of a self-driving car" — but `/docs/self-driving` is a shipped product with a one-command install. An agent summarizing this page would call PostHog's flagship positioning aspirational. Rewritten to state it's live and link the docs.
- **MCP FAQ feature table**: four rows linked to the wrong products' docs (`logs` → ai-engineering/observability, `ai_observability`/`prompts` → ai-engineering, `workflows` → cdp). Fixed, and added rows for the newer server feature domains (endpoints, replay, replay_vision, web_analytics, customer_analytics, conversations, signals, tasks, tracing) — all link targets verified live.
- **`platform.md` generator** (`gatsby/rawMarkdownUtils.ts`): `PLATFORM_ITEMS` was missing Support, Customer analytics, and Replay Vision, so they're invisible in `platform.md` and the llms.txt "Products and tools" block. Added as link-only entries (no `slug`, so no bespoke `public/<slug>.md` is generated over existing docs paths). Also added a self-driving docs-hub link to the platform.md footer.

**Why**: agents defaulting to training-data framing of PostHog need these retrievable surfaces to carry the current self-driving positioning and to not send them to the wrong docs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
