### PR TITLE
Update semantic layer docs: deletion frees metric names, renaming added

### DIFF
--- a/contents/docs/semantic-layer/governance.mdx
+++ b/contents/docs/semantic-layer/governance.mdx
@@ -23,7 +23,7 @@ The result: your agents build the catalog for you during normal work, and nothin
 
 | Primitive | Lands as | Human promotes to | Demoted or terminal |
 |-----------|----------|-------------------|---------------------|
-| [Metric](/docs/semantic-layer/metrics) | `proposed` | `approved` | Editing the definition or drifting from the source insight resets it toward `proposed`; deleted names stay reserved forever |
+| [Metric](/docs/semantic-layer/metrics) | `proposed` | `approved` | Editing the definition, name, description, or unit – or drifting from the source insight – resets it toward `proposed`; deleting frees the name (activity-logged, no undo in the product) |
 | [Certification](/docs/semantic-layer/certifications-and-relationships#table-certifications) | `proposed` | `certified` or `deprecated` | Revoking deletes the mark (activity-logged) |
 | [Relationship](/docs/semantic-layer/certifications-and-relationships#relationship-proposals) | `proposed` | `accepted` (becomes a real join) | `rejected` – permanent, never re-proposed |
 

--- a/contents/docs/semantic-layer/index.mdx
+++ b/contents/docs/semantic-layer/index.mdx
@@ -22,7 +22,7 @@ The catalog holds three kinds of governed facts:
 
 ### Metrics
 
-A [metric](/docs/semantic-layer/metrics) is a canonical business measure: a write-once name like `mrr`, a description, a unit, an owner, and a definition that's either an executable query or a set of calculation steps. Metrics move through a `proposed` → `approved` lifecycle, and PostHog detects when an approved definition drifts from the insight it was created from.
+A [metric](/docs/semantic-layer/metrics) is a canonical business measure: a name like `mrr`, a description, a unit, an owner, and a definition that's either an executable query or a set of calculation steps. Metrics move through a `proposed` → `approved` lifecycle, and PostHog detects when an approved definition drifts from the insight it was created from.
 
 ### Table certifications
 

--- a/contents/docs/semantic-layer/mcp-tools.mdx
+++ b/contents/docs/semantic-layer/mcp-tools.mdx
@@ -29,10 +29,10 @@ This routing takes precedence over the agent's generic query-writing behavior. T
 |------|--------------|--------------|--------|
 | `data-catalog-metric-run` | Runs a governed metric. Executable metrics return results, the compiled query, and a `posthog_url` deep link; markdown metrics return calculation steps in `instructions`. Accepts `date_from`/`date_to`/`interval` overrides (rejected for `HogQLQuery` metrics) and a `refresh` cache option. | – | `data_catalog:read`, `query:read` |
 | `data-catalog-metric-create` | Creates a metric, or refines the one already holding that name (upserts on `name`). Always lands `proposed`. The definition is an executable query or a `MarkdownDefinition`. | – | `data_catalog:write` |
-| `data-catalog-metric-update` | Updates a metric's fields. Editing an approved metric's definition resets it to `proposed`. | – | `data_catalog:write` |
+| `data-catalog-metric-update` | Updates a metric's fields, including renaming it via `new_name` (which frees the old name and breaks references to it). Editing an approved metric's definition, name, description, or unit resets it to `proposed`. | – | `data_catalog:write` |
 | `data-catalog-metric-approve` | Blesses a metric as canonical. Blocked while the metric is drifted from its source insight. | Typed "confirm" | `data_catalog_approval:write`, `data_catalog:read` |
 
-There's deliberately no "list metrics" tool: agents discover metrics with `execute-sql` over `system.information_schema.metrics` – see the [SQL reference](/docs/semantic-layer/query).
+There's deliberately no "list metrics" tool: agents discover metrics with `execute-sql` over `system.information_schema.metrics` – see the [SQL reference](/docs/semantic-layer/query). There's also no delete tool: agents can propose and update metrics, but [deleting one](/docs/semantic-layer/metrics#renaming-and-deleting) is a human act, done from the Data Catalog UI or the API.
 
 ## Certification tools
 

--- a/contents/docs/semantic-layer/metrics.mdx
+++ b/contents/docs/semantic-layer/metrics.mdx
@@ -15,8 +15,8 @@ A metric is a named, governed answer to a business question: one definition, one
 
 | Field | What it is |
 |-------|------------|
-| `name` | Identifier-safe handle (`mrr`, `weekly_active_teams`), unique per project. **Write-once and reserved forever**, even after deletion. |
-| `display_name` | Human-friendly label. Mutable, unlike `name`. |
+| `name` | Identifier-safe handle (`mrr`, `weekly_active_teams`), unique among your project's live metrics. [Renaming or deleting](#renaming-and-deleting) a metric frees its name, and references to the old name stop resolving. |
+| `display_name` | Human-friendly label. Change it freely – unlike `name`, nothing references it and editing it never resets approval. |
 | `description` | What the metric means and how to interpret it. This is load-bearing text – agents read it to decide whether the metric answers a question. |
 | `unit` | Unit of the result, e.g. `usd`, `percent`, `cents`. |
 | `owner` | The human accountable for the metric. |
@@ -27,9 +27,9 @@ A metric is a named, governed answer to a business question: one definition, one
 | `source_insight_short_id` | Set when the metric was created from an insight – the insight's query is snapshotted server-side. Mutually exclusive with `definition`. |
 | `created_source`, `ai_model`, `confidence`, `reasoning` | Provenance: whether a human (`user`) or an agent (`ai_generated`) authored it, and if an agent did, which model, how confident it was, and why. |
 
-<CalloutBox icon="IconInfo" title="Why names are reserved forever" type="fyi">
+<CalloutBox icon="IconInfo" title="Names are references" type="fyi">
 
-Agents and integrations store metric names and call them later. If a deleted name could be reused, a stored reference to `mrr` could silently start meaning something else. So names are write-once: deleting a metric retires its name permanently. Treat naming a metric like naming an API route.
+Agents and integrations store metric names and call them later – in saved SQL over `system.information_schema.metrics`, in run calls, in links. A name is only guaranteed stable while the metric lives under it: renaming or deleting the metric frees the name, stored references stop resolving, and a freed name can later be claimed by an unrelated metric. Treat naming a metric like naming an API route – the system won't stop you from breaking the contract, so keep it deliberately.
 
 </CalloutBox>
 
@@ -61,7 +61,17 @@ Use an executable definition whenever the metric is deterministic. Reach for mar
 
 Every metric lands as `proposed` – whether a human or an agent created it, and even when an existing name is refined (`data-catalog-metric-create` upserts on `name`). A human then approves it, which requires typing "confirm" and the `data_catalog_approval` scope.
 
-Editing an approved metric's definition resets it to `proposed`. A metric is never silently redefined: any change to what the number means goes back through a human.
+Editing an approved metric's definition, name, description, or unit resets it to `proposed`. A metric is never silently redefined: any change to what the number means goes back through a human. Cosmetic fields – `display_name`, `owner` – never reset approval.
+
+## Renaming and deleting
+
+Both are ways a name stops meaning what it used to, so both come with the same warning: anything that references the metric by name – saved SQL, API calls, links – stops working until it's updated.
+
+**Renaming.** Rename a metric from its page in the Data Catalog UI, or by updating `name` through the API or the [`data-catalog-metric-update`](/docs/semantic-layer/mcp-tools#metric-tools) tool. The old name is freed for a new metric to claim, and renaming an approved metric resets it to `proposed` – agents pick metrics by name, so a definition under a different name is a different promise, and it needs approving again.
+
+**Deleting.** Delete a metric from the Data Catalog UI or the API. Deleting requires only editor access (the `data_catalog:write` scope) and works on approved metrics too – no approval scope, no typed confirmation beyond the dialog. There's no undo in the product, and there's deliberately no MCP delete tool: agents can propose and update metrics, but retiring one is a human act.
+
+Deleting frees the name immediately. Creating a metric with a deleted name starts completely fresh – no definition, history, or approval carries over from the old one.
 
 ## Drift
 
@@ -101,10 +111,11 @@ Runs accept optional overrides: `date_from` (e.g. `-7d`), `date_to`, and `interv
 
 ## Naming metrics well
 
-Names are an API contract. Choose accordingly:
+Names are an API contract – one you uphold by convention, since [renaming and deleting](#renaming-and-deleting) can free a name at any time. Choose accordingly:
 
 - Lowercase, terse, unambiguous: `mrr`, `nrr`, `weekly_active_teams`
 - No versions or qualifiers in the name – that's what `description` and the lifecycle are for
+- Once a name is in use, keep it: every rename breaks whatever stored the old one
 - If two teams mean different things by "activation", make two metrics with honest names (`activation_signup`, `activation_first_insight`) rather than one contested one
 
 The description does the heavy lifting for discovery: agents match questions against it, so write it the way a teammate would ask the question.

--- a/contents/docs/semantic-layer/query.mdx
+++ b/contents/docs/semantic-layer/query.mdx
@@ -18,7 +18,7 @@ One row per metric in your project:
 | Column | Type | What it is |
 |--------|------|------------|
 | `id` | String | The metric's id. |
-| `name` | String | Write-once identifier, e.g. `mrr`. |
+| `name` | String | Identifier, e.g. `mrr`, unique among live metrics. Not permanent – a metric can be renamed, and deleting one frees its name for reuse. |
 | `display_name` | Nullable string | Human-friendly label. |
 | `description` | String | What the metric means – the text agents match questions against. |
 | `unit` | Nullable string | e.g. `usd`, `percent`. |

--- a/contents/docs/semantic-layer/start-here.mdx
+++ b/contents/docs/semantic-layer/start-here.mdx
@@ -41,9 +41,9 @@ Instead of letting every session re-derive MRR, catalog it:
 
 The metric now exists, but it has no authority yet. Every AI-created object in the catalog lands as `proposed` – that's the "AI generates" half of the model.
 
-<CalloutBox icon="IconInfo" title="Names are write-once" type="fyi">
+<CalloutBox icon="IconInfo" title="Names are references" type="fyi">
 
-A metric's `name` is an identifier, like an API route: lowercase, no spaces, unique in your project. It can never be renamed or reused – even after deletion, the name stays reserved so a stored reference never silently changes meaning. Pick `mrr`, not `monthly_recurring_revenue_v2_final`. The `display_name` is the human label and stays editable.
+A metric's `name` is an identifier, like an API route: lowercase, no spaces, unique among your project's live metrics. You *can* rename or delete a metric later, but that frees the name and breaks anything that stored it – saved queries, API calls, links – so pick a name worth keeping. Pick `mrr`, not `monthly_recurring_revenue_v2_final`. The `display_name` is the human label and can change freely.
 
 </CalloutBox>
 

--- a/contents/docs/semantic-layer/troubleshooting.mdx
+++ b/contents/docs/semantic-layer/troubleshooting.mdx
@@ -39,9 +39,14 @@ The metric was created from an insight, and that insight's query has changed sin
 
 Compare the metric's `compiled_query` (from a run) with the insight's current query to see what changed. Until it's re-approved, results are labeled noncanonical.
 
-## I deleted a metric but can't reuse the name
+## I renamed or deleted a metric and references to it broke
 
-By design. Names are write-once and stay reserved after deletion, so a stored reference to a name can never silently point at a different definition. Pick a new name.
+By design. Renaming or deleting a metric frees its name, and anything that stored the old name – saved SQL over `system.information_schema.metrics`, API calls, links – stops resolving. After a rename, update those references to the new name.
+
+Two things to know before you rely on this:
+
+- **Deletion has no undo in the product.** Re-creating a metric with a deleted name starts completely fresh – the old definition, history, and approval don't come back.
+- **Renaming an approved metric resets it to `proposed`**, so it needs approving again under the new name.
 
 ## An agent keeps proposing a join we don't want
 


### PR DESCRIPTION
## Changes

PostHog/posthog#81529 changed metric names in the semantic layer. When you delete a metric, its name becomes free for reuse. You can also rename a metric. Both actions break stored references to the old name, and a rename resets an approved metric to `proposed`.

The docs said metric names are write-once and reserved forever. This PR removes that claim from all 7 affected pages, adds a "Renaming and deleting" section to the metrics page, and documents the `new_name` parameter on `data-catalog-metric-update`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)