### PR TITLE
Fix crests overlapping with test

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -251,7 +251,7 @@ export const TeamMember = (props: any) => {
                                             <CloudinaryImage
                                                 src={teamCrestMap[teamData[0].attributes.name]}
                                                 alt={`${teamData[0].attributes.name} Team`}
-                                                imgClassName="absolute -right-1 bottom-0 size-[min(5rem,20cqw)] object-contain transition-all"
+                                                imgClassName="absolute -right-1 bottom-0 size-[20cqw] @[12rem]:size-[30cqw] object-contain transition-all"
                                             />
                                         )}
                                     </div>

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -249,10 +249,9 @@ export const TeamMember = (props: any) => {
                                         {/* Show first team's crest */}
                                         {teamData[0] && teamCrestMap?.[teamData[0].attributes.name] && (
                                             <CloudinaryImage
-                                                width={160}
                                                 src={teamCrestMap[teamData[0].attributes.name]}
                                                 alt={`${teamData[0].attributes.name} Team`}
-                                                imgClassName="absolute -right-1 bottom-0 size-16 @[15rem]:size-20 object-contain transition-all"
+                                                imgClassName="absolute -right-1 bottom-0 size-[min(5rem,20cqw)] object-contain transition-all"
                                             />
                                         )}
                                     </div>


### PR DESCRIPTION
## Changes

Fix issue where team crest overlaps with text on `/people`. This 

Before
<img width="355" height="522" alt="image" src="https://github.com/user-attachments/assets/92ca2672-cf20-4570-beaa-179d697b95b1" />
<img width="689" height="359" alt="image" src="https://github.com/user-attachments/assets/c81738f8-3852-4964-a75d-e0c9f3729b26" />

After
<img width="359" height="514" alt="image" src="https://github.com/user-attachments/assets/879cf85b-1173-4328-b10e-c584176f8ab9" />
<img width="703" height="348" alt="image" src="https://github.com/user-attachments/assets/a5d7fce3-25ab-4393-8c9e-9404c0609163" />


## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
