### PR TITLE
Add Desktop tile to docs 'Use PostHog from anywhere' section

### DIFF
--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -57,7 +57,13 @@ const surfaces = [
         color: 'green',
         description: 'Query your data and ship work from your terminal.',
     },
-    // TODO: Desktop (PostHog Desktop) slots in here once GA
+    {
+        name: 'Desktop',
+        url: '/docs/posthog-desktop',
+        icon: 'IconCoffee',
+        color: 'brown',
+        description: 'Run tasks, review code, and use any model from your desktop.',
+    },
 ]
 
 export const DocsIndex = () => {


### PR DESCRIPTION
## Changes

Adds a Desktop tile to the "Use PostHog from anywhere" surfaces grid on the `/docs` overview page, linking to `/docs/posthog-desktop`. Uses the same `IconCoffee` icon and `brown` color already used for PostHog Desktop elsewhere on the site (taskbar menu, Slack page).

**Why:** The docs surfaces grid already listed Web, Slack, MCP, and CLI as ways to use PostHog, but had a `// TODO: Desktop (PostHog Desktop) slots in here once GA` placeholder instead of a real tile.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*