### PR TITLE
Add Avdhoot Fulsundar as co-author on Grafana Loki alternatives post

### DIFF
--- a/contents/blog/best-grafana-loki-alternatives.mdx
+++ b/contents/blog/best-grafana-loki-alternatives.mdx
@@ -3,6 +3,7 @@ title: "The best Grafana Loki alternatives & competitors, compared"
 date: 2026-07-31
 author:
   - natalia-amorim
+  - avdhoot-fulsundar
 rootpage: /blog
 featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/hog_ql.png

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -746,5 +746,13 @@
         "link_type": "linkedin",
         "link_url": "https://www.linkedin.com/in/rohnx/",
         "profile_id": 46998
+    },
+    {
+        "handle": "avdhoot-fulsundar",
+        "name": "Avdhoot Fulsundar",
+        "role": "Freelance Technical Writer",
+        "link_type": "linkedin",
+        "link_url": "https://www.linkedin.com/in/avdhoot-fulsundar/",
+        "profile_id": 47036
     }
 ]


### PR DESCRIPTION
## Changes

Adds an `authors.json` entry for Avdhoot Fulsundar (community profile 47036, LinkedIn) and lists him as a second author on `contents/blog/best-grafana-loki-alternatives.mdx`.

**Why:** He co-authored the post and wasn't credited.

Note: his role is set to "Freelance Technical Writer" to match other recent external contributors — happy to change if it should be something else.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9AKT9NTY/p1786459069754679)*