### PR TITLE
docs: mark batch export set/set_once columns as deprecated

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.mdx
+++ b/contents/docs/cdp/batch-exports/bigquery.mdx
@@ -127,8 +127,8 @@ This is the default model for BigQuery batch exports. The schema of the model as
 | event                 | `STRING`           | The name of the event that was sent                                       |
 | properties            | `STRING` or `JSON` | A JSON object with all the properties sent along with an event            |
 | elements              | `STRING`           | This field is present for backwards compatibility but has been deprecated |
-| set                   | `STRING` or `JSON` | A JSON object with any person properties sent with the `$set` field       |
-| set_once              | `STRING` or `JSON` | A JSON object with any person properties sent with the `$set_once` field  |
+| set                   | `STRING` or `JSON` | Deprecated. Person update payloads aren't retained on stored events       |
+| set_once              | `STRING` or `JSON` | Deprecated. Person update payloads aren't retained on stored events       |
 | distinct_id           | `STRING`           | The `distinct_id` of the user who sent the event                          |
 | team_id               | `INT64`            | The `team_id` for the event                                               |
 | ip                    | `STRING`           | The IP address that was sent with the event                               |

--- a/contents/docs/cdp/batch-exports/bigquery.mdx
+++ b/contents/docs/cdp/batch-exports/bigquery.mdx
@@ -125,10 +125,11 @@ This is the default model for BigQuery batch exports. The schema of the model as
 | --------------------- | ------------------ | ------------------------------------------------------------------------- |
 | uuid                  | `STRING`           | The unique ID of the event within PostHog                                 |
 | event                 | `STRING`           | The name of the event that was sent                                       |
-| properties            | `STRING` or `JSON` | A JSON object with all the properties sent along with an event            |
+| properties            | `STRING` or `JSON` | All the properties sent along with an event                               |
 | elements              | `STRING`           | This field is present for backwards compatibility but has been deprecated |
 | set                   | `STRING` or `JSON` | Deprecated. Person update payloads aren't retained on stored events       |
 | set_once              | `STRING` or `JSON` | Deprecated. Person update payloads aren't retained on stored events       |
+| person_properties     | `STRING` or `JSON` | All the person properties at the time the event was ingested              |
 | distinct_id           | `STRING`           | The `distinct_id` of the user who sent the event                          |
 | team_id               | `INT64`            | The `team_id` for the event                                               |
 | ip                    | `STRING`           | The IP address that was sent with the event                               |

--- a/contents/docs/cdp/batch-exports/databricks.mdx
+++ b/contents/docs/cdp/batch-exports/databricks.mdx
@@ -154,29 +154,30 @@ This section describes the models that can be exported to Databricks.
 
 This is the default model for Databricks batch exports. The schema of the model as created in Databricks is:
 
-| Field                          | Type        | Description                                                    |
-|--------------------------------|-------------|----------------------------------------------------------------|
-| uuid                           | `STRING`    | The unique ID of the event within PostHog                      |
-| event                          | `STRING`    | The name of the event that was sent                            |
-| properties                     | `VARIANT` or `STRING` | A JSON object with all the properties sent along with an event |
-| distinct_id                    | `STRING`    | The `distinct_id` of the user who sent the event               |
-| team_id                        | `BIGINT`    | The `team_id` for the event                                    |
-| timestamp                      | `TIMESTAMP` | The timestamp associated with an event                         |
-| databricks_ingested_timestamp  | `TIMESTAMP` | An additional metadata column, indicating when the event was ingested into Databricks          |
+| Field                         | Type                  | Description                                                                         |
+| ----------------------------- | --------------------- | ----------------------------------------------------------------------------------- |
+| uuid                          | `STRING`              | The unique ID of the event within PostHog                                           |
+| event                         | `STRING`              | The name of the event that was sent                                                 |
+| properties                    | `VARIANT` or `STRING` | All the properties sent along with an event                                         |
+| person_properties             | `VARIANT` or `STRING` | All the person properties at the time the event was ingested                        |
+| distinct_id                   | `STRING`              | The `distinct_id` of the user who sent the event                                    |
+| team_id                       | `BIGINT`              | The `team_id` for the event                                                         |
+| timestamp                     | `TIMESTAMP`           | The timestamp associated with an event                                              |
+| databricks_ingested_timestamp | `TIMESTAMP`           | An additional metadata column, indicating when the event was ingested into Databricks |
 
 ### Persons model
 
 The schema of the model as created in Databricks is:
 
