### PR TITLE
Link "refund or credit?" guidance from the credits handbook page

### DIFF
--- a/contents/handbook/growth/revops/credits.md
+++ b/contents/handbook/growth/revops/credits.md
@@ -25,5 +25,5 @@ Sometimes we might want to offer a customer one time credits to cover an upcomin
 
 ## Things to keep in mind
 - Credits only apply to upcoming invoices.
-- If you’re trying to adjust a completed invoice, this should be handled as a [refund](/handbook/growth/sales/refunds) instead.
+- If you’re trying to adjust a completed invoice, this should be handled as a [refund](/handbook/growth/sales/refunds) instead. See [refund or credit?](/handbook/growth/sales/refunds#refund-or-credit) for which one to use.
 - Always include enough context in your notes or reference link so others understand why the credit was given.


### PR DESCRIPTION
## Changes

The credits handbook page tells you that a completed invoice should be handled as a refund, but stops there — it does not point at the guidance explaining when to use a credit vs a refund (and that a finalized invoice needs a credit note rather than the refund button). Added a deep link to that section.

**Why:** someone following the credits page had to go hunting for the refund-vs-credit rules separately. One click now.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08UNFX75ST/p1785853306584649?thread_ts=1785853306.584649&cid=C08UNFX75ST)*