### PR TITLE
Blog: add featured image to 'I bribe customers to talk to me'

### DIFF
--- a/contents/blog/bribing-customers-to-talk-to-me.mdx
+++ b/contents/blog/bribing-customers-to-talk-to-me.mdx
@@ -8,7 +8,7 @@ sidebar: Blog
 showTitle: true
 hideAnchor: true
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/mr_potato_hog_83221a5307.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/bribecustomers_3cda5bdd2a.png
 featuredImageType: full
 category: Inside PostHog
 tags:

--- a/contents/blog/bribing-customers-to-talk-to-me.mdx
+++ b/contents/blog/bribing-customers-to-talk-to-me.mdx
@@ -8,8 +8,7 @@ sidebar: Blog
 showTitle: true
 hideAnchor: true
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/c_fill,ar_2:1,g_auto/9_D587_A53_89_FE_49_E2_B5_E2_A023360_F7_B8_B_4429b586d2.PNG
-featuredImageType: full
+  https://res.cloudinary.com/dmukukwp6/image/upload/potato_featured_2x1_e6140ba581.png
 category: Inside PostHog
 tags:
   - Culture

--- a/contents/blog/bribing-customers-to-talk-to-me.mdx
+++ b/contents/blog/bribing-customers-to-talk-to-me.mdx
@@ -8,7 +8,8 @@ sidebar: Blog
 showTitle: true
 hideAnchor: true
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/potato_featured_2x1_e6140ba581.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/mr_potato_hog_83221a5307.png
+featuredImageType: full
 category: Inside PostHog
 tags:
   - Culture

--- a/contents/blog/bribing-customers-to-talk-to-me.mdx
+++ b/contents/blog/bribing-customers-to-talk-to-me.mdx
@@ -7,6 +7,9 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
+featuredImage: >-
+  https://res.cloudinary.com/dmukukwp6/image/upload/c_fill,ar_2:1,g_auto/9_D587_A53_89_FE_49_E2_B5_E2_A023360_F7_B8_B_4429b586d2.PNG
+featuredImageType: full
 category: Inside PostHog
 tags:
   - Culture


### PR DESCRIPTION
## Problem

The post shipped in #19347 without a `featuredImage`. The blog listing card and the post header both render with no hero.

## Changes

I set `featuredImage` to `mr_potato_hog_83221a5307.png` and I added `featuredImageType: full`.

The first version of this PR used a photo of a real potato with my face on it. @jina-yoon requested changes, because blog hero images must use the PostHog brand style. Ian offered brand options in Slack and I picked one. The Mr. Potato Hog illustration keeps the potato joke and it follows the brand style.

The image is already on Cloudinary at 1920x1080, so this PR uploads nothing. Charles Cook's post "We spend $45,000 on doing more weird every month" uses the same file. Hero reuse is normal in this repo: `hog_ql.png` appears on 17 posts.

`featuredImageType: full` follows the convention. 91 of the 92 posts that set a `featuredImage` also set this field, and 88 of those use `full`.

## Checks

1. The frontmatter YAML parses. The folded scalar returns the URL unchanged.
2. The image URL returns `HTTP/2 200` and `content-type: image/png`.
3. `markdownlint-cli2` passed on the pre-commit hook.

## Note on the earlier description

The previous body of this PR described a Cloudinary `c_fill,ar_2:1,g_auto` transform and claimed the PR uploaded nothing new. Both statements were wrong for the commit that was actually on the branch. A pre-cropped 1086x543 PNG had been uploaded, and the URL carried no transform. This description replaces that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
