### PR TITLE
Point handbook launch plan and messaging links at PostHog/marketing

### DIFF
--- a/contents/handbook/company/small-teams.md
+++ b/contents/handbook/company/small-teams.md
@@ -92,7 +92,7 @@ Some guidelines on how to do this are below, but if in doubt team leads should a
 
 **Typically, you must give at least 2-3 weeks notice of a product launch and you should reach out directly to marketing team leads if this is not possible.**
 
--   [ ] [Create a new launch plan issue](https://github.com/PostHog/meta/issues/new?template=launch-plan-.md)
+-   [ ] [Create a new launch plan issue](https://github.com/PostHog/marketing/issues/new?template=launch-plan.md)
 -   [ ] Continue to communicate timelines / updates in the Slack channel created
 
 ## Leading quarterly goal setting

--- a/contents/handbook/marketing/email-comms.md
+++ b/contents/handbook/marketing/email-comms.md
@@ -73,9 +73,9 @@ Important service updates are the _only_ type of email we may send to unsubscrib
 
 > `Service updates` emails are often part of an [engineering incident](/handbook/engineering/operations/incidents). We handle comms for those too. 
 
-Whenever we need to send an email broadcast like this we begin by creating an issue in [the Meta repo](https://github.com/PostHog/meta/), unless it involves discussion of personal information - in which case it is discussed in [Company Internal](https://github.com/PostHog/company-internal). This enables us to summarize information and seek approval from teams while also keeping our work open source, and without requiring everyone to log in to Customer.io. Issues are closed when an email is sent. 
+Whenever we need to send an email broadcast like this we begin by creating an issue using the [messaging template](https://github.com/PostHog/marketing/issues/new?template=messaging-template.md) in the marketing repo, unless it involves discussion of personal information - in which case it is discussed in [Company Internal](https://github.com/PostHog/company-internal). This enables us to summarize information and seek approval from teams while also keeping our work open source, and without requiring everyone to log in to Customer.io. Issues are closed when an email is sent. 
 
-If you'd like to work with Marketing on an email activity, please begin by opening an issue in the `meta` [repo](https://github.com/PostHog/meta/issues).
+If you'd like to work with Marketing on an email activity, please begin by opening an issue with the [messaging template](https://github.com/PostHog/marketing/issues/new?template=messaging-template.md).
 
 ## Email campaigns
 We maintain many email campaigns to help users get the most out of the product. The most developed and documented of these are our four onboarding campaigns.  
@@ -86,7 +86,7 @@ Generally, when we talk about onboarding emails we refer specifically to the flo
 #### PostHog Cloud onboarding emails
 The latest revision is [Onboarding 8](https://github.com/PostHog/requests-for-comments/issues/414). You can [read about old revisions on the blog](/blog/how-we-built-email-onboarding). 
 
-The onboarding flow regularly changes as we test new ideas. Any changes to it are, as with all other email campaigns, documented in [the Meta repo](https://github.com/PostHog/meta/). 
+The onboarding flow regularly changes as we test new ideas. Any changes to it are, as with all other email campaigns, documented in [the marketing repo](https://github.com/PostHog/marketing/issues?q=is%3Aissue+label%3Amessaging). 
 
 We aim for all content in this flow to be relevant and helpful to users, without being salesy. All emails come directly from Joe and he triages replies on a daily basis, answering or redirecting as needed. The campaign is triggered when a user signs up for the first time and has a goal of users achieving `billing product activated` within 7 days of opening any email in the flow. 
 

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -58,7 +58,7 @@ Before you settle on a launch tier, work through the questions below. They shape
 
 ### Tier 1: New product announcements
 
-New product launches are our biggest tier. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/meta/issues/new/choose). Product marketers should always create a launch plan for new product announcements.
+New product launches are our biggest tier. They have their own GitHub template: [Launch Plan](https://github.com/PostHog/marketing/issues/new?template=launch-plan.md). Product marketers should always create a launch plan for new product announcements.
 
 Here are some activities your Tier 1 launch could include:
 
@@ -83,7 +83,7 @@ Some other things we've done for launches:
 - If the product is moving from free beta to paid general availability (GA) you might also want to choose a reward for beta users. Examples of this include giving PostHog AI beta users 30 extra days of unlimited free usage, or giving Workflows beta users a discount code for merch.
 - If the product has been free for a while and it's becoming paid with the launch, make sure to plan to notify free customers in advance and clearly communicate pricing. 
 
-As an example, here's the issue of the [Tier 1 launch for Replay Vision](https://github.com/PostHog/requests-for-comments-public/issues/562).
+As an example, here's the issue of the [Tier 1 launch for Replay Vision](https://github.com/PostHog/marketing/issues/179).
 
 _Note: All of these are suggestions, not must-haves. It's likely that not all of these things can be ready for launch. A case study, for example, can follow a few weeks after._
 

--- a/contents/handbook/product/releasing-new-products-and-features.md
+++ b/contents/handbook/product/releasing-new-products-and-features.md
@@ -88,7 +88,7 @@ Betas do not need to be performant for high-volume users and can have big bugs, 
 
 <CalloutBox icon="IconInfo" title="Launching a new beta?" type="fyi">
 
-  It's helpful to let the marketing team know when new betas are added. They'll then add the beta to [the changelog](/changelog), organize any marketing announcements, plan [a full announcement](https://github.com/PostHog/meta/issues/new?template=launch-plan-.md) for full release, create an email onboarding flow to help you collect user feedback, and anything else you need. You can let them know via [the marketing Slack channel](https://posthog.slack.com/archives/C08CG24E3SR).
+  It's helpful to let the marketing team know when new betas are added. They'll then add the beta to [the changelog](/changelog), organize any marketing announcements, plan [a full announcement](https://github.com/PostHog/marketing/issues/new?template=launch-plan.md) for full release, create an email onboarding flow to help you collect user feedback, and anything else you need. You can let them know via [the marketing Slack channel](https://posthog.slack.com/archives/C08CG24E3SR).
 
 </CalloutBox>
 


### PR DESCRIPTION
Follow-up to the marketing issue migration ([PostHog/marketing#221](https://github.com/PostHog/marketing/pull/221), [PostHog/requests-for-comments-public#592](https://github.com/PostHog/requests-for-comments-public/pull/592)).

The messaging, community event, event plan and launch plan issue templates have moved to `PostHog/marketing`. `PostHog/meta` is the **old name** of `requests-for-comments-public` — those links still redirect today, but they'll land in the wrong repo once the templates are removed.

### Changes

| File | Change |
|---|---|
| `handbook/marketing/product-announcements.md` | Launch Plan template link → marketing repo; Replay Vision example → its new issue number |
| `handbook/marketing/email-comms.md` | Three "Meta repo" references → the messaging template / `messaging` label in the marketing repo |
| `handbook/company/small-teams.md` | Launch plan checklist item → marketing repo |
| `handbook/product/releasing-new-products-and-features.md` | Beta → full announcement link → marketing repo |

**Drive-by fix:** the launch plan links used `?template=launch-plan-.md` (trailing hyphen), a filename that has never existed, so they only ever opened a blank issue picker. Now `?template=launch-plan.md`.

### Deliberately not changed

- **Other `PostHog/meta` links** in `contents/` — historical issue/PR references, or non-marketing (quarterly goals, 1-1 templates, general company issues). All still resolve via the rename redirect. Renaming them is a separate cleanup.
- **Blog and newsletter links** to specific RFC issues (`#513`, `#313`, `#524`, `#540`, `#414`) — all closed issues that stayed in `requests-for-comments-public`, so they're unaffected.
- **Event handbook pages** — they route people through Notion and the `/community-incubator` form, not GitHub templates, so there was nothing to repoint.

### Worth a separate look

`handbook/company/small-teams.md:76` links the "new product RFC template" to `PostHog/requests-for-comments/blob/main/.github/ISSUE_TEMPLATE/new-product.md`, which **does not exist**. Two other handbook pages point the same phrase at `requests-for-comments-internal/blob/main/_TEMPLATES/request-for-comments-new-product.md`. Left alone since picking the right target is a content call unrelated to this migration.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*