### PR TITLE
docs: write the AI evals datasets page

### DIFF
--- a/contents/docs/ai-evals/datasets.mdx
+++ b/contents/docs/ai-evals/datasets.mdx
@@ -6,7 +6,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="Datasets are in beta" type="action">
 
-Datasets are currently in beta and rolling out gradually. If you don't see **Datasets** in AI Evals yet, [let us know](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) – we'd also love your feedback as we develop the feature.
+Datasets are currently in beta. We'd love your [feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we develop the feature.
 
 </CalloutBox>
 
@@ -50,10 +50,7 @@ Both `expected_output` and `source_output` are optional, so you can save a case 
 
 ## Creating a dataset
 
-1. Go to **AI Evals** > **Datasets**
-2. Click **New dataset**
-3. Give it a name (unique within the project), an optional description, and optional metadata
-4. Click **Create dataset**
+You can create a dataset in the PostHog UI or with the [PostHog MCP server](/docs/model-context-protocol).
 
 ## Adding items
 
@@ -61,36 +58,13 @@ Both `expected_output` and `source_output` are optional, so you can save a case 
 
 The fastest way to build a useful dataset is to harvest real traffic. On a [trace](/docs/ai-observability/traces), click **Add to dataset** and pick a dataset. PostHog pre-fills the item with the trace's input, its output as `source_output`, and the trace provenance fields, so you can jump back to where the case came from.
 
-Use the pencil side-action instead to open the item editor before saving – useful when you want to write the `expected_output` while the failure is still in front of you.
-
 ### Manually
 
 Open a dataset and add an item directly, filling in **Input**, **Expected output**, and **Metadata** as JSON.
 
