### PR TITLE
Update screen recording guide: paid exports and Cloudinary uploads

### DIFF
--- a/contents/handbook/content/screen-recording-guide.md
+++ b/contents/handbook/content/screen-recording-guide.md
@@ -20,7 +20,9 @@ You like cookies? Then watch this video. Plus, you’ll learn about how to prope
 
 - [Download Screen Studio](https://screen.studio/download). 
 
-By default, **Screen Studio is free** and there’s **no need to upgrade to a paid plan**.
+Screen Studio is free to record and edit with, but **exporting now requires a paid subscription**. If you just need to hand a `.screenstudio` project to the YouTube team (see step 7), the free version is enough and you don't need to upgrade.
+
+If you need to export the video yourself – for example to embed it in docs or the handbook – go ahead and buy a subscription and expense it. Put it on your Brex virtual card under your own User Limit, as described in [spending money](/handbook/people/spending-money).
 
 ## 2. Set Recording Settings
 
@@ -84,5 +86,13 @@ Use your name or the project’s name for the file name, and ensure the file end
 Drag that file into the [“ScreenStudio Projects” Google Drive](https://drive.google.com/drive/folders/1syLVUYgRkX81fP7LXzt1M7hSK0OarrWn?usp=drive_link) and ping the YouTube team/member in the corresponding GitHub issue.  
         
 > **Important!** If your recording contains any customer-sensitive information that needs to be blurred or removed, please leave exact timestamps of where the information appears in the recording project. Please triple check your work, as our post team will not always be able to catch this on our own.  
-      
+
+## 8. (Optional) Export and upload to Cloudinary
+
+If your recording is going into docs or the handbook rather than through the YouTube team, export it from Screen Studio (this needs a paid plan – see step 1), then upload it to Cloudinary to get a URL you can embed.
+
+You don't need a Cloudinary login. Sign in on posthog.com, then choose **Upload media** under **Moderator tools** in the account menu, upload the file, and copy the URL. See [uploading assets with Cloudinary](/handbook/engineering/posthog-com/assets) for the full walkthrough, and [videos in markdown](/handbook/engineering/posthog-com/markdown#videos) for how to embed the URL once you have it.
+
+Keep exports under 20MB so Cloudinary accepts them – for anything longer, use [Wistia](/handbook/engineering/posthog-com/markdown#embedding-wistia-videos) instead.
+
 And voila! You’re done! Thanks for following these steps, and feel free to ask any questions in the [\#team-youtube](https://posthog.slack.com/archives/C01R387F6H5) Slack channel.

--- a/contents/handbook/content/screen-recording-guide.md
+++ b/contents/handbook/content/screen-recording-guide.md
@@ -91,7 +91,7 @@ Drag that file into the [“ScreenStudio Projects” Google Drive](https://drive
 
 If your recording is going into docs or the handbook rather than through the YouTube team, export it from Screen Studio (this needs a paid plan – see step 1), then upload it to Cloudinary to get a URL you can embed.
 
-You don't need a Cloudinary login. Sign in on posthog.com, then choose **Upload media** under **Moderator tools** in the account menu, upload the file, and copy the URL. See [uploading assets with Cloudinary](/handbook/engineering/posthog-com/assets) for the full walkthrough, and [videos in markdown](/handbook/engineering/posthog-com/markdown#videos) for how to embed the URL once you have it.
+You don't need a Cloudinary login. Sign in on PostHog.com, then choose **Upload media** under **Moderator tools** in the account menu, upload the file, and copy the URL. See [uploading assets with Cloudinary](/handbook/engineering/posthog-com/assets) for the full walkthrough, and [videos in Markdown](/handbook/engineering/posthog-com/markdown#videos) for how to embed the URL once you have it.
 
 Keep exports under 20MB so Cloudinary accepts them – for anything longer, use [Wistia](/handbook/engineering/posthog-com/markdown#embedding-wistia-videos) instead.
 

--- a/contents/handbook/content/screen-recording-guide.md
+++ b/contents/handbook/content/screen-recording-guide.md
@@ -22,7 +22,7 @@ You like cookies? Then watch this video. Plus, you’ll learn about how to prope
 
 Screen Studio is free to record and edit with, but **exporting now requires a paid subscription**. If you just need to hand a `.screenstudio` project to the YouTube team (see step 7), the free version is enough and you don't need to upgrade.
 
-If you need to export the video yourself – for example to embed it in docs or the handbook – go ahead and buy a subscription and expense it. Put it on your Brex virtual card under your own User Limit, as described in [spending money](/handbook/people/spending-money).
+If you need to export the video yourself – for example to embed it in docs or the handbook – you will need to upgrade.
 
 ## 2. Set Recording Settings
 


### PR DESCRIPTION
## Changes

The guide said Screen Studio is free and there is "no need to upgrade to a paid plan", but exporting is now gated behind a subscription. Updated step 1 to explain when the free version is enough (handing a `.screenstudio` project to the YouTube team) and to say that a subscription can be expensed when you need to export yourself.

Added an optional step 8 covering exporting and uploading to Cloudinary via the posthog.com uploader, linking to the existing assets and markdown handbook pages.

## Why

Someone recording a demo for our docs hit the export paywall and could not tell from the handbook whether paying for a subscription was expected.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1785521876278659?thread_ts=1785521876.278659&cid=C02E3BKC78F)*