### PR TITLE
Add semantic layer copy to data modeling page

### DIFF
--- a/src/pages/context-warehouse/data-modeling.tsx
+++ b/src/pages/context-warehouse/data-modeling.tsx
@@ -147,6 +147,22 @@ export default function DataModeling(): JSX.Element {
                     <li>Implement data retention policies</li>
                     <li>Apply GDPR/CCPA compliance rules</li>
                 </ul>
+
+                <hr />
+
+                <h2>Semantic layer: define metrics once, trust them everywhere</h2>
+                <p>
+                    Ask three AI tools "what's our MRR?" and you can get three different numbers, because the definition
+                    lives in people's heads.
+                </p>
+                <p>
+                    The semantic layer fixes this: it's a per-project catalog of governed metrics, table certifications,
+                    and reviewed joins that every agent, and human, reads from the same place. Define a metric once,
+                    approve it once, and every session returns the same number.
+                </p>
+                <p>
+                    <Link to="/docs/semantic-layer">Read the Docs →</Link>
+                </p>
             </ReaderView>
         </>
     )


### PR DESCRIPTION
## Changes

Adds a "Semantic layer" section to the bottom of the [/context-warehouse/data-modeling](https://posthog.com/context-warehouse/data-modeling) page, introducing it as a per-project catalog of governed metrics, table certifications, and reviewed joins that every agent and human reads from the same place, with a link to the docs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)