### PR TITLE
docs: reword Postgres CDC cleanup line that trips the wizard's skill scanner

### DIFF
--- a/contents/docs/cdp/sources/postgres.mdx
+++ b/contents/docs/cdp/sources/postgres.mdx
@@ -356,7 +356,7 @@ PostHog-managed mode is the easiest path if the database user has enough privile
 
 When you disable a CDC table, PostHog removes it from the publication. Changes made while the table is disabled are permanently lost from the CDC stream, so re-enabling the table requires a full resync.
 
-When you delete the source, PostHog soft-deletes the warehouse tables and attempts to drop the PostHog-managed replication slot and publication. Cleanup is best-effort, so you should still verify the slot is gone if the source was failing or unreachable.
+When you delete the source, PostHog soft-deletes the warehouse tables and attempts to drop the replication slot and publication it manages. Cleanup is best-effort, so you should still verify the slot is gone if the source was failing or unreachable.
 
 ### Self-managed
 


### PR DESCRIPTION
## Problem

`/docs/cdp/sources/postgres` is fetched verbatim into the `data-warehouse-source-setup` skill that the wizard installs, and every installed skill is scanned for prompt injection before it's allowed to load. One sentence on this page trips the scanner:

> When you delete the source, PostHog soft-deletes the warehouse tables and attempts to drop **the PostHog-managed** replication slot and publication.

The rule looks for a removal verb followed by `posthog` or `posthog-<suffix>` — a pattern meant to catch package names like `posthog-js` or `posthog-node`. It also matches the adjective "PostHog-managed", so `drop the PostHog-managed` reads as an instruction to remove PostHog.

It's a false positive — the sentence is about dropping a Postgres replication slot, not the SDK — but the scanner fails closed, so the skill got deleted and the install failed. That took the wizard's warehouse setup down with it, on real users' machines.

## Changes

One-line reword. "PostHog-managed" was already redundant inside a section titled **PostHog-managed**, and the subject of the sentence is PostHog, so "it manages" carries the same meaning:

> …attempts to drop the replication slot and publication **it manages**.

## Test plan

Ran the rule's patterns over every file in the published `data-warehouse-source-setup.zip`:

- Before: exactly one match across all 11 files — this sentence, in `references/postgres.md`.
- After: zero.

No other doc pulled into that skill matches any of the rule's patterns.

## Note

This is the content-side fix and it unblocks the skill today. The underlying rule still treats any `PostHog-<word>` compound as a package name, so a future doc phrasing like "drop the PostHog-created publication" would trip it the same way. Worth tightening separately in the scanner rather than steering docs prose around it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCHQJBJR5/p1786384037788729?thread_ts=1786384037.788729&cid=C0BCHQJBJR5)*