### PR TITLE
Document the Terraform-managed incident.io on-call setup

### DIFF
--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -14,30 +14,30 @@ In addition, every engineer regardless is part of the global follow-the-sun on-c
 
 ## Escalation schedules
 
-Two things work together in incident.io, and it's worth keeping them straight:
+Your team's schedules, the escalation paths that page them, and your team's entry in the incident.io Team catalog are all [defined in Terraform](#managing-on-call-in-terraform) – one block per team, in one file. Setting a team up, or changing who's on call and when, means editing that block rather than the incident.io dashboard.
 
-* **Schedules** (rotas) say _who_ is on call. Teams own these and edit them in the incident.io dashboard.
-* **[Escalation paths](#escalation-paths)** say _who gets paged, in what order, and how long they have to respond_. These are managed in Terraform.
+Cover for PTO and swaps is the exception: [overrides](#make-sure-your-availability-is-up-to-date) still happen in the dashboard, because Terraform owns the rotations and not what's layered on top of them.
 
 ### Team schedules
 
-Every team has 2 schedules in [incident.io](https://app.incident.io/posthog/on-call/schedules)
+A team has up to three schedules in [incident.io](https://app.incident.io/posthog/on-call/schedules), and it gets the ones its Terraform block asks for:
+
 * `On call: {team}`
-    - This is the working-hours rotation. Each engineer should have their working hours in place here Mon-Fri with a sensible working day
-    - For example 8:00-17:00 for EU based engineers is likely preferable as there will be US engineers who can take 17:00 onwards
-    - Each member is responsible for ensuring this is up-to-date with PTO. You can create an override for your schedule simply assigned to "No one".
-* `Support: {team}`
-    - This is a weekly or bi-weekly rotation (teams can decide) that covers both who is assigned to the [support hero rotation](/handbook/engineering/operations/support-hero) as well as the out of-hours-escalation for the extreme case
+    - Working-hours cover, and where alerts routed to the team go. Everyone gets their own rotation, running nine hours from their start of day, weekdays only unless you say otherwise
+    - Stagger start times to cover as much of the day as your team can – 08:00 for an EU-based engineer leaves 17:00 onwards for a US-based one
+    - Gaps are fine. Nobody is woken up here: a critical alert that finds nobody on call goes to [global on-call](#global-on-call-schedule) instead
+* `Escalation: {team}`
+    - The "everything is broken" rotation, paged only when [someone escalates by hand](#manual-escalation-schedules)
+* `Support Hero: {team}`
+    - The [support hero rotation](/handbook/engineering/operations/support-hero). Everyone takes turns one at a time, handing over every week or two. Nothing pages it
 
 ### Manual escalation schedules
 
-In addition to the regular on-call schedules, teams that own production-critical services have a manual escalation schedule in incident.io:
-* `Escalation: {team}`
-    - This is the "everything is broken" escalation path for critical out-of-hours emergencies
-    - Only teams that own production-critical services are required to have this schedule - other teams don't need one
-    - **Everyone relevant on the team should be on this schedule** - it's not a rotation like regular on-call
-    - There should be no gaps in coverage since this is the last resort when normal escalation paths fail
-    - This schedule is triggered manually by whoever is handling an incident when they need additional help
+Teams that own production-critical services also have an `Escalation: {team}` schedule, triggered by hand by whoever is handling an incident and needs more help. Other teams don't need one.
+
+Unlike `On call: {team}`, this rotation has to cover the clock, every day of the week. You describe it as groups – blocks of the clock with the people covering each one, an EU group and a US group, or however your team is actually spread. Everyone in a group is on call for the whole of its window rather than taking turns, and the page cycles between them one at a time.
+
+Group windows have to tile the full 24 hours between them. If they don't, the Terraform plan fails and names the first uncovered minute – somebody escalating by hand at 3am should never find nobody there.
 
 #### When to use manual escalation
 
@@ -49,7 +49,7 @@ Manual escalation should be used when:
 #### How to trigger manual escalation
 
 1. From within an incident in incident.io, use the escalation options to page the relevant `Escalation (manual): {team}` path
-2. This pages whoever is on that team's `Escalation: {team}` rota right now, then everyone on it – one person at a time, 10 minutes per level
+2. This pages whoever is on that team's `Escalation: {team}` rotation right now, then everyone on it – one person at a time, 10 minutes per level
 3. Any available team member can then respond and assist with the incident
 
 > 💡 Manual escalation is a safety net, not a shortcut. Always try the normal escalation paths first before manually escalating to an entire team.
@@ -81,46 +81,89 @@ Besides knowledge, being on call requires availability – including weekends. I
 
 ## Escalation paths
 
-A team has up to two escalation paths:
+A schedule says who's on call. An escalation path says who gets paged, in what order, and how long they have to respond. A team gets the paths that follow from the schedules it has:
 
-* `On call: {team}` – where an alert routed to the team goes. Previously named `PostHog: {team}`.
-* `Escalation (manual): {team}` – where you land when you [escalate to a team by hand](#manual-escalation-schedules).
+* `On call: {team}` – where an alert routed to the team goes, previously named `PostHog: {team}`
+* `Escalation (manual): {team}` – where you land when you [escalate to a team by hand](#manual-escalation-schedules)
 
-> **Escalation paths are managed in Terraform, not the dashboard.** Changes made in the incident.io UI get reverted on the next apply. Schedules are the exception – teams change those constantly for PTO and new joiners, so they stay in the dashboard and Terraform looks them up by name.
-
-They live in the [`incidentio-escalation-paths` module](https://github.com/PostHog/posthog-cloud-infra/tree/main/terraform/modules/incidentio-escalation-paths) in `posthog-cloud-infra`, and every team is listed in one file: [`terraform/environments/incidentio/escalation-paths/terragrunt.hcl`](https://github.com/PostHog/posthog-cloud-infra/blob/main/terraform/environments/incidentio/escalation-paths/terragrunt.hcl).
+Two more are org-wide rather than owned by a team: `PostHog: General escalation`, for an escalation that's nobody's in particular, which pages global on-call for 30 minutes and then the last-resort rotation alongside it; and the `Notify: ...` paths, which post to a Slack channel and page nobody.
 
 ### The standard on-call path
 
 Every `On call: {team}` path is the same shape, so paging behavior doesn't vary by team:
 
 1. Post to the team's own alert channel, whatever the priority
-2. If the alert is critical, round-robin the team's `On call: {team}` rota – 10 minutes to ack
-3. Still unacked? Post to #alerts, then round-robin global on-call alongside the team – 15 minutes to ack
+2. If the alert is critical, page the team's `On call: {team}` rotation – 10 minutes to ack
+3. Still unacked? Post to #alerts, then page global on-call alongside the team – 15 minutes to ack
 4. Repeat
 
-Non-critical alerts stop at step 1 – the team sees them in Slack, nobody gets woken up. A few teams escalate sideways to a second team's rota between steps 2 and 3.
+Non-critical alerts stop at step 1 – the team sees them in Slack, nobody gets woken up. Levels page one person at a time, moving on every two minutes until somebody acks, rather than paging a whole rotation at once.
 
-### Adding or changing a path
+## Managing on-call in Terraform
 
-1. Create the rota you need in the [incident.io dashboard](https://app.incident.io/posthog/on-call/schedules) – `On call: {team}` for alert routing, `Escalation: {team}` for manual escalation
-2. Set the `Slack Alerts channel` attribute on your team's entry in the Team catalog. The path reads the channel from there, so an unset one fails the plan
-3. Add your team to `teams` in `terragrunt.hcl` and open a PR against [`posthog-cloud-infra`](https://github.com/PostHog/posthog-cloud-infra). CI runs the plan – read it before merging, since it shows exactly which paging levels move
+Teams, schedules, rotations, and escalation paths all live in the [`incidentio-oncall` module](https://github.com/PostHog/posthog-cloud-infra/tree/main/terraform/modules/incidentio-oncall) in `posthog-cloud-infra`. Everything one team needs is a single block in a single file: [`terraform/environments/incidentio/oncall/terragrunt.hcl`](https://github.com/PostHog/posthog-cloud-infra/blob/main/terraform/environments/incidentio/oncall/terragrunt.hcl).
+
+You supply people and hours. Rotation mechanics aren't configurable, so every team's schedules and paging come out the same shape:
+
+```hcl
+"my-team" = {
+  name                   = "My Team"
+  alert_slack_channel_id = "C0123456789" # #alerts-my-team
+  slack_user_group_id    = "S0123456789" # @Team My Team
+
+  # Working hours. One rotation each, nine hours from start of day.
+  on_call = {
+    members = {
+      "eu-person@posthog.com" = { start_of_day = "07:00" }
+      "us-person@posthog.com" = { start_of_day = "15:00" }
+    }
+  }
+
+  # Round-the-clock cover for manual escalation. Windows must tile the day.
+  escalation = {
+    groups = {
+      "EU" = { start = "06:00", end = "18:00", members = ["eu-person@posthog.com"] }
+      "US" = { start = "18:00", end = "06:00", members = ["us-person@posthog.com"] }
+    }
+  }
+
+  # Support hero, taking turns a week at a time.
+  support_hero = {
+    members                 = ["eu-person@posthog.com", "us-person@posthog.com"]
+    handover_interval_weeks = 1
+    handover_start_at       = "2026-01-05T00:00:00Z"
+  }
+}
+```
+
+Worth knowing before you write one:
+
+* **Every time is UTC**, and you convert from your own timezone yourself. One timezone across every team is the only way the windows can be read off and checked against each other
+* **Schedules and paths follow from the blocks you write**, so there's no separate switch to forget. `on_call` gets you the `On call:` schedule and the path alerts route to, `escalation` gets you the escalation rotation and the manual path, and `support_hero` gets you a support hero rotation that nothing pages
+* **The key is your team's external ID** in the Team catalog rather than its name, so a rename moves nothing. The display name comes from `name`
+* **`handover_start_at` is fixed once it's set.** Changing it re-phases the support hero rotation and hands the pager over mid-turn
+* **`On call: Global` and the last-resort schedule are the exception.** They belong to no team, so they're looked up by name rather than defined here
+* Teams defined here carry a `Managed by Terraform` attribute in the dashboard pointing back at the file, so whoever finds your team knows where to edit it
+
+Open a PR against [`posthog-cloud-infra`](https://github.com/PostHog/posthog-cloud-infra) and CI runs the plan. Read it before merging – it names every rotation and paging level that moves. Don't make these changes in the incident.io dashboard, because the next apply puts them back.
 
 Rather than hand-writing the HCL, point your editor's agent at it:
 
 ```
-In posthog-cloud-infra, add my team to the incident.io escalation paths.
+In posthog-cloud-infra, add my team to the incident.io on-call setup.
 
-Read terraform/modules/incidentio-escalation-paths/ first, then add an entry to
-`teams` in terraform/environments/incidentio/escalation-paths/terragrunt.hcl,
-keyed by my team's external ID in the incident.io Team catalog.
+Read terraform/modules/incidentio-oncall/ first – the README and the `teams`
+variable – then add a block for my team to `teams` in
+terraform/environments/incidentio/oncall/terragrunt.hcl, keyed by our external
+ID in the incident.io Team catalog.
 
-Set `on_call = true` for a standard alert-routing path, and
-`manual_escalation = true` for a manual escalation path. Rota names derive from
-the team's catalog display name as "On call: <team>" and "Escalation: <team>",
-so only set `on_call_schedule` or `escalation_schedule` if our rota is named
-differently. Then run `terragrunt hcl validate` and `terraform fmt`.
+Here's who's on call and when, in local time: <people, their working hours, and
+who covers escalation out of hours>.
+
+Convert every time to UTC, and don't set `timezone` – that field only exists to
+adopt a schedule that isn't UTC yet. Escalation group windows have to tile the
+whole 24 hours or the plan fails. Then run `terragrunt hcl validate` and
+`terraform fmt`, and show me the plan.
 ```
 
 ## Before going on call
@@ -168,10 +211,10 @@ Exact menu paths vary by manufacturer (Pixel, Samsung, OnePlus, etc.), but the s
 
 ## Make sure your availability is up-to-date
 
-If you are unavailable for any of your schedules you need to act!
+If you are unavailable for any of your schedules you need to act! Overrides are the one part of a schedule that isn't in Terraform, so do these in the dashboard – an apply won't undo them.
 
-1. For your `On call: {team}` schedule simply click on your name in your layer, click `create an override` and then remove yourself from the list so it shows `No one`
-1. For your `Support: {team}` schedule or `On call: {global}` schedules click `Request cover` at the top right. This will notify selected team members automatically to find someone to cover you (you should probably do a shout out in #ask-posthog-anything as well). You can trade whole weeks, but also just specific days. Remember not to alter the rotation's core order, as that's an easy way to accidentally shift the schedule for everyone.
+1. For your `On call: {team}` schedule simply click on your name in your rotation, click `create an override` and then remove yourself from the list so it shows `No one`
+1. For your `Support Hero: {team}` or `On call: Global` schedules click `Request cover` at the top right. This will notify selected team members automatically to find someone to cover you (you should probably do a shout out in #ask-posthog-anything as well). You can trade whole weeks, but also just specific days. Remember not to alter the rotation's core order, as that's an easy way to accidentally shift the schedule for everyone.
 
 ## Make sure you have all the access you might need
 

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -14,6 +14,11 @@ In addition, every engineer regardless is part of the global follow-the-sun on-c
 
 ## Escalation schedules
 
+Two things work together in incident.io, and it's worth keeping them straight:
+
+* **Schedules** (rotas) say _who_ is on call. Teams own these and edit them in the incident.io dashboard.
+* **[Escalation paths](#escalation-paths)** say _who gets paged, in what order, and how long they have to respond_. These are managed in Terraform.
+
 ### Team schedules
 
 Every team has 2 schedules in [incident.io](https://app.incident.io/posthog/on-call/schedules)
@@ -43,8 +48,8 @@ Manual escalation should be used when:
 
 #### How to trigger manual escalation
 
-1. From within an incident in incident.io, use the escalation options to page the relevant `Escalation: {team}` schedule
-2. This will notify all members on that escalation schedule simultaneously
+1. From within an incident in incident.io, use the escalation options to page the relevant `Escalation (manual): {team}` path
+2. This pages whoever is on that team's `Escalation: {team}` rota right now, then everyone on it – one person at a time, 10 minutes per level
 3. Any available team member can then respond and assist with the incident
 
 > 💡 Manual escalation is a safety net, not a shortcut. Always try the normal escalation paths first before manually escalating to an entire team.
@@ -73,6 +78,50 @@ And 2 weekend layers:
 If you're in a product team, it's tempting to think that service alerts don't apply to you, or that when you're on call you can just hand everything off to the infrastructure team. That's not the case, because it's important that every engineer has a basic understanding of how our software is deployed, where the weak points in our systems are, and what the failure modes look like. This understanding should be all that's needed to follow the runbooks, and if you follow the causes of alerts, ultimately you'll be less likely to ship code that takes PostHog down.
 
 Besides knowledge, being on call requires availability – including weekends. If teams had their own separate rotations, there would be more people on call in total, and each would have to stand by 24/7 as our teams aren't big enough to follow the sun. This would be more stressful because of availability constraints, while being less productive because of the rare alerts being spread across multiple people.
+
+## Escalation paths
+
+A team has up to two escalation paths:
+
+* `On call: {team}` – where an alert routed to the team goes. Previously named `PostHog: {team}`.
+* `Escalation (manual): {team}` – where you land when you [escalate to a team by hand](#manual-escalation-schedules).
+
+> **Escalation paths are managed in Terraform, not the dashboard.** Changes made in the incident.io UI get reverted on the next apply. Schedules are the exception – teams change those constantly for PTO and new joiners, so they stay in the dashboard and Terraform looks them up by name.
+
+They live in the [`incidentio-escalation-paths` module](https://github.com/PostHog/posthog-cloud-infra/tree/main/terraform/modules/incidentio-escalation-paths) in `posthog-cloud-infra`, and every team is listed in one file: [`terraform/environments/incidentio/escalation-paths/terragrunt.hcl`](https://github.com/PostHog/posthog-cloud-infra/blob/main/terraform/environments/incidentio/escalation-paths/terragrunt.hcl).
+
+### The standard on-call path
+
+Every `On call: {team}` path is the same shape, so paging behavior doesn't vary by team:
+
+1. Post to the team's own alert channel, whatever the priority
+2. If the alert is critical, round-robin the team's `On call: {team}` rota – 10 minutes to ack
+3. Still unacked? Post to #alerts, then round-robin global on-call alongside the team – 15 minutes to ack
+4. Repeat
+
+Non-critical alerts stop at step 1 – the team sees them in Slack, nobody gets woken up. A few teams escalate sideways to a second team's rota between steps 2 and 3.
+
+### Adding or changing a path
+
+1. Create the rota you need in the [incident.io dashboard](https://app.incident.io/posthog/on-call/schedules) – `On call: {team}` for alert routing, `Escalation: {team}` for manual escalation
+2. Set the `Slack Alerts channel` attribute on your team's entry in the Team catalog. The path reads the channel from there, so an unset one fails the plan
+3. Add your team to `teams` in `terragrunt.hcl` and open a PR against [`posthog-cloud-infra`](https://github.com/PostHog/posthog-cloud-infra). CI runs the plan – read it before merging, since it shows exactly which paging levels move
+
+Rather than hand-writing the HCL, point your editor's agent at it:
+
+```
+In posthog-cloud-infra, add my team to the incident.io escalation paths.
+
+Read terraform/modules/incidentio-escalation-paths/ first, then add an entry to
+`teams` in terraform/environments/incidentio/escalation-paths/terragrunt.hcl,
+keyed by my team's external ID in the incident.io Team catalog.
+
+Set `on_call = true` for a standard alert-routing path, and
+`manual_escalation = true` for a manual escalation path. Rota names derive from
+the team's catalog display name as "On call: <team>" and "Escalation: <team>",
+so only set `on_call_schedule` or `escalation_schedule` if our rota is named
+differently. Then run `terragrunt hcl validate` and `terraform fmt`.
+```
 
 ## Before going on call
 
@@ -147,9 +196,7 @@ As well as the above access you should ensure you have access and feel comfortab
 
 ![alert-example](https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Screenshot_2025_10_27_at_08_42_11_f7508c7432.png)
 
-Critical alerts will trigger per-team escalation policies which go like this:
-1. If available, a member of the team associated with the alert is paged first
-1. If nobody is available or nobody responds within the configured time then the `On call: global` schedule is paged
+Critical alerts trigger the team's [`On call: {team}` escalation path](#the-standard-on-call-path), which pages a member of the team associated with the alert first, then global on-call alongside the team if nobody responds in time.
 
 > **If at any point you get paged - always respond!** Even if you are unavailable you should respond as such (either via the app or the personal Slack notification). That way the escalation can continue to the next available person.
 

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -39,6 +39,8 @@ Unlike `On call: {team}`, this rotation has to cover the clock, every day of the
 
 Group windows have to tile the full 24 hours between them. If they don't, the Terraform plan fails and names the first uncovered minute – somebody escalating by hand at 3am should never find nobody there.
 
+> 💡 Don't rearrange this schedule around your own availability, and don't request cover on it. It's best-effort cover rather than a rotation with turns to trade – everyone in a group is on call for the whole window. If you're genuinely unavailable, [add an override on yourself](#make-sure-your-availability-is-up-to-date) and the rest of your group is still there.
+
 #### When to use manual escalation
 
 Manual escalation should be used when:
@@ -103,47 +105,7 @@ Non-critical alerts stop at step 1 – the team sees them in Slack, nobody gets 
 
 Teams, schedules, rotations, and escalation paths all live in the [`incidentio-oncall` module](https://github.com/PostHog/posthog-cloud-infra/tree/main/terraform/modules/incidentio-oncall) in `posthog-cloud-infra`. Everything one team needs is a single block in a single file: [`terraform/environments/incidentio/oncall/terragrunt.hcl`](https://github.com/PostHog/posthog-cloud-infra/blob/main/terraform/environments/incidentio/oncall/terragrunt.hcl).
 
-You supply people and hours. Rotation mechanics aren't configurable, so every team's schedules and paging come out the same shape:
-
-```hcl
-"my-team" = {
-  name                   = "My Team"
-  alert_slack_channel_id = "C0123456789" # #alerts-my-team
-  slack_user_group_id    = "S0123456789" # @Team My Team
-
-  # Working hours. One rotation each, nine hours from start of day.
-  on_call = {
-    members = {
-      "eu-person@posthog.com" = { start_of_day = "07:00" }
-      "us-person@posthog.com" = { start_of_day = "15:00" }
-    }
-  }
-
-  # Round-the-clock cover for manual escalation. Windows must tile the day.
-  escalation = {
-    groups = {
-      "EU" = { start = "06:00", end = "18:00", members = ["eu-person@posthog.com"] }
-      "US" = { start = "18:00", end = "06:00", members = ["us-person@posthog.com"] }
-    }
-  }
-
-  # Support hero, taking turns a week at a time.
-  support_hero = {
-    members                 = ["eu-person@posthog.com", "us-person@posthog.com"]
-    handover_interval_weeks = 1
-    handover_start_at       = "2026-01-05T00:00:00Z"
-  }
-}
-```
-
-Worth knowing before you write one:
-
-* **Every time is UTC**, and you convert from your own timezone yourself. One timezone across every team is the only way the windows can be read off and checked against each other
-* **Schedules and paths follow from the blocks you write**, so there's no separate switch to forget. `on_call` gets you the `On call:` schedule and the path alerts route to, `escalation` gets you the escalation rotation and the manual path, and `support_hero` gets you a support hero rotation that nothing pages
-* **The key is your team's external ID** in the Team catalog rather than its name, so a rename moves nothing. The display name comes from `name`
-* **`handover_start_at` is fixed once it's set.** Changing it re-phases the support hero rotation and hands the pager over mid-turn
-* **`On call: Global` and the last-resort schedule are the exception.** They belong to no team, so they're looked up by name rather than defined here
-* Teams defined here carry a `Managed by Terraform` attribute in the dashboard pointing back at the file, so whoever finds your team knows where to edit it
+You supply people and hours – rotation mechanics aren't configurable. Read the existing team blocks in that file for the structure, and the module's README and `teams` variable for what each field means and the rules they have to follow. Those are the source of truth, so this page doesn't restate them.
 
 Open a PR against [`posthog-cloud-infra`](https://github.com/PostHog/posthog-cloud-infra) and CI runs the plan. Read it before merging – it names every rotation and paging level that moves. Don't make these changes in the incident.io dashboard, because the next apply puts them back.
 
@@ -153,17 +115,15 @@ Rather than hand-writing the HCL, point your editor's agent at it:
 In posthog-cloud-infra, add my team to the incident.io on-call setup.
 
 Read terraform/modules/incidentio-oncall/ first – the README and the `teams`
-variable – then add a block for my team to `teams` in
-terraform/environments/incidentio/oncall/terragrunt.hcl, keyed by our external
-ID in the incident.io Team catalog.
+variable, which document every field and the rules they follow – then add a
+block for my team to `teams` in
+terraform/environments/incidentio/oncall/terragrunt.hcl, following the existing
+team blocks for structure.
 
 Here's who's on call and when, in local time: <people, their working hours, and
 who covers escalation out of hours>.
 
-Convert every time to UTC, and don't set `timezone` – that field only exists to
-adopt a schedule that isn't UTC yet. Escalation group windows have to tile the
-whole 24 hours or the plan fails. Then run `terragrunt hcl validate` and
-`terraform fmt`, and show me the plan.
+Then run `terragrunt hcl validate` and `terraform fmt`, and show me the plan.
 ```
 
 ## Before going on call
@@ -215,6 +175,7 @@ If you are unavailable for any of your schedules you need to act! Overrides are 
 
 1. For your `On call: {team}` schedule simply click on your name in your rotation, click `create an override` and then remove yourself from the list so it shows `No one`
 1. For your `Support Hero: {team}` or `On call: Global` schedules click `Request cover` at the top right. This will notify selected team members automatically to find someone to cover you (you should probably do a shout out in #ask-posthog-anything as well). You can trade whole weeks, but also just specific days. Remember not to alter the rotation's core order, as that's an easy way to accidentally shift the schedule for everyone.
+1. For your [`Escalation: {team}`](#manual-escalation-schedules) schedule, don't request cover and don't reshuffle the groups – nobody needs to take your turn, because there aren't any. Add an override on yourself for the window you're away, the same way as above, so it's clear you're unavailable. Everyone else in your group is still on call.
 
 ## Make sure you have all the access you might need
 

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -23,7 +23,7 @@ Cover for PTO and swaps is the exception: [overrides](#make-sure-your-availabili
 A team has up to three schedules in [incident.io](https://app.incident.io/posthog/on-call/schedules), and it gets the ones its Terraform block asks for:
 
 * `On call: {team}`
-    - Working-hours cover, and where alerts routed to the team go. Everyone gets their own rotation, running nine hours from their start of day, weekdays only unless you say otherwise
+    - Working-hours cover, and where alerts routed to the team go. Everyone gets their own rotation, you just set the start of your normal working day, weekdays only
     - Stagger start times to cover as much of the day as your team can – 08:00 for an EU-based engineer leaves 17:00 onwards for a US-based one
     - Gaps are fine. Nobody is woken up here: a critical alert that finds nobody on call goes to [global on-call](#global-on-call-schedule) instead
 * `Escalation: {team}`

--- a/contents/handbook/engineering/operations/on-call-rotation.md
+++ b/contents/handbook/engineering/operations/on-call-rotation.md
@@ -26,14 +26,14 @@ A team has up to three schedules in [incident.io](https://app.incident.io/postho
     - Working-hours cover, and where alerts routed to the team go. Everyone gets their own rotation, you just set the start of your normal working day, weekdays only
     - Stagger start times to cover as much of the day as your team can – 08:00 for an EU-based engineer leaves 17:00 onwards for a US-based one
     - Gaps are fine. Nobody is woken up here: a critical alert that finds nobody on call goes to [global on-call](#global-on-call-schedule) instead
-* `Escalation: {team}`
+* `Page team (emergency): {team}`
     - The "everything is broken" rotation, paged only when [someone escalates by hand](#manual-escalation-schedules)
 * `Support Hero: {team}`
     - The [support hero rotation](/handbook/engineering/operations/support-hero). Everyone takes turns one at a time, handing over every week or two. Nothing pages it
 
 ### Manual escalation schedules
 
-Teams that own production-critical services also have an `Escalation: {team}` schedule, triggered by hand by whoever is handling an incident and needs more help. Other teams don't need one.
+Teams that own production-critical services also have a `Page team (emergency): {team}` schedule, triggered by hand by whoever is handling an incident and needs more help. Other teams don't need one. The schedule and the escalation path that pages it share this name – there's exactly one of each per team.
 
 Unlike `On call: {team}`, this rotation has to cover the clock, every day of the week. You describe it as groups – blocks of the clock with the people covering each one, an EU group and a US group, or however your team is actually spread. Everyone in a group is on call for the whole of its window rather than taking turns, and the page cycles between them one at a time.
 
@@ -50,8 +50,8 @@ Manual escalation should be used when:
 
 #### How to trigger manual escalation
 
-1. From within an incident in incident.io, use the escalation options to page the relevant `Escalation (manual): {team}` path
-2. This pages whoever is on that team's `Escalation: {team}` rotation right now, then everyone on it – one person at a time, 10 minutes per level
+1. From within an incident in incident.io, use the escalation options to page the relevant `Page team (emergency): {team}`
+2. This pages whoever is on that team's emergency rotation right now, then everyone on it – one person at a time, 10 minutes per level
 3. Any available team member can then respond and assist with the incident
 
 > 💡 Manual escalation is a safety net, not a shortcut. Always try the normal escalation paths first before manually escalating to an entire team.
@@ -65,6 +65,8 @@ Manual escalation should be used when:
 PostHog Cloud doesn't shut down at night (_whose_ night anyway?) nor on Sunday. As a 24/7 service, our goal is to be 100% operational 100% of the time. The global on-call is the last line of defense and is escalated to:
 * if nobody at the `On call: {team}` level is available
 * if the alert is critical but has no team assignment (for whatever reason)
+
+It's also the one schedule not defined in Terraform – it changes too often, and by too many hands, for that to be safe.
 
 This schedule has 3 week day layers:
 - **Europe** (06:00 to 14:00 UTC) - (8 hours)
@@ -86,9 +88,11 @@ Besides knowledge, being on call requires availability – including weekends. I
 A schedule says who's on call. An escalation path says who gets paged, in what order, and how long they have to respond. A team gets the paths that follow from the schedules it has:
 
 * `On call: {team}` – where an alert routed to the team goes, previously named `PostHog: {team}`
-* `Escalation (manual): {team}` – where you land when you [escalate to a team by hand](#manual-escalation-schedules)
+* `Page team (emergency): {team}` – where you land when you [escalate to a team by hand](#manual-escalation-schedules)
 
-Two more are org-wide rather than owned by a team: `PostHog: General escalation`, for an escalation that's nobody's in particular, which pages global on-call for 30 minutes and then the last-resort rotation alongside it; and the `Notify: ...` paths, which post to a Slack channel and page nobody.
+Two more are org-wide rather than owned by a team: `Default escalation`, for an escalation that's nobody's in particular, which pages global on-call for 30 minutes and then the last-resort rotation alongside it; and the `Slack only: ...` paths, which post to a Slack channel and page nobody.
+
+Paths are named so that listing them alphabetically – which is what the escalation picker does – puts them in the order you'd reach for them.
 
 ### The standard on-call path
 
@@ -175,7 +179,7 @@ If you are unavailable for any of your schedules you need to act! Overrides are 
 
 1. For your `On call: {team}` schedule simply click on your name in your rotation, click `create an override` and then remove yourself from the list so it shows `No one`
 1. For your `Support Hero: {team}` or `On call: Global` schedules click `Request cover` at the top right. This will notify selected team members automatically to find someone to cover you (you should probably do a shout out in #ask-posthog-anything as well). You can trade whole weeks, but also just specific days. Remember not to alter the rotation's core order, as that's an easy way to accidentally shift the schedule for everyone.
-1. For your [`Escalation: {team}`](#manual-escalation-schedules) schedule, don't request cover and don't reshuffle the groups – nobody needs to take your turn, because there aren't any. Add an override on yourself for the window you're away, the same way as above, so it's clear you're unavailable. Everyone else in your group is still on call.
+1. For your [`Page team (emergency): {team}`](#manual-escalation-schedules) schedule, don't request cover and don't reshuffle the groups – nobody needs to take your turn, because there aren't any. Add an override on yourself for the window you're away, the same way as above, so it's clear you're unavailable. Everyone else in your group is still on call.
 
 ## Make sure you have all the access you might need
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -16,7 +16,7 @@ Our support engineers, in the <SmallTeam slug="support" />, triage tickets for [
 
 ## When is my turn?
 
-Most engineering teams run an incident.io schedule, check out the [escalation schedules](/handbook/engineering/operations/on-call-rotation#escalation-schedules).
+Most engineering teams run a `Support Hero: {team}` rotation in incident.io, [defined in Terraform](/handbook/engineering/operations/on-call-rotation#managing-on-call-in-terraform) alongside the team's other [escalation schedules](/handbook/engineering/operations/on-call-rotation#escalation-schedules).
 
 The schedules consist of contiguous blocks, but that definitely doesn't mean working 24/7 – you should just work your normal hours.
 

--- a/contents/teams/cloud-foundations/index.mdx
+++ b/contents/teams/cloud-foundations/index.mdx
@@ -16,7 +16,7 @@ We have a bit of overlapping ownership across infra, so you don't need to know "
 
 - **Need our eyes on something, not urgent:** `@support-hero-infra`
 - **Need context or someone in your timezone:** `@infra-folks`
-- **Something is burning and you need to page us:** escalate to **Escalation (manual): Infrastructure** in incident.io
+- **Something is burning and you need to page us:** escalate to **Page team (emergency): Infrastructure** in incident.io
 
 General channel: `#support-infrastructure`. Not sure which infra team to post to? Use `#group-infrastructure`.
 

--- a/contents/teams/cloud-platform/index.mdx
+++ b/contents/teams/cloud-platform/index.mdx
@@ -16,7 +16,7 @@ We have a bit of overlapping ownership across infra, so you don't need to know "
 
 - **Need our eyes on something, not urgent:** `@support-hero-infra`
 - **Need context or someone in your timezone:** `@infra-folks`
-- **Something is burning and you need to page us:** escalate to **Escalation (manual): Infrastructure** in incident.io
+- **Something is burning and you need to page us:** escalate to **Page team (emergency): Infrastructure** in incident.io
 
 General channel: `#support-infrastructure`. Not sure which infra team to post to? Use `#group-infrastructure`.
 


### PR DESCRIPTION
## Changes

The [`incidentio-oncall` module](https://github.com/PostHog/posthog-cloud-infra/tree/main/terraform/modules/incidentio-oncall) now manages a team's on-call setup end to end — its Team catalog entry, all three of its schedules and their rotations, and the escalation paths that page them (PostHog/posthog-cloud-infra#9902, plus the remaining teams and the renaming in PostHog/posthog-cloud-infra#9927). The handbook still described schedules as dashboard-owned, linked to a module that has since been renamed, and used names that are about to stop existing.

⚠️ **Depends on PostHog/posthog-cloud-infra#9927** — the names below are only live once that applies.

In `on-call-rotation.md`:

- New **Managing on-call in Terraform** section: links to the module and to the single file every team is defined in, plus a prompt to hand to an editor agent. It deliberately doesn't restate the field-level rules — the module README and the existing team blocks are the source of truth, and duplicating them here just means two places to keep current.
- **Team schedules** covers all three schedules rather than two, with overrides called out as the one thing still done in the dashboard, and `On call: Global` as the one schedule still outside Terraform.
- The `Page team (emergency): {team}` schedule isn't one to reshuffle or request cover on — it's best-effort cover with no turns to trade, so if you're genuinely unavailable you add an override on yourself and the rest of your group is still on call.
- Names updated throughout:

  | Before | Now |
  | ------ | --- |
  | `Escalation: {team}` (schedule) | `Page team (emergency): {team}` |
  | `Escalation (manual): {team}` (path) | `Page team (emergency): {team}` |
  | `PostHog: General escalation` | `Default escalation` |
  | `Notify: {name}` | `Slack only: {name}` |
  | `PostHog: {team}` | `On call: {team}` |

  Two more were wrong on the page independently of any rename: `Support: {team}` (it's `Support Hero: {team}`) and `On call: {global}` (it's `On call: Global`).

The two infra team pages used the old path name too. They still point at Infrastructure rather than at their own new paths, since both pages deliberately give one front door for all of infra — but worth a second look from those teams now that each has its own.

`support-hero.md` gets a one-line change pointing at where the support hero rotation is defined.

## Why

Every part of on-call is in Terraform now — creating the team, the schedules, the paths — so setting a team up means adding people and their hours to one file. The docs described the old split and the old names, so anyone following them would either go looking for schedules that no longer exist, or make the change in the incident.io dashboard and have it reverted on the next apply.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` — n/a, no pages moved

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