-| Field                      | Type        | Description                                                                                                    |
-|----------------------------|-------------|----------------------------------------------------------------------------------------------------------------|
-| team_id                    | `BIGINT`    | The id of the project (team) the person belongs to                                                             |
-| distinct_id                | `STRING`    | A `distinct_id` associated with the person                                                                     |
-| person_id                  | `STRING`    | The id of the person associated to this (`team_id`, `distinct_id`) pair                                        |
-| properties                 | `VARIANT` or `STRING` | A JSON object with all the latest properties of the person                                           |
-| person_version             | `BIGINT`    | Internal version of the person properties, used by batch export in merge operation                             |
-| person_distinct_id_version | `BIGINT`    | Internal version of the person to `distinct_id` mapping, used by batch export in merge operation               |
-| created_at                 | `TIMESTAMP` | The timestamp when the person was created                                                                      |
+| Field                      | Type                  | Description                                                                                      |
+| -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| team_id                    | `BIGINT`              | The id of the project (team) the person belongs to                                               |
+| distinct_id                | `STRING`              | A `distinct_id` associated with the person                                                       |
+| person_id                  | `STRING`              | The id of the person associated to this (`team_id`, `distinct_id`) pair                          |
+| properties                 | `VARIANT` or `STRING` | A JSON object with all the latest properties of the person                                       |
+| person_version             | `BIGINT`              | Internal version of the person properties, used by batch export in merge operation               |
+| person_distinct_id_version | `BIGINT`              | Internal version of the person to `distinct_id` mapping, used by batch export in merge operation |
+| created_at                 | `TIMESTAMP`           | The timestamp when the person was created                                                        |
 
 The Databricks table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
 

--- a/contents/docs/cdp/batch-exports/postgres.mdx
+++ b/contents/docs/cdp/batch-exports/postgres.mdx
@@ -39,19 +39,20 @@ GRANT USAGE ON SCHEMA posthog_exports TO posthog;
 
 This is the default model for Postgres batch exports. The schema of the model as created in Postgres is:
 
-| Field       | Type                       | Description                                                               |
-| ----------- | -------------------------- | ------------------------------------------------------------------------- |
-| uuid        | `VARCHAR(200)`             | The unique ID of the event within PostHog                                 |
-| event       | `VARCHAR(200)`             | The name of the event that was sent                                       |
-| properties  | `JSONB`                    | A JSON object with all the properties sent along with an event            |
-| elements    | `JSONB`                    | This field is present for backwards compatibility but has been deprecated |
-| set         | `JSONB`                    | Deprecated. Person update payloads aren't retained on stored events       |
-| set_once    | `JSONB`                    | Deprecated. Person update payloads aren't retained on stored events       |
-| distinct_id | `VARCHAR(200)`             | The `distinct_id` of the user who sent the event                          |
-| team_id     | `INTEGER`                  | The `team_id` for the event                                               |
-| ip          | `VARCHAR(200)`             | The IP address that was sent with the event                               |
-| site_url    | `VARCHAR(200)`             | This field is present for backwards compatibility but has been deprecated |
-| timestamp   | `TIMESTAMP WITH TIME ZONE` | The timestamp associated with an event                                    |
+| Field             | Type                       | Description                                                               |
+| ----------------- | -------------------------- | ------------------------------------------------------------------------- |
+| uuid              | `VARCHAR(200)`             | The unique ID of the event within PostHog                                 |
+| event             | `VARCHAR(200)`             | The name of the event that was sent                                       |
+| properties        | `JSONB`                    | All the properties sent along with an event                               |
+| elements          | `JSONB`                    | This field is present for backwards compatibility but has been deprecated |
+| set               | `JSONB`                    | Deprecated. Person update payloads aren't retained on stored events       |
+| set_once          | `JSONB`                    | Deprecated. Person update payloads aren't retained on stored events       |
+| person_properties | `JSONB`                    | All the person properties at the time the event was ingested              |
+| distinct_id       | `VARCHAR(200)`             | The `distinct_id` of the user who sent the event                          |
+| team_id           | `INTEGER`                  | The `team_id` for the event                                               |
+| ip                | `VARCHAR(200)`             | The IP address that was sent with the event                               |
+| site_url          | `VARCHAR(200)`             | This field is present for backwards compatibility but has been deprecated |
+| timestamp         | `TIMESTAMP WITH TIME ZONE` | The timestamp associated with an event                                    |
 
 ### Persons model
 

