### PR TITLE
docs: mention JokerHog can create merch codes

### DIFF
--- a/contents/handbook/company/merch-store.md
+++ b/contents/handbook/company/merch-store.md
@@ -37,7 +37,9 @@ Shipping is also done through Micromerch (in partnership with Shiphero) - they c
 
 ### Customers
 
-Create a discount code in <PrivateLink url="https://admin.shopify.com/store/posthog/discounts">Shopify admin</PrivateLink>. You don't need to be invited to Shopify, instead the login details are stored in [1Password](https://start.1password.com/signin?l=en).
+The quickest way is to ask JokerHog in Slack – tag `@.JokerHog` in any channel and ask it for a merch code (e.g. "can you make me a merch code for $50 for a contributor?"). It creates the discount code in Shopify and replies with the code, so you don't need to log in yourself.
+
+If you'd rather do it manually, create a discount code in <PrivateLink url="https://admin.shopify.com/store/posthog/discounts">Shopify admin</PrivateLink>. You don't need to be invited to Shopify, instead the login details are stored in [1Password](https://start.1password.com/signin?l=en).
 
 To log into Shopify using 1Password:
 


### PR DESCRIPTION
## Changes

Adds a note to the customer merch giveaways section of the merch store handbook page: you can ask JokerHog in Slack to create a merch discount code for you, instead of logging into Shopify yourself. The manual Shopify instructions are kept as a fallback.

**Why:** Someone needed a merch code for a contributor and the handbook only documented the manual Shopify + 1Password route, which is no longer the quickest option.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1786622381404849?thread_ts=1786622381.404849&cid=C02E3BKC78F)*