### PR TITLE
docs: clarify partner program eligibility

### DIFF
--- a/contents/handbook/marketing/startups.md
+++ b/contents/handbook/marketing/startups.md
@@ -75,9 +75,9 @@ Product exclusions are the same as for the PostHog for Startups plan, including 
 
 ### Every.to
 
-Subscribers to [Every](https://every.to/) who are new paying customers get:
+Subscribers to [Every](https://every.to/) get:
 
--   $2,000 in credits for core products, with the same exclusions as for the PostHog for Startups program
+-   $2,000 in credits for core products (only for new paying customers), with the same exclusions as for the PostHog for Startups program
 -   $2,000 in credits for AI products, covering products excluded from the PostHog for Startups program
 
 ## What happens after companies apply?

--- a/contents/handbook/marketing/startups.md
+++ b/contents/handbook/marketing/startups.md
@@ -65,7 +65,7 @@ Alongside the two programs above, we run two external partnerships that offer Po
 
 ### Lenny's Product Pass
 
-Subscribers with [Lenny's Newsletter](https://www.lennysnewsletter.com/) Product Pass get:
+Subscribers with [Lenny's Newsletter](https://www.lennysnewsletter.com/) Product Pass who are new paying customers get:
 
 -   2x the free tier limits on all usage-based products
 -   The Scale add-on for free
@@ -75,10 +75,10 @@ Product exclusions are the same as for the PostHog for Startups plan, including 
 
 ### Every.to
 
-Subscribers to [Every](https://every.to/) get:
+Subscribers to [Every](https://every.to/) who are new paying customers get:
 
--   $2,000 in credits for core products
--   $2,000 in credits for AI products, with the same exclusions as for the PostHog for Startups program
+-   $2,000 in credits for core products, with the same exclusions as for the PostHog for Startups program
+-   $2,000 in credits for AI products, covering products excluded from the PostHog for Startups program
 
 ## What happens after companies apply?
 


### PR DESCRIPTION
## Changes

Clarifies eligibility for the partner offers added in #19451.

- Lenny's Product Pass is only for new paying customers.
- Every's core-product credits are only for new paying customers and follow the same exclusions as PostHog for Startups.
- Every's AI-product credits cover products excluded from PostHog for Startups.

Follow-up to https://github.com/PostHog/posthog.com/pull/19451#discussion_r3774189722.

No screenshots: text-only handbook change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not moved, no redirect needed)
