### PR TITLE
ci: stop rebuilding previews on label changes

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,7 +2,7 @@ name: Deploy preview to Cloudflare Pages
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened, labeled]
+        types: [opened, synchronize, reopened]
 
 concurrency:
     group: deploy-preview-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

One-line change: remove `labeled` from the preview workflow's `pull_request` trigger types.

The trigger existed for the `no-cache` label, whose handling was removed in 25e793286 ("build Gatsby cold in previews"). Today it only causes harm:

1. A PR opens → preview build starts.
2. `auto-label.yml` (which runs on `opened`/`synchronize`) adds `content`/`handbook`/`website` labels.
3. Each label add fires a `labeled` event → the `deploy-preview` concurrency group (`cancel-in-progress: true`) **cancels the in-flight build and restarts it cold from zero**.

Every newly opened PR pays this restart (~13 minutes of duplicated Depot-8 runner time and a later preview link). The workflow body contains no other reference to labels.

## Verification

- `grep -i label .github/workflows/deploy-preview.yml` → only the trigger line.
- The `no-cache` handling removal is documented inline at `deploy-preview.yml:64-67` (cold-build policy comment).

Part of a build-performance series (see #19424–#19428).

🤖 Generated with [Claude Code](https://claude.com/claude-code)