### PR TITLE
use chevron for docs sidenavs

### DIFF
--- a/src/components/Products/ReaderViewProduct/buildProductMenuTabs.tsx
+++ b/src/components/Products/ReaderViewProduct/buildProductMenuTabs.tsx
@@ -58,7 +58,7 @@ const DocsTreeMenu = ({
         )
     }, [items, installItem, platforms])
 
-    return <TreeMenu items={itemsWithInstall as any} variant={variant} appearance="sidebar" rootHeading={rootHeading} />
+    return <TreeMenu items={itemsWithInstall as any} variant={variant} rootHeading={rootHeading} />
 }
 
 interface BuildProductMenuTabsArgs {


### PR DESCRIPTION
## Changes

making all docs sidenavs use the `>` chevron collapsible. the new `+` is buggy and doesn't work in several places

https://github.com/user-attachments/assets/3c180f6f-f34f-4540-82dc-f8ded6a6d551
