### PR TITLE
feat: Mapbox place autosuggest for the profile location field

### DIFF
--- a/src/components/HogMap/PeopleMapSearch.tsx
+++ b/src/components/HogMap/PeopleMapSearch.tsx
@@ -1,5 +1,6 @@
 import { AVATAR_FALLBACK_URL } from 'constants/index'
 import { IconPin } from '@posthog/icons'
+import { PlaceSuggestion, usePlaceSuggestions } from 'components/PlaceAutocomplete/usePlaceSuggestions'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 
 interface EmployeeLike {
@@ -12,13 +13,7 @@ interface EmployeeLike {
     avatar?: { url?: string }
 }
 
-interface LocationSuggestion {
-    id: string
-    name: string
-    subtitle: string
-}
-
-type DropdownItem = { type: 'employee'; member: EmployeeLike } | { type: 'location'; suggestion: LocationSuggestion }
+type DropdownItem = { type: 'employee'; member: EmployeeLike } | { type: 'location'; suggestion: PlaceSuggestion }
 
 interface PeopleMapSearchProps {
     members: EmployeeLike[]
@@ -33,10 +28,6 @@ interface PeopleMapSearchProps {
 
 const fullName = (m: EmployeeLike): string => [m.firstName, m.lastName].filter(Boolean).join(' ')
 
-// Session token for Search Box API billing (rotated after each selection)
-const makeSessionToken = (): string =>
-    typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
-
 // Map search box: matches team members by name first, then Mapbox places.
 export default function PeopleMapSearch({
     members,
@@ -49,13 +40,11 @@ export default function PeopleMapSearch({
     onClear,
 }: PeopleMapSearchProps): JSX.Element {
     const [query, setQuery] = useState(value)
-    const [locationResults, setLocationResults] = useState<LocationSuggestion[]>([])
     const [isOpen, setIsOpen] = useState(false)
     const [highlightIndex, setHighlightIndex] = useState(-1)
-    const [sessionToken, setSessionToken] = useState(makeSessionToken)
     const containerRef = useRef<HTMLDivElement>(null)
     const inputRef = useRef<HTMLInputElement>(null)
-    const abortRef = useRef<AbortController | null>(null)
+    const { suggestions: locationResults, resetSession } = usePlaceSuggestions(query, token)
 
     // Sync the input when the committed term changes (e.g. hash load)
     useEffect(() => {
@@ -67,50 +56,6 @@ export default function PeopleMapSearch({
         if (!q) return []
         return members.filter((m) => fullName(m).toLowerCase().includes(q)).slice(0, 6)
     }, [members, query])
-
-    // Debounced Mapbox place suggestions
-    useEffect(() => {
-        const q = query.trim()
-        const canSearch = typeof window !== 'undefined' && token && q.length >= 2
-        if (!canSearch) {
-            if (abortRef.current) {
-                abortRef.current.abort()
-                abortRef.current = null
-            }
-            setLocationResults([])
-            return
-        }
-        const controller = new AbortController()
-        abortRef.current = controller
-        const handle = setTimeout(async () => {
-            try {
-                const url = new URL('https://api.mapbox.com/search/searchbox/v1/suggest')
-                url.searchParams.set('q', q)
-                url.searchParams.set('limit', '5')
-                // Countries, regions, and cities only (Mapbox "place" == city/town)
-                url.searchParams.set('types', 'country,region,place')
-                url.searchParams.set('language', 'en')
-                url.searchParams.set('session_token', sessionToken)
-                url.searchParams.set('access_token', token as string)
-                const resp = await fetch(url.toString(), { signal: controller.signal })
-                const json = await resp.json()
-                const feats = Array.isArray(json?.suggestions) ? json.suggestions : []
-                setLocationResults(
-                    feats.map((f: Record<string, any>) => ({
-                        id: f.mapbox_id || f.feature_id || f.id,
-                        name: f.name || f.place_formatted || f.description || 'Unknown',
-                        subtitle: f.place_formatted || f.full_address || '',
-                    }))
-                )
-            } catch {
-                // ignore (including aborts)
-            }
-        }, 200)
-        return () => {
-            clearTimeout(handle)
-            controller.abort()
-        }
-    }, [query, token, sessionToken])
 
     const items: DropdownItem[] = useMemo(
         () => [
@@ -140,7 +85,7 @@ export default function PeopleMapSearch({
             setQuery(item.suggestion.name)
             onSelectLocation(item.suggestion.name)
         }
-        setSessionToken(makeSessionToken())
+        resetSession()
     }
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -162,7 +107,6 @@ export default function PeopleMapSearch({
 
     const handleClear = () => {
         setQuery('')
-        setLocationResults([])
         setIsOpen(false)
         setHighlightIndex(-1)
         onClear?.()

--- a/src/components/PlaceAutocomplete/README.md
+++ b/src/components/PlaceAutocomplete/README.md
@@ -1,0 +1,52 @@
+# PlaceAutocomplete
+
+A location text field with a Mapbox place-suggestion dropdown. It's the same suggest API and dropdown behavior the people map search box uses, so a location picked here forward-geocodes to a pin on `/people/map`.
+
+## Why it exists
+
+Profiles store location as free text (`location`) plus an ISO country code (`country`). The map resolves a pin by geocoding `"{location}, {country}"` (see `components/HogMap/usePeopleGeo.ts`), which silently falls back to London when the text isn't a place Mapbox knows. Picking from suggestions means the stored string came out of Mapbox's own gazetteer, so it round-trips, and the suggestion also gives us the country code for the flag.
+
+## Usage
+
+```tsx
+import PlaceAutocomplete from 'components/PlaceAutocomplete'
+
+<PlaceAutocomplete
+    label="Location"
+    name="location"
+    value={values.location || ''}
+    onChange={(value) => setFieldValue('location', value)}
+    onSelect={(place) => {
+        setFieldValue('location', place.label)
+        if (place.countryCode) setFieldValue('country', place.countryCode)
+    }}
+    error={errors.location}
+/>
+```
+
+`onChange` fires on every keystroke, so free text still works – someone can type "Planet Earth" and save it. `onSelect` fires only when a suggestion is picked.
+
+## Props
+
+| Prop          | Default                              | Notes                                                       |
+| ------------- | ------------------------------------ | ----------------------------------------------------------- |
+| `value`       | –                                    | Current field value (controlled)                            |
+| `onChange`    | –                                    | Called with the new string on typing and on selection        |
+| `onSelect`    | –                                    | Called with the picked `PlaceSuggestion`                     |
+| `label`       | `Location`                           |                                                             |
+| `name`        | `location`                           |                                                             |
+| `placeholder` | `Start typing a city or country…`    |                                                             |
+| `token`       | `process.env.GATSBY_MAPBOX_TOKEN`    | Without a token it degrades to a plain text input            |
+| `types`       | `country,region,place`               | Mapbox feature types (`place` is a city/town)                |
+| `direction` / `size` / `dataScheme` / `description` / `tooltip` / `error` | – | Passed through to `OSInput` |
+
+Keyboard: up/down to move through suggestions, enter to pick the highlighted one, escape to close. Clicking outside closes the dropdown. The dropdown only opens while typing, and suggestions are only fetched while it's open, so loading a saved location costs no Mapbox requests.
+
+## `usePlaceSuggestions`
+
+The debounced suggest call lives in `usePlaceSuggestions.ts` and is shared with `components/HogMap/PeopleMapSearch.tsx`. It returns `{ suggestions, resetSession }`:
+
+-   `suggestions` – `{ id, name, subtitle, countryCode, label }[]`. `label` is `"{name}, {region}"` (or just the name for city-states), which is what we store as a location; `subtitle` is Mapbox's full hierarchy, shown as the second line in the dropdown.
+-   `resetSession` – rotates the Mapbox Search Box session token, per Mapbox's session semantics, after a selection.
+
+Options: `types`, `limit`, `minLength`, `debounceMs`, and `enabled` (set false to pause requests, e.g. while a dropdown is closed).

--- a/src/components/PlaceAutocomplete/index.tsx
+++ b/src/components/PlaceAutocomplete/index.tsx
@@ -1,0 +1,149 @@
+import { IconPin } from '@posthog/icons'
+import OSInput from 'components/OSForm/input'
+import React, { useEffect, useRef, useState } from 'react'
+import { PlaceSuggestion, usePlaceSuggestions } from './usePlaceSuggestions'
+
+export type { PlaceSuggestion }
+
+interface PlaceAutocompleteProps {
+    value: string
+    /** Fires on every keystroke and on selection – free text stays allowed */
+    onChange: (value: string) => void
+    /** Fires only when a Mapbox suggestion is picked, with its country code */
+    onSelect?: (place: PlaceSuggestion) => void
+    label?: string
+    name?: string
+    placeholder?: string
+    description?: string
+    tooltip?: string | React.ReactNode
+    error?: string
+    /** Defaults to GATSBY_MAPBOX_TOKEN; without a token this is a plain text input */
+    token?: string
+    types?: string
+    direction?: 'row' | 'column'
+    size?: 'sm' | 'md' | 'lg'
+    dataScheme?: 'primary' | 'secondary' | 'tertiary'
+    className?: string
+}
+
+/**
+ * Location field with Mapbox place suggestions – the same dropdown the people map
+ * search uses, so a location picked here geocodes to a pin on /people/map.
+ */
+export default function PlaceAutocomplete({
+    value,
+    onChange,
+    onSelect,
+    label = 'Location',
+    name = 'location',
+    placeholder = 'Start typing a city or country…',
+    description,
+    tooltip,
+    error,
+    token,
+    types,
+    direction = 'column',
+    size = 'md',
+    dataScheme = 'primary',
+    className = '',
+}: PlaceAutocompleteProps): JSX.Element {
+    const [isOpen, setIsOpen] = useState(false)
+    const [highlightIndex, setHighlightIndex] = useState(-1)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const mapboxToken = token ?? process.env.GATSBY_MAPBOX_TOKEN
+    // The dropdown only opens on typing, and suggestions are only fetched while it's
+    // open, so loading a saved location (or picking a suggestion) costs no requests.
+    const { suggestions, resetSession } = usePlaceSuggestions(value ?? '', mapboxToken, { types, enabled: isOpen })
+
+    useEffect(() => {
+        const onClick = (e: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setIsOpen(false)
+            }
+        }
+        window.addEventListener('click', onClick)
+        return () => window.removeEventListener('click', onClick)
+    }, [])
+
+    const commit = (suggestion: PlaceSuggestion) => {
+        setIsOpen(false)
+        setHighlightIndex(-1)
+        onChange(suggestion.label)
+        onSelect?.(suggestion)
+        resetSession()
+    }
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (!isOpen || suggestions.length === 0) return
+        if (e.key === 'ArrowDown') {
+            e.preventDefault()
+            setHighlightIndex((idx) => (idx + 1) % suggestions.length)
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault()
+            setHighlightIndex((idx) => (idx - 1 + suggestions.length) % suggestions.length)
+        } else if (e.key === 'Enter') {
+            e.preventDefault()
+            const suggestion = suggestions[highlightIndex] || suggestions[0]
+            if (suggestion) commit(suggestion)
+        } else if (e.key === 'Escape') {
+            setIsOpen(false)
+        }
+    }
+
+    return (
+        <div ref={containerRef} className={`relative ${className}`}>
+            <OSInput
+                label={label}
+                name={name}
+                value={value ?? ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    onChange(e.target.value)
+                    setIsOpen(true)
+                    setHighlightIndex(-1)
+                }}
+                onKeyDown={onKeyDown}
+                placeholder={placeholder}
+                description={description}
+                tooltip={tooltip}
+                error={error}
+                touched={!!error}
+                direction={direction}
+                size={size}
+                dataScheme={dataScheme}
+                showLabel={true}
+                autoComplete="off"
+                aria-autocomplete="list"
+                aria-expanded={isOpen && suggestions.length > 0}
+            />
+            {isOpen && suggestions.length > 0 && (
+                <ul
+                    role="listbox"
+                    data-scheme="primary"
+                    className="not-prose list-none absolute z-30 left-0 right-0 top-full mt-1 max-h-60 overflow-auto rounded-md border border-primary bg-primary shadow-2xl p-1 m-0"
+                >
+                    {suggestions.map((suggestion, index) => (
+                        <li
+                            key={suggestion.id}
+                            role="option"
+                            aria-selected={highlightIndex === index}
+                            onMouseEnter={() => setHighlightIndex(index)}
+                            onClick={() => commit(suggestion)}
+                            title={suggestion.subtitle || suggestion.name}
+                            className={`flex items-start gap-2 rounded px-2 py-1.5 cursor-pointer text-primary ${
+                                highlightIndex === index ? 'bg-accent' : 'hover:bg-accent'
+                            }`}
+                        >
+                            <IconPin className="size-4 mt-0.5 text-muted shrink-0" />
+                            <div className="min-w-0 leading-tight">
+                                <div className="text-sm text-primary truncate">{suggestion.name}</div>
+                                {suggestion.subtitle && (
+                                    <div className="text-xs text-secondary truncate">{suggestion.subtitle}</div>
+                                )}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/components/PlaceAutocomplete/usePlaceSuggestions.ts
+++ b/src/components/PlaceAutocomplete/usePlaceSuggestions.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface PlaceSuggestion {
+    id: string
+    /** Mapbox's short name for the place, e.g. "Barcelona" */
+    name: string
+    /** Everything above it in the hierarchy, e.g. "Catalonia, Spain" */
+    subtitle: string
+    /** ISO 3166-1 alpha-2 code, e.g. "ES" – matches the profile `country` field */
+    countryCode?: string
+    /** Name plus its parent region, e.g. "Barcelona, Catalonia" – what we store as a location */
+    label: string
+}
+
+interface Options {
+    /** Mapbox feature types to suggest. Defaults to cities, regions, and countries. */
+    types?: string
+    limit?: number
+    minLength?: number
+    debounceMs?: number
+    /** Set false to pause requests (e.g. while the dropdown is closed) */
+    enabled?: boolean
+}
+
+// Session token for Search Box API billing (rotated after each selection)
+const makeSessionToken = (): string =>
+    typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
+
+// "Barcelona, Catalonia" geocodes as reliably as Mapbox's full "Barcelona, Catalonia, Spain"
+// but reads better on a profile – and we store the country separately anyway.
+const buildLabel = (name: string, context?: Record<string, any>): string => {
+    const region = context?.region?.name
+    const country = context?.country?.name
+    const parent = region && region !== name ? region : country && country !== name ? country : null
+    return parent ? `${name}, ${parent}` : name
+}
+
+/**
+ * Debounced Mapbox Search Box place suggestions, shared by the people map search
+ * and the profile location field so both resolve locations the same way.
+ */
+export const usePlaceSuggestions = (
+    query: string,
+    token: string | undefined,
+    { types = 'country,region,place', limit = 5, minLength = 2, debounceMs = 200, enabled = true }: Options = {}
+): { suggestions: PlaceSuggestion[]; resetSession: () => void } => {
+    const [suggestions, setSuggestions] = useState<PlaceSuggestion[]>([])
+    const [sessionToken, setSessionToken] = useState(makeSessionToken)
+    const abortRef = useRef<AbortController | null>(null)
+
+    useEffect(() => {
+        const q = query.trim()
+        const canSearch = enabled && typeof window !== 'undefined' && token && q.length >= minLength
+        if (!canSearch) {
+            if (abortRef.current) {
+                abortRef.current.abort()
+                abortRef.current = null
+            }
+            setSuggestions([])
+            return
+        }
+        const controller = new AbortController()
+        abortRef.current = controller
+        const handle = setTimeout(async () => {
+            try {
+                const url = new URL('https://api.mapbox.com/search/searchbox/v1/suggest')
+                url.searchParams.set('q', q)
+                url.searchParams.set('limit', String(limit))
+                url.searchParams.set('types', types)
+                url.searchParams.set('language', 'en')
+                url.searchParams.set('session_token', sessionToken)
+                url.searchParams.set('access_token', token as string)
+                const resp = await fetch(url.toString(), { signal: controller.signal })
+                const json = await resp.json()
+                const feats = Array.isArray(json?.suggestions) ? json.suggestions : []
+                setSuggestions(
+                    feats.map((f: Record<string, any>) => {
+                        const name = f.name || f.place_formatted || f.description || 'Unknown'
+                        return {
+                            id: f.mapbox_id || f.feature_id || f.id,
+                            name,
+                            subtitle: f.place_formatted || f.full_address || '',
+                            countryCode: f.context?.country?.country_code || undefined,
+                            label: buildLabel(name, f.context),
+                        }
+                    })
+                )
+            } catch {
+                // ignore (including aborts)
+            }
+        }, debounceMs)
+        return () => {
+            clearTimeout(handle)
+            controller.abort()
+        }
+    }, [query, token, sessionToken, types, limit, minLength, debounceMs, enabled])
+
+    // Mapbox session semantics: start a fresh session once a suggestion is picked
+    const resetSession = useCallback(() => {
+        setSuggestions([])
+        setSessionToken(makeSessionToken())
+    }, [])
+
+    return { suggestions, resetSession }
+}

--- a/src/pages/community/profile/edit.tsx
+++ b/src/pages/community/profile/edit.tsx
@@ -17,6 +17,7 @@ import ScrollArea from 'components/RadixUI/ScrollArea'
 import { profileBackgrounds } from '../../../data/profileBackgrounds'
 import CloudinaryImage from 'components/CloudinaryImage'
 import { OSInput, OSTextarea } from 'components/OSForm'
+import PlaceAutocomplete from 'components/PlaceAutocomplete'
 import ConnectedAccounts from 'components/Squeak/components/ConnectedAccounts'
 import { PROFILE_COLORS } from 'constants/profileColors'
 
@@ -184,6 +185,21 @@ const formSections = [
             location: {
                 label: 'Location',
                 className: 'w-full sm:w-1/2',
+                component: ({ values, setFieldValue, error }) => (
+                    <PlaceAutocomplete
+                        value={values.location || ''}
+                        onChange={(value) => setFieldValue('location', value)}
+                        onSelect={(place) => {
+                            setFieldValue('location', place.label)
+                            // Keeps the flag and the map pin in sync with the place picked
+                            if (place.countryCode) {
+                                setFieldValue('country', place.countryCode)
+                            }
+                        }}
+                        error={error}
+                        tooltip="Pick a suggestion to show up in the right place on the people map."
+                    />
+                ),
             },
             pineappleOnPizza: {
                 className: 'w-full sm:w-1/2',

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -46,6 +46,7 @@ import transformValues from 'components/Squeak/util/transformValues'
 import { profileBackgrounds } from '../../../data/profileBackgrounds'
 import { Select } from 'components/RadixUI/Select'
 import OSInput from 'components/OSForm/input'
+import PlaceAutocomplete from 'components/PlaceAutocomplete'
 import { useToast } from '../../../context/Toast'
 import HeaderBar from 'components/OSChrome/HeaderBar'
 import LevelBadge from 'components/Squeak/components/LevelBadge'
@@ -533,12 +534,18 @@ const Details = ({ profile, isEditing, setFieldValue, values, errors, isTeamMemb
                 )
             )}
             {isEditing ? (
-                <Input
-                    label="Location"
-                    name="location"
-                    value={values.location}
-                    onChange={(e) => setFieldValue('location', e.target.value)}
+                <PlaceAutocomplete
+                    value={values.location || ''}
+                    onChange={(value) => setFieldValue('location', value)}
+                    onSelect={(place) => {
+                        setFieldValue('location', place.label)
+                        // Keeps the flag and the map pin in sync with the place picked
+                        if (place.countryCode) {
+                            setFieldValue('country', place.countryCode)
+                        }
+                    }}
                     error={errors.location}
+                    tooltip="Pick a suggestion to show up in the right place on the people map."
                 />
             ) : (
                 profile.location && (


### PR DESCRIPTION
## Changes

The people map places a pin by forward-geocoding `"{location}, {country}"` from each profile (`components/HogMap/usePeopleGeo.ts`), falling back to London when the free-text location isn't a place Mapbox recognizes — so a typo or an unusual phrasing silently puts someone on the wrong continent.

This applies the map search box's suggestion dropdown to the profile location field:

- Extracts the Mapbox Search Box suggest logic out of `PeopleMapSearch` into a shared `usePlaceSuggestions` hook, plus a new `PlaceAutocomplete` field that wraps `OSInput` with the same dropdown (keyboard nav, debounce, session-token rotation).
- Uses it for the Location input on both edit surfaces: the inline edit on `/community/profiles/[id]` and `/community/profile/edit`.
- Picking a suggestion stores a label from Mapbox's own gazetteer (e.g. "Barcelona, Catalonia") and sets the profile's `country` code from the same result, so the pin and the flag both follow the place picked. Typing free text still saves as before.
- Suggestions are only fetched while the dropdown is open, so opening the form or loading a saved location costs no Mapbox requests.

Map search behavior is unchanged — it's the same component, now reading from the shared hook.

**Why:** requested in Slack after the /people map refresh — pins were showing up in places people don't live, because nothing constrained the location field to something the geocoder could resolve.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AP5NXF8D7/p1786562030457089?thread_ts=1786562030.457089&cid=C0AP5NXF8D7)*
