### PR TITLE
Add @PostHog/editors as code owners for editorial content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,9 @@
 # Serverless API functions
 /api/ @PostHog/website
 
+# Editorial content
+/contents/blog/ @PostHog/editors
+/contents/newsletter/ @PostHog/editors
+/contents/tutorials/ @PostHog/editors
+
 /.github/CODEOWNERS @PostHog/website


### PR DESCRIPTION
Adds `@PostHog/editors` as code owners for editorial content paths, so the team is automatically requested for review on PRs touching them:

- `/contents/blog/`
- `/contents/newsletter/`
- `/contents/tutorials/`

## ⚠️ This is inert until the team gets write access

`@PostHog/editors` currently has **no access grant** on this repo:

```
gh api --paginate orgs/PostHog/teams/editors/repos   # empty
gh api --paginate orgs/PostHog/teams/website/repos   # PostHog/posthog.com  admin
```

GitHub **silently ignores** CODEOWNERS entries for teams without write access — no error, the file reads as correct, and no review is ever requested. So merging this changes nothing until someone with admin grants `@PostHog/editors` **Write** under Settings → Collaborators and teams.

Flagging it here so the next person reading the file doesn't assume editorial review is live when it isn't. Happy to land it now and chase the grant separately.

## Also worth knowing

The `master` ruleset has `require_code_owner_review: true` but `required_approving_review_count: 0`. Even once the grant lands, reviews are **requested but not blocking**. That's intended here.

## Verification

Once the access grant is in place: open a PR touching anything under `contents/tutorials/` and confirm `@PostHog/editors` appears under Reviewers.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*