### PR TITLE
Add Discord link to community profiles

### DIFF
--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -61,6 +61,7 @@ export type ProfileData = {
     biography: string | null
     company: string | null
     companyRole: string | null
+    discord: string | null
     github: string | null
     linkedin: string | null
     location: string | null

--- a/src/pages/community/profile/edit.tsx
+++ b/src/pages/community/profile/edit.tsx
@@ -365,10 +365,10 @@ const formSections = [
                 placeholder: 'https://discord.com/users/{id}',
                 type: 'url',
                 tooltip: (
-                    <>
+                    <p className="max-w-72 text-sm m-0 leading-normal">
                         To get your ID, enable <strong>Developer Mode</strong> in Discord's advanced settings, then
                         right-click your name and choose <strong>Copy User ID</strong>.
-                    </>
+                    </p>
                 ),
             },
         },

--- a/src/pages/community/profile/edit.tsx
+++ b/src/pages/community/profile/edit.tsx
@@ -347,18 +347,29 @@ const formSections = [
             },
             github: {
                 label: 'GitHub',
-                placeholder: 'https://github.com',
+                placeholder: 'https://github.com/{username}',
                 type: 'url',
             },
             linkedin: {
                 label: 'LinkedIn',
-                placeholder: 'https://linkedin.com',
+                placeholder: 'https://linkedin.com/in/{username}',
                 type: 'url',
             },
             twitter: {
                 label: 'X',
-                placeholder: 'https://x.com',
+                placeholder: 'https://x.com/{username}',
                 type: 'url',
+            },
+            discord: {
+                label: 'Discord',
+                placeholder: 'https://discord.com/users/{id}',
+                type: 'url',
+                tooltip: (
+                    <>
+                        To get your ID, enable <strong>Developer Mode</strong> in Discord's advanced settings, then
+                        right-click your name and choose <strong>Copy User ID</strong>.
+                    </>
+                ),
             },
         },
     },
