### PR TITLE
Event graphic v2: brand-aligned redesign + landscape format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __pycache__
 .env*.local
 /.claude/worktrees/
 .env*
+
+# Local design reference exports (not part of the site)
+design-refs/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ __pycache__
 /.claude/worktrees/
 /.claude/settings.local.json
 .env*
+
+# Local design reference exports (not part of the site)
+design-refs/

--- a/src/components/EventForm/index.tsx
+++ b/src/components/EventForm/index.tsx
@@ -13,7 +13,8 @@ import Toggle from 'components/Toggle'
 import ImageDrop, { type Image as UploadImage } from 'components/ImageDrop'
 import uploadImage from 'components/Squeak/util/uploadImage'
 import { toBlob, toPng } from 'html-to-image'
-import EventGraphic, { type EventGraphicSpeaker } from 'components/EventGraphic'
+import EventGraphic, { type EventGraphicFormat, type EventGraphicSpeaker } from 'components/EventGraphic'
+import { EVENT_GRAPHIC_STYLE_COUNT, eventGraphicStyleIndex } from 'constants/eventGraphicPalette'
 import { useToast } from '../../context/Toast'
 import { Event } from '../../pages/events'
 import CreatableMultiSelect from 'components/CreatableMultiSelect'
@@ -230,8 +231,16 @@ const validationSchema = Yup.object().shape({
     presentation: Yup.string().url('Enter a valid URL').optional(),
 })
 
