### PR TITLE
Add CardHog to sparks-joy games

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -1001,6 +1001,12 @@ export const SparksJoyItems = {
             iconName: 'games' as AppIconName,
             customIcon: null,
         },
+        {
+            label: 'CardHog',
+            link: '/sparks-joy/cardhog',
+            iconName: 'games' as AppIconName,
+            customIcon: null,
+        },
     ],
     notGames: [
         {

--- a/src/pages/sparks-joy/cardhog/index.tsx
+++ b/src/pages/sparks-joy/cardhog/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import Explorer from 'components/Explorer'
+import SEO from 'components/seo'
+
+export default function CardHog(): JSX.Element {
+    return (
+        <>
+            <SEO
+                title="CardHog - PostHog"
+                description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
+                image={`/images/og/default.png`}
+            />
+            <Explorer
+                template="generic"
+                slug="cardhog"
+                title="CardHog"
+                showAddressBar={false}
+                headerBarOptions={[]}
+                fullScreen
+            >
+                {/* Swap to the custom domain (e.g. https://cardhog.posthog.com/) once it's set up. */}
+                <iframe src="https://cardhog-ua7rv.ondigitalocean.app/" className="w-full h-full border-0" />
+            </Explorer>
+        </>
+    )
+}


### PR DESCRIPTION
## Changes

Adds **CardHog** as a game on the PostHog OS "fun desktop" site, alongside BrickHog, HogWars, and HogPatch.

- New page at `/sparks-joy/cardhog` that embeds the deployed app in an `<Explorer>` iframe — the same pattern the other iframe games use.
- One registry entry in `src/components/TaskBarMenu/menuData.tsx` so CardHog shows up in the `/sparks-joy` grid and the "Sparks joy" taskbar menu, using the shared `games` icon.

The iframe points at the app's current DigitalOcean deployment; there's an inline comment marking where to swap in a custom domain (e.g. `cardhog.posthog.com`) once it's set up.

## Why

Integrates CardHog into the site's collection of easter-egg games so it's playable from the fun desktop site.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
