### PR TITLE
docs: clarify "Stop evaluation at first matching condition set" with an example

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -170,9 +170,9 @@ Use this when you want a user who is excluded by a targeted condition's rollout 
 
 ##### Things to keep in mind
 
-- **The rollout has to be what excluded them.** If a user doesn't match a condition set's property filters at all, that set is skipped and evaluation continues as normal. In the example above, a user whose email isn't `@example.com` moves on to set 2 regardless of this setting.
-- **Order your condition sets narrowest first.** A broad catch-all set near the top will short-circuit the more specific sets below it.
-- **Rollout buckets are shared across condition sets.** A user's bucket comes from the flag key and their identifier, not the condition set, so falling through to a set with an equal or smaller rollout percentage can never succeed – only a larger one can.
+- **The rollout percentage has to be what excluded them.** This is the only check that triggers an early exit. Anything else that fails – a property filter, a cohort, a [flag dependency](/docs/feature-flags/dependencies), or a missing group key – just means that condition set didn't match, and evaluation continues to the next one as normal. In the example above, a user whose email isn't `@example.com` moves on to set 2 regardless of this setting.
+- **Order your condition sets narrowest first.** A broad catch-all set near the top will short-circuit the more specific sets below it. A set rolled out to 100% never triggers an early exit, since nobody falls outside its rollout.
+- **Rollout buckets are shared across condition sets.** For sets that target the same entity, a user's bucket comes from the flag key and their identifier, not the condition set – so falling through to a set with an equal or smaller rollout percentage can never succeed, only a larger one can.
 
 <CalloutBox icon="IconInfo" title="Local evaluation support varies by SDK" type="fyi">
 

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -145,14 +145,12 @@ When you target a person property of `distinct_id equals`, the value field searc
 
 #### Stop evaluation at first matching condition set
 
-**Stop evaluation at first matching condition set** is an opt-in circuit breaker. It's off by default, and leaving it off means your flag evaluates exactly as it always has. Turning it on only ever adds a way for evaluation to stop early – so whether you want it depends entirely on what you're trying to achieve with the flag.
+This setting is off by default, and leaving it off means your flag evaluates exactly as it always has. Turning it on only changes what happens when a user matches a condition set's property filters but falls outside that set's rollout percentage:
 
-The setting changes what happens when a user matches a condition set's property filters but falls outside that set's rollout percentage:
+- **Off (default):** the user falls through to the next condition set. A pass on any condition set is a pass.
+- **On:** evaluation stops there and the flag returns `false`. Later condition sets are never evaluated.
 
-- **Off (default):** the user "falls through" to the next condition set and keeps being evaluated. A pass on any condition set is a pass.
-- **On:** evaluation stops right there and the flag returns `false`. Later condition sets are never evaluated.
-
-Condition sets are always evaluated top to bottom, in the order they appear in the UI.
+Condition sets are evaluated top to bottom, in the order they appear in the UI.
 
 ##### Example
 
@@ -164,24 +162,17 @@ Say a flag has three condition sets, and your test user matches the property fil
 | 2 | `plan` equals `enterprise` | 25% |
 | 3 | Everyone | 100% |
 
-**With the setting off (default):**
+**Off (default):** the user is evaluated against set 1, where there's a 25% chance they fall inside the rollout. If they're in the 75% that don't, they move on to set 2, then to set 3 – where they match the 100% rollout and the flag returns `true`.
 
-1. The user is evaluated against set 1. They match the property filter, and there's a 25% chance they fall inside the rollout.
-2. If they're in the 75% that don't, they move on to set 2. Same story there.
-3. If they don't match set 2's rollout either, they move on to set 3, match the 100% rollout, and the flag returns `true`.
+**On:** the user is evaluated against set 1. If they're in the 75% outside its rollout, the flag returns `false` immediately and sets 2 and 3 are never evaluated.
 
-**With the setting on:**
-
-1. The user is evaluated against set 1. They match the property filter, and there's a 25% chance they fall inside the rollout.
-2. If they're in the 75% that don't, the flag returns `false` immediately. Sets 2 and 3 are never evaluated.
-
-This is useful when you want more deterministic flag behavior – for example, ensuring that a user who is excluded by a targeted condition's rollout doesn't fall through to a broader catch-all condition below.
+Use this when you want a user who is excluded by a targeted condition's rollout to stay excluded, rather than falling through to a broader catch-all condition below.
 
 ##### Things to keep in mind
 
