### PR TITLE
docs: add UI display names for bot virtual properties

### DIFF
--- a/contents/docs/web-analytics/bot-detection.mdx
+++ b/contents/docs/web-analytics/bot-detection.mdx
@@ -132,13 +132,15 @@ ORDER BY hits DESC
 
 For convenience, PostHog exposes the classification as virtual event properties. They read the user agent for you (falling back from `$raw_user_agent` to `$user_agent`), so you don't have to pass it in. They're available wherever you select event properties, including breakdowns:
 
-| Property                 | Equivalent to             |
-| ------------------------ | ------------------------- |
-| `$virt_is_bot`           | `isLikelyBot(...)`        |
-| `$virt_traffic_type`     | `getTrafficType(...)`     |
-| `$virt_traffic_category` | `getTrafficCategory(...)` |
-| `$virt_bot_name`         | `getBotName(...)`         |
-| `$virt_bot_operator`     | `getBotOperator(...)`     |
+| Property                 | Name in the UI     | Equivalent to             |
+| ------------------------ | ------------------ | ------------------------- |
+| `$virt_is_bot`           | Is bot             | `isLikelyBot(...)`        |
+| `$virt_traffic_type`     | Traffic type       | `getTrafficType(...)`     |
+| `$virt_traffic_category` | Traffic category   | `getTrafficCategory(...)` |
+| `$virt_bot_name`         | Bot name           | `getBotName(...)`         |
+| `$virt_bot_operator`     | Bot operator       | `getBotOperator(...)`     |
+
+The **Property** column is the name you use in SQL. The **Name in the UI** column is what you search for in the property picker when building an insight, dashboard, or breakdown.
 
 For example, to break down traffic without writing out the function:
 
@@ -158,9 +160,9 @@ You don't need to write SQL to break traffic down. As long as your events carry 
 
 For example:
 
-- **Exclude bots from an insight** – add a filter where `$virt_is_bot` equals `false`.
-- **Break down traffic by type** – set the breakdown to `$virt_traffic_type` to split a trend into Regular, AI Agent, Bot, and Automation.
-- **See which crawlers hit a page** – filter to `$virt_is_bot` is `true` and break down by `$virt_bot_name`.
+- **Exclude bots from an insight** – add a filter where **Is bot** equals `false`.
+- **Break down traffic by type** – set the breakdown to **Traffic type** to split a trend into Regular, AI Agent, Bot, and Automation.
+- **See which crawlers hit a page** – filter to **Is bot** is `true` and break down by **Bot name**.
 
 Because the classification reads the raw user agent, this works for any event that carries one – including server-side and `$http_log` traffic – using the standard insight builder.
 

--- a/contents/docs/web-analytics/live.mdx
+++ b/contents/docs/web-analytics/live.mdx
@@ -30,7 +30,7 @@ Live separates automated traffic from human visitors, so a crawl or scrape doesn
 - **Bot requests per minute** – a chart alongside the live users chart, so you can see automated load at a glance and tell a crawl apart from real traffic.
 - **Bot traffic tile** – the bots hitting you right now, ranked by share of recent events and tagged with their category (AI agent, search crawler, automation, and so on). Select a row to open a breakdown for that specific bot.
 
-This is handy when an AI crawler or scraper spikes your numbers and you want to confirm it's automated before reacting. To pull bots out of the rest of the live feed, filter on `$virt_is_bot` – see [bot and traffic detection](/docs/web-analytics/bot-detection) for the full set of properties.
+This is handy when an AI crawler or scraper spikes your numbers and you want to confirm it's automated before reacting. To pull bots out of the rest of the live feed, filter on **Is bot** (`$virt_is_bot`) – see [bot and traffic detection](/docs/web-analytics/bot-detection) for the full set of properties.
 
 > **Note:** The live bot tiles are rolling out and may not be enabled for your project yet. Bot classification in queries and Product Analytics is available to everyone today.
 

