### PR TITLE
perf: sparse blobless checkout for the monorepo docs clone

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -487,6 +487,10 @@ module.exports = {
                 // scripts, and unrelated frontend/skills code paths. They never become
                 // pages — see shouldBlockNodeFromTransformation above and onCreateNode.
                 patterns: ['docs/published/**', 'docs/onboarding/**', 'products/*/skills/*/SKILL.md'],
+                // Git sparse-checkout equivalents of `patterns` (non-cone syntax). With these
+                // set, the plugin does a blobless sparse clone that downloads and writes out
+                // only these paths instead of the monorepo's entire working tree.
+                sparsePatterns: ['/docs/published/', '/docs/onboarding/', '/products/*/skills/*/SKILL.md'],
             },
         },
         // {

--- a/patches/gatsby-source-git+1.1.0.patch
+++ b/patches/gatsby-source-git+1.1.0.patch
@@ -1,0 +1,55 @@
+diff --git a/node_modules/gatsby-source-git/gatsby-node.js b/node_modules/gatsby-source-git/gatsby-node.js
+index eedfc0ef4..223f60c76 100644
+--- a/node_modules/gatsby-source-git/gatsby-node.js
++++ b/node_modules/gatsby-source-git/gatsby-node.js
+@@ -17,7 +17,7 @@ async function getTargetBranch(repo, branch) {
+   }
+ }
+ 
+-async function getRepo(path, remote, branch) {
++async function getRepo(path, remote, branch, sparsePatterns) {
+   // If the directory doesn't exist or is empty, clone. This will be the case if
+   // our config has changed because Gatsby trashes the cache dir automatically
+   // in that case.
+@@ -26,8 +26,22 @@ async function getRepo(path, remote, branch) {
+     if (typeof branch == `string`) {
+       opts.push(`--branch`, branch);
+     }
++    if (sparsePatterns) {
++      // Blobless, checkout-less clone: only the commit and trees are fetched up
++      // front. Blobs are downloaded on demand by the sparse checkout below, so
++      // only files matching sparsePatterns are ever transferred or written out.
++      opts.push(`--filter=blob:none`, `--no-checkout`);
++    }
+     await Git().clone(remote, path, opts);
+-    return Git(path);
++    const repo = Git(path);
++    if (sparsePatterns) {
++      await repo.raw([`sparse-checkout`, `set`, `--no-cone`, ...sparsePatterns]);
++      const head = await repo
++        .raw([`symbolic-ref`, `--short`, `HEAD`])
++        .then(result => result.trim());
++      await repo.raw([`checkout`, head]);
++    }
++    return repo;
+   } else if (await isAlreadyCloned(remote, path)) {
+     const repo = await Git(path);
+     const target = await getTargetBranch(repo, branch);
+@@ -49,7 +63,7 @@ exports.sourceNodes = async (
+     createContentDigest,
+     reporter
+   },
+-  { name, remote, branch, patterns = `**`, local }
++  { name, remote, branch, patterns = `**`, local, sparsePatterns }
+ ) => {
+   const programDir = store.getState().program.directory;
+   const localPath = local || require("path").join(
+@@ -62,7 +76,7 @@ exports.sourceNodes = async (
+ 
+   let repo;
+   try {
+-    repo = await getRepo(localPath, remote, branch);
++    repo = await getRepo(localPath, remote, branch, sparsePatterns);
+   } catch (e) {
+     return reporter.error(e);
+   }


### PR DESCRIPTION
## Summary

Re-lands one independent piece of #18650 (reverted in #18913 "Breaking blog pages"). **This piece does not touch MDX** — the breakage candidates in that revert were the two MDX changes, which are not included here.

`gatsby-source-git` clones the **entire posthog/posthog repository (831 MB, 43,506 files)** on every cold build, then applies its file `patterns` only after checkout. The site consumes ~440 files from that clone (27 published docs + SKILL.md files). CI builds cold by policy, so every preview build re-downloads all of it.

This adds a `patch-package` patch to `gatsby-source-git` that, when a new `sparsePatterns` option is set, clones with `--filter=blob:none --no-checkout` and then does a non-cone sparse checkout of only the configured paths. Blobs are downloaded on demand by the sparse checkout, so only matching files are ever transferred or written out. Existing clones (the `isAlreadyCloned` path) are untouched.

## Verification

- `fast-glob` over the plugin's `patterns` returns the **identical 440-file set** from a sparse clone and a full clone pinned to the same commit (`237331d5307`).
- Clone size: **831 MB → 254 MB**; worktree contains only the sourced paths.
- Behavior without `sparsePatterns` is unchanged (option is opt-in per plugin instance).

Original measurement in #18650 attributed the largest share of the 298 s → 10 s source-phase reduction to this change.

Part of a build-performance series; see also the re-lands of the other non-MDX pieces of #18650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)