### PR TITLE
Add blog post on log patterns and LLM token cost

### DIFF
--- a/contents/blog/log-patterns-ai-agents.mdx
+++ b/contents/blog/log-patterns-ai-agents.mdx
@@ -96,7 +96,7 @@ The order is the point. The agent gets oriented on a ranked list of templates, d
 
 In practice, asking your agent to "compare log patterns from the last hour against the same hour yesterday" is a better opening move than any query you'd write by hand, because it doesn't require you to have a hypothesis yet.
 
-## The side effect: a smaller logging bill
+## Your logging bill gets smaller too
 
 Once you can see which templates dominate your volume, the distribution is usually lopsided: a handful of log statements produce the bulk of your ingest, and a good fraction of those were never going to be read by anyone.
 

--- a/contents/blog/log-patterns-ai-agents.mdx
+++ b/contents/blog/log-patterns-ai-agents.mdx
@@ -18,7 +18,7 @@ seo:
     }
 ---
 
-Debugging has quietly changed shape. A year ago you read your logs. Now, more often than not, an agent reads them for you — you describe the bug in your editor, it goes and looks.
+Debugging has quietly changed shape. A year ago you read your logs. Now, more often than not, an agent reads them for you – you describe the bug in your editor, it goes and looks.
 
 Which surfaces a problem that was always there but never cost you money before. Logs have two failure modes, and they are different failure modes.
 
@@ -26,11 +26,11 @@ Which surfaces a problem that was always there but never cost you money before. 
 
 **They're too expensive to hand to an AI.** A 500,000-line window is on the order of 10 million tokens, and the overwhelming majority of it is the same heartbeat, request, and retry lines repeating. That's more than any context window holds, and it's expensive long before it's impossible. Every routine line your agent reads is budget it isn't spending on the fix.
 
-The instinct is to reach for summarization — have a model read the logs and describe them. That trades one problem for a worse one. A summary is a paraphrase, and you can't debug from a paraphrase. You need the actual line, the actual timestamp, the actual request ID.
+The instinct is to reach for summarization – have a model read the logs and describe them. That trades one problem for a worse one. A summary is a paraphrase, and you can't debug from a paraphrase. You need the actual line, the actual timestamp, the actual request ID.
 
 [Log patterns](/docs/logs/patterns) take the other route: compress, don't summarize.
 
-## What pattern mining actually does
+## What pattern mining does
 
 It reads your log messages, masks the parts that vary, and clusters what's left into templates.
 
@@ -50,13 +50,13 @@ User <*> not found
 
 Do that across a whole window and millions of lines collapse into a few dozen templates, each carrying its severity, how often it fired, its share of total volume, how many of those were errors, and a sparkline of its volume over time.
 
-That's the whole trick, and it's an old one — log template mining predates the current AI wave by a decade. What changed is who's reading the output and what their attention costs.
+That's the whole trick, and it's an old one – log template mining predates the current AI wave by a decade. What changed is who's reading the output and what their attention costs.
 
 ## Compression, not summarization
 
-Nothing is paraphrased and nothing is invented. Every template is derived from lines that actually exist in your logs, it carries real example lines, and it pivots straight back to the records it came from.
+Nothing is paraphrased and nothing is invented. Every template is derived from lines that exist in your logs, it carries real example lines, and it pivots straight back to the records it came from.
 
-Click **View matching logs** on any pattern and you land in the Logs view filtered to exactly those lines — via a validated regex compiled from the template, or a literal-text filter when the regex can't be verified against the pattern's own examples. It arrives as a normal, visible, removable filter chip, not a black box.
+Click **View matching logs** on any pattern and you land in the Logs view filtered to exactly those lines – via a validated regex compiled from the template, or a literal-text filter when the regex can't be verified against the pattern's own examples. It arrives as a normal, visible, removable filter chip, not a black box.
 
 This is the property that matters when an agent is doing the reading. An agent working from a summary will confidently cite evidence that doesn't exist. An agent working from templates can only point at lines you can go and open.
 
@@ -80,7 +80,7 @@ That last one is usually your incident.
 
 The highest-value question after a release isn't "how many errors do we have." It's "what is different now."
 
