### PR TITLE
Fix Product/Pricing/Docs tab nav disappearing on AI Observability docs pages

### DIFF
--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -384,10 +384,11 @@ export default function Handbook({ data: { post, postHogSource }, pageContext: {
     const allProducts = useProduct() as any[]
     const docsProductSlug = typeof slug === 'string' && slug.startsWith('/docs/') ? slug.split('/')[2] : null
     const productSurfaceData = docsProductSlug
-        ? allProducts.find((p: any) => {
-              const lastSegment = p.slug?.split('/').pop()
-              return lastSegment === docsProductSlug
-          })
+        ? allProducts
+              .filter((p: any) => p.slug?.split('/').pop() === docsProductSlug)
+              // Multiple products can share a slug (e.g. UI-only cards like "AI Evals" that
+              // link into another product's page) - prefer the canonical one with a productMenu.
+              .sort((a: any, b: any) => (b.productMenu?.length ? 1 : 0) - (a.productMenu?.length ? 1 : 0))[0]
         : null
     const isProductDocsPage = !!productSurfaceData?.productMenu?.length
     const productMenuTabs = isProductDocsPage

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -386,8 +386,6 @@ export default function Handbook({ data: { post, postHogSource }, pageContext: {
     const productSurfaceData = docsProductSlug
         ? allProducts
               .filter((p: any) => p.slug?.split('/').pop() === docsProductSlug)
-              // Multiple products can share a slug (e.g. UI-only cards like "AI Evals" that
-              // link into another product's page) - prefer the canonical one with a productMenu.
               .sort((a: any, b: any) => (b.productMenu?.length ? 1 : 0) - (a.productMenu?.length ? 1 : 0))[0]
         : null
     const isProductDocsPage = !!productSurfaceData?.productMenu?.length


### PR DESCRIPTION
## Changes

Clicking the docs sidebar icon on the AI Observability product page made the Product/Pricing/Docs tab strip disappear, unlike other product pages (e.g. Product Analytics) where it persists.

**Why:** `src/templates/Handbook.tsx` resolves which product's tab data to use for a docs page by matching the last segment of `/docs/<slug>/...` against `useProduct()`'s product list, taking the first match. A UI-only "AI Evals" card (`src/hooks/useProduct.ts`) shares `slug: 'ai-observability'` with the real AI Observability product but has no `productMenu`, and it appears earlier in the array — so it won the lookup and the tab strip had nothing to render. Product Analytics has no such colliding placeholder, so it worked fine.

**Fix:** the lookup now prefers whichever matching entry actually has a `productMenu`, so the real product always wins regardless of array order.

## Screenshots

_Sampled from the local dev server (images hosted on the disposable `posthog/pr-19469-assets` branch — delete it after merge)._

**Before** — tab strip missing on `/docs/ai-observability`:

<img src="https://raw.githubusercontent.com/PostHog/posthog.com/posthog/pr-19469-assets/pr-assets/before-ai-observability-docs.png" width="700" alt="Before: tab strip missing" />

**After** — tab strip persists, matching other product docs pages:

<img src="https://raw.githubusercontent.com/PostHog/posthog.com/posthog/pr-19469-assets/pr-assets/after-ai-observability-docs.png" width="700" alt="After: tab strip persists" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*