### PR TITLE
Point achievement creation docs at the achievement manager

### DIFF
--- a/contents/handbook/community/profiles.mdx
+++ b/contents/handbook/community/profiles.mdx
@@ -49,18 +49,19 @@ PostHog community members can earn achievements for various activities. Each ach
 
 Achievements are valued based on the time we expect someone to spend earning them. For example, someone who votes on the roadmap, updates their bio, and asks their first question has earned enough points for a sticker.
 
-Assigning, revoking, and creating new achievements is handled in Strapi, our website CMS.
+Creating and editing achievements is handled in the [achievement manager](/achievements/manage). Manually assigning and revoking achievements is handled in Strapi, our website CMS.
 
 ### Creating a new achievement
 
-1. Login to our website CMS. (Request an account from [Eli](/elik) or [Cory](/cory) if you don't already have one.)
-2. Click "Content Manager" > "Achievements" > "Create New Entry"
-3. Fill in the achievement details
-4. Click "Save" > "Publish"
+1. Go to the [achievement manager](/achievements/manage) and log in with a moderator account.
+2. On the "Create / edit" tab, choose "Create new achievement" (or pick an existing one to edit).
+3. Fill in the achievement details and save.
+
+You can also assign an achievement to a batch of community members by email from the "Assign" tab.
 
 ### Manually assigning an achievement to a community member
 
-1. Click "Content Manager" > "Profiles"
+1. Login to our website CMS. (Request an account from [Eli](/elik) or [Cory](/cory) if you don't already have one.) Click "Content Manager" > "Profiles"
 2. Find and click the desired profile
 4. Scroll to the "achievements" field > Click "Add an entry"
 5. Select the desired achievement from the "achievement" dropdown

--- a/contents/handbook/community/profiles.mdx
+++ b/contents/handbook/community/profiles.mdx
@@ -61,7 +61,7 @@ You can also assign an achievement to a batch of community members by email from
 
 ### Manually assigning an achievement to a community member
 
-1. Login to our website CMS. (Request an account from [Eli](/elik) or [Cory](/cory) if you don't already have one.) Click "Content Manager" > "Profiles"
+1. Login to our website CMS. (Request an account from [Eli](/community/profiles/28804) or [Ian](/community/profiles/46139) if you don't already have one.) Click "Content Manager" > "Profiles"
 2. Find and click the desired profile
 4. Scroll to the "achievements" field > Click "Add an entry"
 5. Select the desired achievement from the "achievement" dropdown


### PR DESCRIPTION
## Changes

Updates the Achievements section of the community profiles handbook page so "Creating a new achievement" points at the [achievement manager](/achievements/manage) instead of the Strapi admin, and mentions the bulk-assign-by-email tab. Manual assign/revoke steps still describe Strapi, so the CMS login note moved into that section.

**Why:** I thought I might need to use Strapi but seems like i can do this on posthog.com now and i totally missed this tool!

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1786484150846969?thread_ts=1786484150.846969&cid=C01V9AT7DK4)*