### PR TITLE
perf: prefetch the OpenAPI spec while gatsby boots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ CLAUDE.local.md
 # Generated data files
 src/data/mcp-tools.json
 .cloudinary-resources.json
+.api-spec-prefetch.json*
 
 # Python cache
 __pycache__

--- a/gatsby/onPreBootstrap.ts
+++ b/gatsby/onPreBootstrap.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 
 import { fetchAndProcessMCPTools, writeMCPToolsToFile } from './utils/fetchMCPTools'
 import { enrichVideos } from './enrichVideos'
+import { primeApiSpec } from './sourceNodes'
 
 export const PAGEVIEW_CACHE_KEY = 'onPreBootstrap@@posthog-pageviews'
 export const MCP_TOOLS_CACHE_KEY = 'onPreBootstrap@@mcp-tools'
@@ -49,6 +50,9 @@ function invalidateGitCacheIfBranchChanged(): void {
 }
 
 export const onPreBootstrap: GatsbyNode['onPreBootstrap'] = async ({ cache }) => {
+    // Start the slow (~9s server-side) API schema fetch now so it resolves during the
+    // pre-sourcing build phases; sourceNodes awaits the same promise.
+    primeApiSpec()
     // Invalidate gatsby-source-git cache if branch has changed
     invalidateGitCacheIfBranchChanged()
     // Enrich video data with thumbnails and titles from APIs

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -1,5 +1,8 @@
 import { GatsbyNode } from 'gatsby'
 
+import fs from 'fs'
+import path from 'path'
+
 import qs from 'qs'
 import { ApiInfoModel, MenuBuilder, OpenAPIParser } from 'redoc'
 import type {
@@ -152,66 +155,137 @@ const findAllReferencedSchemas = (items: any[], allSchemas: Record<string, any>)
     }
 }
 
