### PR TITLE
Document the {filters} placeholder and column-bound filter bindings

### DIFF
--- a/contents/docs/data-warehouse/sql/variables.mdx
+++ b/contents/docs/data-warehouse/sql/variables.mdx
@@ -61,7 +61,7 @@ If person scope isn't what you want, bind the columns yourself instead.
 
 ### Binding filters to columns
 
-For any other table, view, or join – or to override the defaults above – tell PostHog which of your columns each filter applies to by binding them:
+For any other table, view, or join (or to override the defaults above), tell PostHog which of your columns each filter applies to by binding them:
 
 ```sql
 select *
@@ -76,6 +76,48 @@ Each argument binds one of your query's expressions to a filter key with `AS`:
 - `null AS key` opts the query out of filtering on that key. For example, `null AS timestamp` opts out of date filtering.
 
 If a filter is active but not bound, the query shows an error instead of silently ignoring the filter. This way a filtered dashboard never shows unfiltered data. Cohort filters and SQL expression filters can't be bound and show an error too.
+
+[Test account filtering](/docs/product-analytics/trends/filters#filtering-internal-and-test-users) works the same way: when it's on for the insight, or forced on by the dashboard's own toggle, the properties your test account filters use need bindings too.
+
+### Applying the dashboard interval
+
+Use `{filters.interval}` where a time unit goes, for example in `dateTrunc`:
+
+```sql
+select dateTrunc({filters.interval('week')}, timestamp) as period, count() as event_count
+from events
+where {filters}
+group by period
+order by period
+```
+
+The placeholder becomes the dashboard's interval as a string constant, like `'week'`. The argument sets your default for when the dashboard doesn't set an interval. Without an argument, the default is `'day'`. Valid intervals are `second`, `minute`, `hour`, `day`, `week`, `month`, `quarter`, and `year`.
+
+### Applying the dashboard breakdown
+
+When the dashboard sets a breakdown, `{filters.breakdown(...)}` becomes the expression you bound to that breakdown key:
+
+```sql
+select {filters.breakdown(properties.plan AS 'plan')} as breakdown, count() as event_count
+from events
+where {filters}
+group by breakdown
+```
+
+Bindings work like the column-bound form above: bind an expression to each breakdown key you support, or `null AS 'plan'` to opt out of one. Without a breakdown set, the placeholder becomes `null` and the query returns a single group, so it still runs outside the dashboard. A breakdown on an unbound key shows an error.
+
+The placeholder supports a single plain breakdown. Cohort breakdowns, numeric binning, and multiple breakdowns show an error. The breakdown value shows up as a regular column in your results. Chart series don't split on it automatically.
+
+The filter placeholders combine. This query takes its date range, property filters, interval, and breakdown from the dashboard:
+
+```sql
+select dateTrunc({filters.interval('week')}, day) as period,
+       {filters.breakdown(account_plan AS 'plan')} as breakdown,
+       count() as order_count
+from my_revenue_view
+where {filters(day AS timestamp, account_id AS 'account_id')}
+group by period, breakdown
+```
 
 ## Dashboard date range filter variables
 

--- a/contents/docs/data-warehouse/sql/variables.mdx
+++ b/contents/docs/data-warehouse/sql/variables.mdx
@@ -55,9 +55,13 @@ and {filters}
 
 This works when selecting from PostHog tables: `events`, `sessions`, `persons`, `groups`, logs, and traces. The date range applies to `timestamp` on events, logs, and traces, to `$start_timestamp` on sessions, and to `created_at` on groups and persons.
 
+Property filters resolve in the scope that fits the table. A query selecting only from `persons` takes person properties. Event properties show an error, because the query has no events to filter. A query that joins `persons` to `events` keeps event behavior: the date range applies to `timestamp` and properties resolve in event scope.
+
+If person scope isn't what you want, bind the columns yourself instead.
+
 ### Binding filters to columns
 
-For any other table, view, or join, tell PostHog which of your columns each filter applies to by binding them:
+For any other table, view, or join – or to override the defaults above – tell PostHog which of your columns each filter applies to by binding them:
 
 ```sql
 select *

