### PR TITLE
ci: cancel superseded PR runs in lint and security workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,11 @@ name: Non-Blocking Basic Checks
 on:
     - pull_request
 
+# Cancel superseded runs when a PR gets new pushes.
+concurrency:
+    group: checks-${{ github.event.pull_request.number || github.run_id }}
+    cancel-in-progress: true
+
 jobs:
     standard_checks:
         name: Spelling

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -6,6 +6,12 @@ on:
 
 name: Security
 
+# Cancel superseded runs on PR pushes. Master-push runs get a unique group via
+# run_id, so they are never queued or cancelled.
+concurrency:
+    group: security-${{ github.event.pull_request.number || github.run_id }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,12 @@ on:
     schedule:
         - cron: '41 14 * * 1'
 
+# Cancel superseded runs on PR pushes. Non-PR runs (master push, weekly cron) get a
+# unique group via run_id, so they are never queued or cancelled.
+concurrency:
+    group: codeql-${{ github.event.pull_request.number || github.run_id }}
+    cancel-in-progress: true
+
 jobs:
     analyze:
         name: Analyze (${{ matrix.language }})

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -3,6 +3,11 @@ name: Markdown Lint
 on:
     pull_request:
 
+# Cancel superseded runs when a PR gets new pushes.
+concurrency:
+    group: markdown-lint-${{ github.event.pull_request.number || github.run_id }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/product-changelog-check.yml
+++ b/.github/workflows/product-changelog-check.yml
@@ -9,6 +9,11 @@ on:
             - 'scripts/check-product-changelogs.js'
             - '.github/workflows/product-changelog-check.yml'
 
+# Cancel superseded runs when a PR gets new pushes.
+concurrency:
+    group: product-changelog-${{ github.event.pull_request.number || github.run_id }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -13,6 +13,12 @@ on:
                 required: true
                 type: string
 
+# Cancel superseded runs on PR pushes. Manual dispatches get a unique group via
+# run_id, so they are never queued or cancelled.
+concurrency:
+    group: vale-${{ github.event.pull_request.number || github.run_id }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
     pull-requests: write


### PR DESCRIPTION
## Summary

Only 4 of 19 workflows cancel in-progress runs today. Rapid pushes to a PR queue full redundant runs of CodeQL (3-language matrix), Semgrep (3 container jobs), Vale, codespell, markdown lint, and the product-changelog check.

This adds a per-PR concurrency group with `cancel-in-progress: true` to six workflows:

| Workflow | Also runs on |
|---|---|
| `codeql.yml` (CodeQL Advanced) | master push, weekly cron |
| `ci-security.yml` (Semgrep ×3) | master push |
| `vale-lint.yml` | manual dispatch |
| `checks.yml` (codespell + md-redirects) | — |
| `markdown-lint.yml` | — |
| `product-changelog-check.yml` | — |

**Safety:** the group key is `<workflow>-${{ github.event.pull_request.number || github.run_id }}`. For non-PR events the PR number is empty, so the key falls back to the unique `run_id` — master-push runs, the weekly CodeQL cron, and manual dispatches are never grouped, queued, or cancelled. Only superseded runs of the same PR are.

The two Inkeep workflows are left alone: they are comment/review-driven bots, not per-push checks.

## Verification

- `actionlint`-style review by hand: expression syntax matches the existing pattern in `deploy-preview.yml:7-9`.
- Behavior on this PR itself: pushing a second commit should cancel this PR's first CodeQL/Semgrep/Vale runs.

Part of a build-performance series (see #19424–#19431).

🤖 Generated with [Claude Code](https://claude.com/claude-code)