@@ -459,6 +470,7 @@ const ValidationSchema = Yup.object().shape({
     github: Yup.string().url('Invalid URL').nullable(),
     linkedin: Yup.string().url('Invalid URL').nullable(),
     twitter: Yup.string().url('Invalid URL').nullable(),
+    discord: Yup.string().url('Invalid URL').nullable(),
     biography: Yup.string().max(3000, 'Please limit your bio to 3,000 characters, you wordsmith!').nullable(),
     avatar: Yup.mixed()
         .nullable()
@@ -599,6 +611,7 @@ function EditProfile({ profile, mutate }) {
                                                             error={error}
                                                             direction="column"
                                                             size="md"
+                                                            tooltip={field.tooltip}
                                                         />
                                                     )}
                                                     {error && (

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -273,10 +273,10 @@ const Links = ({
                         value={formValues.discord}
                         onChange={(e) => setFieldValue('discord', e.target.value)}
                         tooltip={
-                            <>
+                            <p className="max-w-72 text-sm m-0 leading-normal">
                                 To get your ID, enable <strong>Developer Mode</strong> in Discord's advanced settings,
                                 then right-click your name and choose <strong>Copy User ID</strong>.
-                            </>
+                            </p>
                         }
                     />
                 </li>

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -50,7 +50,7 @@ import { useToast } from '../../../context/Toast'
 import HeaderBar from 'components/OSChrome/HeaderBar'
 import LevelBadge from 'components/Squeak/components/LevelBadge'
 import OSButton from 'components/OSButton'
-import { IconNoEntry, IconStrapi } from 'components/OSIcons'
+import { IconDiscord, IconNoEntry, IconStrapi } from 'components/OSIcons'
 import Points from 'components/Points'
 import ConnectedAccounts from 'components/Squeak/components/ConnectedAccounts'
 import { useWindow } from '../../../context/Window'
@@ -162,6 +162,7 @@ const Links = ({
                         error={errors.github}
                         label="GitHub"
                         name="github"
+                        placeholder="https://github.com/{username}"
                         value={formValues.github}
                         onChange={(e) => setFieldValue('github', e.target.value)}
                     />
@@ -188,6 +189,7 @@ const Links = ({
                         error={errors.twitter}
                         label="X"
                         name="twitter"
+                        placeholder="https://x.com/{username}"
                         value={formValues.twitter}
                         onChange={(e) => setFieldValue('twitter', e.target.value)}
                     />
@@ -214,6 +216,7 @@ const Links = ({
                         error={errors.linkedin}
                         label="LinkedIn"
                         name="linkedin"
+                        placeholder="https://linkedin.com/in/{username}"
                         value={formValues.linkedin}
                         onChange={(e) => setFieldValue('linkedin', e.target.value)}
                     />
@@ -260,6 +263,39 @@ const Links = ({
                     </li>
                 )
             )}
+            {isEditing ? (
+                <li>
+                    <Input
+                        error={errors.discord}
+                        label="Discord"
+                        name="discord"
+                        placeholder="https://discord.com/users/{id}"
+                        value={formValues.discord}
+                        onChange={(e) => setFieldValue('discord', e.target.value)}
+                        tooltip={
+                            <>
+                                To get your ID, enable <strong>Developer Mode</strong> in Discord's advanced settings,
+                                then right-click your name and choose <strong>Copy User ID</strong>.
+                            </>
+                        }
+                    />
+                </li>
+            ) : (
+                profile.discord && (
+                    <li>
+                        <Tooltip
+                            delay={0}
+                            trigger={
+                                <Link to={profile.discord} externalNoIcon>
+                                    <IconDiscord className="w-6 h-6 opacity-80 hover:opacity-100 transition-opacity" />
+                                </Link>
+                            }
+                        >
+                            {stripUrlPrefix(profile.discord)}
+                        </Tooltip>
+                    </li>
+                )
+            )}
         </ul>
     )
 }
@@ -272,6 +308,7 @@ const Input = ({
     error,
     dataScheme,
     tooltip,
+    placeholder,
 }: {
     label: string
     name: string
@@ -280,6 +317,7 @@ const Input = ({
     error?: string
     tooltip?: string | React.ReactNode
     dataScheme?: 'primary' | 'secondary' | 'tertiary'
+    placeholder?: string
 }) => {
     return (
         <OSInput
@@ -287,7 +325,7 @@ const Input = ({
             name={name}
             value={value}
             onChange={onChange}
-            placeholder={label}
+            placeholder={placeholder ?? label}
             direction="column"
             error={error}
             touched={!!error}
@@ -1104,6 +1142,7 @@ const ValidationSchema = Yup.object().shape({
     github: Yup.string().url('Invalid URL').nullable(),
     linkedin: Yup.string().url('Invalid URL').nullable(),
     twitter: Yup.string().url('Invalid URL').nullable(),
+    discord: Yup.string().url('Invalid URL').nullable(),
     biography: Yup.string().max(3000, 'Please limit your bio to 3,000 characters, you wordsmith!').nullable(),
     country: Yup.string().nullable(),
     location: Yup.string().nullable(),
@@ -1307,6 +1346,7 @@ export default function ProfilePage({ params }: PageProps) {
             twitter: profile?.twitter,
             linkedin: profile?.linkedin,
             github: profile?.github,
+            discord: profile?.discord,
             avatar: getAvatarURL(profile),
             firstName: profile?.firstName,
             lastName: profile?.lastName,


### PR DESCRIPTION
## What this does

Adds a **Discord** field to community profiles so members can link their Discord identity to their profile and find each other. (May also be useful as I try to tie together user activity across discord and fourm).

<img width="412" height="454" alt="CleanShot 2026-08-11 at 14 53 47" src="https://github.com/user-attachments/assets/e5de3e3b-e80e-47de-9f4b-28f5aca04b74" />


- New Discord icon in the profile links row (alongside GitHub, X, LinkedIn, website), linking to the user's Discord profile URL (`https://discord.com/users/{id}`)
- Discord input in both edit surfaces (inline profile editor and `/community/profile/edit`) with an info tooltip explaining how to find your user ID (enable Developer Mode → Copy User ID)
- URL validation matching the other link fields
- Updated GitHub/X/LinkedIn placeholders to show the expected URL format (e.g. `https://github.com/{username}`) so it's clear a full link is expected, not just a handle

## ⚠️ Dependency

Profile fields live on the **Profile content type in Strapi**. A `discord` short-text field (same settings as `github`/`twitter`) must be added there before saves persist — requested separately. The UI is safe to ship beforehand: the field renders and validates, the value just won't save until the Strapi field exists.

✅ @smallbrownbike took care of that here: https://github.com/PostHog/squeak-strapi/pull/206

## How to test

1. Open a community profile → edit — the Discord input renders with placeholder and tooltip
2. Enter a non-URL → "Invalid URL" error; enter `https://discord.com/users/123` → passes
3. Same on `/community/profile/edit`
4. With a value saved (post-Strapi change), the Discord icon shows in the profile's links row with a tooltip of the stripped URL

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*