### PR TITLE
Add "Install with AI" alongside "Get started" on the context warehouse page

### DIFF
--- a/src/components/ContextWarehouseCTA/README.md
+++ b/src/components/ContextWarehouseCTA/README.md
@@ -2,13 +2,17 @@
 
 The CTA slot on `/context-warehouse`, behind the `context-warehouse-cta` experiment.
 
-| Variant          | What renders                                                                       |
-| ---------------- | ---------------------------------------------------------------------------------- |
-| `control`        | The button the page shipped with, into `app.posthog.com/data-management/sources`    |
-| `wizard-command` | `<WizardCommand command="warehouse" />` — copies `npx -y @posthog/wizard@latest warehouse` |
+| Variant           | What renders                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `control`         | The button the page shipped with, into `app.posthog.com/data-management/sources`                 |
+| `install-with-ai` | That button, plus an "Install with AI" button that reveals the wizard command — additive         |
+| `wizard-command`  | The wizard command instead of the button, copying `npx -y @posthog/wizard@latest warehouse`      |
 
-Anything other than `wizard-command` (including an unresolved or blocked flag) falls back to control, so
-the page never renders without a CTA.
+Any value other than a known variant key — control, an unresolved flag, an adblocked one — falls back to
+control, so the page never renders without a CTA.
+
+`install-with-ai` mirrors the pattern already used elsewhere on the site: "Get started" keeps its place and
+the terminal route is offered next to it rather than replacing it.
 
 ## Usage
 
@@ -18,18 +22,19 @@ import ContextWarehouseCTA from 'components/ContextWarehouseCTA'
 <ContextWarehouseCTA label="Get started" />
 ```
 
-`label` sets the control button's text and is ignored by the wizard variant. Both CTAs on the page render
+`label` sets the "Get started" button's text and is ignored by `wizard-command`. Both CTAs on the page render
 through this component, so a visitor gets one consistent path from top to bottom rather than a mix.
 
 ## Notes
 
-- Client-only via `RenderInClient`, like `Home/HeroCTA` — a server-rendered variant would be wrong for half
-  of visitors and cause a hydration mismatch. The placeholder reserves the CTA height so the surrounding
-  card doesn't shift when flags resolve.
+- Client-only via `RenderInClient`, like `Home/HeroCTA` — a server-rendered variant would be wrong for most
+  visitors and cause a hydration mismatch. The placeholder reserves the CTA height so the surrounding card
+  doesn't shift when flags resolve.
 - Reading the flag inside the component is what emits the exposure event, so only people who actually load
   the page enter the experiment.
-- Clicks are tracked as `contextwarehousecta-getstarted-clicked` and `contextwarehousecta-copy-clicked`,
-  mirroring the homepage `homepagecta-*` naming so the two tests can be compared.
+- Clicks are tracked as `contextwarehousecta-getstarted-clicked`, `contextwarehousecta-installwithai-clicked`,
+  and `contextwarehousecta-copy-clicked`, mirroring the homepage `homepagecta-*` naming so the two tests can
+  be compared. The "Install with AI" event only fires when the panel is opened, not when it's collapsed again.
 
 ## Cleanup
 

--- a/src/components/ContextWarehouseCTA/README.md
+++ b/src/components/ContextWarehouseCTA/README.md
@@ -1,18 +1,11 @@
 # ContextWarehouseCTA
 
-The CTA slot on `/context-warehouse`, behind the `context-warehouse-cta` experiment.
+The CTA slot on `/context-warehouse`: a "Get started" button into in-app source setup, with an
+"Install with AI" button beside it that reveals `npx @posthog/wizard warehouse`.
 
-| Variant           | What renders                                                                                    |
-| ----------------- | ----------------------------------------------------------------------------------------------- |
-| `control`         | The button the page shipped with, into `app.posthog.com/data-management/sources`                 |
-| `install-with-ai` | That button, plus an "Install with AI" button that reveals the wizard command — additive         |
-| `wizard-command`  | The wizard command instead of the button, copying `npx -y @posthog/wizard@latest warehouse`      |
-
-Any value other than a known variant key — control, an unresolved flag, an adblocked one — falls back to
-control, so the page never renders without a CTA.
-
-`install-with-ai` mirrors the pattern already used elsewhere on the site: "Get started" keeps its place and
-the terminal route is offered next to it rather than replacing it.
+Additive on purpose — the button keeps its place and the terminal route is offered next to it, matching the
+pattern used elsewhere on the site. The wizard scans the user's codebase for databases and APIs and connects
+every source it finds, rather than having them configure sources one at a time.
 
 ## Usage
 
@@ -22,21 +15,16 @@ import ContextWarehouseCTA from 'components/ContextWarehouseCTA'
 <ContextWarehouseCTA label="Get started" />
 ```
 
