### PR TITLE
Clarify how to cover a credit gap at the end of a contract term

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -276,6 +276,14 @@ We have CreditBot alerts set up in <PrivateLink url="https://posthog.slack.com/a
 -   If they fall **in between** the two cases above (running out of credit with <6 months and >2 months to go) then we need them to sign a new 12 month (or longer) order form lined up with their monthly billing date. This makes ARR calculation slightly trickier as there are two overlapping contracts in play at the same time.
     -   Example: Their original order form was signed on 1st January with a 12-month term and they run out of credits in September. We need a new 12-month order form in place with a Contract Start Date of September 1st.
 
+#### How to actually cover the gap
+
+Where we've agreed to cover usage for free until the renewal date, do it by adding a one-off credit allocation to the customer's credit balance in billing admin. You don't need billing engineering to do this.
+
+Always add the credit _before_ the invoice is generated. If you wait for the invoice and credit it afterwards, we've charged the customer an amount we already knew we weren't going to collect.
+
+You don't need to get the amount exactly right. Add your best estimate of the remaining usage and top it up if it falls short, or wait until the last day before the invoice is generated so you're working from close to actual usage. Over-allocating is fine: the balance resets at the actual contract end date, so anything left over doesn't carry into the new contract.
+
 For any of the above scenarios you should use our [discounting principles](contract-rules#discounts) which apply to the credit purchase amount.
 
 > In scenario one above, if their expansion credit purchase takes them into a higher volume discount tier, we should include this discount tier for them in the expansion contract. We won't issue a refund for the difference in discount when the expansion order form discount tier is greater than the discount tier of the original order form.

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -282,7 +282,7 @@ Where we've agreed to cover usage for free until the renewal date, do it by addi
 
 Always add the credit _before_ the invoice is generated. If you wait for the invoice and credit it afterwards, we've charged the customer an amount we already knew we weren't going to collect.
 
-You don't need to get the amount exactly right. Add your best estimate of the remaining usage and top it up if it falls short, or wait until the last day before the invoice is generated so you're working from close to actual usage. Over-allocating is fine: the balance resets at the actual contract end date, so anything left over doesn't carry into the new contract.
+You don't need to get the amount exactly right. Add your best estimate of the remaining usage and top it up the day before invoice is generated if it falls short. Over-allocating is fine: the balance resets at the actual contract end date, so anything left over doesn't carry into the new contract. Make sure to note this in other details field in the related Salesforce opportunity so the revops team can make sure the final credit balance is correct during contract setup.
 
 For any of the above scenarios you should use our [discounting principles](contract-rules#discounts) which apply to the credit purchase amount.
 


### PR DESCRIPTION
## Changes

Adds a short subsection to the contract rules handbook page explaining how to actually deliver the "we cover usage for free until the renewal date" case: add a one-off credit allocation to the customer's credit balance in billing admin *before* the invoice is generated, estimate and top up if needed, and don't worry about over-allocating since the balance resets at the actual contract end date.

**Why:** Came up in a sales question about the right sequence for bridging an insufficient credit balance at the end of a term — the rule was documented but the mechanic wasn't, so it wasn't obvious whether to credit before or after the invoice. Billing confirmed the before-invoice approach in the thread.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08ERRQT41E/p1786347656824939?thread_ts=1786347656.824939&cid=C08ERRQT41E)*