### PR TITLE
Clarify volume discount tier is per contract year and based on credit value

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -28,13 +28,18 @@ In our consumption-based pricing model, the first way for a customer to reduce s
 
 Beyond optimization, we offer discounts based on four levers:
 
-#### 1. Volume discount (based on credit purchase amount - Customers **must** qualify for this discount before receiving discounts 2 through 4)
+#### 1. Volume discount (based on credit purchase amount per contract year - Customers **must** qualify for this discount before receiving discounts 2 through 4)
 - **$25-59k:** 20% base discount
 - **$60-99k:** 25% base discount
 - **$100-249k:** 30% base discount
 - **$250-499k:** 35% base discount
 - **$500-999k:** 40% base discount
 - **$1M+:** Contact us for custom pricing
+
+> Two things to be clear on when working out which tier applies:
+>
+> - **It's credit value, not cash.** The tier is set by the amount of credit the customer receives (the pre-discount, list-price value), not the amount they pay us after discounts.
+> - **It's per contract year, not per term.** On a multi-year deal, use the credit allocated for a single contract year. A 2-year deal with $250k of credit a year sits in the $250-499k tier at 35%, not the $500-999k tier at 40% — the reward for the longer term is the length of commitment and timing of cash levers below, not a bigger volume tier.
 
 #### 2. Length of commitment discount (additive)
 - **1-year commitment:** No additional discount


### PR DESCRIPTION
## Changes

Clarifies the volume discount tier in the contract rules:

- The heading now says the tier is based on credit purchase amount **per contract year**.
- Added a note under the tier table making explicit that (a) the tier is set by credit value at list price, not the cash paid after discounts, and (b) on multi-year deals it's the credit for a single contract year, not the total across the term — with a worked example.

**Why:** the current wording is ambiguous on both points, and a customer read it as letting a 2-year deal stack its two annual credit amounts into a higher volume tier. Nothing about the tiers themselves changes; this just states the intended reading.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09677WV1GW/p1786623637190689?thread_ts=1786623637.190689&cid=C09677WV1GW)*
