### PR TITLE
docs(ai-observability): swap evals screenshot for video on start-here

### DIFF
--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -81,8 +81,8 @@ PostHog's SDK wrappers handle all the heavy lifting. Use your LLM provider as no
   - **Code-based (Hog)** – deterministic checks written in code
   - **Sentiment analysis** – classifies user sentiment as positive, neutral, or negative
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/evaluations_screenshot_959ba893da.png"
+<ProductVideo
+  videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/evals_e00c3b28ea.mp4"
   alt="AI Observability evaluations"
   classes="rounded"
 />


### PR DESCRIPTION
## Changes

Replaces the static evaluations screenshot with a video in the "Evaluate AI quality" step of the AI Observability start-here page, matching the video style used elsewhere on the page.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case

🤖 Generated with [Claude Code](https://claude.com/claude-code)