### PR TITLE
perf: parallelize Squeak Strapi fetches and roadmap pagination

### DIFF
--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -304,7 +304,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
         })
     })
 
-    const createRoadmapItems = async (page = 1) => {
+    const fetchRoadmapPage = async (page: number) => {
         const roadmapQuery = qs.stringify(
             {
                 pagination: {
@@ -339,7 +339,21 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
             }
         )
         const roadmapsURL = `${process.env.GATSBY_SQUEAK_API_HOST}/api/roadmaps?${roadmapQuery}`
-        const { data: roadmaps, meta } = await fetch(roadmapsURL).then((res) => res.json())
+        return await fetch(roadmapsURL).then((res) => res.json())
+    }
+    // Page 1 tells us the page count, then the remaining pages fetch concurrently
+    // instead of one after another (~0.6s per page, 10 pages).
+    const createRoadmapItems = async () => {
+        const firstPage = await fetchRoadmapPage(1)
+        const pageCount = firstPage.meta?.pagination?.pageCount || 1
+        const remainingPages = await Promise.all(
+            Array.from({ length: pageCount - 1 }, (_, i) => fetchRoadmapPage(i + 2))
+        )
+        for (const { data: roadmaps } of [firstPage, ...remainingPages]) {
+            createRoadmapPageNodes(roadmaps)
+        }
+    }
+    const createRoadmapPageNodes = (roadmaps) => {
         roadmaps.forEach((roadmap) => {
             const {
                 id,
@@ -380,7 +394,6 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
             }
             createNode(roadmapNode)
         })
-        if (meta?.pagination?.pageCount > meta?.pagination?.page) await createRoadmapItems(page + 1)
     }
     const sourceChangelogVideos = async () => {
         const changelogPlaylistVideos = await fetchChangelogPlaylistVideos()

--- a/plugins/gatsby-source-squeak/gatsby-node.ts
+++ b/plugins/gatsby-source-squeak/gatsby-node.ts
@@ -13,13 +13,158 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     const { createNode } = actions
 
     // Fetch all profiles (active team members + any author with a profile_id)
-    let page = 1
-    while (true) {
-        let profileQuery = qs.stringify(
+    const fetchProfiles = async () => {
+        let page = 1
+        while (true) {
+            let profileQuery = qs.stringify(
+                {
+                    filters: {
+                        $or: [
+                            {
+                                $and: [
+                                    {
+                                        startDate: {
+                                            $notNull: true,
+                                        },
+                                    },
+                                    {
+                                        startDate: {
+                                            $lte: new Date(),
+                                        },
+                                    },
+                                ],
+                            },
+                            {
+                                id: {
+                                    $in: authorProfileIds,
+                                },
+                            },
+                        ],
+                    },
+                    pagination: {
+                        page,
+                        pageSize: 100,
+                    },
+                    populate: ['avatar', 'teams', 'leadTeams', 'quotes', 'color'],
+                },
+                {
+                    encodeValuesOnly: true, // prettify URL
+                }
+            )
+
+            const profiles = await fetch(`${apiHost}/api/profiles?${profileQuery}`).then((res) => res.json())
+
+            for (const profile of profiles.data) {
+                const { avatar, ...profileData } = profile.attributes
+
+                createNode({
+                    type: `SqueakProfile`,
+                    id: createNodeId(`squeak-profile-${profile.id}`),
+                    squeakId: profile.id,
+                    internal: {
+                        contentDigest: createContentDigest(profileData),
+                        type: `SqueakProfile`,
+                    },
+                    avatar: avatar.data?.attributes,
+                    ...profileData,
+                })
+
+                /*async function createImageNode(imageURL) {
+                    return createRemoteFileNode({
+                        url: imageURL,
+                        parentNodeId: node.id,
+                        createNode,
+                        createNodeId,
+                        cache,
+                        store,
+                    }).catch((e) => console.error(e))
+                }
+                if (node.imageURL) {
+                    const imageNode = await createImageNode(node.imageURL)
+                    node.avatar___NODE = imageNode && imageNode.id
+                }*/
+            }
+
+            if (profiles.meta.pagination.page >= profiles.meta.pagination.pageCount) {
+                break
+            }
+            page++
+        }
+    }
+
+    // Fetch all topic groups
+    const fetchTopicGroups = async () => {
+        let query = qs.stringify({
+            populate: {
+                topics: {
+                    fields: ['id'],
+                },
+            },
+        })
+
+        const topicGroups = await fetch(`${apiHost}/api/topic-groups?${query}`).then((res) => res.json())
+
+        topicGroups.data.forEach((topicGroup) => {
+            const { topics, ...rest } = topicGroup.attributes
+
+            const node = {
+                id: createNodeId(`squeak-topic-group-${topicGroup.id}`),
+                internal: {
+                    type: `SqueakTopicGroup`,
+                    contentDigest: createContentDigest(topicGroup),
+                },
+                ...rest,
+                topics: topics.data.map((topic) => ({
+                    id: createNodeId(`squeak-topic-${topic.id}`),
+                })),
+            }
+            createNode(node)
+        })
+    }
+
+    // Fetch all topics
+    const fetchTopics = async () => {
+        let topicQuery = qs.stringify(
             {
-                filters: {
-                    $or: [
-                        {
+                pagination: {
+                    page: 1,
+                    pageSize: 100,
+                },
+            },
+            {
+                encodeValuesOnly: true, // prettify URL
+            }
+        )
+
+        const topics = await fetch(`${apiHost}/api/topics?${topicQuery}`).then((res) => res.json())
+
+        for (const topic of topics.data) {
+            createNode({
+                id: createNodeId(`squeak-topic-${topic.id}`),
+                squeakId: topic.id,
+                internal: {
+                    type: `SqueakTopic`,
+                    contentDigest: createContentDigest(topic),
+                },
+                ...topic.attributes,
+            })
+        }
+    }
+
+    // Fetch all teams
+    const fetchTeams = async () => {
+        let teamQuery = qs.stringify(
+            {
+                pagination: {
+                    page: 1,
+                    pageSize: 100,
+                },
+                populate: {
+                    roadmaps: {
+                        fields: ['id'],
+                    },
+                    profiles: {
+                        filters: {
                             $and: [
                                 {
                                     startDate: {
@@ -33,232 +178,96 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
                                 },
                             ],
                         },
-                        {
-                            id: {
-                                $in: authorProfileIds,
-                            },
+                        populate: '*',
+                    },
+                    leadProfiles: {
+                        filters: {
+                            $and: [
+                                {
+                                    startDate: {
+                                        $notNull: true,
+                                    },
+                                },
+                                {
+                                    startDate: {
+                                        $lte: new Date(),
+                                    },
+                                },
+                            ],
                         },
-                    ],
+                        fields: 'id',
+                    },
+                    crest: true,
+                    crestOptions: true,
+                    miniCrest: true,
+                    teamImage: {
+                        populate: {
+                            image: true,
+                        },
+                    },
+                    tagline: true,
                 },
-                pagination: {
-                    page,
-                    pageSize: 100,
-                },
-                populate: ['avatar', 'teams', 'leadTeams', 'quotes', 'color'],
             },
             {
                 encodeValuesOnly: true, // prettify URL
             }
         )
 
-        const profiles = await fetch(`${apiHost}/api/profiles?${profileQuery}`).then((res) => res.json())
+        const teams = await fetch(`${apiHost}/api/teams?${teamQuery}`).then((res) => res.json())
 
-        for (const profile of profiles.data) {
-            const { avatar, ...profileData } = profile.attributes
+        for (const team of teams.data) {
+            const { roadmaps, crest, miniCrest, teamImage, ...rest } = team.attributes
 
-            createNode({
-                type: `SqueakProfile`,
-                id: createNodeId(`squeak-profile-${profile.id}`),
-                squeakId: profile.id,
-                internal: {
-                    contentDigest: createContentDigest(profileData),
-                    type: `SqueakProfile`,
-                },
-                avatar: avatar.data?.attributes,
-                ...profileData,
-            })
-
-            /*async function createImageNode(imageURL) {
-                return createRemoteFileNode({
-                    url: imageURL,
-                    parentNodeId: node.id,
-                    createNode,
-                    createNodeId,
-                    cache,
-                    store,
-                }).catch((e) => console.error(e))
+            const cloudinaryTeamImage = {
+                ...teamImage,
+                cloudName: process.env.GATSBY_CLOUDINARY_CLOUD_NAME,
+                publicId: teamImage?.image?.data?.attributes?.provider_metadata?.public_id,
+                originalHeight: teamImage?.image?.data?.attributes?.height,
+                originalWidth: teamImage?.image?.data?.attributes?.width,
+                originalFormat: (teamImage?.image?.data?.attributes?.ext || '').replace('.', ''),
             }
-            if (node.imageURL) {
-                const imageNode = await createImageNode(node.imageURL)
-                node.avatar___NODE = imageNode && imageNode.id
-            }*/
-        }
 
-        if (profiles.meta.pagination.page >= profiles.meta.pagination.pageCount) {
-            break
+            const cloudinaryCrest = {
+                ...crest,
+                cloudName: process.env.GATSBY_CLOUDINARY_CLOUD_NAME,
+                publicId: crest?.data?.attributes?.provider_metadata?.public_id,
+                originalHeight: crest?.data?.attributes?.height,
+                originalWidth: crest?.data?.attributes?.width,
+                originalFormat: (crest?.data?.attributes?.ext || '').replace('.', ''),
+            }
+
+            const cloudinaryMiniCrest = {
+                ...miniCrest,
+                cloudName: process.env.GATSBY_CLOUDINARY_CLOUD_NAME,
+                publicId: miniCrest?.data?.attributes?.provider_metadata?.public_id,
+                originalHeight: miniCrest?.data?.attributes?.height,
+                originalWidth: miniCrest?.data?.attributes?.width,
+                originalFormat: (miniCrest?.data?.attributes?.ext || '').replace('.', ''),
+            }
+
+            const node = {
+                id: createNodeId(`squeak-team-${team.id}`),
+                squeakId: team.id,
+                internal: {
+                    type: `SqueakTeam`,
+                    contentDigest: createContentDigest(team),
+                },
+                teamImage: cloudinaryTeamImage,
+                crest: cloudinaryCrest,
+                miniCrest: cloudinaryMiniCrest,
+                ...rest,
+                roadmaps: roadmaps.data.map((roadmap) => ({
+                    id: createNodeId(`squeak-roadmap-${roadmap.id}`),
+                })),
+            }
+
+            createNode(node)
         }
-        page++
     }
 
-    // Fetch all topic groups
-    let query = qs.stringify({
-        populate: {
-            topics: {
-                fields: ['id'],
-            },
-        },
-    })
-
-    const topicGroups = await fetch(`${apiHost}/api/topic-groups?${query}`).then((res) => res.json())
-
-    topicGroups.data.forEach((topicGroup) => {
-        const { topics, ...rest } = topicGroup.attributes
-
-        const node = {
-            id: createNodeId(`squeak-topic-group-${topicGroup.id}`),
-            internal: {
-                type: `SqueakTopicGroup`,
-                contentDigest: createContentDigest(topicGroup),
-            },
-            ...rest,
-            topics: topics.data.map((topic) => ({
-                id: createNodeId(`squeak-topic-${topic.id}`),
-            })),
-        }
-        createNode(node)
-    })
-
-    // Fetch all topics
-    let topicQuery = qs.stringify(
-        {
-            pagination: {
-                page: 1,
-                pageSize: 100,
-            },
-        },
-        {
-            encodeValuesOnly: true, // prettify URL
-        }
-    )
-
-    const topics = await fetch(`${apiHost}/api/topics?${topicQuery}`).then((res) => res.json())
-
-    for (const topic of topics.data) {
-        createNode({
-            id: createNodeId(`squeak-topic-${topic.id}`),
-            squeakId: topic.id,
-            internal: {
-                type: `SqueakTopic`,
-                contentDigest: createContentDigest(topic),
-            },
-            ...topic.attributes,
-        })
-    }
-
-    // Fetch all teams
-    let teamQuery = qs.stringify(
-        {
-            pagination: {
-                page: 1,
-                pageSize: 100,
-            },
-            populate: {
-                roadmaps: {
-                    fields: ['id'],
-                },
-                profiles: {
-                    filters: {
-                        $and: [
-                            {
-                                startDate: {
-                                    $notNull: true,
-                                },
-                            },
-                            {
-                                startDate: {
-                                    $lte: new Date(),
-                                },
-                            },
-                        ],
-                    },
-                    populate: '*',
-                },
-                leadProfiles: {
-                    filters: {
-                        $and: [
-                            {
-                                startDate: {
-                                    $notNull: true,
-                                },
-                            },
-                            {
-                                startDate: {
-                                    $lte: new Date(),
-                                },
-                            },
-                        ],
-                    },
-                    fields: 'id',
-                },
-                crest: true,
-                crestOptions: true,
-                miniCrest: true,
-                teamImage: {
-                    populate: {
-                        image: true,
-                    },
-                },
-                tagline: true,
-            },
-        },
-        {
-            encodeValuesOnly: true, // prettify URL
-        }
-    )
-
-    const teams = await fetch(`${apiHost}/api/teams?${teamQuery}`).then((res) => res.json())
-
-    for (const team of teams.data) {
-        const { roadmaps, crest, miniCrest, teamImage, ...rest } = team.attributes
-
-        const cloudinaryTeamImage = {
-            ...teamImage,
-            cloudName: process.env.GATSBY_CLOUDINARY_CLOUD_NAME,
-            publicId: teamImage?.image?.data?.attributes?.provider_metadata?.public_id,
-            originalHeight: teamImage?.image?.data?.attributes?.height,
-            originalWidth: teamImage?.image?.data?.attributes?.width,
-            originalFormat: (teamImage?.image?.data?.attributes?.ext || '').replace('.', ''),
-        }
-
-        const cloudinaryCrest = {
-            ...crest,
-            cloudName: process.env.GATSBY_CLOUDINARY_CLOUD_NAME,
-            publicId: crest?.data?.attributes?.provider_metadata?.public_id,
-            originalHeight: crest?.data?.attributes?.height,
-            originalWidth: crest?.data?.attributes?.width,
-            originalFormat: (crest?.data?.attributes?.ext || '').replace('.', ''),
-        }
-
-        const cloudinaryMiniCrest = {
-            ...miniCrest,
-            cloudName: process.env.GATSBY_CLOUDINARY_CLOUD_NAME,
-            publicId: miniCrest?.data?.attributes?.provider_metadata?.public_id,
-            originalHeight: miniCrest?.data?.attributes?.height,
-            originalWidth: miniCrest?.data?.attributes?.width,
-            originalFormat: (miniCrest?.data?.attributes?.ext || '').replace('.', ''),
-        }
-
-        const node = {
-            id: createNodeId(`squeak-team-${team.id}`),
-            squeakId: team.id,
-            internal: {
-                type: `SqueakTeam`,
-                contentDigest: createContentDigest(team),
-            },
-            teamImage: cloudinaryTeamImage,
-            crest: cloudinaryCrest,
-            miniCrest: cloudinaryMiniCrest,
-            ...rest,
-            roadmaps: roadmaps.data.map((roadmap) => ({
-                id: createNodeId(`squeak-roadmap-${roadmap.id}`),
-            })),
-        }
-
-        createNode(node)
-    }
-
-    // Fetch all roadmaps
-    const fetchRoadmaps = async (page = 1) => {
+    // Fetch all roadmaps. Page 1 tells us the page count, then the remaining
+    // pages are fetched concurrently instead of one after another.
+    const fetchRoadmapPage = async (page: number) => {
         let roadmapQuery = qs.stringify({
             pagination: {
                 page,
@@ -276,8 +285,10 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
             },
         })
 
-        const roadmaps = await fetch(`${apiHost}/api/roadmaps?${roadmapQuery}`).then((res) => res.json())
+        return await fetch(`${apiHost}/api/roadmaps?${roadmapQuery}`).then((res) => res.json())
+    }
 
+    const createRoadmapNodes = async (roadmaps) => {
         for (const roadmap of roadmaps.data) {
             const { teams, githubUrls, image, ...rest } = roadmap.attributes
 
@@ -339,12 +350,22 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
             createNode(node)
         }
-        if (roadmaps.meta.pagination.page < roadmaps.meta.pagination.pageCount) {
-            await fetchRoadmaps(page + 1)
+    }
+
+    const fetchRoadmaps = async () => {
+        const firstPage = await fetchRoadmapPage(1)
+        const pageCount = firstPage.meta?.pagination?.pageCount || 1
+        const remainingPages = await Promise.all(
+            Array.from({ length: pageCount - 1 }, (_, i) => fetchRoadmapPage(i + 2))
+        )
+        for (const page of [firstPage, ...remainingPages]) {
+            await createRoadmapNodes(page)
         }
     }
 
-    await fetchRoadmaps()
+    // The five collections are independent — cross-references between them use
+    // deterministic createNodeId seeds, not fetched data — so fetch them concurrently.
+    await Promise.all([fetchProfiles(), fetchTopicGroups(), fetchTopics(), fetchTeams(), fetchRoadmaps()])
 }
 
 export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] = async ({ actions }) => {


### PR DESCRIPTION
## Summary

Re-lands one independent piece of #18650 (reverted in #18913 "Breaking blog pages"). **This piece does not touch MDX** — the breakage candidates in that revert were the two MDX changes, which are not included here.

Two changes, same pattern:

1. **`plugins/gatsby-source-squeak`** fetched five independent Strapi collections (profiles, topic groups, topics, teams, roadmaps) one after another, and paginated roadmaps sequentially. Cross-references between the collections use deterministic `createNodeId` seeds, not fetched data, so the five fetches now run concurrently, and roadmap pagination fetches page 1 for the page count, then the remaining pages in parallel.
2. **`gatsby/sourceNodes.ts` `createRoadmapItems`** did the same sequential page-by-page recursion (~0.6 s per page, ~10 pages); same page-1-then-`Promise.all` restructure, adapted to the current query shape from #19198.

**GitHub API calls are untouched** — they stay serial, respecting the deliberate serialization in #19290.

## Verification

Ran the old and new plugin implementations side by side against the live Strapi API with stubbed Gatsby actions and compared every created node:

- Identical node counts per type: 306 SqueakProfile, 1,079 SqueakRoadmap, 56 SqueakTeam, 52 SqueakTopic, 6 SqueakTopicGroup.
- The only content diffs were 7 SqueakTeam nodes whose populated arrays the server returns in nondeterministic order — running the **old code twice** produces 9 such diffs on the same type, so this is pre-existing server-side noise, not a behavior change.

Part of a build-performance series re-landing the non-MDX pieces of #18650 individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)