--- a/contents/docs/cdp/batch-exports/postgres.mdx
+++ b/contents/docs/cdp/batch-exports/postgres.mdx
@@ -45,8 +45,8 @@ This is the default model for Postgres batch exports. The schema of the model as
 | event       | `VARCHAR(200)`             | The name of the event that was sent                                       |
 | properties  | `JSONB`                    | A JSON object with all the properties sent along with an event            |
 | elements    | `JSONB`                    | This field is present for backwards compatibility but has been deprecated |
-| set         | `JSONB`                    | A JSON object with any person properties sent with the `$set` field       |
-| set_once    | `JSONB`                    | A JSON object with any person properties sent with the `$set_once` field  |
+| set         | `JSONB`                    | Deprecated. Person update payloads aren't retained on stored events       |
+| set_once    | `JSONB`                    | Deprecated. Person update payloads aren't retained on stored events       |
 | distinct_id | `VARCHAR(200)`             | The `distinct_id` of the user who sent the event                          |
 | team_id     | `INTEGER`                  | The `team_id` for the event                                               |
 | ip          | `VARCHAR(200)`             | The IP address that was sent with the event                               |

--- a/contents/docs/cdp/batch-exports/redshift.mdx
+++ b/contents/docs/cdp/batch-exports/redshift.mdx
@@ -60,8 +60,8 @@ This is the default model for Redshift batch exports. The schema of the model as
 | event        | `VARCHAR(200)`                | The name of the event that was sent                                       |
 | properties   | `SUPER` or `VARCHAR(65535)`   | A JSON object with all the properties sent along with an event            |
 | elements     | `VARCHAR(65535)`              | This field is present for backwards compatibility but has been deprecated |
-| set          | `SUPER` or `VARCHAR(65535)`   | A JSON object with any person properties sent with the `$set` field       |
-| set_once     | `SUPER` or `VARCHAR(65535)`   | A JSON object with any person properties sent with the `$set_once` field  |
+| set          | `SUPER` or `VARCHAR(65535)`   | Deprecated. Person update payloads aren't retained on stored events       |
+| set_once     | `SUPER` or `VARCHAR(65535)`   | Deprecated. Person update payloads aren't retained on stored events       |
 | distinct_id  | `VARCHAR(200)`                | The `distinct_id` of the user who sent the event                          |
 | team_id      | `INTEGER`                     | The `team_id` for the event                                               |
 | ip           | `VARCHAR(200)`                | The IP address that was sent with the event                               |

--- a/contents/docs/cdp/batch-exports/redshift.mdx
+++ b/contents/docs/cdp/batch-exports/redshift.mdx
@@ -54,33 +54,34 @@ Finally, Redshift needs access to your S3 bucket too, and we must provide it wit
 
 This is the default model for Redshift batch exports. The schema of the model as created in Redshift is:
 
-| Field        | Type                          | Description                                                               |
-|--------------|-------------------------------|---------------------------------------------------------------------------|
-| uuid         | `VARCHAR(200)`                | The unique ID of the event within PostHog                                 |
-| event        | `VARCHAR(200)`                | The name of the event that was sent                                       |
-| properties   | `SUPER` or `VARCHAR(65535)`   | A JSON object with all the properties sent along with an event            |
-| elements     | `VARCHAR(65535)`              | This field is present for backwards compatibility but has been deprecated |
-| set          | `SUPER` or `VARCHAR(65535)`   | Deprecated. Person update payloads aren't retained on stored events       |
-| set_once     | `SUPER` or `VARCHAR(65535)`   | Deprecated. Person update payloads aren't retained on stored events       |
-| distinct_id  | `VARCHAR(200)`                | The `distinct_id` of the user who sent the event                          |
-| team_id      | `INTEGER`                     | The `team_id` for the event                                               |
-| ip           | `VARCHAR(200)`                | The IP address that was sent with the event                               |
-| site_url     | `VARCHAR(200)`                | This field is present for backwards compatibility but has been deprecated |
-| timestamp    | `TIMESTAMP WITH TIME ZONE`    | The timestamp associated with an event                                    |
+| Field             | Type                        | Description                                                               |
+| ----------------- | --------------------------- | ------------------------------------------------------------------------- |
+| uuid              | `VARCHAR(200)`              | The unique ID of the event within PostHog                                 |
+| event             | `VARCHAR(200)`              | The name of the event that was sent                                       |
+| properties        | `SUPER` or `VARCHAR(65535)` | All the properties sent along with an event                               |
+| elements          | `VARCHAR(65535)`            | This field is present for backwards compatibility but has been deprecated |
+| set               | `SUPER` or `VARCHAR(65535)` | Deprecated. Person update payloads aren't retained on stored events       |
+| set_once          | `SUPER` or `VARCHAR(65535)` | Deprecated. Person update payloads aren't retained on stored events       |
+| person_properties | `SUPER` or `VARCHAR(65535)` | All the person properties at the time the event was ingested              |
+| distinct_id       | `VARCHAR(200)`              | The `distinct_id` of the user who sent the event                          |
+| team_id           | `INTEGER`                   | The `team_id` for the event                                               |
+| ip                | `VARCHAR(200)`              | The IP address that was sent with the event                               |
+| site_url          | `VARCHAR(200)`              | This field is present for backwards compatibility but has been deprecated |
+| timestamp         | `TIMESTAMP WITH TIME ZONE`  | The timestamp associated with an event                                    |
 
 ### Persons model
 
 The schema of the model as created in Redshift is:
 