-### Programmatically
-
-See [Programmatic access](#programmatic-access) below.
-
 ## Versioning
 
-Datasets are append-only. Nothing you do to an item destroys what was there before.
-
-- **Editing an item** creates a new item version (`version` increments by 1) and a new dataset revision.
-- **Archiving or restoring an item** also creates a new version – archival is a state change recorded in the version history, not a deletion.
-- **No-op edits are free.** If your update resolves to content identical to the current version, PostHog returns the existing version instead of creating a duplicate.
-- **Dataset name, description, and metadata edits don't create a revision.** Only item changes move the revision forward.
-
-### Viewing a past revision
-
-On a dataset, use the revision selector to switch from **Latest** to any historical revision. The list then shows the exact snapshot at that revision, read-only – editing is disabled while you're viewing history, and a **Revision _n_** tag plus a banner make it obvious you aren't on the latest data. Click **View latest** to go back.
-
-You can also open a single item's version history to compare its input, expected output, source output, and metadata across versions, and restore an earlier version's content.
-
-### Concurrent edits
-
-Item mutations use optimistic concurrency. You send the `base_version` you last read, and if someone else – or another agent – changed the item in the meantime, the request is rejected with a `stale_version` conflict that tells you the current version. Reload and retry rather than clobbering their change.
-
-Other conflicts work the same way, each with a stable code you can branch on: `dataset_archived`, `dataset_name_conflict`, `dataset_item_archived`, `dataset_item_active`, `client_item_id_conflict`, and `limit_reached`.
+Every item change creates an immutable version and a new dataset revision. You can view past revisions and restore an earlier version of an item without losing its history.
 
 ### Archiving
 
@@ -149,18 +123,7 @@ CLI access is on the way, so you'll be able to pull a dataset revision and run i
 
 ## Limits
 
-| Limit                      | Value                                                                   |
-| -------------------------- | ----------------------------------------------------------------------- |
-| Datasets per project       | 100                                                                     |
-| Items per dataset          | 5,000                                                                   |
-| Versions per item          | 100 (one slot is reserved so you can always restore)                    |
-| Item payload size          | 40 KB across `input`, `expected_output`, `source_output`, and `metadata` |
-| Dataset metadata size      | 1 MB                                                                    |
-| Dataset name / description | 400 / 10,000 characters                                                 |
-| Export size                | 250 MB                                                                  |
-| Export requests            | 10 per minute                                                           |
-
-If you hit a limit, the response includes a `limit_reached` code with the resource, current count, and limit. Get in touch if you need more headroom.
+PostHog applies limits to datasets to prevent abuse. These limits are subject to change.
 
 ## Coming soon: offline evals reporting
 

--- a/contents/docs/ai-evals/datasets.mdx
+++ b/contents/docs/ai-evals/datasets.mdx
@@ -2,8 +2,174 @@
 title: Datasets
 ---
 
-Datasets let you curate sets of input/output pairs you can replay against prompt or model changes to catch regressions before they reach production.
+import CalloutBox from 'components/Docs/CalloutBox'
 
-## Documentation coming soon
+<CalloutBox icon="IconFlask" title="Datasets are in beta" type="action">
 
-We're still writing the full guide for datasets. In the meantime, see the [AI Evals overview](/docs/ai-evals) to learn how datasets fit alongside evaluations and trace reviews.
+Datasets are currently in beta and rolling out gradually. If you don't see **Datasets** in AI Evals yet, [let us know](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) – we'd also love your feedback as we develop the feature.
+
+</CalloutBox>
+
+Datasets let you curate sets of inputs and expected outputs that you can replay against prompt or model changes to catch regressions before they reach production. Instead of hoping a prompt tweak didn't break anything, you keep a growing collection of the cases you care about – the tricky ones, the ones users complained about, the ones that broke last time – and re-run them.
+
+Because every change is versioned, a dataset is also an audit trail. You can always see what a dataset looked like at the moment you ran a test against it.
+
+## Why use datasets?
+
+- **Catch regressions before shipping** – Replay real cases against a new prompt, model, or agent version.
+- **Turn production failures into test cases** – Add a trace to a dataset directly from AI observability the moment you spot a problem.
+- **Keep tests reproducible** – Every dataset change creates an immutable revision, so a test run can be pinned to exactly the data it used.
+- **Work programmatically** – Build and update datasets from agents and scripts, not just the PostHog UI.
+
+## How datasets work
+
+Datasets have three layers:
+
+- **Dataset** – A named collection of items, scoped to a project. It has a description and a free-form `metadata` object.
+- **Dataset item** – A single test case with a stable ID. An item's content lives in its versions, not on the item itself.
+- **Item version** – An immutable snapshot of one item's content. Editing an item never overwrites anything, it appends a new version.
+
+On top of item versions sit **dataset revisions**: monotonically increasing snapshots of the whole dataset. Every item mutation creates a new revision, so revision `12` describes exactly which version of every item was current at that point.
+
+A brand new dataset has no revision. Its first revision is created along with its first item.
+
+### Item fields
+
+| Field              | Description                                                                                                    |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `input`            | The input given to the system under test. Any non-null JSON value – a string, an array of messages, an object.  |
+| `expected_output`  | Optional. The output you want, authored by you. This is what you compare against.                              |
+| `source_output`    | Optional. The actual output captured from the source trace, kept for reference.                                 |
+| `metadata`         | Optional JSON object for your own labels – category, difficulty, owning team, whatever you filter on later.     |
+| `client_item_id`   | Optional case-sensitive key you own. Makes creates idempotent and safe to retry. It can't be changed.           |
+| `source_trace_id`  | The trace the item came from. Provide it together with `source_timestamp`.                                      |
+| `source_event_id`  | Optional. The specific event within the trace.                                                                 |
+| `source_timestamp` | Required when you set `source_trace_id`. Needed to look the source trace back up.                              |
+
+Both `expected_output` and `source_output` are optional, so you can save a case you know is wrong before you've decided what the right answer looks like.
+
+## Creating a dataset
+
+1. Go to **AI Evals** > **Datasets**
+2. Click **New dataset**
+3. Give it a name (unique within the project), an optional description, and optional metadata
+4. Click **Create dataset**
+
+## Adding items
+
+### From a trace
+
+The fastest way to build a useful dataset is to harvest real traffic. On a [trace](/docs/ai-observability/traces), click **Add to dataset** and pick a dataset. PostHog pre-fills the item with the trace's input, its output as `source_output`, and the trace provenance fields, so you can jump back to where the case came from.
+
+Use the pencil side-action instead to open the item editor before saving – useful when you want to write the `expected_output` while the failure is still in front of you.
+
+### Manually
+
+Open a dataset and add an item directly, filling in **Input**, **Expected output**, and **Metadata** as JSON.
+
+### Programmatically
+
+See [Programmatic access](#programmatic-access) below.
+
+## Versioning
+
+Datasets are append-only. Nothing you do to an item destroys what was there before.
+
+- **Editing an item** creates a new item version (`version` increments by 1) and a new dataset revision.
+- **Archiving or restoring an item** also creates a new version – archival is a state change recorded in the version history, not a deletion.
+- **No-op edits are free.** If your update resolves to content identical to the current version, PostHog returns the existing version instead of creating a duplicate.
+- **Dataset name, description, and metadata edits don't create a revision.** Only item changes move the revision forward.
+
+### Viewing a past revision
+
+On a dataset, use the revision selector to switch from **Latest** to any historical revision. The list then shows the exact snapshot at that revision, read-only – editing is disabled while you're viewing history, and a **Revision _n_** tag plus a banner make it obvious you aren't on the latest data. Click **View latest** to go back.
+
+You can also open a single item's version history to compare its input, expected output, source output, and metadata across versions, and restore an earlier version's content.
+
+### Concurrent edits
+
+Item mutations use optimistic concurrency. You send the `base_version` you last read, and if someone else – or another agent – changed the item in the meantime, the request is rejected with a `stale_version` conflict that tells you the current version. Reload and retry rather than clobbering their change.
+
+Other conflicts work the same way, each with a stable code you can branch on: `dataset_archived`, `dataset_name_conflict`, `dataset_item_archived`, `dataset_item_active`, `client_item_id_conflict`, and `limit_reached`.
+
+### Archiving
+
+Datasets and items can be archived instead of deleted. An archived dataset stays readable but rejects item mutations until you restore it. Archived items are filtered out of the default view – and out of exports – but their history is intact.
+
+## Exporting a dataset
+
+Exports let you run a dataset through your own harness, in CI or on your machine, and keep the results comparable over time.
+
+Click **Export** on a dataset to generate a JSONL file. Exports are:
+
+- **Asynchronous** – The export is prepared in the background, then made available to download. Exported files expire, so download or re-export as needed.
+- **Pinned to a revision** – Exporting from **Latest** pins to the current revision, and exporting while viewing a historical revision pins to that one. Because revisions are immutable, re-downloading the same export always gives you identical data.
+- **Active items only** – Archived items are excluded.
+
+Each line is one item, with the revision recorded on every row:
+
+```json
+{"dataset_id":"018f...","dataset_revision":12,"item_id":"018f...","client_item_id":"ticket-4821","version":3,"input":{"messages":[{"role":"user","content":"How do I cancel?"}]},"expected_output":"Point the user to the billing settings page.","source_output":"You can cancel any time.","metadata":{"category":"billing"},"source_trace_id":"trace_abc","source_event_id":"event_def","source_timestamp":"2026-05-04T10:12:33+00:00"}
+```
+
+Pinning to a revision is what makes an export worth storing next to your test results: "this run scored 84% on revision 12" stays meaningful even after the dataset has moved on.
+
+## Programmatic access
+
+### MCP
+
+The [PostHog MCP server](/docs/model-context-protocol) exposes datasets to AI agents like Claude Code and Cursor, so an agent that just debugged a bad generation can add it to your regression set without you switching windows.
+
+| Tool                             | Description                                                           |
+| -------------------------------- | --------------------------------------------------------------------- |
+| `llma-dataset-list`              | List datasets, with search and an active/archived filter              |
+| `llma-dataset-get`               | Get a dataset by ID                                                   |
+| `llma-dataset-create`            | Create a dataset                                                      |
+| `llma-dataset-update`            | Update a dataset's name, description, or metadata                     |
+| `llma-dataset-archive`           | Archive a dataset                                                     |
+| `llma-dataset-restore`           | Restore an archived dataset                                           |
+| `llma-dataset-revision-list`     | List a dataset's revisions, newest first                              |
+| `llma-dataset-item-list`         | List items, optionally as they appeared at a specific revision        |
+| `llma-dataset-item-get`          | Get an item, optionally at a specific revision                        |
+| `llma-dataset-item-create`       | Add an item and create its first version                              |
+| `llma-dataset-item-update`       | Create a new version of an item                                       |
+| `llma-dataset-item-archive`      | Archive an item                                                       |
+| `llma-dataset-item-restore`      | Restore an archived item, optionally from a chosen historical version |
+| `llma-dataset-item-version-list` | List an item's version history                                        |
+
+Pass a `client_item_id` when an agent creates items. An identical retry returns the existing item instead of creating a duplicate, which makes agent loops safe to re-run.
+
+### API
+
+The same operations are available over REST at [`/api/projects/:project_id/datasets`](/docs/api/datasets) and [`/api/projects/:project_id/dataset_items`](/docs/api/dataset-items), including creating exports and downloading their content. Use a [personal API key](/docs/api#authentication) with the `dataset` scope.
+
+### CLI
+
+CLI access is on the way, so you'll be able to pull a dataset revision and run it as part of a build without writing API glue. It isn't available yet.
+
+## Limits
+
+| Limit                      | Value                                                                   |
+| -------------------------- | ----------------------------------------------------------------------- |
+| Datasets per project       | 100                                                                     |
+| Items per dataset          | 5,000                                                                   |
+| Versions per item          | 100 (one slot is reserved so you can always restore)                    |
+| Item payload size          | 40 KB across `input`, `expected_output`, `source_output`, and `metadata` |
+| Dataset metadata size      | 1 MB                                                                    |
+| Dataset name / description | 400 / 10,000 characters                                                 |
+| Export size                | 250 MB                                                                  |
+| Export requests            | 10 per minute                                                           |
+
+If you hit a limit, the response includes a `limit_reached` code with the resource, current count, and limit. Get in touch if you need more headroom.
+
+## Coming soon: offline evals reporting
+
+Today datasets are the curation and export half of the loop. You export a revision, run it in your own harness, and read the results wherever you run them.
+
+We're working on closing that loop. Soon you'll be able to report the results of an offline evaluation run back into PostHog, scored per dataset item and grouped by run, so you can compare a prompt or model change against the previous run and see which specific items regressed – all next to the [online evaluations](/docs/ai-evals) already scoring your production traffic.
+
+## Further reading
+
+- [Evaluations overview](/docs/ai-evals) – online evaluations that score production generations automatically
+- [Trace reviews](/docs/ai-observability/trace-reviews) – the manual review workflow for finding failure modes worth adding to a dataset
+- [Traces](/docs/ai-observability/traces) – where dataset items usually come from


### PR DESCRIPTION
## Changes

Replaces the "documentation coming soon" placeholder on `/docs/ai-evals/datasets` with a full guide, grounded in the datasets implementation in the main repo:

- How datasets, items, and immutable item versions/dataset revisions fit together, plus the item field reference
- Adding items from a trace, manually, or programmatically
- The versioning system: revision snapshots, viewing/restoring history, optimistic concurrency and conflict codes, archiving
- JSONL exports (async, pinned to a revision, active items only) with a sample row
- Programmatic access via the MCP dataset tools and REST API, and a note that CLI access is coming
- Limits table, and a sneak peek at offline evals reporting

The page is marked as beta with a `CalloutBox`, matching the other beta AI observability pages.

**Why:** datasets shipped in beta but the docs page was still a stub, so there was nowhere to point people asking how versioning, exports, or agent access work.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1786470814303109)*