### PR TITLE
perf: enable Gatsby's PARALLEL_SOURCING flag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,11 +72,6 @@ module.exports = {
     },
     flags: {
         DEV_SSR: false,
-        // This site registers ~10 source plugins (5x gatsby-source-filesystem, ashby, squeak,
-        // mapbox-locations, git-metadata, source-git). Gatsby otherwise runs each plugin's
-        // sourceNodes serially; this runs them concurrently. Node creation is independent of
-        // ordering, so output is unaffected — only wall-clock during "source and transform
-        // nodes" changes.
         PARALLEL_SOURCING: true,
     },
     siteMetadata: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,6 +72,12 @@ module.exports = {
     },
     flags: {
         DEV_SSR: false,
+        // This site registers ~10 source plugins (5x gatsby-source-filesystem, ashby, squeak,
+        // mapbox-locations, git-metadata, source-git). Gatsby otherwise runs each plugin's
+        // sourceNodes serially; this runs them concurrently. Node creation is independent of
+        // ordering, so output is unaffected — only wall-clock during "source and transform
+        // nodes" changes.
+        PARALLEL_SOURCING: true,
     },
     siteMetadata: {
         title: 'PostHog',


### PR DESCRIPTION
## Summary

Re-lands one independent piece of #18650 (reverted in #18913 "Breaking blog pages"). **This piece does not touch MDX** — the breakage candidates in that revert were the two MDX changes, which are not included here.

The site registers ~10 source plugins (5× `gatsby-source-filesystem`, ashby, squeak, mapbox-locations, git-metadata, source-git). Gatsby runs each plugin's `sourceNodes` serially by default, so network-bound plugins wait on each other. The `PARALLEL_SOURCING` flag runs them concurrently. Node creation is independent of ordering, so output is unaffected — only wall-clock during "source and transform nodes" changes.

## Verification

- Config-only change; the preview build on this PR exercises the flag end-to-end with a cold cache.
- The "source and transform nodes" timing in this PR's build log can be compared directly against master's (~102 s in recent preview builds).

Part of a build-performance series re-landing the non-MDX pieces of #18650 individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)