### PR TITLE
docs: Add data warehouse source docs for impact.com and impact.com Partner

### DIFF
--- a/contents/docs/cdp/sources/impact-partner.md
+++ b/contents/docs/cdp/sources/impact-partner.md
@@ -1,0 +1,59 @@
+---
+title: Linking impact.com Partner as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: ImpactPartner
+---
+
+import SourceSetupIntro from "../\_snippets/source-setup-intro.mdx"
+import SyncModes from "../\_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../\_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../\_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The impact.com Partner connector syncs the data your partner (publisher) account sees on [impact.com](https://impact.com): the brand programs you've joined, the conversions credited to you, and the invoices for your earnings. If your account is a brand (advertiser) account, use the [impact.com source](/docs/cdp/sources/impact) instead.
+
+## Prerequisites
+
+You need an impact.com partner account with API access. The connector authenticates with an API access token, which any account user can create from their profile settings.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking impact.com Partner, you'll need:
+
+- **Account SID** and **Auth token** from an impact.com API access token.
+
+To get these:
+
+1. Log in to [impact.com](https://app.impact.com).
+2. Go to your user profile, then **Settings** → **Technical** → **API**.
+3. Create an access token with read-only scopes.
+4. Copy the token's Account SID and Auth Token into PostHog.
+
+## Sync modes
+
+<SyncModes />
+
+The `Actions` table supports incremental sync on `EventDate`, and `Invoices` on `CreatedDate`. On the first sync, `Actions` backfills up to 3 years of history in 44-day chunks, which is a limit of the impact.com API.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- **Invalid credentials when connecting**: check that the Account SID and Auth Token belong to a partner (publisher) account. Brand and agency accounts use different APIs, so a brand token won't validate here. For brand accounts, use the [impact.com source](/docs/cdp/sources/impact).
+- **Missing older actions**: the impact.com API only returns actions from the last 3 years, so the initial backfill stops there.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/impact.md
+++ b/contents/docs/cdp/sources/impact.md
@@ -1,0 +1,59 @@
+---
+title: Linking impact.com as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: Impact
+---
+
+import SourceSetupIntro from "../\_snippets/source-setup-intro.mdx"
+import SyncModes from "../\_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../\_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../\_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The impact.com connector syncs your brand (advertiser) account's partnership data from [impact.com](https://impact.com): your campaigns, the partners promoting them, the conversions they drive, and partner payout invoices. If your account is a partner (publisher) account, use the [impact.com Partner source](/docs/cdp/sources/impact-partner) instead.
+
+## Prerequisites
+
+You need an impact.com brand account with API access. The connector authenticates with an API access token, which any account user can create from their profile settings.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking impact.com, you'll need:
+
+- **Account SID** and **Auth token** from an impact.com API access token.
+
+To get these:
+
+1. Log in to [impact.com](https://app.impact.com).
+2. Go to your user profile, then **Settings** → **Technical** → **API**.
+3. Create an access token with read-only scopes.
+4. Copy the token's Account SID and Auth Token into PostHog.
+
+## Sync modes
+
+<SyncModes />
+
+The `Actions` table supports incremental sync on `EventDate`, and `MediaPartners` on `DateLastUpdated`. On the first sync, `Actions` backfills up to 3 years of history per campaign in 44-day chunks, which is a limit of the impact.com API.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- **Invalid credentials when connecting**: check that the Account SID and Auth Token belong to a brand (advertiser) account. Partner and agency accounts use different APIs, so a partner token won't validate here. For partner accounts, use the [impact.com Partner source](/docs/cdp/sources/impact-partner).
+- **Missing older actions**: the impact.com API only returns actions from the last 3 years, so the initial backfill stops there.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

- Adds `contents/docs/cdp/sources/impact-partner.md` for the new impact.com Partner source, shipping in [PostHog/posthog#79770](https://github.com/PostHog/posthog/pull/79770).
- Backfills `contents/docs/cdp/sources/impact.md` for the impact.com (brand) source, which shipped without a doc, so its listed docs link currently 404s.
- Both follow the standard source doc template: shared snippets, `<SourceParameters />`, and `<SourceTables />` render the form fields and table catalog from the source API.
- The partner doc's `<SourceParameters />` and `<SourceTables />` sections stay empty until PostHog/posthog#79770 deploys; the page copy stands on its own until then.

Verified with the posthog repo's `manage.py audit_source_docs`: both files' `sourceId` and slug match the source registry, and merging removes the existing missing-doc finding for `Impact`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*