### PR TITLE
docs: add Google Tag Manager data warehouse source page

### DIFF
--- a/contents/docs/cdp/sources/google-tag-manager.md
+++ b/contents/docs/cdp/sources/google-tag-manager.md
@@ -1,0 +1,54 @@
+---
+title: Linking Google Tag Manager as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: GoogleTagManager
+---
+
+import SourceSetupIntro from "../\_snippets/source-setup-intro.mdx"
+import SyncModes from "../\_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../\_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../\_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Google Tag Manager connector syncs your tagging setup into PostHog: accounts, containers, workspaces, tags, triggers, variables, and container versions. Use it to query and monitor how tags and triggers are configured across your sites and apps.
+
+## Prerequisites
+
+You need a Google account with at least read access to the Tag Manager accounts you want to sync.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+When linking Google Tag Manager, you'll need:
+
+- **Google Tag Manager account** – connect a Google account that has read access to your Tag Manager accounts. PostHog requests the `tagmanager.readonly` scope when you authorize.
+- **Account IDs** (optional) – comma-separated Tag Manager account IDs to sync, found in Tag Manager under **Admin**. Leave blank to sync every account the connected Google user can access.
+
+## Sync modes
+
+<SyncModes />
+
+The Google Tag Manager API has no modification-time filter, so every table syncs as a full refresh. The tables hold configuration objects and stay small.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+Each row carries a `path` column, the resource's API relative path (for example `accounts/1/containers/2/workspaces/3/tags/4`), which is the table's primary key. Tags, triggers, and variables are workspace-scoped: the same tag appears once per workspace that contains it.
+
+## Troubleshooting
+
+The Google Tag Manager API enforces strict rate limits. Syncs pace their requests to stay within them, so a large setup with many containers and workspaces can take a few minutes to sync. If a sync fails with a quota error, it retries automatically once the quota refills.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

Adds the source doc for the new Google Tag Manager data warehouse connector, following the standard source template (`<SourceParameters />` + `<SourceTables />`, alpha callout). The connector ships in [PostHog/posthog#79789](https://github.com/PostHog/posthog/pull/79789); the page renders its fields and table catalog from the `public_source_configs` API once that PR deploys.

No screenshots: the page is a standard source doc assembled from shared snippets and API-driven components.

`audit_source_docs` in the posthog repo passes against this checkout (filename, `docsUrl`, and `sourceId` agree).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
