### PR TITLE
Refresh questions table when a question is marked as resolved

### DIFF
--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -1,6 +1,6 @@
 import qs from 'qs'
 import { QuestionData, StrapiRecord, TopicData } from 'lib/strapi'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { useUser } from 'hooks/useUser'
 import usePostHog from 'hooks/usePostHog'
 
@@ -115,6 +115,7 @@ const query = (id: string | number, isModerator: boolean) =>
 export const useQuestion = (id: number | string, options?: UseQuestionOptions) => {
     const { getJwt, fetchUser, user, isModerator, isValidating } = useUser()
     const posthog = usePostHog()
+    const { mutate: globalMutate } = useSWRConfig()
 
     const key =
         isValidating || options?.data
@@ -153,6 +154,11 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
 
     const questionData: StrapiRecord<QuestionData> | undefined = question || options?.data
     const questionID = typeof id !== 'string' ? id : question?.id
+
+    // Revalidates this question along with any question lists (e.g. the questions table) that are
+    // mounted elsewhere, so changes show up without a page refresh
+    const mutateQuestions = () =>
+        globalMutate((key) => typeof key === 'string' && key.includes('/api/questions?'))
 
     const reply = async (body: string) => {
         try {
@@ -418,7 +424,7 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
 
             await replyRes.json()
 
-            mutate()
+            mutateQuestions()
 
             posthog?.capture('squeak resolve', {
                 questionId: questionID,
@@ -434,7 +440,7 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
                 error: JSON.stringify(error),
             })
 
-            await mutate()
+            await mutateQuestions()
 
             throw error
         }

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -115,7 +115,7 @@ const query = (id: string | number, isModerator: boolean) =>
 export const useQuestion = (id: number | string, options?: UseQuestionOptions) => {
     const { getJwt, fetchUser, user, isModerator, isValidating } = useUser()
     const posthog = usePostHog()
-    const { mutate: globalMutate } = useSWRConfig()
+    const { cache, mutate: globalMutate } = useSWRConfig()
 
     const key =
         isValidating || options?.data
@@ -156,9 +156,16 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
     const questionID = typeof id !== 'string' ? id : question?.id
 
     // Revalidates this question along with any question lists (e.g. the questions table) that are
-    // mounted elsewhere, so changes show up without a page refresh
+    // mounted elsewhere, so changes show up without a page refresh.
+    // Note: we iterate cache keys and mutate each one directly instead of passing a filter function
+    // to mutate() — SWR's filter-based mutate skips useSWRInfinite caches (keys prefixed with $inf$),
+    // which is exactly what the questions table uses.
     const mutateQuestions = () =>
-        globalMutate((key) => typeof key === 'string' && key.includes('/api/questions?'))
+        Promise.all(
+            Array.from(cache.keys())
+                .filter((key) => typeof key === 'string' && key.includes('/api/questions?'))
+                .map((key) => globalMutate(key))
+        )
 
     const reply = async (body: string) => {
         try {


### PR DESCRIPTION
## Changes

Marking a question as resolved only revalidated the single-question SWR cache, so a questions table mounted elsewhere on the page kept showing the old status until a manual page refresh.

`handleResolve` in `useQuestion` now revalidates every cached `/api/questions` request — the question itself plus any list/table queries from `useQuestions` — using SWR's global `mutate` with a key matcher.

**Why:** reported in Slack — after marking a question resolved on /questions, the check mark didn't appear in the table without refreshing the page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AB78YBCNA/p1786646284797039)*