### PR TITLE
Update self-driving docs sidebar: Code -> Desktop

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2327,8 +2327,8 @@ export const docsMenu = {
                     url: '/docs/cli',
                 },
                 {
-                    name: 'Code',
-                    url: '/desktop',
+                    name: 'Desktop',
+                    url: '/docs/posthog-desktop',
                 },
                 {
                     name: 'Concepts',


### PR DESCRIPTION
## Changes

Renamed the "Code" entry in the self-driving docs sidebar to "Desktop" and pointed it to [/docs/posthog-desktop](https://posthog.com/docs/posthog-desktop) instead of the `/desktop` product page.

**Why:** the sidebar link should send users to the Desktop docs, not the marketing/product page.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A, no page moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*