-Mine patterns for the hour after the deploy, mine them for the same hour yesterday, and diff: which templates are new, which are gone, which are spiking. A brand-new error template at low volume is frequently a better early signal than an existing one doubling — and it's precisely the thing a volume threshold never fires on.
+Mine patterns for the hour after the deploy, mine them for the same hour yesterday, and diff: which templates are new, which are gone, which are spiking. A brand-new error template at low volume is frequently a better early signal than an existing one doubling – and it's precisely the thing a volume threshold never fires on.
 
 ## Your agent can do this itself
 
@@ -96,13 +96,13 @@ In practice, asking your agent to "compare log patterns from the last hour again
 
 ## The side effect: a smaller logging bill
 
-Once you can see which templates dominate your volume, most teams find that a small handful of log statements produce the bulk of their ingest — and that a good fraction of those were never going to be read by anyone.
+Once you can see which templates dominate your volume, most teams find that a small handful of log statements produce the bulk of their ingest – and that a good fraction of those were never going to be read by anyone.
 
-Patterns give you the list. From there you either fix the statement at the source, or drop it with a [sampling rule](/docs/logs/best-practices#sample-strategically) and keep paying for the lines you'd actually open.
+Patterns give you the list. From there you either fix the statement at the source, or drop it with a [sampling rule](/docs/logs/best-practices#sample-strategically) and keep paying for the lines you'd open.
 
 ## Try it
 
-If you already send logs to PostHog, open the [Logs page](https://app.posthog.com/logs) and switch to the **Patterns** tab — it uses whatever date range, service, and severity filters you've got applied. If you don't, PostHog Logs is [OpenTelemetry-native](/docs/logs/installation), so there's no proprietary SDK to adopt: point an OTLP client at us and your lines start arriving.
+If you already send logs to PostHog, open the [Logs page](https://app.posthog.com/logs) and switch to the **Patterns** tab – it uses whatever date range, service, and severity filters you've got applied. If you don't, PostHog Logs is [OpenTelemetry-native](/docs/logs/installation), so there's no proprietary SDK to adopt: point an OTLP client at us and your lines start arriving.
 
 Then stop pasting logs into your agent. Hand it the shape instead.
 

--- a/contents/blog/log-patterns-ai-agents.mdx
+++ b/contents/blog/log-patterns-ai-agents.mdx
@@ -5,10 +5,12 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
+author:
+    - jon-mccallum
 featuredImage: >-
     https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/hog_ql.png
 featuredImageType: full
-category: Product
+category: General
 tags:
     - Logs
 seo:
@@ -18,7 +20,7 @@ seo:
     }
 ---
 
-Debugging has quietly changed shape. A year ago you read your logs. Now, more often than not, an agent reads them for you – you describe the bug in your editor, it goes and looks.
+Debugging has quietly changed shape. A year ago you read your logs. Now an agent reads them for you – you describe the bug in your editor, it goes and looks.
 
 Which surfaces a problem that was always there but never cost you money before. Logs have two failure modes, and they are different failure modes.
 
@@ -60,7 +62,7 @@ Click **View matching logs** on any pattern and you land in the Logs view filter
 
 This is the property that matters when an agent is doing the reading. An agent working from a summary will confidently cite evidence that doesn't exist. An agent working from templates can only point at lines you can go and open.
 
-## It costs nothing to run
+## No model, no token bill
 
 Pattern mining is deterministic. It doesn't call a model, so it doesn't bill AI spend, and the same window produces the same templates every time.
 
@@ -80,7 +82,7 @@ That last one is usually your incident.
 
 The highest-value question after a release isn't "how many errors do we have." It's "what is different now."
 
-Mine patterns for the hour after the deploy, mine them for the same hour yesterday, and diff: which templates are new, which are gone, which are spiking. A brand-new error template at low volume is frequently a better early signal than an existing one doubling – and it's precisely the thing a volume threshold never fires on.
+Mine patterns for the hour after the deploy, mine them for the same hour yesterday, and diff: which templates are new, which are gone, which are spiking. A brand-new error template at low volume is a better early signal than an existing one doubling – and it's precisely the thing a volume threshold never fires on.
 
 ## Your agent can do this itself
 
@@ -96,7 +98,7 @@ In practice, asking your agent to "compare log patterns from the last hour again
 
 ## The side effect: a smaller logging bill
 
-Once you can see which templates dominate your volume, most teams find that a small handful of log statements produce the bulk of their ingest – and that a good fraction of those were never going to be read by anyone.
+Once you can see which templates dominate your volume, the distribution is usually lopsided: a handful of log statements produce the bulk of your ingest, and a good fraction of those were never going to be read by anyone.
 
 Patterns give you the list. From there you either fix the statement at the source, or drop it with a [sampling rule](/docs/logs/best-practices#sample-strategically) and keep paying for the lines you'd open.
 

--- a/contents/blog/log-patterns-ai-agents.mdx
+++ b/contents/blog/log-patterns-ai-agents.mdx
@@ -1,0 +1,111 @@
+---
+title: 'Logs are too big to read, and too expensive to hand to an AI'
+date: 2026-08-12
+rootPage: /blog
+sidebar: Blog
+showTitle: true
+hideAnchor: true
+featuredImage: >-
+    https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/hog_ql.png
+featuredImageType: full
+category: Product
+tags:
+    - Logs
+seo:
+    {
+        metaTitle: 'Logs are too big to read, and too expensive to hand to an AI',
+        metaDescription: 'Log patterns compress millions of log lines into a few dozen templates, so you and your AI agent debug from the lines that matter instead of paying for the noise.',
+    }
+---
+
+Debugging has quietly changed shape. A year ago you read your logs. Now, more often than not, an agent reads them for you — you describe the bug in your editor, it goes and looks.
+
+Which surfaces a problem that was always there but never cost you money before. Logs have two failure modes, and they are different failure modes.
+
+**They're too big to read.** A busy service emits millions of lines a day. Nobody scrolls through that, so you grep for a string you already suspect. Which means you only ever find the problems you already knew about.
+
+**They're too expensive to hand to an AI.** A 500,000-line window is on the order of 10 million tokens, and the overwhelming majority of it is the same heartbeat, request, and retry lines repeating. That's more than any context window holds, and it's expensive long before it's impossible. Every routine line your agent reads is budget it isn't spending on the fix.
+
+The instinct is to reach for summarization — have a model read the logs and describe them. That trades one problem for a worse one. A summary is a paraphrase, and you can't debug from a paraphrase. You need the actual line, the actual timestamp, the actual request ID.
+
+[Log patterns](/docs/logs/patterns) take the other route: compress, don't summarize.
+
+## What pattern mining actually does
+
+It reads your log messages, masks the parts that vary, and clusters what's left into templates.
+
+So these three lines:
+
+```
+User abc123 not found
+User def456 not found
+User ghi789 not found
+```
+
+Become one pattern:
+
+```
+User <*> not found
+```
+
+Do that across a whole window and millions of lines collapse into a few dozen templates, each carrying its severity, how often it fired, its share of total volume, how many of those were errors, and a sparkline of its volume over time.
+
+That's the whole trick, and it's an old one — log template mining predates the current AI wave by a decade. What changed is who's reading the output and what their attention costs.
+
+## Compression, not summarization
+
+Nothing is paraphrased and nothing is invented. Every template is derived from lines that actually exist in your logs, it carries real example lines, and it pivots straight back to the records it came from.
+
+Click **View matching logs** on any pattern and you land in the Logs view filtered to exactly those lines — via a validated regex compiled from the template, or a literal-text filter when the regex can't be verified against the pattern's own examples. It arrives as a normal, visible, removable filter chip, not a black box.
+
+This is the property that matters when an agent is doing the reading. An agent working from a summary will confidently cite evidence that doesn't exist. An agent working from templates can only point at lines you can go and open.
+
+## It costs nothing to run
+
+Pattern mining is deterministic. It doesn't call a model, so it doesn't bill AI spend, and the same window produces the same templates every time.
+
+That sounds like a footnote until you're doing it on every investigation. The expensive way to use an LLM on logs is to make the LLM do the compression. Do the compression deterministically, then spend your tokens on the reasoning.
+
+## It ranks by signal, so you find what you weren't looking for
+
+Grep only finds what you already suspect. A patterns table is ranked, so the things you didn't know to search for show up anyway:
+
+- Sort by **Errors** and the noisiest failure shapes surface immediately.
+- Sort by **Share** and you find the one `info` line burning 40% of your logging bill for no reason.
+- Scan the **Trend** sparklines and a template that was flat all week and spiked an hour ago stands out on sight.
+
+That last one is usually your incident.
+
+## Diffing two windows tells you what your deploy did
+
+The highest-value question after a release isn't "how many errors do we have." It's "what is different now."
+
+Mine patterns for the hour after the deploy, mine them for the same hour yesterday, and diff: which templates are new, which are gone, which are spiking. A brand-new error template at low volume is frequently a better early signal than an existing one doubling — and it's precisely the thing a volume threshold never fires on.
+
+## Your agent can do this itself
+
+All of it is available over the [PostHog MCP server](/docs/logs/surfaces/mcp), so your coding agent doesn't need you to prepare anything:
+
+- `logs-patterns` mines templates for a service, severity, and time range.
+- `logs-patterns-diff` compares two windows and returns what's new, gone, or spiking.
+- `query-logs` pulls the actual lines once it knows which template matters.
+
+The order is the point. The agent gets oriented on a ranked list of templates, decides which one is suspicious, and only then spends context on raw lines. And because your codebase is in the same session, it can tie a template back to the log statement that emitted it and draft the fix in one pass.
+
+In practice, asking your agent to "compare log patterns from the last hour against the same hour yesterday" is a better opening move than any query you'd write by hand, because it doesn't require you to have a hypothesis yet.
+
+## The side effect: a smaller logging bill
+
+Once you can see which templates dominate your volume, most teams find that a small handful of log statements produce the bulk of their ingest — and that a good fraction of those were never going to be read by anyone.
+
+Patterns give you the list. From there you either fix the statement at the source, or drop it with a [sampling rule](/docs/logs/best-practices#sample-strategically) and keep paying for the lines you'd actually open.
+
+## Try it
+
+If you already send logs to PostHog, open the [Logs page](https://app.posthog.com/logs) and switch to the **Patterns** tab — it uses whatever date range, service, and severity filters you've got applied. If you don't, PostHog Logs is [OpenTelemetry-native](/docs/logs/installation), so there's no proprietary SDK to adopt: point an OTLP client at us and your lines start arriving.
+
+Then stop pasting logs into your agent. Hand it the shape instead.
+
+- [Log patterns docs](/docs/logs/patterns)
+- [Use Logs over MCP](/docs/logs/surfaces/mcp)
+- [Logging best practices](/docs/logs/best-practices)

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -754,5 +754,12 @@
         "link_type": "linkedin",
         "link_url": "https://www.linkedin.com/in/avdhoot-fulsundar/",
         "profile_id": 47036
+    },
+    {
+        "handle": "jon-mccallum",
+        "name": "Jon McCallum",
+        "role": "Product Engineer",
+        "link_type": "github",
+        "link_url": "https://github.com/jonmcwest"
     }
 ]


### PR DESCRIPTION
## Changes

New blog post: **"Logs are too big to read, and too expensive to hand to an AI"** (`contents/blog/log-patterns-ai-agents.mdx`).

**Why:** framing production logs as having two distinct failure modes — too big for a human to read, too expensive to hand to an AI agent — is a sharper way to explain why [log patterns](/docs/logs/patterns) matter than "group similar lines." Nothing in the Logs product area currently argues the token-cost angle.

The argument, in order: why summarization is the wrong trade (you can't debug from a paraphrase), why deterministic compression is the cheap move, ranking so you find what you weren't searching for, diffing two windows as the best post-deploy question, doing all of it over MCP, and the smaller logging bill that falls out once you can see which templates dominate volume.

Two things left for a human before this publishes:

- **No `author` set** — I didn't want to attribute the post to someone who hasn't read it. Needs an author slug.
- **`featuredImage` is a placeholder**, reusing the generic image from the log monitoring comparison post. Wants a bespoke one.

Docs changes for the same positioning are split out into a separate PR: #19409.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — nothing moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01NWR6F58F/p1786521130882479?thread_ts=1786521130.882479&cid=C01NWR6F58F)*
