### PR TITLE
fix compensation calculator combobox selection

### DIFF
--- a/src/components/CompensationCalculator/Combobox.tsx
+++ b/src/components/CompensationCalculator/Combobox.tsx
@@ -52,13 +52,8 @@ export const Combobox = (props: ComboboxProps) => {
                         <HeadlessCombobox.Input
                             autoComplete="off"
                             onBlur={() => setFocused(false)}
-                            onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
-                                event.target.value = ''
-                                setFocused(true)
-                            }}
-                            onClick={(event: React.MouseEvent<HTMLInputElement>) =>
-                                ((event.target as HTMLInputElement).value = '')
-                            }
+                            onFocus={() => setFocused(true)}
+                            onClick={(event: React.MouseEvent<HTMLInputElement>) => event.currentTarget.select()}
                             onChange={(event) => setQuery(event.target.value)}
                             displayValue={props.display}
                             placeholder={currentValue || props.placeholder || 'Select a value'}
@@ -84,10 +79,7 @@ export const Combobox = (props: ComboboxProps) => {
                         leaveFrom="opacity-100"
                         leaveTo="opacity-0"
                     >
-                        <HeadlessCombobox.Options
-                            onMouseDown={(e) => e.preventDefault()}
-                            className="absolute top-full mt-1 w-full bg-white dark:bg-accent-dark dark:text-primary-dark rounded p-0 z-[50] text-sm max-h-[12rem] overflow-y-scroll py-1 focus:outline-none space-y-1 shadow-xl border border-black/10"
-                        >
+                        <HeadlessCombobox.Options className="absolute top-full mt-1 w-full bg-white dark:bg-accent-dark dark:text-primary-dark rounded p-0 z-[50] text-sm max-h-[12rem] overflow-y-scroll py-1 focus:outline-none space-y-1 shadow-xl border border-black/10">
                             {filteredOptions.length === 0 && query !== '' ? (
                                 <div className="px-2.5 py-1 text-sm text-gray">No results</div>
                             ) : (


### PR DESCRIPTION
## Changes

- Fix the compensation calculator combobox so selecting a filtered region replaces the typed search query.
- Let Headless UI process the option focus change, which clears its internal typing state before applying the selected value.

### What the code does

- `onFocus={() => setFocused(true)}` keeps the component's visual focus state without directly clearing the input. This leaves Headless UI responsible for synchronizing the displayed text with the selected value.
- `onClick={(event) => event.currentTarget.select()}` selects the existing value only when the user clicks the input, so typing immediately replaces it. Headless UI's automatic refocus after choosing an option does not trigger this handler, so the selected region is not left highlighted.
- Removing `onMouseDown={(e) => e.preventDefault()}` from the options list allows the input's normal blur event to run when an option is clicked. Headless UI then clears its internal typing state and can replace the search query (for example, `Mary`) with the selected value (`Maryland`).

## Reproduction

1. Enter Mary in the Region combobox.
2. Select Maryland.

Previously, the input continued to display Mary. It now displays Maryland.

[Before](https://screen.studio/share/O1rr287E)
[After](https://screen.studio/share/Uq0wH7lE)

## Verification

- Verified the fix's intended behavior by eye, see the Before and After links above.
- Gatsby development bundle rebuilt successfully.
- Prettier check passes for the changed component.
- ESLint reports 0 errors; the component retains 5 pre-existing warnings.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in vercel.json (not applicable)
