### PR TITLE
fix: direct feature requests to the public roadmap

### DIFF
--- a/contents/docs/ai-engineering/index.mdx
+++ b/contents/docs/ai-engineering/index.mdx
@@ -32,7 +32,7 @@ Here are the AI products, tools, and resources we offer so far:
 
 Everything here is open source. Feel free to take our AI code, fork it, and use it yourself. Just remember to check the license and open a PR if you have any feedback.
 
-We're always thinking of new AI features that can make PostHog *even* better. If you have any ideas or requests, comment on this page or open a feature request on [GitHub](https://github.com/PostHog/posthog/issues/new?template=feature_request.yml).
+We're always thinking of new AI features that can make PostHog *even* better. If you have any ideas or requests, comment on this page or open a feature request on [our roadmap](/roadmap).
 
 <CalloutBox icon="IconInfo" title="Software licenses" type="fyi">
 

--- a/contents/docs/cdp/batch-exports/index.mdx
+++ b/contents/docs/cdp/batch-exports/index.mdx
@@ -35,7 +35,7 @@ You can test the configurations of each destination by clicking the **Start test
 
 This test can detect and diagnose configuration issues, like invalid credentials or missing permissions, before running the batch export.
 
-Support for new destinations will be added based on demand. Message us via the [in-app support form](https://us.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue) or create an [issue in GitHub](https://github.com/PostHog/posthog/issues/new?template=feature_request.yml) to voice your interest in new destinations.
+Support for new destinations will be added based on demand. Message us via the [in-app support form](https://us.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue) or open a request on [our roadmap](/roadmap) to voice your interest in new destinations.
 
 import InboundIpAddresses from "../_snippets/inbound-ip-addresses.mdx";
 import PersonsModelNote from "../_snippets/persons-model-note.mdx";

--- a/contents/docs/health-checks/index.mdx
+++ b/contents/docs/health-checks/index.mdx
@@ -9,7 +9,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 Health checks continuously inspect your PostHog setup for problems that quietly degrade your data – a missing SDK, traffic that bypasses your reverse proxy, a broken materialized view, and more. When a check finds an issue, PostHog surfaces it in the relevant **Health** section of the app, can notify you through alerts, and – if you use [PostHog Desktop](/docs/posthog-desktop) – can investigate and fix it for you automatically.
 
 <CalloutBox icon="IconInfo" title="Health checks are in beta" type="fyi">
-  The set of checks below is expanding over time. If there's a problem you'd like PostHog to catch, <a href="https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&projects=&template=feature_request.yml">let us know</a>.
+  The set of checks below is expanding over time. If there's a problem you'd like PostHog to catch, <a href="/roadmap">let us know</a>.
 </CalloutBox>
 
 <ProductScreenshot
@@ -93,5 +93,5 @@ This integration was added in [PostHog/posthog#61955](https://github.com/PostHog
 
 Health checks are actively being developed. We'd love your feedback:
 
-- [Report bugs](https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) or [request features](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&projects=&template=feature_request.yml)
+- [Report bugs](https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) or [request features](/roadmap)
 - Use the feedback link in the Health section of the app

--- a/contents/docs/revenue-analytics/troubleshooting.mdx
+++ b/contents/docs/revenue-analytics/troubleshooting.mdx
@@ -79,7 +79,7 @@ There's also one exception to what you'd expect from a zero-decimal currency, an
 
 ## What if you don't support the currency on my revenue event?
 
-This is unlikely given the large range of currencies we support, but in this event we'd track that revenue event as if it had `0` value. We welcome [feature requests](https://github.com/PostHog/posthog/issues/new?assignees=&labels=feature&template=feature_request.md&title=) for currencies you'd like us to support.
+This is unlikely given the large range of currencies we support, but in this event we'd track that revenue event as if it had `0` value. We welcome [feature requests on our roadmap](/roadmap) for currencies you'd like us to support.
 
 ### Why isn't my revenue showing up?
 
@@ -151,4 +151,4 @@ Computing Customer Acquisition Cost (CAC) and Cost Per Click (CPC) will be possi
 
 Currently, PostHog does not support using custom currency conversion data. We rely on the exchange rates provided by Open Exchange Rates.
 
-If you need support for custom conversion rates, please [create a feature request](https://github.com/PostHog/posthog/issues/new?assignees=&labels=feature&template=feature_request.md&title=), so our team can consider adding this functionality.
+If you need support for custom conversion rates, please [create a feature request on our roadmap](/roadmap), so our team can consider adding this functionality.

--- a/contents/faq.mdx
+++ b/contents/faq.mdx
@@ -189,7 +189,7 @@ We love contributions big or small. You can be helpful by:
 1. Reporting bugs or issues. 
 2. Voting on [our roadmap](/roadmap).
 3. Open a PR (see our instructions on [developing PostHog locally](/handbook/engineering/developing-locally)).
-4. Submit a feature request.
+4. Submit a feature request on [our roadmap](/roadmap).
 
 [See our contributing guide](/docs/contribute) for more.
 

--- a/contents/handbook/support/customer-support.md
+++ b/contents/handbook/support/customer-support.md
@@ -159,7 +159,7 @@ Locate the user's profile in admin and send them a 2FA reset link. The link expi
 
 #### How do I handle a bug report or feature request?
 
-For feature requests from low priority users, [give them this link](https://github.com/PostHog/posthog/issues/new/choose) and suggest they open a feature request.
+For feature requests from low priority users, [give them this link](/roadmap) and suggest they open a feature request on our public roadmap.
 
 For bug reports from normal and high priority users (assuming you've confirmed it's a bug, and that there's not already an open bug report):
 


### PR DESCRIPTION
## Changes

Readers who want to request a feature are sent to GitHub's issue form from several docs, the FAQ, and the support handbook. We want feature requests on the public roadmap instead, so those links now point to [/roadmap](https://posthog.com/roadmap).

- Docs updated: AI engineering overview, batch exports, health checks, and revenue analytics troubleshooting.
- FAQ: "Submit a feature request" in the contributing list now links to the roadmap.
- Handbook: the customer support page now sends low priority feature requesters to the roadmap.

Left unchanged: bug report links, historical blog posts, pages that track a specific existing GitHub issue, and the support flow where staff file requests for normal and high priority users.

A companion PR updates the same links in the app and README (link to follow in a comment).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