-`label` sets the "Get started" button's text and is ignored by `wizard-command`. Both CTAs on the page render
-through this component, so a visitor gets one consistent path from top to bottom rather than a mix.
+`label` sets the "Get started" button's text. Both CTAs on the page render through this component, so a
+visitor gets one consistent path from top to bottom rather than a mix.
 
 ## Notes
 
-- Client-only via `RenderInClient`, like `Home/HeroCTA` — a server-rendered variant would be wrong for most
-  visitors and cause a hydration mismatch. The placeholder reserves the CTA height so the surrounding card
-  doesn't shift when flags resolve.
-- Reading the flag inside the component is what emits the exposure event, so only people who actually load
-  the page enter the experiment.
+- `WizardCommand` displays the clean `npx @posthog/wizard warehouse` and copies the pinned
+  `npx -y @posthog/wizard@latest warehouse`.
+- The reveal animates `grid-template-rows` rather than height, so it stays smooth without measuring the
+  command's height (which varies with the card's width).
 - Clicks are tracked as `contextwarehousecta-getstarted-clicked`, `contextwarehousecta-installwithai-clicked`,
-  and `contextwarehousecta-copy-clicked`, mirroring the homepage `homepagecta-*` naming so the two tests can
-  be compared. The "Install with AI" event only fires when the panel is opened, not when it's collapsed again.
-
-## Cleanup
-
-When the experiment ends, inline the winning variant into `src/pages/context-warehouse/index.tsx` and delete
-this component along with the `context-warehouse-cta` flag.
+  and `contextwarehousecta-copy-clicked`, mirroring the homepage `homepagecta-*` naming. These aren't wired to
+  an experiment — they're here so the split between the two routes stays visible in the data. The
+  "Install with AI" event only fires when the panel is opened, not when it's collapsed again.

--- a/src/components/ContextWarehouseCTA/README.md
+++ b/src/components/ContextWarehouseCTA/README.md
@@ -1,0 +1,37 @@
+# ContextWarehouseCTA
+
+The CTA slot on `/context-warehouse`, behind the `context-warehouse-cta` experiment.
+
+| Variant          | What renders                                                                       |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `control`        | The button the page shipped with, into `app.posthog.com/data-management/sources`    |
+| `wizard-command` | `<WizardCommand command="warehouse" />` — copies `npx -y @posthog/wizard@latest warehouse` |
+
+Anything other than `wizard-command` (including an unresolved or blocked flag) falls back to control, so
+the page never renders without a CTA.
+
+## Usage
+
+```tsx
+import ContextWarehouseCTA from 'components/ContextWarehouseCTA'
+
+<ContextWarehouseCTA label="Get started" />
+```
+
+`label` sets the control button's text and is ignored by the wizard variant. Both CTAs on the page render
+through this component, so a visitor gets one consistent path from top to bottom rather than a mix.
+
+## Notes
+
+- Client-only via `RenderInClient`, like `Home/HeroCTA` — a server-rendered variant would be wrong for half
+  of visitors and cause a hydration mismatch. The placeholder reserves the CTA height so the surrounding
+  card doesn't shift when flags resolve.
+- Reading the flag inside the component is what emits the exposure event, so only people who actually load
+  the page enter the experiment.
+- Clicks are tracked as `contextwarehousecta-getstarted-clicked` and `contextwarehousecta-copy-clicked`,
+  mirroring the homepage `homepagecta-*` naming so the two tests can be compared.
+
+## Cleanup
+
+When the experiment ends, inline the winning variant into `src/pages/context-warehouse/index.tsx` and delete
+this component along with the `context-warehouse-cta` flag.

