### PR TITLE
chore(handbook): add Lenny and Every partnerships to startups page

### DIFF
--- a/contents/handbook/marketing/startups.md
+++ b/contents/handbook/marketing/startups.md
@@ -1,12 +1,12 @@
 ---
-title: Startups & Y Combinator
+title: Startup programs and partnerships
 sidebar: Handbook
 showTitle: true
 ---
 
 > **Want to apply for our startups program?** [Sign-up here](/startups), or [apply on Bookface if you're in Y Combinator](https://bookface.ycombinator.com/deals/687). 
 
-We run two special programs for early-stage teams. The primary place for discussing both programs is the [#project-startups-and-yc](https://posthog.slack.com/archives/C088RSQKH2T) channel in Slack.
+We run two special programs for early-stage teams, plus [external partnerships](#external-partnerships) with Lenny's Product Pass and Every. The primary place for discussing these is the [#project-startups-and-yc](https://posthog.slack.com/archives/C088RSQKH2T) channel in Slack.
 
 | Feature                     | Startups                                              | Y Combinator                                          |
 | --------------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
@@ -58,6 +58,27 @@ You can find the copy for the latest deal on Bookface in this [doc](https://docs
 YC teams must apply via [our secret YC page](https://app.posthog.com/startups/yc), where we ask for a screenshot from Bookface to prove their eligibility.
 
 We track all PostHog for YC applications in [this Zapier table](https://tables.zapier.com/app/tables/t/01JRCYMWYAJNP3K0B6GTYKKBQB).
+
+## External partnerships
+
+Alongside the two programs above, we run two external partnerships that offer PostHog benefits to partner audiences. See [campaigns and coupons](/handbook/marketing/campaigns-and-coupons) for how redemption works.
+
+### Lenny's Product Pass
+
+Subscribers with [Lenny's Newsletter](https://www.lennysnewsletter.com/) Product Pass get:
+
+-   2x the free tier limits on all usage-based products
+-   The Scale add-on for free
+-   Valid for one year
+
+Product exclusions are the same as for the PostHog for Startups plan, including PostHog Desktop, Inbox, and Replay Vision. See [posthog.com/startups](/startups) for more detail.
+
+### Every
+
+Subscribers to [Every](https://every.to/) get:
+
+-   $2,000 in credits for core products
+-   $2,000 in credits for AI products (the same four products excluded from startup credits: PostHog Desktop, Replay Vision, PostHog AI, and Inbox)
 
 ## What happens after companies apply?
 

--- a/contents/handbook/marketing/startups.md
+++ b/contents/handbook/marketing/startups.md
@@ -6,7 +6,7 @@ showTitle: true
 
 > **Want to apply for our startups program?** [Sign-up here](/startups), or [apply on Bookface if you're in Y Combinator](https://bookface.ycombinator.com/deals/687). 
 
-We run two special programs for early-stage teams, plus [external partnerships](#external-partnerships) with Lenny's Product Pass and Every. The primary place for discussing these is the [#project-startups-and-yc](https://posthog.slack.com/archives/C088RSQKH2T) channel in Slack.
+We run two special programs for early-stage teams, plus external partnerships with [Lenny's Product Pass and Every.to](#external-partnerships). The primary place for discussing these is the [#project-startups-and-students](https://posthog.slack.com/archives/C088RSQKH2T) channel in Slack, where we also discuss [PostHog for Students](/students).
 
 | Feature                     | Startups                                              | Y Combinator                                          |
 | --------------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
@@ -73,12 +73,12 @@ Subscribers with [Lenny's Newsletter](https://www.lennysnewsletter.com/) Product
 
 Product exclusions are the same as for the PostHog for Startups plan, including PostHog Desktop, Inbox, and Replay Vision. See [posthog.com/startups](/startups) for more detail.
 
-### Every
+### Every.to
 
 Subscribers to [Every](https://every.to/) get:
 
 -   $2,000 in credits for core products
--   $2,000 in credits for AI products (the same four products excluded from startup credits: PostHog Desktop, Replay Vision, PostHog AI, and Inbox)
+-   $2,000 in credits for AI products, with the same exclusions as for the PostHog for Startups program
 
 ## What happens after companies apply?
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1107,7 +1107,7 @@ export const handbookSidebar = [
                         url: '/handbook/marketing/press',
                     },
                     {
-                        name: 'Startups & YC Programs',
+                        name: 'Startup programs and partnerships',
                         url: '/handbook/marketing/startups',
                     },
                     {


### PR DESCRIPTION
## Changes

The startups handbook page only covered the two credit programs, so the Lenny and Every partnerships had no internal documentation.

- Retitles the page and its handbook nav entry to "Startup programs and partnerships".
- Adds an "External partnerships" section covering Lenny's Product Pass and Every.
- Lenny's Product Pass: 2x free tier limits and the free Scale add-on for one year, with the same product exclusions as PostHog for Startups.
- Every: $2,000 in credits for core products and $2,000 for AI products (the four products excluded from startup credits).

**Why:** we now have two external partnerships alongside the startup and YC programs, and the team needs one page describing all of them.

No screenshots: text-only handbook change plus a nav label rename.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not moved, no redirect needed)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
