### PR TITLE
docs: explain how to choose which events are sent to Braze

### DIFF
--- a/contents/docs/cdp/destinations/braze.md
+++ b/contents/docs/cdp/destinations/braze.md
@@ -7,8 +7,7 @@ templateId:
 import FeedbackQuestions from "../_snippets/feedback-questions.mdx"
 import PostHogMaintained from "../_snippets/posthog-maintained.mdx"
 
-
-You'll also need access to the relevant Braze account.
+You can use your PostHog event data to track events and update user attributes in Braze. You'll also need access to the relevant Braze account.
 
 ## Installation
 
@@ -17,6 +16,26 @@ You'll also need access to the relevant Braze account.
 3. Search for 'Braze' and click **+ Create**.
 4. Add your Braze API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Users' list get populated in Braze!
+
+<HideOnCDPIndex>
+
+### Choosing which events are sent
+
+By default, the destination sends every event it receives to Braze. To send only the events you care about, use the destination's **Filters** section, which is where you choose the events, actions, and property conditions that trigger the destination. Everything that doesn't match is dropped before a request is made to Braze. See [filtering destinations](/docs/cdp/destinations#filtering) for the full set of options.
+
+A few things worth filtering on for Braze:
+
+- **Specific events.** Add only the events you want to appear in Braze, such as `purchase_completed` or `subscription_started`, rather than the full firehose. Braze bills on data points, so sending `$pageview` and other high-volume autocaptured events gets expensive quickly.
+- **Events from known users.** Braze matches users on `external_id`, which this destination maps from the event's `distinct_id`. Events from anonymous users create records in Braze keyed on a randomly generated ID, so it's usually worth filtering to identified users only.
+- **A required property.** If your `attributes` mapping depends on a person property such as `email`, filter to events where that property is set so you don't create incomplete profiles.
+
+You can also change *what* gets sent for each matched event. The **Attributes to set** and **Event payload** fields are templated, so you control which person and event properties are included in the request body. See [customizing destinations](/docs/cdp/destinations/customizing-destinations) for the templating syntax.
+
+### Testing
+
+Once you've configured your Braze destination, click **Start testing** to verify everything works the way you want. Clicking **Test function** sends a test event to Braze so you can confirm the user and event show up in your account.
+
+***
 
 ## Configuration
 
@@ -31,3 +50,5 @@ PostHog is open-source and so are all the destination on the platform. The [sour
 <PostHogMaintained />
 
 <FeedbackQuestions />
+
+</HideOnCDPIndex>


### PR DESCRIPTION
## Changes

Docs feedback asked how to control which events PostHog sends to Braze. The Braze page didn't say — it only covered creating the destination.

- Adds a **Choosing which events are sent** section pointing at destination filters, with the Braze-specific things worth filtering on (specific events rather than the full firehose, identified users since Braze matches on `external_id` which the template maps from `distinct_id`, and a required property such as `email`).
- Notes that the **Attributes to set** and **Event payload** fields are templated, so they control *what* is sent per matched event.
- Adds a **Testing** section, matching the other destination pages.
- Wraps the page body in `<HideOnCDPIndex>`. Braze was the only destination doc missing it (41 of 43 have it), so its full installation and FAQ content rendered on the CDP index preview alongside the auto-generated configuration table.
- Gives the page a proper opening sentence — it previously started mid-thought with "You'll also need access to the relevant Braze account."

Filter guidance is grounded in `posthog/cdp/templates/braze/template_braze.py`, which maps `external_id` from `event.distinct_id` and defaults `attributes` to `{person.properties.email}`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C076K2A8UF4/p1785769265064479?thread_ts=1785769265.064479&cid=C076K2A8UF4)*