-| Field                      | Type               | Description                                                                                                                        |
-|----------------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| team_id                    | `INTEGER`        | The id of the project (team) the person belongs to                                                                                 |
-| distinct_id                | `VARCHAR(200)`           | A `distinct_id` associated with the person                                                                                         |
-| person_id                  | `VARCHAR(200)`           | The id of the person associated to this (`team_id`, `distinct_id`) pair                                                            |
-| properties                 | `SUPER` or `VARCHAR(65535)`   | A JSON object with all the latest properties of the person                                                                         |
-| person_distinct_id_version | `INTEGER`        | Internal version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation |
-| person_version             | `INTEGER`        | Internal version of the person properties associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation               |
-| created_at                 | `TIMESTAMP WITH TIME ZONE`    | The timestamp when the person was created                                                                                          |
+| Field                      | Type                        | Description                                                                                                                                        |
+| -------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| team_id                    | `INTEGER`                   | The id of the project (team) the person belongs to                                                                                                 |
+| distinct_id                | `VARCHAR(200)`              | A `distinct_id` associated with the person                                                                                                         |
+| person_id                  | `VARCHAR(200)`              | The id of the person associated to this (`team_id`, `distinct_id`) pair                                                                            |
+| properties                 | `SUPER` or `VARCHAR(65535)` | A JSON object with all the latest properties of the person                                                                                         |
+| person_distinct_id_version | `INTEGER`                   | Internal version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation |
+| person_version             | `INTEGER`                   | Internal version of the person properties associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation               |
+| created_at                 | `TIMESTAMP WITH TIME ZONE`  | The timestamp when the person was created                                                                                                          |
 
 The Redshift table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
 

--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -31,18 +31,18 @@ This section describes the models that can be exported to S3.
 
 This is the default model for S3 batch exports. When exported in the Parquet file format, the schema is:
 
