### PR TITLE
perf: read the pageviews cache once, not once per node

### DIFF
--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -140,6 +140,17 @@ function getPublicID(image: string) {
     return imagePath.substring(0, imagePath.lastIndexOf('.'))
 }
 
+// onCreateNode runs once per source node (thousands of Mdx/MarkdownRemark nodes). The
+// pageviews cache is written once in onPreBootstrap and never changes mid-build, so fetch
+// it at most once here instead of re-reading it from the on-disk cache for every node.
+let pageViewsPromise: Promise<Record<string, number> | undefined> | null = null
+function getPageViews(cache): Promise<Record<string, number> | undefined> {
+    if (!pageViewsPromise) {
+        pageViewsPromise = cache.get(PAGEVIEW_CACHE_KEY)
+    }
+    return pageViewsPromise
+}
+
 export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
     node,
     getNode,
@@ -262,7 +273,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
         })
 
         if (slug) {
-            const pageViews = await cache.get(PAGEVIEW_CACHE_KEY)
+            const pageViews = await getPageViews(cache)
 
             if (pageViews && slug.slice(0, -1) in pageViews) {
                 createNodeField({


### PR DESCRIPTION
## Summary

Re-lands one independent piece of #18650 (reverted in #18913 "Breaking blog pages"). **This piece does not touch MDX** — the breakage candidates in that revert were the two MDX changes, which are not included here.

`onCreateNode` runs once per source node. For every Mdx/MarkdownRemark node (~3,000+ per build) it did `await cache.get(PAGEVIEW_CACHE_KEY)` — an LMDB read that deserializes the full pageview map each time. The map is written once in `onPreBootstrap` and never changes mid-build, so this memoizes the read behind a module-level promise. Same values reach `createNodeField`; only the repeated deserialization goes away.

## Verification

- Identical logic to the reviewed change in #18650.
- The preview build on this PR exercises the path for every node; `pageViews` fields in the built site are unchanged.

Part of a build-performance series re-landing the non-MDX pieces of #18650 individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)