--- a/contents/docs/data-warehouse/sql/variables.mdx
+++ b/contents/docs/data-warehouse/sql/variables.mdx
@@ -42,6 +42,37 @@ You can set the value for the variable in the **Variables** dropdown. For exampl
   classes="rounded"
 />
 
+## Applying dashboard filters
+
+Adding the `{filters}` placeholder to your query's `where` clause applies the dashboard or insight date range, property filters, and test account filtering to your query:
+
+```sql
+select *
+from events
+where event = '$pageview'
+and {filters}
+```
+
+This works when selecting from PostHog tables: `events`, `sessions`, `persons`, `groups`, logs, and traces. The date range applies to `timestamp` on events, logs, and traces, to `$start_timestamp` on sessions, and to `created_at` on groups and persons.
+
+### Binding filters to columns
+
+For any other table, view, or join, tell PostHog which of your columns each filter applies to by binding them:
+
+```sql
+select *
+from my_revenue_view
+where {filters(day AS timestamp, account_id AS 'account_id')}
+```
+
+Each argument binds one of your query's expressions to a filter key with `AS`:
+
+- The reserved key `timestamp` receives the date range.
+- Any other key, written as a string like `'plan'`, receives the dashboard and insight property filters on that key. Operators and multiple values work like they do elsewhere in PostHog.
+- `null AS key` opts the query out of filtering on that key. For example, `null AS timestamp` opts out of date filtering.
+
+If a filter is active but not bound, the query shows an error instead of silently ignoring the filter. This way a filtered dashboard never shows unfiltered data. Cohort filters and SQL expression filters can't be bound and show an error too.
+
 ## Dashboard date range filter variables
 
 Beyond the SQL variables you set up, you can access the dashboard's date range filters through the `filters.dateRange.from` and `filters.dateRange.to` variables like this:


### PR DESCRIPTION
## TL;DR

The SQL variables page now explains `{filters}`. ELI5: dashboards have date, property, interval, and breakdown filters, and SQL insights need placeholders to receive them. The docs only showed a small piece of this; now they cover the whole feature, including the way to apply filters to any table.

## Changes

The SQL variables page (`/docs/data-warehouse/sql/variables`) only documented `{filters.dateRange.from/to}`, while several pages link to it as the reference for dashboard filters in SQL insights. This adds an "Applying dashboard filters" section covering:

- Plain `{filters}` and the PostHog tables it supports, with the date column used per table.
- Which scope property filters resolve in. A persons-only query takes person properties and errors on event properties; joining persons to events keeps event behavior.
- The column-bound form `{filters(day AS timestamp, account_id AS 'account_id')}` for any other table, view, or join, or to override the defaults: the reserved `timestamp` key, string property keys, `null` opt-outs, and the error behavior for unbound active filters.
- Test account filtering under the column-bound form: the properties the team's test account filters use need bindings too.
- `{filters.interval('week')}` for the dashboard interval: substitution as a `dateTrunc`-compatible string, the author default, and the valid units.
- `{filters.breakdown(properties.plan AS 'plan')}` for the dashboard breakdown: the binding contract, `null` degradation when no breakdown is set, and the unsupported shapes (cohort, numeric binning, multiple breakdowns).
- A combined example pulling date range, property filters, interval, and breakdown into one query.

> [!NOTE]
> The column-bound form shipped in [PostHog/posthog#76532](https://github.com/PostHog/posthog/pull/76532); interval, breakdown, and the test-accounts override in [PostHog/posthog#76718](https://github.com/PostHog/posthog/pull/76718). Persons support is still in review in [PostHog/posthog#78705](https://github.com/PostHog/posthog/pull/78705): merge this after that lands.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
