### PR TITLE
fix(merch): make accordion body text readable in dark mode

### DIFF
--- a/src/components/RadixUI/Accordion.tsx
+++ b/src/components/RadixUI/Accordion.tsx
@@ -54,7 +54,11 @@ const AccordionContent = React.forwardRef<HTMLDivElement, AccordionContentProps>
             {...props}
             ref={forwardedRef}
         >
-            <div className={`text-base pb-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0 ${className ?? ''}`}>
+            <div
+                className={`text-base text-primary pb-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0 ${
+                    className ?? ''
+                }`}
+            >
                 {children}
             </div>
         </RadixAccordion.Content>


### PR DESCRIPTION
## Changes

In dark mode the merch store sidebar renders its answers in black on the dark panel, so anyone opening "About our merch" or "Returns & cancellations" cannot read them.

- `body.dark` sets no text color, while `body.light` applies `text-primary`, so accordion content inherits the browser default black.
- The accordion trigger already sets `text-primary`, which is why the titles stay light and only the body copy breaks.
- This adds `text-primary` to the accordion content wrapper in `src/components/RadixUI/Accordion.tsx`. The token is scheme aware, so it follows `data-scheme` in both themes.
- Every accordion whose content sets no color of its own gets the fix, not only the merch sidebar.

### Reported

![Merch store sidebar in dark mode with unreadable body text](https://raw.githubusercontent.com/Silthus/posthog.com/dd00f196a70cc044dcc42bc93c7b1a66294abca9/merch-store-dark-reported.png)

### Before and after

| Before | After |
| --- | --- |
| ![Sidebar accordion in dark mode, body text black on the dark panel](https://raw.githubusercontent.com/Silthus/posthog.com/dd00f196a70cc044dcc42bc93c7b1a66294abca9/merch-accordion-dark-before.png) | ![Sidebar accordion in dark mode, body text light on the dark panel](https://raw.githubusercontent.com/Silthus/posthog.com/dd00f196a70cc044dcc42bc93c7b1a66294abca9/merch-accordion-dark-after.png) |

The merch pages need Shopify credentials to build, so I rendered the real `Accordion` component with the merch sidebar items against the site's compiled `global.css` in headless Chrome. Light mode looks the same before and after.

I (actually Claude) made this change.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
