### PR TITLE
docs: document capture-group aliases for path cleaning

### DIFF
--- a/contents/docs/_snippets/path-cleaning.mdx
+++ b/contents/docs/_snippets/path-cleaning.mdx
@@ -34,6 +34,8 @@ Each rule has two parts:
 
 When a URL matches the regex, the matched portion is replaced with the alias. The rest of the URL remains unchanged.
 
+Rules run against whichever URL property is being cleaned. That's a path like `/user/123/profile` for the web analytics tiles, but a full URL like `https://example.com/user/123/profile` for a [Paths insight](/docs/product-analytics/paths) or a breakdown by `$current_url` – so a pattern anchored with `^/` matches the first and not the second. Test a rule against a sample URL in project settings before you save it.
+
 ## Examples
 
 Here are common path cleaning patterns:
@@ -67,27 +69,39 @@ This turns `https://example.com/merchant/12345/dashboard` and `https://example.c
 
 ## Reusing part of the matched URL
 
-The examples above replace the matched text with a fixed string. When your routes all share a shape, that forces one rule per route – a rule for `/team/:id/settings`, another for `/team/:id/billing`, and so on for every page.
+Because only the matched portion is replaced, a fixed alias already handles a segment that varies. The `/user/:id` rule above cleans both `/user/123/profile` and `/user/456/settings`, because `/profile` and `/settings` sit outside the match and are left alone.
 
-Instead, wrap the part of the URL you want to keep in a capture group and reference it from the alias with `\1`. One rule then covers every route with that shape.
+You need a capture group when the part you want to keep sits *inside* the match – when the regex has to reach past it to get to whatever you're removing. Wrap that part in parentheses and reference it from the alias with `\1`.
 
-### Replace a prefix, keep the rest
+### Group deep pages by their section
 
-Locale-prefixed routes split each page into one row per language. To collapse them into a single row:
+To collapse everything below the second path segment into one row per section:
 
-- **Regex:** `^/[a-z]{2}-[a-z]{2}(/.*)$`
-- **Alias:** `/:locale\1`
+- **Regex:** `^(/[^/]+/[^/]+)/.*$`
+- **Alias:** `\1`
 
-This turns `/en-us/pricing` and `/de-de/pricing` into `/:locale/pricing`, and `/en-us/docs` into `/:locale/docs`. Without the capture group, you'd need a separate rule for every page on the site.
+| Original path                     | Cleaned path              |
+| --------------------------------- | ------------------------- |
+| `/docs/product-analytics/trends`  | `/docs/product-analytics` |
+| `/docs/product-analytics/funnels` | `/docs/product-analytics` |
+| `/docs/web-analytics/dashboard`   | `/docs/web-analytics`     |
+
+The regex has to run to the end of the path to match the part it's dropping, which means it also matches the two segments you want to keep. `\1` puts them back. A fixed alias can't do this, because the text to keep is different on every row. Paths shorter than three segments don't match at all, so `/docs` is left as it is.
 
 ### Keep the path, drop a trailing fragment
 
-To strip an in-page fragment while keeping the first three segments of the path:
+To strip an in-page fragment, but only from paths that are exactly three segments deep:
 
 - **Regex:** `^(/[^/#]+/[^/#]+/[^/#]+)/#.*$`
 - **Alias:** `\1`
 
-This turns `/reports/2024/summary/#revenue` and `/reports/2024/summary/#costs` into `/reports/2024/summary`.
+| Original path                    | Cleaned path            |
+| -------------------------------- | ----------------------- |
+| `/reports/2024/summary/#revenue` | `/reports/2024/summary` |
+| `/reports/2024/summary/#costs`   | `/reports/2024/summary` |
+| `/reports/2023/detail/#revenue`  | `/reports/2023/detail`  |
+
+Here the capture group does double duty: it keeps the path, and spelling out the three segments is what limits the rule to that shape. A rule that matched only `/#...` would strip fragments from every path on the site.
 
 ### Alias syntax
 
@@ -106,9 +120,9 @@ Everything else in the alias is treated as literal text. A few things to watch f
 
 ### When to use capture groups
 
-A rule with capture groups costs more per row than one with a fixed alias, because the regex engine has to track where each group starts and ends instead of only whether the pattern matched. That's still a win when it collapses several near-identical rules into one, since every rule runs against every row: five rules replaced by one means four fewer patterns to evaluate.
+A capture group costs more per row than a fixed alias, because the regex engine has to track where each group starts and ends instead of only whether the pattern matched. It still pays off when it collapses several near-identical rules into one, since every rule runs against every row.
 
-Anchor your regex with `^` either way. Path cleaning replaces every match in a URL, not just the first, so an unanchored pattern keeps scanning the rest of the string.
+Anchor your regex where you can – `^` when you're matching a path, `$` when the pattern runs to the end of the URL. Path cleaning replaces every match in the value, not just the first, so an unanchored pattern keeps scanning after it has found what you were looking for, and can match again somewhere you didn't intend.
 
 ## Where path cleaning applies
 

--- a/contents/docs/_snippets/path-cleaning.mdx
+++ b/contents/docs/_snippets/path-cleaning.mdx
@@ -34,7 +34,7 @@ Each rule has two parts:
 
 When a URL matches the regex, the matched portion is replaced with the alias. The rest of the URL remains unchanged.
 
-Rules run against whichever URL property is being cleaned. That's a path like `/user/123/profile` for the web analytics tiles, but a full URL like `https://example.com/user/123/profile` for a [Paths insight](/docs/product-analytics/paths) or a breakdown by `$current_url` – so a pattern anchored with `^/` matches the first and not the second. Test a rule against a sample URL in project settings before you save it.
+Rules run against whichever URL property is being cleaned. That's a path like `/user/123/profile` for the web analytics tiles, but a full URL like `https://example.com/user/123/profile` for a [Paths insight](/docs/product-analytics/paths) or a breakdown by `$current_url` – so a pattern anchored with `^/` matches the first and not the second. Test a rule against a sample URL in project settings before you save it, or write one that [handles both](#matching-both-paths-and-full-urls).
 
 ## Examples
 
@@ -102,6 +102,22 @@ To strip an in-page fragment, but only from paths that are exactly three segment
 | `/reports/2023/detail/#revenue`  | `/reports/2023/detail`  |
 
 Here the capture group does double duty: it keeps the path, and spelling out the three segments is what limits the rule to that shape. A rule that matched only `/#...` would strip fragments from every path on the site.
+
+### Matching both paths and full URLs
+
+Both rules above are anchored with `^/`, so they only match a path. Don't fix that by dropping the anchor – an unanchored pattern happily matches the hostname as if it were a path segment. The section rule without its `^` turns `https://example.com/docs/product-analytics/trends` into `https://example.com/docs`, because `example.com` gets counted as the first segment.
+
+Make the scheme and host an optional group instead, and put it back with `\1`:
+
+- **Regex:** `^(https?://[^/]+)?(/[^/]+/[^/]+)/.*$`
+- **Alias:** `\1\2`
+
+| Original URL                                        | Cleaned URL                                  |
+| --------------------------------------------------- | -------------------------------------------- |
+| `/docs/product-analytics/trends`                    | `/docs/product-analytics`                    |
+| `https://example.com/docs/product-analytics/trends` | `https://example.com/docs/product-analytics` |
+
+When the value has no scheme and host, group 1 matches nothing and `\1` substitutes an empty string, so one rule covers both.
 
 ### Alias syntax
 

--- a/contents/docs/_snippets/path-cleaning.mdx
+++ b/contents/docs/_snippets/path-cleaning.mdx
@@ -30,7 +30,7 @@ Path cleaning rules are configured globally in your [project settings](https://a
 Each rule has two parts:
 
 - **Regex** – a regular expression that matches the URL patterns you want to combine.
-- **Alias** – the replacement string for the matched portion of the URL.
+- **Alias** – the replacement for the matched portion of the URL. This is usually a fixed placeholder like `/user/:id`, but it can also [reuse part of the matched URL](#reusing-part-of-the-matched-url).
 
 When a URL matches the regex, the matched portion is replaced with the alias. The rest of the URL remains unchanged.
 
@@ -64,6 +64,51 @@ To combine merchant-specific dashboards:
 - **Alias:** `/merchant/dashboard`
 
 This turns `https://example.com/merchant/12345/dashboard` and `https://example.com/merchant/6789/dashboard` into `https://example.com/merchant/dashboard`.
+
+## Reusing part of the matched URL
+
+The examples above replace the matched text with a fixed string. When your routes all share a shape, that forces one rule per route – a rule for `/team/:id/settings`, another for `/team/:id/billing`, and so on for every page.
+
+Instead, wrap the part of the URL you want to keep in a capture group and reference it from the alias with `\1`. One rule then covers every route with that shape.
+
+### Replace a prefix, keep the rest
+
+Locale-prefixed routes split each page into one row per language. To collapse them into a single row:
+
+- **Regex:** `^/[a-z]{2}-[a-z]{2}(/.*)$`
+- **Alias:** `/:locale\1`
+
+This turns `/en-us/pricing` and `/de-de/pricing` into `/:locale/pricing`, and `/en-us/docs` into `/:locale/docs`. Without the capture group, you'd need a separate rule for every page on the site.
+
+### Keep the path, drop a trailing fragment
+
+To strip an in-page fragment while keeping the first three segments of the path:
+
+- **Regex:** `^(/[^/#]+/[^/#]+/[^/#]+)/#.*$`
+- **Alias:** `\1`
+
+This turns `/reports/2024/summary/#revenue` and `/reports/2024/summary/#costs` into `/reports/2024/summary`.
+
+### Alias syntax
+
+| Syntax       | Meaning                                                          |
+| ------------ | ---------------------------------------------------------------- |
+| `\1` to `\9` | The first to ninth capture group, counted by opening parenthesis |
+| `\0`         | The whole matched string                                         |
+| `\\`         | A literal backslash                                              |
+
+Everything else in the alias is treated as literal text. A few things to watch for:
+
+- **`$1` does nothing.** Aliases use `\1`, not the `$1` syntax you may know from JavaScript. `$` is always literal, so an alias of `/user/$1` cleans paths to the literal string `/user/$1`.
+- **There's no `\10`.** Only `\1` to `\9` are capture groups. `\10` reads as group 1 followed by a literal `0`, so with a regex capturing `123`, an alias of `/user/\10` gives `/user/1230`.
+- **The group has to exist.** PostHog rejects a rule when you save it if the alias references a group that its regex doesn't define, such as `\2` in a regex with only one group.
+- **Double the backslash in JSON.** In your project settings, type `\1`. If you set rules through the API, JSON needs the backslash escaped: `"alias": "/:locale\\1"`.
+
+### When to use capture groups
+
+A rule with capture groups costs more per row than one with a fixed alias, because the regex engine has to track where each group starts and ends instead of only whether the pattern matched. That's still a win when it collapses several near-identical rules into one, since every rule runs against every row: five rules replaced by one means four fewer patterns to evaluate.
+
+Anchor your regex with `^` either way. Path cleaning replaces every match in a URL, not just the first, so an unanchored pattern keeps scanning the rest of the string.
 
 ## Where path cleaning applies
 


### PR DESCRIPTION
## Changes

Documents capture-group aliases on the path cleaning page. Until now the page described the alias as *"the replacement string for the matched portion of the URL"* and showed only fixed aliases, so there was no way to discover that an alias can reference the regex's capture groups.

Adds a **Reusing part of the matched URL** section to `contents/docs/_snippets/path-cleaning.mdx` (imported by both the Web Analytics and Product Analytics path cleaning pages, so one edit covers both) with:

- Two worked examples, each shown as a before/after table, where the capture group is genuinely load-bearing – grouping deep pages by section, and dropping a trailing fragment from paths of a given shape.
- The alias syntax table: `\1` to `\9`, `\0`, `\\`.
- The gotchas that actually bite: `$1` stays literal, there's no `\10`, PostHog rejects an out-of-range group reference on save, and JSON callers need the backslash doubled.
- When a capture group is worth its extra per-row cost.

The **Alias** bullet in "Configuring path cleaning rules" is also updated so it no longer implies the alias must be a fixed string, and a new line there spells out which value rules are matched against – a path for the web analytics tiles, but a full URL for a Paths insight or a URL breakdown. That distinction was missing, and it decides whether a leading `^/` anchor matches anything at all.

A **Matching both paths and full URLs** subsection then gives the way out: make the scheme and host an optional capture group. It also documents the trap, since simply dropping the `^` anchor doesn't fail loudly – the hostname gets counted as a path segment instead, so the rule quietly returns the wrong grouping.

## Why

Capture-group aliases shipped in PostHog/posthog#78193, which fixed the in-app previews, added save-time validation, and updated the in-app and MCP copy. Its own "Docs update" note flags this public page as the remaining follow-up. Without it, anyone whose routes share a shape still writes one rule per route instead of one rule for all of them.

Every example was verified by running the same replacement the query layer uses, rather than taken from the implementation on trust. That check is what caught the first draft's flagship example: it collapsed a locale prefix, which needs no capture group at all, because path cleaning only replaces the *matched* portion of the URL and a fixed alias already leaves the rest alone. Both forms produced byte-identical output, so the example taught the feature on a case that didn't need it. The section now leads with why a fixed alias is usually enough, then shows the cases where the text you want to keep differs on every row and only `\1` will do.

The new section was also checked with `markdownlint-cli2` and compiled through MDX v1 to confirm the backslashes survive the parse.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a – no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

