### PR TITLE
chore: move Comments/Discussions ownership to conversations

### DIFF
--- a/contents/teams/platform-features/index.mdx
+++ b/contents/teams/platform-features/index.mdx
@@ -25,7 +25,6 @@ template: team
     -   Activity logs (audit logs)
     -   Approvals
     -   Reminders
-    -   Comments
     -   Resource transfer (copy between projects)
     -   Emails / notifications
 

--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -123,7 +123,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     comments: {
         feature: 'Comments/Discussions',
-        owner: ['platform-features'],
+        owner: ['conversations'],
         label: 'feature/comments',
     },
     'csp-tracking': {


### PR DESCRIPTION
## Changes

The feature ownership table lists Comments/Discussions under Platform features. This PR moves it to Conversations.

Conversations is the team that builds on the feature. It stores every support ticket message as a comment, so the model and its schema are Conversations code in practice. Platform features has not developed the feature in the last year and has no plans to.

- `src/hooks/useFeatureOwnership.tsx`: the `comments` entry now names the `conversations` team.
- `contents/teams/platform-features/index.mdx`: the "what we own" list drops Comments.

The `conversations` slug already appears in this file as the owner of Support, so the `SmallTeam` link resolves.

The Conversations team has no `index.mdx`, only `objectives.mdx`. I did not create one, so Comments does not appear in a "what we own" list on their page.

The matching repo change is [PostHog/posthog#80296](https://github.com/PostHog/posthog/pull/80296). It moves the three `owners.yaml` rules that route reviews.

I (actually Claude, via Claude Code) made this change at Yasen's direction. Both PRs are drafts until the Conversations team agrees to the handover.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)
