### PR TITLE
fix(ci): Run link check on depot runner

### DIFF
--- a/.github/workflows/internal-links-check.yml
+++ b/.github/workflows/internal-links-check.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
     check-internal-links:
-        runs-on: ubuntu-latest
+        runs-on: depot-ubuntu-latest-8
 
         env:
             NODE_OPTIONS: '--max-old-space-size=16384 --expose-gc'


### PR DESCRIPTION
## Changes

The weekly link check job dies mid-build: its `ubuntu-latest` runner has 16GB RAM total while `NODE_OPTIONS` allows node a 16GB heap, so the VM gets killed once the Gatsby build actually needs it ("The runner has received a shutdown signal", see [this run](https://github.com/PostHog/posthog.com/actions/runs/31364534487)). Recent site growth pushed the build over the line, so every run now fails this way, including the Monday scheduled ones.

Moves the job to `depot-ubuntu-latest-8` (32GB), the same runner pool `deploy-preview.yml` already uses. Also cuts the build from ~30 min to ~12.

## Checklist

N/A, CI only.
