### PR TITLE
Teach suggest-links which words to wrap in a backlink

### DIFF
--- a/.claude/commands/suggest-links.md
+++ b/.claude/commands/suggest-links.md
@@ -46,10 +46,12 @@ Scan the content for opportunities to add internal links. For each suggestion, p
 
 ## Step 4: Suggest backlinks (existing posts → new post)
 
-Find at least 3 existing posts in `contents/` that would naturally link to the new content. For each:
+Find existing posts in `contents/` that would naturally link to the new content. Three is a reasonable target, **not a quota** — a backlink that has to be argued for is one the author will delete. Two strong backlinks beat five padded ones, so drop any candidate that only half-fits.
+
+For each:
 
 1. Read the candidate file to find an **existing** sentence whose topic closely matches a specific section of the new post — one that already contains words you can wrap a link around. If no such sentence exists, skip that candidate rather than writing one.
-2. Suggest wrapping the link around existing text in that sentence — do not reword the sentence beyond what's needed to insert the `[...]()` markup. **Prefer linking to a specific section anchor** (e.g., `/founders/my-post#section-name`) rather than just the root URL, so readers land in the most relevant part.
+2. Suggest wrapping the link around existing text in that sentence — do not reword the sentence beyond what's needed to insert the `[...]()` markup. Link to a specific section anchor (e.g., `/founders/my-post#section-name`) when the sentence points at one particular part of the new post; link to the root URL when it points at the post's overall argument. Don't force an anchor on for its own sake.
 3. Write anchor text that fits naturally into the surrounding sentence. **Do not use the article title as anchor text.** The link should feel like it belongs in the prose, not like a citation. Good examples:
    - "making those traits [queryable across every team](/founders/growth-metrics-for-startups#2-make-customer-traits-queryable-across-all-functions)"
    - "[Consistent growth in ICP customers](/founders/growth-metrics-for-startups#4-be-opinionated-but-defensible-with-your-numbers) who pay..."
@@ -58,9 +60,19 @@ Find at least 3 existing posts in `contents/` that would naturally link to the n
 ### Backlink rules
 
 - **Find the most relevant existing posts** by searching for content that discusses the same concepts as the new post's sections. Use `grep` or `Bash` if needed.
-- **Match section to section.** Don't just link to the new post's root — link to the specific `#anchor` that matches the concept being discussed in the existing post. Derive the anchor from the heading text (lowercase, spaces → hyphens, punctuation removed).
+- **Link the thing, not the claim.** This is the mistake authors most often have to undo. Within a sentence, pick the concrete noun phrase — the mechanism, artifact, or practice being named — not the rhetorical payload the sentence is building toward. Wrapping the punchline turns the author's own emphasis into navigation and reads as though the link is making the argument for them.
+
+  | Sentence | Don't link | Link |
+  | --- | --- | --- |
+  | "This means we can have a world where humans review code less. … We're continuing to work on tools and agentic flows we can use in CI…" | "a world where humans review code less" | "tools and agentic flows we can use in CI" |
+  | "If you need to be involved in every code review, you will always be the bottleneck. Instead, put yourself outside of the loop by building a pipeline that…" | "you will always be the bottleneck" | "building a pipeline" |
+
+- **Keep the anchor tight.** Wrap the shortest phrase that still names the concept. Don't swallow a whole clause or a full list — if the sentence reads "your moat is the source code, usage data, customer data, and product skills you feed it", link a span within the list, not the entire predicate. A long anchor underlines half the sentence and buries the emphasis.
+- **Leave punctuation outside the link.** Anchors ending in a comma, period, or colon (`[customer data,](...)`) look like a selection error rather than a choice. Trim to the last word of the phrase.
+- **Match section to section where a section is the referent.** Derive the anchor from the heading text (lowercase, spaces → hyphens, punctuation removed). But a root-URL link is correct when the sentence gestures at the post as a whole — see step 2.
 - **The backlink must fit within an existing sentence.** Wrap the link around words already present in the candidate post. Never propose a new sentence, clause, or "further reading" line to carry the link — if there's no existing text to attach it to, skip the candidate.
 - **Don't use the new article's title as anchor text.** Describe the concept, not the article.
+- **Read the linked sentence back before proposing it.** If removing the link markup would change nothing about how the sentence reads, it's a good backlink. If the sentence now leans on the link to finish its point, move it.
 
 ## Step 5: Output
 


### PR DESCRIPTION
## Changes

Updates the backlink guidance in `/suggest-links` based on the corrections an author made by hand to a batch of generated backlinks in [#19440](https://github.com/PostHog/posthog.com/pull/19440).

The recurring problem: links landed on the **rhetorical payload** of a sentence rather than the concrete thing it names — "you will always be the bottleneck" instead of "building a pipeline". That turns the author's own emphasis into navigation, so nearly every one had to be moved or deleted.

Adds a "link the thing, not the claim" rule with before/after examples drawn from those corrections, plus rules on keeping the anchor tight, leaving trailing punctuation outside it, and reading the sentence back before proposing it. Also drops the "at least 3" floor, which pushed marginal candidates over the line, and softens the section-anchor preference — a root-URL link is right when the sentence points at a post's overall argument rather than one section.

**Why:** the command produced backlinks that were individually defensible but read wrong in context, so the cost landed on the author to undo rather than on the tool to get right.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build (n/a — agent command, not a page)
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*