-export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createContentDigest, createNodeId }) => {
-    const { createNode } = actions
+// The API schema endpoint takes ~9s server-side to generate its ~13MB response, which
+// would otherwise be the longest wait in "source and transform nodes". The build script
+// starts scripts/prefetch-api-spec.mjs before gatsby boots; loadApiSpec() consumes its
+// output, waiting briefly on the in-flight marker before falling back to fetching
+// inline. primeApiSpec() is called (not awaited) from onPreBootstrap; sourceApiEndpoints
+// below awaits the same promise, so failures still surface exactly where they used to.
+const API_SPEC_PREFETCH_FILE = path.resolve(__dirname, '../.api-spec-prefetch.json')
+const API_SPEC_PREFETCH_PENDING = `${API_SPEC_PREFETCH_FILE}.pending`
+// Anything older belongs to a previous (crashed) run — ignore it and fetch inline.
+const API_SPEC_PREFETCH_MAX_AGE_MS = 5 * 60 * 1000
 
+const readFreshPrefetchedSpec = (expectedUrl: string): any | null => {
+    try {
+        const stat = fs.statSync(API_SPEC_PREFETCH_FILE)
+        if (Date.now() - stat.mtimeMs < API_SPEC_PREFETCH_MAX_AGE_MS) {
+            const envelope = JSON.parse(fs.readFileSync(API_SPEC_PREFETCH_FILE, 'utf-8'))
+            // Only trust a prefetch fetched from the URL this build is configured for — a
+            // leftover from a run against a different POSTHOG_OPEN_API_SPEC_URL (or the
+            // pre-envelope file format) must not leak into this build's api_endpoint nodes.
+            if (envelope?.url === expectedUrl && envelope.spec) {
+                return envelope.spec
+            }
+        }
+    } catch {
+        // Missing or unreadable — caller falls back.
+    }
+    return null
+}
+
+const isPrefetchInFlight = (expectedUrl: string): boolean => {
+    try {
+        const stat = fs.statSync(API_SPEC_PREFETCH_PENDING)
+        if (Date.now() - stat.mtimeMs >= API_SPEC_PREFETCH_MAX_AGE_MS) {
+            return false
+        }
+        const marker = JSON.parse(fs.readFileSync(API_SPEC_PREFETCH_PENDING, 'utf-8'))
+        return marker?.url === expectedUrl
+    } catch {
+        return false
+    }
+}
+
+async function loadApiSpec(): Promise<any> {
     const openApiSpecUrl = process.env.POSTHOG_OPEN_API_SPEC_URL || 'https://app.posthog.com/api/schema/'
-    const spec = await fetch(openApiSpecUrl, {
+
+    const prefetched = readFreshPrefetchedSpec(openApiSpecUrl)
+    if (prefetched) return prefetched
+
+    // A prefetch for this same URL started alongside this build may still be in
+    // flight — give it a bounded window to land before fetching inline.
+    for (let waited = 0; isPrefetchInFlight(openApiSpecUrl) && waited < 20000; waited += 250) {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+        const spec = readFreshPrefetchedSpec(openApiSpecUrl)
+        if (spec) return spec
+    }
+
+    return fetch(openApiSpecUrl, {
         headers: {
             Accept: 'application/json',
         },
     }).then((res) => res.json())
+}
 
-    const parser = new OpenAPIParser(spec)
-    const menu = MenuBuilder.buildStructure(parser, {} as any)
+let apiSpecPromise: Promise<any> | null = null
+export function primeApiSpec(): void {
+    if (!apiSpecPromise) {
+        apiSpecPromise = loadApiSpec()
+        // Swallow rejections on a side-listener so an early failure doesn't raise an
+        // unhandled rejection before sourceNodes awaits the original promise.
+        apiSpecPromise.catch(() => {})
+    }
+}
 
-    const allSchemas = spec.components?.schemas || {}
+export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createContentDigest, createNodeId }) => {
+    const { createNode } = actions
 
-    let all_endpoints = menu[menu.length - 1]['items'] // all grouped endpoints
-    const maxEndpointItems = 20
-    all_endpoints = all_endpoints.flatMap((endpoint) => {
-        if (endpoint.items.length > maxEndpointItems) {
-            const chunks = []
-            for (let i = 0; i < endpoint.items.length; i += maxEndpointItems) {
-                const pos = Math.floor(i / maxEndpointItems)
-                const next = i + maxEndpointItems < endpoint.items.length && `${endpoint.name}-${pos + 2}`
-                const name = pos === 0 ? endpoint.name : `${endpoint.name}-${pos + 1}`
-                const previous = pos === 0 ? null : pos === 1 ? endpoint.name : `${endpoint.name}-${pos}`
-                const chunk = {
-                    ...endpoint,
-                    name,
-                    items: endpoint.items.slice(i, i + maxEndpointItems),
-                    next,
-                    previous,
+    const sourceApiEndpoints = async () => {
+        primeApiSpec()
+        const spec = await apiSpecPromise
+
+        const parser = new OpenAPIParser(spec)
+        const menu = MenuBuilder.buildStructure(parser, {} as any)
+
+        const allSchemas = spec.components?.schemas || {}
+
+        let all_endpoints = menu[menu.length - 1]['items'] // all grouped endpoints
+        const maxEndpointItems = 20
+        all_endpoints = all_endpoints.flatMap((endpoint) => {
+            if (endpoint.items.length > maxEndpointItems) {
+                const chunks = []
+                for (let i = 0; i < endpoint.items.length; i += maxEndpointItems) {
+                    const pos = Math.floor(i / maxEndpointItems)
+                    const next = i + maxEndpointItems < endpoint.items.length && `${endpoint.name}-${pos + 2}`
+                    const name = pos === 0 ? endpoint.name : `${endpoint.name}-${pos + 1}`
+                    const previous = pos === 0 ? null : pos === 1 ? endpoint.name : `${endpoint.name}-${pos}`
+                    const chunk = {
+                        ...endpoint,
+                        name,
+                        items: endpoint.items.slice(i, i + maxEndpointItems),
+                        next,
+                        previous,
+                    }
+                    chunks.push(chunk)
                 }
-                chunks.push(chunk)
+                return chunks
             }
-            return chunks
-        }
-        return endpoint
-    })
-    all_endpoints.forEach((endpoint) => {
-        const components = findAllReferencedSchemas(endpoint.items, allSchemas)
+            return endpoint
+        })
+        all_endpoints.forEach((endpoint) => {
+            const components = findAllReferencedSchemas(endpoint.items, allSchemas)
 
-        const node = {
-            id: createNodeId(`api_endpoint-${endpoint.name}`),
-            internal: {
-                type: `api_endpoint`,
-                contentDigest: createContentDigest({
-                    items: endpoint.items,
-                }),
-            },
-            items: JSON.stringify(endpoint.items.map((item) => item.operationSpec)),
-            components: JSON.stringify(components),
-            url: '/docs/api/' + endpoint.name.replace(/_/g, '-'),
-            name: endpoint.name,
-            nextURL: endpoint.next ? '/docs/api/' + endpoint.next.replace(/_/g, '-') : null,
-            previousURL: (endpoint as any).previous
-                ? '/docs/api/' + (endpoint as any).previous.replace(/_/g, '-')
-                : null,
-        }
-        createNode(node)
-    })
+            const node = {
+                id: createNodeId(`api_endpoint-${endpoint.name}`),
+                internal: {
+                    type: `api_endpoint`,
+                    contentDigest: createContentDigest({
+                        items: endpoint.items,
+                    }),
+                },
+                items: JSON.stringify(endpoint.items.map((item) => item.operationSpec)),
+                components: JSON.stringify(components),
+                url: '/docs/api/' + endpoint.name.replace(/_/g, '-'),
+                name: endpoint.name,
+                nextURL: endpoint.next ? '/docs/api/' + endpoint.next.replace(/_/g, '-') : null,
+                previousURL: (endpoint as any).previous
+                    ? '/docs/api/' + (endpoint as any).previous.replace(/_/g, '-')
+                    : null,
+            }
+            createNode(node)
+        })
+    }
 
     // --- Begin parallel sourcing of independent data ---
     const sourceProductUsageStats = async () => {
@@ -1468,6 +1542,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
     }
 
     await Promise.all([
+        sourceApiEndpoints(),
         createProductDataNode(),
         createRoadmapItems(),
         sourceEarlyAccessFeatures(),

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "private": true,
     "scripts": {
         "prebuild-move": "pnpm generate-brand-assets",
-        "build-move": "gatsby build && bash ./src/scripts/move-index.sh",
+        "build-move": "node scripts/prefetch-api-spec.mjs & gatsby build && bash ./src/scripts/move-index.sh",
         "prebuild": "pnpm generate-brand-assets",
-        "build": "gatsby build",
+        "build": "node scripts/prefetch-api-spec.mjs & gatsby build",
         "prebuild:minimal": "pnpm generate-brand-assets",
         "build:minimal": "GATSBY_MINIMAL=true gatsby build",
         "start": "./bin/start",

--- a/scripts/prefetch-api-spec.mjs
+++ b/scripts/prefetch-api-spec.mjs
@@ -1,0 +1,40 @@
+// Prefetches the PostHog OpenAPI schema while gatsby boots. The schema endpoint takes
+// ~9s of server-side generation, which would otherwise stall "source and transform
+// nodes" — starting the fetch before gatsby's compile/bootstrap phases hides most of
+// that wait. gatsby/sourceNodes.ts reads the result (or falls back to fetching inline),
+// keyed on the `.pending` marker so a crashed or failed prefetch never blocks the build.
+import fs from 'fs'
+import path from 'path'
+
+const OUT = path.resolve(process.cwd(), '.api-spec-prefetch.json')
+const PENDING = `${OUT}.pending`
+const url = process.env.POSTHOG_OPEN_API_SPEC_URL || 'https://app.posthog.com/api/schema/'
+
+try {
+    fs.rmSync(OUT, { force: true })
+    fs.writeFileSync(PENDING, JSON.stringify({ pid: process.pid, url }))
+} catch {
+    // If we can't even write the marker, the build just fetches inline.
+}
+
+try {
+    // Bound the fetch so a mid-response stall can't leave this background process alive
+    // holding the build's inherited stdio open. 30s is well above the ~9s normal path.
+    const res = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(30_000) })
+    if (!res.ok) throw new Error(`status ${res.status}`)
+    const text = await res.text()
+    JSON.parse(text) // validate before publishing the file
+    // The envelope records which URL the spec came from, so a build configured with a
+    // different POSTHOG_OPEN_API_SPEC_URL never consumes a leftover file from this run.
+    fs.writeFileSync(`${OUT}.tmp`, `{"url":${JSON.stringify(url)},"spec":${text}}`)
+    fs.renameSync(`${OUT}.tmp`, OUT)
+    console.log('[prefetch-api-spec] done')
+} catch (e) {
+    console.warn(`[prefetch-api-spec] failed, build will fetch inline: ${e.message}`)
+} finally {
+    try {
+        fs.rmSync(PENDING, { force: true })
+    } catch {
+        // Stale markers expire by mtime in sourceNodes, so this is best-effort.
+    }
+}


### PR DESCRIPTION
## Summary

Re-lands one independent piece of #18650 (reverted in #18913 "Breaking blog pages"). **This piece does not touch MDX.**

> **Stacked on #19427** (both change `gatsby/sourceNodes.ts`). Merge that first; this PR's base is its branch.

The PostHog API schema endpoint takes ~9 s of server-side generation for its ~13 MB response, and `sourceNodes` awaited it before starting any other sourcing task. This PR:

- starts `scripts/prefetch-api-spec.mjs` as a sibling process from the build script, so the fetch overlaps gatsby's compile/bootstrap phases (~60 s of runway)
- writes the result as an envelope keyed by source URL, with a `.pending` marker handshake and a 5-minute freshness window, so a crashed or mismatched prefetch is ignored
- has `sourceNodes` consume the prefetched spec or fall back to fetching inline — failure behavior is unchanged, a failed fetch still rejects exactly where it used to
- moves endpoint sourcing into the existing `Promise.all` so the other ~20 sourcing tasks no longer wait behind it
- primes the same promise from `onPreBootstrap` so `gatsby develop` (which never runs the prefetch script) also starts the fetch early

## Verification

- Ran the prefetch script against the live endpoint: it fetches, validates, and writes the real spec (1,310 paths, 12.7 MB) with a correct envelope.
- The stale-file and URL-mismatch guards are the reviewed logic from #18650, including the follow-up fixes for envelope keying and the 30 s abort timeout.
- CI preview builds run `pnpm build`, so this PR's build exercises the prefetch handshake end to end; the inline-fetch fallback is exercised by `gatsby develop` and by any run where the prefetch fails.

Part of a build-performance series re-landing the non-MDX pieces of #18650 individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)