### PR TITLE
docs: capture_ai public beta page

### DIFF
--- a/contents/docs/ai-observability/capture-ai.mdx
+++ b/contents/docs/ai-observability/capture-ai.mdx
@@ -98,8 +98,12 @@ In Python, call `posthog.flush()` before exit (or enable `sync_mode`), just like
 
 ## Other platforms
 
-Not on Python or Node? Send AI events through [manual capture](/docs/ai-observability/installation/manual-capture) instead.
+Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the dedicated AI endpoint instead of the regular one — same request format, different path:
+
+```shell
+POST <ph_client_api_host>/i/v0/ai/batch/
+```
 
 ## Limits
 
-Events up to **8MB** are accepted for now — larger events are dropped. This limit may change as the beta evolves.
+Events up to **8MB** are accepted for now — larger events are dropped. The limit will increase as the beta continues.

--- a/contents/docs/ai-observability/capture-ai.mdx
+++ b/contents/docs/ai-observability/capture-ai.mdx
@@ -1,0 +1,142 @@
+---
+title: Capturing AI events with capture_ai
+sidebar: Docs
+showTitle: true
+---
+
+> 🚧 **Beta.** The `capture_ai` surface is frozen — signatures won't change —
+> but the operational limits listed below may. Available in
+> [posthog-python](/docs/libraries/python) and
+> [posthog-node](/docs/libraries/node).
+
+AI events are big. A single generation can carry megabytes of prompt context
+or base64 media — far past what analytics capture accepts. `capture_ai` sends
+AI events (`$ai_generation`, `$ai_span`, `$ai_trace`, `$ai_embedding`, ...)
+through a dedicated AI ingestion path with much higher payload limits, on an
+isolated queue that never delays or displaces your analytics events.
+
+Our [SDK integrations](/docs/ai-observability/installation) use it under the
+hood. Use it directly when you build AI events yourself
+([manual capture](/docs/ai-observability/installation/manual-capture)).
+
+## Capturing manually
+
+`capture_ai` takes exactly the same arguments as `capture` and returns the
+event's UUID — keep it if you want to correlate this capture with the trace
+you later query.
+
+```python
+from posthog import Posthog
+
+posthog = Posthog("<ph_project_api_key>", host="<ph_client_api_host>")
+
+uuid = posthog.capture_ai(
+    "$ai_generation",
+    distinct_id="user_123",
+    properties={
+        "$ai_trace_id": trace_id,
+        "$ai_model": "gpt-5",
+        "$ai_input": messages,
+        "$ai_output_choices": choices,
+    },
+)
+```
+
+```ts
+import { PostHog } from 'posthog-node'
+
+const posthog = new PostHog('<ph_project_api_key>', { host: '<ph_client_api_host>' })
+
+const uuid = posthog.captureAi({
+  distinctId: 'user_123',
+  event: '$ai_generation',
+  properties: {
+    $ai_trace_id: traceId,
+    $ai_model: 'gpt-5',
+    $ai_input: messages,
+    $ai_output_choices: choices,
+  },
+})
+```
+
+In Node, `captureAi` returns `undefined` when the client is disabled. In
+Python, `capture_ai` returns `None` when the event wasn't admitted (disabled
+client, or dropped by `before_send`).
+
+Send content as your provider produced it — provider-native message parts,
+including base64 and data URIs. The platform recognizes media at ingestion;
+you don't need to reshape payloads per provider.
+
+`capture_ai` is a pipe: it never redacts or truncates what you pass it.
+Payloads you build yourself are your responsibility;
+[privacy mode](/docs/ai-observability/privacy-mode) and the size limits below
+still apply.
+
+### Short-lived processes
+
+In serverless environments, use the awaitable variant so the event is
+delivered before the runtime freezes:
+
+```ts
+await posthog.captureAiImmediate({ distinctId: 'user_123', event: '$ai_generation', properties })
+```
+
+Python has no per-call immediate variant — use `sync_mode=True` or call
+`posthog.flush()` before exit, as with `capture`.
+
+## Full AI capture
+
+By default, PostHog's AI wrappers redact media and truncate very long strings
+before capture. Opt into full-fidelity capture with one flag:
+
+```python
+posthog = Posthog("<ph_project_api_key>", enable_full_ai_capture=True)
+```
+
+```ts
+const posthog = new PostHog('<ph_project_api_key>', { enableFullAiCapture: true })
+```
+
+What the flag changes — for wrapper-captured events only:
+
+| | `enable_full_ai_capture` off (default) | on |
+|---|---|---|
+| Delivery | analytics capture path | dedicated AI path |
+| Long strings | truncated | kept intact |
+| Media (base64 / data URIs) | type-aware placeholders, e.g. `[base64 audio redacted]` | passed through unmodified |
+| Privacy mode on | content stripped | content stripped |
+
+Notes:
+
+- [Privacy mode](/docs/ai-observability/privacy-mode) always wins: content
+  properties are stripped entirely, flag or no flag.
+- Truncation is skipped together with media passthrough because a cut through
+  base64 corrupts the media as surely as redacting it.
+- Very short base64 strings in media fields are kept even when redacting
+  (under 200 characters in Python, under 64 in Node).
+- In Node, the OpenTelemetry export path always redacts, regardless of this
+  flag.
+
+## Delivery and failure semantics
+
+- `capture_ai` never throws. Delivery failures surface through the SDK's
+  error hooks (`on_error` in Python), not the return value.
+- Every AI event carries a client-generated UUIDv7 (unless you pass your own
+  UUID), which is what the method returns. Retries after partial failures may
+  re-send an event; ingestion dedupes on the UUID, so you never see
+  duplicates.
+- Events exceeding the per-event size limit are dropped, logging only the
+  event name and byte size — payload content never reaches logs.
+
+## Current operational limits
+
+These are operating values, **not** API guarantees — they may change without
+notice as the AI ingestion pipeline evolves:
+
+| | |
+|---|---|
+| Per-event size cap | 8 MiB |
+| Endpoint | `/i/v0/ai/batch/` |
+| Batching | isolated queue, ~5 MiB target per batch (Node) |
+| Compression | Node: gzip (unless `disableCompression`); Python: opt-in `gzip=True` |
+| Retries | bounded, with backoff; failed batches are reported then discarded |

