### PR TITLE
Document the opt-out and suppression APIs in workflows docs

### DIFF
--- a/contents/docs/workflows/opt-outs.mdx
+++ b/contents/docs/workflows/opt-outs.mdx
@@ -28,6 +28,18 @@ The suppression list is address-level and category-independent – a suppressed 
 
 PostHog adds addresses automatically when mail to them hard-bounces, which is what protects your sending domain's reputation. You can add an address by hand, and you can remove an entry if you believe the bounce was a one-off – but removing a genuine hard bounce means you'll bounce again.
 
+## Managing the lists over the API
+
+Both lists are available over the [REST API](/docs/api), so your own product can honor an unsubscribe or a resubscribe without anyone opening PostHog.
+
+The [messaging preferences API](/docs/api/messaging-preferences) manages the opt-out list: list a category's opt-outs, add them one at a time or up to 1,000 in bulk, remove one when a recipient opts back in, and export a category's list as CSV. Leave out the category to work with the global opt-out that covers all marketing messages.
+
+Sends check the message's category and the global opt-out together, so opting someone back in to one marketing category also lifts a global opt-out if they have one. Their other marketing categories stay opted out, which keeps the resubscribe scoped to the category you named.
+
+The [messaging suppressions API](/docs/api/messaging-suppressions) manages the suppression list: list entries, add one, or remove one.
+
+Authenticate with a [personal API key](/docs/api/personal-api-keys) that has the `hog_flow:read` scope for reads or `hog_flow:write` for writes.
+
 ## Related
 
 - [Import opt-out lists from Customer.io](/docs/workflows/import-customerio-optouts)

--- a/contents/docs/workflows/surfaces/api.mdx
+++ b/contents/docs/workflows/surfaces/api.mdx
@@ -15,6 +15,8 @@ Workflows are stored as **hog flows**, and every one of them is available over t
 
 - **Manage workflows.** `/api/projects/:project_id/hog_flows/` lists, creates, reads, updates, and deletes workflows, including their trigger, graph of actions, and enabled state.
 - **Reuse templates.** `/api/projects/:project_id/hog_flow_templates/` covers the workflow templates in your project.
+- **Honor unsubscribes and resubscribes.** `/api/projects/:project_id/messaging_preferences/` manages the [opt-out list](/docs/workflows/opt-outs): list a category's opt-outs, add them one at a time or in bulk, remove one when a recipient opts back in, and export the list as CSV. Full details in the [messaging preferences API reference](/docs/api/messaging-preferences).
+- **Keep the suppression list current.** `/api/projects/:project_id/messaging_suppressions/` lists, adds, and removes [suppressed addresses](/docs/workflows/opt-outs#the-suppression-list). Full details in the [messaging suppressions API reference](/docs/api/messaging-suppressions).
 - **Check blast radius before you publish.** The API can report how many people a workflow's audience filters would match, so you don't accidentally message everyone.
 - **Inspect runs.** Batch job status endpoints report on workflows triggered against a batch audience.
 
@@ -22,7 +24,7 @@ A workflow's graph is validated on write. If a trigger, action, or template refe
 
 ## Authentication
 
-Use a [personal API key](/docs/api#authentication) scoped to the project you're writing to, and send it as a bearer token. Treat the key like a password – it can create and enable workflows that send real messages, so keep it in a secret store, never in client-side code.
+Use a [personal API key](/docs/api#authentication) scoped to the project you're writing to, and send it as a bearer token. Workflows, opt-outs, and suppressions all use the `hog_flow` scope: grant the key `hog_flow:read` for reads and `hog_flow:write` for writes. Treat the key like a password – it can create and enable workflows that send real messages, so keep it in a secret store, never in client-side code.
 
 ## Related
 


### PR DESCRIPTION
## Changes

The workflows docs never say the opt-out and suppression lists have an API, so readers assume the lists are UI-only. PostHog/posthog#74632 opened those endpoints to personal API keys, and they already appear in the auto-generated API reference, but no page links to them.

- The [opt-outs and suppression guide](https://posthog.com/docs/workflows/opt-outs) gets a section on managing both lists over the API, linking the [messaging preferences](https://posthog.com/docs/api/messaging-preferences) and [messaging suppressions](https://posthog.com/docs/api/messaging-suppressions) references.
- The section explains the one non-obvious behavior: a per-category resubscribe lifts a global opt-out, and the other marketing categories stay opted out.
- The [Workflows API surface page](https://posthog.com/docs/workflows/surfaces/api) adds bullets for both endpoint groups.
- Its Authentication section names the `hog_flow:read` and `hog_flow:write` scopes.

I (actually Claude, via a PostHog Desktop task) wrote the sections from the merged PR and the live OpenAPI spec. Not checked: the Vercel preview build; the changes are plain MDX text.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
