### PR TITLE
fix(links): Fix all broken internal links sitewide

### DIFF
--- a/contents/blog/analytics-tips-for-customer-success-teams.md
+++ b/contents/blog/analytics-tips-for-customer-success-teams.md
@@ -22,7 +22,7 @@ You can find out more about [how our customer success team works](/handbook/peop
 ## 1. Use funnels to find out where customers get stuck
 ![Top to bottom funnels in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/activation-checklist-images/top-down-funnel.png)
 
-Using a combination of [autocapture](/docs/data/autocapture) and [custom or calculated events](/tutorials/event-tracking-guide#using-custom-events-to-track-advanced-behaviors), PostHog makes it possible to track every part of your product experience. This makes it trivial to track where users are getting stuck by using [funnel insights](/manual/funnels) to visualize the user journey.
+Using a combination of [autocapture](/docs/data/autocapture) and [custom or calculated events](/tutorials/event-tracking-guide#setting-up-custom-events), PostHog makes it possible to track every part of your product experience. This makes it trivial to track where users are getting stuck by using [funnel insights](/manual/funnels) to visualize the user journey.
 
 At PostHog, for example, new users have to go through several common steps to be successful — they must create an account, login, ingest events and then make a discovery through an insight. Using funnels, we’re able to identify which stage users get stuck on and then monitor how successful we are in our attempts to fix the problem.
 

--- a/contents/blog/best-braintrust-alternatives.mdx
+++ b/contents/blog/best-braintrust-alternatives.mdx
@@ -760,7 +760,7 @@ You can steer it from [Slack](/slack), the [web app](/ai), the [desktop app](/de
 <details>
 <summary>What is the difference between AI observability and AI evals?</summary>
 
-[AI observability](/what-is-ai-observability) answers "what is my system doing in production?" capturing traces, latency, token counts, errors, costs, and user interactions. 
+[AI observability](/blog/what-is-ai-observability) answers "what is my system doing in production?" capturing traces, latency, token counts, errors, costs, and user interactions. 
 
 AI evals answer "is my system producing good outputs?" scoring responses against defined quality criteria, running test datasets, tracking regressions, and blocking deploys. 
 

--- a/contents/blog/best-hipaa-compliant-analytics-tools.md
+++ b/contents/blog/best-hipaa-compliant-analytics-tools.md
@@ -35,7 +35,7 @@ While similar in some respects to the EU's General Data Protection Regulation (G
 
 There are two ways to be HIPAA-compliant while using analytics tools:
 
-1. [Self-host your analytics](/best-open-source-analytics-tools), so data remains totally within your control.
+1. [Self-host your analytics](/blog/best-open-source-analytics-tools), so data remains totally within your control.
 2. Sign a Business Associate Agreement (BAA) with a third-party analytics tool.
 
 ## What is a Business Associate Agreement (BAA)?

--- a/contents/blog/best-langfuse-alternatives.mdx
+++ b/contents/blog/best-langfuse-alternatives.mdx
@@ -16,7 +16,7 @@ seo:
   metaDescription: 'Looking for a Langfuse alternative? Compare the best LLM observability tools, including PostHog, Helicone, LangSmith, and more.'
 ---
 
-**Langfuse** is a well-known [open-source LLM observability platform](/blog/best-open-source-llm-observability-tools). It combines [tracing](/docs/ai-observability/traces), [prompt management](/docs/prompt-management/prompts), [evaluations](/docs/ai-evals/evaluations), and cost tracking to help developers understand how their LLM applications behave in production.
+**Langfuse** is a well-known [open-source LLM observability platform](/blog/best-open-source-llm-observability-tools). It combines [tracing](/docs/ai-observability/traces), [prompt management](/docs/prompt-management/prompts), [evaluations](/docs/ai-evals), and cost tracking to help developers understand how their LLM applications behave in production.
 
 But just like pineapple on pizza isn't for everyone, Langfuse isn't right for every team. Some need deeper evaluation tooling, a better way to understand how AI performance affects the overall product experience, or may just want a cheaper alternative.
 
@@ -52,11 +52,11 @@ PostHog ships new AI observability features fast, including prompt management fo
 
 ### Key features
 
-- [**Generations**](docs/ai-observability/generations): Monitor model performance, token usage, costs, latency, and errors across your AI features from a single view.
-- [**Traces**](docs/ai-observability/traces): Follow AI workflows from start to finish to understand how requests move through prompts, tools, and model calls.
-- [**AI evals**](docs/ai-evals/evaluations): Automatically score model outputs using LLM-as-a-judge or code-based checks to track quality and identify regressions over time.
-- [**Prompt management**](docs/prompt-management): Create, version, and update prompts without redeploying code. Compare versions and understand how prompt changes affect outputs.
-- [**SQL access**](docs/sql): Query AI observability data with SQL and analyze it alongside product, user, and business data.
+- [**Generations**](/docs/ai-observability/generations): Monitor model performance, token usage, costs, latency, and errors across your AI features from a single view.
+- [**Traces**](/docs/ai-observability/traces): Follow AI workflows from start to finish to understand how requests move through prompts, tools, and model calls.
+- [**AI evals**](/docs/ai-evals): Automatically score model outputs using LLM-as-a-judge or code-based checks to track quality and identify regressions over time.
+- [**Prompt management**](/docs/prompt-management): Create, version, and update prompts without redeploying code. Compare versions and understand how prompt changes affect outputs.
+- [**SQL access**](/docs/sql): Query AI observability data with SQL and analyze it alongside product, user, and business data.
 - [**Session replay**](/docs/ai-observability/link-session-replay): Watch recordings of users interacting with AI features and investigate issues alongside the actions that triggered them.
 
 ### How does PostHog compare to Langfuse?
@@ -87,7 +87,7 @@ PostHog ships new AI observability features fast, including prompt management fo
 <summary>Main differences between PostHog and Langfuse</summary>
 
 - Langfuse includes prompt management with versioning and deployment controls. [PostHog's prompt management](/docs/prompt-management) is newer, covering versioning, labels, configuration, runtime fetching, and A/B testing of prompt versions.
-- PostHog adds built-in [sentiment classification](docs/ai-observability/sentiment) (currently in beta) and [trace summarization](docs/ai-observability/summarization) on top of raw trace data. Langfuse has no direct, built-in equivalent for either.
+- PostHog adds built-in [sentiment classification](/docs/ai-observability/sentiment) (currently in beta) and [trace summarization](/docs/ai-observability/summarization) on top of raw trace data. Langfuse has no direct, built-in equivalent for either.
 - Langfuse provides more detailed agent and multi-step tracing. PostHog supports traces and spans, but its tracing capabilities are less specialized.
 - PostHog connects LLM traces to product analytics covering funnels, retention, and feature adoption. Langfuse focuses primarily on LLM observability.
 

--- a/contents/blog/best-logrocket-alternatives.mdx
+++ b/contents/blog/best-logrocket-alternatives.mdx
@@ -35,7 +35,7 @@ This guide compares the best LogRocket alternatives honestly – what they're go
 
 ### What is PostHog?
 
-[PostHog](/) (that's us 👋) is a developer platform combining [product analytics](/product-analytics), [session replay](/session-replay), [feature flags](/feature-flags), [experiments](/experiments), [error tracking](/error-tracking), [user surveys](/user-surveys), and [a lot more](/products) into one product. 
+[PostHog](/) (that's us 👋) is a developer platform combining [product analytics](/product-analytics), [session replay](/session-replay), [feature flags](/feature-flags), [experiments](/experiments), [error tracking](/error-tracking), [user surveys](/surveys), and [a lot more](/products) into one product. 
 
 This means it's not just an alternative to [LogRocket](/blog/posthog-vs-logrocket), but also tools like [LaunchDarkly](/blog/posthog-vs-launchdarkly), [Sentry](/blog/posthog-vs-sentry), [FullStory](/blog/posthog-vs-fullstory), and [Amplitude](/blog/posthog-vs-amplitude).
 
@@ -418,7 +418,7 @@ FullStory is particularly popular with enterprise UX and customer experience tea
 
 ### How does FullStory compare to LogRocket?
 
-Both [FullStory](/best-fullstory-alternatives) and LogRocket have tools to understand user experience, but LogRocket captures more data on errors and issues.
+Both [FullStory](/blog/best-fullstory-alternatives) and LogRocket have tools to understand user experience, but LogRocket captures more data on errors and issues.
 
 <p>
 <ProductComparisonTable

--- a/contents/blog/best-matomo-alternatives.mdx
+++ b/contents/blog/best-matomo-alternatives.mdx
@@ -35,7 +35,7 @@ If you've outgrown it or just want to compare your options, here are the best al
 
 ### What is PostHog?
 
-[PostHog](/) (that's us 👋) is an all-in-one developer platform combining [web](/web-analytics) and [product analytics](/product-analytics), [session replay](/session-replay), [experiments](/experiments), [feature flags](/feature-flags), [error tracking](/error-tracking), [LLM observability](/llm-analytics), [user surveys](/user-surveys), and more into one product. 
+[PostHog](/) (that's us 👋) is an all-in-one developer platform combining [web](/web-analytics) and [product analytics](/product-analytics), [session replay](/session-replay), [experiments](/experiments), [feature flags](/feature-flags), [error tracking](/error-tracking), [LLM observability](/llm-analytics), [user surveys](/surveys), and more into one product. 
 
 This means it's not only an alternative to [Matomo](/blog/posthog-vs-matomo) but also tools like [Mixpanel](/blog/posthog-vs-mixpanel), [Amplitude](/blog/posthog-vs-amplitude), [Sentry](/blog/posthog-vs-sentry), and [LaunchDarkly](/blog/posthog-vs-launchdarkly).
 
@@ -390,7 +390,7 @@ According to [G2](https://www.g2.com/products/google-analytics/reviews), users c
 
 It's known for its visual event editor that lets non-technical teams tag and track events without engineering support. 
 
-[Contentsquare](blog/best-contentsquare-alternatives) acquired Heap and has been integrating the two products.
+[Contentsquare](/blog/best-contentsquare-alternatives) acquired Heap and has been integrating the two products.
 
 #### Key features
 

--- a/contents/blog/best-open-source-llm-observability-tools.md
+++ b/contents/blog/best-open-source-llm-observability-tools.md
@@ -245,7 +245,7 @@ Most tools on this list are free to start, so there's no reason to wait.
 
 No. PostHog's [LLM observability](/docs/ai-observability) product is built into the platform, so if you're already using PostHog for product analytics or session replay, you can add LLM observability without any additional setup or contract. You get 100k LLM events free per month.
 
-[Getting started](docs/ai-observability/start-here) is easy; once you install the SDK, it will handle all the heavy lifting. Use your LLM provider as normal and we'll capture everything automatically.
+[Getting started](/docs/ai-observability/start-here) is easy; once you install the SDK, it will handle all the heavy lifting. Use your LLM provider as normal and we'll capture everything automatically.
 
 </details>
 

--- a/contents/blog/best-open-source-session-replay-tools.md
+++ b/contents/blog/best-open-source-session-replay-tools.md
@@ -206,7 +206,7 @@ Self-hosted lifetime licenses start at **$200 one-time** (Startup – up to 3 we
 
 ### Who is Matomo for?
 
-[Matomo](blog/best-matomo-alternatives) is mainly built with marketing and content teams in mind, offering insights into website content engagement for optimization of user journeys. Features like session recording are part of a wider set of tools that are useful for product teams as well, but they aren't included in Matomo's open source release.
+[Matomo](/blog/best-matomo-alternatives) is mainly built with marketing and content teams in mind, offering insights into website content engagement for optimization of user journeys. Features like session recording are part of a wider set of tools that are useful for product teams as well, but they aren't included in Matomo's open source release.
 
 To learn more, read our [PostHog vs Matomo comparison](/blog/posthog-vs-matomo).
 

--- a/contents/blog/best-split-alternatives.mdx
+++ b/contents/blog/best-split-alternatives.mdx
@@ -32,7 +32,7 @@ If you're a former Split customer evaluating your options, or if you're just sho
 
 [PostHog](/) (that's us 👋) is an all-in-one suite of dev tools combining [A/B testing](/experiments), [feature flags](/feature-flags), [product analytics](/product-analytics), [session replay](/session-replay), [error tracking](/error-tracking), [LLM observability](/llm-analytics), [surveys](/surveys), and more. 
 
-This means it's not only an alternative to Split but also tools like [Mixpanel](/blog/posthog-vs-mixpanel), [Sentry](/blog/posthog-vs-sentry), [LaunchDarkly](/posthog-vs-launchdarkly), and [Hotjar](/blog/posthog-vs-hotjar).
+This means it's not only an alternative to Split but also tools like [Mixpanel](/blog/posthog-vs-mixpanel), [Sentry](/blog/posthog-vs-sentry), [LaunchDarkly](/blog/posthog-vs-launchdarkly), and [Hotjar](/blog/posthog-vs-hotjar).
 
 #### Key features
 

--- a/contents/blog/best-vwo-alternatives.mdx
+++ b/contents/blog/best-vwo-alternatives.mdx
@@ -33,7 +33,7 @@ If you've outgrown VWO, need something more developer-friendly, or want more tra
 
 ### What is PostHog?
 
-[PostHog](/) (that's us 💪) is an all-in-one suite of dev tools like [experiments](/experiments), [feature flags](/feature-flags), [product analytics](/product-analytics), [session replay](/session-replay), [error tracking](/error-tracking), [user surveys](/user-surveys), and more. 
+[PostHog](/) (that's us 💪) is an all-in-one suite of dev tools like [experiments](/experiments), [feature flags](/feature-flags), [product analytics](/product-analytics), [session replay](/session-replay), [error tracking](/error-tracking), [user surveys](/surveys), and more. 
 
 This means it's not only an alternative to VWO but also tools like [Mixpanel](/blog/posthog-vs-mixpanel), [Sentry](/blog/posthog-vs-sentry), and [Hotjar](/blog/posthog-vs-hotjar).
 

--- a/contents/blog/hotjar-for-mobile-ios-android-react-native-flutter.mdx
+++ b/contents/blog/hotjar-for-mobile-ios-android-react-native-flutter.mdx
@@ -246,7 +246,7 @@ It's designed for product-minded engineers, growth teams, and product managers w
 
 ### How much does PostHog cost?
 
-PostHog has [transparent pricing](/session-replay#pricing) based on usage. It’s free to get started and completely free for the first 2,500 mobile recordings and 5,000 web ones per month. After this, pricing starts at $0.0100 per mobile recording, and recordings cost progressively less the more you use. This makes PostHog significantly cheaper than all the other companies on this list (apart from [Microsoft Clarity](#3-microsoft-clarity)).
+PostHog has [transparent pricing](/pricing) based on usage. It’s free to get started and completely free for the first 2,500 mobile recordings and 5,000 web ones per month. After this, pricing starts at $0.0100 per mobile recording, and recordings cost progressively less the more you use. This makes PostHog significantly cheaper than all the other companies on this list (apart from [Microsoft Clarity](#3-microsoft-clarity)).
 
 ### Why do companies use PostHog?
 

--- a/contents/blog/posthog-alternatives.mdx
+++ b/contents/blog/posthog-alternatives.mdx
@@ -496,7 +496,7 @@ But PostHog's free tier – 1M analytics events, 5,000 replays, 1M feature flag 
 
 Yes, for most teams. PostHog covers everything Mixpanel does (funnels, retention, user paths, cohorts) and adds session replay, feature flags, A/B testing, and error tracking.
 
-See our [PostHog vs Mixpanel](/blog/posthog-vs-mixpanel) comparison for details or get started with [our managed migration](/migrate/managed-migrations) for an easy switch.
+See our [PostHog vs Mixpanel](/blog/posthog-vs-mixpanel) comparison for details or get started with [our managed migration](/docs/migrate/managed-migrations) for an easy switch.
  
 </details>
  
@@ -505,7 +505,7 @@ See our [PostHog vs Mixpanel](/blog/posthog-vs-mixpanel) comparison for details 
 
 For engineering and product teams, yes. For growth and marketing teams who rely on multi-touch attribution and predictive analytics, Amplitude has capabilities PostHog doesn't. 
 
-See our [PostHog vs Amplitude](/blog/posthog-vs-amplitude) comparison or get started with [our managed migration](/migrate/managed-migrations) for an easy switch.
+See our [PostHog vs Amplitude](/blog/posthog-vs-amplitude) comparison or get started with [our managed migration](/docs/migrate/managed-migrations) for an easy switch.
  
 </details>
  

--- a/contents/blog/the-posthog-array-1-5-0.md
+++ b/contents/blog/the-posthog-array-1-5-0.md
@@ -77,6 +77,6 @@ Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog
 
 We’re growing rapidly, and we’re constantly expanding our team. We’re looking for a [strong devops engineer](https://news.ycombinator.com/item?id=23044768) to join us. If that sounds like you, please email tim@posthog.com.
 
-We are also looking for a really strong [designer / UX person](/careers#designer--ux)! [Email James](mailto:james@posthog.com) if this sounds like it's for you!
+We are also looking for a really strong [designer / UX person](/careers)! [Email James](mailto:james@posthog.com) if this sounds like it's for you!
 
 <ArrayCTA />

--- a/contents/blog/traces-beta.mdx
+++ b/contents/blog/traces-beta.mdx
@@ -23,7 +23,7 @@ seo:
 
 PostHog starts with your user data and provides you with all the tools you need to build successful products, so debugging is an obvious must-have to keep your products working as expected. We have [Error Tracking](/error-tracking), [Session Replay](/session-replay), and [Logs](/logs) in the PostHog debugging stack, so tracing will complement nicely to give you more of the context you need to resolve issues quickly, and more fuel for the agents doing it for you. 
 
-[A trace](/tracing) is the full journey of a single request through your system, from the first incoming call to every service, queue, database, and third-party API it touches along the way. Each step is a span, stamped with how long it took and whether it succeeded, and they nest into a waterfall you can read top to bottom. Where a log tells you what happened at one point and an error tells you something broke, a trace shows you the whole path: what called what, in what order, and exactly where the time went.
+[A trace](/traces) is the full journey of a single request through your system, from the first incoming call to every service, queue, database, and third-party API it touches along the way. Each step is a span, stamped with how long it took and whether it succeeded, and they nest into a waterfall you can read top to bottom. Where a log tells you what happened at one point and an error tells you something broke, a trace shows you the whole path: what called what, in what order, and exactly where the time went.
 
 ## What's in the beta
 
@@ -70,4 +70,4 @@ Tracing is in beta now. The fastest way to get to it in is the wizard, which set
 
 <WizardCommand command="self-driving" />
 
-Already instrumented? Point your existing OTel exporter at the endpoint and open [the PostHog app](app.posthog.com/tracing) to watch the spans land. 
+Already instrumented? Point your existing OTel exporter at the endpoint and open [the PostHog app](https://app.posthog.com/tracing) to watch the spans land. 

--- a/contents/docs/experiments/start-here.mdx
+++ b/contents/docs/experiments/start-here.mdx
@@ -179,7 +179,7 @@ Experiments are billed with feature flags requests.
 - First 1 million feature flag requests per month are free
 - Above 1 million we have usage-based pricing starting at $0.0001/request with discounts as volume increases
 - Set billing limits to avoid surprise charges
-- See our [pricing page](/experiments#pricing) for more up-to-date details
+- See our [pricing page](/pricing) for more up-to-date details
 
 ---
 

--- a/contents/tutorials/scroll-depth.md
+++ b/contents/tutorials/scroll-depth.md
@@ -68,7 +68,7 @@ We now calculate and capture these scroll depth measurements. Depending on how m
 
 ### Capturing scroll depth on page change
 
-Similar to how we [capture pageviews in Next.js](/tutorials/nextjs-analytics#capturing-pageviews-in-nextjs), use `next/router` to listen for route change events, then capture the scroll depth values when those happen. Use the `routeChangeStart` event as the `routeChangeComplete` event doesn’t give us access to the `window` data we want.
+Similar to how we [capture pageviews in Next.js](/tutorials/nextjs-analytics#setting-up-posthog-on-the-client-side), use `next/router` to listen for route change events, then capture the scroll depth values when those happen. Use the `routeChangeStart` event as the `routeChangeComplete` event doesn’t give us access to the `window` data we want.
 
 ```js
 // pages/_app.js

--- a/src/components/Products/ProductsTest.tsx
+++ b/src/components/Products/ProductsTest.tsx
@@ -345,39 +345,6 @@ export default function ProductsTest(): JSX.Element {
                             </p>
 
                             <GetStarted selfDriving showSecondaryActions={false} />
-
-                            {/*
-                        <div className="flex flex-wrap items-center gap-3 not-prose">
-                            <Link
-                                to="https://desktop.posthog.com/download"
-                                state={{ newWindow: true }}
-                                className="inline-flex items-center gap-2 bg-dark text-white dark:bg-white dark:text-dark font-semibold text-sm px-4 py-2.5 rounded-md hover:opacity-90 no-underline"
-                            >
-                                <IconApple className="size-4" />
-                                Download for Mac
-                                <IconArrowRight className="size-4" />
-                            </Link>
-                            <WizardCommand slim />
-                        </div>
-
-                        <div className="flex gap-4 text-sm">
-                            <Link
-                                to="/docs/libraries/vscode"
-                                state={{ newWindow: true }}
-                                className="underline underline-offset-2 font-medium"
-                            >
-                                Get our VS Code extension
-                            </Link>
-                            <span className="text-secondary">or</span>
-                            <Link
-                                to="/docs/model-context-protocol"
-                                state={{ newWindow: true }}
-                                className="underline underline-offset-2 font-medium"
-                            >
-                                Try the MCP
-                            </Link>
-                        </div>
-                             */}
                         </div>
                     </header>
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2102,7 +2102,7 @@ export const communityMenu = {
                     name: 'Product Analytics',
                     icon: 'IconGraph',
                     color: 'blue',
-                    url: '/tutorials/categories/dashboards',
+                    url: '/tutorials/categories/product-analytics',
                     children: [
                         { name: 'Dashboards', url: '/tutorials/categories/dashboards' },
                         { name: 'Funnels', url: '/tutorials/categories/funnels' },

--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -235,7 +235,7 @@ export const postsMenu: IMenu[] = [
             },
             {
                 name: 'AI Observability',
-                url: '/tutorials/ai-observability',
+                url: '/tutorials/categories/ai-observability',
                 color: 'purple',
                 icon: 'IconLlmAnalytics',
                 tag: 'AI Observability',


### PR DESCRIPTION
## Changes

Fixes every broken internal link the weekly link checker currently reports: 21 in markdown content, 5 broken anchors and 20 hardcoded in source code. With this merged the Monday check goes green.

Highlights: the footer linked to `/changelogå` (typo, sitewide), the tutorials sidebar had 12 entries pointing at category pages that no longer generate and several comparison posts had links missing their leading slash. Anchor links to `#pricing` sections that no longer exist now point at /pricing. Nav entries whose category pages are gone were removed, the rest retargeted to existing pages (all verified against the sitemap). Also removed a commented-out hero block in ProductsTest.tsx whose `/download` link kept tripping the checker.

Verified locally: `pnpm check-src-links` now reports 0 broken links.

## Checklist

- [x] Words are spelled using American English
- [x] Use relative URLs for internal links

Remaining items N/A, link fixes only.
