### PR TITLE
Document that commit signing is enforced org-wide

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -26,6 +26,10 @@ It is recommended to have most passkeys saved in 1Password itself, which will al
 
 We previously required all employees to purchase and configure two Yubikeys. These have been replaced with passkeys, and Yubikeys are no longer required nor recommended.
 
+## Signed commits
+
+Every commit pushed to a PostHog repository must be cryptographically signed. An org-wide GitHub ruleset enforces this on all branches, so we can verify who authored a commit instead of trusting the `Author` field, which anyone can set. Engineers should [set up commit signing](/handbook/engineering/security#commit-signing) in their first week.
+
 ## Mobile device management (MDM)
 
 We use [Fleet](https://fleetdm.com/) to manage all of our laptops. It applies targeted policies that raise the security baseline of every device, including:

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -274,6 +274,8 @@ Branch protection on the `posthog` repo requires a review and green CI before an
 - The PR author is a member of the PostHog GitHub org (no fork PRs from external contributors).
 - You're a full Slack workspace member with a `@posthog.com` email.
 
+It bypasses required reviews and checks, but **not** [commit signing](/handbook/engineering/security#commit-signing). A PR carrying an unsigned commit can't be force-merged, so sign your commits before reaching for this during an incident.
+
 **Everything is audited.** Each force-merge posts an audit message to Slack, comments on the PR recording who triggered it and the reason, and writes a tamper-proof (object-locked) record, alongside an EventBridge event and a CloudWatch metric that alarms on unusual volume. Accountability is after the fact, so expect to justify any force-merge — and cover it in the [post-mortem](/handbook/engineering/operations/post-mortems) if it was part of an incident.
 
 ### Deploy notification bot

--- a/contents/handbook/engineering/sdks/releases.mdx
+++ b/contents/handbook/engineering/sdks/releases.mdx
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-This guide documents our semi-automated release process for PostHog SDKs. Each SDK repository uses a GitHub App with restricted permissions to handle releases securely, requiring team approval before any release is published. SDK repositories also require all commits [to be signed](/handbook/engineering/security#commit-signing) by their author.
+This guide documents our semi-automated release process for PostHog SDKs. Each SDK repository uses a GitHub App with restricted permissions to handle releases securely, requiring team approval before any release is published. Commits must be [signed](/handbook/engineering/security#commit-signing), as in every PostHog repository.
 
 <CalloutBox type="fyi">
 
@@ -112,13 +112,14 @@ The GitHub App needs to bypass certain protections to push release commits direc
 2. Navigate to **Rules** → **Rulesets**
 3. Open the ruleset that requires PRs (may have various names)
    1. If this ruleset doesn't exist, create one requiring PRs and reviews from codeowners which should be `@PostHog/client-libraries-approvers` for all files
-   2. Under **Rules**, make sure **Require signed commits** is enabled
 4. Under **Bypass list**, click **Add bypass**
 5. Select your GitHub App (`Releaser (<sdk_name>)`)
 6. Click the three-dot menu and choose **Exempt**
 7. Save the ruleset
 
 ![Repository PR bypass](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_12_29_T17_30_39_537_Z_a60a06feae.png)
+
+> **Don't add a Require signed commits rule at the repo level.** The [org-wide ruleset](/handbook/engineering/security#commit-signing) already requires signed commits in every repo, and a duplicate repo rule only adds another bypass list to maintain. Note that this bypass exempts the app from the *pull request* requirement, not from signing: the org signing ruleset has no bypass actors, and the release workflows create their commits through the GitHub API, so they are signed like any other.
 
 > **Check for classic branch protection too.** The steps above exempt the app in a ruleset, but a repository can also have classic branch protection under **Settings** → **Branches** → **Branch protection rules**, which GitHub enforces alongside rulesets and which has its own separate bypass list. If a classic rule requires pull requests, the release still fails with `protected branch 'main' check failed: Changes must be made through a pull request` even after the ruleset exemption. Remove the classic rule, since the ruleset already covers it, or add the app to its bypass settings as well. Older repos are most likely to have this; newer ones tend to be rulesets-only.
 

--- a/contents/handbook/engineering/security.md
+++ b/contents/handbook/engineering/security.md
@@ -44,7 +44,7 @@ Follow the [1Password SSH key management guide](https://developer.1password.com/
 
 ### Commit signing
 
-A git commit's `Author` field is completely user controllable and can be forged. Signing your commits cryptographically proves you authored them, preventing impersonation and confusion.
+A git commit's `Author` field is completely user controllable and can be forged. Signing your commits cryptographically proves you authored them, preventing impersonation and confusion. **Signing is required, not optional:** an org-wide GitHub ruleset rejects unsigned commits in every PostHog repository, on every branch. Set this up before your first push, rather than when a push fails. This applies to automation too, see [signing commits from workflows](#signing-commits-from-workflows).
 
 You can sign commits with either [Secretive](https://github.com/maxgoedjen/secretive/) or [1Password](https://developer.1password.com/docs/ssh/git-commit-signing/). We have a slight preference for Secretive because it stores your key in the macOS Secure Enclave, ensuring the key can never be exported or extracted, even by malware.
 
@@ -94,7 +94,7 @@ Follow the [1Password git commit signing guide](https://developer.1password.com/
 
 #### After setup
 
-Once commit signing is configured, enable the option in your [GitHub Profile](https://github.com/settings/keys) to "Flag unsigned commits as unverified".
+Once commit signing is configured, enable the option in your [GitHub Profile](https://github.com/settings/keys) to "Flag unsigned commits as unverified". The org ruleset already blocks unsigned commits in PostHog repos, but this marks any commit attributed to your email and not signed by you as **Unverified** everywhere else on GitHub, including your personal repos.
 
 #### Troubleshooting
 
@@ -117,11 +117,26 @@ Great care should be taken when writing or modifying a GitHub Actions workflow. 
 
 #### Authentication
 
-Most Actions use the default `GITHUB_TOKEN`, whose permissions can be scoped via the `permissions` property. However, `GITHUB_TOKEN` cannot trigger other workflows — so commits or PRs created by an Action won't run CI, leaving PRs unmergeable without manual intervention. The workaround is a Personal Access Token (PAT) or GitHub App. We use GitHub Apps because PATs are tied to an individual user and break when that user leaves PostHog.
+Most Actions use the default `GITHUB_TOKEN`, whose permissions can be scoped via the `permissions` property. However, `GITHUB_TOKEN` cannot trigger other workflows, so commits or PRs created by an Action won't run CI, leaving PRs unmergeable without manual intervention. The workaround is a GitHub App.
 
-Scope each GitHub App to its use case and ideally a single repo. Prefer creating a new App over expanding an existing one's permissions, otherwise every Action using that App inherits permissions it doesn't need.
+Personal access tokens are not an option here. Classic PATs are blocked org-wide. Fine-grained PATs require approval and are generally not approved, because they are tied to an individual user and break when that user leaves PostHog.
+
+Use a finely scoped, purpose-specific GitHub App instead. Scope each App to its use case and ideally a single repo. Prefer creating a new App over expanding an existing one's permissions, otherwise every Action using that App inherits permissions it doesn't need.
 
 Send a message in #team-security if you need help setting up a new GitHub App.
+
+#### Signing commits from workflows
+
+The org ruleset applies to Actions too. A workflow that commits with `git push` is rejected, because there is no signing key on the runner. Create the commit through the GitHub API instead, which GitHub signs with its own key. In practice that means one of:
+
+- [`planetscale/ghcommit-action`](https://github.com/planetscale/ghcommit-action), a wrapper around the GraphQL `createCommitOnBranch` mutation. This is what most of our workflows use.
+- [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) with `sign-commits: true` (v6.1 or later)
+- [`changesets/action`](https://github.com/changesets/action) with `commitMode: github-api`
+- calling `createCommitOnBranch` yourself
+
+> **Signing only works with a bot-generated token**, meaning `GITHUB_TOKEN` or a GitHub App installation token. With a PAT, `sign-commits` and its equivalents are a silent no-op: the action reports success, the commit is not signed, and the push is rejected.
+
+Two limits of `createCommitOnBranch` to plan for. Its `FileAddition` input takes only `path` and `contents`, so it cannot set a file's executable bit. And it sends `expectedHeadOid`, so the commit is rejected if the branch moved since the run read the head. Re-read the head and retry rather than forcing.
 
 #### External contributors
 


### PR DESCRIPTION
## Changes

Commit signing is now enforced across every repository in the org by a GitHub ruleset, but the handbook still read as though it were optional setup advice. Nothing said it was required.

**`engineering/security.md`**

- State the policy in the Commit signing intro: signing is required, and unsigned commits are rejected on every branch of every repo.
- Add "Signing commits from workflows". A workflow that commits with `git push` is rejected, so commits have to go through the GitHub API, which GitHub signs.
- Call out the failure that is silent: signing needs a bot-generated token, and with a PAT `sign-commits` reports success and then gets rejected at push.
- Rewrite "Authentication" to state the real token policy. Classic PATs are blocked, fine-grained PATs need approval and are rarely granted, and the expectation is a purpose-specific GitHub App.
- Reframe "After setup". Enabling "Flag unsigned commits as unverified" was reading as the control. It is a personal setting, useful in repos the ruleset cannot reach.

**Other pages**

- `sdks/releases.mdx` said signing was an SDK-repo requirement, which now implies other repos are exempt. It also told you to add a per-repo rule the org ruleset supersedes.
- The replacement note corrects an implication: the Releaser App bypass covers the pull request requirement, not signing. The org ruleset has no bypass actors, and the release workflows commit through the API.
- `company/security.md` gains a "Signed commits" section next to MFA, since this is now an enforced company-wide control.
- `development-process.md` records that the force-merge break-glass app bypasses reviews and checks, but not signing.

No page claims that signing prevents forged or malicious commits. A compromised App token still produces GitHub-signed commits through the API, so the copy stops at "unsigned commits are rejected" and "author identity is verifiable".

Not touched: `how-we-review.md`, whose header comment declares it canonical for review guidance, and signing is not review guidance. Also the Shai-Hulud post-mortem, which is a dated account of a Nov 2025 incident; this control landed later, so adding it there muddies the timeline. Happy to add that bullet if you and the author want it.

A companion PR, [posthog#78555](https://github.com/PostHog/posthog/pull/78555), adds a GitHub access prerequisite to "Developing locally", which walked a new engineer to their first push without mentioning keys or signing.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)

I ran Vale locally and filtered it to the lines this PR changes: no error-level findings. These files carry pre-existing errors, mostly em-dashes, that this PR does not add to. I resolved one on a line I was already editing.
