### PR TITLE
Fix /vibe-check logo in dark mode

### DIFF
--- a/src/pages/vibe-check/index.tsx
+++ b/src/pages/vibe-check/index.tsx
@@ -102,7 +102,14 @@ export default function Ick() {
                     {!isFinalSlide && (
                         <header className="pb-4">
                             <h1 className="text-2xl flex items-center justify-center gap-2 text-primary dark:text-white">
-                                You'll hate <Logo className="relative -top-px h-6 w-auto" width="auto" /> if...
+                                You'll hate <Logo className="relative -top-px h-6 w-auto dark:hidden" width="auto" />
+                                <Logo
+                                    className="relative -top-px hidden h-6 w-auto dark:block"
+                                    variant="mono"
+                                    color="white"
+                                    width="auto"
+                                />{' '}
+                                if...
                             </h1>
                         </header>
                     )}


### PR DESCRIPTION
## Summary

- render the standard PostHog logo in light mode on `/vibe-check`
- render the white mono logo in dark mode
- select the variant with the existing pre-paint `dark` class behavior

## Why

The page rendered only the default logo, so its dark wordmark did not have enough contrast against the dark-mode header. Rendering both lightweight variants and selecting them with CSS also avoids switching the logo after hydration.

## Impact

The `/vibe-check` heading now shows a readable PostHog logo in both themes. No shared theme state or other routes are changed.

## Validation

- `prettier --check src/pages/vibe-check/index.tsx`
- `git diff --check`
- focused ESLint: 0 errors (4 pre-existing warnings in the page)
- signed commit verified with `git verify-commit HEAD`

Closes #19283