### PR TITLE
Add redirects for 404ing docs and site paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -180,6 +180,216 @@
     ],
     "redirects": [
         {
+            "source": "/docs/web-analytics/scroll-depth:ext(\\.md)?",
+            "destination": "/docs/web-analytics/dashboard:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/support/teams:ext(\\.md)?",
+            "destination": "/docs/support:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/session-replay/network-performance-recording:ext(\\.md)?",
+            "destination": "/docs/session-replay/network-recording:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/session-replay/pricing:ext(\\.md)?",
+            "destination": "/docs/session-replay:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/max-ai:ext(\\.md)?",
+            "destination": "/docs/posthog-ai:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/cookieless-tracking:ext(\\.md)?",
+            "destination": "/docs/privacy/data-collection:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/data-residency:ext(\\.md)?",
+            "destination": "/docs/privacy/data-storage:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/data-retention:ext(\\.md)?",
+            "destination": "/docs/data:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/environments:ext(\\.md)?",
+            "destination": "/docs/settings/projects:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/regions:ext(\\.md)?",
+            "destination": "/docs/privacy/data-storage:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/privacy/cookieless-tracking:ext(\\.md)?",
+            "destination": "/docs/privacy/data-collection:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/product-analytics/cookieless-tracking:ext(\\.md)?",
+            "destination": "/docs/privacy/data-collection:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/product-analytics/alerts:ext(\\.md)?",
+            "destination": "/docs/alerts:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/cdp/apps:ext(\\.md)?",
+            "destination": "/docs/cdp/destinations:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/cdp/sources/custom:ext(\\.md)?",
+            "destination": "/docs/cdp/sources/custom-rest-source:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data-warehouse/sources/customerio:ext(\\.md)?",
+            "destination": "/docs/cdp/sources/customer-io:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/revenue-analytics/getting-started:ext(\\.md)?",
+            "destination": "/docs/revenue-analytics/start-here:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/libraries/rails:ext(\\.md)?",
+            "destination": "/docs/libraries/ruby-on-rails:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/libraries/nuxt:ext(\\.md)?",
+            "destination": "/docs/libraries/nuxt-js:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/libraries/sentry:ext(\\.md)?",
+            "destination": "/docs/error-tracking:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/libraries/js/installation:ext(\\.md)?",
+            "destination": "/docs/libraries/js:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/error-tracking/installation/nodejs:ext(\\.md)?",
+            "destination": "/docs/error-tracking/installation/node:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/workflows/customerio-import:ext(\\.md)?",
+            "destination": "/docs/workflows/import-customerio-optouts:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/messaging:ext(\\.md)?",
+            "destination": "/docs/workflows:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/mcp:ext(\\.md)?",
+            "destination": "/docs/model-context-protocol:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/settings/environments:ext(\\.md)?",
+            "destination": "/docs/settings/projects:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/ai-observability/installation/vercel-ai-gateway:ext(\\.md)?",
+            "destination": "/docs/ai-observability/installation/vercel-ai:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/ai-observability/manual-capture:ext(\\.md)?",
+            "destination": "/docs/ai-observability/installation/manual-capture:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/ai-engineering/manual-capture:ext(\\.md)?",
+            "destination": "/docs/ai-observability/installation/manual-capture:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/ai-analytics:ext(\\.md)?",
+            "destination": "/docs/ai-observability:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/api/rate-limits:ext(\\.md)?",
+            "destination": "/docs/api:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/live-events/cli:ext(\\.md)?",
+            "destination": "/docs/activity:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/handbook/growth/customer-support:ext(\\.md)?",
+            "destination": "/handbook/support/customer-support:ext?",
+            "statusCode": 301
+        },
+        {
+            "source": "/changelog/2024",
+            "destination": "/changelog",
+            "statusCode": 301
+        },
+        {
+            "source": "/changelog/2026",
+            "destination": "/changelog",
+            "statusCode": 301
+        },
+        {
+            "source": "/jobs",
+            "destination": "/careers",
+            "statusCode": 301
+        },
+        {
+            "source": "/manual/session-recordings",
+            "destination": "/docs/session-replay",
+            "statusCode": 301
+        },
+        {
+            "source": "/sitemap.xml",
+            "destination": "/sitemap/sitemap-index.xml",
+            "statusCode": 301
+        },
+        {
+            "source": "/blog/rss.xml",
+            "destination": "/rss.xml",
+            "statusCode": 301
+        },
+        {
+            "source": "/blog/feed",
+            "destination": "/rss.xml",
+            "statusCode": 301
+        },
+        {
+            "source": "/feed",
+            "destination": "/rss.xml",
+            "statusCode": 301
+        },
+        {
+            "source": "/status",
+            "destination": "https://status.posthog.com",
+            "statusCode": 301
+        },
+        {
             "source": "/activity",
             "destination": "/docs/activity",
             "statusCode": 301

--- a/vercel.json
+++ b/vercel.json
@@ -195,8 +195,13 @@
             "statusCode": 301
         },
         {
-            "source": "/docs/session-replay/pricing:ext(\\.md)?",
-            "destination": "/docs/session-replay:ext?",
+            "source": "/docs/session-replay/pricing",
+            "destination": "/session-replay/pricing",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/session-replay/pricing.md",
+            "destination": "/session-replay/pricing",
             "statusCode": 301
         },
         {
@@ -205,8 +210,13 @@
             "statusCode": 301
         },
         {
-            "source": "/docs/data/cookieless-tracking:ext(\\.md)?",
-            "destination": "/docs/privacy/data-collection:ext?",
+            "source": "/docs/data/cookieless-tracking",
+            "destination": "/tutorials/cookieless-tracking",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/data/cookieless-tracking.md",
+            "destination": "/tutorials/cookieless-tracking",
             "statusCode": 301
         },
         {
@@ -230,13 +240,23 @@
             "statusCode": 301
         },
         {
-            "source": "/docs/privacy/cookieless-tracking:ext(\\.md)?",
-            "destination": "/docs/privacy/data-collection:ext?",
+            "source": "/docs/privacy/cookieless-tracking",
+            "destination": "/tutorials/cookieless-tracking",
             "statusCode": 301
         },
         {
-            "source": "/docs/product-analytics/cookieless-tracking:ext(\\.md)?",
-            "destination": "/docs/privacy/data-collection:ext?",
+            "source": "/docs/privacy/cookieless-tracking.md",
+            "destination": "/tutorials/cookieless-tracking",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/product-analytics/cookieless-tracking",
+            "destination": "/tutorials/cookieless-tracking",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/product-analytics/cookieless-tracking.md",
+            "destination": "/tutorials/cookieless-tracking",
             "statusCode": 301
         },
         {
@@ -366,7 +386,7 @@
         },
         {
             "source": "/sitemap.xml",
-            "destination": "/sitemap/sitemap-index.xml",
+            "destination": "/sitemap/sitemap-0.xml",
             "statusCode": 301
         },
         {


### PR DESCRIPTION
## Changes

Adds redirects for 42 paths that currently return 404 on posthog.com.

The list was built from server-side request logs rather than by guessing: paths were ranked by how much traffic they lose, then each one was verified against production before being added. Every source still 404s today, and every destination returns 200 — including its `.md` sibling, since agents and "copy as markdown" both hit those.

Most are renames from earlier docs reorganisations that never got a redirect (`/docs/libraries/rails`, `/docs/libraries/nuxt`, `/docs/error-tracking/installation/nodejs`, `/docs/cdp/apps`, `/docs/revenue-analytics/getting-started`), plus a few section moves (`/docs/data/*` privacy pages, `/docs/ai-engineering/manual-capture`) and some non-docs strays (`/changelog/2024`, `/jobs`, `/sitemap.xml`, the RSS aliases, `/status`).

Docs entries use the `:ext(\.md)?` convention from #19100 so the markdown sibling redirects alongside the HTML page.

## Why

We were looking into why traffic referred from AI assistants had shifted away from docs pages. Our own server logs showed a non-trivial share of assistant fetches were being served 404s — so some of what looked like "AI tools stopped citing our docs" was really us serving dead links on paths that had quietly moved. This fixes the ones with a clear successor page.

## Not included

Left out deliberately, as they need a human decision rather than a mechanical redirect:

- `/docs/links` — the single highest-volume 404 on the site, and almost entirely human traffic. No "Links" page or product exists anywhere in the repo or its history, so it's unclear what this ever pointed at. Worth tracking down separately, since something is linking to it heavily.
- `/docs/data/geoip` and `/docs/cdp/transformations/posthog-plugin-geoip` — the GeoIP transformation content has been removed entirely. Note the existing `/docs/cdp/geoip-enrichment` redirect now points at a page that no longer exists, so it's broken too.
- `/docs/slack-app/pricing` — no `slack-app` docs section exists.
- `/docs/references/posthog-js/types/*` — these are generated from SDK typedoc data, not repo files, so stale type names need fixing at the generator.
- `/long-term-contract-template` — plausibly `/handbook/growth/sales/contracts`, but I couldn't confirm the original intent.

## Follow-up: `.md` siblings of non-MDX hub pages still 404

Separate from this PR, the `.md` sibling is missing for every `/docs` route that isn't backed by an MDX file — `/docs.md`, `/handbook.md`, `/docs/frameworks.md`, `/docs/distributed-tracing.md`, and all `/docs/api/*.md`. `generateRawMarkdownPages()` only walks `allMdx`, so hand-written `src/pages/docs/*.tsx` routes and the `allApiEndpoint`-derived API hubs are invisible to it (`src/components/MarkdownActions/README.md` documents this). The API reference ones matter most — they take real agent traffic. Keying the generator off `allSitePage` instead of `allMdx` would cover them. Happy to open that as a separate PR.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BMKTE4NG5/p1786022871183179?thread_ts=1786022871.183179&cid=C0BMKTE4NG5)*
