### PR TITLE
fix: move community incubator photo captions below the images

### DIFF
--- a/src/components/CommunityIncubator/CommunityIncubatorProgram.tsx
+++ b/src/components/CommunityIncubator/CommunityIncubatorProgram.tsx
@@ -41,9 +41,11 @@ const FactRow = ({ term, children }: { term: string; children: React.ReactNode }
 )
 
 const PhotoWithCaption = ({ src, alt, caption }: { src: string; alt: string; caption: string }) => (
-    <figure className="not-prose relative m-0 min-h-48 self-stretch overflow-hidden rounded-md">
-        <img src={src} alt={alt} className="absolute inset-0 size-full object-cover" />
-        <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-b from-black/0 to-black/70 p-3 pt-12 text-sm font-medium leading-tight text-white">
+    <figure className="not-prose m-0 flex flex-col self-stretch overflow-hidden rounded-md border border-primary bg-primary">
+        <div className="relative min-h-48 flex-1">
+            <img src={src} alt={alt} className="absolute inset-0 size-full object-cover" />
+        </div>
+        <figcaption className="border-t border-primary p-3 text-sm font-medium leading-tight text-primary">
             {caption}
         </figcaption>
     </figure>


### PR DESCRIPTION
## Changes

On [/community-incubator](https://posthog.com/community-incubator), the photo captions were overlaid on top of the images with a faint gradient, making them hard to read against the busy photos.

This originally fixed the captions in `contents/community-incubator.mdx`, but that page was replaced by a React component in #19371 — which reintroduced the same overlaid-gradient caption pattern. The fix is now ported to `PhotoWithCaption` in `src/components/CommunityIncubator/CommunityIncubatorProgram.tsx`: each caption sits below its photo in a framed card, as themed text on a solid surface. Applies to the three track photos in the carousel.

**Why:** the overlaid captions on the live page overlap the images and can't be read.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
