### PR TITLE
fix navbar minimization not sticking

### DIFF
--- a/src/components/ReaderView/context/ReaderViewContext.tsx
+++ b/src/components/ReaderView/context/ReaderViewContext.tsx
@@ -21,12 +21,16 @@ const ReaderViewContext = createContext<ReaderViewContextType | undefined>(undef
 const isLabel = (item: any) => !item?.url && item?.name
 
 const SIDEBAR_PINNED_KEY = 'reader-sidebar-pinned'
+// Declaring here as a variable lets it survive re-renders - navigating between pages will not reset it.
+let persistedPinnedMemory: boolean | null = null
 
 const readPersistedPinned = (): boolean | null => {
     if (typeof window === 'undefined') return null
+    if (persistedPinnedMemory !== null) return persistedPinnedMemory
     const raw = localStorage.getItem(SIDEBAR_PINNED_KEY)
-    if (raw === 'true') return true
-    if (raw === 'false') return false
+    if (raw === 'true') persistedPinnedMemory = true
+    if (raw === 'false') persistedPinnedMemory = false
+    if (persistedPinnedMemory !== null) return persistedPinnedMemory
     return null
 }
 
@@ -45,8 +49,8 @@ export function ReaderViewProvider({
     // control cluster + off-canvas drawer. Only treat as narrow once the width
     // is actually known so SSR/first paint defaults to the desktop layout.
     const isNarrow = !!appWindow?.size?.width && appWindow.size.width < 672
-    const [isNavVisible, setIsNavVisible] = useState<boolean>(defaultNavVisible ?? true)
-    const [navUserToggled, setNavUserToggled] = useState(false)
+    const [isNavVisible, setIsNavVisible] = useState<boolean>(defaultNavVisible ?? persistedPinnedMemory ?? true)
+    const [navUserToggled, setNavUserToggled] = useState(persistedPinnedMemory !== null)
     // @6xl breakpoint is 72rem = 1152px
     const isLarge = appWindow?.size?.width && appWindow?.size?.width >= 1152
     const [isTocVisible, setIsTocVisible] = useState(true)
@@ -54,7 +58,7 @@ export function ReaderViewProvider({
     const [fullWidthContent, setFullWidthContent] = useState(false)
     const [backgroundImage, setBackgroundImage] = useState<string | null>(null)
     const [hasMounted, setHasMounted] = useState(false)
-    const [persistedStateLoaded, setPersistedStateLoaded] = useState(false)
+    const [persistedStateLoaded, setPersistedStateLoaded] = useState(persistedPinnedMemory !== null)
 
     // Hydrate persisted state after mount
     useEffect(() => {
@@ -72,6 +76,7 @@ export function ReaderViewProvider({
         setNavUserToggled(true)
         setIsNavVisible((prev) => {
             const next = !prev
+            persistedPinnedMemory = next
             if (typeof window !== 'undefined') {
                 localStorage.setItem(SIDEBAR_PINNED_KEY, String(next))
             }

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -805,6 +805,7 @@ interface LeftSidebarProps {
     children: React.ReactNode
     contentRef?: React.RefObject<HTMLElement>
     currentPath?: string
+    windowKey?: string
     isMdx?: boolean
     /** On narrow windows the sidebar renders as an off-canvas drawer instead
      *  of an inline column, driven by the props below. */
@@ -935,6 +936,7 @@ const SidebarTabButton = ({ tab, active, showLabel, stacked, onClick }: SidebarT
  * switching tabs instead of reloading from the top on each page.
  */
 const SIDEBAR_SCROLL_MEMORY = new Map<string, number>()
+const SIDEBAR_HOVERED_WINDOWS = new Set<string>()
 
 const sidebarScrollKeyFromPath = (path?: string): string => {
     if (!path) return 'default'
@@ -958,6 +960,7 @@ const LeftSidebar = ({
     children,
     contentRef,
     currentPath,
+    windowKey,
     isMdx = false,
     mobile = false,
     mobileOpen = false,
@@ -993,7 +996,23 @@ const LeftSidebar = ({
     // transitions and icon-row → icon-column layout flip share the same boolean.
     const isPinned = isNavVisible
     const [searchFocused, setSearchFocused] = useState(false)
-    const [hovered, setHovered] = useState(false)
+    const [hovered, setHovered] = useState(() => !!windowKey && SIDEBAR_HOVERED_WINDOWS.has(windowKey))
+    const panelRef = useRef<HTMLDivElement>(null)
+
+    // A ReaderView remount should not collapse a hovered sidebar during an
+    // in-window navigation. Keep it expanded for the first render, then clear
+    // stale memory after the browser recalculates which element is under the
+    // pointer. Keying by window prevents hover state leaking between windows.
+    useLayoutEffect(() => {
+        if (!hovered || !windowKey || mobile) return
+        const frame = requestAnimationFrame(() => {
+            if (!panelRef.current?.matches(':hover')) {
+                SIDEBAR_HOVERED_WINDOWS.delete(windowKey)
+                setHovered(false)
+            }
+        })
+        return () => cancelAnimationFrame(frame)
+    }, [hovered, mobile, windowKey])
     // On mobile the panel is a drawer: it's fully expanded whenever open and
     // fully hidden otherwise, so pin/hover state is bypassed entirely.
     const expanded = mobile ? mobileOpen : isPinned || searchFocused || hovered
@@ -1059,9 +1078,13 @@ const LeftSidebar = ({
     }
 
     const handleMouseEnter = () => {
-        if (!isPinned && !mobile) setHovered(true)
+        if (!isPinned && !mobile) {
+            if (windowKey) SIDEBAR_HOVERED_WINDOWS.add(windowKey)
+            setHovered(true)
+        }
     }
     const handleMouseLeave = () => {
+        if (windowKey) SIDEBAR_HOVERED_WINDOWS.delete(windowKey)
         setHovered(false)
     }
 
@@ -1084,6 +1107,7 @@ const LeftSidebar = ({
             }`}
         >
             <div
+                ref={panelRef}
                 onTransitionEnd={(e) => {
                     if (e.propertyName === 'width' && e.target === e.currentTarget && !expanded) {
                         setDisplayExpanded(false)
@@ -1570,6 +1594,7 @@ function ReaderViewContent({
                         menuTabs={menuTabs}
                         contentRef={onSearch ? undefined : contentRef}
                         currentPath={appWindow?.path}
+                        windowKey={appWindow?.key}
                         isMdx={body?.type === 'mdx'}
                     >
                         {leftSidebar || (!hideMenu && <Menu parent={parent as MenuItem} />)}


### PR DESCRIPTION
## Changes

Previously, navbars on the left side of the ReaderView would always reset to expanded after every refresh or remount due to an effect race. This PR fixes this to persist user preference.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>