### PR TITLE
Cosmetic updates to tool pages

### DIFF
--- a/src/components/Home/ToolsTicker/index.tsx
+++ b/src/components/Home/ToolsTicker/index.tsx
@@ -7,7 +7,7 @@ import ToolsTickerStrip from './ToolsTickerStrip'
 const SECONDS_PER_ITEM = 2.5
 
 // Core products plus notable betas, in the order they scroll.
-const DEFAULT_HANDLES = [
+export const DEFAULT_HANDLES = [
     'product_analytics',
     'web_analytics',
     'session_replay',
@@ -38,12 +38,15 @@ interface ToolsTickerProps {
     handles?: string[]
     label?: string
     className?: string
+    /** Which way the names travel. `'left'` (default) is the homepage direction. */
+    direction?: 'left' | 'right'
 }
 
 export default function ToolsTicker({
     handles = DEFAULT_HANDLES,
     label = 'Built-in tools for your agents:',
     className = '',
+    direction = 'left',
 }: ToolsTickerProps): JSX.Element | null {
     const allProducts = useProduct()
     const [isPaused, setIsPaused] = useState(false)
@@ -74,6 +77,8 @@ export default function ToolsTicker({
                         className="flex w-max motion-reduce:[animation:none!important]"
                         style={{
                             animation: `tools-ticker-marquee ${products.length * SECONDS_PER_ITEM}s linear infinite`,
+                            // Same keyframes played backwards, so the homepage ticker is untouched.
+                            animationDirection: direction === 'right' ? 'reverse' : undefined,
                             animationPlayState: isPaused ? 'paused' : 'running',
                         }}
                     >

--- a/src/components/Products/ReaderViewProduct/helpers.tsx
+++ b/src/components/Products/ReaderViewProduct/helpers.tsx
@@ -1,5 +1,30 @@
 import React from 'react'
 
+/** Title inside a bordered card or panel. Stays small on purpose. */
+export const CARD_H3 = 'text-base font-bold text-primary mt-0 mb-1 leading-snug'
+
+/**
+ * Section header: a heading plus an optional lede paragraph.
+ *
+ * These sections are `not-prose`, where `global.css` sizes a bare `<h2>` at
+ * 1.5rem – a touch small against the reader's `proseSize="lg"` body copy, hence
+ * the nudge to 1.75rem. The lede restates `text-lg` for the same reason.
+ */
+export const SectionHeading = ({
+    children,
+    lede,
+    className = '',
+}: {
+    children: React.ReactNode
+    lede?: React.ReactNode
+    className?: string
+}) => (
+    <header className={`mb-4 ${className}`}>
+        <h2 className="text-[1.75rem] font-bold text-primary mt-0 mb-3 leading-tight text-balance">{children}</h2>
+        {lede && <p className="text-lg text-secondary leading-relaxed m-0 mb-6 max-w-prose text-balance">{lede}</p>}
+    </header>
+)
+
 export const LabeledList = ({
     items,
     columns = [1, 2],

--- a/src/components/Products/ReaderViewProduct/templates/CommunityQuestions.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/CommunityQuestions.tsx
@@ -5,7 +5,7 @@ import CommunityQuestionsList from './CommunityQuestionsList'
 import OSButton2 from 'components/OSButton/OSButton2'
 import { useQuestions } from 'hooks/useQuestions'
 import { SectionComponentProps } from '../types'
-import OSButton from 'components/OSButton'
+import { SectionHeading } from '../helpers'
 import Link from 'components/Link'
 import { useApp } from '../../../../context/App'
 import SmallTeam from 'components/SmallTeam'
@@ -25,7 +25,7 @@ const CommunityQuestions = ({ id, productData }: SectionComponentProps) => {
 
     const { questions, isLoading } = useQuestions({
         topicId: forumTopicId,
-        limit: 5,
+        limit: 3,
         sortBy: 'activity',
     })
 
@@ -47,7 +47,6 @@ const CommunityQuestions = ({ id, productData }: SectionComponentProps) => {
     )
 
     const forumUrl = `/questions/topic/${slug}`
-    const fmt = (n: number) => n.toLocaleString()
     const approxCount = (n: number) => {
         if (n >= 1000) return `With over ${(Math.floor(n / 1000) * 1000).toLocaleString()}`
         if (n >= 100) return `With over ${(Math.floor(n / 100) * 100).toLocaleString()}`
@@ -58,9 +57,7 @@ const CommunityQuestions = ({ id, productData }: SectionComponentProps) => {
 
     return (
         <section id={id} className="scroll-mt-20">
-            <h2 className="text-3xl @md/reader-content:text-4xl font-bold text-primary m-0 leading-tight">
-                Questions?
-            </h2>
+            <SectionHeading>Questions?</SectionHeading>
 
             <div className="grid grid-cols-1 @2xl/reader-content:grid-cols-2 gap-4 @xl/reader-content:gap-8 @2xl/reader-content:gap-12">
                 <div>
@@ -127,15 +124,6 @@ const CommunityQuestions = ({ id, productData }: SectionComponentProps) => {
                             </p>
                         </li>
                     </ol>
-                    {/*                 
-                    {stats && stats.questions > 0 && (
-                        <ul className="mb-4">
-                            <li>Questions asked: {fmt(stats.questions)}</li>
-                            <li>Questions resolved: {fmt(stats.resolved)}</li>
-                            <li>Community replies: {fmt(stats.replies)}</li>
-                            <li>Replies marked as helpful: {fmt(stats.helpful)}</li>
-                        </ul>
-                    )} */}
                 </div>
 
                 <div>
@@ -157,6 +145,18 @@ const CommunityQuestions = ({ id, productData }: SectionComponentProps) => {
                             <IconArrowRight className="size-4" />
                         </OSButton2>
                     </div>
+
+                    {productData?.teamSlug && (
+                        <div className="mt-8 not-prose">
+                            <h3 className="mb-3 text-secondary !text-lg font-semibold">Who builds this?</h3>
+                            {/* Tilted so the crest reads as a sticker slapped on the page. */}
+                            <SmallTeam
+                                slug={productData.teamSlug}
+                                variant="crest"
+                                crestClassName="size-20 @lg/reader-content:size-24 -rotate-6 group-hover:-rotate-3"
+                            />
+                        </div>
+                    )}
                 </div>
             </div>
         </section>

--- a/src/components/Products/ReaderViewProduct/templates/CommunityQuestionsList.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/CommunityQuestionsList.tsx
@@ -20,7 +20,6 @@ function avatarColorClass(id: number | string | undefined): string {
 type Props = {
     questions: Omit<StrapiResult<QuestionData[]>, 'meta'>
     isLoading: boolean
-    currentPage?: { url: string; title: string }
     forumUrl: string
 }
 
@@ -29,7 +28,7 @@ const MAX_VISIBLE = 4
 const AvatarStack = ({ profiles }: { profiles: any[] }) => {
     const visible = profiles.slice(0, MAX_VISIBLE)
     const overflow = Math.max(profiles.length - visible.length, 0)
-    const sizing = 'size-7 @md/reader-content:size-8'
+    const sizing = 'size-6 @md/reader-content:size-7'
 
     return (
         <div className="flex shrink-0 items-center">
@@ -69,7 +68,7 @@ const AvatarStack = ({ profiles }: { profiles: any[] }) => {
     )
 }
 
-const Row = ({ question, currentPage }: { question: QuestionData; currentPage?: { url: string; title: string } }) => {
+const Row = ({ question }: { question: QuestionData }) => {
     const {
         attributes: { profile, subject, permalink, replies, resolved, activeAt },
     } = question as any
@@ -104,7 +103,7 @@ const Row = ({ question, currentPage }: { question: QuestionData; currentPage?: 
                 <div className="flex items-center gap-4 @md/reader-content:gap-5">
                     <div className="min-w-0 flex-1">
                         <div className="flex items-start gap-2">
-                            <h3 className="m-0 !text-sm @md/reader-content:!text-base @2xl/reader-content:!text-lg font-semibold leading-snug text-primary line-clamp-2 group-hover:underline">
+                            <h3 className="m-0 !text-[15px] font-semibold leading-snug text-primary line-clamp-2 group-hover:underline">
                                 {subject}
                             </h3>
                             {resolved && (
@@ -140,7 +139,7 @@ const SkeletonRow = () => (
                     {[0, 1, 2].map((i) => (
                         <div
                             key={i}
-                            className={`size-7 @md/reader-content:size-8 rounded-full ring-2 ring-white dark:ring-dark bg-accent animate-pulse ${
+                            className={`size-6 @md/reader-content:size-7 rounded-full ring-2 ring-white dark:ring-dark bg-accent animate-pulse ${
                                 i === 0 ? '' : '-ml-2 @md/reader-content:-ml-2.5'
                             }`}
                         />
@@ -151,13 +150,13 @@ const SkeletonRow = () => (
     </li>
 )
 
-const CommunityQuestionsList = ({ questions, isLoading, currentPage, forumUrl }: Props) => {
+const CommunityQuestionsList = ({ questions, isLoading, forumUrl }: Props) => {
     const items = (questions?.data ?? []).filter(Boolean)
 
     if (isLoading && items.length === 0) {
         return (
             <ul className="m-0 p-0 list-none">
-                {Array.from({ length: 5 }).map((_, i) => (
+                {Array.from({ length: 3 }).map((_, i) => (
                     <SkeletonRow key={i} />
                 ))}
             </ul>
@@ -183,7 +182,7 @@ const CommunityQuestionsList = ({ questions, isLoading, currentPage, forumUrl }:
     return (
         <ul className="m-0 p-0 list-none">
             {items.map((question: any) => (
-                <Row key={question.id} question={question} currentPage={currentPage} />
+                <Row key={question.id} question={question} />
             ))}
         </ul>
     )

--- a/src/components/Products/ReaderViewProduct/templates/Eli5.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/Eli5.tsx
@@ -1,35 +1,22 @@
 import React from 'react'
 import { SectionComponentProps } from '../types'
-import CloudinaryImage from 'components/CloudinaryImage'
-import { DebugContainerQuery } from 'components/DebugContainerQuery'
+import { SectionHeading } from '../helpers'
 
 const Eli5 = ({ id, productData }: SectionComponentProps) => {
     const eli5 = productData?.overview?.eli5
-    const mobileHog = productData?.hogs?.mobileHog
-    const defaultHog = productData?.hogs?.default
-    const HogComponent = mobileHog?.Component || defaultHog?.Component
-    const hogSrc = mobileHog?.src || defaultHog?.src
-    const hogAlt = mobileHog?.alt || defaultHog?.alt || 'Mobile hog'
-    // Optional per-product size override (e.g. surveys sets a slightly larger hog).
-    const hogSizeClasses = mobileHog?.className || 'w-36 @lg/reader-content:w-48 @2xl/reader-content:w-56'
 
     if (!eli5) return null
 
     return (
         <section id={id} className="scroll-mt-20 not-prose">
-            <h2 className="mb-3">What does it do?</h2>
-            {(HogComponent || hogSrc) && (
-                <div
-                    className={`float-right ml-4 @2xl/reader-content:ml-8 @5xl/reader-content:-mt-8 max-w-full ${hogSizeClasses}`}
-                >
-                    {HogComponent ? (
-                        <HogComponent className="w-full h-auto" title={hogAlt} />
-                    ) : (
-                        <CloudinaryImage src={hogSrc} alt={hogAlt} className="w-full" />
-                    )}
-                </div>
-            )}
-            {typeof eli5 === 'string' ? <p>{eli5}</p> : eli5}
+            <SectionHeading>What does it do?</SectionHeading>
+            {/* Capped to a readable measure – around 75 characters a line. The
+                bullets used to sit in an 18rem column beside this copy, which
+                held it to roughly this width; without them it would run the full
+                container and hit 160+ characters a line on a wide monitor. */}
+            <div className="max-w-3xl text-lg leading-relaxed [&>p]:m-0 [&>p+p]:mt-4">
+                {typeof eli5 === 'string' ? <p>{eli5}</p> : eli5}
+            </div>
         </section>
     )
 }

--- a/src/components/Products/ReaderViewProduct/templates/Overview.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/Overview.tsx
@@ -7,7 +7,12 @@ import { DebugContainerQuery } from 'components/DebugContainerQuery'
 
 const Overview = ({ id, productData }: SectionComponentProps) => {
     const { name, Icon, overview, screenshots, status, hogs } = productData ?? {}
-    const HogComponent = hogs?.default?.Component
+    // Sized by height, not width: the art ranges from wide to tall portraits, and
+    // a fixed width makes the tall ones swamp the screenshot. It dips at `@3xl`
+    // because that is where the screenshot's own `max-w-*` cap shrinks it.
+    const hog = hogs?.mobileHog
+    const HogComponent = hog?.Component
+    const hogSizeClasses = hog?.className || 'h-32 @2xl/reader-content:h-52 @3xl/reader-content:h-44'
 
     return (
         <section id={id} className="scroll-mt-20 not-prose flex flex-col gap-12 max-w-9xl mx-auto w-full">
@@ -32,19 +37,16 @@ const Overview = ({ id, productData }: SectionComponentProps) => {
                                 imgClassName="h-auto rounded-lg transition-all duration-300"
                             />
                         )}
-                        {/* Optional – composite heroes (hog already in the art) skip this. */}
-                        {(HogComponent || hogs?.default?.src) && (
-                            <div className="absolute bottom-0 -right-4">
+                        {(HogComponent || hog?.src) && (
+                            <div className={`absolute -bottom-3 -right-6 ${hogSizeClasses}`}>
                                 {HogComponent ? (
-                                    <HogComponent
-                                        className="h-36 @2xl/reader-content:h-48 w-auto transition-all duration-300"
-                                        title={hogs.default.alt || name}
-                                    />
+                                    <HogComponent className="h-full w-auto" title={hog.alt || name} />
                                 ) : (
                                     <CloudinaryImage
-                                        src={hogs.default.src as `https://res.cloudinary.com/${string}`}
-                                        alt={hogs.default.alt || name}
-                                        imgClassName="h-36 @2xl/reader-content:h-48 transition-all duration-300"
+                                        src={hog.src as `https://res.cloudinary.com/${string}`}
+                                        alt={hog.alt || `${name} hedgehog`}
+                                        className="h-full"
+                                        imgClassName="h-full w-auto"
                                     />
                                 )}
                             </div>

--- a/src/components/Products/ReaderViewProduct/templates/PairsWith.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/PairsWith.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import Link from 'components/Link'
+import Glow, { type GlowColor } from 'components/Glow'
+import ToolsTicker, { DEFAULT_HANDLES } from 'components/Home/ToolsTicker'
 import { isAppIconName, AppIcon } from 'components/OSIcons/AppIcon'
+import { CARD_H3, SectionHeading } from '../helpers'
 import { SectionComponentProps } from '../types'
 
 interface PairItem {
@@ -10,45 +13,109 @@ interface PairItem {
     className?: string
 }
 
+const GLOW_COLORS: GlowColor[] = [
+    'yellow',
+    'blue',
+    'red',
+    'green',
+    'green-2',
+    'purple',
+    'orange',
+    'teal',
+    'seagreen',
+    'salmon',
+    'black',
+    'white',
+]
+
+/** Product colors are free-form strings; only some of them are valid glow colors. */
+const toGlowColor = (color?: string): GlowColor | undefined => GLOW_COLORS.find((glowColor) => glowColor === color)
+
 const PairsWith = ({ id, productData, allProducts }: SectionComponentProps) => {
     const pairsWith: PairItem[] = productData?.pairsWith || []
     if (!pairsWith.length) return null
 
+    // The ticker is the long tail, so drop anything already carded above (plus
+    // this product itself) or it just repeats what the reader has just read.
+    // `productData.handle` directly, because not every product surfaces in
+    // `allProducts` for the slug lookup to resolve — AI Observability doesn't,
+    // and was advertising itself in its own ticker.
+    const carded = new Set(
+        [
+            productData?.handle,
+            ...[productData?.slug, ...pairsWith.map((pair) => pair.slug)].map(
+                (slug) => allProducts.find((product: any) => product.slug === slug)?.handle
+            ),
+        ].filter(Boolean)
+    )
+    const tickerHandles = DEFAULT_HANDLES.filter((handle) => !carded.has(handle))
+
     return (
         <section id={id} className="scroll-mt-20 not-prose">
-            <h2 className="text-3xl font-bold text-primary mt-0 mb-3">Works with other PostHog tools</h2>
-            <p className="text-base text-secondary leading-relaxed m-0 mb-4">
-                Use {productData?.name} with these other PostHog apps to maximize shareholder value.
-            </p>
-            <h3 className="mb-4 !text-base">Works with...</h3>
-            <ul className="list-none space-y-4">
+            <SectionHeading
+                lede={`Use ${productData?.name} with these other PostHog apps to maximize shareholder value.`}
+            >
+                Works with other PostHog tools
+            </SectionHeading>
+            <ul className="grid grid-cols-1 @xl/reader-content:grid-cols-2 gap-3 list-none m-0 p-0">
                 {pairsWith.map((pair) => {
                     const productDetails = allProducts.find((product: any) => product.slug === pair.slug)
                     if (!productDetails) return null
 
+                    const glowColor = toGlowColor(productDetails.color)
+
+                    const card = (
+                        <Link
+                            to={`/${pair.slug}`}
+                            state={{ newWindow: true }}
+                            className="flex items-start gap-2.5 h-full border border-primary rounded bg-primary p-3 hover:bg-accent transition-colors"
+                        >
+                            <span
+                                className={`inline-block size-6 shrink-0 ${
+                                    productDetails.color ? `text-${productDetails.color}` : 'text-primary opacity-50'
+                                }`}
+                            >
+                                {productDetails.parentIcon && isAppIconName(productDetails.parentIcon) ? (
+                                    <AppIcon name={productDetails.parentIcon} className={pair.className} />
+                                ) : (
+                                    productDetails.Icon && <productDetails.Icon className={pair.className} />
+                                )}
+                            </span>
+                            <span className="min-w-0">
+                                <strong className={`block underline ${CARD_H3}`}>{productDetails.name}</strong>
+                                <span className="block text-sm text-secondary leading-relaxed">{pair.description}</span>
+                            </span>
+                        </Link>
+                    )
+
                     return (
-                        <li key={pair.slug} className="">
-                            <Link to={`/${pair.slug}`} state={{ newWindow: true }} className="flex items-center gap-2">
-                                <span
-                                    className={`inline-block size-6 ${
-                                        productDetails.color
-                                            ? `text-${productDetails.color}`
-                                            : 'text-primary opacity-50'
-                                    }`}
+                        <li key={pair.slug} className="m-0">
+                            {glowColor ? (
+                                <Glow
+                                    color={glowColor}
+                                    size="sm"
+                                    intensity="gentle"
+                                    rounded="md"
+                                    hover
+                                    className="h-full"
                                 >
-                                    {productDetails.parentIcon && isAppIconName(productDetails.parentIcon) ? (
-                                        <AppIcon name={productDetails.parentIcon} className={pair.className} />
-                                    ) : (
-                                        productDetails.Icon && <productDetails.Icon className={pair.className} />
-                                    )}
-                                </span>
-                                <h3 className="!text-lg font-bold text-primary underline">{productDetails.name}</h3>
-                            </Link>
-                            <p className="text-sm text-secondary m-0 pl-8">{pair.description}</p>
+                                    {card}
+                                </Glow>
+                            ) : (
+                                card
+                            )}
                         </li>
                     )
                 })}
             </ul>
+            {tickerHandles.length > 0 && (
+                <ToolsTicker
+                    handles={tickerHandles}
+                    label="And the rest of PostHog:"
+                    direction="right"
+                    className="mt-6"
+                />
+            )}
         </section>
     )
 }

--- a/src/components/Products/ReaderViewProduct/templates/UseCases.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/UseCases.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import OSTable from 'components/OSTable'
+import CloudinaryImage from 'components/CloudinaryImage'
+import { SectionHeading } from '../helpers'
 import { SectionComponentProps } from '../types'
 
 const columns = [
@@ -15,6 +17,9 @@ interface UseCasesData {
 const UseCases = ({ id, productData }: SectionComponentProps) => {
     const useCases: UseCasesData | undefined = productData?.useCases
     const rows = useCases?.rows ?? []
+    // The table caps out well short of the column, so the product hog fills the
+    // gap on the right. Desktop only – on mobile there is no gap to fill.
+    const hog = productData?.hogs?.default
 
     if (!rows.length) return null
 
@@ -24,16 +29,33 @@ const UseCases = ({ id, productData }: SectionComponentProps) => {
 
     return (
         <section id={id} className="scroll-mt-20 not-prose">
-            <h2 className="mb-3">Who is it for?</h2>
-            {useCases?.intro && <p>{useCases.intro}</p>}
-            <OSTable
-                columns={columns}
-                rows={tableRows}
-                size="sm"
-                rowAlignment="top"
-                width="full"
-                className="@2xl/reader-content-container:max-w-3xl"
-            />
+            <SectionHeading lede={useCases?.intro}>Who is it for?</SectionHeading>
+            {/* The hog column is a fixed width, so it costs the table 18rem plus
+                the gap wherever it appears. `@5xl` is where the container can
+                afford that and still leave the table ~44rem – enough to keep the
+                use-case cells at one or two lines. Below it the table goes full
+                width instead: a squeezed table wraps every cell to three lines,
+                which makes it tall, which in turn leaves the hog floating in
+                dead space. Both problems are the same problem. */}
+            <div className="grid grid-cols-1 gap-6 @5xl/reader-content:grid-cols-[minmax(0,1fr)_18rem] @5xl/reader-content:gap-8 items-stretch">
+                <div className="min-w-0">
+                    <OSTable columns={columns} rows={tableRows} size="sm" rowAlignment="top" width="full" />
+                </div>
+                {hog?.src && (
+                    // `relative` with no in-flow children means this grid item
+                    // contributes zero height to the row, so the row (and this
+                    // item, via `items-stretch`) is sized by the table alone –
+                    // the image can never end up taller than it, whatever its
+                    // native aspect ratio. `object-contain` then fits the image
+                    // into that box without distorting it.
+                    <CloudinaryImage
+                        src={hog.src}
+                        alt={hog.alt || `${productData?.name} hedgehog`}
+                        className="hidden @5xl/reader-content:block relative"
+                        imgClassName="absolute inset-0 size-full object-contain"
+                    />
+                )}
+            </div>
         </section>
     )
 }

--- a/src/components/SmallTeam/README.md
+++ b/src/components/SmallTeam/README.md
@@ -13,6 +13,8 @@ A component for mentioning PostHog small teams in MDX/Markdown content.
 -   `slug` (string, required): The team slug as stored in Strapi
 -   `noMiniCrest` (boolean, optional): If true, hides the mini crest and border for inline usage
 -   `className` (string, optional): Additional CSS classes
+-   `variant` (`'pill' | 'crest'`, optional, default `'pill'`): See "Crest variant" below
+-   `crestClassName` (string, optional): Sizing for the large crest when `variant="crest"`
 
 ## Features
 
@@ -20,6 +22,16 @@ A component for mentioning PostHog small teams in MDX/Markdown content.
 -   Links to the team's page (`/teams/{slug}`)
 -   Shows full crest in tooltip on hover, clicking tooltip opens team page in new window
 -   Falls back to displaying the slug as text if team is not found
+
+## Crest variant
+
+```tsx
+<SmallTeam slug="ai-observability" variant="crest" />
+```
+
+Renders the full crest at size next to the team name and tagline, with no tooltip — for places where the team is the point rather than a passing mention. Product pages use this in the "Questions?" section to credit the team that owns the product (`productData.teamSlug`).
+
+Degrades in steps: no full crest falls back to the mini crest, and no crest at all still renders the name as a link to the team page.
 
 ## Example with no mini crest
 

--- a/src/components/SmallTeam/index.tsx
+++ b/src/components/SmallTeam/index.tsx
@@ -10,9 +10,25 @@ export interface SmallTeamProps {
     noMiniCrest?: boolean
     inline?: boolean
     className?: string
+    /**
+     * `'pill'` (default) renders the inline mini-crest pill with the full crest
+     * in a hover tooltip. `'crest'` renders the full crest at size, next to the
+     * team name and tagline — for when the team is the point, not an aside.
+     */
+    variant?: 'pill' | 'crest'
+    /** Sizing for the large crest in `variant="crest"`. */
+    crestClassName?: string
 }
 
-export default function SmallTeam({ slug, children, inline = false, noMiniCrest = false, className = '' }: SmallTeamProps): JSX.Element | null {
+export default function SmallTeam({
+    slug,
+    children,
+    inline = false,
+    noMiniCrest = false,
+    className = '',
+    variant = 'pill',
+    crestClassName = '',
+}: SmallTeamProps): JSX.Element | null {
     const {
         allSqueakTeam: { nodes },
     } = useStaticQuery(graphql`
@@ -48,13 +64,52 @@ export default function SmallTeam({ slug, children, inline = false, noMiniCrest 
     const miniCrestImage = getImage(team.miniCrest)
     const fullCrestUrl = team.crest?.data?.attributes?.url
 
+    if (variant === 'crest') {
+        return (
+            <Link
+                to={`/teams/${team.slug}`}
+                state={{ newWindow: true }}
+                className={`group not-prose flex items-center gap-4 no-underline text-primary ${className}`}
+            >
+                {fullCrestUrl ? (
+                    <img
+                        src={fullCrestUrl}
+                        alt={`${team.name} team crest`}
+                        loading="lazy"
+                        className={`shrink-0 object-contain transition-transform group-hover:scale-105 ${
+                            crestClassName || 'size-20 @lg/reader-content:size-24'
+                        }`}
+                    />
+                ) : (
+                    miniCrestImage && (
+                        <GatsbyImage
+                            image={miniCrestImage}
+                            alt={`${team.name} mini crest`}
+                            className="size-8 shrink-0"
+                        />
+                    )
+                )}
+                <span className="min-w-0">
+                    <strong className="block text-[15px] text-primary group-hover:underline">{team.name} Team</strong>
+                    {team.tagline && (
+                        <em className="block text-sm text-secondary text-balance mt-0.5">{team.tagline}</em>
+                    )}
+                </span>
+            </Link>
+        )
+    }
+
     // The invisible block is necessary to make sure we have the proper width
     // with the `relative inline-block` parent when we include a mini crest
     const triggerContent = (
         <span className="relative inline-block">
             <Link to={`/teams/${team.slug}`} className={`group text-primary ${className}`} state={{ newWindow: true }}>
                 {!noMiniCrest && miniCrestImage && (
-                    <span className={`invisible max-h-4 inline-flex items-center gap-1.5 ${!inline && 'p-0.5 pr-1.5 border border-primary rounded-full'}`}>
+                    <span
+                        className={`invisible max-h-4 inline-flex items-center gap-1.5 ${
+                            !inline && 'p-0.5 pr-1.5 border border-primary rounded-full'
+                        }`}
+                    >
                         <span className="h-6 shrink-0 rounded-full overflow-hidden">
                             <GatsbyImage
                                 image={miniCrestImage}
@@ -68,13 +123,16 @@ export default function SmallTeam({ slug, children, inline = false, noMiniCrest 
                     </span>
                 )}
                 <span
-                    className={`inline-flex items-center ${!noMiniCrest && miniCrestImage
-                        ? [
-                            'absolute top-0 left-0 whitespace-nowrap gap-1.5',
-                            !inline ? 'p-0.5 pr-1.5 border border-primary rounded-full' : '',
-                        ].filter(Boolean).join(' ')
-                        : ''
-                        }`}
+                    className={`inline-flex items-center ${
+                        !noMiniCrest && miniCrestImage
+                            ? [
+                                  'absolute top-0 left-0 whitespace-nowrap gap-1.5',
+                                  !inline ? 'p-0.5 pr-1.5 border border-primary rounded-full' : '',
+                              ]
+                                  .filter(Boolean)
+                                  .join(' ')
+                            : ''
+                    }`}
                 >
                     {!noMiniCrest && miniCrestImage && (
                         <GatsbyImage
@@ -83,7 +141,11 @@ export default function SmallTeam({ slug, children, inline = false, noMiniCrest 
                             className="size-5 shrink-0"
                         />
                     )}
-                    <span className={`!text-sm ${inline ? 'underline' : 'group-hover:underline'} font-semibold inline-block truncate`}>
+                    <span
+                        className={`!text-sm ${
+                            inline ? 'underline' : 'group-hover:underline'
+                        } font-semibold inline-block truncate`}
+                    >
                         {children ? children : <>{team.name} Team</>}
                     </span>
                 </span>

--- a/src/hooks/productData/ai_observability.tsx
+++ b/src/hooks/productData/ai_observability.tsx
@@ -140,20 +140,20 @@ export const aiObservability = {
     },
     // Rendered in the Pricing surface footer CTA. The Product surface uses `hogs` below.
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/ai_robo_hog_9c1c225c94.png',
-        alt: 'A robot hedgehog',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/hog_cash_64f561fac6.png',
+        alt: 'A hedgehog showered in the money it saved on tokens',
         footerClasses: 'max-w-[220px]',
     },
     hogs: {
-        // Reused from the /docs/ai-observability hero – AI Observability has no
-        // dedicated product hog yet.
         default: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/ai_robo_hog_9c1c225c94.png',
-            alt: 'A hedgehog with a robot',
-        },
-        mobileHog: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_07_30_T02_00_13_105_Z_20a891ad6d.png',
             alt: 'A hedgehog inspecting a trace with a magnifying glass',
+        },
+        // Reused from the /docs/ai-observability hero – AI Observability has no
+        // dedicated product hog yet.
+        mobileHog: {
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/ai_robo_hog_9c1c225c94.png',
+            alt: 'A hedgehog with a robot',
         },
     },
     slider: {

--- a/src/hooks/productData/error_tracking.tsx
+++ b/src/hooks/productData/error_tracking.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import {
-    IconWarning,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconInfo,
+    IconList,
+    IconMagic,
     IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
+    IconWarning,
 } from '@posthog/icons'
 import { features } from './error_tracking/features'
 import { applications, topFeatures } from './error_tracking/slides'
@@ -148,8 +148,9 @@ export const errorTracking = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/error_hog_c2eff84e29.png',
-        alt: 'Just another hedgehog',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/police_hog_eb78977120.png',
+        alt: 'A hedgehog police officer on the case',
+        footerClasses: 'max-w-[200px]',
         classes: 'absolute bottom-0 right-0 max-w-[250px]',
     },
     hogs: {
@@ -351,8 +352,8 @@ export const errorTracking = {
         },
     ],
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/ERROR_TRACKING_2f807c123b.png',
-        imageAlt: 'PostHog AI and error tracking',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/Group_9514_d562b785cc.png',
+        imageAlt: 'A hedgehog inspecting a stack trace with a magnifying glass',
         description: 'investigate the exception and ship the fix',
         intro: 'Ask PostHog AI to find issues, inspect stack traces, and help ship the fix.',
         mcpFeatures: ['error_tracking'],

--- a/src/hooks/productData/experiments.tsx
+++ b/src/hooks/productData/experiments.tsx
@@ -1,20 +1,20 @@
 import React from 'react'
 import { getTool } from '../../data/tools'
 import {
-    IconFlask,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconFlask,
+    IconInfo,
+    IconList,
+    IconMagic,
     IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
     IconToggle,
 } from '@posthog/icons'
 import { features } from './experiments/features'
@@ -155,8 +155,9 @@ export const experiments = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/hogs/ab-testing-hog.png',
-        alt: 'Hedgehog experimenting',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/celebration.png',
+        alt: 'Hedgehogs celebrating a shipped experiment',
+        footerClasses: 'max-w-[420px]',
         classes: 'absolute bottom-0 right-0 max-w-md',
     },
     hogs: {
@@ -397,7 +398,8 @@ export const experiments = {
         ai: 'The PostHog MCP server lets your AI coding agent create and manage Experiments directly from your code editor. Set up A/B tests, check results, and manage Experiment lifecycle – without switching to the PostHog app.',
     },
     ai: {
-        // Distinct from hogs.mobileHog (test-tube hog on Eli5) – flask mascot from the PostHog AI page.
+        // Flask mascot from the PostHog AI page – deliberately different art from
+        // `hogs.mobileHog` (header) and `hogs.default` (use cases).
         image: 'https://res.cloudinary.com/dmukukwp6/image/upload/experiments_f90ed26268.png',
         imageAlt: 'PostHog AI and experiments',
         description: 'set up experiments, read the results, and ship the winner',
@@ -449,7 +451,7 @@ export const experiments = {
                 title: 'Timeseries',
                 tool: 'experiment-timeseries-results',
                 prompts: [
-                    'Show daily results for this experiment — is the lift a novelty effect?',
+                    'Show daily results for this experiment – is the lift a novelty effect?',
                     'Plot the experiment over time, not just the summary',
                 ],
             },
@@ -470,7 +472,7 @@ export const experiments = {
                 title: 'Duplicate',
                 tool: 'experiment-duplicate',
                 prompts: [
-                    'That pricing test won — clone it for the mobile flow and launch',
+                    'That pricing test won – clone it for the mobile flow and launch',
                     'Duplicate this experiment onto the signup page',
                 ],
             },

--- a/src/hooks/productData/feature_flags.tsx
+++ b/src/hooks/productData/feature_flags.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import {
-    IconToggle,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconInfo,
+    IconList,
+    IconMagic,
     IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
+    IconToggle,
 } from '@posthog/icons'
 import { features } from './feature_flags/features'
 import { applications, topFeatures } from './feature_flags/slides'
@@ -145,8 +145,9 @@ export const featureFlags = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/v1/posthog.com/src/components/Product/hogs/feature-flags-hog.png',
-        alt: 'A hedgehog toggling a feature flag',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/hogmillionaire_6a6c2c958d.png',
+        alt: 'A hedgehog holding an enormous banknote',
+        footerClasses: 'max-w-[240px]',
         classes: 'absolute bottom-0 right-0 max-w-md',
     },
     hogs: {
@@ -391,8 +392,8 @@ export const featureFlags = {
         ai: 'The PostHog MCP server lets your AI coding agent create and manage Feature Flags directly from your code editor. Create flags, configure targeting rules, and check rollout status – without switching to the PostHog app.',
     },
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/FEATURE_FLAGS_hog_95e008723c.png',
-        imageAlt: 'PostHog AI and feature flags',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/business_hog_adb9cf3c35.png',
+        imageAlt: 'A hedgehog in a suit deciding who gets the flag',
         description: 'roll a change out, watch the impact, and roll it back',
         intro: 'Ask PostHog AI to create flags, explain targeting, and clean up stale ones.',
         mcpFeatures: ['flags'],

--- a/src/hooks/productData/logs.tsx
+++ b/src/hooks/productData/logs.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 import {
     IconActivity,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconCursorClick,
     IconChat,
-    IconInfo,
-    IconMagic,
+    IconCheckCircle,
     IconCode,
     IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconInfo,
+    IconList,
+    IconMagic,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
 } from '@posthog/icons'
 import { HedgehogMagnifyingGlass } from '@posthog/brand/hoggies'
 import { features } from './logs/features'
@@ -126,8 +126,8 @@ export const logs = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/log_hog_55f5aaca56.png',
-        alt: 'A hedgehog perusing some logs',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/products/data-warehouse/warehouse-hog.png',
+        alt: 'A hedgehog in its log store',
         classes: 'hidden @2xl:block max-w-sm',
         footerClasses: 'max-w-[240px]',
     },
@@ -334,8 +334,8 @@ export const logs = {
     ],
     worksWith: ['session_replay', 'error_tracking', 'product_analytics', 'feature_flags'],
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/log_hog_55f5aaca56.png',
-        imageAlt: 'PostHog AI and logs',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/night_hog_219fff00f3.png',
+        imageAlt: 'A hedgehog asleep at a laptop after a long log dive',
         description: 'find the bug in your logs and ship the fix',
         intro: 'Ask PostHog AI to find error logs, mine patterns, and explain what changed.',
         mcpFeatures: ['logs'],

--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -259,7 +259,7 @@ export const posthog_ai = {
             icon: <IconRewindPlay className="size-5" />,
             color: 'yellow',
             description:
-                "Don't scrub through hours of recordings — let a robot suffer instead. Ask PostHog AI for the bloopers, sizzle reel, or directors cut of user behavior.",
+                "Don't scrub through hours of recordings – let a robot suffer instead. Ask PostHog AI for the bloopers, sizzle reel, or directors cut of user behavior.",
             images: [
                 {
                     src: 'https://res.cloudinary.com/dmukukwp6/image/upload/session_reply_6846989ead.png',
@@ -305,7 +305,7 @@ export const posthog_ai = {
             icon: <IconToggle className="size-5" />,
             color: 'green',
             description:
-                'PostHog AI sets up, monitors, manages, and rolls out your feature flags — making releases safe by default.',
+                'PostHog AI sets up, monitors, manages, and rolls out your feature flags – making releases safe by default.',
             images: [
                 {
                     src: 'https://res.cloudinary.com/dmukukwp6/image/upload/feature_flags_ce422c1e73.png',
@@ -349,7 +349,7 @@ export const posthog_ai = {
             icon: <IconFlask className="size-5" />,
             color: 'purple',
             description:
-                'Ship ideas like a mad scientist. PostHog AI handles setup, flags, and metrics — you decide what deploys (and which experiments never leave the lab).',
+                'Ship ideas like a mad scientist. PostHog AI handles setup, flags, and metrics – you decide what deploys (and which experiments never leave the lab).',
             images: [
                 {
                     src: 'https://res.cloudinary.com/dmukukwp6/image/upload/experiments_f90ed26268.png',
@@ -396,7 +396,7 @@ export const posthog_ai = {
             icon: <IconWarning className="size-5" />,
             color: 'orange',
             description:
-                'Find out what broke before your users tweet about it. PostHog AI connects exceptions to user sessions, revenue impact, and business context—not just stack traces.',
+                'Find out what broke before your users tweet about it. PostHog AI connects exceptions to user sessions, revenue impact, and business context – not just stack traces.',
             images: [
                 {
                     src: 'https://res.cloudinary.com/dmukukwp6/image/upload/error_tracking_53fc0bc180.png',

--- a/src/hooks/productData/product_analytics.tsx
+++ b/src/hooks/productData/product_analytics.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import {
-    IconGraph,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconGraph,
+    IconInfo,
+    IconList,
+    IconMagic,
     IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
 } from '@posthog/icons'
 import { FIFTY_MILLION, MAX_PRODUCT_ANALYTICS, MILLION, TEN_MILLION } from 'components/Pricing/pricingLogic'
 import { features } from './product_analytics/features'
@@ -170,14 +170,15 @@ export const productAnalytics = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/v1/posthog.com/src/components/Product/hogs/product-analytics-hog.png',
-        alt: 'A hedgehog presenting some shocking findings',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/competitors-hog.png',
+        alt: 'A hedgehog wearing a chart apron',
+        footerClasses: 'max-w-[220px]',
         classes: 'absolute bottom-0 right-4 max-w-lg',
     },
     hogs: {
         default: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/v1/posthog.com/src/components/Product/hogs/product-analytics-hog.png',
-            alt: 'A hedgehog presenting some shocking findings',
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/steve_hogs_17c7900b07.png',
+            alt: 'A hedgehog presenting a chart on stage',
         },
         mobileHog: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_hog_23b2808c18.png',
@@ -384,8 +385,8 @@ export const productAnalytics = {
         },
     ],
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_hog_23b2808c18.png',
-        imageAlt: 'PostHog AI and product analytics',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_hog_f6db3a01c9.png',
+        imageAlt: 'A hedgehog presenting some shocking findings',
         intro: 'Ask PostHog AI to answer product questions, build insights, and write SQL.',
         mcpFeatures: ['product_analytics', 'insights', 'sql', 'dashboards'],
         groups: [

--- a/src/hooks/productData/session_replay.tsx
+++ b/src/hooks/productData/session_replay.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import {
-    IconRewindPlay,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconInfo,
+    IconList,
+    IconMagic,
     IconMessage,
+    IconPieChart,
+    IconRewindPlay,
+    IconRocket,
+    IconSparkles,
 } from '@posthog/icons'
 import { features } from './session_replay/features'
 import { applications, topFeatures } from './session_replay/slides'
@@ -112,7 +112,7 @@ export const sessionReplay = {
         title: 'See how people use your product',
         description:
             'Session Replay is one of the tools that makes your product self-driving: play back sessions to see exactly why something happened so the fix is obvious. The context agents use to debug UI issues and nuanced user behavior in your product, website, or mobile app.',
-        eli5: "Session Replay records what happens in a user's session — clicks, scrolls, form inputs, page views, network requests, console logs — and plays it back like video. It's like watching a user's screen over their shoulder – it gives the nuance context you only get when you're actually watching them experience your product.",
+        eli5: "Session Replay records what happens in a user's session – clicks, scrolls, form inputs, page views, network requests, console logs – and plays it back like video. It's like watching a user's screen over their shoulder – it gives the nuance context you only get when you're actually watching them experience your product.",
         textColor: 'text-black', // tw
     },
     screenshots: {
@@ -227,8 +227,9 @@ export const sessionReplay = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/replay_hog_20fc000c14.png',
-        alt: 'A hedgehog watching some session recordings',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/FooterCTA/images/surprised-hog.png',
+        alt: 'A surprised hedgehog',
+        footerClasses: 'max-w-[240px]',
         classes: 'absolute bottom-0 right-0 max-w-[698px]',
     },
     hogs: {
@@ -236,7 +237,8 @@ export const sessionReplay = {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/replay_hog_20fc000c14.png',
         },
         mobileHog: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/w_800,c_limit,q_auto,f_auto/replay_mobile_hog_03d948364a.png',
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/SESSION_REPLAY_a3ca565731.png',
+            alt: 'A hedgehog film director with a clapperboard',
         },
     },
     slider: {
@@ -438,8 +440,8 @@ export const sessionReplay = {
         },
     ],
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/SESSION_REPLAY_a3ca565731.png',
-        imageAlt: 'PostHog AI and session replay',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/replay_mobile_hog_03d948364a.png',
+        imageAlt: 'A hedgehog filming and a hedgehog peeking around a phone showing session replay',
         intro: 'Ask PostHog AI to find a specific session or summarize a group of them.',
         groups: [
             {

--- a/src/hooks/productData/support.tsx
+++ b/src/hooks/productData/support.tsx
@@ -94,8 +94,13 @@ export const support = {
         textColor: 'text-black', // tw
     },
     hogs: {
+        default: {
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog_ai_hogs_d4c45b4550.png',
+            alt: 'A support team of hedgehogs at their desks',
+        },
         mobileHog: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/hog_phone_638d7d1ae4.png',
+            alt: 'A hedgehog answering a ticket on the phone',
         },
     },
     useCases: {
@@ -115,6 +120,8 @@ export const support = {
         ],
     },
     ai: {
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/support_hog_f7ed8447c9.png',
+        imageAlt: 'A lifeguard hedgehog with binoculars and a life ring',
         intro: 'Ask PostHog AI to triage, investigate, and answer tickets. Works in PostHog AI (in-app chat), PostHog Desktop, Slack, and your product editor (using the MCP).',
         mcpFeatures: ['conversations'],
         groups: [

--- a/src/hooks/productData/surveys.tsx
+++ b/src/hooks/productData/surveys.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import { getTool } from '../../data/tools'
 import {
-    IconMessage,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconInfo,
+    IconList,
+    IconMagic,
+    IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
 } from '@posthog/icons'
 import { features } from './surveys/features'
 import { applications, topFeatures } from './surveys/slides'
@@ -136,20 +136,19 @@ export const surveys = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png',
-        alt: 'A hedgehog looking at survey results',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/hoggie_mail_48daf2f4b4.png',
+        alt: 'A hedgehog posting a survey response',
         classes: 'absolute bottom-0 right-0 max-w-md',
         footerClasses: 'max-w-[240px]',
     },
     hogs: {
         default: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png',
-            alt: 'A hedgehog looking at survey results',
-        },
-        mobileHog: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png',
             alt: 'A hedgehog taking a survey with a rating scale',
-            className: 'w-44 @lg/reader-content:w-56 @2xl/reader-content:w-72',
+        },
+        mobileHog: {
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_hog_99cd6e8e8b.png',
+            alt: 'A hedgehog looking at survey results',
         },
     },
     slider: {

--- a/src/hooks/productData/web_analytics.tsx
+++ b/src/hooks/productData/web_analytics.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 import {
-    IconPieChart,
-    IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconCheckCircle,
-    IconInfo,
-    IconCursorClick,
-    IconMagic,
     IconChat,
+    IconCheckCircle,
     IconCode,
+    IconConfetti,
+    IconCursorClick,
+    IconEye,
+    IconInfo,
+    IconList,
+    IconMagic,
     IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
 } from '@posthog/icons'
 import { FIFTY_MILLION, MAX_PRODUCT_ANALYTICS, MILLION, TEN_MILLION } from 'components/Pricing/pricingLogic'
 import Link from 'components/Link'
@@ -161,15 +161,15 @@ export const webAnalytics = {
         },
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/web-analytics-hog.png',
-        alt: 'A hedgehog looking at web analytics',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/happy_hog_ebc59e4658.png',
+        alt: 'A hedgehog at a desk surrounded by charts',
         classes: 'absolute bottom-0 right-0 max-w-md',
         footerClasses: 'max-w-[240px]',
     },
     hogs: {
         default: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/web-analytics-hog.png',
-            alt: 'A hedgehog looking at web analytics',
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_92791a9d9b.png',
+            alt: 'PostHog AI and web analytics',
         },
         mobileHog: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/web_cursor_hog_2e5fec02ad.png',
@@ -364,8 +364,8 @@ export const webAnalytics = {
         },
     ],
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_92791a9d9b.png',
-        imageAlt: 'PostHog AI and web analytics',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/web-analytics-hog.png',
+        imageAlt: 'A hedgehog looking at web analytics',
         imageClasses: 'w-96',
         // Reshaped from presenterNotes.ai (existing MCP blurb)
         intro: 'Query web analytics data to check traffic trends, investigate anomalies, and build dashboards.',

--- a/src/hooks/productData/workflows.tsx
+++ b/src/hooks/productData/workflows.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import {
+    IconChat,
+    IconCheckCircle,
+    IconCode,
+    IconConfetti,
+    IconCursorClick,
     IconDecisionTree,
     IconEye,
-    IconSparkles,
-    IconList,
-    IconConfetti,
-    IconRocket,
-    IconPieChart,
-    IconCheckCircle,
     IconInfo,
-    IconCursorClick,
+    IconList,
     IconMagic,
-    IconChat,
-    IconCode,
     IconMessage,
+    IconPieChart,
+    IconRocket,
+    IconSparkles,
 } from '@posthog/icons'
 import { features } from './workflows/features'
 import { applications, topFeatures } from './workflows/slides'
@@ -315,8 +315,8 @@ export const workflows = {
     ],
     worksWith: ['experiments', 'product-analytics', 'feature-flags', 'error-tracking'],
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_hog_791169c2d0.png',
-        imageAlt: 'A hedgehog automating workflows',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/transformer_hedgehog_2a379334d7.png',
+        imageAlt: 'A robot hedgehog running a workflow',
         imageClasses: 'max-w-[360px]',
         description: 'build the automation and ship it on your behalf',
         // Reshaped from ai.skills + contents/docs/workflows/create-emails-ai.mdx
@@ -382,19 +382,20 @@ export const workflows = {
         },
     ],
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_066caea85f.png',
-        alt: 'the automator hedgehog',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/phone-hog-light.png',
+        alt: 'A hedgehog wiring up a workflow',
+        footerClasses: 'max-w-[360px]',
         classes: 'absolute bottom-0 right-0 w-auto h-auto max-w-[min(90vw,480px)] @2xl:max-w-xl',
     },
     hogs: {
         default: {
-            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_066caea85f.png',
-            alt: 'the automator hedgehog',
-        },
-        // Same art as ai.image – used as the Eli5 float-right hog.
-        mobileHog: {
             src: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_hog_791169c2d0.png',
             alt: 'A hedgehog automating workflows',
+        },
+        // Perches on the bottom-right of the Overview screenshot.
+        mobileHog: {
+            src: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_066caea85f.png',
+            alt: 'the automator hedgehog',
         },
     },
     videos: {


### PR DESCRIPTION
## Changes
Cosmetic updates to the tool pages. There's a lot more I'd like to do here, but this addresses the most pressing nits.

1. The pages are mixing old and new hoggie designs. Some (like product analytics) repeat a similar design. Updated all pages to have a new hog style in the header.

<img width="300" height="" alt="CleanShot 2026-08-06 at 14 00 03@2x" src="https://github.com/user-attachments/assets/1ef373b9-32b4-43da-aa24-477c71b00ec4" />
<img width="300" height="" alt="CleanShot 2026-08-06 at 13 59 11@2x" src="https://github.com/user-attachments/assets/0a57d24b-9d6f-4ed3-bc38-558d1bbb8ff7" />

2. Removed the hog next to "What does it do?" It felt unnecessary to have two spot illustrations above the fold. The paragraph is capped at a fixed max-width so it doesn't stretch full-bleed on big screens. 

3. Moved it next to "Who is it for?" table UseCases.tsx since there was a logical blank space there. The hog shows up beside the table, but only once the screen is wide enough to fit both without cramping the table. Below that width, it hides and the table gets the full row.

<img width="300" height="" alt="CleanShot 2026-08-06 at 14 10 54@2x" src="https://github.com/user-attachments/assets/77cee3a3-30df-4188-bac5-4560d6b4d4a1" />
<img width="300" height="" alt="CleanShot 2026-08-06 at 14 10 33@2x" src="https://github.com/user-attachments/assets/90ac217b-8919-45d2-8656-3297f925a07f" />

4. The headings we getting lost with the body text size being rather large.  Swapped in a bigger shared heading style, used only in the 4 sections that needed it (Eli5, Who is it for, Works with, Questions). Went from 1.5rem to 1.75rem.

<img width="300" height="" alt="CleanShot 2026-08-06 at 14 13 26@2x" src="https://github.com/user-attachments/assets/5fb7d55e-f23a-4336-acb7-1552ad0834eb" />
<img width="400" height="" alt="CleanShot 2026-08-06 at 14 13 08@2x" src="https://github.com/user-attachments/assets/10887ede-acef-474d-8e7e-172e11a28123" />

5. Swapped a few AI-prompt images that were repeats of an image higher on the page (updated art in error_tracking, support, session_replay, product_analytics, and web_analytics)

6. "Works with other tools" redesign + the scroller PairsWith.tsx since that's quite a nice component! I reversed the scroll because it doesn't make sense to me to go right to left (but I don't feel that strongly if it's bloat). Also turned the list (boring) into a card grid (icon + name + description per product) instead of a plain list, each card gets a subtle colored glow on hover (might be too subtle?)

<img width="300" height="" alt="CleanShot 2026-08-06 at 14 16 01@2x" src="https://github.com/user-attachments/assets/327aba8a-963a-49ff-beff-e1afb88d8487" />
<img width="400" height="" alt="CleanShot 2026-08-06 at 14 13 56@2x" src="https://github.com/user-attachments/assets/668f44c1-fef0-4f0a-861a-d0ab18521cad" />

7. "Who builds this" + community questions layout CommunityQuestions.tsx. Cut the questions shown from 5 to 3 (it was kind of overwhelming and too large). Added a "Who builds this" section added with the team's crest as I thought that a nbice callout without having the team member cards which were cut from another version. SmallTeam component got the crest display mode this needed.

<img width="300" height="" alt="CleanShot 2026-08-06 at 14 17 00@2x" src="https://github.com/user-attachments/assets/b5b0a826-2cc3-4657-b3f5-058e34e8369d" />
<img width="400" height="" alt="CleanShot 2026-08-06 at 14 16 40@2x" src="https://github.com/user-attachments/assets/af2e08b6-784e-4085-8078-b34ba837ffa4" />