--- a/contents/docs/web-analytics/managing-bot-traffic.mdx
+++ b/contents/docs/web-analytics/managing-bot-traffic.mdx
@@ -22,7 +22,7 @@ You don't have to treat every bot the same. Because classification happens at qu
 There are three points where you can deal with bots, from most aggressive to most flexible:
 
 1. **Block at capture (client-side).** The [PostHog JavaScript SDK](/docs/libraries/js) blocks known bots before they ever send an event. Lowest effort, but you lose the data entirely, and it only affects traffic that runs JavaScript. See [blocking bots](/docs/web-analytics/troubleshooting#do-stats-include-bots-and-crawlers).
-2. **Exclude at query time.** Keep the events and filter them out where you don't want them – add a `$virt_is_bot` is `false` filter to an insight or dashboard. Flexible and reversible: the underlying data stays intact, so you can include or break down bot traffic whenever you want.
+2. **Exclude at query time.** Keep the events and filter them out where you don't want them – add an **Is bot** (`$virt_is_bot`) is `false` filter to an insight or dashboard. Flexible and reversible: the underlying data stays intact, so you can include or break down bot traffic whenever you want.
 3. **Capture server-side to measure bots.** Most bots and AI agents never run JavaScript, so the SDK never sees them. To measure that traffic, forward your server logs as [`$http_log` events](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) – they carry the user agent and get classified the same way.
 
 ## See bots in the Bots tab
@@ -39,14 +39,24 @@ The tab reads `$pageview`, `$screen`, and [`$http_log`](/docs/web-analytics/bot-
 
 ## Exclude bots from an insight or dashboard
 
-In any [Product Analytics](/docs/product-analytics) insight or [Web Analytics](/docs/web-analytics/dashboard) view, add a filter where `$virt_is_bot` equals `false`. Your visitor, session, and pageview counts then reflect human traffic only, without changing the stored data.
+In any [Product Analytics](/docs/product-analytics) insight or [Web Analytics](/docs/web-analytics/dashboard) view, add a filter where **Is bot** equals `false`. Your visitor, session, and pageview counts then reflect human traffic only, without changing the stored data.
 
-To exclude a narrower set – say, only automation and HTTP clients while keeping AI agents – filter on `$virt_traffic_type` or `$virt_traffic_category` instead.
+The property picker lists these under their display names rather than their raw keys, though searching for either works:
+
+| Name in the UI   | Property                 |
+| ---------------- | ------------------------ |
+| Is bot           | `$virt_is_bot`           |
+| Traffic type     | `$virt_traffic_type`     |
+| Traffic category | `$virt_traffic_category` |
+| Bot name         | `$virt_bot_name`         |
+| Bot operator     | `$virt_bot_operator`     |
+
+To exclude a narrower set – say, only automation and HTTP clients while keeping AI agents – filter on **Traffic type** or **Traffic category** instead.
 
 ## See which bots are hitting you
 
 - **Right now** – open the [Live tab](/docs/web-analytics/live#bot-traffic) and check the bot traffic tile to see which bots are crawling you in real time.
-- **Over time** – open the [Bots tab](#see-bots-in-the-bots-tab) for a ready-made dashboard, or build a trend filtered to `$virt_is_bot` is `true` and broken down by `$virt_bot_name`. See [example queries](/docs/web-analytics/bot-detection#example-queries) for the SQL equivalent.
+- **Over time** – open the [Bots tab](#see-bots-in-the-bots-tab) for a ready-made dashboard, or build a trend filtered to **Is bot** is `true` and broken down by **Bot name**. See [example queries](/docs/web-analytics/bot-detection#example-queries) for the SQL equivalent.
 
 ## Track AI bot traffic
 
@@ -59,7 +69,7 @@ AI traffic is worth measuring on its own: these visits are how AI tools discover
 To track them:
 
 1. **Capture the traffic.** Most AI bots don't run JavaScript, so the SDK never sees them. Forward your server or CDN logs as [`$http_log` events](/docs/web-analytics/bot-detection#capturing-server-side-traffic-with-http_log) – without this, you only measure the small slice of AI traffic that executes your snippet.
-2. **See who's reading your site.** Open the [Bots tab](#see-bots-in-the-bots-tab) and switch the trend to the **Category** breakdown, or build a trend on the `$pageview` and `$http_log` events (a `$pageview`-only trend misses the server-side traffic you set up in step 1), filtered to `$virt_traffic_type` equals `AI Agent` and broken down by `$virt_bot_name` or `$virt_bot_operator` to compare OpenAI, Anthropic, Perplexity, and others.
+2. **See who's reading your site.** Open the [Bots tab](#see-bots-in-the-bots-tab) and switch the trend to the **Category** breakdown, or build a trend on the `$pageview` and `$http_log` events (a `$pageview`-only trend misses the server-side traffic you set up in step 1), filtered to **Traffic type** equals `AI Agent` and broken down by **Bot name** or **Bot operator** to compare OpenAI, Anthropic, Perplexity, and others.
 3. **See what they're reading.** Check **Most crawled paths** in the Bots tab, or break the same trend down by `$pathname`, to find which content AI tools hit most.
 
 Assistant traffic deserves particular attention: each `ai_assistant` request has a person on the other end asking about your content right now, even though the request itself is automated. A rise in assistant traffic to a page means AI tools are reading it on users' behalf.


### PR DESCRIPTION
## Changes

The bot and AI traffic docs only referenced the raw HogQL keys (`$virt_is_bot`, `$virt_traffic_type`, …), but the property picker in insights lists them under their taxonomy labels ("Is bot", "Traffic type"). Anyone following the docs in the UI had nothing to search for.

- Added a **Name in the UI** column to the virtual properties table in `bot-detection.mdx`, and a mapping table in `managing-bot-traffic.mdx`.
- Switched the "do this in an insight" instructions on both pages (plus the bot filter tip in `live.mdx`) to use the display names, since that's what you actually click.

**Why:** raised in Slack – the docs page shows only the HogQL property name, not the taxonomic version, so the properties are hard to find in the UI.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C05LJK1N3CP/p1786035189173889?thread_ts=1786035189.173889&cid=C05LJK1N3CP)*