### PR TITLE
chore(blog): add test message to articles authored by Andy Vandervell

### DIFF
--- a/contents/blog/aruba-hackathon.md
+++ b/contents/blog/aruba-hackathon.md
@@ -206,3 +206,5 @@ Some hackathon projects, such as our new dashboard templates, have already shipp
 Fancy joining us at our next all-company offsite? We're [always hiring](/careers).
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/behind-the-scenes-posthog-hackathon.md
+++ b/contents/blog/behind-the-scenes-posthog-hackathon.md
@@ -32,3 +32,5 @@ You can watch the first episode below, or on [our YouTube channel](https://www.y
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/gwUZRA0Y7xI?si=ZpbEqAJV6dYV1FPE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 And if you'd like to participate in a PostHog hackathon, we're [always hiring](/careers).
+
+Joe is Cool

--- a/contents/blog/best-gdpr-compliant-analytics-tools.md
+++ b/contents/blog/best-gdpr-compliant-analytics-tools.md
@@ -431,3 +431,5 @@ Yes. **PostHog**, **Plausible**, **Fathom**, **Matomo**, and **TelemetryDeck** a
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-heap-alternatives.mdx
+++ b/contents/blog/best-heap-alternatives.mdx
@@ -787,3 +787,5 @@ For detailed comparisons, see our guides to [Mixpanel alternatives](/blog/best-m
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-hipaa-compliant-ab-testing-tools.mdx
+++ b/contents/blog/best-hipaa-compliant-ab-testing-tools.mdx
@@ -179,3 +179,5 @@ Note that a BAA requires subscribing to a paid platform package (Boost, Scale, o
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-hipaa-compliant-analytics-tools.md
+++ b/contents/blog/best-hipaa-compliant-analytics-tools.md
@@ -239,3 +239,5 @@ That matters for HIPAA compliance because every additional vendor means another 
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-hotjar-alternatives.mdx
+++ b/contents/blog/best-hotjar-alternatives.mdx
@@ -854,3 +854,5 @@ For detailed comparisons, see our guides to [Mixpanel alternatives](/blog/best-m
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-microsoft-clarity-alternatives.mdx
+++ b/contents/blog/best-microsoft-clarity-alternatives.mdx
@@ -739,3 +739,5 @@ For more options, see our guides to the [best session replay tools](/blog/best-s
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-mixpanel-alternatives.mdx
+++ b/contents/blog/best-mixpanel-alternatives.mdx
@@ -566,3 +566,5 @@ Beyond the tools in this guide, there are many other options worth considering. 
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-open-source-ab-testing-tools.md
+++ b/contents/blog/best-open-source-ab-testing-tools.md
@@ -305,3 +305,5 @@ Yes – that's one of the main advantages of open-source A/B testing tools. **Gr
 - [PostHog vs. GrowthBook](/blog/posthog-vs-growthbook)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-open-source-analytics-tools.mdx
+++ b/contents/blog/best-open-source-analytics-tools.mdx
@@ -659,3 +659,5 @@ PostHog is more than an analytics tool. It combines everything developers need t
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-open-source-feature-flag-tools.md
+++ b/contents/blog/best-open-source-feature-flag-tools.md
@@ -321,3 +321,5 @@ Local evaluation means feature flags are checked locally within your application
 - [The benefits of feature flags and how to use them](/product-engineers/feature-flag-benefits-use-cases)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/best-open-source-session-replay-tools.md
+++ b/contents/blog/best-open-source-session-replay-tools.md
@@ -337,3 +337,5 @@ See our full guide to the [best session replay tools](/blog/best-session-replay-
 
 <NewsletterForm />
  
+
+Joe is Cool

--- a/contents/blog/best-statsig-alternatives.mdx
+++ b/contents/blog/best-statsig-alternatives.mdx
@@ -842,3 +842,5 @@ See our comparisons of the [best LaunchDarkly alternatives](/blog/best-launchdar
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/ga4-alternatives.mdx
+++ b/contents/blog/ga4-alternatives.mdx
@@ -797,3 +797,5 @@ The [top web analytics tools in 2026](/blog/best-web-analytics-tools) include:
 See our full guide to the [best web analytics tools](/blog/best-web-analytics-tools) for more options.
 
 </details>
+
+Joe is Cool

--- a/contents/blog/google-analytics-to-posthog.md
+++ b/contents/blog/google-analytics-to-posthog.md
@@ -248,3 +248,5 @@ This makes it an easy way to track new and returning visitors to your website, a
 - [A non-technical guide to understanding data in PostHog](/tutorials/non-technical-guide-to-data)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/google-optimize-alternatives.md
+++ b/contents/blog/google-optimize-alternatives.md
@@ -168,3 +168,5 @@ Experimentation is available on LaunchDarkly's Pro plan, which costs $20 per sea
 - **Square:** Mobile payments
 - **Ryanair:** Affordable airline
 - **HashiCorp:** Infrastructure automation and security
+
+Joe is Cool

--- a/contents/blog/hightouch-posthog-reverse-etl-integration.md
+++ b/contents/blog/hightouch-posthog-reverse-etl-integration.md
@@ -82,3 +82,5 @@ We also recently ran a [PostHog App Bounty](https://github.com/PostHog/posthog/i
 Whether you have an idea for an app or just need some help, please [let us know](https://app.posthog.com/home#supportModal) if you'd like to get involved.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-14.md
+++ b/contents/blog/hogmail-14.md
@@ -62,3 +62,5 @@ category: General
 - [How To Download All of Wikipedia onto a USB Flash Drive](https://planetofthepaul.com/wikipedia-download-usb-flash/)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-15.md
+++ b/contents/blog/hogmail-15.md
@@ -70,3 +70,5 @@ category: General
 * [How Do You Prove a Secret?](https://www.quantamagazine.org/how-to-prove-you-know-a-secret-without-giving-it-away-20221011/)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-16.md
+++ b/contents/blog/hogmail-16.md
@@ -79,3 +79,5 @@ All the ways you can use filters to find useful session recordings.
 - [Exploring massive, real-world data sets: 100+ Years of Weather Records in ClickHouse](https://clickhouse.com/blog/real-world-data-noaa-climate-data)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-17.md
+++ b/contents/blog/hogmail-17.md
@@ -83,3 +83,5 @@ Charles shares his practical guide to how we run finance without a dedicated fin
 - [Marie Kondo your software stack with open source](https://github.com/readme/featured/open-source-minimalism) (17 min read)
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-18.md
+++ b/contents/blog/hogmail-18.md
@@ -77,3 +77,5 @@ Mental note: y'all love articles with 'how' in the title, eh? Thanks for your su
 - [How The New York Times Uses Machine Learning To Make Its Paywall Smarter](https://open.nytimes.com/how-the-new-york-times-uses-machine-learning-to-make-its-paywall-smarter-e5771d5f46f8) – one for the data science and ML fans out there.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-19.md
+++ b/contents/blog/hogmail-19.md
@@ -72,3 +72,5 @@ John Cutler explores this idea further in [Product GTM Fitness](https://cutlefis
 - [How employees can think like shareholders](https://www.mostlymetrics.com/p/questions-to-ask-before-taking-a) – Or, to use the post's original title, "the REAL questions you should ask before taking a job", though the questions here are still relevant outside of that context. CEO James has written about this in the past, too.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-20.md
+++ b/contents/blog/hogmail-20.md
@@ -82,3 +82,5 @@ Kite's source code is [now open source](https://github.com/kiteco).
 - [Corey Haines on SaaS metrics that lie](https://twitter.com/coreyhainesco/status/1612943630997819394) – Former Head of Growth at Baremetrics shares some insightful points on popular metrics that might mislead you.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-21.md
+++ b/contents/blog/hogmail-21.md
@@ -74,3 +74,5 @@ Balfour makes three final points:
 * [How to Measure “Hard-to-Measure” Marketing Channels](https://sparktoro.com/blog/how-to-measure-hard-to-measure-marketing-channels/) – Rand Fishkin on how to stop avoiding hard-to-measure marketing channels (e.g. native social, PR, events etc.) by learning how to measure them.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/hogmail-22.md
+++ b/contents/blog/hogmail-22.md
@@ -70,3 +70,5 @@ Dissent fuels innovation, but a "challenge everything" culture can "quickly meta
 **Read:** [Challenging the status quo at work](https://workweek.com/2022/11/28/challenging-the-status-quo-at-work/) by Hebba Youseff
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/introducing-hogql.md
+++ b/contents/blog/introducing-hogql.md
@@ -137,3 +137,5 @@ Got an opinion on what we should do next? Share it via the [feedback modal in Po
 [^1]: 68.5% of 🇺🇸 residents think 🍍 belongs on 🍕. People in 🇪🇸 are the greatest 🍍 deniers at 10%. One person in Aruba 🇦🇼 voted, but we're pretty sure that was one of us during our [2023 all-company offsite](/blog/aruba-hackathon). We built some cool hackathon projects there, like our [dashboard template library](/templates), and an open-source tool for [monitoring and managing ClickHouse clusters](https://github.com/PostHog/HouseWatch). You could say it was openly... sourcey. "_Hello, HR? Are bad puns a firing offense?_"
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/is-google-analytics-hipaa-compliant.md
+++ b/contents/blog/is-google-analytics-hipaa-compliant.md
@@ -53,3 +53,5 @@ HIPAA fines operate on a sliding scale based on the severity of the breach and t
 Fines aren't limited to large businesses. In 2017, a [children's charity was fined](https://www.hhs.gov/hipaa/for-professionals/compliance-enforcement/agreements/ccdh/index.html) due to storing PHI on a third-party platform without a BAA.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/launch-week-universe-of-new-features.md
+++ b/contents/blog/launch-week-universe-of-new-features.md
@@ -93,3 +93,5 @@ Today, Neil Kakkar shares three things we've learned about running effective A/B
 _Enjoyed this? Subscribe to our [newsletter](https://newsletter.posthog.com/subscribe) to hear more from us twice a month!_
 
 
+
+Joe is Cool

--- a/contents/blog/posthog-alternatives.mdx
+++ b/contents/blog/posthog-alternatives.mdx
@@ -537,3 +537,5 @@ PostHog also has an enterprise plan with SSO, SAML, and a dedicated customer suc
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/posthog-cloud-eu.md
+++ b/contents/blog/posthog-cloud-eu.md
@@ -64,3 +64,5 @@ We recommend completing the following steps to ensure GDPR compliance when using
 5. **Create "right to be forgotten" process:** A user must be able to request that their data be removed from PostHog. How you facilitate that request is up to you. Information on how to delete user data is [available in our docs](/docs/privacy/data-deletion).
 
 <GDPRForm />
+
+Joe is Cool

--- a/contents/blog/posthog-marketing.md
+++ b/contents/blog/posthog-marketing.md
@@ -226,3 +226,5 @@ We hope this look at how we use PostHog will inspire you (and your marketing tea
 - [How to track performance marketing](/tutorials/performance-marketing): An in-depth guide to tracking signups and conversions from different marketing channels.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/posthog-vs-amplitude.mdx
+++ b/contents/blog/posthog-vs-amplitude.mdx
@@ -566,3 +566,5 @@ Still need some convincing? See our guide to the [most popular Amplitude alterna
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/posthog-vs-heap.mdx
+++ b/contents/blog/posthog-vs-heap.mdx
@@ -357,3 +357,5 @@ Amplitude and Mixpanel offer similar product analytics features to Heap. Read th
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/posthog-vs-matomo.mdx
+++ b/contents/blog/posthog-vs-matomo.mdx
@@ -358,3 +358,5 @@ See our full guide to the [best web analytics tools](/blog/best-web-analytics-to
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/posthog-vs-mixpanel.mdx
+++ b/contents/blog/posthog-vs-mixpanel.mdx
@@ -687,3 +687,5 @@ We make this super easy by offering a [managed reverse proxy](/docs/advanced/pro
 </details>
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/blog/posthog-wallpapers.md
+++ b/contents/blog/posthog-wallpapers.md
@@ -118,3 +118,5 @@ All wallpapers are hand drawn by the peerless [Lottie Coxon](https://x.com/Lotti
 - [21:9](https://res.cloudinary.com/dmukukwp6/image/upload/21x9_a5dc1c79b0.png) (Most ultrawide monitors)
 - [7:10](https://res.cloudinary.com/dmukukwp6/image/upload/i_Pad_8be4203b56.png) (iPads, tablets, and vertical monitors)
 - [6:13](https://res.cloudinary.com/dmukukwp6/image/upload/i_Phone_63405aee57.png) (iPhone and smartphones)
+
+Joe is Cool

--- a/contents/blog/send-love-to-open-source.md
+++ b/contents/blog/send-love-to-open-source.md
@@ -61,3 +61,5 @@ Also, getting people who care about open-source projects to star our repo is of 
 > PostHog is an open source developer platform that helps people build successful products. We help you debug and ship your product faster.
 
 <ArrayCTA />
+
+Joe is Cool

--- a/contents/blog/using-posthog.md
+++ b/contents/blog/using-posthog.md
@@ -234,3 +234,5 @@ Want to see where people are clicking on any page on your website or web app, ju
 Try the [PostHog Toolbar](/tutorials/toolbar).
 
 <ArrayCTA />
+
+Joe is Cool

--- a/contents/blog/what-is-personal-data-pii.md
+++ b/contents/blog/what-is-personal-data-pii.md
@@ -114,3 +114,5 @@ PostHog offers EU hosting for GDPR compliance and a Business Associate Agreement
 Read our [privacy compliance documentation](/docs/privacy), which covers the [GDPR](/docs/privacy/gdpr-compliance), [HIPAA](/docs/privacy/hipaa-compliance) and [CCPA](/docs/privacy/ccpa-compliance) for more information on how to deploy PostHog in a privacy-compliant manner.
 
 <ArrayCTA />
+
+Joe is Cool

--- a/contents/founders/measure-product-market-fit.md
+++ b/contents/founders/measure-product-market-fit.md
@@ -404,3 +404,5 @@ And, if you find yourself unable to find product-market fit, we share how we fou
 [^7]: [Growth at All Costs is Perilous](https://review.firstround.com/growth-at-all-costs-is-perilous-this-is-how-to-scale-sales-sustainably) – Karen Rhorer – Sep 25, 2018
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/founders/north-star-metrics.md
+++ b/contents/founders/north-star-metrics.md
@@ -128,3 +128,5 @@ Needless to say, a developer platform like PostHog is essential for tracking any
 - [How to measure product engagement](/blog/how-to-measure-product-engagement): How to define engagement for your platform, and how to use analytics tools to measure and build on the results
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/founders/posthog-first-five.md
+++ b/contents/founders/posthog-first-five.md
@@ -115,3 +115,5 @@ Michael currently works on the product analytics team, and he built a lot of wha
 > **What we learned:** Look for T or M-shaped people. This is especially important for your early hires. You can't afford to hire specialists in every arena, so it's vital to find people who are experts in one or two disciplines, but are capable in others as well. Michael's experience of shipping his own project showed he had that quality.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/b2b-startup-marketing-strategy.md
+++ b/contents/newsletter/b2b-startup-marketing-strategy.md
@@ -165,3 +165,5 @@ Once you’ve built this content out, focus on SEO content targeting your rivals
 *Words by Andy Vandervell, who thinks people who use a hyphen instead of en dash are sociopaths.*
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/bad-behaviors.md
+++ b/contents/newsletter/bad-behaviors.md
@@ -177,3 +177,5 @@ _Words by Andy Vandervell, mechanical pencil enthusiast._
 [^2]: We’ve since split this team into three dedicated teams – <SmallTeam slug="feature-flags" />, <SmallTeam slug="experiments" />, and <SmallTeam slug="surveys" /> – because of the magic of small engineering teams. We’ll be hiring for these teams soon so, you know, see above.
 
 [^3]: We find charging for a specific product increases usage because people see you’re taking it more seriously. One of our goals for pricing is to make experiments cheaper, so users can run more of them without fear of running up a big bill.
+
+Joe is Cool

--- a/contents/newsletter/compound-startups.md
+++ b/contents/newsletter/compound-startups.md
@@ -100,3 +100,5 @@ So, next time you’re considering what bets to take with your startup, consider
 - **[Why we use GitHub as our CMS](/blog/github-cms) – Ian Vanagas:** GitHub is the ideal CMS for engineers and developers because they already use it, and it encourages [non-technical people to be more technical](/blog/github-cms).”
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/finding-a-job-product-engineer.md
+++ b/contents/newsletter/finding-a-job-product-engineer.md
@@ -197,3 +197,5 @@ Not writing a cover letter might work for bigger companies that are hiring at a 
 <NewsletterForm />
 
 [^1]: Figuring this out isn’t straightforward. If you pay for LinkedIn Premium, you can look up the spread of roles at a company via the “Insights” tab on a company’s page. This data isn’t perfect, but it is directionally useful.
+
+Joe is Cool

--- a/contents/newsletter/first-time-founders.md
+++ b/contents/newsletter/first-time-founders.md
@@ -134,3 +134,5 @@ He's got one final piece of advice for first-time founders:
 *Words by Andy Vandervell, who will accept almond croissants as payment.*
 
 [^1]: “Trust me bro” not enough for you, eh? A 2006 study by researchers from Harvard Business School and the Federal Reserve Bank of New York found first-time founders only succeed 18% of the time, compared to 20% for founders on their second, third, etc. startup. Founders who’d previously led a successful startup, however, had a much higher 30% success rate. Naturally, this study comes with some caveats. It only looked at VC-funded startups, and it’s old – it used data from between 1987 and 2006, when the startup environment was very different to now. I imagine the real success rate for first-time founders is much lower than 18%, but that’s not the point. The study argues (pretty convincingly, imo) that successful founders aren’t just lucky and more risk tolerant, they’re also more skillful. This makes intuitive sense, but now you know I actually read the source I’m quoting. You should have trusted me, bro. 
+
+Joe is Cool

--- a/contents/newsletter/hiring-at-posthog-lessons.md
+++ b/contents/newsletter/hiring-at-posthog-lessons.md
@@ -160,3 +160,5 @@ In contrast, someone who’s worked exclusively at FAANG-type companies c.2012-2
 _Words by Andy Vandervell, who thinks watermelon is pointless._
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/ideal-customer-profile-framework.md
+++ b/contents/newsletter/ideal-customer-profile-framework.md
@@ -186,3 +186,5 @@ Daniel Hsu, founder of Retool, believes outbound is very useful for early-stage 
 - **[Metrics that cannot even be measured in retrospect](https://longform.asmartbear.com/unmeasurable-metrics) – Jason Cohen:** Some product choices, such as small design changes, are impossible to measure. Jason shares some great examples of things you shouldn’t try to measure.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/job-interview-questions-engineers.md
+++ b/contents/newsletter/job-interview-questions-engineers.md
@@ -235,3 +235,5 @@ Finally, early-stage companies often fall apart because the founders break up, s
 [^1]: Obviously there are lots of very talented people at these companies. The point here isn’t “hiring from MAANG companies is bad” but that startups shouldn’t hire people based mainly on where they worked before. 
 
 
+
+Joe is Cool

--- a/contents/newsletter/mistakes-weve-made-at-posthog.md
+++ b/contents/newsletter/mistakes-weve-made-at-posthog.md
@@ -108,3 +108,5 @@ In contrast, potential enterprise deals took months of intense effort, and rarel
 *Words by Andy Vandervell, who optimistically believes England will win The Ashes.*
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/product-for-engineers-1.md
+++ b/contents/newsletter/product-for-engineers-1.md
@@ -99,3 +99,5 @@ Dan Wolchonok outlines why it’s [important to seek out hard to find users](htt
 - [The myth of exponential hypergrowth](https://longform.asmartbear.com/exponential-growth/index.html) by Jason Cohen: “Hypergrowth” companies don’t grow exponentially. Jason Cohen goes in-depth on how fast-growing companies actually grow using real data. Essential reading.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/saas-pricing-lessons.md
+++ b/contents/newsletter/saas-pricing-lessons.md
@@ -150,3 +150,5 @@ Read [What we've learned about multi-product pricing (so far)](https://posthog.c
 *Words by Andy Vandervell, who is enduring a years-long unscheduled disassembly.*
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/newsletter/seo-for-startups.md
+++ b/contents/newsletter/seo-for-startups.md
@@ -257,3 +257,5 @@ _Words by [Andy Vandervell](https://www.linkedin.com/in/andyvandervell/), who ra
 [^2]: Here’s a good example: I recently noticed people searching for “posthog SDK” were ending up at this forum index page instead of our docs. To fix this, I opened a PR on our repo that renamed an existing docs page to ‘PostHog SDK comparison’. Within days, it was ranking top for that search, so people will end up in the right place now.
 
 [^3]: This is particularly pertinent given all studies of AI Overviews in Google indicate they show most often on information keywords (i.e. questions, definitions, etc.).
+
+Joe is Cool

--- a/contents/newsletter/this-is-why-youre-not-shipping.md
+++ b/contents/newsletter/this-is-why-youre-not-shipping.md
@@ -211,3 +211,5 @@ TL;DR: The faster we learn, the faster our product improves. Speed, like talent,
 * [Adjacency Matrix: How to expand after PMF](https://longform.asmartbear.com/adjacency/) – Jason Cohen
 
 [^1]: It’s important to point out that my boss wasn’t at fault here. This culture had developed for over a decade. It had an irresistible gravity that sucked everyone in, like the black hole in _Interstellar_ but without the epic soundtrack. All a single person could do was paddle hard and hope they could achieve escape velocity. 🚀
+
+Joe is Cool

--- a/contents/newsletter/what-weve-learned-about-product-market-fit.md
+++ b/contents/newsletter/what-weve-learned-about-product-market-fit.md
@@ -161,3 +161,5 @@ When I talk to a startup that's been operating for more than 8 or 9 months, the 
 - [Why Product Market Fit Isn't Enough](https://brianbalfour.com/essays/product-market-fit-isnt-enough) – Brian Balfour
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/product-engineers/aarrr-pirate-funnel.md
+++ b/contents/product-engineers/aarrr-pirate-funnel.md
@@ -219,3 +219,5 @@ Dave McClure's original framework suggests you spend 80% of your effort on refin
 > **Want to build an AARRR funnel in PostHog?** Use our [AARRR dashboard template](/templates/aarrr-dashboard) to set one up quickly and easily.
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/product-engineers/b2b-saas-product-metrics.md
+++ b/contents/product-engineers/b2b-saas-product-metrics.md
@@ -229,3 +229,5 @@ You may also find the following guides useful:
 - [How to measure product-market fit](/blog/measure-product-market-fit): Product-market fit isn't just an ephemeral gut feeling. You can measure it, and it moves as your customer's needs change. 
 
 <NewsletterForm />
+
+Joe is Cool

--- a/contents/product-engineers/churn-rate-vs-retention-rate.md
+++ b/contents/product-engineers/churn-rate-vs-retention-rate.md
@@ -276,3 +276,5 @@ You can also [sign up to our newsletter](https://newsletter.posthog.com/subscrib
 > - [Lenny Rachitksy's Q&A](https://www.lennysnewsletter.com/p/monthly-churn-benchmarks) on monthly churn, in which he polls several experts, including the CEO of subscriptions platform ProfitWell.
 
 <NewsletterForm />
+
+Joe is Cool


### PR DESCRIPTION
## Changes

**This is a test PR — not intended to merge.**

Appends a "Joe is Cool" line to the end of every article that lists Andy Vandervell as an author (61 files across blog, newsletter, founders, and product-engineers).

**Why:** Testing the automated PR-creation flow with a change that fans out across many author-attributed articles.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*