-- **The rollout has to be what excluded them.** Early exit only triggers when a condition set's property filters *matched* and only the rollout check failed. If the user doesn't match a set's property filters at all, that set is simply skipped and evaluation continues as normal. In the example above, a user whose email isn't `@example.com` moves on to set 2 regardless of this setting.
-- **Order your condition sets narrowest first.** Because evaluation stops at the first property-filter match that fails its rollout, a broad catch-all set placed near the top will short-circuit the more specific sets below it.
-- **Rollout buckets are shared across condition sets.** A user's bucket is derived from the flag key and their identifier, not from the individual condition set, so the same user is in the same position for every set. That means falling through to a set with an equal or smaller rollout percentage can never succeed – only a larger one can.
+- **The rollout has to be what excluded them.** If a user doesn't match a condition set's property filters at all, that set is skipped and evaluation continues as normal. In the example above, a user whose email isn't `@example.com` moves on to set 2 regardless of this setting.
+- **Order your condition sets narrowest first.** A broad catch-all set near the top will short-circuit the more specific sets below it.
+- **Rollout buckets are shared across condition sets.** A user's bucket comes from the flag key and their identifier, not the condition set, so falling through to a set with an equal or smaller rollout percentage can never succeed – only a larger one can.
 
 <CalloutBox icon="IconInfo" title="Local evaluation support varies by SDK" type="fyi">
 

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -145,11 +145,43 @@ When you target a person property of `distinct_id equals`, the value field searc
 
 #### Stop evaluation at first matching condition set
 
-By default, PostHog evaluates all condition sets and returns a match if any condition passes. This means a user who is excluded by one condition's rollout percentage can still match a later condition.
+**Stop evaluation at first matching condition set** is an opt-in circuit breaker. It's off by default, and leaving it off means your flag evaluates exactly as it always has. Turning it on only ever adds a way for evaluation to stop early – so whether you want it depends entirely on what you're trying to achieve with the flag.
 
-Enable **Stop evaluation at first matching condition set** to change this behavior. When enabled, conditions are evaluated in order – the first matching condition set determines the result and later conditions are skipped. If a user matches a condition's property filters but falls outside the rollout percentage, evaluation stops immediately and the flag returns `false`.
+The setting changes what happens when a user matches a condition set's property filters but falls outside that set's rollout percentage:
 
-This is useful when you want more deterministic flag behavior – for example, ensuring that a user who matches a targeted condition but is excluded by its rollout doesn't "fall through" to a broader catch-all condition below.
+- **Off (default):** the user "falls through" to the next condition set and keeps being evaluated. A pass on any condition set is a pass.
+- **On:** evaluation stops right there and the flag returns `false`. Later condition sets are never evaluated.
+
+Condition sets are always evaluated top to bottom, in the order they appear in the UI.
+
+##### Example
+
+Say a flag has three condition sets, and your test user matches the property filters on all three:
+
+| # | Condition set | Rollout |
+| --- | --- | --- |
+| 1 | `email` contains `@example.com` | 25% |
+| 2 | `plan` equals `enterprise` | 25% |
+| 3 | Everyone | 100% |
+
+**With the setting off (default):**
+
+1. The user is evaluated against set 1. They match the property filter, and there's a 25% chance they fall inside the rollout.
+2. If they're in the 75% that don't, they move on to set 2. Same story there.
+3. If they don't match set 2's rollout either, they move on to set 3, match the 100% rollout, and the flag returns `true`.
+
+**With the setting on:**
+
+1. The user is evaluated against set 1. They match the property filter, and there's a 25% chance they fall inside the rollout.
+2. If they're in the 75% that don't, the flag returns `false` immediately. Sets 2 and 3 are never evaluated.
+
+This is useful when you want more deterministic flag behavior – for example, ensuring that a user who is excluded by a targeted condition's rollout doesn't fall through to a broader catch-all condition below.
+
+##### Things to keep in mind
+
+- **The rollout has to be what excluded them.** Early exit only triggers when a condition set's property filters *matched* and only the rollout check failed. If the user doesn't match a set's property filters at all, that set is simply skipped and evaluation continues as normal. In the example above, a user whose email isn't `@example.com` moves on to set 2 regardless of this setting.
+- **Order your condition sets narrowest first.** Because evaluation stops at the first property-filter match that fails its rollout, a broad catch-all set placed near the top will short-circuit the more specific sets below it.
+- **Rollout buckets are shared across condition sets.** A user's bucket is derived from the flag key and their identifier, not from the individual condition set, so the same user is in the same position for every set. That means falling through to a set with an equal or smaller rollout percentage can never succeed – only a larger one can.
 
 <CalloutBox icon="IconInfo" title="Local evaluation support varies by SDK" type="fyi">
 


### PR DESCRIPTION
## Changes

Rewrites the **Stop evaluation at first matching condition set** section of the feature flags creation docs so the behavior is explicit rather than implied:

- States up front that it's opt-in and that leaving it off means flag evaluation is unchanged.
- Adds a worked example with three condition sets, walking through evaluation with the setting off vs on.
- Documents three gotchas: early exit only triggers when the *rollout* excluded the user (a property-filter miss just moves on to the next set), condition set ordering matters, and rollout buckets are shared across condition sets so falling through to an equal-or-smaller rollout can never succeed.

Verified against the evaluation logic in the monorepo (`rust/feature-flags/src/flags/flag_matching.rs`), where the early exit only fires on an `OutOfRolloutBound` reason, and against the in-app checkbox copy.

## Why

A user asked for help understanding what this checkbox actually does — the previous wording described the mechanism correctly but was easy to misread, most notably by suggesting evaluation stops at the first condition set rather than only at one whose property filters matched but whose rollout excluded the user. Adding a concrete example makes the distinction obvious.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1786466859234729)*
