### PR TITLE
docs: align early exit docs with the renamed checkbox

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -117,7 +117,7 @@ This specifies the conditions a user must meet to access the feature flag and re
 
 > **Tip:** You can configure [default release conditions](/docs/feature-flags/project-wide-settings#default-release-conditions) in your project settings to pre-populate release conditions when creating new flags. These defaults aren't enforced – you can modify or remove them during flag creation. Default release conditions don't apply to remote config flags.
 
-By default, all condition sets are evaluated and a pass on any condition is a pass. A condition matches when all property filters pass and the target falls within the rollout percentage. You can change this behavior with the **Stop evaluation at first matching condition set** option – see [early exit](#stop-evaluation-at-first-matching-condition-set) below.
+By default, all condition sets are evaluated and a pass on any condition is a pass. A condition matches when all property filters pass and the target falls within the rollout percentage. You can change this behavior with the **Stop at the first condition set whose property filters match** option – see [early exit](#stop-at-the-first-condition-set-whose-property-filters-match) below.
 
 By default, release conditions use **Properties** targeting, which evaluates flags based on user or group property filters. You can change the top-level targeting mode:
 
@@ -143,7 +143,7 @@ When you target a person property of `distinct_id equals`, the value field searc
   classes="rounded"
 />
 
-#### Stop evaluation at first matching condition set
+#### Stop at the first condition set whose property filters match
 
 This setting is off by default, and leaving it off means your flag evaluates exactly as it always has. Turning it on only changes what happens when a user matches a condition set's property filters but falls outside that set's rollout percentage:
 

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -334,7 +334,7 @@ Local evaluation is not possible for flags that:
 2. Are linked to an [early access feature](/docs/feature-flags/early-access-feature-management)
 3. Depend on [static cohorts](/docs/data/cohorts#static-cohorts)
 4. Use the `is_not_set` property operator, since local evaluation can only check properties you provide — it can't determine whether a property is absent on a person.
-5. Have ["Stop evaluation at first matching condition set"](/docs/feature-flags/creating-feature-flags#stop-evaluation-at-first-matching-condition-set) (early exit) enabled. Local evaluation currently always evaluates all condition groups, even when this setting is enabled. This is a temporary limitation while support is rolled out across SDKs. For now, the setting only takes effect when flags are evaluated through the `/flags` endpoint.
+5. Have ["Stop at the first condition set whose property filters match"](/docs/feature-flags/creating-feature-flags#stop-at-the-first-condition-set-whose-property-filters-match) (early exit) enabled. Local evaluation currently always evaluates all condition groups, even when this setting is enabled. This is a temporary limitation while support is rolled out across SDKs. For now, the setting only takes effect when flags are evaluated through the `/flags` endpoint.
 
 ### Dynamic cohort restrictions
 


### PR DESCRIPTION
## Changes

Follow-up to #19388. The feature flag checkbox is being renamed from "Stop evaluation at first matching condition set" to **"Stop at the first condition set whose property filters match"** in PostHog/posthog#81476 — the old label used "matching" to mean "property filters matched", while the panel two lines above defines a match as property filters passing *and* the rollout including the target.

Updates the section heading in `creating-feature-flags.mdx` plus the two places that reference the option by name (the release conditions intro on the same page, and the local evaluation limitations list) so the docs match what people see in the product.

**Merge after PostHog/posthog#81476**, or the docs will name a checkbox that doesn't exist yet.

Heads up for the reviewer: renaming the heading changes the section anchor to `#stop-at-the-first-condition-set-whose-property-filters-match`. Both in-repo links are updated in this PR, and I checked the app — nothing in the monorepo deep-links to the old anchor. External links to it will break, and anchors can't be handled by `vercel.json` redirects.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved; see the anchor note above)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1786466859234729)*