--- a/contents/docs/ai-observability/capture-ai.mdx
+++ b/contents/docs/ai-observability/capture-ai.mdx
@@ -6,7 +6,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="Public beta" type="fyi">
 
-Full AI capture is in public beta, available in [posthog-python](/docs/libraries/python) and [posthog-node](/docs/libraries/node). We'd love to [hear your feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we roll it out.
+Full AI capture is in public beta, available in [posthog-python](/docs/libraries/python) 7.39+ and [posthog-node](/docs/libraries/node) 5.49+ (with `@posthog/ai` 8.8+). We'd love to [hear your feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we roll it out.
 
 </CalloutBox>
 
@@ -16,7 +16,7 @@ During the beta, this path is opt-in. How you opt in depends on how you capture 
 
 ## Using the SDK integrations
 
-By default, our [SDK integrations](/docs/ai-observability/installation) truncate very long strings and redact base64 media before capture. To capture everything in full, pass a single flag when creating your PostHog client:
+By default, our [SDK integrations](/docs/ai-observability/installation) redact base64 media and may truncate very long strings before capture. To capture everything in full, pass a single flag when creating your PostHog client:
 
 <MultiLanguage>
 
@@ -86,7 +86,7 @@ const uuid = posthog.captureAi({
 
 </MultiLanguage>
 
-Send content as your provider produced it, including base64 and data URIs – there's no need to reshape payloads. `capture_ai` captures exactly what you pass it, without truncating or redacting anything, though [privacy mode](/docs/ai-observability/privacy-mode) still applies.
+Send content as your provider produced it, including base64 and data URIs – there's no need to reshape payloads. `capture_ai` captures exactly what you pass it, without truncating or redacting anything. [Privacy mode](/docs/ai-observability/privacy-mode) doesn't apply here, so leave out any content you don't want stored.
 
 In serverless and other short-lived environments, use the awaitable variant in Node so the event is delivered before the runtime exits:
 
@@ -106,4 +106,4 @@ POST <ph_client_api_host>/i/v0/ai/batch/
 
 ## Limits
 
-Events up to **8MB** are accepted for now – larger events are dropped. The limit will increase as the beta continues.
+Events up to **8MB** are accepted for now. The SDKs drop larger events before sending and log an error instead. The limit will increase as the beta continues.

--- a/contents/docs/ai-observability/capture-ai.mdx
+++ b/contents/docs/ai-observability/capture-ai.mdx
@@ -1,29 +1,54 @@
 ---
 title: Capturing AI events with capture_ai
-sidebar: Docs
-showTitle: true
 ---
 
-> 🚧 **Beta.** The `capture_ai` surface is frozen — signatures won't change —
-> but the operational limits listed below may. Available in
-> [posthog-python](/docs/libraries/python) and
-> [posthog-node](/docs/libraries/node).
+import CalloutBox from 'components/Docs/CalloutBox'
 
-AI events are big. A single generation can carry megabytes of prompt context
-or base64 media — far past what analytics capture accepts. `capture_ai` sends
-AI events (`$ai_generation`, `$ai_span`, `$ai_trace`, `$ai_embedding`, ...)
-through a dedicated AI ingestion path with much higher payload limits, on an
-isolated queue that never delays or displaces your analytics events.
+<CalloutBox icon="IconFlask" title="Public beta" type="fyi">
 
-Our [SDK integrations](/docs/ai-observability/installation) use it under the
-hood. Use it directly when you build AI events yourself
-([manual capture](/docs/ai-observability/installation/manual-capture)).
+Full AI capture is in public beta, available in [posthog-python](/docs/libraries/python) and [posthog-node](/docs/libraries/node). We'd love to [hear your feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we roll it out.
 
-## Capturing manually
+</CalloutBox>
 
-`capture_ai` takes exactly the same arguments as `capture` and returns the
-event's UUID — keep it if you want to correlate this capture with the trace
-you later query.
+AI events can get big — a single generation can carry megabytes of prompt context or base64-encoded media, more than regular event capture accepts. To handle this, PostHog sends AI events like `$ai_generation` and `$ai_embedding` through a dedicated ingestion path that accepts events up to **8MB**.
+
+During the beta, this path is opt-in. How you opt in depends on how you capture AI events today.
+
+## Using the SDK integrations
+
+By default, our [SDK integrations](/docs/ai-observability/installation) truncate very long strings and redact base64 media before capture. To capture everything in full, pass a single flag when creating your PostHog client:
+
+<MultiLanguage>
+
+```python
+from posthog import Posthog
+
+posthog = Posthog(
+    "<ph_project_api_key>",
+    host="<ph_client_api_host>",
+    enable_full_ai_capture=True
+)
+```
+
+```ts
+const posthog = new PostHog(
+  '<ph_project_api_key>',
+  {
+    host: '<ph_client_api_host>',
+    enableFullAiCapture: true
+  }
+)
+```
+
+</MultiLanguage>
+
+With the flag on, nothing is truncated or redacted. The one exception is [privacy mode](/docs/ai-observability/privacy-mode): when it's enabled, input and output content is still stripped, flag or no flag.
+
+## Calling capture_ai directly
+
+If you build AI events yourself instead of using the integrations, call `capture_ai` (Python) or `captureAi` (Node) instead of `capture`. It takes the same arguments as `capture` and returns the captured event's UUID.
+
+<MultiLanguage>
 
 ```python
 from posthog import Posthog
@@ -59,84 +84,22 @@ const uuid = posthog.captureAi({
 })
 ```
 
-In Node, `captureAi` returns `undefined` when the client is disabled. In
-Python, `capture_ai` returns `None` when the event wasn't admitted (disabled
-client, or dropped by `before_send`).
+</MultiLanguage>
 
-Send content as your provider produced it — provider-native message parts,
-including base64 and data URIs. The platform recognizes media at ingestion;
-you don't need to reshape payloads per provider.
+Send content as your provider produced it, including base64 and data URIs — there's no need to reshape payloads. `capture_ai` captures exactly what you pass it, without truncating or redacting anything, though [privacy mode](/docs/ai-observability/privacy-mode) still applies.
 
-`capture_ai` is a pipe: it never redacts or truncates what you pass it.
-Payloads you build yourself are your responsibility;
-[privacy mode](/docs/ai-observability/privacy-mode) and the size limits below
-still apply.
-
-### Short-lived processes
-
-In serverless environments, use the awaitable variant so the event is
-delivered before the runtime freezes:
+In serverless and other short-lived environments, use the awaitable variant in Node so the event is delivered before the runtime exits:
 
 ```ts
 await posthog.captureAiImmediate({ distinctId: 'user_123', event: '$ai_generation', properties })
 ```
 
-Python has no per-call immediate variant — use `sync_mode=True` or call
-`posthog.flush()` before exit, as with `capture`.
+In Python, call `posthog.flush()` before exit (or enable `sync_mode`), just like with `capture`.
 
-## Full AI capture
+## Other platforms
 
-By default, PostHog's AI wrappers redact media and truncate very long strings
-before capture. Opt into full-fidelity capture with one flag:
+Not on Python or Node? Send AI events through [manual capture](/docs/ai-observability/installation/manual-capture) instead.
 
-```python
-posthog = Posthog("<ph_project_api_key>", enable_full_ai_capture=True)
-```
+## Limits
 
-```ts
-const posthog = new PostHog('<ph_project_api_key>', { enableFullAiCapture: true })
-```
-
-What the flag changes — for wrapper-captured events only:
-
-| | `enable_full_ai_capture` off (default) | on |
-|---|---|---|
-| Delivery | analytics capture path | dedicated AI path |
-| Long strings | truncated | kept intact |
-| Media (base64 / data URIs) | type-aware placeholders, e.g. `[base64 audio redacted]` | passed through unmodified |
-| Privacy mode on | content stripped | content stripped |
-
-Notes:
-
-- [Privacy mode](/docs/ai-observability/privacy-mode) always wins: content
-  properties are stripped entirely, flag or no flag.
-- Truncation is skipped together with media passthrough because a cut through
-  base64 corrupts the media as surely as redacting it.
-- Very short base64 strings in media fields are kept even when redacting
-  (under 200 characters in Python, under 64 in Node).
-- In Node, the OpenTelemetry export path always redacts, regardless of this
-  flag.
-
-## Delivery and failure semantics
-
-- `capture_ai` never throws. Delivery failures surface through the SDK's
-  error hooks (`on_error` in Python), not the return value.
-- Every AI event carries a client-generated UUIDv7 (unless you pass your own
-  UUID), which is what the method returns. Retries after partial failures may
-  re-send an event; ingestion dedupes on the UUID, so you never see
-  duplicates.
-- Events exceeding the per-event size limit are dropped, logging only the
-  event name and byte size — payload content never reaches logs.
-
-## Current operational limits
-
-These are operating values, **not** API guarantees — they may change without
-notice as the AI ingestion pipeline evolves:
-
-| | |
-|---|---|
-| Per-event size cap | 8 MiB |
-| Endpoint | `/i/v0/ai/batch/` |
-| Batching | isolated queue, ~5 MiB target per batch (Node) |
-| Compression | Node: gzip (unless `disableCompression`); Python: opt-in `gzip=True` |
-| Retries | bounded, with backoff; failed batches are reported then discarded |
+Events up to **8MB** are accepted for now — larger events are dropped. This limit may change as the beta evolves.

--- a/contents/docs/ai-observability/capture-ai.mdx
+++ b/contents/docs/ai-observability/capture-ai.mdx
@@ -10,7 +10,7 @@ Full AI capture is in public beta, available in [posthog-python](/docs/libraries
 
 </CalloutBox>
 
-AI events can get big — a single generation can carry megabytes of prompt context or base64-encoded media, more than regular event capture accepts. To handle this, PostHog sends AI events like `$ai_generation` and `$ai_embedding` through a dedicated ingestion path that accepts events up to **8MB**.
+AI events can get big – a single generation can carry megabytes of prompt context or base64-encoded media, more than regular event capture accepts. To handle this, PostHog sends AI events like `$ai_generation` and `$ai_embedding` through a dedicated ingestion path that accepts events up to **8MB**.
 
 During the beta, this path is opt-in. How you opt in depends on how you capture AI events today.
 
@@ -86,7 +86,7 @@ const uuid = posthog.captureAi({
 
 </MultiLanguage>
 
-Send content as your provider produced it, including base64 and data URIs — there's no need to reshape payloads. `capture_ai` captures exactly what you pass it, without truncating or redacting anything, though [privacy mode](/docs/ai-observability/privacy-mode) still applies.
+Send content as your provider produced it, including base64 and data URIs – there's no need to reshape payloads. `capture_ai` captures exactly what you pass it, without truncating or redacting anything, though [privacy mode](/docs/ai-observability/privacy-mode) still applies.
 
 In serverless and other short-lived environments, use the awaitable variant in Node so the event is delivered before the runtime exits:
 
@@ -98,7 +98,7 @@ In Python, call `posthog.flush()` before exit (or enable `sync_mode`), just like
 
 ## Other platforms
 
-Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the dedicated AI endpoint instead of the regular one — same request format, different path:
+Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the dedicated AI endpoint instead of the regular one – same request format, different path:
 
 ```shell
 POST <ph_client_api_host>/i/v0/ai/batch/
@@ -106,4 +106,4 @@ POST <ph_client_api_host>/i/v0/ai/batch/
 
 ## Limits
 
-Events up to **8MB** are accepted for now — larger events are dropped. The limit will increase as the beta continues.
+Events up to **8MB** are accepted for now – larger events are dropped. The limit will increase as the beta continues.

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -47,4 +47,4 @@ import EmbeddingEvent from '../_snippets/embedding-event.mdx'
 
 ## Large events
 
-For large events (multimodal content, or prompts and outputs that approach 1MB), use the large event path instead. See [capturing large AI events](/docs/ai-observability/large-events).
+For large events, use the dedicated AI ingestion path – see [capturing large AI events](/docs/ai-observability/large-events).

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -44,3 +44,7 @@ import EmbeddingEvent from '../_snippets/embedding-event.mdx'
 <OnboardingContentWrapper snippets={{ GenerationEvent, TraceEvent, SpanEvent, EmbeddingEvent }}>
     <ManualInstallation modifySteps={addNextStepsStep} />
 </OnboardingContentWrapper>
+
+## Large or multimodal events
+
+For large or multimodal events, send them through [capture_ai](/docs/ai-observability/capture-ai), which uses the dedicated AI ingestion path.

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -47,4 +47,4 @@ import EmbeddingEvent from '../_snippets/embedding-event.mdx'
 
 ## Large or multimodal events
 
-In Python and Node, send large or multimodal events through [capture_ai](/docs/ai-observability/capture-ai), which uses the dedicated AI ingestion path.
+For large or multimodal events, use the dedicated AI ingestion path — see [capture_ai](/docs/ai-observability/capture-ai).

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -45,6 +45,6 @@ import EmbeddingEvent from '../_snippets/embedding-event.mdx'
     <ManualInstallation modifySteps={addNextStepsStep} />
 </OnboardingContentWrapper>
 
-## Large or multimodal events
+## Large events
 
-For large or multimodal events, use the dedicated AI ingestion path – see [capture_ai](/docs/ai-observability/capture-ai).
+For large events (multimodal content, or prompts and outputs that approach 1MB), use the large event path instead. See [capturing large AI events](/docs/ai-observability/large-events).

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -47,4 +47,4 @@ import EmbeddingEvent from '../_snippets/embedding-event.mdx'
 
 ## Large or multimodal events
 
-For large or multimodal events, send them through [capture_ai](/docs/ai-observability/capture-ai), which uses the dedicated AI ingestion path.
+In Python and Node, send large or multimodal events through [capture_ai](/docs/ai-observability/capture-ai), which uses the dedicated AI ingestion path.

--- a/contents/docs/ai-observability/installation/manual-capture.mdx
+++ b/contents/docs/ai-observability/installation/manual-capture.mdx
@@ -47,4 +47,4 @@ import EmbeddingEvent from '../_snippets/embedding-event.mdx'
 
 ## Large or multimodal events
 
-For large or multimodal events, use the dedicated AI ingestion path — see [capture_ai](/docs/ai-observability/capture-ai).
+For large or multimodal events, use the dedicated AI ingestion path – see [capture_ai](/docs/ai-observability/capture-ai).

--- a/contents/docs/ai-observability/large-events.mdx
+++ b/contents/docs/ai-observability/large-events.mdx
@@ -10,13 +10,13 @@ Large event capture is in public beta, available in [posthog-python](/docs/libra
 
 </CalloutBox>
 
-Most AI events are small, and the regular capture path handles them fine. Some aren't: a single generation can carry megabytes of prompt context or base64-encoded images and audio, more than regular event capture accepts. For these large events, PostHog has a dedicated ingestion path that accepts events up to **8MB**.
+AI events can get big – a single generation can carry megabytes of prompt context or base64-encoded media, more than regular event capture accepts. To handle this, PostHog sends AI events like `$ai_generation` and `$ai_embedding` through a dedicated ingestion path that accepts events up to **8MB**.
 
-During the beta, this path is opt-in. You only need it if your events are large: multimodal content, or prompts and outputs that approach 1MB. How you opt in depends on how you capture AI events today.
+During the beta, this path is opt-in. How you opt in depends on how you capture AI events today.
 
 ## Using the SDK integrations
 
-By default, our [SDK integrations](/docs/ai-observability/installation) redact base64 media and may truncate very long strings before capture. That's the right setting for most apps, and there's nothing to change. If you do need the full payload, pass a single flag when creating your PostHog client:
+By default, our [SDK integrations](/docs/ai-observability/installation) redact base64 media and may truncate very long strings before capture. To capture everything in full, pass a single flag when creating your PostHog client:
 
 <MultiLanguage>
 
@@ -42,11 +42,11 @@ const posthog = new PostHog(
 
 </MultiLanguage>
 
-With the flag on, nothing is truncated or redacted, and AI events go through the large event path. The one exception is [privacy mode](/docs/ai-observability/privacy-mode): when it's enabled, input and output content is still stripped, flag or no flag.
+With the flag on, nothing is truncated or redacted. The one exception is [privacy mode](/docs/ai-observability/privacy-mode): when it's enabled, input and output content is still stripped, flag or no flag.
 
 ## Calling capture_ai directly
 
-If you build AI events yourself instead of using the integrations, call `capture_ai` (Python) or `captureAi` (Node) instead of `capture`. It takes the same arguments as `capture`, sends the event through the large event path, and returns the captured event's UUID.
+If you build AI events yourself instead of using the integrations, call `capture_ai` (Python) or `captureAi` (Node) instead of `capture`. It takes the same arguments as `capture` and returns the captured event's UUID.
 
 <MultiLanguage>
 
@@ -98,7 +98,7 @@ In Python, call `posthog.flush()` before exit (or enable `sync_mode`), just like
 
 ## Other platforms
 
-Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the large event endpoint instead of the regular one – same request format, different path:
+Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the dedicated AI endpoint instead of the regular one – same request format, different path:
 
 ```shell
 POST <ph_client_api_host>/i/v0/ai/batch/

--- a/contents/docs/ai-observability/large-events.mdx
+++ b/contents/docs/ai-observability/large-events.mdx
@@ -1,22 +1,22 @@
 ---
-title: Capturing AI events with capture_ai
+title: Capturing large AI events
 ---
 
 import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="Public beta" type="fyi">
 
-Full AI capture is in public beta, available in [posthog-python](/docs/libraries/python) 7.39+ and [posthog-node](/docs/libraries/node) 5.49+ (with `@posthog/ai` 8.8+). We'd love to [hear your feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we roll it out.
+Large event capture is in public beta, available in [posthog-python](/docs/libraries/python#ai-observability) 7.39+ and [posthog-node](/docs/libraries/node#ai-observability) 5.49+ (with `@posthog/ai` 8.8+). We'd love to [hear your feedback](https://app.posthog.com/ai-observability#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we roll it out.
 
 </CalloutBox>
 
-AI events can get big – a single generation can carry megabytes of prompt context or base64-encoded media, more than regular event capture accepts. To handle this, PostHog sends AI events like `$ai_generation` and `$ai_embedding` through a dedicated ingestion path that accepts events up to **8MB**.
+Most AI events are small, and the regular capture path handles them fine. Some aren't: a single generation can carry megabytes of prompt context or base64-encoded images and audio, more than regular event capture accepts. For these large events, PostHog has a dedicated ingestion path that accepts events up to **8MB**.
 
-During the beta, this path is opt-in. How you opt in depends on how you capture AI events today.
+During the beta, this path is opt-in. You only need it if your events are large: multimodal content, or prompts and outputs that approach 1MB. How you opt in depends on how you capture AI events today.
 
 ## Using the SDK integrations
 
-By default, our [SDK integrations](/docs/ai-observability/installation) redact base64 media and may truncate very long strings before capture. To capture everything in full, pass a single flag when creating your PostHog client:
+By default, our [SDK integrations](/docs/ai-observability/installation) redact base64 media and may truncate very long strings before capture. That's the right setting for most apps, and there's nothing to change. If you do need the full payload, pass a single flag when creating your PostHog client:
 
 <MultiLanguage>
 
@@ -42,11 +42,11 @@ const posthog = new PostHog(
 
 </MultiLanguage>
 
-With the flag on, nothing is truncated or redacted. The one exception is [privacy mode](/docs/ai-observability/privacy-mode): when it's enabled, input and output content is still stripped, flag or no flag.
+With the flag on, nothing is truncated or redacted, and AI events go through the large event path. The one exception is [privacy mode](/docs/ai-observability/privacy-mode): when it's enabled, input and output content is still stripped, flag or no flag.
 
 ## Calling capture_ai directly
 
-If you build AI events yourself instead of using the integrations, call `capture_ai` (Python) or `captureAi` (Node) instead of `capture`. It takes the same arguments as `capture` and returns the captured event's UUID.
+If you build AI events yourself instead of using the integrations, call `capture_ai` (Python) or `captureAi` (Node) instead of `capture`. It takes the same arguments as `capture`, sends the event through the large event path, and returns the captured event's UUID.
 
 <MultiLanguage>
 
@@ -98,7 +98,7 @@ In Python, call `posthog.flush()` before exit (or enable `sync_mode`), just like
 
 ## Other platforms
 
-Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the dedicated AI endpoint instead of the regular one – same request format, different path:
+Not on Python or Node? Build events with [manual capture](/docs/ai-observability/installation/manual-capture) and point your capture requests at the large event endpoint instead of the regular one – same request format, different path:
 
 ```shell
 POST <ph_client_api_host>/i/v0/ai/batch/

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6718,6 +6718,13 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
+                    name: 'Capture AI events',
+                    url: '/docs/ai-observability/capture-ai',
+                    icon: 'IconSend',
+                    color: 'teal',
+                    featured: true,
+                },
+                {
                     name: 'Self-driving',
                     url: '/docs/ai-observability/self-driving',
                     icon: 'IconBolt',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6723,6 +6723,10 @@ export const docsMenu = {
                     icon: 'IconSend',
                     color: 'teal',
                     featured: true,
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
                 },
                 {
                     name: 'Self-driving',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6718,17 +6718,6 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
-                    name: 'Capture AI events',
-                    url: '/docs/ai-observability/capture-ai',
-                    icon: 'IconSend',
-                    color: 'teal',
-                    featured: true,
-                    badge: {
-                        title: 'Beta',
-                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
-                    },
-                },
-                {
                     name: 'Self-driving',
                     url: '/docs/ai-observability/self-driving',
                     icon: 'IconBolt',
@@ -6952,6 +6941,16 @@ export const docsMenu = {
                     icon: 'IconBalance',
                     color: 'green',
                     featured: true,
+                },
+                {
+                    name: 'Large events',
+                    url: '/docs/ai-observability/large-events',
+                    icon: 'IconSend',
+                    color: 'teal',
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
                 },
                 {
                     name: 'Evaluations',


### PR DESCRIPTION
## Changes

New page `contents/docs/ai-observability/capture-ai.mdx` documenting the `capture_ai` public beta, written for end users: why AI events need a dedicated ingestion path, the 8MB limit (for now), and the three ways to opt in — the `enable_full_ai_capture` / `enableFullAiCapture` flag for SDK integration users, calling `capture_ai` (Python) / `captureAi` (Node) instead of `capture` when building AI events yourself (with `captureAiImmediate` for serverless), and manual capture pointed at the dedicated AI endpoint (`/i/v0/ai/batch/`) on other platforms.

Also adds a Beta badge to the new nav entry (next to Privacy mode) and a one-line cross-link from the manual capture installation page.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

## 🤖 Agent context

Companion SDK branches: `feat(aio)/capture-ai-public-beta` (posthog-python) and posthog-js #4289.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
