### PR TITLE
Docs: experiment metrics reject events that have never been ingested

### DIFF
--- a/contents/docs/experiments/troubleshooting.mdx
+++ b/contents/docs/experiments/troubleshooting.mdx
@@ -46,6 +46,24 @@ Experiments require feature flags to meet specific requirements. You may see val
 
 - **"Feature flag must have a variant with key 'control'"**: One of your variants must have the key `control`. This is used as the baseline for comparison.
 
+## Why am I getting an error that my metric's event has not been ingested?
+
+When you save an experiment's primary or secondary metrics, PostHog checks that every event the metric references has been ingested by your project at least once. If it hasn't, saving fails with an error like:
+
+> Event(s) `purchase_completed` not found. No events with these names have been ingested by this project.
+
+This is a guardrail against typos and against metrics that point at events you haven't shipped yet, since those metrics would silently return no data for the whole experiment.
+
+You'll rarely see this in the UI, because the metric event picker only lets you choose events PostHog has already seen. It usually shows up when you create or update an experiment through the API, the [MCP server](/docs/model-context-protocol), or another programmatic client.
+
+To fix it:
+
+- **Check the event name for typos.** Confirm the exact name under [data management](https://app.posthog.com/data-management/events).
+- **Send the event first.** If the event is new, capture it once from your app so PostHog creates its definition, then add the metric.
+- **Bypass the check deliberately.** If you're setting up a metric ahead of the event shipping, pass `allow_unknown_events: true` when creating or updating the experiment. The metric saves, but shows no data until the event starts arriving.
+
+This check applies to metrics defined directly on an experiment. [Shared metrics](/docs/experiments/metrics#shared-metrics) are not validated this way, so a shared metric can reference an event that has never been ingested.
+
 ## How can I run experiments with my custom feature flag setup?
 
 See our docs on [how to run an experiment without using feature flags](/docs/experiments/running-experiments-without-feature-flags).


### PR DESCRIPTION
## Changes

Adds a troubleshooting entry to the Experiments docs covering a validation error that isn't documented anywhere today: saving an experiment's primary or secondary metric fails if the metric references an event with no event definition in the project.

The entry explains the error, why it exists, why it mostly shows up via the API/MCP rather than the UI (the metric event picker only offers ingested events), how to fix it, the `allow_unknown_events` opt-out, and the fact that shared metrics are not validated this way.

**Why:** someone asked whether this behavior was real and our docs had nothing on it — the only source of truth was the backend validation code.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07TQR0V16U/p1786445599546149?thread_ts=1786445599.546149&cid=C07TQR0V16U)*