--- a/src/components/ContextWarehouseCTA/index.tsx
+++ b/src/components/ContextWarehouseCTA/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { RenderInClient } from 'components/RenderInClient'
+import { TrackedCTA } from 'components/CallToAction'
+import WizardCommand from 'components/WizardCommand'
+import usePostHog from '../../hooks/usePostHog'
+
+export const CONTEXT_WAREHOUSE_CTA_FLAG = 'context-warehouse-cta'
+
+const SOURCES_URL = 'https://app.posthog.com/data-management/sources'
+
+const GET_STARTED_EVENT = 'contextwarehousecta-getstarted-clicked'
+const COPY_EVENT = 'contextwarehousecta-copy-clicked'
+
+/**
+ * Control. The CTA exactly as it shipped before the experiment: a button into the in-app source
+ * setup flow. Tracked so the experiment can compare click-through against the wizard variant, not
+ * just the downstream source-connected rate.
+ */
+const GetStartedButton = ({ label }: { label: string }) => (
+    <TrackedCTA to={SOURCES_URL} externalNoIcon size="md" event={{ name: GET_STARTED_EVENT }}>
+        {label}
+    </TrackedCTA>
+)
+
+/**
+ * Test. `npx @posthog/wizard warehouse` in place of the button — the wizard auto-detects databases
+ * and APIs in the user's codebase and connects them, rather than sending them to configure a source
+ * by hand. WizardCommand copies the pinned `npx -y @posthog/wizard@latest warehouse` form.
+ */
+const WizardCommandCTA = () => {
+    const posthog = usePostHog()
+
+    return <WizardCommand command="warehouse" variant="bordered" onCopy={() => posthog?.capture(COPY_EVENT)} />
+}
+
+const VariantSlot = ({ label }: { label: string }) => {
+    const posthog = usePostHog()
+
+    // Reading the flag here is what emits the exposure event, so it fires only for people who
+    // actually load this page — which is what the experiment's exposure criteria expect.
+    return posthog?.getFeatureFlag?.(CONTEXT_WAREHOUSE_CTA_FLAG) === 'wizard-command' ? (
+        <WizardCommandCTA />
+    ) : (
+        <GetStartedButton label={label} />
+    )
+}
+
+/**
+ * The CTA slot on /context-warehouse, behind the `context-warehouse-cta` experiment: the existing
+ * "Get started" button (control) vs the warehouse wizard command (test). Both of the page's CTAs
+ * render through this component so a visitor sees one consistent path down the whole page.
+ *
+ * Renders client-side only, like the homepage HeroCTA — a server-rendered variant would be wrong for
+ * half of visitors and cause a hydration mismatch. The placeholder reserves the CTA's height so the
+ * surrounding card doesn't shift once flags resolve.
+ */
+export default function ContextWarehouseCTA({ label = 'Get started' }: { label?: string }): JSX.Element {
+    return (
+        <RenderInClient
+            placeholder={<div className="h-10" aria-hidden />}
+            render={() => <VariantSlot label={label} />}
+        />
+    )
+}

--- a/src/components/ContextWarehouseCTA/index.tsx
+++ b/src/components/ContextWarehouseCTA/index.tsx
@@ -1,31 +1,29 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { RenderInClient } from 'components/RenderInClient'
-import { TrackedCTA } from 'components/CallToAction'
+import { CallToAction, TrackedCTA } from 'components/CallToAction'
 import WizardCommand from 'components/WizardCommand'
 import usePostHog from '../../hooks/usePostHog'
