### PR TITLE
Strip "Team " prefix when matching roadmap role assignees to small teams

### DIFF
--- a/src/hooks/useRoadmapEarlyAccessFeatures.ts
+++ b/src/hooks/useRoadmapEarlyAccessFeatures.ts
@@ -34,6 +34,17 @@ const normalizeName = (name: string): string =>
         .replace(/\s+/g, ' ')
         .trim()
 
+/**
+ * Normalized candidates for matching a role assignee to a small team. PostHog roles are
+ * conventionally named "Team X" while Squeak team names are just "X", so try the name
+ * with a leading "team " (or trailing " team") stripped as well as verbatim.
+ */
+const roleNameCandidates = (name: string): string[] => {
+    const normalized = normalizeName(name)
+    const stripped = normalized.replace(/^team /, '').replace(/ team$/, '')
+    return stripped && stripped !== normalized ? [normalized, stripped] : [normalized]
+}
+
 interface SqueakTeamOwnershipNode {
     slug: string
     name: string
@@ -105,8 +116,14 @@ export function useRoadmapEarlyAccessFeatures({
                 return undefined
             }
             if (assignee.type === 'role') {
-                const asSlug = slugify(assignee.name)
-                return teamSlugByTeamName[normalizeName(assignee.name)] || (teamSlugs.has(asSlug) ? asSlug : undefined)
+                for (const candidate of roleNameCandidates(assignee.name)) {
+                    const asSlug = slugify(candidate)
+                    const match = teamSlugByTeamName[candidate] || (teamSlugs.has(asSlug) ? asSlug : undefined)
+                    if (match) {
+                        return match
+                    }
+                }
+                return undefined
             }
             return teamSlugByPerson[normalizeName(assignee.name)]
         },


### PR DESCRIPTION
## Changes

Every early access feature on /roadmap shows as Unassigned, even though assignees are set in PostHog and [#19198](https://github.com/PostHog/posthog.com/pull/19198) shipped the dynamic resolution.

- PostHog roles are named with a "Team " prefix ("Team Data Tools"), while Squeak team names are just "Data Tools".
- The role matcher compared normalized names and slugs verbatim, so every role assignee missed and fell back to Unassigned.
- The matcher now also tries the role name with a leading "Team " (or trailing " team") stripped.
- I (actually Claude) verified against the live public EAF endpoint: all five role names in use resolve to their team slug with this change, and none did before.

**Why:** the roadmap should reflect the team ownership set on early access features in the PostHog app, and today it shows Unassigned for all of them.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*