### PR TITLE
docs: add SIEM integration guide for activity logs

### DIFF
--- a/contents/docs/settings/activity-logs.mdx
+++ b/contents/docs/settings/activity-logs.mdx
@@ -347,6 +347,8 @@ Exports include all log entry fields and respect any filters you have applied.
 
 > **Note**: Export is currently only available in the project view. Organization-wide exports are not yet supported.
 
+For an ongoing feed rather than a one-off file, see [SIEM integration](/docs/settings/activity-logs/siem).
+
 ## Common use cases
 
 ### Investigating unexpected changes

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -104,27 +104,37 @@ Install the [PostHog Splunk add-on](https://github.com/PostHog/splunk-add-on). S
 
 On **Splunk Cloud Platform**, go to **Apps** > **Find More Apps**, search for PostHog, and install.
 
-On **Splunk Enterprise**, install from Splunkbase, or copy the `TA-posthog-activity-logs` directory into `$SPLUNK_HOME/etc/apps/` and restart Splunk.
+On **Splunk Enterprise**, install from Splunkbase, or build it from source and copy the result into `$SPLUNK_HOME/etc/apps/`.
 
-### 2. Add an input
+### 2. Add your PostHog account
 
-Go to **Settings** > **Data inputs** > **PostHog activity logs** and click **New**.
+Open the add-on from the Splunk apps menu, go to **Configuration**, and click **Add**.
 
 | Field | Value |
 | --- | --- |
-| PostHog host | `https://us.posthog.com` or `https://eu.posthog.com` |
-| Organization ID | Find it in PostHog under **Settings** > **Organization** |
+| Name | A name for the account, so you can pick it when you add an input |
+| Region | US Cloud or EU Cloud |
 | Personal API key | A key with the `activity_log:read` scope |
+
+The key is held in Splunk's encrypted credential store. One account can serve several inputs.
+
+### 3. Add an input
+
+Go to **Inputs** and click **Create New Input**.
+
+| Field | Value |
+| --- | --- |
+| Name | A name for this input |
+| Account | The account you just added |
+| Organization ID | Find it in PostHog under **Settings** > **Organization** |
 | Interval | How often to poll, in seconds. 300 is a reasonable start |
+| Index | The index to write to. Note which one you pick, you need it to search |
 | Include changed values | Leave off unless you need before and after values |
 | Start date | Optional ISO-8601 lower bound for the first run |
-| Index | Under **More settings**, choose the index to write to. Note which one you pick, you need it to search |
 
 Save. Splunk polls on your interval and resumes from where it stopped, so entries are not collected twice.
 
-The add-on moves your API key into Splunk's encrypted credential store on the first run.
-
-### 3. Confirm events are arriving
+### 4. Confirm events are arriving
 
 Search the index you chose when you added the input:
 
@@ -142,7 +152,7 @@ Events are timestamped with when the activity happened in PostHog, not when Splu
 
 ### Troubleshooting
 
-Splunk records the add-on's messages in `$SPLUNK_HOME/var/log/splunk/splunkd.log`. Search for `posthog_activity_logs`.
+The add-on writes its own log, which you can search in Splunk with `index=_internal source=*ta_posthog_activity_logs*`. Raise the detail level on the add-on's **Configuration** > **Logging** tab.
 
 | Problem | Cause |
 | --- | --- |
@@ -150,7 +160,7 @@ Splunk records the add-on's messages in `$SPLUNK_HOME/var/log/splunk/splunkd.log
 | `403` from PostHog | The key does not have the `activity_log:read` scope |
 | Runs but indexes nothing | The input is up to date. Make a change in PostHog and wait for the next poll |
 
-To re-read history from the beginning, delete the input's checkpoint under `$SPLUNK_HOME/var/lib/splunk/modinputs/posthog_activity_logs/` and restart Splunk.
+To re-read history from the beginning, delete the input and add it again.
 
 ### Building your own input
 

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -102,7 +102,7 @@ Install the [PostHog Splunk add-on](https://github.com/PostHog/splunk-add-on). S
 
 ### 1. Install the add-on
 
-On **Splunk Cloud Platform**, go to **Apps** > **Find More Apps**, search for PostHog, and install.
+On **Splunk Cloud Platform**, go to **Apps** > **Find More Apps**, search for PostHog, and install. Splunk asks for your Splunk.com login to complete the install, which is a separate account from the one you use to sign in to Splunk Cloud. No restart is needed.
 
 On **Splunk Enterprise**, install from Splunkbase, or build it from source and copy the result into `$SPLUNK_HOME/etc/apps/`.
 
@@ -153,6 +153,8 @@ index=<your index> sourcetype="posthog:activity_log" | stats count by class_uid,
 ```
 
 Events are timestamped with when the activity happened in PostHog, not when Splunk indexed them, so a `timechart` reflects real history.
+
+Set the time range to **All time** for this first check. Splunk's default range covers the last 24 hours, and your history is older than that, so a narrower range shows only a fraction of what was collected and looks like a partial sync.
 
 ### Troubleshooting
 

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -1,0 +1,232 @@
+---
+title: SIEM integration
+sidebar: Docs
+showTitle: true
+availability:
+  free: none
+  selfServe: none
+  scale: full
+  enterprise: full
+---
+
+You can forward PostHog [activity logs](/docs/settings/activity-logs) into a security information and event management (SIEM) system to keep an audit trail alongside the rest of your security data, alert on changes, and satisfy compliance requirements.
+
+PostHog exposes activity logs as a paginated API that your SIEM polls on a schedule. Most SIEM platforms ship a scheduled input for exactly this, so in most cases you configure the integration in your SIEM rather than in PostHog.
+
+## Before you start
+
+You need:
+
+- A personal API key with the `activity_log:read` scope. See [API authentication](/docs/api).
+- Organization admin or owner access, if you want activity across every project rather than one.
+
+## Recommended setup
+
+### 1. Choose an endpoint
+
+| Endpoint | Use it for |
+| --- | --- |
+| `GET /api/projects/@current/advanced_activity_logs/` | Activity in a single project |
+| `GET /api/organizations/<organization_id>/advanced_activity_logs/` | Activity across every project in the organization. Restricted to admins and owners |
+
+Most SIEM integrations use the organization endpoint, so one input covers the whole account.
+
+### 2. Poll oldest first and keep the cursor
+
+Set `ordering=created_at` to return the oldest entry first, and `follow=true` to keep the `next` link valid after the last entry.
+
+```
+GET /api/organizations/<organization_id>/advanced_activity_logs/?ordering=created_at&follow=true&page_size=200
+```
+
+Save the `next` link from each response and request it on the following poll. It returns only entries recorded since the previous request, so your SIEM never re-indexes the same entry.
+
+With `follow=true`, stop when `results` is empty rather than when `next` is null. The link stays valid so you can keep polling it.
+
+Without `follow=true`, the `next` link becomes null once you reach the newest entry, and you have no position to resume from.
+
+### 3. Request OCSF
+
+Set `schema=ocsf` to receive events in [Open Cybersecurity Schema Framework](https://schema.ocsf.io/) 1.5.0 instead of PostHog's own format. Most SIEM platforms parse OCSF without a custom parser.
+
+Activity maps to three OCSF classes:
+
+| Class | `class_uid` | Covers |
+| --- | --- | --- |
+| Entity Management | 3004 | Changes to insights, dashboards, feature flags, and other resources |
+| Authentication | 3002 | Logins and logouts |
+| Account Change | 3001 | SCIM provisioning changes |
+
+Activity types without a direct OCSF equivalent use `activity_id: 99` and carry the original PostHog activity name in `activity_name`, so nothing is dropped.
+
+### 4. Decide whether to include values
+
+By default, an event records which fields changed but not their values:
+
+```json
+{
+  "class_uid": 3004,
+  "activity_id": 3,
+  "time": 1785932169290,
+  "entity": { "type": "FeatureFlag", "uid": "1234", "name": "beta-checkout" },
+  "actor": { "user": { "email_addr": "person@example.com" } },
+  "src_endpoint": { "ip": "203.0.113.4" },
+  "unmapped": { "changed_fields": ["filters"] }
+}
+```
+
+This answers who changed what and when, which is what an audit trail needs.
+
+Set `include_values=true` to also receive the previous and new values, mapped to the OCSF `entity` and `entity_result` attributes. Values can contain the content of the changed object, such as the body of a notebook or the targeting rules on a feature flag. Including them makes responses larger and sends that content to your SIEM, where it counts toward your ingest volume.
+
+### 5. Bound the first run
+
+Your first poll returns your full retained history, which can be large. To start from a specific point, add `start_date` with an ISO 8601 timestamp:
+
+```
+&start_date=2026-01-01T00:00:00Z
+```
+
+You can only backfill as far as your [retention period](/docs/settings/activity-logs#retention-periods) allows.
+
+## Splunk
+
+These steps use a scripted input, which is built into Splunk Enterprise and needs no add-ons.
+
+### 1. Create the app directory
+
+On your Splunk instance, create an app to hold the poller:
+
+```bash
+mkdir -p $SPLUNK_HOME/etc/apps/posthog_activity/{bin,default,local}
+```
+
+Add `$SPLUNK_HOME/etc/apps/posthog_activity/default/app.conf`:
+
+```ini
+[install]
+is_configured = 1
+
+[ui]
+is_visible = 1
+label = PostHog activity logs
+```
+
+Store your personal API key in `$SPLUNK_HOME/etc/apps/posthog_activity/local/posthog_pat.txt` and restrict access to it:
+
+```bash
+chmod 600 $SPLUNK_HOME/etc/apps/posthog_activity/local/posthog_pat.txt
+```
+
+### 2. Add the poller script
+
+Save this as `$SPLUNK_HOME/etc/apps/posthog_activity/bin/posthog_activity.py` and make it executable. Set `POSTHOG_HOST` and `ORGANIZATION_ID` for your account.
+
+```python
+#!/usr/bin/env python3
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlencode
+
+POSTHOG_HOST = "https://us.posthog.com"
+ORGANIZATION_ID = "your-organization-id"
+PAGE_SIZE = "200"
+
+APP_DIR = Path(__file__).resolve().parent.parent
+CHECKPOINT = APP_DIR / "local" / "cursor.txt"
+PAT_FILE = APP_DIR / "local" / "posthog_pat.txt"
+
+
+def first_url():
+    params = {
+        "schema": "ocsf",
+        "ordering": "created_at",
+        "follow": "true",
+        "page_size": PAGE_SIZE,
+    }
+    return f"{POSTHOG_HOST}/api/organizations/{ORGANIZATION_ID}/advanced_activity_logs/?{urlencode(params)}"
+
+
+def main():
+    pat = PAT_FILE.read_text().strip()
+    CHECKPOINT.parent.mkdir(parents=True, exist_ok=True)
+    url = CHECKPOINT.read_text().strip() if CHECKPOINT.exists() else first_url()
+
+    while url:
+        request = urllib.request.Request(url, headers={"Authorization": f"Bearer {pat}"})
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.loads(response.read())
+
+        for event in body["results"]:
+            print(json.dumps(event))
+
+        next_url = body.get("next")
+        if next_url:
+            CHECKPOINT.write_text(next_url)
+        # With follow=true the link stays valid, so an empty page means there is nothing new.
+        if not body["results"]:
+            break
+        url = next_url
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+The script writes each event to stdout as one JSON object, which is what Splunk indexes. It saves the `next` link to `local/cursor.txt` after every page, so an interrupted run does not re-send what it already printed.
+
+### 3. Restart Splunk
+
+```bash
+$SPLUNK_HOME/bin/splunk restart
+```
+
+### 4. Configure the input
+
+In Splunk Web:
+
+1. Go to **Settings** > **Data inputs** > **Scripts**, then click **New Local Script**.
+2. Set **Script Path** to `$SPLUNK_HOME/etc/apps/posthog_activity/bin`.
+3. Set **Script Name** to `posthog_activity.py`.
+4. Set **Interval** to how often you want to poll, in seconds. 60 is a reasonable starting point.
+5. Click **Next**, then set **Source type** to `_json` so Splunk parses the event fields.
+6. Choose your index, then click **Review** and **Submit**.
+
+### 5. Confirm events are arriving
+
+Search for the events in Splunk:
+
+```
+index=<your index> source="*posthog_activity.py"
+```
+
+To check the OCSF fields parsed correctly:
+
+```
+index=<your index> source="*posthog_activity.py" | stats count by class_uid, activity_id
+```
+
+Events are timestamped with when the activity happened in PostHog, not when Splunk indexed them, so a `timechart` reflects real history.
+
+### Troubleshooting
+
+If no events appear, check `$SPLUNK_HOME/var/log/splunk/splunkd.log` for lines mentioning `posthog_activity.py`. Splunk logs the script's stderr there.
+
+| Problem | Cause |
+| --- | --- |
+| `401` from PostHog | The personal API key is missing or wrong |
+| `403` from PostHog | The key does not have the `activity_log:read` scope |
+| Script runs but indexes nothing | The checkpoint is already at the newest entry. Make a change in PostHog and wait for the next poll |
+| Events all share one timestamp | The source type is not `_json`, so Splunk is not reading the event time |
+
+To re-index your history from the beginning, delete `local/cursor.txt` and wait for the next run.
+
+## Other SIEM platforms
+
+The approach is the same for any platform that can poll an HTTP endpoint on a schedule: request OCSF, order oldest first, follow the cursor, and store it between runs.
+
+If you are integrating with a platform not covered here, [let us know](/questions) and we can add steps for it.

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -113,10 +113,14 @@ Open the add-on from the Splunk apps menu, go to **Configuration**, and click **
 | Field | Value |
 | --- | --- |
 | Name | A name for the account, so you can pick it when you add an input |
-| Region | US Cloud or EU Cloud |
+| PostHog host | `https://us.posthog.com`, `https://eu.posthog.com`, or your self-hosted address |
 | Personal API key | A key with the `activity_log:read` scope |
 
 The key is held in Splunk's encrypted credential store. One account can serve several inputs.
+
+Changing an account's host requires entering the key again, so a key does not travel to a new host on its own.
+
+If you self-host PostHog, enter your own address. It has to be https, because the key is sent as a bearer token on every request. If PostHog sits behind a reverse proxy, the proxy has to preserve the `Host` header: PostHog builds the paging links in its responses from the host it sees, and if those point at an internal address the add-on will not follow them.
 
 ### 3. Add an input
 

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -57,9 +57,9 @@ Activity maps to three OCSF classes:
 
 | Class | `class_uid` | Covers |
 | --- | --- | --- |
-| Entity Management | 3004 | Changes to insights, dashboards, feature flags, and other resources |
-| Authentication | 3002 | Logins and logouts |
-| Account Change | 3001 | SCIM provisioning changes |
+| Entity Management | `3004` | Changes to insights, dashboards, feature flags, and other resources |
+| Authentication | `3002` | Logins and logouts |
+| Account Change | `3001` | SCIM provisioning changes |
 
 Activity types without a direct OCSF equivalent use `activity_id: 99` and carry the original PostHog activity name in `activity_name`, so nothing is dropped.
 

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -11,7 +11,9 @@ availability:
 
 You can forward PostHog [activity logs](/docs/settings/activity-logs) into a security information and event management (SIEM) system to keep an audit trail alongside the rest of your security data, alert on changes, and satisfy compliance requirements.
 
-PostHog exposes activity logs as a paginated API that your SIEM polls on a schedule. Most SIEM platforms ship a scheduled input for exactly this, so in most cases you configure the integration in your SIEM rather than in PostHog.
+PostHog exposes activity logs as a paginated API that your SIEM polls on a schedule, so you configure the integration in your SIEM rather than in PostHog.
+
+If you use Splunk, [skip to the Splunk steps](#splunk). An add-on does all of this for you. The rest of this page describes the API, which you need when integrating with a platform we do not ship an add-on for.
 
 ## Before you start
 
@@ -67,15 +69,20 @@ By default, an event records which fields changed but not their values:
 {
   "class_uid": 3004,
   "activity_id": 3,
+  "severity_id": 1,
   "time": 1785932169290,
+  "time_dt": "2026-08-06T12:16:09.290628+00:00",
+  "metadata": { "uid": "00000000-0000-0000-0000-000000000000", "version": "1.5.0" },
   "entity": { "type": "FeatureFlag", "uid": "1234", "name": "beta-checkout" },
-  "actor": { "user": { "email_addr": "person@example.com" } },
+  "actor": { "user": { "email_addr": "person@example.com" }, "app_name": "posthog-python" },
   "src_endpoint": { "ip": "203.0.113.4" },
   "unmapped": { "changed_fields": ["filters"] }
 }
 ```
 
 This answers who changed what and when, which is what an audit trail needs.
+
+`time` is epoch milliseconds, as OCSF specifies. `metadata.uid` is the activity log entry's ID and is stable across replays, so you can deduplicate on it.
 
 Set `include_values=true` to also receive the previous and new values, mapped to the OCSF `entity` and `entity_result` attributes. Values can contain the content of the changed object, such as the body of a notebook or the targeting rules on a feature flag. Including them makes responses larger and sends that content to your SIEM, where it counts toward your ingest volume.
 
@@ -91,142 +98,63 @@ You can only backfill as far as your [retention period](/docs/settings/activity-
 
 ## Splunk
 
-These steps use a scripted input, which is built into Splunk Enterprise and needs no add-ons.
+Install the [PostHog Splunk add-on](https://github.com/PostHog/splunk-add-on). Splunk polls PostHog on a schedule you set, so there is nothing to run or host yourself. The add-on works on both Splunk Cloud Platform and Splunk Enterprise.
 
-### 1. Create the app directory
+### 1. Install the add-on
 
-On your Splunk instance, create an app to hold the poller:
+On **Splunk Cloud Platform**, go to **Apps** > **Find More Apps**, search for PostHog, and install.
 
-```bash
-mkdir -p $SPLUNK_HOME/etc/apps/posthog_activity/{bin,default,local}
-```
+On **Splunk Enterprise**, install from Splunkbase, or copy the `TA-posthog-activity-logs` directory into `$SPLUNK_HOME/etc/apps/` and restart Splunk.
 
-Add `$SPLUNK_HOME/etc/apps/posthog_activity/default/app.conf`:
+### 2. Add an input
 
-```ini
-[install]
-is_configured = 1
+Go to **Settings** > **Data inputs** > **PostHog activity logs** and click **New**.
 
-[ui]
-is_visible = 1
-label = PostHog activity logs
-```
+| Field | Value |
+| --- | --- |
+| PostHog host | `https://us.posthog.com` or `https://eu.posthog.com` |
+| Organization ID | Find it in PostHog under **Settings** > **Organization** |
+| Personal API key | A key with the `activity_log:read` scope |
+| Interval | How often to poll, in seconds. 300 is a reasonable start |
+| Include changed values | Leave off unless you need before and after values |
+| Start date | Optional ISO-8601 lower bound for the first run |
 
-Store your personal API key in `$SPLUNK_HOME/etc/apps/posthog_activity/local/posthog_pat.txt` and restrict access to it:
+Save. Splunk polls on your interval and resumes from where it stopped, so entries are not collected twice.
 
-```bash
-chmod 600 $SPLUNK_HOME/etc/apps/posthog_activity/local/posthog_pat.txt
-```
+The add-on moves your API key into Splunk's encrypted credential store on the first run, so it is not left in plain text in `inputs.conf`.
 
-### 2. Add the poller script
-
-Save this as `$SPLUNK_HOME/etc/apps/posthog_activity/bin/posthog_activity.py` and make it executable. Set `POSTHOG_HOST` and `ORGANIZATION_ID` for your account.
-
-```python
-#!/usr/bin/env python3
-import json
-import sys
-import urllib.request
-from pathlib import Path
-from urllib.parse import urlencode
-
-POSTHOG_HOST = "https://us.posthog.com"
-ORGANIZATION_ID = "your-organization-id"
-PAGE_SIZE = "200"
-
-APP_DIR = Path(__file__).resolve().parent.parent
-CHECKPOINT = APP_DIR / "local" / "cursor.txt"
-PAT_FILE = APP_DIR / "local" / "posthog_pat.txt"
-
-
-def first_url():
-    params = {
-        "schema": "ocsf",
-        "ordering": "created_at",
-        "follow": "true",
-        "page_size": PAGE_SIZE,
-    }
-    return f"{POSTHOG_HOST}/api/organizations/{ORGANIZATION_ID}/advanced_activity_logs/?{urlencode(params)}"
-
-
-def main():
-    pat = PAT_FILE.read_text().strip()
-    CHECKPOINT.parent.mkdir(parents=True, exist_ok=True)
-    url = CHECKPOINT.read_text().strip() if CHECKPOINT.exists() else first_url()
-
-    while url:
-        request = urllib.request.Request(url, headers={"Authorization": f"Bearer {pat}"})
-        with urllib.request.urlopen(request, timeout=60) as response:
-            body = json.loads(response.read())
-
-        for event in body["results"]:
-            print(json.dumps(event))
-
-        next_url = body.get("next")
-        if next_url:
-            CHECKPOINT.write_text(next_url)
-        # With follow=true the link stays valid, so an empty page means there is nothing new.
-        if not body["results"]:
-            break
-        url = next_url
-
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
-```
-
-The script writes each event to stdout as one JSON object, which is what Splunk indexes. It saves the `next` link to `local/cursor.txt` after every page, so an interrupted run does not re-send what it already printed.
-
-### 3. Restart Splunk
-
-```bash
-$SPLUNK_HOME/bin/splunk restart
-```
-
-### 4. Configure the input
-
-In Splunk Web:
-
-1. Go to **Settings** > **Data inputs** > **Scripts**, then click **New Local Script**.
-2. Set **Script Path** to `$SPLUNK_HOME/etc/apps/posthog_activity/bin`.
-3. Set **Script Name** to `posthog_activity.py`.
-4. Set **Interval** to how often you want to poll, in seconds. 60 is a reasonable starting point.
-5. Click **Next**, then set **Source type** to `_json` so Splunk parses the event fields.
-6. Choose your index, then click **Review** and **Submit**.
-
-### 5. Confirm events are arriving
-
-Search for the events in Splunk:
+### 3. Confirm events are arriving
 
 ```
-index=<your index> source="*posthog_activity.py"
+index=<your index> sourcetype="posthog:activity_log"
 ```
 
 To check the OCSF fields parsed correctly:
 
 ```
-index=<your index> source="*posthog_activity.py" | stats count by class_uid, activity_id
+index=<your index> sourcetype="posthog:activity_log" | stats count by class_uid, activity_id
 ```
 
 Events are timestamped with when the activity happened in PostHog, not when Splunk indexed them, so a `timechart` reflects real history.
 
 ### Troubleshooting
 
-If no events appear, check `$SPLUNK_HOME/var/log/splunk/splunkd.log` for lines mentioning `posthog_activity.py`. Splunk logs the script's stderr there.
+Splunk records the add-on's messages in `$SPLUNK_HOME/var/log/splunk/splunkd.log`. Search for `posthog_activity_logs`.
 
 | Problem | Cause |
 | --- | --- |
-| `401` from PostHog | The personal API key is missing or wrong |
+| `401` from PostHog | The personal API key is wrong or was revoked |
 | `403` from PostHog | The key does not have the `activity_log:read` scope |
-| Script runs but indexes nothing | The checkpoint is already at the newest entry. Make a change in PostHog and wait for the next poll |
-| Events all share one timestamp | The source type is not `_json`, so Splunk is not reading the event time |
+| Runs but indexes nothing | The input is up to date. Make a change in PostHog and wait for the next poll |
 
-To re-index your history from the beginning, delete `local/cursor.txt` and wait for the next run.
+To re-read history from the beginning, delete the input's checkpoint under `$SPLUNK_HOME/var/lib/splunk/modinputs/posthog_activity_logs/` and restart Splunk.
+
+### Building your own input
+
+Splunk Cloud does not let you create scripted inputs, and the roles available to customers do not include the capability to add one. Polling from Splunk Cloud requires an add-on, which is why the one above exists. On Splunk Enterprise you can write a scripted input against the API described earlier on this page if you would rather not use the add-on.
 
 ## Other SIEM platforms
 
-The approach is the same for any platform that can poll an HTTP endpoint on a schedule: request OCSF, order oldest first, follow the cursor, and store it between runs.
+The approach is the same for any platform that can poll an HTTP endpoint on a schedule: request OCSF, order oldest first, follow the cursor, and store it between runs. Deduplicate on `metadata.uid`, which carries the PostHog activity log ID and is stable across replays.
 
 If you are integrating with a platform not covered here, [let us know](/questions) and we can add steps for it.

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -118,12 +118,15 @@ Go to **Settings** > **Data inputs** > **PostHog activity logs** and click **New
 | Interval | How often to poll, in seconds. 300 is a reasonable start |
 | Include changed values | Leave off unless you need before and after values |
 | Start date | Optional ISO-8601 lower bound for the first run |
+| Index | Under **More settings**, choose the index to write to. Note which one you pick, you need it to search |
 
 Save. Splunk polls on your interval and resumes from where it stopped, so entries are not collected twice.
 
-The add-on moves your API key into Splunk's encrypted credential store on the first run, so it is not left in plain text in `inputs.conf`.
+The add-on moves your API key into Splunk's encrypted credential store on the first run.
 
 ### 3. Confirm events are arriving
+
+Search the index you chose when you added the input:
 
 ```
 index=<your index> sourcetype="posthog:activity_log"
@@ -157,4 +160,4 @@ Splunk Cloud does not let you create scripted inputs, and the roles available to
 
 The approach is the same for any platform that can poll an HTTP endpoint on a schedule: request OCSF, order oldest first, follow the cursor, and store it between runs. Deduplicate on `metadata.uid`, which carries the PostHog activity log ID and is stable across replays.
 
-If you are integrating with a platform not covered here, [let us know](/questions) and we can add steps for it.
+If you are integrating with a platform not covered here, [open a support ticket](https://us.posthog.com/#panel=support:support) and we can add steps for it.

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -164,7 +164,7 @@ The add-on writes its own log, which you can search in Splunk with `index=_inter
 | `403` from PostHog | The key does not have the `activity_log:read` scope |
 | Runs but indexes nothing | The input is up to date. Make a change in PostHog and wait for the next poll |
 
-To re-read history from the beginning, delete the input and add it again.
+To re-read history from the beginning, add a new input with a different name. The collection position is stored per input name and is not removed when you delete an input, so an input recreated under the same name resumes where the old one stopped and collects nothing.
 
 ### Building your own input
 

--- a/contents/docs/settings/activity-logs/siem.mdx
+++ b/contents/docs/settings/activity-logs/siem.mdx
@@ -13,7 +13,9 @@ You can forward PostHog [activity logs](/docs/settings/activity-logs) into a sec
 
 PostHog exposes activity logs as a paginated API that your SIEM polls on a schedule, so you configure the integration in your SIEM rather than in PostHog.
 
-If you use Splunk, [skip to the Splunk steps](#splunk). An add-on does all of this for you. The rest of this page describes the API, which you need when integrating with a platform we do not ship an add-on for.
+There are two ways to configure a SIEM integration:
+- **Recommended setup:** Use the API
+- Use the [Splunk add-on](#splunk)
 
 ## Before you start
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3882,6 +3882,16 @@ export const docsMenu = {
                         {
                             name: 'Activity logs',
                             url: '/docs/settings/activity-logs',
+                            children: [
+                                {
+                                    name: 'Overview',
+                                    url: '/docs/settings/activity-logs',
+                                },
+                                {
+                                    name: 'SIEM integration',
+                                    url: '/docs/settings/activity-logs/siem',
+                                },
+                            ],
                         },
                         {
                             name: 'Approvals',


### PR DESCRIPTION
## Changes

A security team that wants PostHog activity logs in their SIEM has no documented path. The activity logs page mentions SIEM export in one line and gives no steps.

- Adds `/docs/settings/activity-logs/siem`, covering the general integration and Splunk setup.
- Points the Splunk steps at the [PostHog Splunk add-on](https://github.com/PostHog/splunk-add-on), so Splunk polls on its own schedule with nothing for the customer to host.
- Describes the general pattern for other platforms: poll oldest first, keep the cursor, request OCSF, deduplicate on the entry ID.
- Explains that field values are excluded by default, and what including them sends to your SIEM.
- Says to use a new input name when re-reading history, because deleting an input does not reset its position.
- Nests the new page under Activity logs in the docs sidebar.

The sidebar entry gains children:

```diff
  Activity logs
+   Overview
+   SIEM integration
```

I first wrote the Splunk steps around a scripted input. Testing against a real Splunk Cloud trial showed that path cannot work there: creating a scripted input needs the `edit_scripted` capability, which the `sc_admin` role does not have. Splunk routes all API polling through add-ons by design, so the add-on came out of that finding and the steps now match it.

The add-on builds its configuration UI with Splunk's [UCC framework](https://splunk.github.io/addonfactory-ucc-generator/), so it has its own Configuration and Inputs pages. The steps here follow that flow: add an account holding the API key, then add an input that references it.

## How did you test this code?

- Ran the documented steps end to end against Splunk Enterprise 10.4.2, polling PostHog Cloud. 63 events indexed with OCSF fields parsed, one per unique entry ID, timestamped with event time rather than ingest time.
- Verified the API examples against `us.posthog.com` with a scoped personal API key.
- Checked the re-read instruction against a running Splunk after it looked wrong. Recreating an input under the same name collected zero events; a new name collected the full history. The page said to delete and recreate, which would have sent readers down the failing path.
- Not checked: the Vercel preview, which builds after this PR opens. No page moved, so no redirect is needed.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The API parameters this page documents shipped in PostHog/posthog#78172 and PostHog/posthog#78846, both merged and deployed. The payload example matches what the API returns today.

The one external link is to a support ticket rather than a docs page, so a reader on an unsupported SIEM platform reaches someone who can act on the request.

