### PR TITLE
chore(pocket-guides): add attribution for conversion tracking

### DIFF
--- a/src/components/SelfDrivingInbox/scoutDeepLink.ts
+++ b/src/components/SelfDrivingInbox/scoutDeepLink.ts
@@ -47,6 +47,8 @@ export function buildScoutDeepLink(scout?: ScoutSpec): string {
             name: scout.name,
             description: scout.description,
             ...(body ? { body } : {}),
+            // Attribution for the app's scout-created capture; older decoders ignore unknown fields.
+            source: 'pocket_guide',
         })
     )
 


### PR DESCRIPTION
## Changes
add attribution for pocket guide CTA tracking to see how many people actually create custom scouts via pocket guides

merge w/ https://github.com/PostHog/posthog/pull/80858

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