-const graphicFileName = (eventName?: string): string =>
-    `${(eventName || 'posthog-event').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.png`
+const graphicFileName = (eventName?: string, format: EventGraphicFormat = 'square'): string =>
+    `${(eventName || 'posthog-event').toLowerCase().replace(/[^a-z0-9]+/g, '-')}${
+        format === 'landscape' ? '-landscape' : ''
+    }.png`
+
+// Export sizes: a square social graphic, and the standard Open Graph ratio for link previews.
+const GRAPHIC_EXPORT_SIZES: Record<EventGraphicFormat, { width: number; height: number }> = {
+    square: { width: 1080, height: 1080 },
+    landscape: { width: 1200, height: 630 },
+}
 
 const transformEventToFormValues = (event: Event, speakerOptions?: SelectOption[]): EventFormValues => {
     const parsed = dayjs(event?.date)
@@ -274,8 +283,11 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
     const { getJwt } = useUser()
     const { addToast } = useToast()
     const [submitting, setSubmitting] = React.useState<boolean>(false)
-    const [downloadingGraphic, setDownloadingGraphic] = React.useState<boolean>(false)
+    const [downloadingGraphic, setDownloadingGraphic] = React.useState<EventGraphicFormat | null>(null)
+    // Null means "follow the event name"; shuffling pins an explicit hue + light/dark combo.
+    const [graphicStyleOverride, setGraphicStyleOverride] = React.useState<number | null>(null)
     const graphicRef = React.useRef<HTMLDivElement>(null)
+    const landscapeGraphicRef = React.useRef<HTMLDivElement>(null)
     const data = useStaticQuery(graphql`
         query {
             allEvent {
@@ -736,17 +748,41 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
         }
     }, [formik.values.speakers, data.allSqueakProfile.nodes])
 
-    const handleDownloadGraphic = async () => {
-        if (!graphicRef.current) return
-        setDownloadingGraphic(true)
+    // Falls back to a stable hash of the event name so the same event always starts on the same style.
+    const graphicStyleIndex = graphicStyleOverride ?? eventGraphicStyleIndex(formik.values.name)
+
+    // Step by a random non-zero offset so every press lands on a different hue/variant combination.
+    const shuffleGraphicStyle = () =>
+        setGraphicStyleOverride(
+            (graphicStyleIndex + 1 + Math.floor(Math.random() * (EVENT_GRAPHIC_STYLE_COUNT - 1))) %
+                EVENT_GRAPHIC_STYLE_COUNT
+        )
+
+    const graphicProps = {
+        title: formik.values.name || 'Your event name',
+        date: formik.values.date,
+        startTime: formik.values.startTime,
+        venue: formik.values.venueName,
+        location: formik.values.locationLabel,
+        online: formik.values.online,
+        speaker: firstSpeakerProfile,
+        partners: formik.values.partners.filter((partner) => partner.name),
+        styleIndex: graphicStyleIndex,
+    }
+
+    const handleDownloadGraphic = async (format: EventGraphicFormat) => {
+        const node = format === 'landscape' ? landscapeGraphicRef.current : graphicRef.current
+        if (!node) return
+        setDownloadingGraphic(format)
         try {
-            const dataUrl = await toPng(graphicRef.current, {
-                canvasWidth: 1080,
-                canvasHeight: 1080,
+            const { width, height } = GRAPHIC_EXPORT_SIZES[format]
+            const dataUrl = await toPng(node, {
+                canvasWidth: width,
+                canvasHeight: height,
                 pixelRatio: 1,
             })
             const link = document.createElement('a')
-            link.download = graphicFileName(formik.values.name)
+            link.download = graphicFileName(formik.values.name, format)
             link.href = dataUrl
             link.click()
             link.remove()
@@ -754,7 +790,7 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
             console.error('Error generating event graphic:', error)
             addToast({ description: 'Failed to generate the event graphic' })
         } finally {
-            setDownloadingGraphic(false)
+            setDownloadingGraphic(null)
         }
     }
 
@@ -1087,32 +1123,52 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                 <div>
                     <label className="text-[15px] block mb-1">Default event graphic</label>
                     <p className="text-sm text-secondary mb-2">
-                        This graphic is generated from the details above. If you don't upload a photo, it's saved
-                        automatically and used as the event's photo everywhere on the site. The background comes from
-                        the first speaker's favorite color on their community profile.
+                        These graphics are generated from the details above. If you don't upload a photo, the square one
+                        is saved automatically and used as the event's photo everywhere on the site. Shuffle to try a
+                        different color and light/dark treatment — whatever is showing when you save is what gets used.
                     </p>
-                    <EventGraphic
-                        ref={graphicRef}
-                        title={formik.values.name || 'Your event name'}
-                        date={formik.values.date}
-                        location={formik.values.locationLabel}
-                        online={formik.values.online}
-                        speaker={firstSpeakerProfile}
-                        partners={formik.values.partners.filter((partner) => partner.name)}
-                        className="rounded border border-primary"
-                    />
-                    <div className="mt-2">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <EventGraphic
+                            ref={graphicRef}
+                            {...graphicProps}
+                            format="square"
+                            className="rounded border border-primary"
+                        />
+                        <EventGraphic
+                            ref={landscapeGraphicRef}
+                            {...graphicProps}
+                            format="landscape"
+                            className="rounded border border-primary self-start"
+                        />
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                        <OSButton size="sm" variant="secondary" type="button" onClick={shuffleGraphicStyle}>
+                            Shuffle style
+                        </OSButton>
                         <OSButton
                             size="sm"
                             variant="secondary"
                             type="button"
-                            disabled={downloadingGraphic}
-                            onClick={handleDownloadGraphic}
+                            disabled={downloadingGraphic !== null}
+                            onClick={() => handleDownloadGraphic('square')}
                         >
-                            {downloadingGraphic ? (
+                            {downloadingGraphic === 'square' ? (
                                 <IconSpinner className="animate-spin size-4" />
                             ) : (
-                                'Download graphic (1080×1080)'
+                                'Download square (1080×1080)'
+                            )}
+                        </OSButton>
+                        <OSButton
+                            size="sm"
+                            variant="secondary"
+                            type="button"
+                            disabled={downloadingGraphic !== null}
+                            onClick={() => handleDownloadGraphic('landscape')}
+                        >
+                            {downloadingGraphic === 'landscape' ? (
+                                <IconSpinner className="animate-spin size-4" />
+                            ) : (
+                                'Download landscape (1200×630)'
                             )}
                         </OSButton>
                     </div>

--- a/src/components/EventForm/index.tsx
+++ b/src/components/EventForm/index.tsx
@@ -13,7 +13,8 @@ import Toggle from 'components/Toggle'
 import ImageDrop, { type Image as UploadImage } from 'components/ImageDrop'
 import uploadImage from 'components/Squeak/util/uploadImage'
 import { toBlob, toPng } from 'html-to-image'
-import EventGraphic, { type EventGraphicSpeaker } from 'components/EventGraphic'
+import EventGraphic, { type EventGraphicFormat, type EventGraphicSpeaker } from 'components/EventGraphic'
+import { EVENT_GRAPHIC_STYLE_COUNT, eventGraphicStyleIndex } from 'constants/eventGraphicPalette'
 import { useToast } from '../../context/Toast'
 import { Event } from '../../pages/events'
 import CreatableMultiSelect from 'components/CreatableMultiSelect'
@@ -230,8 +231,24 @@ const validationSchema = Yup.object().shape({
     presentation: Yup.string().url('Enter a valid URL').optional(),
 })
 
-const graphicFileName = (eventName?: string): string =>
-    `${(eventName || 'posthog-event').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.png`
+const graphicFileName = (eventName?: string, format: EventGraphicFormat = 'square'): string =>
+    `${(eventName || 'posthog-event').toLowerCase().replace(/[^a-z0-9]+/g, '-')}${
+        format === 'landscape' ? '-landscape' : ''
+    }.png`
+
+// Export sizes: a square social graphic, and the standard Open Graph ratio for link previews.
+const GRAPHIC_EXPORT_SIZES: Record<EventGraphicFormat, { width: number; height: number }> = {
+    square: { width: 1080, height: 1080 },
+    landscape: { width: 1200, height: 630 },
+}
+
+// The landscape title auto-fits, but its wide/short canvas can leave the type looking small, so the
+// organizer can nudge it up or down in fixed steps. Each step is 15% off the format's default; the range
+// is clamped so a press can't run past a sensible size (the graphic itself still width-clamps every word).
+// It's steps rather than a slider deliberately — no drag thumb to style across browsers, nothing to break.
+const TITLE_SCALE_STEP = 0.15
+const TITLE_SCALE_MIN_STEP = -2
+const TITLE_SCALE_MAX_STEP = 2
 
 const transformEventToFormValues = (event: Event, speakerOptions?: SelectOption[]): EventFormValues => {
     const parsed = dayjs(event?.date)
@@ -274,8 +291,15 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
     const { getJwt } = useUser()
     const { addToast } = useToast()
     const [submitting, setSubmitting] = React.useState<boolean>(false)
-    const [downloadingGraphic, setDownloadingGraphic] = React.useState<boolean>(false)
+    const [downloadingGraphic, setDownloadingGraphic] = React.useState<EventGraphicFormat | null>(null)
+    // Null means "follow the event name"; shuffling pins an explicit hue + light/dark combo.
+    const [graphicStyleOverride, setGraphicStyleOverride] = React.useState<number | null>(null)
+    // Landscape-only title-size nudge. 0 = the format default; each step is ±15%. Since the landscape
+    // graphic is download-only (only the square is auto-uploaded), this only ever needs to drive the live
+    // preview and the downloaded PNG — no persisted field.
+    const [landscapeTitleStep, setLandscapeTitleStep] = React.useState<number>(0)
     const graphicRef = React.useRef<HTMLDivElement>(null)
+    const landscapeGraphicRef = React.useRef<HTMLDivElement>(null)
     const data = useStaticQuery(graphql`
         query {
             allEvent {
@@ -736,17 +760,43 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
         }
     }, [formik.values.speakers, data.allSqueakProfile.nodes])
 
-    const handleDownloadGraphic = async () => {
-        if (!graphicRef.current) return
-        setDownloadingGraphic(true)
+    // Falls back to a stable hash of the event name so the same event always starts on the same style.
+    const graphicStyleIndex = graphicStyleOverride ?? eventGraphicStyleIndex(formik.values.name)
+
+    // Step by a random non-zero offset so every press lands on a different hue/variant combination.
+    const shuffleGraphicStyle = () =>
+        setGraphicStyleOverride(
+            (graphicStyleIndex + 1 + Math.floor(Math.random() * (EVENT_GRAPHIC_STYLE_COUNT - 1))) %
+                EVENT_GRAPHIC_STYLE_COUNT
+        )
+
+    const graphicProps = {
+        title: formik.values.name || 'Your event name',
+        date: formik.values.date,
+        startTime: formik.values.startTime,
+        venue: formik.values.venueName,
+        location: formik.values.locationLabel,
+        online: formik.values.online,
+        speaker: firstSpeakerProfile,
+        partners: formik.values.partners.filter((partner) => partner.name),
+        styleIndex: graphicStyleIndex,
+    }
+
+    const landscapeTitleScale = 1 + landscapeTitleStep * TITLE_SCALE_STEP
+
+    const handleDownloadGraphic = async (format: EventGraphicFormat) => {
+        const node = format === 'landscape' ? landscapeGraphicRef.current : graphicRef.current
+        if (!node) return
+        setDownloadingGraphic(format)
         try {
-            const dataUrl = await toPng(graphicRef.current, {
-                canvasWidth: 1080,
-                canvasHeight: 1080,
+            const { width, height } = GRAPHIC_EXPORT_SIZES[format]
+            const dataUrl = await toPng(node, {
+                canvasWidth: width,
+                canvasHeight: height,
                 pixelRatio: 1,
             })
             const link = document.createElement('a')
-            link.download = graphicFileName(formik.values.name)
+            link.download = graphicFileName(formik.values.name, format)
             link.href = dataUrl
             link.click()
             link.remove()
@@ -754,7 +804,7 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
             console.error('Error generating event graphic:', error)
             addToast({ description: 'Failed to generate the event graphic' })
         } finally {
-            setDownloadingGraphic(false)
+            setDownloadingGraphic(null)
         }
     }
 
@@ -762,6 +812,7 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
     // this reverts to the saved event rather than emptying the form.
     const clearForm = () => {
         formik.resetForm()
+        setLandscapeTitleStep(0)
         setCityQuery('')
         setCitySuggestions([])
         setCityOpen(false)
@@ -1087,34 +1138,85 @@ export default function EventForm({ onSuccess, event }: { onSuccess?: () => void
                 <div>
                     <label className="text-[15px] block mb-1">Default event graphic</label>
                     <p className="text-sm text-secondary mb-2">
-                        This graphic is generated from the details above. If you don't upload a photo, it's saved
-                        automatically and used as the event's photo everywhere on the site. The background comes from
-                        the first speaker's favorite color on their community profile.
+                        These graphics are generated from the details above. If you don't upload a photo, the square one
+                        is saved automatically and used as the event's photo everywhere on the site. Shuffle to try a
+                        different color and light/dark treatment — whatever is showing when you save is what gets used.
+                        The landscape (link preview) graphic has its own title-size control below.
                     </p>
-                    <EventGraphic
-                        ref={graphicRef}
-                        title={formik.values.name || 'Your event name'}
-                        date={formik.values.date}
-                        location={formik.values.locationLabel}
-                        online={formik.values.online}
-                        speaker={firstSpeakerProfile}
-                        partners={formik.values.partners.filter((partner) => partner.name)}
-                        className="rounded border border-primary"
-                    />
-                    <div className="mt-2">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <EventGraphic
+                            ref={graphicRef}
+                            {...graphicProps}
+                            format="square"
+                            className="rounded border border-primary"
+                        />
+                        <EventGraphic
+                            ref={landscapeGraphicRef}
+                            {...graphicProps}
+                            format="landscape"
+                            titleScale={landscapeTitleScale}
+                            className="rounded border border-primary self-start"
+                        />
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                        <OSButton size="sm" variant="secondary" type="button" onClick={shuffleGraphicStyle}>
+                            Shuffle style
+                        </OSButton>
                         <OSButton
                             size="sm"
                             variant="secondary"
                             type="button"
-                            disabled={downloadingGraphic}
-                            onClick={handleDownloadGraphic}
+                            disabled={downloadingGraphic !== null}
+                            onClick={() => handleDownloadGraphic('square')}
                         >
-                            {downloadingGraphic ? (
+                            {downloadingGraphic === 'square' ? (
                                 <IconSpinner className="animate-spin size-4" />
                             ) : (
-                                'Download graphic (1080×1080)'
+                                'Download square (1080×1080)'
                             )}
                         </OSButton>
+                        <OSButton
+                            size="sm"
+                            variant="secondary"
+                            type="button"
+                            disabled={downloadingGraphic !== null}
+                            onClick={() => handleDownloadGraphic('landscape')}
+                        >
+                            {downloadingGraphic === 'landscape' ? (
+                                <IconSpinner className="animate-spin size-4" />
+                            ) : (
+                                'Download landscape (1200×630)'
+                            )}
+                        </OSButton>
+                        <div className="flex items-center gap-1 sm:ml-auto">
+                            <span className="text-sm text-secondary mr-1">Landscape title size</span>
+                            <OSButton
+                                size="sm"
+                                variant="secondary"
+                                type="button"
+                                aria-label="Make the landscape title smaller"
+                                tooltip="Smaller landscape title"
+                                disabled={landscapeTitleStep <= TITLE_SCALE_MIN_STEP}
+                                onClick={() =>
+                                    setLandscapeTitleStep((step) => Math.max(TITLE_SCALE_MIN_STEP, step - 1))
+                                }
+                            >
+                                A-
+                            </OSButton>
+                            <OSButton
+                                size="sm"
+                                variant="secondary"
+                                type="button"
+                                aria-label="Make the landscape title bigger"
+                                tooltip="Bigger landscape title"
+                                disabled={landscapeTitleStep >= TITLE_SCALE_MAX_STEP}
+                                onClick={() =>
+                                    setLandscapeTitleStep((step) => Math.min(TITLE_SCALE_MAX_STEP, step + 1))
+                                }
+                            >
+                                A+
+                            </OSButton>
+                        </div>
                     </div>
                 </div>
                 <OSTextarea

--- a/src/components/EventGraphic/index.tsx
+++ b/src/components/EventGraphic/index.tsx
@@ -1,107 +1,674 @@
 import React, { forwardRef } from 'react'
 import dayjs from 'dayjs'
 import { Logo } from '@posthog/brand/logo'
-import { PROFILE_COLORS } from 'constants/profileColors'
+import {
+    HedgehogBallHog,
+    HedgehogBeaker,
+    HedgehogCardHog,
+    HedgehogChef,
+    HedgehogConstruction,
+    HedgehogHogpatch,
+    HedgehogIpad,
+    HedgehogMountie,
+    HedgehogRoboHog,
+    HedgehogSailorHog,
+    HedgehogSpeakerHog,
+} from '@posthog/brand/hoggies'
+import {
+    EVENT_GRAPHIC_CREAM_FROM,
+    EVENT_GRAPHIC_CREAM_TO,
+    EVENT_GRAPHIC_INK,
+    EVENT_GRAPHIC_INK_MUTED,
+    eventGraphicHogIndex,
+    eventGraphicStyle,
+    eventGraphicStyleIndex,
+    type EventGraphicVariant,
+} from 'constants/eventGraphicPalette'
 
 export type EventGraphicSpeaker = {
     name: string
+    /** Kept for the community profile shape — no longer drives the graphic's color. */
     color?: string
     avatarUrl?: string
     companyRole?: string
 }
 
+export type EventGraphicPartner = {
+    name: string
+    /** Partner logo from Strapi. Falls back to the name set in Squeak when absent. */
+    logoUrl?: string
+}
+
+export type EventGraphicFormat = 'square' | 'landscape'
+
 export type EventGraphicProps = {
     title: string
     date?: string
+    /** 'HH:mm'. Falls back to the time embedded in `date` when that isn't midnight. */
+    startTime?: string
+    /** Venue name, rendered above the location line. */
+    venue?: string
     location?: string
     online?: boolean
     speaker?: EventGraphicSpeaker
-    partners?: Array<{ name: string }>
+    partners?: EventGraphicPartner[]
+    format?: EventGraphicFormat
+    /** Resolves to a hue + light/dark variant. Defaults to a stable hash of the title. */
+    styleIndex?: number
+    /**
+     * Organizer nudge on the title size, on top of the per-format auto-fit and its base scale. 1 = the
+     * format's default; the landscape stepper in the form steps it up and down. Always width-clamped, so
+     * no value can push a word off the edge or break it mid-word.
+     */
+    titleScale?: number
     className?: string
 }
 
-// Profile colors light enough to need dark text — the rest get white
-const LIGHT_BACKGROUNDS = ['lime-green', 'teal', 'yellow', 'orange']
+/**
+ * The fallback hogs used when an event has no speaker photo, picked independently of the hue — hog/color
+ * pairings are no longer part of the brand system. Edit this list to change which hogs are in rotation;
+ * the names come from `@posthog/brand`, which is generated from the Hoggies brand file.
+ */
+const FALLBACK_HOGS = [
+    HedgehogRoboHog,
+    HedgehogMountie,
+    HedgehogSailorHog,
+    HedgehogChef,
+    HedgehogConstruction,
+    HedgehogCardHog,
+    HedgehogIpad,
+    HedgehogSpeakerHog,
+    HedgehogHogpatch,
+    HedgehogBallHog,
+    HedgehogBeaker,
+]
 
-const DEFAULT_BACKGROUND = 'yellow'
+/**
+ * Everything except the title is the same physical size in both formats (a ~30px margin, a 126px badge,
+ * a 48px logo), so the tokens below are those measurements expressed against each canvas width — 800 for
+ * the square, 1200 for the landscape. They're applied as inline `cqw` styles rather than Tailwind classes
+ * because the values are computed, and that also keeps them out of `safelist.txt`.
+ */
+const FORMATS = {
+    square: {
+        aspect: '100%',
+        pad: 4,
+        // Step down as the title gets longer, so it always fills the space without overflowing.
+        titleSizes: [15, 12.5, 10.4, 8.7, 7.6],
+        // Narrower than the title so it stays clear of the artwork — display type can run over a hog and
+        // still read, but a smaller subtitle crossing it just looks like a mistake.
+        subtitleScale: 0.36,
+        subtitleWidth: 58,
+        // The square has the height to carry a subtitle without shrinking the title.
+        subtitleStepDown: 0,
+        titleWidth: 76,
+        // A speaker portrait is much wider than the hog art, so the title column narrows to clear the
+        // face — and the title steps down with it, or long words break mid-word in the narrower column.
+        titleWidthSpeaker: 49,
+        speakerStepDown: 1,
+        titleGap: 2.6,
+        // Abbreviated, as the reference speaker frames are ("Saturday, Jan 31"). The shorter line keeps
+        // the date clear of the portrait, which is what lets the portrait sit as large as it does.
+        dateFormat: 'dddd, MMM D',
+        infoWidth: 46,
+        date: 4,
+        time: 3.2,
+        venue: 3.75,
+        rule: 11,
+        ruleThickness: 0.5,
+        footerBottom: 6.9,
+        logo: 6,
+        badge: 15.75,
+        badgeTop: 3.7,
+        badgeRight: 4.1,
+        badgeRadius: 0.75,
+        badgeHeader: 5.9,
+        badgeMonth: 3,
+        badgeDay: 8.5,
+        artWidth: 54,
+        artRight: -3,
+        artBottom: 11,
+        // The portrait is drawn much larger than the hog art so the face reads at a distance.
+        //
+        // It sits flush to the right edge with NO bleed, unlike the reference frames. Those were drawn
+        // around one illustration whose subject is head-left with the shoulder trailing off-canvas, so a
+        // bleed there clips only jacket. Measuring the 101 speaker avatars actually in Strapi, the head
+        // reaches 0.82–0.99 of the source frame — several touch the right edge outright — so the same
+        // bleed cuts faces in half. Flush right puts the head at x 0.50–0.96 of the canvas, which is
+        // within a couple of percent of where the reference frame puts it, and no face is ever clipped.
+        speakerWidth: 80,
+        speakerRight: 0,
+        barHeight: 13.95,
+        // The square already fills its height, so its auto-fit size is the baseline (1).
+        titleBaseScale: 1,
+        // High enough that the square title (which is well within its tall canvas) never hits it — the
+        // height clamp only exists to protect the short landscape canvas.
+        titleHeightBudget: 60,
+    },
+    landscape: {
+        aspect: '52.5%',
+        pad: 2.33,
+        // The landscape canvas is short, so long titles have to step down harder than the square's
+        // to keep the date block clear of the footer.
+        titleSizes: [12.5, 10.5, 8.6, 6.9, 6],
+        subtitleScale: 0.36,
+        subtitleWidth: 62,
+        // Only 630px tall, so a subtitle has to buy its space back out of the title.
+        subtitleStepDown: 2,
+        titleWidth: 84,
+        titleWidthSpeaker: 58,
+        speakerStepDown: 2,
+        titleGap: 2,
+        // The OpenGraph canvas abbreviates the month — "Wednesday, Sep 23" rather than
+        // "Wednesday, September 23". The full string was the widest thing in this layout and the reason
+        // the date column had to be so wide; shortening it buys the space back for the artwork.
+        dateFormat: 'dddd, MMM D',
+        infoWidth: 26,
+        date: 2.75,
+        time: 2.2,
+        venue: 2.4,
+        rule: 7,
+        ruleThickness: 0.33,
+        footerBottom: 6,
+        logo: 4,
+        badge: 10.5,
+        badgeTop: 2.34,
+        badgeRight: 2.62,
+        badgeRadius: 0.5,
+        badgeHeader: 3.94,
+        badgeMonth: 2,
+        badgeDay: 5.67,
+        // Grown to use the space the abbreviated date frees up.
+        artWidth: 34,
+        artRight: -2,
+        artBottom: 5.5,
+        // No landscape speaker frame exists in the references, so these hold the square's proportions
+        // against the short edge. Flush right for the same reason as the square — see above.
+        speakerWidth: 46,
+        speakerRight: 0,
+        barHeight: 7.3,
+        // The landscape canvas is short and wide, so the title tiers step down hard to protect the
+        // footer — which left the type floating in empty space (the brand team's feedback). The auto-fit
+        // size is scaled up by default so a graphic looks right with no manual input, which matters
+        // because most of these are generated for events that never uploaded a photo, with nobody at the
+        // size control. The width clamp still applies afterwards, so this can't push a word off the edge.
+        titleBaseScale: 1.3,
+        // The title must clear the info block and the footer on the 52.5cqw-tall canvas. This caps its
+        // height so a multi-line title (or a large manual size) stops growing instead of colliding — the
+        // key guard for auto-generated graphics, where nobody is watching to fix an overlap.
+        titleHeightBudget: 30,
+    },
+} as const
 
-// Fallback artwork for events without a speaker (or speakers without an avatar)
-const DEFAULT_HEDGEHOG = 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hogzilla_73b822a689.png'
+/**
+ * Long event names are usually already two parts — "AI Demo Night: Building for Model Volatility" — so
+ * the leading clause becomes the display title and the remainder a subtitle. That keeps the title short
+ * and large, which is what the reference frames all do, without needing a separate field on the event.
+ *
+ * Only long names split: a short name already sets at the largest size, and breaking it would shrink it.
+ */
+const splitTitle = (title: string): { title: string; subtitle?: string } => {
+    if (title.length <= 28) return { title }
+    const at = title.indexOf(': ')
+    if (at < 4 || at > 40) return { title }
+    return { title: title.slice(0, at), subtitle: title.slice(at + 2) }
+}
+
+/**
+ * Advance width of each Squeak uppercase glyph, in ems, measured from the rendered font.
+ *
+ * A character count is not good enough here: Squeak's 'W' is 0.87em and its 'I' is 0.44em, so "WORKFLOWS"
+ * is nearly twice the width of "VOLATILITY" at the same length. Summing real advances is what keeps a
+ * long word inside its column — otherwise `break-words` splits it mid-word and it reads as a typo
+ * ("WORKFLOW / S"). Kerning makes the sum run ~2% wide, which errs towards a smaller, safer size.
+ */
+const SQUEAK_ADVANCE: Record<string, number> = {
+    A: 0.5609,
+    B: 0.5821,
+    C: 0.6233,
+    D: 0.5804,
+    E: 0.5378,
+    F: 0.5068,
+    G: 0.6327,
+    H: 0.579,
+    I: 0.4408,
+    J: 0.5335,
+    K: 0.6124,
+    L: 0.4292,
+    M: 0.8488,
+    N: 0.6479,
+    O: 0.6504,
+    P: 0.5549,
+    Q: 0.6553,
+    R: 0.5865,
+    S: 0.5788,
+    T: 0.439,
+    U: 0.5778,
+    V: 0.657,
+    W: 0.866,
+    X: 0.6473,
+    Y: 0.6177,
+    Z: 0.576,
+    '0': 0.5826,
+    '1': 0.4144,
+    '2': 0.542,
+    '3': 0.5719,
+    '4': 0.5738,
+    '5': 0.5499,
+    '6': 0.554,
+    '7': 0.5275,
+    '8': 0.5577,
+    '9': 0.5659,
+    ' ': 0.2275,
+    '&': 0.7285,
+    "'": 0.2019,
+    '"': 0.4025,
+    '!': 0.2256,
+    '?': 0.4966,
+    '.': 0.1989,
+    ',': 0.1979,
+    ':': 0.2329,
+    ';': 0.2339,
+    '-': 0.5427,
+    '–': 0.4768,
+    '—': 0.7061,
+    '/': 0.3794,
+    '(': 0.3418,
+    ')': 0.3408,
+    '+': 0.5405,
+    '@': 0.9575,
+    '#': 0.6968,
+    '%': 0.7549,
+}
+const SQUEAK_FALLBACK_ADVANCE = 0.6
+
+const squeakWidth = (word: string): number =>
+    word
+        .toUpperCase()
+        .split('')
+        .reduce((sum, char) => sum + (SQUEAK_ADVANCE[char] ?? SQUEAK_FALLBACK_ADVANCE), 0)
+
+/** Largest font size, in cqw, at which every word in `text` still fits inside a `columnWidth` column. */
+const fitToLongestWord = (text: string, columnWidth: number): number => {
+    const widest = text.split(/\s+/).reduce((max, word) => Math.max(max, squeakWidth(word)), 0)
+    return widest > 0 ? columnWidth / widest : Infinity
+}
+
+/**
+ * How many lines `text` greedily wraps onto in a `columnWidth`-wide column at `size` cqw — the same
+ * greedy fill the browser does with `break-words`. Used to hold the title inside a vertical budget so a
+ * long title can't grow down into the info block and footer (see `titleSizeFor`).
+ */
+const wrapLineCount = (text: string, columnWidth: number, size: number): number => {
+    const space = SQUEAK_ADVANCE[' '] * size
+    let lines = 1
+    let width = 0
+    for (const word of text.split(/\s+/).filter(Boolean)) {
+        const wordWidth = squeakWidth(word) * size
+        if (width === 0) {
+            width = wordWidth
+        } else if (width + space + wordWidth <= columnWidth) {
+            width += space + wordWidth
+        } else {
+            lines += 1
+            width = wordWidth
+        }
+    }
+    return lines
+}
+
+const titleSizeFor = (
+    title: string,
+    sizes: readonly number[],
+    columnWidth: number,
+    stepDown = 0,
+    scale = 1,
+    heightBudget = Infinity
+): number => {
+    const tier = title.length <= 20 ? 0 : title.length <= 32 ? 1 : title.length <= 48 ? 2 : title.length <= 64 ? 3 : 4
+    // The auto-fit tier is the default; `scale` lets the organizer nudge it. Two clamps then keep the
+    // result inside the canvas no matter the scale: the width fit stops a word running off the edge or
+    // breaking mid-word, and the height fit stops a multi-line title growing down into the info block and
+    // footer.
+    const autoSize = sizes[Math.min(tier + stepDown, sizes.length - 1)]
+    const desired = Math.min(autoSize * scale, fitToLongestWord(title, columnWidth))
+
+    // Height fit: the largest size, up to `desired`, whose wrapped line count still clears the vertical
+    // budget. Line pitch is 0.9em (the title's line-height), and the last line adds its own cap height on
+    // top. Growing the size can only add line breaks, never remove them, so this height is monotonic in
+    // size — a binary search converges on the exact crossover. (A one-shot "solve backwards from the
+    // measured line count" can't: shrinking enough to drop a line reveals headroom at the new, smaller
+    // line count that it never goes back to spend, understating the true maximum.)
+    const heightAt = (size: number) => (0.9 * wrapLineCount(title, columnWidth, size) + 0.1) * size
+    if (heightAt(desired) <= heightBudget) return desired
+    let lo = 0
+    let hi = desired
+    for (let pass = 0; pass < 20; pass++) {
+        const mid = (lo + hi) / 2
+        if (heightAt(mid) <= heightBudget) {
+            lo = mid
+        } else {
+            hi = mid
+        }
+    }
+    return lo
+}
+
+/**
+ * The event's time only exists inside `date`, and only when the organizer set one — a midnight value
+ * means "no time given", so nothing is shown rather than a misleading 12:00 AM. There is no end time or
+ * timezone in the data, so this is a single start time in the same format `/events` already uses.
+ */
+const startTimeLabel = (date?: string, startTime?: string): string | null => {
+    if (startTime) {
+        const withTime = dayjs(`${dayjs(date).format('YYYY-MM-DD')} ${startTime}`)
+        return withTime.isValid() ? withTime.format('h:mm A') : null
+    }
+    const parsed = date ? dayjs(date) : null
+    if (!parsed?.isValid() || parsed.format('HH:mm') === '00:00') return null
+    return parsed.format('h:mm A')
+}
 
 const EventGraphic = forwardRef<HTMLDivElement, EventGraphicProps>(function EventGraphic(
-    { title, date, location, online, speaker, partners, className = '' },
+    {
+        title,
+        date,
+        startTime,
+        venue,
+        location,
+        online,
+        speaker,
+        partners,
+        format = 'square',
+        styleIndex,
+        titleScale = 1,
+        className = '',
+    },
     ref
 ) {
-    const color = speaker?.color && PROFILE_COLORS.includes(speaker.color) ? speaker.color : DEFAULT_BACKGROUND
-    const darkText = LIGHT_BACKGROUNDS.includes(color)
+    const t = FORMATS[format]
+    const resolvedIndex = styleIndex ?? eventGraphicStyleIndex(title)
+    const { hue, variant } = eventGraphicStyle(resolvedIndex)
+    const Hog = FALLBACK_HOGS[eventGraphicHogIndex(title, FALLBACK_HOGS.length)]
+    const { title: displayTitle, subtitle } = splitTitle(title)
+
+    const light = variant === 'light'
+    const onDarkIsWhite = hue.titleOnDark === '#FFFFFF'
+
+    const background = light
+        ? `linear-gradient(180deg, ${EVENT_GRAPHIC_CREAM_FROM} 0%, ${EVENT_GRAPHIC_CREAM_TO} 100%)`
+        : `linear-gradient(180deg, ${hue.from} 0%, ${hue.to} 100%)`
+    const titleColor = light ? hue.titleOnLight : hue.titleOnDark
+    const titleWidth = speaker?.avatarUrl ? t.titleWidthSpeaker : t.titleWidth
+    const titleSize = titleSizeFor(
+        displayTitle,
+        t.titleSizes,
+        titleWidth,
+        (subtitle ? t.subtitleStepDown : 0) + (speaker?.avatarUrl ? t.speakerStepDown : 0),
+        t.titleBaseScale * titleScale,
+        // A subtitle sits under the title and eats into the same vertical space, so hand the title a
+        // smaller height budget when one is present.
+        subtitle ? t.titleHeightBudget * 0.66 : t.titleHeightBudget
+    )
+    const subtitleWidth = Math.min(t.subtitleWidth, titleWidth)
+    const subtitleSize = subtitle ? Math.min(titleSize * t.subtitleScale, fitToLongestWord(subtitle, subtitleWidth)) : 0
+    const titleGlow = `0 0 ${t.pad * 0.28}cqw ${light ? `${hue.titleOnLight}47` : `${hue.to}66`}`
+    const ink = light ? EVENT_GRAPHIC_INK : hue.titleOnDark
+    const inkMuted = light ? EVENT_GRAPHIC_INK_MUTED : onDarkIsWhite ? 'rgba(255,255,255,0.75)' : 'rgba(21,21,21,0.65)'
+    const ruleColor = light ? 'rgba(57,65,80,0.35)' : onDarkIsWhite ? 'rgba(255,255,255,0.4)' : 'rgba(21,21,21,0.3)'
+
     const parsedDate = date ? dayjs(date) : null
-    const partnerNames = (partners || []).map((partner) => partner.name).filter(Boolean)
+    const hasDate = Boolean(parsedDate?.isValid())
+    const timeLabel = startTimeLabel(date, startTime)
     const locationLine = online ? 'Online' : location
+    const venueLine = online ? undefined : venue
+    const partnerList = (partners || []).filter((partner) => partner.name)
+
+    // The speaker portrait bleeds to the bottom edge, so it needs a solid bar to sit against. Hog
+    // artwork stops short of the footer, letting the logos sit straight on the background.
+    const hasBar = Boolean(speaker?.avatarUrl)
+    const barColor = light ? hue.from : '#FFFFFF'
+    const barInk = light ? hue.titleOnDark : EVENT_GRAPHIC_INK
+
+    const footerInk = hasBar ? barInk : light ? EVENT_GRAPHIC_INK : hue.titleOnDark
+    // Per the brand team the mark is mono everywhere except on white or cream, where it goes full color.
+    // That's cream with no bar, or the white bar drawn over an accent background.
+    const logoOnPaper = light !== hasBar
+    const logoVariant = logoOnPaper ? 'gradient' : 'mono'
 
     return (
         <div className={`@container overflow-hidden ${className}`}>
-            <div
-                ref={ref}
-                className={`relative aspect-square w-full overflow-hidden bg-${color} ${
-                    darkText ? 'text-black' : 'text-white'
-                }`}
-            >
-                <div className="absolute right-[6%] top-[31%] aspect-square w-[46%]">
-                    <div className="absolute inset-0 rounded-full border-[0.75cqw] border-white bg-tan shadow-xl" />
-                    {/* Clip only below the circle's midline so illustrations break out of the top instead of being cropped */}
-                    <div className="absolute inset-x-0 -top-[18%] bottom-0 overflow-hidden rounded-b-full">
+            <div ref={ref} className="relative w-full overflow-hidden" style={{ paddingBottom: t.aspect, background }}>
+                {/* Artwork sits behind the copy so long titles can run over it, as the designs do. */}
+                <div
+                    className="absolute"
+                    style={{
+                        width: `${speaker?.avatarUrl ? t.speakerWidth : t.artWidth}cqw`,
+                        right: `${speaker?.avatarUrl ? t.speakerRight : t.artRight}cqw`,
+                        bottom: `${hasBar ? 0 : t.artBottom}cqw`,
+                    }}
+                >
+                    {speaker?.avatarUrl ? (
                         <img
-                            src={speaker?.avatarUrl || DEFAULT_HEDGEHOG}
-                            alt={speaker?.name || 'Max the hedgehog'}
+                            src={speaker.avatarUrl}
+                            alt={speaker.name}
                             crossOrigin="anonymous"
-                            className="absolute bottom-0 left-1/2 w-[108%] max-w-none -translate-x-1/2"
+                            className="block w-full"
                         />
-                    </div>
+                    ) : (
+                        <Hog className="block h-auto w-full" />
+                    )}
                 </div>
-                <div className="absolute inset-0 flex flex-col p-[6%]">
-                    <h3
-                        className={`m-0 w-full break-words font-squeak font-bold uppercase leading-[0.95] ${
-                            title.length > 40 ? 'text-[7.5cqw]' : title.length > 22 ? 'text-[9.5cqw]' : 'text-[12cqw]'
-                        }`}
+
+                {/* Calendar badge */}
+                {hasDate && (
+                    <div
+                        className="absolute overflow-hidden bg-white"
+                        style={{
+                            width: `${t.badge}cqw`,
+                            height: `${t.badge}cqw`,
+                            top: `${t.badgeTop}cqw`,
+                            right: `${t.badgeRight}cqw`,
+                            borderRadius: `${t.badgeRadius}cqw`,
+                            boxShadow: `0 ${t.badgeRadius}cqw ${t.badgeRadius * 1.5}cqw rgba(0,0,0,0.16)`,
+                        }}
                     >
-                        {title}
-                    </h3>
-                    <div className="mt-[3%] w-[46%] font-rounded text-[3.75cqw] font-bold uppercase leading-snug">
-                        {parsedDate?.isValid() && <div>{parsedDate.format('dddd, MMMM D')}</div>}
-                        {locationLine && <div>{locationLine}</div>}
+                        <div
+                            className="flex items-center justify-center font-rounded font-extrabold uppercase text-white"
+                            style={{
+                                height: `${t.badgeHeader}cqw`,
+                                background: hue.badge,
+                                fontSize: `${t.badgeMonth}cqw`,
+                                letterSpacing: '0.02em',
+                            }}
+                        >
+                            {parsedDate?.format('MMM')}
+                        </div>
+                        <div
+                            className="flex items-center justify-center font-rounded font-extrabold"
+                            style={{
+                                height: `${t.badge - t.badgeHeader}cqw`,
+                                fontSize: `${t.badgeDay}cqw`,
+                                color: EVENT_GRAPHIC_INK,
+                            }}
+                        >
+                            {parsedDate?.format('D')}
+                        </div>
                     </div>
-                    {speaker && (
-                        <div className="mb-[6%] mt-auto w-[52%]">
-                            <div className="mb-[1.5%] font-rounded text-[2.75cqw] font-semibold uppercase leading-none">
-                                Featuring:
-                            </div>
-                            <div className="break-words font-squeak text-[5.5cqw] font-bold uppercase leading-none">
-                                {speaker.name}
-                            </div>
-                            {speaker.companyRole && (
-                                <div className="mt-[1.5%] font-rounded text-[2.75cqw] font-semibold uppercase leading-none">
-                                    {speaker.companyRole}
+                )}
+
+                {/* Copy */}
+                <div className="absolute inset-0" style={{ padding: `${t.pad}cqw` }}>
+                    <h3
+                        className="m-0 break-words font-squeak font-bold uppercase"
+                        style={{
+                            width: `${titleWidth}cqw`,
+                            fontSize: `${titleSize}cqw`,
+                            lineHeight: 0.9,
+                            color: titleColor,
+                            // Soft same-hue bloom behind the type, as the designs have it
+                            textShadow: titleGlow,
+                        }}
+                    >
+                        {displayTitle}
+                    </h3>
+                    {subtitle && (
+                        <div
+                            className="break-words font-squeak font-bold uppercase"
+                            style={{
+                                width: `${subtitleWidth}cqw`,
+                                fontSize: `${subtitleSize}cqw`,
+                                lineHeight: 1,
+                                marginTop: `${t.pad * 0.32}cqw`,
+                                color: titleColor,
+                                textShadow: titleGlow,
+                            }}
+                        >
+                            {subtitle}
+                        </div>
+                    )}
+
+                    <div
+                        className={
+                            format === 'landscape'
+                                ? 'flex items-start font-rounded font-extrabold'
+                                : 'font-rounded font-extrabold'
+                        }
+                        style={{
+                            marginTop: `${t.titleGap}cqw`,
+                            gap: format === 'landscape' ? `${t.pad}cqw` : undefined,
+                        }}
+                    >
+                        {/* Landscape sizes this column to its content — a fixed width wrapped long dates
+                            like "Wednesday, Sep 23" onto a second line and into the footer. */}
+                        <div
+                            style={{
+                                minWidth: format === 'landscape' ? `${t.infoWidth}cqw` : undefined,
+                                flexShrink: format === 'landscape' ? 0 : undefined,
+                            }}
+                        >
+                            {hasDate && (
+                                <div
+                                    className={format === 'landscape' ? 'whitespace-nowrap' : undefined}
+                                    style={{ fontSize: `${t.date}cqw`, color: ink, lineHeight: 1.2 }}
+                                >
+                                    {parsedDate?.format(t.dateFormat)}
+                                </div>
+                            )}
+                            {timeLabel && (
+                                <div
+                                    style={{
+                                        fontSize: `${t.time}cqw`,
+                                        color: inkMuted,
+                                        lineHeight: 1.3,
+                                        marginTop: `${t.pad * 0.3}cqw`,
+                                    }}
+                                >
+                                    {timeLabel}
                                 </div>
                             )}
                         </div>
-                    )}
-                    <div
-                        className={`flex items-center justify-center gap-[2.5cqw] rounded-[2cqw] bg-white px-[4%] py-[2.5%] text-black ${
-                            speaker ? '' : 'mt-auto'
-                        }`}
-                    >
-                        <Logo className="h-[5cqw] w-auto shrink-0" width="auto" />
-                        {partnerNames.length > 0 && (
+
+                        {/* Square stacks the venue under a horizontal rule; landscape puts it in a second
+                            column behind a vertical one. */}
+                        {format === 'square' ? (
                             <>
-                                <span className="font-rounded text-[3cqw] font-semibold uppercase leading-none">
-                                    with
-                                </span>
-                                <span className="truncate font-squeak text-[4.5cqw] font-bold uppercase leading-none">
-                                    {partnerNames.join(' & ')}
-                                </span>
+                                {(venueLine || locationLine) && (
+                                    <div
+                                        style={{
+                                            width: `${t.rule}cqw`,
+                                            height: `${t.ruleThickness}cqw`,
+                                            background: ruleColor,
+                                            margin: `${t.pad * 0.7}cqw 0`,
+                                        }}
+                                    />
+                                )}
+                                <div style={{ width: `${t.infoWidth}cqw` }}>
+                                    {venueLine && (
+                                        <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.45 }}>
+                                            {venueLine},
+                                        </div>
+                                    )}
+                                    {locationLine && (
+                                        <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.45 }}>
+                                            {locationLine}
+                                        </div>
+                                    )}
+                                </div>
                             </>
+                        ) : (
+                            (venueLine || locationLine) && (
+                                <>
+                                    <div
+                                        style={{
+                                            width: `${t.ruleThickness}cqw`,
+                                            alignSelf: 'stretch',
+                                            background: ruleColor,
+                                        }}
+                                    />
+                                    <div>
+                                        {venueLine && (
+                                            <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.4 }}>
+                                                {venueLine},
+                                            </div>
+                                        )}
+                                        {locationLine && (
+                                            <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.4 }}>
+                                                {locationLine}
+                                            </div>
+                                        )}
+                                    </div>
+                                </>
+                            )
                         )}
                     </div>
+                </div>
+
+                {/* Footer */}
+                <div
+                    className={`absolute bottom-0 flex items-center ${hasBar ? 'justify-center' : ''}`}
+                    style={{
+                        left: 0,
+                        right: 0,
+                        height: hasBar ? `${t.barHeight}cqw` : undefined,
+                        background: hasBar ? barColor : undefined,
+                        padding: hasBar ? `0 ${t.pad}cqw` : `0 ${t.pad}cqw ${t.footerBottom}cqw`,
+                        color: footerInk,
+                        gap: `${t.pad * 0.6}cqw`,
+                    }}
+                >
+                    <Logo
+                        variant={logoVariant}
+                        className="w-auto shrink-0"
+                        style={{ height: `${t.logo}cqw` }}
+                        width="auto"
+                    />
+                    {partnerList.map((partner) => (
+                        <React.Fragment key={partner.name}>
+                            <span
+                                className="font-rounded font-medium"
+                                style={{ fontSize: `${t.logo * 0.7}cqw`, opacity: 0.4 }}
+                            >
+                                /
+                            </span>
+                            {partner.logoUrl ? (
+                                <img
+                                    src={partner.logoUrl}
+                                    alt={partner.name}
+                                    crossOrigin="anonymous"
+                                    className="w-auto shrink-0 object-contain"
+                                    style={{ height: `${t.logo}cqw` }}
+                                />
+                            ) : (
+                                <span
+                                    className="whitespace-nowrap font-squeak font-bold uppercase"
+                                    style={{ fontSize: `${t.logo * 0.78}cqw`, lineHeight: 1 }}
+                                >
+                                    {partner.name}
+                                </span>
+                            )}
+                        </React.Fragment>
+                    ))}
                 </div>
             </div>
         </div>

--- a/src/components/EventGraphic/index.tsx
+++ b/src/components/EventGraphic/index.tsx
@@ -1,107 +1,432 @@
 import React, { forwardRef } from 'react'
 import dayjs from 'dayjs'
 import { Logo } from '@posthog/brand/logo'
-import { PROFILE_COLORS } from 'constants/profileColors'
+import {
+    HedgehogBallHog,
+    HedgehogBeaker,
+    HedgehogCardHog,
+    HedgehogChef,
+    HedgehogConstruction,
+    HedgehogHogpatch,
+    HedgehogIpad,
+    HedgehogMountie,
+    HedgehogRoboHog,
+    HedgehogSailorHog,
+    HedgehogSpeakerHog,
+} from '@posthog/brand/hoggies'
+import {
+    EVENT_GRAPHIC_CREAM_FROM,
+    EVENT_GRAPHIC_CREAM_TO,
+    EVENT_GRAPHIC_INK,
+    EVENT_GRAPHIC_INK_MUTED,
+    eventGraphicStyle,
+    eventGraphicStyleIndex,
+    type EventGraphicVariant,
+} from 'constants/eventGraphicPalette'
 
 export type EventGraphicSpeaker = {
     name: string
+    /** Kept for the community profile shape — no longer drives the graphic's color. */
     color?: string
     avatarUrl?: string
     companyRole?: string
 }
 
+export type EventGraphicPartner = {
+    name: string
+    /** Partner logo from Strapi. Falls back to the name set in Squeak when absent. */
+    logoUrl?: string
+}
+
+export type EventGraphicFormat = 'square' | 'landscape'
+
 export type EventGraphicProps = {
     title: string
     date?: string
+    /** 'HH:mm'. Falls back to the time embedded in `date` when that isn't midnight. */
+    startTime?: string
+    /** Venue name, rendered above the location line. */
+    venue?: string
     location?: string
     online?: boolean
     speaker?: EventGraphicSpeaker
-    partners?: Array<{ name: string }>
+    partners?: EventGraphicPartner[]
+    format?: EventGraphicFormat
+    /** Resolves to a hue + light/dark variant. Defaults to a stable hash of the title. */
+    styleIndex?: number
     className?: string
 }
 
-// Profile colors light enough to need dark text — the rest get white
-const LIGHT_BACKGROUNDS = ['lime-green', 'teal', 'yellow', 'orange']
+// One hog per hue, so a given color always brings the same artwork — the pairing the brand team set up
+// in Figma. Ordered to match EVENT_GRAPHIC_HUES.
+const HUE_HOGS = [
+    HedgehogRoboHog, // blue
+    HedgehogMountie, // sky
+    HedgehogSailorHog, // ocean
+    HedgehogChef, // coral
+    HedgehogConstruction, // lime
+    HedgehogCardHog, // green
+    HedgehogIpad, // lilac
+    HedgehogSpeakerHog, // purple
+    HedgehogHogpatch, // teal
+    HedgehogBallHog, // tangerine
+    HedgehogBeaker, // yellow
+]
 
-const DEFAULT_BACKGROUND = 'yellow'
+/**
+ * Everything except the title is the same physical size in both formats (a ~30px margin, a 126px badge,
+ * a 48px logo), so the tokens below are those measurements expressed against each canvas width — 800 for
+ * the square, 1200 for the landscape. They're applied as inline `cqw` styles rather than Tailwind classes
+ * because the values are computed, and that also keeps them out of `safelist.txt`.
+ */
+const FORMATS = {
+    square: {
+        aspect: '100%',
+        pad: 4,
+        // Step down as the title gets longer, so it always fills the space without overflowing.
+        titleSizes: [15, 12.5, 10.4, 8.7, 7.6],
+        titleWidth: 76,
+        titleGap: 2.6,
+        infoWidth: 46,
+        date: 4,
+        time: 3.2,
+        venue: 3.75,
+        rule: 11,
+        ruleThickness: 0.5,
+        footerBottom: 6.9,
+        logo: 6,
+        badge: 15.75,
+        badgeTop: 3.7,
+        badgeRight: 4.1,
+        badgeRadius: 0.75,
+        badgeHeader: 5.9,
+        badgeMonth: 3,
+        badgeDay: 8.5,
+        artWidth: 54,
+        artRight: -3,
+        artBottom: 11,
+        barHeight: 12.5,
+    },
+    landscape: {
+        aspect: '52.5%',
+        pad: 2.33,
+        // The landscape canvas is short, so long titles have to step down harder than the square's
+        // to keep the date block clear of the footer.
+        titleSizes: [12.5, 10.5, 8.6, 6.9, 6],
+        titleWidth: 84,
+        titleGap: 2,
+        infoWidth: 32,
+        date: 2.75,
+        time: 2.2,
+        venue: 2.4,
+        rule: 7,
+        ruleThickness: 0.33,
+        footerBottom: 6,
+        logo: 4,
+        badge: 10.5,
+        badgeTop: 2.34,
+        badgeRight: 2.62,
+        badgeRadius: 0.5,
+        badgeHeader: 3.94,
+        badgeMonth: 2,
+        badgeDay: 5.67,
+        artWidth: 27,
+        artRight: -1,
+        artBottom: 7,
+        barHeight: 9,
+    },
+} as const
 
-// Fallback artwork for events without a speaker (or speakers without an avatar)
-const DEFAULT_HEDGEHOG = 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hogzilla_73b822a689.png'
+const titleSizeFor = (title: string, sizes: readonly number[]): number => {
+    if (title.length <= 20) return sizes[0]
+    if (title.length <= 32) return sizes[1]
+    if (title.length <= 48) return sizes[2]
+    if (title.length <= 64) return sizes[3]
+    return sizes[4]
+}
+
+/**
+ * The event's time only exists inside `date`, and only when the organizer set one — a midnight value
+ * means "no time given", so nothing is shown rather than a misleading 12:00 AM. There is no end time or
+ * timezone in the data, so this is a single start time in the same format `/events` already uses.
+ */
+const startTimeLabel = (date?: string, startTime?: string): string | null => {
+    if (startTime) {
+        const withTime = dayjs(`${dayjs(date).format('YYYY-MM-DD')} ${startTime}`)
+        return withTime.isValid() ? withTime.format('h:mm A') : null
+    }
+    const parsed = date ? dayjs(date) : null
+    if (!parsed?.isValid() || parsed.format('HH:mm') === '00:00') return null
+    return parsed.format('h:mm A')
+}
 
 const EventGraphic = forwardRef<HTMLDivElement, EventGraphicProps>(function EventGraphic(
-    { title, date, location, online, speaker, partners, className = '' },
+    {
+        title,
+        date,
+        startTime,
+        venue,
+        location,
+        online,
+        speaker,
+        partners,
+        format = 'square',
+        styleIndex,
+        className = '',
+    },
     ref
 ) {
-    const color = speaker?.color && PROFILE_COLORS.includes(speaker.color) ? speaker.color : DEFAULT_BACKGROUND
-    const darkText = LIGHT_BACKGROUNDS.includes(color)
+    const t = FORMATS[format]
+    const resolvedIndex = styleIndex ?? eventGraphicStyleIndex(title)
+    const { hue, variant } = eventGraphicStyle(resolvedIndex)
+    const Hog = HUE_HOGS[Math.abs(resolvedIndex) % HUE_HOGS.length]
+
+    const light = variant === 'light'
+    const onDarkIsWhite = hue.titleOnDark === '#FFFFFF'
+
+    const background = light
+        ? `linear-gradient(180deg, ${EVENT_GRAPHIC_CREAM_FROM} 0%, ${EVENT_GRAPHIC_CREAM_TO} 100%)`
+        : `linear-gradient(180deg, ${hue.from} 0%, ${hue.to} 100%)`
+    const titleColor = light ? hue.titleOnLight : hue.titleOnDark
+    const ink = light ? EVENT_GRAPHIC_INK : hue.titleOnDark
+    const inkMuted = light ? EVENT_GRAPHIC_INK_MUTED : onDarkIsWhite ? 'rgba(255,255,255,0.75)' : 'rgba(21,21,21,0.65)'
+    const ruleColor = light ? 'rgba(57,65,80,0.35)' : onDarkIsWhite ? 'rgba(255,255,255,0.4)' : 'rgba(21,21,21,0.3)'
+
     const parsedDate = date ? dayjs(date) : null
-    const partnerNames = (partners || []).map((partner) => partner.name).filter(Boolean)
+    const hasDate = Boolean(parsedDate?.isValid())
+    const timeLabel = startTimeLabel(date, startTime)
     const locationLine = online ? 'Online' : location
+    const venueLine = online ? undefined : venue
+    const partnerList = (partners || []).filter((partner) => partner.name)
+
+    // The speaker portrait bleeds to the bottom edge, so it needs a solid bar to sit against. Hog
+    // artwork stops short of the footer, letting the logos sit straight on the background.
+    const hasBar = Boolean(speaker?.avatarUrl)
+    const barColor = light ? hue.from : '#FFFFFF'
+    const barInk = light ? hue.titleOnDark : EVENT_GRAPHIC_INK
+
+    const footerInk = hasBar ? barInk : light ? EVENT_GRAPHIC_INK : hue.titleOnDark
+    // The 4-color mark reads best on the white bar; everywhere else the mono mark keeps contrast.
+    const logoVariant = hasBar && !light ? 'gradient' : 'mono'
 
     return (
         <div className={`@container overflow-hidden ${className}`}>
-            <div
-                ref={ref}
-                className={`relative aspect-square w-full overflow-hidden bg-${color} ${
-                    darkText ? 'text-black' : 'text-white'
-                }`}
-            >
-                <div className="absolute right-[6%] top-[31%] aspect-square w-[46%]">
-                    <div className="absolute inset-0 rounded-full border-[0.75cqw] border-white bg-tan shadow-xl" />
-                    {/* Clip only below the circle's midline so illustrations break out of the top instead of being cropped */}
-                    <div className="absolute inset-x-0 -top-[18%] bottom-0 overflow-hidden rounded-b-full">
+            <div ref={ref} className="relative w-full overflow-hidden" style={{ paddingBottom: t.aspect, background }}>
+                {/* Artwork sits behind the copy so long titles can run over it, as the designs do. */}
+                <div
+                    className="absolute"
+                    style={{
+                        width: `${t.artWidth}cqw`,
+                        right: `${t.artRight}cqw`,
+                        bottom: `${hasBar ? 0 : t.artBottom}cqw`,
+                    }}
+                >
+                    {speaker?.avatarUrl ? (
                         <img
-                            src={speaker?.avatarUrl || DEFAULT_HEDGEHOG}
-                            alt={speaker?.name || 'Max the hedgehog'}
+                            src={speaker.avatarUrl}
+                            alt={speaker.name}
                             crossOrigin="anonymous"
-                            className="absolute bottom-0 left-1/2 w-[108%] max-w-none -translate-x-1/2"
+                            className="block w-full"
                         />
-                    </div>
+                    ) : (
+                        <Hog className="block h-auto w-full" />
+                    )}
                 </div>
-                <div className="absolute inset-0 flex flex-col p-[6%]">
+
+                {/* Calendar badge */}
+                {hasDate && (
+                    <div
+                        className="absolute overflow-hidden bg-white"
+                        style={{
+                            width: `${t.badge}cqw`,
+                            height: `${t.badge}cqw`,
+                            top: `${t.badgeTop}cqw`,
+                            right: `${t.badgeRight}cqw`,
+                            borderRadius: `${t.badgeRadius}cqw`,
+                            boxShadow: `0 ${t.badgeRadius}cqw ${t.badgeRadius * 1.5}cqw rgba(0,0,0,0.16)`,
+                        }}
+                    >
+                        <div
+                            className="flex items-center justify-center font-rounded font-extrabold uppercase text-white"
+                            style={{
+                                height: `${t.badgeHeader}cqw`,
+                                background: hue.badge,
+                                fontSize: `${t.badgeMonth}cqw`,
+                                letterSpacing: '0.02em',
+                            }}
+                        >
+                            {parsedDate?.format('MMM')}
+                        </div>
+                        <div
+                            className="flex items-center justify-center font-rounded font-extrabold"
+                            style={{
+                                height: `${t.badge - t.badgeHeader}cqw`,
+                                fontSize: `${t.badgeDay}cqw`,
+                                color: EVENT_GRAPHIC_INK,
+                            }}
+                        >
+                            {parsedDate?.format('D')}
+                        </div>
+                    </div>
+                )}
+
+                {/* Copy */}
+                <div className="absolute inset-0" style={{ padding: `${t.pad}cqw` }}>
                     <h3
-                        className={`m-0 w-full break-words font-squeak font-bold uppercase leading-[0.95] ${
-                            title.length > 40 ? 'text-[7.5cqw]' : title.length > 22 ? 'text-[9.5cqw]' : 'text-[12cqw]'
-                        }`}
+                        className="m-0 break-words font-squeak font-bold uppercase"
+                        style={{
+                            width: `${t.titleWidth}cqw`,
+                            fontSize: `${titleSizeFor(title, t.titleSizes)}cqw`,
+                            lineHeight: 1.01,
+                            color: titleColor,
+                            // Soft same-hue bloom behind the type, as the designs have it
+                            textShadow: `0 0 ${t.pad * 0.28}cqw ${light ? `${hue.titleOnLight}47` : `${hue.to}66`}`,
+                        }}
                     >
                         {title}
                     </h3>
-                    <div className="mt-[3%] w-[46%] font-rounded text-[3.75cqw] font-bold uppercase leading-snug">
-                        {parsedDate?.isValid() && <div>{parsedDate.format('dddd, MMMM D')}</div>}
-                        {locationLine && <div>{locationLine}</div>}
-                    </div>
-                    {speaker && (
-                        <div className="mb-[6%] mt-auto w-[52%]">
-                            <div className="mb-[1.5%] font-rounded text-[2.75cqw] font-semibold uppercase leading-none">
-                                Featuring:
-                            </div>
-                            <div className="break-words font-squeak text-[5.5cqw] font-bold uppercase leading-none">
-                                {speaker.name}
-                            </div>
-                            {speaker.companyRole && (
-                                <div className="mt-[1.5%] font-rounded text-[2.75cqw] font-semibold uppercase leading-none">
-                                    {speaker.companyRole}
+
+                    <div
+                        className={
+                            format === 'landscape'
+                                ? 'flex items-start font-rounded font-extrabold'
+                                : 'font-rounded font-extrabold'
+                        }
+                        style={{
+                            marginTop: `${t.titleGap}cqw`,
+                            gap: format === 'landscape' ? `${t.pad}cqw` : undefined,
+                        }}
+                    >
+                        {/* Landscape sizes this column to its content — a fixed width wrapped long dates
+                            like "Wednesday, September 23" onto a second line and into the footer. */}
+                        <div
+                            style={{
+                                minWidth: format === 'landscape' ? `${t.infoWidth}cqw` : undefined,
+                                flexShrink: format === 'landscape' ? 0 : undefined,
+                            }}
+                        >
+                            {hasDate && (
+                                <div
+                                    className={format === 'landscape' ? 'whitespace-nowrap' : undefined}
+                                    style={{ fontSize: `${t.date}cqw`, color: ink, lineHeight: 1.2 }}
+                                >
+                                    {parsedDate?.format('dddd, MMMM D')}
+                                </div>
+                            )}
+                            {timeLabel && (
+                                <div
+                                    style={{
+                                        fontSize: `${t.time}cqw`,
+                                        color: inkMuted,
+                                        lineHeight: 1.3,
+                                        marginTop: `${t.pad * 0.3}cqw`,
+                                    }}
+                                >
+                                    {timeLabel}
                                 </div>
                             )}
                         </div>
-                    )}
-                    <div
-                        className={`flex items-center justify-center gap-[2.5cqw] rounded-[2cqw] bg-white px-[4%] py-[2.5%] text-black ${
-                            speaker ? '' : 'mt-auto'
-                        }`}
-                    >
-                        <Logo className="h-[5cqw] w-auto shrink-0" width="auto" />
-                        {partnerNames.length > 0 && (
+
+                        {/* Square stacks the venue under a horizontal rule; landscape puts it in a second
+                            column behind a vertical one. */}
+                        {format === 'square' ? (
                             <>
-                                <span className="font-rounded text-[3cqw] font-semibold uppercase leading-none">
-                                    with
-                                </span>
-                                <span className="truncate font-squeak text-[4.5cqw] font-bold uppercase leading-none">
-                                    {partnerNames.join(' & ')}
-                                </span>
+                                {(venueLine || locationLine) && (
+                                    <div
+                                        style={{
+                                            width: `${t.rule}cqw`,
+                                            height: `${t.ruleThickness}cqw`,
+                                            background: ruleColor,
+                                            margin: `${t.pad * 0.7}cqw 0`,
+                                        }}
+                                    />
+                                )}
+                                <div style={{ width: `${t.infoWidth}cqw` }}>
+                                    {venueLine && (
+                                        <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.45 }}>
+                                            {venueLine},
+                                        </div>
+                                    )}
+                                    {locationLine && (
+                                        <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.45 }}>
+                                            {locationLine}
+                                        </div>
+                                    )}
+                                </div>
                             </>
+                        ) : (
+                            (venueLine || locationLine) && (
+                                <>
+                                    <div
+                                        style={{
+                                            width: `${t.ruleThickness}cqw`,
+                                            alignSelf: 'stretch',
+                                            background: ruleColor,
+                                        }}
+                                    />
+                                    <div>
+                                        {venueLine && (
+                                            <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.4 }}>
+                                                {venueLine},
+                                            </div>
+                                        )}
+                                        {locationLine && (
+                                            <div style={{ fontSize: `${t.venue}cqw`, color: ink, lineHeight: 1.4 }}>
+                                                {locationLine}
+                                            </div>
+                                        )}
+                                    </div>
+                                </>
+                            )
                         )}
                     </div>
+                </div>
+
+                {/* Footer */}
+                <div
+                    className={`absolute bottom-0 flex items-center ${hasBar ? 'justify-center' : ''}`}
+                    style={{
+                        left: 0,
+                        right: 0,
+                        height: hasBar ? `${t.barHeight}cqw` : undefined,
+                        background: hasBar ? barColor : undefined,
+                        padding: hasBar ? `0 ${t.pad}cqw` : `0 ${t.pad}cqw ${t.footerBottom}cqw`,
+                        color: footerInk,
+                        gap: `${t.pad * 0.6}cqw`,
+                    }}
+                >
+                    <Logo
+                        variant={logoVariant}
+                        className="w-auto shrink-0"
+                        style={{ height: `${t.logo}cqw` }}
+                        width="auto"
+                    />
+                    {partnerList.map((partner) => (
+                        <React.Fragment key={partner.name}>
+                            <span
+                                className="font-rounded font-medium"
+                                style={{ fontSize: `${t.logo * 0.7}cqw`, opacity: 0.4 }}
+                            >
+                                /
+                            </span>
+                            {partner.logoUrl ? (
+                                <img
+                                    src={partner.logoUrl}
+                                    alt={partner.name}
+                                    crossOrigin="anonymous"
+                                    className="w-auto shrink-0 object-contain"
+                                    style={{ height: `${t.logo}cqw` }}
+                                />
+                            ) : (
+                                <span
+                                    className="whitespace-nowrap font-squeak font-bold uppercase"
+                                    style={{ fontSize: `${t.logo * 0.78}cqw`, lineHeight: 1 }}
+                                >
+                                    {partner.name}
+                                </span>
+                            )}
+                        </React.Fragment>
+                    ))}
                 </div>
             </div>
         </div>

--- a/src/constants/eventGraphicPalette.ts
+++ b/src/constants/eventGraphicPalette.ts
@@ -1,0 +1,100 @@
+// The approved palette for the generated event graphic (v2), taken from the brand team's Figma file.
+//
+// These hues are deliberately scoped to the event graphic and are NOT the Tailwind palette — none of
+// them match `tailwind.config.js` (v2 blue is #0457FF, Tailwind's is #2F80FA). Until the brand team
+// confirms whether they supersede the site palette, keeping them here avoids changing anything else.
+//
+// Each entry is a vertical two-stop gradient plus the title color to use on a light (cream) background
+// and on the accent background itself. `badge` is the calendar chip's header color, which the designs
+// intentionally set to a contrasting hue rather than the title color.
+
+export type EventGraphicHue = {
+    name: string
+    /** Accent gradient, top to bottom. */
+    from: string
+    to: string
+    /** Title color on the cream background. */
+    titleOnLight: string
+    /** Title color when the accent is the background — light hues need dark type. */
+    titleOnDark: string
+    /** Calendar badge header color. */
+    badge: string
+}
+
+/** Ink used for date, time and venue copy on the cream background. */
+export const EVENT_GRAPHIC_INK = '#394150'
+
+/** Muted ink for the secondary (time) line. */
+export const EVENT_GRAPHIC_INK_MUTED = '#8A8F9B'
+
+/** Cream background gradient. */
+export const EVENT_GRAPHIC_CREAM_FROM = '#FDFDF8'
+export const EVENT_GRAPHIC_CREAM_TO = '#F8F8E6'
+
+const WHITE = '#FFFFFF'
+const BLACK = '#151515'
+
+// Contrasting badge hues, assigned per entry to match the designs.
+const BADGE_ORANGE = '#FF5C1C'
+const BADGE_LIME = '#A0CA21'
+const BADGE_SKY = '#2BB3DF'
+const BADGE_CORAL = '#E9292F'
+
+export const EVENT_GRAPHIC_HUES: EventGraphicHue[] = [
+    { name: 'blue', from: '#0457FF', to: '#0347D1', titleOnLight: '#0457FF', titleOnDark: WHITE, badge: BADGE_LIME },
+    { name: 'sky', from: '#2BB3DF', to: '#0B8FB9', titleOnLight: '#2BB3DF', titleOnDark: WHITE, badge: BADGE_CORAL },
+    { name: 'ocean', from: '#1590E7', to: '#0070BF', titleOnLight: '#1590E7', titleOnDark: WHITE, badge: BADGE_LIME },
+    { name: 'coral', from: '#FF474D', to: '#E9292F', titleOnLight: '#E9292F', titleOnDark: WHITE, badge: BADGE_SKY },
+    { name: 'lime', from: '#A0CA21', to: '#8AB211', titleOnLight: '#8AB211', titleOnDark: WHITE, badge: BADGE_CORAL },
+    { name: 'green', from: '#47C861', to: '#26B343', titleOnLight: '#26B343', titleOnDark: WHITE, badge: BADGE_ORANGE },
+    { name: 'lilac', from: '#6D4FFF', to: '#5332F5', titleOnLight: '#6D4FFF', titleOnDark: WHITE, badge: BADGE_ORANGE },
+    {
+        name: 'purple',
+        from: '#A737D2',
+        to: '#981CC8',
+        titleOnLight: '#A737D2',
+        titleOnDark: WHITE,
+        badge: BADGE_ORANGE,
+    },
+    { name: 'teal', from: '#43DAB3', to: '#0FBB8F', titleOnLight: '#0FBB8F', titleOnDark: WHITE, badge: BADGE_ORANGE },
+    // Light hues carry dark type when used as the background.
+    {
+        name: 'tangerine',
+        from: '#FFA81C',
+        to: '#F09000',
+        titleOnLight: '#F09000',
+        titleOnDark: BLACK,
+        badge: BADGE_CORAL,
+    },
+    { name: 'yellow', from: '#FFCE1C', to: '#F1BD00', titleOnLight: '#F0A800', titleOnDark: BLACK, badge: BADGE_SKY },
+]
+
+export type EventGraphicVariant = 'light' | 'dark'
+
+/**
+ * Stable 32-bit string hash, so a given event always lands on the same hue and variant instead of
+ * changing on every render.
+ */
+const hash = (value: string): number => {
+    let h = 0
+    for (let i = 0; i < value.length; i++) {
+        h = (h << 5) - h + value.charCodeAt(i)
+        h |= 0
+    }
+    return Math.abs(h)
+}
+
+/** Total number of hue + variant combinations the shuffle button cycles through. */
+export const EVENT_GRAPHIC_STYLE_COUNT = EVENT_GRAPHIC_HUES.length * 2
+
+/** Resolve a style index (any integer) to a concrete hue and light/dark variant. */
+export const eventGraphicStyle = (index: number): { hue: EventGraphicHue; variant: EventGraphicVariant } => {
+    const normalized = ((index % EVENT_GRAPHIC_STYLE_COUNT) + EVENT_GRAPHIC_STYLE_COUNT) % EVENT_GRAPHIC_STYLE_COUNT
+    return {
+        hue: EVENT_GRAPHIC_HUES[normalized % EVENT_GRAPHIC_HUES.length],
+        variant: normalized < EVENT_GRAPHIC_HUES.length ? 'light' : 'dark',
+    }
+}
+
+/** Deterministic starting style for an event, so the list and detail views agree. */
+export const eventGraphicStyleIndex = (seed?: string): number => (seed ? hash(seed) : 0) % EVENT_GRAPHIC_STYLE_COUNT

--- a/src/constants/eventGraphicPalette.ts
+++ b/src/constants/eventGraphicPalette.ts
@@ -1,0 +1,107 @@
+// The approved palette for the generated event graphic (v2), taken from the brand team's Figma file.
+//
+// These hues are deliberately scoped to the event graphic and are NOT the Tailwind palette — none of
+// them match `tailwind.config.js` (v2 blue is #0457FF, Tailwind's is #2F80FA). Until the brand team
+// confirms whether they supersede the site palette, keeping them here avoids changing anything else.
+//
+// Each entry is a vertical two-stop gradient plus the title color to use on a light (cream) background
+// and on the accent background itself. `badge` is the calendar chip's header color, which the designs
+// intentionally set to a contrasting hue rather than the title color.
+
+export type EventGraphicHue = {
+    name: string
+    /** Accent gradient, top to bottom. */
+    from: string
+    to: string
+    /** Title color on the cream background. */
+    titleOnLight: string
+    /** Title color when the accent is the background — light hues need dark type. */
+    titleOnDark: string
+    /** Calendar badge header color. */
+    badge: string
+}
+
+/** Ink used for date, time and venue copy on the cream background. */
+export const EVENT_GRAPHIC_INK = '#394150'
+
+/** Muted ink for the secondary (time) line. */
+export const EVENT_GRAPHIC_INK_MUTED = '#8A8F9B'
+
+/** Cream background gradient. */
+export const EVENT_GRAPHIC_CREAM_FROM = '#FDFDF8'
+export const EVENT_GRAPHIC_CREAM_TO = '#F8F8E6'
+
+const WHITE = '#FFFFFF'
+const BLACK = '#151515'
+
+// Contrasting badge hues, assigned per entry to match the designs.
+const BADGE_ORANGE = '#FF5C1C'
+const BADGE_LIME = '#A0CA21'
+const BADGE_SKY = '#2BB3DF'
+const BADGE_CORAL = '#E9292F'
+
+export const EVENT_GRAPHIC_HUES: EventGraphicHue[] = [
+    { name: 'blue', from: '#0457FF', to: '#0347D1', titleOnLight: '#0457FF', titleOnDark: WHITE, badge: BADGE_LIME },
+    { name: 'sky', from: '#2BB3DF', to: '#0B8FB9', titleOnLight: '#2BB3DF', titleOnDark: WHITE, badge: BADGE_CORAL },
+    { name: 'ocean', from: '#1590E7', to: '#0070BF', titleOnLight: '#1590E7', titleOnDark: WHITE, badge: BADGE_LIME },
+    { name: 'coral', from: '#FF474D', to: '#E9292F', titleOnLight: '#E9292F', titleOnDark: WHITE, badge: BADGE_SKY },
+    { name: 'lime', from: '#A0CA21', to: '#8AB211', titleOnLight: '#8AB211', titleOnDark: WHITE, badge: BADGE_CORAL },
+    { name: 'green', from: '#47C861', to: '#26B343', titleOnLight: '#26B343', titleOnDark: WHITE, badge: BADGE_ORANGE },
+    { name: 'lilac', from: '#6D4FFF', to: '#5332F5', titleOnLight: '#6D4FFF', titleOnDark: WHITE, badge: BADGE_ORANGE },
+    {
+        name: 'purple',
+        from: '#A737D2',
+        to: '#981CC8',
+        titleOnLight: '#A737D2',
+        titleOnDark: WHITE,
+        badge: BADGE_ORANGE,
+    },
+    { name: 'teal', from: '#43DAB3', to: '#0FBB8F', titleOnLight: '#0FBB8F', titleOnDark: WHITE, badge: BADGE_ORANGE },
+    // Light hues carry dark type when used as the background.
+    {
+        name: 'tangerine',
+        from: '#FFA81C',
+        to: '#F09000',
+        titleOnLight: '#F09000',
+        titleOnDark: BLACK,
+        badge: BADGE_CORAL,
+    },
+    { name: 'yellow', from: '#FFCE1C', to: '#F1BD00', titleOnLight: '#F0A800', titleOnDark: BLACK, badge: BADGE_SKY },
+]
+
+export type EventGraphicVariant = 'light' | 'dark'
+
+/**
+ * Stable 32-bit string hash, so a given event always lands on the same hue and variant instead of
+ * changing on every render.
+ */
+const hash = (value: string): number => {
+    let h = 0
+    for (let i = 0; i < value.length; i++) {
+        h = (h << 5) - h + value.charCodeAt(i)
+        h |= 0
+    }
+    return Math.abs(h)
+}
+
+/** Total number of hue + variant combinations the shuffle button cycles through. */
+export const EVENT_GRAPHIC_STYLE_COUNT = EVENT_GRAPHIC_HUES.length * 2
+
+/** Resolve a style index (any integer) to a concrete hue and light/dark variant. */
+export const eventGraphicStyle = (index: number): { hue: EventGraphicHue; variant: EventGraphicVariant } => {
+    const normalized = ((index % EVENT_GRAPHIC_STYLE_COUNT) + EVENT_GRAPHIC_STYLE_COUNT) % EVENT_GRAPHIC_STYLE_COUNT
+    return {
+        hue: EVENT_GRAPHIC_HUES[normalized % EVENT_GRAPHIC_HUES.length],
+        variant: normalized < EVENT_GRAPHIC_HUES.length ? 'light' : 'dark',
+    }
+}
+
+/** Deterministic starting style for an event, so the list and detail views agree. */
+export const eventGraphicStyleIndex = (seed?: string): number => (seed ? hash(seed) : 0) % EVENT_GRAPHIC_STYLE_COUNT
+
+/**
+ * The hog is picked independently of the hue. An earlier draft paired one hog to each color, but per the
+ * brand team hog/hue pairings are no longer a thing — hedgehogs carry a single hue from the brand book —
+ * so the two rotate separately and Shuffle only cycles the color.
+ */
+export const eventGraphicHogIndex = (seed: string, count: number): number => (count > 0 ? hash(seed) % count : 0)

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -15,6 +15,7 @@ import { IconPencil, IconTrash } from '@posthog/icons'
 import { useToast } from '../context/Toast'
 import EventsMap, { LAYER_EVENTS_UPCOMING, LAYER_EVENTS_PAST } from 'components/HogMap/EventsMap'
 import EventGraphic, { type EventGraphicProps, type EventGraphicSpeaker } from 'components/EventGraphic'
+import { eventGraphicStyleIndex } from 'constants/eventGraphicPalette'
 import MobileDrawer from 'components/MobileDrawer'
 import { useApp } from '../context/App'
 
@@ -36,7 +37,7 @@ export type Event = {
     speakers?: string[]
     speakerProfiles?: EventGraphicSpeaker[]
     speakerTopic?: string
-    partners?: Array<{ name: string; url?: string }>
+    partners?: Array<{ name: string; url?: string; logoUrl?: string }>
     attendees?: number
     vibeScore?: number
     photos?: { id: number; url: string }[]
@@ -66,7 +67,12 @@ export const transformStrapiEvent = (strapiEvent: any): Event => {
         avatarUrl: s.attributes?.avatar?.data?.attributes?.url || undefined,
         companyRole: s.attributes?.companyRole || undefined,
     }))
-    const partners = partnersData?.map((p: any) => ({ name: p.name, url: p.url || undefined }))
+    const partners = partnersData?.map((p: any) => ({
+        name: p.name,
+        url: p.url || undefined,
+        // Optional — partners without an uploaded logo fall back to their name set in Squeak
+        logoUrl: p.logo?.data?.attributes?.url || p.logo?.url || undefined,
+    }))
 
     return {
         ...strapiEvent.attributes,
@@ -83,10 +89,14 @@ export const transformStrapiEvent = (strapiEvent: any): Event => {
 const eventGraphicProps = (event: Event): EventGraphicProps => ({
     title: event.name,
     date: event.date,
+    startTime: event.startTime,
+    venue: event.location?.venue?.name,
     location: event.location?.label,
     online: event.online,
     speaker: event.speakerProfiles?.[0],
     partners: event.partners,
+    // Keyed to the event so the list card and the detail panel always agree
+    styleIndex: eventGraphicStyleIndex(`${event.id}-${event.name}`),
 })
 
 export const useEvents = (): { events: Event[]; refreshEvents: () => void; deleteEvent: (eventId: number) => void } => {
@@ -110,7 +120,9 @@ export const useEvents = (): { events: Event[]; refreshEvents: () => void; delet
                         speakers: {
                             populate: ['avatar'],
                         },
-                        partners: true,
+                        partners: {
+                            populate: ['logo'],
+                        },
                     },
                 },
                 { encodeValuesOnly: true }


### PR DESCRIPTION
## What

A v2 of the auto-generated event graphic from #18451, rebuilt against Lottie's Figma direction, plus an OpenGraph landscape format.

**Behavior is unchanged.** Still the default event photo when no photo is uploaded, still previewed live in the create/edit form, still downloadable as PNG, still auto-uploaded on submit.

@lottiecoxon — this is yours to redline. The renders below are the real component, headless-rendered at export size, so anything you flag maps directly to a value in the code. There's a list of open questions at the bottom I couldn't resolve from the refs alone.

## v2 inverts v1 rather than restyling it

| | v1 | v2 |
|---|---|---|
| Background | saturated accent | cream gradient (light) **or** full-bleed accent (dark) |
| Title color | white / black | the accent hue |
| Artwork | avatar in a white-ringed circle | bleeds off the canvas edge, no circle |
| Date | one line | calendar badge + date + time + venue block |

So this is a rewrite of `EventGraphic`, not a patch. It keeps the good bones: `forwardRef`, and container-query `cqw` sizing so one component serves the 80px list thumbnail, the form preview, and the 1080px export.

## Square — 1080×1080

![square contact sheet](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/_contact-sheet-square.png)

Top row, left to right: no date/no location · online, no time · two partners · very long title · blue dark.
Bottom row: blue light · green dark (speaker) · green light (speaker) · yellow dark (speaker, co-branded) · yellow light.

Note the two speaker rows: the portrait bleeds to the bottom edge, so those get a solid footer bar to sit against, exactly as the refs do. Hog variants get no bar and the logos float on the background.

## Landscape — 1200×630

![landscape contact sheet](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/_contact-sheet-landscape.png)

The bottom-left case is the stress test: longest realistic date string (`Wednesday, September 23`) next to a 4-line title. Both were breaking into the footer earlier in the branch.

Individual full-size renders: [square light](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/square-blue-hog-cobranded-light.png) · [square dark](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/square-blue-hog-cobranded-dark.png) · [speaker light](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/square-green-speaker-solo-light.png) · [speaker dark](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/square-green-speaker-solo-dark.png) · [landscape light](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/landscape-blue-hog-cobranded-light.png) · [landscape dark](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/landscape-blue-hog-cobranded-dark.png) · [long title](https://raw.githubusercontent.com/PostHog/posthog.com/posthog-code/event-graphic-v2-renders/ls-long-title.png)

## Changes

- **`src/constants/eventGraphicPalette.ts`** (new) — 11 hues × light/dark = 22 combinations, each with a gradient, a title color per variant, and a contrasting calendar-badge color.
- **`src/components/EventGraphic/index.tsx`** (rewrite) — new `format` and `styleIndex` props; reads `startTime` and `venue`; partners can carry a `logoUrl`.
- **`src/components/EventForm/index.tsx`** — previews both formats side by side, adds a **Shuffle style** button and a download button per format.
- **`src/pages/events.tsx`** — populates `partners.logo`, and keys the style index to the event so the list card and detail panel always agree.

Two incidental wins: all color is applied via inline `style` instead of dynamic `bg-*` classes, which **drops the `safelist.txt` entries v1 needed**; and v1's hardcoded single `hogzilla` URL is replaced with a curated per-hue hoggie set from `@posthog/brand`.

### The palette is deliberately scoped to this graphic

None of the v2 hues match `tailwind.config.js` — v2 blue is `#0457FF`, Tailwind's is `#2F80FA`. Same for every other hue, and the ink `#394150` isn't a Tailwind token either. Rather than quietly introduce a third color source site-wide, the palette lives in one file with a comment explaining why. @lottiecoxon: **do the v2 hues supersede the site palette, or are they specific to event graphics?** If they supersede it, that's a separate PR.

### Shuffle persists for free

The square graphic is rasterized and uploaded as the event photo on submit, so whatever combo is on screen when the organizer saves is frozen into the PNG. No new Strapi field needed. The deterministic hash only governs legacy events that have no photo at all.

## Needs a Strapi change (parallel track, not blocking)

The co-branded refs show real partner logo artwork, but the Strapi partner object today is only `{ id, name, url }`. A `logo` media field needs adding to the partner content type on the hosted instance — that's admin work, not code. This PR reads `partner.logoUrl` when present and **falls back to the partner name set in Squeak**, which the refs already do for `HACK AI`, so existing logo-less partners don't render blank.

**Simplification worth considering:** if co-branded footers always sit on a white/cream bar (a treatment the refs already use), one full-color logo works on both variants — avoiding a `logoLight`/`logoDark` pair and halving the asset collection effort. CSS-filter knockout isn't viable; it rasterizes unreliably through `html-to-image`.

## Design review — resolved

@lottiecoxon has answered all nine questions ([reply thread](https://github.com/PostHog/posthog.com/pull/19276#issuecomment-5292273958)) and the feedback is applied in 2ef35e2. Headlines:

- Speaker portraits were **about half the size they should have been** — measured off the reference frames and corrected.
- Title line height is now **90%**.
- Long names **split on their colon** into title + subtitle, so titles stay short and large without a schema change.
- The logo goes **full colour on white and cream**, mono on accent.
- **Hogs are no longer paired to hues** — hog/colour pairings are not part of the brand system anymore.

Two questions remain open with the design team, neither blocking review:

1. **Which hogs should be in rotation?** The current 11 are a guess, not a curated set. It's one array in the code.
2. **Who updates the handbook?** `contents/handbook/brand/visual-identity.md` still forbids gradients. Deliberately not touched here — brand guidance shouldn't ride along in a feature PR.

And still on the parallel track: the `logo` media field on the Strapi partner content type. Until it lands, partners fall back to their name set in Squeak.

## Verification

Headless renders across a 16-case matrix: hog vs speaker, solo vs co-branded, light vs dark, 5 title lengths, online vs located, 1 vs 2 partners, no-date, no-location, and the 80px thumbnail. Typecheck and lint clean.

Worth noting one thing the harness caught: body copy was rendering ~25% narrower than the refs. Tailwind's `font-bold` is weight 700, which in this repo's `Fonts.css` maps to RoundHog **SemiBold** — the refs use RoundHog **Bold**, which is weight **800**. All body copy is `font-extrabold` as a result.

The renders are hosted on `posthog-code/event-graphic-v2-renders` purely so they can be embedded here. That branch is safe to delete after review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