+import { cn } from '../../utils'
 
 export const CONTEXT_WAREHOUSE_CTA_FLAG = 'context-warehouse-cta'
 
 const SOURCES_URL = 'https://app.posthog.com/data-management/sources'
 
 const GET_STARTED_EVENT = 'contextwarehousecta-getstarted-clicked'
+const INSTALL_WITH_AI_EVENT = 'contextwarehousecta-installwithai-clicked'
 const COPY_EVENT = 'contextwarehousecta-copy-clicked'
 
-/**
- * Control. The CTA exactly as it shipped before the experiment: a button into the in-app source
- * setup flow. Tracked so the experiment can compare click-through against the wizard variant, not
- * just the downstream source-connected rate.
- */
-const GetStartedButton = ({ label }: { label: string }) => (
-    <TrackedCTA to={SOURCES_URL} externalNoIcon size="md" event={{ name: GET_STARTED_EVENT }}>
+/** The button the page ships with today: straight into the in-app source setup flow. */
+const GetStartedButton = ({ label, width = 'auto' }: { label: string; width?: string }) => (
+    <TrackedCTA to={SOURCES_URL} externalNoIcon size="md" width={width} event={{ name: GET_STARTED_EVENT }}>
         {label}
     </TrackedCTA>
 )
 
 /**
- * Test. `npx @posthog/wizard warehouse` in place of the button — the wizard auto-detects databases
- * and APIs in the user's codebase and connects them, rather than sending them to configure a source
- * by hand. WizardCommand copies the pinned `npx -y @posthog/wizard@latest warehouse` form.
+ * `npx @posthog/wizard warehouse` — the wizard scans the user's codebase for databases and APIs and
+ * connects them, instead of sending them to configure one source at a time. WizardCommand displays
+ * the clean form and copies the pinned `npx -y @posthog/wizard@latest warehouse`.
  */
 const WizardCommandCTA = () => {
     const posthog = usePostHog()
@@ -33,25 +31,89 @@ const WizardCommandCTA = () => {
     return <WizardCommand command="warehouse" variant="bordered" onCopy={() => posthog?.capture(COPY_EVENT)} />
 }
 
+/* -------------------------------------------------------------------------------------------------
+ * control — the CTA exactly as it shipped before the experiment.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantControl = ({ label }: { label: string }) => <GetStartedButton label={label} />
+
+/* -------------------------------------------------------------------------------------------------
+ * install-with-ai — additive. "Get started" keeps its place and "Install with AI" sits beside it,
+ * revealing the command on click. This is the pattern the rest of the site already uses, and it's the
+ * conservative arm: the homepage test showed that taking "Get started" away is what costs conversion,
+ * not that offering the terminal route hurts.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantInstallWithAI = ({ label }: { label: string }) => {
+    const [showCommand, setShowCommand] = useState(false)
+    const posthog = usePostHog()
+
+    const toggleCommand = () => {
+        setShowCommand((current) => {
+            // Only count opening it — a second click is the user collapsing it again, not new intent.
+            if (!current) {
+                posthog?.capture(INSTALL_WITH_AI_EVENT)
+            }
+            return !current
+        })
+    }
+
+    return (
+        <div className="@container">
+            <div className="flex flex-col @[340px]:flex-row gap-2">
+                <GetStartedButton label={label} />
+                <CallToAction type="secondary" size="md" onClick={toggleCommand}>
+                    <span className="whitespace-nowrap">Install with AI</span>
+                </CallToAction>
+            </div>
+            <div
+                className={cn(
+                    'grid transition-[grid-template-rows] duration-300 ease-in-out',
+                    showCommand ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                )}
+            >
+                <div className="overflow-hidden min-h-0">
+                    <div className="pt-3 space-y-1.5">
+                        <p className="!text-xs text-secondary m-0">Happier in the terminal? Skip the browser:</p>
+                        <WizardCommandCTA />
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * wizard-command — all in. The command replaces the button outright. Worth measuring even though the
+ * equivalent homepage arm didn't win, because the warehouse subcommand connects every source it finds
+ * in one pass, so the upside here is more data connected rather than just a faster signup.
+ * ---------------------------------------------------------------------------------------------- */
+
+const VariantWizardCommand = () => <WizardCommandCTA />
+
+const VARIANTS: Record<string, ({ label }: { label: string }) => JSX.Element> = {
+    'install-with-ai': VariantInstallWithAI,
+    'wizard-command': VariantWizardCommand,
+}
+
 const VariantSlot = ({ label }: { label: string }) => {
     const posthog = usePostHog()
 
     // Reading the flag here is what emits the exposure event, so it fires only for people who
     // actually load this page — which is what the experiment's exposure criteria expect.
-    return posthog?.getFeatureFlag?.(CONTEXT_WAREHOUSE_CTA_FLAG) === 'wizard-command' ? (
-        <WizardCommandCTA />
-    ) : (
-        <GetStartedButton label={label} />
-    )
+    const variant = posthog?.getFeatureFlag?.(CONTEXT_WAREHOUSE_CTA_FLAG)
+    const Variant = (typeof variant === 'string' && VARIANTS[variant]) || VariantControl
+
+    return <Variant label={label} />
 }
 
 /**
- * The CTA slot on /context-warehouse, behind the `context-warehouse-cta` experiment: the existing
- * "Get started" button (control) vs the warehouse wizard command (test). Both of the page's CTAs
- * render through this component so a visitor sees one consistent path down the whole page.
+ * The CTA slot on /context-warehouse, behind the `context-warehouse-cta` experiment. Any value other
+ * than a known variant key — control, an unresolved flag, an adblocked one — falls back to the
+ * "Get started" button, so the page never renders without a CTA.
  *
  * Renders client-side only, like the homepage HeroCTA — a server-rendered variant would be wrong for
- * half of visitors and cause a hydration mismatch. The placeholder reserves the CTA's height so the
+ * most visitors and cause a hydration mismatch. The placeholder reserves the CTA's height so the
  * surrounding card doesn't shift once flags resolve.
  */
 export default function ContextWarehouseCTA({ label = 'Get started' }: { label?: string }): JSX.Element {

--- a/src/components/ContextWarehouseCTA/index.tsx
+++ b/src/components/ContextWarehouseCTA/index.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from 'react'
-import { RenderInClient } from 'components/RenderInClient'
 import { CallToAction, TrackedCTA } from 'components/CallToAction'
 import WizardCommand from 'components/WizardCommand'
 import usePostHog from '../../hooks/usePostHog'
 import { cn } from '../../utils'
-
-export const CONTEXT_WAREHOUSE_CTA_FLAG = 'context-warehouse-cta'
 
 const SOURCES_URL = 'https://app.posthog.com/data-management/sources'
 
@@ -13,38 +10,21 @@ const GET_STARTED_EVENT = 'contextwarehousecta-getstarted-clicked'
 const INSTALL_WITH_AI_EVENT = 'contextwarehousecta-installwithai-clicked'
 const COPY_EVENT = 'contextwarehousecta-copy-clicked'
 
-/** The button the page ships with today: straight into the in-app source setup flow. */
-const GetStartedButton = ({ label, width = 'auto' }: { label: string; width?: string }) => (
-    <TrackedCTA to={SOURCES_URL} externalNoIcon size="md" width={width} event={{ name: GET_STARTED_EVENT }}>
-        {label}
-    </TrackedCTA>
-)
-
 /**
- * `npx @posthog/wizard warehouse` — the wizard scans the user's codebase for databases and APIs and
- * connects them, instead of sending them to configure one source at a time. WizardCommand displays
- * the clean form and copies the pinned `npx -y @posthog/wizard@latest warehouse`.
+ * The CTA slot on /context-warehouse: "Get started" into the in-app source setup, with "Install with
+ * AI" beside it revealing `npx @posthog/wizard warehouse` — the wizard scans the user's codebase for
+ * databases and APIs and connects every source it finds, instead of asking them to configure sources
+ * one at a time. WizardCommand displays the clean command and copies the pinned
+ * `npx -y @posthog/wizard@latest warehouse`.
+ *
+ * Additive on purpose: the button keeps its place and the terminal route is offered next to it, which
+ * is the pattern the rest of the site already uses. Both CTAs on the page render through this
+ * component so a visitor gets one consistent path from top to bottom.
+ *
+ * The three events below aren't wired to an experiment — they're here so the split between the two
+ * routes stays visible in the data.
  */
-const WizardCommandCTA = () => {
-    const posthog = usePostHog()
-
-    return <WizardCommand command="warehouse" variant="bordered" onCopy={() => posthog?.capture(COPY_EVENT)} />
-}
-
-/* -------------------------------------------------------------------------------------------------
- * control — the CTA exactly as it shipped before the experiment.
- * ---------------------------------------------------------------------------------------------- */
-
-const VariantControl = ({ label }: { label: string }) => <GetStartedButton label={label} />
-
-/* -------------------------------------------------------------------------------------------------
- * install-with-ai — additive. "Get started" keeps its place and "Install with AI" sits beside it,
- * revealing the command on click. This is the pattern the rest of the site already uses, and it's the
- * conservative arm: the homepage test showed that taking "Get started" away is what costs conversion,
- * not that offering the terminal route hurts.
- * ---------------------------------------------------------------------------------------------- */
-
-const VariantInstallWithAI = ({ label }: { label: string }) => {
+export default function ContextWarehouseCTA({ label = 'Get started' }: { label?: string }): JSX.Element {
     const [showCommand, setShowCommand] = useState(false)
     const posthog = usePostHog()
 
@@ -61,11 +41,15 @@ const VariantInstallWithAI = ({ label }: { label: string }) => {
     return (
         <div className="@container">
             <div className="flex flex-col @[340px]:flex-row gap-2">
-                <GetStartedButton label={label} />
+                <TrackedCTA to={SOURCES_URL} externalNoIcon size="md" event={{ name: GET_STARTED_EVENT }}>
+                    {label}
+                </TrackedCTA>
                 <CallToAction type="secondary" size="md" onClick={toggleCommand}>
                     <span className="whitespace-nowrap">Install with AI</span>
                 </CallToAction>
             </div>
+            {/* Animating grid rows rather than height keeps the reveal smooth without measuring the
+                command's height, which varies with the card's width. */}
             <div
                 className={cn(
                     'grid transition-[grid-template-rows] duration-300 ease-in-out',
@@ -75,52 +59,14 @@ const VariantInstallWithAI = ({ label }: { label: string }) => {
                 <div className="overflow-hidden min-h-0">
                     <div className="pt-3 space-y-1.5">
                         <p className="!text-xs text-secondary m-0">Happier in the terminal? Skip the browser:</p>
-                        <WizardCommandCTA />
+                        <WizardCommand
+                            command="warehouse"
+                            variant="bordered"
+                            onCopy={() => posthog?.capture(COPY_EVENT)}
+                        />
                     </div>
                 </div>
             </div>
         </div>
-    )
-}
-
-/* -------------------------------------------------------------------------------------------------
- * wizard-command — all in. The command replaces the button outright. Worth measuring even though the
- * equivalent homepage arm didn't win, because the warehouse subcommand connects every source it finds
- * in one pass, so the upside here is more data connected rather than just a faster signup.
- * ---------------------------------------------------------------------------------------------- */
-
-const VariantWizardCommand = () => <WizardCommandCTA />
-
-const VARIANTS: Record<string, ({ label }: { label: string }) => JSX.Element> = {
-    'install-with-ai': VariantInstallWithAI,
-    'wizard-command': VariantWizardCommand,
-}
-
-const VariantSlot = ({ label }: { label: string }) => {
-    const posthog = usePostHog()
-
-    // Reading the flag here is what emits the exposure event, so it fires only for people who
-    // actually load this page — which is what the experiment's exposure criteria expect.
-    const variant = posthog?.getFeatureFlag?.(CONTEXT_WAREHOUSE_CTA_FLAG)
-    const Variant = (typeof variant === 'string' && VARIANTS[variant]) || VariantControl
-
-    return <Variant label={label} />
-}
-
-/**
- * The CTA slot on /context-warehouse, behind the `context-warehouse-cta` experiment. Any value other
- * than a known variant key — control, an unresolved flag, an adblocked one — falls back to the
- * "Get started" button, so the page never renders without a CTA.
- *
- * Renders client-side only, like the homepage HeroCTA — a server-rendered variant would be wrong for
- * most visitors and cause a hydration mismatch. The placeholder reserves the CTA's height so the
- * surrounding card doesn't shift once flags resolve.
- */
-export default function ContextWarehouseCTA({ label = 'Get started' }: { label?: string }): JSX.Element {
-    return (
-        <RenderInClient
-            placeholder={<div className="h-10" aria-hidden />}
-            render={() => <VariantSlot label={label} />}
-        />
     )
 }

--- a/src/pages/context-warehouse/index.tsx
+++ b/src/pages/context-warehouse/index.tsx
@@ -5,7 +5,7 @@ import Link from 'components/Link'
 import CloudinaryImage from 'components/CloudinaryImage'
 import { customerDataInfrastructureNav } from '../../hooks/useCustomerDataInfrastructureNavigation'
 import { TreeMenu } from 'components/TreeMenu'
-import { CallToAction } from 'components/CallToAction'
+import ContextWarehouseCTA from 'components/ContextWarehouseCTA'
 import {
     Hedgehog996,
     HedgehogCaveman,
@@ -613,14 +613,7 @@ export default function DataStack(): JSX.Element {
                                         ))}
                                     </ul>
                                     <div className="mt-6">
-                                        <CallToAction
-                                            to="https://app.posthog.com/data-management/sources"
-                                            externalNoIcon
-                                            size="md"
-                                            className="max-w-[175px]"
-                                        >
-                                            Get started
-                                        </CallToAction>
+                                        <ContextWarehouseCTA label="Get started" />
                                     </div>
                                 </div>
                                 <div className="hidden justify-center @lg/reader-content:flex">
@@ -706,13 +699,7 @@ export default function DataStack(): JSX.Element {
                                         the whole point.
                                     </p>
                                     <div className="flex flex-wrap items-center gap-3">
-                                        <CallToAction
-                                            to="https://app.posthog.com/data-management/sources"
-                                            externalNoIcon
-                                            size="md"
-                                        >
-                                            Get Started
-                                        </CallToAction>
+                                        <ContextWarehouseCTA label="Get Started" />
                                         <p className="mb-0 text-sm text-secondary">
                                             Not using PostHog?{' '}
                                             <Link


### PR DESCRIPTION
## Changes

Adds an "Install with AI" button next to "Get started" on `/context-warehouse`, revealing `npx @posthog/wizard warehouse` (copying the pinned `npx -y @posthog/wizard@latest warehouse`). Both CTAs on the page render through a new `ContextWarehouseCTA` component, so a visitor gets one consistent path from top to bottom.

Additive rather than a replacement: "Get started" keeps its place and the terminal route is offered beside it, matching the pattern used elsewhere on the site.

Clicks are tracked as `contextwarehousecta-getstarted-clicked` / `-installwithai-clicked` / `-copy-clicked`, mirroring the homepage `homepagecta-*` naming. There's no experiment behind this — the events are there so the split between the two routes stays visible.

## Why

The page was an outlier for offering no AI-install option at all, even though the wizard has a warehouse subcommand that scans a codebase and connects every source it finds rather than making you configure them one at a time.

This started out as an A/B test of three CTA variants, but the page doesn't get enough traffic to power it — detecting even a large relative lift in warehouse sources connected would have taken about eleven weeks, and anything subtler was out of reach. So the additive variant ships for everyone instead of waiting on a result we couldn't get. Earlier commits on this branch have the experiment scaffolding if it's ever worth revisiting at higher traffic.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in \`vercel.json\` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ALU3889A6/p1786613937010889?thread_ts=1786613937.010889&cid=C0ALU3889A6)*