-| Field             | Type        | Description                                                                                                 |
-| ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
-| uuid              | `STRING`    | The unique ID of the event within PostHog                                                                   |
-| event             | `STRING`    | The name of the event that was sent                                                                         |
-| distinct_id       | `STRING`    | The `distinct_id` of the user who sent the event                                                            |
-| person_id         | `STRING`    | The ID of the person the event is attributed to, resolved at ingestion time                                 |
-| properties        | `STRING`    | A JSON object with all the properties sent along with the event, stored as a JSON-encoded string in Parquet |
-| person_properties | `STRING`    | A JSON object with the person's properties at ingestion time, stored as a JSON-encoded string in Parquet    |
-| elements_chain    | `STRING`    | The chain of DOM elements for `$autocapture` events. Empty for other events                                 |
-| timestamp         | `TIMESTAMP` | When the event occurred, as reported by the client. Microsecond precision, UTC                              |
-| created_at        | `TIMESTAMP` | When PostHog ingested the event. Microsecond precision, UTC                                                 |
-| \_inserted_at     | `TIMESTAMP` | Internal field used by batch exports to track export progress. Included in files but safe to ignore         |
+| Field             | Type        | Description                                                                                              |
+| ----------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| uuid              | `STRING`    | The unique ID of the event within PostHog                                                                |
+| event             | `STRING`    | The name of the event that was sent                                                                      |
+| distinct_id       | `STRING`    | The `distinct_id` of the user who sent the event                                                         |
+| person_id         | `STRING`    | The ID of the person the event is attributed to, resolved at ingestion time                              |
+| properties        | `STRING`    | All the properties sent along with the event, stored as a JSON-encoded string in Parquet                 |
+| person_properties | `STRING`    | All the person properties at the time the event was ingested, stored as a JSON-encoded string in Parquet |
+| elements_chain    | `STRING`    | The chain of DOM elements for `$autocapture` events. Empty for other events                              |
+| timestamp         | `TIMESTAMP` | When the event occurred, as reported by the client. Microsecond precision, UTC                           |
+| created_at        | `TIMESTAMP` | When PostHog ingested the event. Microsecond precision, UTC                                              |
+| \_inserted_at     | `TIMESTAMP` | Internal field used by batch exports to track export progress. Included in files but safe to ignore      |
 
 > **Note:** The types above describe the **Parquet** file format. Other file formats represent the same data differently. For example, in **JSONLines** exports the timestamp fields (`timestamp`, `created_at`, and `_inserted_at`) are ISO 8601 strings, and `properties` and `person_properties` are nested JSON objects rather than JSON-encoded strings.
 

--- a/contents/docs/cdp/batch-exports/snowflake.mdx
+++ b/contents/docs/cdp/batch-exports/snowflake.mdx
@@ -86,8 +86,8 @@ This is the default model for Snowflake batch exports. The schema of the model a
 | event                        | `STRING`    | The name of the event that was sent                                       |
 | properties                   | `VARIANT`   | A JSON object with all the properties sent along with an event            |
 | elements                     | `VARIANT`   | This field is present for backwards compatibility but has been deprecated |
-| people_set                   | `VARIANT`   | A JSON object with any person properties sent with the `$set` field       |
-| people_set_once              | `VARIANT`   | A JSON object with any person properties sent with the `$set_once` field  |
+| people_set                   | `VARIANT`   | Deprecated. Person update payloads aren't retained on stored events       |
+| people_set_once              | `VARIANT`   | Deprecated. Person update payloads aren't retained on stored events       |
 | distinct_id                  | `STRING`    | The `distinct_id` of the user who sent the event                          |
 | team_id                      | `INTEGER`   | The `team_id` for the event                                               |
 | ip                           | `STRING`    | The IP address that was sent with the event                               |

--- a/contents/docs/cdp/batch-exports/snowflake.mdx
+++ b/contents/docs/cdp/batch-exports/snowflake.mdx
@@ -84,10 +84,11 @@ This is the default model for Snowflake batch exports. The schema of the model a
 | ---------------------------- | ----------- | ------------------------------------------------------------------------- |
 | uuid                         | `STRING`    | The unique ID of the event within PostHog                                 |
 | event                        | `STRING`    | The name of the event that was sent                                       |
-| properties                   | `VARIANT`   | A JSON object with all the properties sent along with an event            |
+| properties                   | `VARIANT`   | All the properties sent along with an event                               |
 | elements                     | `VARIANT`   | This field is present for backwards compatibility but has been deprecated |
 | people_set                   | `VARIANT`   | Deprecated. Person update payloads aren't retained on stored events       |
 | people_set_once              | `VARIANT`   | Deprecated. Person update payloads aren't retained on stored events       |
+| person_properties            | `VARIANT`   | All the person properties at the time the event was ingested              |
 | distinct_id                  | `STRING`    | The `distinct_id` of the user who sent the event                          |
 | team_id                      | `INTEGER`   | The `team_id` for the event                                               |
 | ip                           | `STRING`    | The IP address that was sent with the event                               |


### PR DESCRIPTION
## Changes

Marks the `set` / `set_once` columns as deprecated in the default model schema tables for the BigQuery, Snowflake, Postgres, and Redshift batch export destinations. The wording matches what those same tables already use for the deprecated `elements` and `site_url` columns.

Split out of [#19325](https://github.com/PostHog/posthog.com/pull/19325), which handles the rest of the `$set` / `$set_once` query deprecation, so that migration guidance for these columns can land here separately.

### Why

`$set` and `$set_once` are being deprecated from querying, so the destination columns fed by them shouldn't be presented as a way to read person data. A follow-up will document what to migrate to.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*