### PR TITLE
Document managed warehouse performance tuning

### DIFF
--- a/contents/docs/data-warehouse/managed-warehouse/connect.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/connect.mdx
@@ -71,3 +71,5 @@ A few things a Postgres veteran will notice are absent: server-side functions an
 ## Querying from PostHog
 
 You don't need an external client to use the warehouse. Once provisioned, it's available in PostHog's [SQL editor](/docs/data-warehouse/query) alongside your other sources, and PostHog's AI features can use it as context. External connections are for everything else – dashboards in your BI tool, notebooks, scheduled jobs, or ad-hoc `psql` sessions.
+
+For larger or latency-sensitive workloads, [tune the worker's CPU, memory, and idle lifetime](/docs/data-warehouse/managed-warehouse/performance-tuning).

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -41,7 +41,7 @@ PostHog sizes DuckDB from the selected worker and provides managed scratch stora
 
 | DuckDB setting | Effective default | How it works |
 |---|---|---|
-| `threads` | Worker CPU count | Sets the maximum parallelism available to the query |
+| `threads` | 2.5× worker CPU, rounded up | Sets the maximum parallelism available to the query; the default 15-CPU worker gets 38 threads |
 | `memory_limit` | 90 GB (83.8 GiB) on the default worker | Limits DuckDB's buffer manager; PostHog derives it from the selected worker memory while reserving headroom for results, metadata, and the worker process |
 | `temp_directory` | Worker-local temporary storage | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
 | `max_temp_directory_size` | 90% of available temporary disk | Limits how much spill data DuckDB can write |
@@ -60,6 +60,12 @@ PostHog also caches object-storage byte ranges on managed local disk. This is se
 Prefetch and cache settings trade object-storage requests, memory, and latency. Benchmark representative cold and repeated scans before changing them.
 
 For more information about these and other settings, see [DuckDB's configuration reference](https://duckdb.org/docs/stable/configuration/overview).
+
+### Example: Tune threads for remote reads
+
+On the default 15-core worker, a simple query that reads many remote Parquet ranges but does little computation may run faster with `SET threads = 45`. Each DuckDB thread can make one HTTP request at a time, so more threads can overlap more network reads.
+
+Don't apply the same value to a CPU- or memory-bound `JOIN`, `GROUP BY`, sort, or window query. Extra threads can increase CPU contention and memory pressure, so keep these queries at the 38-thread default unless testing shows a benefit.
 
 Inspect the effective settings on your connection with:
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -43,9 +43,12 @@ PostHog sizes DuckDB from the selected worker and provides managed scratch stora
 |---|---|---|
 | `threads` | 2.5× worker CPU, rounded up | Sets the maximum parallelism available to the query; the default 15-CPU worker gets 38 threads |
 | `memory_limit` | 90 GB (83.8 GiB) on the default worker | Limits DuckDB's buffer manager; PostHog derives it from the selected worker memory while reserving headroom for results, metadata, and the worker process |
-| `temp_directory`, `max_temp_directory_size` | Worker-local storage with a 90% disk cap | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
-| `disable_parquet_prefetching`, `prefetch_all_parquet_files` | `false`, `false` (remote prefetching on) | Prefetches remote Parquet files by grouping nearby reads; disabling prefetching can reduce over-reading on selective scans but increase requests |
-| `enable_external_file_cache`, `parquet_metadata_cache` | `true`, `false` (data on, metadata off) | Caches external-file byte ranges in memory but not parsed Parquet metadata; metadata caching can help repeated scans of the same files |
+| `temp_directory` | Worker-local temporary storage | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
+| `max_temp_directory_size` | 90% of available temporary disk | Caps how much spill data DuckDB can write |
+| `disable_parquet_prefetching` | `false` (prefetching on) | Groups nearby Parquet reads to reduce object-storage requests; disabling it can reduce over-reading on selective scans but increase requests |
+| `prefetch_all_parquet_files` | `false` (remote files only) | Restricts prefetching to remote files; managed warehouse Parquet is remote, so this doesn't turn prefetching off |
+| `enable_external_file_cache` | `true` | Caches external-file byte ranges in memory under `memory_limit`, so repeated scans can avoid object-storage reads |
+| `parquet_metadata_cache` | `false` | Doesn't retain parsed Parquet footer and schema metadata; enabling it can help repeated scans of the same files |
 | `preserve_insertion_order` | `true` | Preserves insertion order where possible; setting it to `false` can reduce memory use for large imports and exports when result order doesn't matter |
 
 PostHog also caches object-storage byte ranges on managed local disk. This is separate from DuckDB's in-memory external file cache and needs no client configuration.

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -1,5 +1,5 @@
 ---
-title: Performance tuning
+title: Performance
 sidebar: Docs
 showTitle: true
 ---
@@ -35,7 +35,7 @@ PGOPTIONS="-c duckgres.worker_cpu=30 -c duckgres.worker_memory=240Gi -c duckgres
 
 Most Postgres clients expose the same `options` connection parameter. These settings only apply when the connection opens. Running SQL `SET` commands later doesn't resize its worker.
 
-## Understand the DuckDB defaults
+## DuckDB defaults
 
 PostHog sizes DuckDB from the selected worker and provides managed scratch storage. These are the effective defaults:
 
@@ -57,6 +57,8 @@ For more information about these and other settings, see [DuckDB's configuration
 ### Example: Tune threads for remote reads
 
 The default 15-core worker starts DuckDB with 38 threads. A simple query that reads many remote Parquet ranges but does little computation may run faster with a higher value, such as `SET threads = 60`. Each DuckDB thread can make one HTTP request at a time, so more threads can overlap more network reads.
+
+This tuning is a workaround for synchronous remote I/O. [Asynchronous I/O in an upcoming DuckDB release](https://duckdb.org/2026/07/31/asynchronous-io) will let DuckDB overlap requests without dedicating a thread to each one, reducing the need to increase `threads` solely for network concurrency.
 
 Don't apply the same value to a CPU- or memory-bound `JOIN`, `GROUP BY`, sort, or window query. Extra threads can increase CPU contention and memory pressure, so keep these queries at the 38-thread default unless testing shows a benefit.
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -82,5 +82,3 @@ WHERE name IN (
     'http_retry_backoff'
 );
 ```
-
-Prefer the `duckgres.worker_*` connection options over raising `threads` or `memory_limit` with SQL: changing a DuckDB setting doesn't add resources to the worker. Benchmark representative queries before and after resizing because not every query can use more cores or memory.

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -59,6 +59,8 @@ PostHog also caches object-storage byte ranges on managed local disk. This is se
 
 Prefetch and cache settings trade object-storage requests, memory, and latency. Benchmark representative cold and repeated scans before changing them.
 
+For more information about these and other settings, see [DuckDB's configuration reference](https://duckdb.org/docs/stable/configuration/overview).
+
 Inspect the effective settings on your connection with:
 
 ```sql

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -43,19 +43,12 @@ PostHog sizes DuckDB from the selected worker and provides managed scratch stora
 |---|---|---|
 | `threads` | 2.5× worker CPU, rounded up | Sets the maximum parallelism available to the query; the default 15-CPU worker gets 38 threads |
 | `memory_limit` | 90 GB (83.8 GiB) on the default worker | Limits DuckDB's buffer manager; PostHog derives it from the selected worker memory while reserving headroom for results, metadata, and the worker process |
-| `temp_directory` | Worker-local temporary storage | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
-| `max_temp_directory_size` | 90% of available temporary disk | Limits how much spill data DuckDB can write |
-| `disable_parquet_prefetching` | `false` (prefetching on) | Groups nearby Parquet reads to reduce object-storage requests; disabling it can reduce over-reading on selective scans but increase requests |
-| `prefetch_all_parquet_files` | `false` (remote files only) | Restricts prefetching to remote files; managed warehouse Parquet is remote, so this doesn't turn prefetching off |
-| `enable_external_file_cache` | `true` | Caches external-file byte ranges in worker memory under `memory_limit`, so repeated scans can avoid object-storage reads |
-| `validate_external_file_cache` | `VALIDATE_ALL` | Validates cached ranges against source metadata before reuse |
-| `parquet_metadata_cache` | `false` | Doesn't retain parsed Parquet footer and schema metadata across scans |
-| `enable_http_metadata_cache` | `false` | Keeps the shared cross-query HTTP metadata cache off; query-local metadata caching still occurs |
+| `temp_directory`, `max_temp_directory_size` | Worker-local storage with a 90% disk cap | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
+| `disable_parquet_prefetching`, `prefetch_all_parquet_files` | `false`, `false` (remote prefetching on) | Prefetches remote Parquet files by grouping nearby reads; disabling prefetching can reduce over-reading on selective scans but increase requests |
+| `enable_external_file_cache`, `parquet_metadata_cache` | `true`, `false` (data on, metadata off) | Caches external-file byte ranges in memory but not parsed Parquet metadata; metadata caching can help repeated scans of the same files |
 | `preserve_insertion_order` | `true` | Preserves insertion order where possible; setting it to `false` can reduce memory use for large imports and exports when result order doesn't matter |
-| `ducklake_max_retry_count` | `100` | Retries optimistic write conflicts caused by concurrent writers |
-| `http_retries`, `http_retry_wait_ms`, `http_retry_backoff` | `10`, `500`, `2` | Retries transient object-storage throttling with exponential backoff instead of failing immediately |
 
-PostHog also caches object-storage byte ranges on managed local disk. This is separate from DuckDB's in-memory external file cache and needs no client configuration. The legacy `enable_object_cache` setting does nothing.
+PostHog also caches object-storage byte ranges on managed local disk. This is separate from DuckDB's in-memory external file cache and needs no client configuration.
 
 Prefetch and cache settings trade object-storage requests, memory, and latency. Benchmark representative cold and repeated scans before changing them.
 
@@ -80,13 +73,7 @@ WHERE name IN (
     'disable_parquet_prefetching',
     'prefetch_all_parquet_files',
     'enable_external_file_cache',
-    'validate_external_file_cache',
     'parquet_metadata_cache',
-    'enable_http_metadata_cache',
-    'preserve_insertion_order',
-    'ducklake_max_retry_count',
-    'http_retries',
-    'http_retry_wait_ms',
-    'http_retry_backoff'
+    'preserve_insertion_order'
 );
 ```

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -45,9 +45,19 @@ PostHog sizes DuckDB from the selected worker and provides managed scratch stora
 | `memory_limit` | 90 GB (83.8 GiB) on the default worker | Limits DuckDB's buffer manager; PostHog derives it from the selected worker memory while reserving headroom for results, metadata, and the worker process |
 | `temp_directory` | Worker-local temporary storage | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
 | `max_temp_directory_size` | 90% of available temporary disk | Limits how much spill data DuckDB can write |
+| `disable_parquet_prefetching` | `false` (prefetching on) | Groups nearby Parquet reads to reduce object-storage requests; disabling it can reduce over-reading on selective scans but increase requests |
+| `prefetch_all_parquet_files` | `false` (remote files only) | Restricts prefetching to remote files; managed warehouse Parquet is remote, so this doesn't turn prefetching off |
+| `enable_external_file_cache` | `true` | Caches external-file byte ranges in worker memory under `memory_limit`, so repeated scans can avoid object-storage reads |
+| `validate_external_file_cache` | `VALIDATE_ALL` | Validates cached ranges against source metadata before reuse |
+| `parquet_metadata_cache` | `false` | Doesn't retain parsed Parquet footer and schema metadata across scans |
+| `enable_http_metadata_cache` | `false` | Keeps the shared cross-query HTTP metadata cache off; query-local metadata caching still occurs |
 | `preserve_insertion_order` | `true` | Preserves insertion order where possible; setting it to `false` can reduce memory use for large imports and exports when result order doesn't matter |
 | `ducklake_max_retry_count` | `100` | Retries optimistic write conflicts caused by concurrent writers |
-| `http_retries` | `10` with exponential backoff | Retries transient object-storage throttling instead of failing immediately |
+| `http_retries`, `http_retry_wait_ms`, `http_retry_backoff` | `10`, `500`, `2` | Retries transient object-storage throttling with exponential backoff instead of failing immediately |
+
+PostHog also caches object-storage byte ranges on managed local disk. This is separate from DuckDB's in-memory external file cache and needs no client configuration. The legacy `enable_object_cache` setting does nothing.
+
+Prefetch and cache settings trade object-storage requests, memory, and latency. Benchmark representative cold and repeated scans before changing them.
 
 Inspect the effective settings on your connection with:
 
@@ -59,9 +69,17 @@ WHERE name IN (
     'memory_limit',
     'temp_directory',
     'max_temp_directory_size',
+    'disable_parquet_prefetching',
+    'prefetch_all_parquet_files',
+    'enable_external_file_cache',
+    'validate_external_file_cache',
+    'parquet_metadata_cache',
+    'enable_http_metadata_cache',
     'preserve_insertion_order',
     'ducklake_max_retry_count',
-    'http_retries'
+    'http_retries',
+    'http_retry_wait_ms',
+    'http_retry_backoff'
 );
 ```
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -14,6 +14,8 @@ Need access first? [Join the waitlist](/context-warehouse/managed-warehouse), th
 
 Each active connection gets a dedicated DuckDB worker. The default worker fits most queries, but you can request more CPU or memory for large scans, joins, aggregations, sorts, and window functions.
 
+The cluster also automatically caches object-storage byte ranges on node-local NVMe storage, so workers on the same node can reuse recently read data instead of fetching it again. This is separate from DuckDB's per-worker in-memory cache.
+
 ## Choose a worker size
 
 Pass these settings when you open the connection:
@@ -50,8 +52,6 @@ PostHog sizes DuckDB from the selected worker and provides managed scratch stora
 | `enable_external_file_cache` | `true` | Caches external-file byte ranges in memory under `memory_limit`, so repeated scans can avoid object-storage reads |
 | `parquet_metadata_cache` | `false` | Doesn't retain parsed Parquet footer and schema metadata; enabling it can help repeated scans of the same files |
 | `preserve_insertion_order` | `true` | Preserves insertion order where possible; setting it to `false` can reduce memory use for large imports and exports when result order doesn't matter |
-
-PostHog also caches object-storage byte ranges on managed local disk. This is separate from DuckDB's in-memory external file cache and needs no client configuration.
 
 Prefetch and cache settings trade object-storage requests, memory, and latency. Benchmark representative cold and repeated scans before changing them.
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -58,7 +58,7 @@ For more information about these and other settings, see [DuckDB's configuration
 
 The default 15-core worker starts DuckDB with 38 threads. A simple query that reads many remote Parquet ranges but does little computation may run faster with a higher value, such as `SET threads = 60`. Each DuckDB thread can make one HTTP request at a time, so more threads can overlap more network reads.
 
-This tuning is a workaround for synchronous remote I/O. [Asynchronous I/O in an upcoming DuckDB release](https://duckdb.org/2026/07/31/asynchronous-io) will let DuckDB overlap requests without dedicating a thread to each one, reducing the need to increase `threads` solely for network concurrency.
+This kind of tuning will become less important after DuckDB releases [asynchronous I/O](https://duckdb.org/2026/07/31/asynchronous-io), which will handle network concurrency internally instead of relying on extra execution threads.
 
 Don't apply the same value to a CPU- or memory-bound `JOIN`, `GROUP BY`, sort, or window query. Extra threads can increase CPU contention and memory pressure, so keep these queries at the 38-thread default unless testing shows a benefit.
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -57,7 +57,7 @@ Prefetch and cache settings trade object-storage requests, memory, and latency. 
 
 For more information about these and other settings, see [DuckDB's configuration reference](https://duckdb.org/docs/stable/configuration/overview).
 
-### Example: Tune threads for remote reads
+### Tuning threads
 
 The default 15-core worker starts DuckDB with 38 threads. A simple query that reads many remote Parquet ranges but does little computation may run faster with a higher value, such as `SET threads = 60`. Each DuckDB thread can make one HTTP request at a time, so more threads can overlap more network reads.
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -20,7 +20,7 @@ Pass these settings when you open the connection:
 
 | Setting | Default | Range | What it controls |
 |---|---:|---:|---|
-| `duckgres.worker_cpu` | 15 | 1–46 | Worker CPU cores and DuckDB parallelism |
+| `duckgres.worker_cpu` | 15 | 1–46 | Worker CPU cores; DuckDB defaults to 2.5 threads per core, rounded up |
 | `duckgres.worker_memory` | 120 GiB | 4–360 GiB | Worker memory for joins, sorts, caching, and other intermediate data |
 | `duckgres.worker_ttl` | 1 minute | 0–24 hours | How long the worker stays warm after the connection closes |
 
@@ -63,7 +63,7 @@ For more information about these and other settings, see [DuckDB's configuration
 
 ### Example: Tune threads for remote reads
 
-On the default 15-core worker, a simple query that reads many remote Parquet ranges but does little computation may run faster with `SET threads = 45`. Each DuckDB thread can make one HTTP request at a time, so more threads can overlap more network reads.
+The default 15-core worker starts DuckDB with 38 threads. A simple query that reads many remote Parquet ranges but does little computation may run faster with a higher value, such as `SET threads = 60`. Each DuckDB thread can make one HTTP request at a time, so more threads can overlap more network reads.
 
 Don't apply the same value to a CPU- or memory-bound `JOIN`, `GROUP BY`, sort, or window query. Extra threads can increase CPU contention and memory pressure, so keep these queries at the 38-thread default unless testing shows a benefit.
 

--- a/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx
@@ -1,0 +1,68 @@
+---
+title: Performance tuning
+sidebar: Docs
+showTitle: true
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconFlask" title="The managed warehouse is in beta" type="action">
+
+Need access first? [Join the waitlist](/context-warehouse/managed-warehouse), then [set up your warehouse](/docs/data-warehouse/managed-warehouse/setup).
+
+</CalloutBox>
+
+Each active connection gets a dedicated DuckDB worker. The default worker fits most queries, but you can request more CPU or memory for large scans, joins, aggregations, sorts, and window functions.
+
+## Choose a worker size
+
+Pass these settings when you open the connection:
+
+| Setting | Default | Range | What it controls |
+|---|---:|---:|---|
+| `duckgres.worker_cpu` | 15 | 1–46 | Worker CPU cores and DuckDB parallelism |
+| `duckgres.worker_memory` | 120 GiB | 4–360 GiB | Worker memory for joins, sorts, caching, and other intermediate data |
+| `duckgres.worker_ttl` | 1 minute | 0–24 hours | How long the worker stays warm after the connection closes |
+
+You can set CPU and memory independently. The default shape uses 8 GiB per CPU core, which is a useful starting point when setting both. A longer TTL reduces cold starts for recurring jobs, but keeps the worker allocated for longer. Values outside the ranges are clamped.
+
+For example, this starts a 30-core, 240 GiB worker and keeps it warm for 30 minutes after disconnecting:
+
+```bash
+PGOPTIONS="-c duckgres.worker_cpu=30 -c duckgres.worker_memory=240Gi -c duckgres.worker_ttl=30m" \
+  psql "host=my-warehouse.dw.us.postwh.com dbname=ducklake user=root sslmode=require"
+```
+
+Most Postgres clients expose the same `options` connection parameter. These settings only apply when the connection opens. Running SQL `SET` commands later doesn't resize its worker.
+
+## Understand the DuckDB defaults
+
+PostHog sizes DuckDB from the selected worker and provides managed scratch storage. These are the effective defaults:
+
+| DuckDB setting | Effective default | How it works |
+|---|---|---|
+| `threads` | Worker CPU count | Sets the maximum parallelism available to the query |
+| `memory_limit` | 90 GB (83.8 GiB) on the default worker | Limits DuckDB's buffer manager; PostHog derives it from the selected worker memory while reserving headroom for results, metadata, and the worker process |
+| `temp_directory` | Worker-local temporary storage | Lets supported joins, sorts, aggregations, and window functions spill to disk when they exceed memory |
+| `max_temp_directory_size` | 90% of available temporary disk | Limits how much spill data DuckDB can write |
+| `preserve_insertion_order` | `true` | Preserves insertion order where possible; setting it to `false` can reduce memory use for large imports and exports when result order doesn't matter |
+| `ducklake_max_retry_count` | `100` | Retries optimistic write conflicts caused by concurrent writers |
+| `http_retries` | `10` with exponential backoff | Retries transient object-storage throttling instead of failing immediately |
+
+Inspect the effective settings on your connection with:
+
+```sql
+SELECT name, value, description
+FROM duckdb_settings()
+WHERE name IN (
+    'threads',
+    'memory_limit',
+    'temp_directory',
+    'max_temp_directory_size',
+    'preserve_insertion_order',
+    'ducklake_max_retry_count',
+    'http_retries'
+);
+```
+
+Prefer the `duckgres.worker_*` connection options over raising `threads` or `memory_limit` with SQL: changing a DuckDB setting doesn't add resources to the worker. Benchmark representative queries before and after resizing because not every query can use more cores or memory.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6346,6 +6346,16 @@ export const docsMenu = {
                     url: '/docs/data-warehouse/managed-warehouse/connect',
                     icon: 'IconTerminal',
                     color: 'seagreen',
+                    children: [
+                        {
+                            name: 'Overview',
+                            url: '/docs/data-warehouse/managed-warehouse/connect',
+                        },
+                        {
+                            name: 'Performance tuning',
+                            url: '/docs/data-warehouse/managed-warehouse/performance-tuning',
+                        },
+                    ],
                 },
                 {
                     name: 'Resources',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6352,7 +6352,7 @@ export const docsMenu = {
                             url: '/docs/data-warehouse/managed-warehouse/connect',
                         },
                         {
-                            name: 'Performance tuning',
+                            name: 'Performance',
                             url: '/docs/data-warehouse/managed-warehouse/performance-tuning',
                         },
                     ],


### PR DESCRIPTION
## Changes

- Add a concise performance tuning guide under **Connect and query** for the managed warehouse.
- Document worker CPU, memory, and idle TTL connection options, including production defaults, ranges, and a `psql` example.
- Explain the effective DuckDB defaults, including the 2.5× CPU-derived thread count, prefetching, caching, spill, and retry settings.
- Add focused guidance for tuning remote reads and show how to inspect settings on a live connection.

The 2.5× thread default is implemented in [PostHog/duckgres#1066](https://github.com/PostHog/duckgres/pull/1066).

## Checks

- `node scripts/fix-mdx.js contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx`
- `markdownlint-cli2 contents/docs/data-warehouse/managed-warehouse/performance-tuning.mdx`
- `prettier --check src/navs/index.js`
- `eslint src/navs/index.js`
- `git diff --check`
- Independent technical review against Duckgres worker profiles and production chart values

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable; no page moved)