### PR TITLE
feat(data-warehouse): document warehouse person and group properties

### DIFF
--- a/contents/docs/data-warehouse/join.mdx
+++ b/contents/docs/data-warehouse/join.mdx
@@ -46,15 +46,15 @@ Person joins are a special type of table joins. They are joins on the `persons` 
 
 > **Note:** Be sure that your joined keys actually match. For example `persons.id` returns a UUID, even if you use an email as a `distinct_id` when capturing events. You might need to add a person property like `email`.
 
-### Syncing warehouse data to person properties
+### Syncing warehouse data to person and group properties
 
-In addition to person joins (which enrich data at query time), you can sync warehouse table columns directly to person properties. This creates first-class person properties that persist on the person profile and are available everywhere in PostHog, including [feature flags](/docs/feature-flags), [cohorts](/docs/data/cohorts), [experiments](/docs/experiments), and insights.
+A person join resolves when a query runs. That covers insights and SQL, but feature flags, experiments, and surveys evaluate against stored person properties, so a join is invisible to them.
 
-To set this up, go to [Customer Analytics → Configuration → Custom properties](https://app.posthog.com/customer_analytics/configuration) and create a new custom property with the target set to **Person**. Pick a synced warehouse table, specify the distinct ID column, and map warehouse columns to person property names.
+To use warehouse data there, write it onto the profile instead. Go to **Data** > **Warehouse properties**, pick a synced table and the column holding each row's distinct ID, then map warehouse columns to person property names. The same works for [group properties](/docs/product-analytics/group-analytics), matched by a group key column.
 
-Use **person joins** when you only need external data in insights and SQL queries. Use **property syncing** when you want the data stored on the person and usable across all PostHog features.
+Use a **person join** when you only need external data in insights and SQL queries. Use **warehouse properties** when something outside a query has to read the value.
 
-For more details, see [person properties](/docs/product-analytics/person-properties).
+For more details, see [warehouse properties](/docs/data-warehouse/warehouse-properties).
 
 ## Query joins
 

--- a/contents/docs/data-warehouse/warehouse-properties.mdx
+++ b/contents/docs/data-warehouse/warehouse-properties.mdx
@@ -1,0 +1,151 @@
+---
+title: Warehouse properties
+sidebarTitle: Warehouse properties
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+Warehouse properties copy columns from a synced [data warehouse](/docs/data-warehouse) table onto your [person properties](/docs/product-analytics/person-properties) and [group properties](/docs/product-analytics/group-analytics). Each row is matched to a person or a group by a key column. The mapped columns then stay up to date on every sync.
+
+Use it when the truth about a customer lives in another system. Plan tier, seat count, MRR, contract renewal date, and lifecycle stage usually live in Stripe, Salesforce, HubSpot, or your own Postgres, not in your product events.
+
+Once a column is mapped, it behaves like any other person or group property. You can filter insights with it, build [cohorts](/docs/data/cohorts) from it, target [feature flags](/docs/feature-flags) and [experiments](/docs/experiments) with it, and use it in [surveys](/docs/surveys).
+
+<CalloutBox icon="IconWarning" title="Beta feature" type="action">
+
+Warehouse properties are currently in beta. Contact support if you don't see **Warehouse properties** in the **Data** menu.
+
+</CalloutBox>
+
+## Warehouse properties or a join?
+
+PostHog gives you two ways to use warehouse data about a person. They are not interchangeable.
+
+| | Warehouse properties | [Person join](/docs/data-warehouse/join#person-joins) |
+|---|---|---|
+| How it works | The value is written onto the person profile | The tables are joined when a query runs |
+| Where you can use it | Anywhere a person property works | Insights, filters, and breakdowns |
+| Feature flags and experiments | Yes | No |
+| Cost of a value | One property update per changed row | No writes |
+| Freshness | Updated on each warehouse sync | Always current at query time |
+
+Choose warehouse properties when something outside of a query has to read the value. Feature flags and experiments evaluate against stored person properties, so a join is invisible to them.
+
+Choose a join when you only need the data in insights and SQL. A join adds no writes and never goes stale.
+
+## Before you start
+
+You need three things:
+
+1. A [linked source](/docs/data-warehouse/sources) that syncs the table you want to read.
+2. A column in that table holding each row's distinct ID, for person properties. For group properties, you need the column holding each row's group key.
+3. People or groups that already exist in PostHog.
+
+The last point is the one that catches people out. A sync only updates a person who is already in PostHog. It never creates one. If your warehouse holds 50,000 customers and only 12,000 of them have used your product, the other 38,000 rows are skipped.
+
+Group properties also need [group analytics](/docs/product-analytics/group-analytics) and at least one group type. The **Groups** tab is hidden until you have both.
+
+## Set up a warehouse property
+
+1. Go to **Data** > **Warehouse properties**.
+2. Select the **Persons** or the **Groups** tab.
+3. Click **Add person property**, or **Add group property**.
+4. Give the mapping a name, and a description if it helps the next person to read it.
+5. For groups, select the **Group type** it attaches to.
+6. Select the **Warehouse table** to read from. You can search the whole synced catalog.
+7. Select the **Distinct ID column**, or the **Group key column** for groups. This is how a row finds the person or group to update.
+8. Map each warehouse column to the property name to write it to. Add one row per column. Each mapped column takes its own optional description.
+9. Save.
+
+PostHog starts a backfill as soon as you save, so the first values arrive without another sync.
+
+You need project admin access, plus edit access on the warehouse source behind the table. Mapping a table drives its billable sync, so viewing the source is not enough.
+
+### What you can change later
+
+The table and the column mappings are fixed once you save. To change either, delete the mapping and create it again.
+
+The key column and the on/off toggle stay editable.
+
+Properties that arrive this way carry a **Warehouse** provenance tag in property lists, so you can tell them apart from the ones your SDK sets.
+
+### Naming the property
+
+The property name is what you see in filters, so write it the way you want to read it later. A warehouse column called `sub_plan_tier` can map to a property called `plan`.
+
+The value itself is copied as it stands. PostHog does not convert units or reformat it, so a column holding cents arrives as cents.
+
+You can only map a table a source syncs. A [view](/docs/data-warehouse/views) or a saved query is not selectable, so a value that needs SQL to derive has to be computed upstream, in the system you sync from.
+
+Map a column once. Two sources that write the same property name fight each other, and the last sync wins.
+
+## How syncing works
+
+A warehouse property sync rides on the table's own warehouse sync. It does not run on its own schedule. When the import for the table finishes, the sync runs for every enabled mapping on that table, in this order:
+
+1. It reads the rows the import staged. An incremental import stages only the rows it added or changed, so a quiet table reads zero rows.
+2. It builds a bundle of the mapped values for each row, keyed by the distinct ID or group key.
+3. It compares each bundle against the values it last sent, and drops the ones that did not change.
+4. It drops the rows whose key matches no existing person or group.
+5. It sends one property update per surviving row.
+
+Step 3 means a full refresh does not resend everything. It only sends what actually differs from the last send.
+
+Step 4 is where rows go missing. The run history reports that count separately, under **Skipped (no person)**.
+
+A person update arrives as a `$set` event. A group update arrives as a `$groupidentify` event. PostHog sends them at a controlled rate, so a large backfill lands over time rather than all at once.
+
+### Sync now and backfill
+
+Two buttons sit on each row of the table:
+
+- **Sync now** runs the table's warehouse import, then the property sync behind it. Use it when the warehouse has new rows you want now.
+- **Backfill** reads the whole table instead of the last import's changed rows. Use it after you add a column to a mapping, so people who have not changed since then get the new property.
+
+Only one run happens at a time per table. Both buttons are disabled while a run is in flight.
+
+### Reading the run history
+
+Expand a row to see its runs. The counts follow the steps above:
+
+| Column | What it means |
+|---|---|
+| **Status** | Whether the run finished. A completed run that updated nobody is normal |
+| **Trigger** | What started the run: the sync schedule, **Sync now**, or **Backfill** |
+| **Rows read** | Rows the import staged for this run |
+| **Updated** | People or groups updated, out of the rows whose values changed, with the share of those rows |
+| **Skipped (no person)** | Changed rows whose key matched no existing person. Reads **Skipped (no group)** on the Groups tab |
+
+A row of zeros is not a failure on its own. The status carries a short note that says which zero you are looking at: `no new rows` means the import brought nothing, and `no changes` means every row already holds the values last sent.
+
+## Turning a mapping off
+
+Toggle a mapping off to stop updating its properties without deleting it. Values already synced stay on the people and groups. They stop changing.
+
+Deleting the mapping does the same and removes the configuration. Neither action removes the property values from person profiles.
+
+## Costs
+
+Each updated person or group sends one event, so it counts toward your event volume. The comparison in step 3 exists to keep that number down. A column that rarely changes costs almost nothing after the first sync.
+
+A wide mapping costs more than a narrow one. One changed column resends every property the mapping covers for that person, because the comparison covers the whole bundle rather than each property on its own. Split volatile columns into their own mapping if you map a mix of stable and fast-changing data.
+
+The warehouse sync itself is billed by rows synced. See [data warehouse pricing](/pricing?product=data-warehouse).
+
+## Troubleshooting
+
+**A property never appears on anyone.** Check the **Skipped (no person)** count in the run history. A high number means the key column does not hold the same value as the person's distinct ID. Compare a row in the warehouse table against the person in PostHog.
+
+**A property appears on some people only.** The people who are missing it probably do not exist in PostHog yet, or have not changed in the warehouse since you added the mapping. Run a backfill.
+
+**Every run reads zero rows.** The import itself brought nothing. Open the table's sync history in the data warehouse to see the import's own runs and errors.
+
+**A run failed.** The status tag carries the error. A property sync that rode a failing import fails with it, so check the table's sync history first.
+
+**The mapping turned itself off.** Five failed runs in a row disable a mapping, so a broken table does not retry forever. Fix the underlying sync, then toggle it back on. The failure count resets after a run succeeds.

--- a/contents/docs/data/cohorts.mdx
+++ b/contents/docs/data/cohorts.mdx
@@ -49,6 +49,8 @@ Your cohorts are available in the [People](https://us.posthog.com/persons) page 
 
 > **Note:** Cohorts rely on [person properties](/docs/product-analytics/person-properties), so you need to capture identified events to create them.
 
+To build cohorts on data from another system, such as a plan tier or a renewal date, map that table onto person properties with [warehouse properties](/docs/data-warehouse/warehouse-properties) first.
+
 ## Where can you use cohorts?
 
 You can use cohorts in many different ways, such as:

--- a/contents/docs/data/persons.mdx
+++ b/contents/docs/data/persons.mdx
@@ -65,6 +65,8 @@ These properties only tell PostHog how to update person data during ingestion â€
 
 To control costs, you can [configure anonymous vs identified events](/docs/data/anonymous-vs-identified-events) for events that don't need person profiles.
 
+A [data warehouse](/docs/data-warehouse) table can also enrich profiles that already exist. See [warehouse properties](/docs/data-warehouse/warehouse-properties). It never creates a profile, so a customer who has not used your product yet stays out of PostHog until they do.
+
 ## Duplicate person profiles
 
 If your [`identify`](/docs/product-analytics/identify) implementation has gaps, a single real-world user can end up with multiple person profiles. For example, if a user visits your app on a phone and a laptop but `identify` is only called on one device, each device creates its own profile with a separate anonymous distinct ID. This usually points to a misconfiguration â€” when `identify` is called correctly on every device and session, PostHog merges these into one profile automatically.

--- a/contents/docs/experiments/creating-an-experiment.mdx
+++ b/contents/docs/experiments/creating-an-experiment.mdx
@@ -77,6 +77,8 @@ By default, your experiment rolls out to 100% of participants. You can adjust th
 
 For more advanced release conditions – such as targeting specific user properties, cohorts, or groups – click **Manage distribution** or **Manage release conditions** _after_ saving your experiment as a draft. This modifies the [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) for the underlying feature flag.
 
+To target on data that lives outside your product, like a plan tier in Stripe or an account owner in Salesforce, sync that table into the [data warehouse](/docs/data-warehouse) and map its columns onto person or group properties with [warehouse properties](/docs/data-warehouse/warehouse-properties). The properties then work in release conditions like any other.
+
 > **Note:** If you select a server-side event, you may see a warning that no feature flag information can be detected with the event. To resolve this issue, see [step 2 of adding your experiment code and how to submit feature flag information with your events](/docs/experiments/adding-experiment-code#step-2-server-side-only-add-the-feature-flag-property-to-your-events).
 >
 > <ProductScreenshot

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -134,6 +134,8 @@ Rollout percentages support decimal values with up to two decimal places of prec
 
 - If you enabled group analytics, you can target based on [group properties](/docs/product-analytics/group-analytics#how-to-set-group-properties).
 
+- If the property you want to target lives in another system, like a plan tier in Stripe or a lifecycle stage in Salesforce, sync that table into the [data warehouse](/docs/data-warehouse) and map it onto person or group properties with [warehouse properties](/docs/data-warehouse/warehouse-properties). Flags can then target it like any other property. A [join](/docs/data-warehouse/join) does not work here, because flags evaluate against stored properties rather than at query time.
+
 When you target a person property of `distinct_id equals`, the value field searches persons by name, email, or distinct_id, so you don't need to paste a raw ID. A person with multiple distinct_ids – for example an anonymous device ID plus an identified email – appears as a separate option per ID, so you can pick the specific one the SDK captures under. The stored filter value is still the literal distinct_id, so flag evaluation is unchanged.
 
 <ProductScreenshot

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -134,6 +134,8 @@ import SettingGroupPropertiesSnippet from "../_snippets/setting-group-properties
 
 <SettingGroupPropertiesSnippet />
 
+You can also set group properties from a synced [data warehouse](/docs/data-warehouse) table instead of sending them from your app. Map the columns of a table like your accounts or subscriptions table onto group properties with [warehouse properties](/docs/data-warehouse/warehouse-properties), matched by a group key column. The properties stay up to date on every sync.
+
 ### Link events to groups
 
 How you link events to individual groups depends on your SDK:

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -102,19 +102,22 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 ## Syncing person properties from the data warehouse
 
-You can create person properties that automatically sync from [data warehouse](/docs/data-warehouse) tables. This is configured in the [customer analytics configuration](https://app.posthog.com/customer_analytics/configuration) under **Custom properties**.
+If the data you want already lives in Stripe, Salesforce, HubSpot, or your own database, you don't need to send it from your app. Sync the table into the [data warehouse](/docs/data-warehouse), then map its columns onto person properties.
 
-To set up a warehouse-synced person property:
+To set one up:
 
-1. Click **New property** and select **Person** as the target type.
-2. Choose a synced warehouse table as the data source.
-3. Set the **distinct ID column** – the column whose values match your PostHog person distinct IDs.
-4. Add one or more **column mappings** to map warehouse columns to person property names.
-5. Click **Save**.
+1. Go to **Data** > **Warehouse properties**.
+2. Click **Add person property**.
+3. Choose a synced warehouse table as the data source.
+4. Set the **distinct ID column** – the column whose values match your PostHog person distinct IDs.
+5. Add one or more **column mappings** to map warehouse columns to person property names.
+6. Click **Save**.
 
-Once created, the warehouse table binding and column mappings are fixed. You can still change the distinct ID column and toggle syncing on or off, but to change the table or mappings you need to delete and recreate the property.
+The mapped properties then stay up to date on every sync of that table. Properties synced this way show a **Warehouse** provenance tag in property lists, and work like any other person property in [feature flags](/docs/feature-flags), [cohorts](/docs/data/cohorts), [insights](/docs/product-analytics/insights), and filters.
 
-Properties synced from the warehouse show a **Warehouse** provenance tag in property lists. They work like any other person property – you can use them in [feature flags](/docs/feature-flags), [cohorts](/docs/data/cohorts), [insights](/docs/product-analytics/insights), and filters.
+A sync only updates a person who already exists in PostHog. It never creates one.
+
+See [warehouse properties](/docs/data-warehouse/warehouse-properties) for how syncing works, how to read the run history, what a backfill does, and how to do the same for [group properties](/docs/product-analytics/group-analytics).
 
 ## `last_seen_at` field
 

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -295,7 +295,7 @@ You can display your survey to specific users based on:
 
 - **Wait period**: Hide surveys from users who have seen any survey in the last X days. A user who completes a survey is never shown the same survey again, even if no wait period is set ([but there are exceptions to this rule](#repeating-surveys)).
 
-- **Person and group properties:** If you are capturing identified events, you can display a survey to users who have specific [person](/docs/product-analytics/person-properties) or [group properties](/docs/product-analytics/group-analytics#how-to-set-group-properties). For example, you can target a survey to users who have a property `is_paying=true`. This also includes a percentage rollout option. The person and group properties are evaluated with internal feature flags.
+- **Person and group properties:** If you are capturing identified events, you can display a survey to users who have specific [person](/docs/product-analytics/person-properties) or [group properties](/docs/product-analytics/group-analytics#how-to-set-group-properties). For example, you can target a survey to users who have a property `is_paying=true`. This also includes a percentage rollout option. The person and group properties are evaluated with internal feature flags. To target on data from another system, such as a plan tier in Stripe, map it onto person or group properties first with [warehouse properties](/docs/data-warehouse/warehouse-properties).
 
 - **User sends events:** Display a survey to users who have sent a specific event during their session.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6233,6 +6233,10 @@ export const docsMenu = {
                             url: '/docs/data-warehouse/join',
                         },
                         {
+                            name: 'Sync to person properties',
+                            url: '/docs/data-warehouse/warehouse-properties',
+                        },
+                        {
                             name: 'Visualize with insights',
                             url: '/docs/data-warehouse/insights',
                         },


### PR DESCRIPTION
## Changes

Warehouse properties let you map columns of a synced warehouse table onto person and group properties. The feature had two short mentions in the docs, both pointing at a page that no longer holds it, and neither covered groups, backfills, or why a sync updates nobody.

- Adds [Warehouse properties](/docs/data-warehouse/warehouse-properties), a full page under Data warehouse: when to use it over a person join, prerequisites, setup, how a sync works, reading the run history, costs, and troubleshooting.
- Fixes the two stale pointers. Both sent people to **Customer analytics** > **Configuration** > **Custom properties**. The feature now has its own scene at **Data** > **Warehouse properties**.
- Rewrites the section in `person-properties.mdx` with the correct path, and adds that a sync never creates a person.
- Rewrites the section in `join.mdx` to say why a join cannot serve feature flags, experiments, or surveys.
- Adds a pointer from the person-heavy products, where "use a person property" was the whole answer and warehouse data was not mentioned: feature flags, experiments, surveys, cohorts, people, and group analytics.
- Adds the page to the Data warehouse nav, under PostHog Web.

The page is marked as a beta feature, matching how the app gates it today.

No visual changes beyond the new page and one nav entry.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

I have not opened the preview build yet. Every internal link in the new page points at a file that exists on master, checked by path, and the nav file parses. The prose itself is unverified against a render.

The behavior described is drawn from the implementation, not from a walkthrough of the product: the sync activity, the source model and its validation, the run recorder, and the setup modal. Two claims came from the existing docs and I confirmed both still hold in the code, that the table and mappings are fixed after saving, and that synced properties carry a **Warehouse** provenance tag.
