### PR TITLE
fix(startups): Point talk-to-sales link to talk-to-a-human

### DIFF
--- a/src/components/Startups/StartupProgram.tsx
+++ b/src/components/Startups/StartupProgram.tsx
@@ -244,7 +244,7 @@ const faqItems = [
             <p>
                 Unfortunately, no. Credits cannot be used to claim a BAA under the Boost plan due to legal risk. If
                 you’d like to claim a BAA, you can instead{' '}
-                <Link to="/talk-to-sales" state={{ newWindow: true }} className="underline font-semibold">
+                <Link to="/talk-to-a-human" state={{ newWindow: true }} className="underline font-semibold">
                     contact us to discuss options
                 </Link>
                 . Credits can be used towards all other aspects of the Boost package.


### PR DESCRIPTION
## Changes

The Boost plan BAA FAQ on /startups linked to /talk-to-sales, which 404s (no page, no redirect). Updated it to /talk-to-a-human, the current contact sales page. A repo-wide sweep found no other links to the dead URL.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A, no page moved)