### PR TITLE
chore: delete dead createPages override in gatsby-node.ts

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs/promises'
 import { GatsbyNode } from 'gatsby'
-const axios = require('axios')
 
 export { createPages } from './gatsby/createPages'
 export { onCreateNode, onPreInit } from './gatsby/onCreateNode'
@@ -130,26 +129,5 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({ sta
         actions.setWebpackConfig({
             plugins: [new EmitWebpackGraphPlugin(path.resolve(__dirname, 'bundle-report', 'webpack-graph.json'))],
         })
-    }
-}
-
-exports.createPages = async ({ actions }) => {
-    const { createPage } = actions
-
-    try {
-        const response = await axios.get('https://jobs.ashbyhq.com/supabase')
-        const jobData = JSON.parse(response.data)
-        const jobs = jobData?.jobBoard?.jobPostings || []
-
-        // Create the jobs page with the data
-        createPage({
-            path: '/jobs',
-            component: require.resolve('./src/templates/jobs.tsx'),
-            context: {
-                jobs: jobs,
-            },
-        })
-    } catch (error) {
-        console.error('Error fetching jobs:', error)
     }
 }


### PR DESCRIPTION
## Summary

`gatsby-node.ts:6` re-exports `createPages` from `./gatsby/createPages`. At the bottom of the same file (`:136-155`), a second `exports.createPages = …` assignment fetches **Supabase's** public Ashby job board (a copy-paste artifact) and would create a `/jobs` page from it.

That block has never run:

- Parcel (which compiles `gatsby-node.ts`) turns the re-export into a **getter-only** `Object.defineProperty` — the later plain assignment is a silent no-op. Verified directly against Parcel's `esmodule-helpers`: after `export(o, 'createPages', getter)`, assigning `o.createPages` leaves the getter in place.
- The template it references, `src/templates/jobs.tsx`, **does not exist in the repo**.

Deleting the block also removes the `axios` require, which existed only for it. No behavior change — the compiled output Gatsby executes is identical in effect.

## Verification

- Runtime proof of the getter-vs-assignment behavior (above).
- `src/templates/jobs.tsx` absent; no other reference to it in the repo.
- TS compiles; the real `createPages` re-export is untouched.

Part of a build-performance series (see #19424–#19432) — found while auditing `gatsby-node.ts` for build-time work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)