### PR TITLE
ci: refresh the Cloudinary cache with a script, not a full build

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -11,14 +11,11 @@ concurrency:
     group: cache-warmup
     cancel-in-progress: true
 
-env:
-    NODE_OPTIONS: '--max_old_space_size=12288'
-
 jobs:
     warm-cache:
         name: Refresh Cloudinary cache
         runs-on: depot-ubuntu-latest-8
-        timeout-minutes: 45
+        timeout-minutes: 10
         permissions:
             contents: read
 
@@ -26,27 +23,14 @@ jobs:
             - name: Checkout
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-            - name: Set up pnpm
-              uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
-
-            - name: Set up Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-              with:
-                  node-version: '22'
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            # Build cold (no Gatsby cache) purely to run onPreInit's Cloudinary crawl, which
-            # writes .cloudinary-resources.json for preview builds to restore.
-            - name: Build site
-              run: pnpm build
+            # Dependency-free crawl of the Cloudinary resource list. Writes the same
+            # .cloudinary-resources.json that gatsby/onCreateNode.ts's onPreInit produces,
+            # without running a full Gatsby build (which this workflow previously did,
+            # ~15-20 minutes per day, purely for this file). Cloud name comes from the
+            # committed .env.production.
+            - name: Refresh Cloudinary metadata
+              run: node scripts/refresh-cloudinary-cache.mjs
               env:
-                  GATSBY_MINIMAL: 'true'
-                  # Provide Cloudinary creds so onPreInit crawls the resource list and writes
-                  # .cloudinary-resources.json for preview builds to restore (cloud name comes
-                  # from the committed .env.production).
                   CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
                   CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
 

--- a/scripts/refresh-cloudinary-cache.mjs
+++ b/scripts/refresh-cloudinary-cache.mjs
@@ -1,0 +1,66 @@
+// Refreshes .cloudinary-resources.json — the Cloudinary metadata cache that preview
+// builds restore to skip the ~140s onPreInit crawl (see gatsby/onCreateNode.ts).
+//
+// This is a dependency-free replacement for running a full Gatsby build in
+// .github/workflows/cache-warmup.yml: it performs the same paginated crawl of the
+// Cloudinary resource list and writes the same public_id → resource map.
+import fs from 'fs'
+import path from 'path'
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const OUT = path.join(repoRoot, '.cloudinary-resources.json')
+
+// Overridable so tests can point the crawl at a mock server.
+const apiBase = process.env.CLOUDINARY_API_BASE || 'https://api.cloudinary.com'
+
+function readCloudNameFromEnvFile() {
+    try {
+        const envFile = fs.readFileSync(path.join(repoRoot, '.env.production'), 'utf-8')
+        const match = envFile.match(/^GATSBY_CLOUDINARY_CLOUD_NAME=(.+)$/m)
+        return match?.[1]?.trim()
+    } catch {
+        return undefined
+    }
+}
+
+const cloudName = process.env.GATSBY_CLOUDINARY_CLOUD_NAME || readCloudNameFromEnvFile()
+const apiKey = process.env.CLOUDINARY_API_KEY
+const apiSecret = process.env.CLOUDINARY_API_SECRET
+
+if (!cloudName || !apiKey || !apiSecret) {
+    console.error(
+        'Missing Cloudinary configuration (GATSBY_CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET)'
+    )
+    process.exit(1)
+}
+
+const auth = `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString('base64')}`
+
+const cache = {}
+let nextCursor = null
+let pages = 0
+
+do {
+    const url = `${apiBase}/v1_1/${cloudName}/resources/image?type=upload&max_results=500${
+        nextCursor ? `&next_cursor=${nextCursor}` : ''
+    }`
+    const res = await fetch(url, { headers: { Authorization: auth }, signal: AbortSignal.timeout(60_000) })
+    if (!res.ok) {
+        console.error(`Cloudinary request failed (${res.status}): ${await res.text()}`)
+        process.exit(1)
+    }
+    const { resources, next_cursor } = await res.json()
+    if (!Array.isArray(resources)) {
+        console.error('Unexpected Cloudinary response: no resources array')
+        process.exit(1)
+    }
+    resources.forEach((resource) => {
+        cache[resource.public_id] = resource
+    })
+    nextCursor = next_cursor
+    pages++
+} while (nextCursor)
+
+// Same format gatsby/onCreateNode.ts writes and reads (public_id → resource map).
+fs.writeFileSync(OUT, JSON.stringify(cache))
+console.log(`Wrote ${Object.keys(cache).length} Cloudinary resources (${pages} pages) to ${OUT}`)


### PR DESCRIPTION
## Summary

The daily `cache-warmup.yml` workflow ran a **complete cold Gatsby build** (~15–20 minutes on a Depot-8 runner, with a 12 GB heap) purely to execute `onPreInit`'s Cloudinary crawl and save one ~2 MB JSON file — the workflow's own comment acknowledged this.

This replaces the build with `scripts/refresh-cloudinary-cache.mjs`, a dependency-free Node script that performs the same paginated crawl of the Cloudinary resource list and writes the same `public_id → resource` map to `.cloudinary-resources.json`. The workflow now needs only a checkout — no pnpm setup, no install, no build — and finishes in under a minute.

Reliability notes:
- A failed or malformed crawl exits non-zero, and the cache save step runs `if: success()`, so a bad file is never saved — same guarantee as before.
- Cloud name resolution matches the build's behavior (env var, falling back to the committed `.env.production`).
- The consumer (`gatsby/onCreateNode.ts`) is unchanged.

## Verification

Tested against a mock paginated Cloudinary API (two pages, auth required): the script paginates via `next_cursor`, sends Basic auth, and the written file is **format-identical to what `onPreInit` writes** (`public_id → resource` map, single-line JSON).

Part of a build-performance series (see #19424–#19429). A follow-up PR stacks on this to make the same file reachable by Vercel production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)