### PR TITLE
docs(session-replay): reorganize recording controls around trigger groups

### DIFF
--- a/contents/docs/libraries/js/usage.mdx
+++ b/contents/docs/libraries/js/usage.mdx
@@ -381,7 +381,7 @@ posthog.capture("survey sent", {
 
 To set up [session replay](/docs/session-replay) in your project, all you need to do is install the JavaScript web library and enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay).
 
-For [fine-tuning control](/docs/session-replay/how-to-control-which-sessions-you-record) of which sessions you record, you can use [feature flags](/docs/session-replay/how-to-control-which-sessions-you-record#with-feature-flags), [sampling](/docs/session-replay/how-to-control-which-sessions-you-record#sampling), [minimum duration](/docs/session-replay/how-to-control-which-sessions-you-record#minimum-duration), or set the `disable_session_recording` [config option](/docs/libraries/js/config) and use the following methods:
+For [fine-tuning control](/docs/session-replay/how-to-control-which-sessions-you-record) of which sessions you record, you can use [feature flags](/docs/session-replay/how-to-control-which-sessions-you-record#feature-flag-triggers), [sampling](/docs/session-replay/how-to-control-which-sessions-you-record#sampling), [minimum duration](/docs/session-replay/how-to-control-which-sessions-you-record#minimum-duration), or set the `disable_session_recording` [config option](/docs/libraries/js/config) and use the following methods:
 
 ```js-web
 // Turns session recording on

--- a/contents/docs/session-replay/_snippets/flutter-installation.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-installation.mdx
@@ -66,7 +66,7 @@ Setting `config.sessionReplay = true` in your PostHog configuration will start s
 
 ### Manually control session recordings
 
-You can programmatically start and stop session recordings. See [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings) for details.
+You can programmatically start and stop session recordings. See [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record#programmatic-start-and-stop-controls) for details.
 
 ### Configuration options
 

--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -36,7 +36,7 @@ Setting `config.sessionReplay = true` to your PostHog configuration will start s
 
 ### Manually control session recordings
 
-You can programmatically start and stop session recordings. See [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings) for details.
+You can programmatically start and stop session recordings. See [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record#programmatic-start-and-stop-controls) for details.
 
 ## Configuration options
 

--- a/contents/docs/session-replay/_snippets/sensitive-third-party-screens.mdx
+++ b/contents/docs/session-replay/_snippets/sensitive-third-party-screens.mdx
@@ -1,3 +1,3 @@
 ### Handling sensitive third-party screens
 
-For third-party components (like payment forms or authentication screens) that can't be masked, you can manually stop and start session recordings. See [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings) for details.
+For third-party components (like payment forms or authentication screens) that can't be masked, you can manually stop and start session recordings. See [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record#programmatic-start-and-stop-controls) for details.

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -41,8 +41,8 @@ In most cases, you can initialize the PostHog SDK with the default settings and 
 A trigger group is one rule for starting a recording. Each group carries its own conditions — URL triggers, event triggers, and a feature flag — plus its own sample rate, minimum duration, and match type (ANY/ALL).
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/c_crop,w_2577,h_1964,x_0,y_40/c_pad,w_2705,h_2092,b_rgb:F3F4F1/w_1600,c_limit,q_auto,f_auto/Trigger_group_light_31225a9908.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/c_crop,w_2577,h_1964,x_0,y_40/c_pad,w_2705,h_2092,b_rgb:131316/w_1600,c_limit,q_auto,f_auto/Trigger_group_dark_8300beb2ae.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/trigger_group_light_062209f6b0.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/trigger_group_dark_80e077d3d8.png"
   alt="A trigger group's settings: group name, sample rate, minimum duration, match type, and its conditions"
   classes="rounded"
 />

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -149,6 +149,8 @@ You can select a [feature flag](/docs/feature-flags) to control whether to recor
 
 Sampling enables you to record a percentage of all sessions. To set a sampling rate, go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers).
 
+> **Note:** [Trigger groups](#trigger-groups) carry their own sample rate, set per group and applied to the sessions that matched that group's conditions. The project-wide sample rate described here applies to the legacy recording conditions, used by SDK versions before 1.369.0 and as a fallback when no trigger groups are configured.
+
 Sampling is supported on the following SDKs:
 
 - **Web** - posthog-js 1.85.0+
@@ -183,6 +185,8 @@ This means:
 ## Combining controls
 
 Since version 1.238.0 of the web SDK you can control how multiple triggers are combined. Choosing whether recording will start when all triggers match or when any trigger matches.
+
+> **Note:** This section describes the legacy recording conditions, where match type and sampling are configured project-wide. [Trigger groups](#trigger-groups) set match type per group, and their sample rate is applied after a group's conditions match rather than as another condition alongside them.
 
 For example if you set an event trigger for Exception events, a URL trigger for the checkout page, and sampling to 20%.
 
@@ -240,7 +244,7 @@ You can edit the groups after creating them.
 
 ## Minimum duration
 
-In your [replay ingestion settings](https://app.posthog.com/settings/project-replay#replay-ingestion), you can set a minimum duration for sessions to be recorded.
+In your [replay ingestion settings](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), you can set a minimum duration for sessions to be recorded. Trigger groups carry their own minimum duration, set per group.
 
 Supported on the following SDKs:
 

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -25,9 +25,9 @@ export const ImgMinDurationDark =
 
 There are several ways to control which sessions you record:
 
-## Programmatically start and stop recordings
+## Programmatic start and stop controls
 
-Most users should initialize PostHog with the default settings (which starts recording automatically) and use the other options on this page — like [URL triggers](#with-url-trigger-conditions), [event triggers](#with-event-trigger-conditions), [feature flags](#with-feature-flags), or [sampling](#sampling) — to control what gets recorded. Manual control is only needed for advanced use cases where you need to programmatically start and stop recording at specific points in your application.
+Most users should initialize PostHog with the default settings (which starts recording automatically) and use [trigger groups](#trigger-groups) — URL triggers, event triggers, feature flags, sampling, and minimum duration — to control what gets recorded. Manual control is only needed for advanced use cases where you need to programmatically start and stop recording at specific points in your application.
 
 <Tab.Group tabs={["Web", "iOS", "Android", "React Native", "Flutter"]}>
   <Tab.List>
@@ -56,7 +56,64 @@ Most users should initialize PostHog with the default settings (which starts rec
   </Tab.Panels>
 </Tab.Group>
 
-## With URL trigger conditions
+## Trigger groups
+
+A trigger group is one rule for starting a recording. Each group carries its own conditions — URL triggers, event triggers, and a feature flag — plus its own sample rate, minimum duration, and match type (ANY/ALL).
+
+Multiple trigger groups can be active at the same time. A session is recorded if it matches **any** of your trigger groups. Within a group, conditions are combined based on that group's match type.
+
+Trigger groups are configured on the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), and are supported on posthog-js 1.369.0+. Earlier versions, and projects with no trigger groups configured, fall back to the [legacy controls](#legacy-controls) below.
+
+> **Note:** Creating, editing, and deleting trigger groups requires project admin permissions. Non-admin project members can view trigger group configurations but cannot modify them.
+
+For example, you could create:
+
+- A group that records all sessions on your checkout page at 100% sample rate
+- A group that records 10% of all sessions across your entire site
+- A group that records any session where an exception event occurs
+
+To create a trigger group, go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers) and click **Add** in the **Trigger groups** section.
+
+If you delete your last trigger group, PostHog automatically replaces it with a default "Record all sessions" group at 100% sampling with no conditions. This keeps your project on trigger groups rather than reverting to legacy recording settings.
+
+> **Note:** A trigger group with no conditions matches every session, so its sample rate becomes the recording rate for your whole project.
+
+### Sampling
+
+Sampling enables you to record a percentage of sessions. Each trigger group has its own sample rate, applied to the sessions that matched that group's conditions.
+
+Sampling is supported on the following SDKs:
+
+- **Web** - posthog-js 1.85.0+
+- **Android** - 3.34.0+
+- **iOS** - 3.42.0+
+- **React Native** - 4.37.0+
+- **Flutter** - 5.26.0+
+
+<ProductScreenshot
+  imageLight={ImgSampleConfigLight}
+  imageDark={ImgSampleConfigDark}
+  alt="Sampling config shown set to 100% i.e. no sampling"
+  classes="rounded"
+/>
+
+Our recommendation is to start with capturing 100% of sessions and decrease it as needed. This helps you get a sense of how many sessions you’re recording and how much data you’re collecting.
+
+#### How sampling works
+
+Sampling is deterministic based on the session ID. When a new session starts, PostHog converts the session ID into a number between 0 and 1 using a hash function. This number is then compared to your configured sample rate (for example, 0.1 for 10% or 0.2 for 20%).
+
+If the generated number is less than the sample rate, the session is recorded. Because the same session ID always produces the same number, the decision to record or not is consistent throughout the session's lifetime.
+
+This means:
+
+- Sessions are selected based on their ID, not by time period or order
+- The same session will always get the same recording decision, even across page refreshes
+- At 20% sampling, roughly 20% of your unique sessions will be recorded, distributed evenly across your traffic
+
+> **Note:** Sampling reduces the number of sessions you record, but you cannot control which specific sessions are selected — the selection is determined by the session ID hash.
+
+### URL triggers
 
 You can opt to only start recordings once your user visits a certain page. After the URL matches, the recording continues even after they leave the matching page.
 The client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see how they arrived at the page.
@@ -78,7 +135,7 @@ https://([a-zA-Z0-9-]+\.)?example\.com(/.*)?
 
 Use the URL tester in the settings panel to check your pattern against real URLs before saving.
 
-## With Event trigger conditions
+### Event triggers
 
 You can opt to only start recordings once your user emits a particular event. After the event is captured, the recording continues for the rest of the session.
 On the web, the client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see activity leading up to that event.
@@ -102,7 +159,7 @@ Event triggers are supported on the following SDKs:
 
 > On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.
 
-### Triggering on exceptions
+#### Triggering on exceptions
 
 If you use [error tracking](/docs/error-tracking), exceptions are captured as events. You can select the exception event as an event trigger to start session recording.
 
@@ -113,7 +170,7 @@ If you use [error tracking](/docs/error-tracking), exceptions are captured as ev
   classes="rounded"
 />
 
-### How the trigger buffer works
+#### How the trigger buffer works
 
 When using URL or event triggers, the client buffers recording data in-memory while waiting for a trigger to match. Here's how it works:
 
@@ -130,13 +187,13 @@ This approach balances providing useful context with browser performance — kee
 
 > **Note:** Full page navigations (page refreshes) clear the buffer and start over from a new snapshot.
 
-## With feature flags
+### Feature flag triggers
 
 You can select a [feature flag](/docs/feature-flags) to control whether to record sessions or not. Recordings will only be collected for users when the flag is enabled for them.
 
 1. [Create a boolean or multiple variant flag](/docs/feature-flags/creating-feature-flags) that determines whether to record sessions or not.
 2. Go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers).
-3. Link your newly created flag in the **Enable recordings using feature flag**.
+3. Link your newly created flag in the trigger group's **Feature flag** condition.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/v1725441098/posthog.com/contents/Screenshot_2024-09-04_at_10.11.12_AM.png"
@@ -145,106 +202,9 @@ You can select a [feature flag](/docs/feature-flags) to control whether to recor
   classes="rounded"
 />
 
-## Sampling
+### Minimum duration
 
-Sampling enables you to record a percentage of all sessions. To set a sampling rate, go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers).
-
-> **Note:** [Trigger groups](#trigger-groups) carry their own sample rate, set per group and applied to the sessions that matched that group's conditions. The project-wide sample rate described here applies to the legacy recording conditions, used by SDK versions before 1.369.0 and as a fallback when no trigger groups are configured.
-
-Sampling is supported on the following SDKs:
-
-- **Web** - posthog-js 1.85.0+
-- **Android** - 3.34.0+
-- **iOS** - 3.42.0+
-- **React Native** - 4.37.0+
-- **Flutter** - 5.26.0+
-
-<ProductScreenshot
-  imageLight={ImgSampleConfigLight}
-  imageDark={ImgSampleConfigDark}
-  alt="Sampling config shown set to 100% i.e. no sampling"
-  classes="rounded"
-/>
-
-Our recommendation is to start with capturing 100% of sessions and decrease it as needed. This helps you get a sense of how many sessions you’re recording and how much data you’re collecting.
-
-### How sampling works
-
-Sampling is deterministic based on the session ID. When a new session starts, PostHog converts the session ID into a number between 0 and 1 using a hash function. This number is then compared to your configured sample rate (for example, 0.1 for 10% or 0.2 for 20%).
-
-If the generated number is less than the sample rate, the session is recorded. Because the same session ID always produces the same number, the decision to record or not is consistent throughout the session's lifetime.
-
-This means:
-
-- Sessions are selected based on their ID, not by time period or order
-- The same session will always get the same recording decision, even across page refreshes
-- At 20% sampling, roughly 20% of your unique sessions will be recorded, distributed evenly across your traffic
-
-> **Note:** Sampling reduces the number of sessions you record, but you cannot control which specific sessions are selected — the selection is determined by the session ID hash.
-
-## Combining controls
-
-Since version 1.238.0 of the web SDK you can control how multiple triggers are combined. Choosing whether recording will start when all triggers match or when any trigger matches.
-
-> **Note:** This section describes the legacy recording conditions, where match type and sampling are configured project-wide. [Trigger groups](#trigger-groups) set match type per group, and their sample rate is applied after a group's conditions match rather than as another condition alongside them.
-
-For example if you set an event trigger for Exception events, a URL trigger for the checkout page, and sampling to 20%.
-
-### With any matching
-
-You'll capture 20% of every session, and any session that has an exception event or is on the checkout page.
-
-### With all matching
-
-You'll capture 20% of any session on the checkout page that has an exception event.
-
-<CalloutBox icon="IconWarning" title="100% sampling with ANY matching records every session" type="caution">
-
-If you use "any" matching with 100% sampling and other conditions (URL triggers, event triggers, or feature flags), the 100% sampling causes every session to be recorded. Your other conditions become ineffective because the sampling condition alone matches every session.
-
-To fix this, either lower your sample rate or switch to "all" matching.
-
-</CalloutBox>
-
-## Trigger groups
-
-Trigger groups are a more flexible way to configure recording triggers. Each trigger group can have its own combination of URL triggers, event triggers, feature flags, sample rate, minimum duration, and match type (ANY/ALL).
-
-Multiple trigger groups can be active at the same time. A session is recorded if it matches **any** of your trigger groups. Within a group, conditions are combined based on that group's match type.
-
-> **Note:** Creating, editing, and deleting trigger groups requires project admin permissions. Non-admin project members can view trigger group configurations but cannot modify them.
-
-For example, you could create:
-
-- A group that records all sessions on your checkout page at 100% sample rate
-- A group that records 10% of all sessions across your entire site
-- A group that records any session where an exception event occurs
-
-To create a trigger group, go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers) and click **Add** in the **Trigger groups** section.
-
-If you delete your last trigger group, PostHog automatically replaces it with a default "Record all sessions" group at 100% sampling with no conditions. This keeps your project on trigger groups rather than reverting to legacy recording settings.
-
-### Migrating from legacy trigger settings
-
-If you have existing legacy trigger settings (URL triggers, event triggers, feature flags, sampling, and match type configured outside of trigger groups), you can automatically convert them to trigger groups.
-
-1. Go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers).
-2. Click **Create from legacy triggers** in the **Trigger groups** section.
-3. Review the preview of trigger groups that will be created.
-4. Click **Create** to confirm.
-
-You can edit the groups after creating them.
-
-> **Note:** When your legacy settings use "ANY" match type with both trigger conditions (URLs, events, or feature flags) **and** sampling below 100%, the migration creates two groups:
->
-> 1. A group with your trigger conditions at a 100% sample rate
-> 2. A group with no conditions at your legacy sample rate
->
-> This preserves the original behavior where recording starts if **any** condition matches **or** the session was sampled.
-
-## Minimum duration
-
-In your [replay ingestion settings](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), you can set a minimum duration for sessions to be recorded. Trigger groups carry their own minimum duration, set per group.
+In your [replay ingestion settings](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), you can set a minimum duration for sessions to be recorded. Each trigger group carries its own minimum duration.
 
 Supported on the following SDKs:
 
@@ -263,7 +223,7 @@ Supported on the following SDKs:
 
 There are two modes for how minimum duration is enforced, controlled by the `strictMinimumDuration` configuration option. This is useful if you want to exclude sessions that are too short to be useful. For example, you might want to exclude sessions that are less than 2 seconds long to avoid recording sessions where users quickly bounce off your site.
 
-### Legacy mode (default)
+#### Legacy mode (default)
 
 In legacy mode (`strictMinimumDuration: false` or not set), the minimum duration is checked against the **total session age**. When a session starts, the browser records the start time. If the minimum duration has passed since the session start time, the recording data is sent to the backend.
 
@@ -284,7 +244,7 @@ For example, with a 12 second minimum:
 - After 6 more seconds on page B (12 seconds total session age), we start sending the recording
 - Result: You get 6 seconds of recording from page B, but miss the 6 seconds from page A
 
-### Strict mode (available in 1.291.0+)
+#### Strict mode (available in 1.291.0+)
 
 In strict mode (`strictMinimumDuration: true`), the minimum duration is checked against the **actual buffered recording data** (from first to last timestamp), not the session age. We only start sending the recording once we have the minimum duration of continuous data in the buffer.
 
@@ -312,12 +272,12 @@ Once a session has passed the minimum duration threshold on any page, subsequent
 
 This mode is **more accurate** for filtering out short sessions, especially on sites with full page refreshes, but may result in missing more session data if users **bounce quickly** across multiple pages.
 
-### Choosing the right mode
+#### Choosing the right mode
 
 - **Use legacy mode** if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes
 - **Use strict mode** if you want to ensure you only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users
 
-### Mobile behavior
+#### Mobile behavior
 
 On mobile, minimum duration is enforced using **buffer length**, similar to web strict mode:
 
@@ -327,6 +287,76 @@ On mobile, minimum duration is enforced using **buffer length**, similar to web 
 
 If the session changes before the threshold is reached, the buffer is cleared, and the next session starts buffering from zero.
 
-## Billing Limits
+### Combining controls
+
+Each trigger group has a match type that decides how its conditions combine:
+
+- **ANY** — the group matches if any one of its conditions matches
+- **ALL** — the group matches only if every one of its conditions matches
+
+Groups themselves are always combined with ANY: a session is recorded if it matches any group.
+
+The sample rate is not a condition. It's applied after a group's conditions match, to whatever survived them. So a group with an exception event trigger and a 20% sample rate records 20% of the sessions that threw an exception — not 20% of all sessions plus every exception.
+
+For example, take one group with an event trigger for exception events and a URL trigger for your checkout page:
+
+- **With ANY matching**, you'll capture sessions that threw an exception anywhere, and sessions that visited checkout.
+- **With ALL matching**, you'll capture only sessions that threw an exception while on checkout.
+
+To record both patterns independently at different rates, use two groups rather than one.
+
+## Legacy controls
+
+Since posthog-js 1.369.0, all of these controls live in [trigger groups](#trigger-groups). The project-wide settings below are retained for backward compatibility, and are used by earlier SDK versions and by projects that have no trigger groups configured.
+
+If you're using the controls below, upgrade to a current SDK and migrate your configuration to trigger groups.
+
+<details>
+
+<summary>Migrating to trigger groups</summary>
+
+If you have existing legacy trigger settings (URL triggers, event triggers, feature flags, sampling, and match type configured outside of trigger groups), you can automatically convert them to trigger groups.
+
+1. Go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers).
+2. Click **Create from legacy triggers** in the **Trigger groups** section.
+3. Review the preview of trigger groups that will be created.
+4. Click **Create** to confirm.
+
+You can edit the groups after creating them.
+
+> **Note:** When your legacy settings use "ANY" match type with both trigger conditions (URLs, events, or feature flags) **and** sampling below 100%, the migration creates two groups:
+>
+> 1. A group with your trigger conditions at a 100% sample rate
+> 2. A group with no conditions at your legacy sample rate
+>
+> This preserves the original behavior where recording starts if **any** condition matches **or** the session was sampled.
+
+</details>
+
+<details>
+
+<summary>Project-wide match type</summary>
+
+Since version 1.238.0 of the web SDK you can control how multiple triggers are combined, choosing whether recording will start when all triggers match or when any trigger matches. In the legacy configuration, match type and sampling apply to the project as a whole rather than per group.
+
+For example if you set an event trigger for Exception events, a URL trigger for the checkout page, and sampling to 20%.
+
+**With any matching**, you'll capture 20% of every session, and any session that has an exception event or is on the checkout page.
+
+**With all matching**, you'll capture 20% of any session on the checkout page that has an exception event.
+
+<CalloutBox icon="IconWarning" title="100% sampling with ANY matching records every session" type="caution">
+
+If you use "any" matching with 100% sampling and other conditions (URL triggers, event triggers, or feature flags), the 100% sampling causes every session to be recorded. Your other conditions become ineffective because the sampling condition alone matches every session.
+
+To fix this, either lower your sample rate or switch to "all" matching.
+
+</CalloutBox>
+
+This trap does not apply to trigger groups, where the sample rate is applied after a group's conditions match rather than as another condition alongside them.
+
+</details>
+
+## Billing limits
 
 You can set a [billing limit](/docs/billing/limits-alerts). We'll stop ingesting recordings when you reach your limit.

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -179,9 +179,9 @@ Supported on the following SDKs:
 | React Native | 4.52.0+ |
 | Flutter | 5.24.3+ |
 
-There are two modes for how minimum duration is enforced, controlled by the `strictMinimumDuration` configuration option. This is useful if you want to exclude sessions that are too short to be useful. For example, you might want to exclude sessions that are less than 2 seconds long to avoid recording sessions where users quickly bounce off your site.
+Use this to exclude sessions that are too short to be useful. For example, you might want to exclude sessions that are less than 2 seconds long to avoid recording sessions where users quickly bounce off your site.
 
-#### Strict mode (default)
+#### How minimum duration is enforced
 
 In strict mode (`strictMinimumDuration: true`), the minimum duration is checked against the **actual buffered recording data** (from first to last timestamp), not the session age. We only start sending the recording once we have the minimum duration of continuous data in the buffer.
 
@@ -272,9 +272,7 @@ Since posthog-js 1.369.0, all of these controls live in [trigger groups](#trigge
 
 If you're using the controls below, upgrade to a current SDK and migrate your configuration to trigger groups.
 
-<details>
-
-<summary>Migrating to trigger groups</summary>
+### Migrating to trigger groups
 
 If you have existing legacy trigger settings (URL triggers, event triggers, feature flags, sampling, and match type configured outside of trigger groups), you can automatically convert them to trigger groups.
 
@@ -292,11 +290,8 @@ You can edit the groups after creating them.
 >
 > This preserves the original behavior where recording starts if **any** condition matches **or** the session was sampled.
 
-</details>
 
-<details>
-
-<summary>Project-wide match type</summary>
+### Project-wide match type and sampling
 
 Since version 1.238.0 of the web SDK you can control how multiple triggers are combined, choosing whether recording will start when all triggers match or when any trigger matches. In the legacy configuration, match type and sampling apply to the project as a whole rather than per group.
 
@@ -316,11 +311,8 @@ To fix this, either lower your sample rate or switch to "all" matching.
 
 This trap does not apply to trigger groups, where the sample rate is applied after a group's conditions match rather than as another condition alongside them.
 
-</details>
 
-<details>
-
-<summary id="legacy-minimum-duration-mode">Legacy minimum duration mode</summary>
+### Legacy minimum duration mode
 
 In legacy mode (`strictMinimumDuration: false` or not set), the minimum duration is checked against the **total session age**. When a session starts, the browser records the start time. If the minimum duration has passed since the session start time, the recording data is sent to the backend.
 
@@ -343,9 +335,8 @@ For example, with a 12 second minimum:
 - After 6 more seconds on page B (12 seconds total session age), we start sending the recording
 - Result: You get 6 seconds of recording from page B, but miss the 6 seconds from page A
 
-Use legacy mode if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes. Use [strict mode](#strict-mode-default) if you want to only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users.
+Use legacy mode if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes. Use [strict mode](#how-minimum-duration-is-enforced) if you want to only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users.
 
-</details>
 
 ## Billing limits
 

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -268,9 +268,14 @@ To record both patterns independently at different rates, use two groups rather 
 
 ## Legacy controls
 
-Since posthog-js 1.369.0, all of these controls live in [trigger groups](#trigger-groups). The project-wide settings below are retained for backward compatibility, and are used by earlier SDK versions and by projects that have no trigger groups configured.
+Since posthog-js 1.369.0, all of these controls live in [trigger groups](#trigger-groups). The settings below are kept for backward compatibility. You get them in either of these cases:
 
-If you're using the controls below, upgrade to a current SDK and migrate your configuration to trigger groups.
+| Your SDK | What you get |
+| --- | --- |
+| posthog-js before 1.369.0 | Always the legacy controls below |
+| posthog-js 1.369.0 or later | Trigger groups, unless your project has no groups configured |
+
+If you are using the controls below, upgrade to a current SDK and migrate your configuration to trigger groups.
 
 ### Migrating to trigger groups
 
@@ -293,7 +298,9 @@ You can edit the groups after creating them.
 
 ### Project-wide match type and sampling
 
-Since version 1.238.0 of the web SDK you can control how multiple triggers are combined, choosing whether recording will start when all triggers match or when any trigger matches. In the legacy configuration, match type and sampling apply to the project as a whole rather than per group.
+**Applies to posthog-js 1.238.0 through 1.368.x, and to 1.369.0 or later when no trigger groups are configured.** Match type arrived in 1.238.0. Before that, you could not choose how triggers combined.
+
+In this configuration, match type and sampling apply to the project as a whole rather than per group. You choose whether recording starts when all triggers match, or when any trigger matches.
 
 For example if you set an event trigger for Exception events, a URL trigger for the checkout page, and sampling to 20%.
 
@@ -301,7 +308,7 @@ For example if you set an event trigger for Exception events, a URL trigger for 
 
 **With all matching**, you'll capture 20% of any session on the checkout page that has an exception event.
 
-<CalloutBox icon="IconWarning" title="100% sampling with ANY matching records every session" type="caution">
+<CalloutBox icon="IconWarning" title="Legacy only: 100% sampling with ANY matching records every session" type="caution">
 
 If you use "any" matching with 100% sampling and other conditions (URL triggers, event triggers, or feature flags), the 100% sampling causes every session to be recorded. Your other conditions become ineffective because the sampling condition alone matches every session.
 
@@ -313,6 +320,8 @@ This trap does not apply to trigger groups, where the sample rate is applied aft
 
 
 ### Legacy minimum duration mode
+
+**Applies to posthog-js 1.291.0 or later with a `defaults` earlier than `2025-11-30`, or with no `defaults` set. Before 1.291.0 there was no strict mode, so this was the only behavior.**
 
 In legacy mode (`strictMinimumDuration: false` or not set), the minimum duration is checked against the **total session age**. When a session starts, the browser records the start time. If the minimum duration has passed since the session start time, the recording data is sent to the backend.
 

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -23,7 +23,11 @@ export const ImgMinDurationLight =
 export const ImgMinDurationDark =
   "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/limit-session-recordings/min-duration-dark-mode.png";
 
-> This page is written with the assumed `defaults: '2026-06-25'` when initializing the PostHog SDK. Earlier `defaults` values change some of the behavior described below.
+<CalloutBox icon="IconInfo" title="This page assumes current SDK defaults" type="fyi">
+
+This page is written with the assumed `defaults: '2026-06-25'` when initializing the PostHog SDK. Earlier `defaults` values change some of the behavior described below.
+
+</CalloutBox>
 
 When setting up recording rules, there are three questions to ask yourself:
 - Which sessions are worth starting a recording for
@@ -37,8 +41,8 @@ In most cases, you can initialize the PostHog SDK with the default settings and 
 A trigger group is one rule for starting a recording. Each group carries its own conditions — URL triggers, event triggers, and a feature flag — plus its own sample rate, minimum duration, and match type (ANY/ALL).
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Trigger_group_light_31225a9908.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Trigger_group_dark_8300beb2ae.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/c_crop,w_2577,h_1964,x_0,y_40/c_pad,w_2705,h_2092,b_rgb:F3F4F1/w_1600,c_limit,q_auto,f_auto/Trigger_group_light_31225a9908.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/c_crop,w_2577,h_1964,x_0,y_40/c_pad,w_2705,h_2092,b_rgb:131316/w_1600,c_limit,q_auto,f_auto/Trigger_group_dark_8300beb2ae.png"
   alt="A trigger group's settings: group name, sample rate, minimum duration, match type, and its conditions"
   classes="rounded"
 />
@@ -47,7 +51,11 @@ Multiple trigger groups can be active at the same time. A session is recorded if
 
 Trigger groups are configured on the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), and are supported on posthog-js 1.369.0+. Earlier versions, and projects with no trigger groups configured, fall back to the [legacy controls](#legacy-controls) below. You should aim to upgrade to the latest version of `posthog-js` to use trigger groups as soon as possible.
 
-> **Note:** Creating, editing, and deleting trigger groups requires project admin permissions. Non-admin project members can view trigger group configurations but cannot modify them.
+<CalloutBox icon="IconInfo" title="Admin permissions required" type="fyi">
+
+Creating, editing, and deleting trigger groups requires project admin permissions. Non-admin project members can view trigger group configurations but cannot modify them.
+
+</CalloutBox>
 
 For example, you could create:
 
@@ -59,7 +67,11 @@ To create a trigger group, go to the [replay ingestion settings page](https://ap
 
 If you delete your last trigger group, PostHog automatically replaces it with a default "Record all sessions" group at 100% sampling with no conditions. This keeps your project on trigger groups rather than reverting to legacy recording settings.
 
-> **Note:** A trigger group with no conditions matches every session, so its sample rate becomes the recording rate for your whole project.
+<CalloutBox icon="IconInfo" title="No conditions means every session matches" type="fyi">
+
+A trigger group with no conditions matches every session, so its sample rate becomes the recording rate for your whole project.
+
+</CalloutBox>
 
 ### Controls available
 
@@ -80,11 +92,11 @@ Sampling is supported on the following SDKs:
 
 | Platform | Minimum version |
 | --- | --- |
-| Web | posthog-js 1.85.0+ |
-| Android | 3.34.0+ |
-| iOS | 3.42.0+ |
-| React Native | 4.37.0+ |
-| Flutter | 5.26.0+ |
+| [Web](/docs/libraries/js) | posthog-js 1.85.0+ |
+| [Android](/docs/libraries/android) | 3.34.0+ |
+| [iOS](/docs/libraries/ios) | 3.42.0+ |
+| [React Native](/docs/libraries/react-native) | 4.37.0+ |
+| [Flutter](/docs/libraries/flutter) | 5.26.0+ |
 
 Our recommendation is to start with capturing 100% of sessions and decrease it as needed. This helps you get a sense of how many sessions you’re recording and how much data you’re collecting.
 
@@ -100,7 +112,11 @@ This means:
 - The same session will always get the same recording decision, even across page refreshes
 - At 20% sampling, roughly 20% of your unique sessions will be recorded, distributed evenly across your traffic
 
-> **Note:** Sampling reduces the number of sessions you record, but you cannot control which specific sessions are selected — the selection is determined by the session ID hash.
+<CalloutBox icon="IconInfo" title="You can't choose which sessions are sampled" type="fyi">
+
+Sampling reduces the number of sessions you record, but you cannot control which specific sessions are selected — the selection is determined by the session ID hash.
+
+</CalloutBox>
 
 ### URL triggers
 
@@ -122,19 +138,27 @@ Use the URL tester in the settings panel to check your pattern against real URLs
 You can opt to only start recordings once your user emits a particular event. After the event is captured, the recording continues for the rest of the session.
 On the web, the client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see activity leading up to that event.
 
-> **Note:** Event triggers match on the event name only. Property filters are not applied, so an event trigger can't be scoped to a specific domain or page. Use a URL trigger for that.
+<CalloutBox icon="IconInfo" title="Event triggers match on the event name only" type="fyi">
+
+Property filters are not applied, so an event trigger can't be scoped to a specific domain or page. Use a URL trigger for that.
+
+</CalloutBox>
 
 Event triggers are supported on the following SDKs:
 
 | Platform | Minimum version |
 | --- | --- |
-| Web | posthog-js 1.186.0+ |
-| iOS | 3.48.0+ |
-| Android | 3.40.1+ |
-| React Native | 4.52.0+ |
-| Flutter | 5.25.0+ |
+| [Web](/docs/libraries/js) | posthog-js 1.186.0+ |
+| [iOS](/docs/libraries/ios) | 3.48.0+ |
+| [Android](/docs/libraries/android) | 3.40.1+ |
+| [React Native](/docs/libraries/react-native) | 4.52.0+ |
+| [Flutter](/docs/libraries/flutter) | 5.25.0+ |
 
-> On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.
+<CalloutBox icon="IconInfo" title="Mobile platforms have no pre-buffer" type="fyi">
+
+On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.
+
+</CalloutBox>
 
 #### Triggering on exceptions
 
@@ -155,7 +179,11 @@ The actual buffered duration varies depending on timing. For example:
 
 This approach balances providing useful context with browser performance — keeping multiple snapshots would be more expensive for the browser.
 
-> **Note:** Full page navigations (page refreshes) clear the buffer and start over from a new snapshot.
+<CalloutBox icon="IconInfo" title="Page refreshes clear the buffer" type="fyi">
+
+Full page navigations (page refreshes) clear the buffer and start over from a new snapshot.
+
+</CalloutBox>
 
 ### Feature flag triggers
 
@@ -173,11 +201,11 @@ Supported on the following SDKs:
 
 | Platform | Minimum version |
 | --- | --- |
-| Web | posthog-js 1.291.0+ |
-| iOS | 3.53.0+ |
-| Android | 3.44.0+ |
-| React Native | 4.52.0+ |
-| Flutter | 5.24.3+ |
+| [Web](/docs/libraries/js) | posthog-js 1.291.0+ |
+| [iOS](/docs/libraries/ios) | 3.53.0+ |
+| [Android](/docs/libraries/android) | 3.44.0+ |
+| [React Native](/docs/libraries/react-native) | 4.52.0+ |
+| [Flutter](/docs/libraries/flutter) | 5.24.3+ |
 
 Use this to exclude sessions that are too short to be useful. For example, you might want to exclude sessions that are less than 2 seconds long to avoid recording sessions where users quickly bounce off your site.
 
@@ -288,12 +316,16 @@ If you have existing legacy trigger settings (URL triggers, event triggers, feat
 
 You can edit the groups after creating them.
 
-> **Note:** When your legacy settings use "ANY" match type with both trigger conditions (URLs, events, or feature flags) **and** sampling below 100%, the migration creates two groups:
->
-> 1. A group with your trigger conditions at a 100% sample rate
-> 2. A group with no conditions at your legacy sample rate
->
-> This preserves the original behavior where recording starts if **any** condition matches **or** the session was sampled.
+<CalloutBox icon="IconInfo" title="ANY matching with sampling migrates to two groups" type="fyi">
+
+When your legacy settings use "ANY" match type with both trigger conditions (URLs, events, or feature flags) **and** sampling below 100%, the migration creates two groups:
+
+1. A group with your trigger conditions at a 100% sample rate
+2. A group with no conditions at your legacy sample rate
+
+This preserves the original behavior where recording starts if **any** condition matches **or** the session was sampled.
+
+</CalloutBox>
 
 
 ### Project-wide match type and sampling

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -23,46 +23,29 @@ export const ImgMinDurationLight =
 export const ImgMinDurationDark =
   "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/limit-session-recordings/min-duration-dark-mode.png";
 
-There are several ways to control which sessions you record:
+> This page is written with the assumed `defaults: '2026-06-25'` when initializing the PostHog SDK. Earlier `defaults` values change some of the behavior described below.
 
-## Programmatic start and stop controls
+When setting up recording rules, there are three questions to ask yourself:
+- Which sessions are worth starting a recording for
+- How many of those matching sessions you actually need
+- How short is too short to be worth keeping
 
-Most users should initialize PostHog with the default settings (which starts recording automatically) and use [trigger groups](#trigger-groups) — URL triggers, event triggers, feature flags, sampling, and minimum duration — to control what gets recorded. Manual control is only needed for advanced use cases where you need to programmatically start and stop recording at specific points in your application.
-
-<Tab.Group tabs={["Web", "iOS", "Android", "React Native", "Flutter"]}>
-  <Tab.List>
-    <Tab>Web</Tab>
-    <Tab>iOS</Tab>
-    <Tab>Android</Tab>
-    <Tab>React Native</Tab>
-    <Tab>Flutter</Tab>
-  </Tab.List>
-  <Tab.Panels>
-    <Tab.Panel>
-      <WebManualReplayControl />
-    </Tab.Panel>
-    <Tab.Panel>
-      <IOSManualReplayControl />
-    </Tab.Panel>
-    <Tab.Panel>
-      <AndroidManualReplayControl />
-    </Tab.Panel>
-    <Tab.Panel>
-      <ReactNativeManualReplayControl />
-    </Tab.Panel>
-    <Tab.Panel>
-      <FlutterManualReplayControl />
-    </Tab.Panel>
-  </Tab.Panels>
-</Tab.Group>
+In most cases, you can initialize the PostHog SDK with the default settings and use the trigger group conditions above to control what gets recorded. If you need more control, you can use [manual start/stop controls](#programmatic-start-and-stop-controls).
 
 ## Trigger groups
 
 A trigger group is one rule for starting a recording. Each group carries its own conditions — URL triggers, event triggers, and a feature flag — plus its own sample rate, minimum duration, and match type (ANY/ALL).
 
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Trigger_group_light_31225a9908.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Trigger_group_dark_8300beb2ae.png"
+  alt="A trigger group's settings: group name, sample rate, minimum duration, match type, and its conditions"
+  classes="rounded"
+/>
+
 Multiple trigger groups can be active at the same time. A session is recorded if it matches **any** of your trigger groups. Within a group, conditions are combined based on that group's match type.
 
-Trigger groups are configured on the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), and are supported on posthog-js 1.369.0+. Earlier versions, and projects with no trigger groups configured, fall back to the [legacy controls](#legacy-controls) below.
+Trigger groups are configured on the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), and are supported on posthog-js 1.369.0+. Earlier versions, and projects with no trigger groups configured, fall back to the [legacy controls](#legacy-controls) below. You should aim to upgrade to the latest version of `posthog-js` to use trigger groups as soon as possible.
 
 > **Note:** Creating, editing, and deleting trigger groups requires project admin permissions. Non-admin project members can view trigger group configurations but cannot modify them.
 
@@ -78,24 +61,30 @@ If you delete your last trigger group, PostHog automatically replaces it with a 
 
 > **Note:** A trigger group with no conditions matches every session, so its sample rate becomes the recording rate for your whole project.
 
+### Controls available
+
+| Control | What it does |
+| --- | --- |
+| [Sampling](#sampling) | Records a percentage of the sessions that matched this group. |
+| [URL triggers](#url-triggers) | Starts recording when the user visits a matching URL. |
+| [Event triggers](#event-triggers) | Starts recording when a matching event is captured. |
+| [Feature flag triggers](#feature-flag-triggers) | Records only the users who have the flag enabled. |
+| [Minimum duration](#minimum-duration) | Discards sessions shorter than the threshold you set. |
+| [Combining controls](#combining-controls) | Decides whether a group needs any of its conditions, or all of them. |
+
 ### Sampling
 
 Sampling enables you to record a percentage of sessions. Each trigger group has its own sample rate, applied to the sessions that matched that group's conditions.
 
 Sampling is supported on the following SDKs:
 
-- **Web** - posthog-js 1.85.0+
-- **Android** - 3.34.0+
-- **iOS** - 3.42.0+
-- **React Native** - 4.37.0+
-- **Flutter** - 5.26.0+
-
-<ProductScreenshot
-  imageLight={ImgSampleConfigLight}
-  imageDark={ImgSampleConfigDark}
-  alt="Sampling config shown set to 100% i.e. no sampling"
-  classes="rounded"
-/>
+| Platform | Minimum version |
+| --- | --- |
+| Web | posthog-js 1.85.0+ |
+| Android | 3.34.0+ |
+| iOS | 3.42.0+ |
+| React Native | 4.37.0+ |
+| Flutter | 5.26.0+ |
 
 Our recommendation is to start with capturing 100% of sessions and decrease it as needed. This helps you get a sense of how many sessions you’re recording and how much data you’re collecting.
 
@@ -118,13 +107,6 @@ This means:
 You can opt to only start recordings once your user visits a certain page. After the URL matches, the recording continues even after they leave the matching page.
 The client keeps a buffer in-memory (see [how the buffer works](#how-the-trigger-buffer-works) below), so you'll still be able to see how they arrived at the page.
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/replay_url_trigger_light_bc6130e3d0.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/replay_url_trigger_dark_9c6ebb6c37.png"
-  alt="Adding URL trigger to control session recordings"
-  classes="rounded"
-/>
-
 URL trigger patterns are regular expressions and are automatically anchored: PostHog wraps your pattern in `^` and `$`, so it must match the full URL including the path. A bare domain like `https://example.com` won't match `https://example.com/` or any subpage.
 
 To record on a domain, all of its subdomains, and every path:
@@ -142,33 +124,21 @@ On the web, the client keeps a buffer in-memory (see [how the buffer works](#how
 
 > **Note:** Event triggers match on the event name only. Property filters are not applied, so an event trigger can't be scoped to a specific domain or page. Use a URL trigger for that.
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/event_trigger_light_21a531edbb.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/event_trigger_dark_f67b3ffb30.png"
-  alt="Adding event trigger to control session recordings"
-  classes="rounded"
-/>
-
 Event triggers are supported on the following SDKs:
 
-- **Web** - posthog-js 1.186.0+
-- **iOS** - 3.48.0+
-- **Android** - 3.40.1+
-- **React Native** - 4.52.0+
-- **Flutter** - 5.25.0+
+| Platform | Minimum version |
+| --- | --- |
+| Web | posthog-js 1.186.0+ |
+| iOS | 3.48.0+ |
+| Android | 3.40.1+ |
+| React Native | 4.52.0+ |
+| Flutter | 5.25.0+ |
 
 > On mobile platforms, there's no URL or in-memory pre-buffer. Recording starts when the matching event is captured and continues for the rest of the session. A new session re-arms the trigger and requires a fresh matching event.
 
 #### Triggering on exceptions
 
 If you use [error tracking](/docs/error-tracking), exceptions are captured as events. You can select the exception event as an event trigger to start session recording.
-
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/replay_on_exception_light_4a88e6f239.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/replay_on_exception_dark_621ce757d3.png"
-  alt="Triggering session recordings on exceptions"
-  classes="rounded"
-/>
 
 #### How the trigger buffer works
 
@@ -195,60 +165,27 @@ You can select a [feature flag](/docs/feature-flags) to control whether to recor
 2. Go to the [replay ingestion settings page](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers).
 3. Link your newly created flag in the trigger group's **Feature flag** condition.
 
-<ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/v1725441098/posthog.com/contents/Screenshot_2024-09-04_at_10.11.12_AM.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/v1725441098/posthog.com/contents/Screenshot_2024-09-04_at_10.11.20_AM.png"
-  alt="Selecting a feature flag to control session recordings"
-  classes="rounded"
-/>
-
 ### Minimum duration
 
 In your [replay ingestion settings](https://app.posthog.com/replay/settings#selectedSetting=replay-triggers), you can set a minimum duration for sessions to be recorded. Each trigger group carries its own minimum duration.
 
 Supported on the following SDKs:
 
-- **Web:** posthog-js 1.291.0+
-- **iOS:** 3.53.0+
-- **Android:** 3.44.0+
-- **React Native:** 4.52.0+
-- **Flutter:** 5.24.3+
-
-<ProductScreenshot
-  imageLight={ImgMinDurationLight}
-  imageDark={ImgMinDurationDark}
-  alt="Minimum duration config shown set to 2 seconds"
-  classes="rounded"
-/>
+| Platform | Minimum version |
+| --- | --- |
+| Web | posthog-js 1.291.0+ |
+| iOS | 3.53.0+ |
+| Android | 3.44.0+ |
+| React Native | 4.52.0+ |
+| Flutter | 5.24.3+ |
 
 There are two modes for how minimum duration is enforced, controlled by the `strictMinimumDuration` configuration option. This is useful if you want to exclude sessions that are too short to be useful. For example, you might want to exclude sessions that are less than 2 seconds long to avoid recording sessions where users quickly bounce off your site.
 
-#### Legacy mode (default)
-
-In legacy mode (`strictMinimumDuration: false` or not set), the minimum duration is checked against the **total session age**. When a session starts, the browser records the start time. If the minimum duration has passed since the session start time, the recording data is sent to the backend.
-
-```js-web
-posthog.init('<ph_project_token>', {
-  api_host: '<ph_client_api_host>',
-  session_recording: {
-    strictMinimumDuration: false // +
-  }
-})
-```
-
-**Limitation**: If you set a high minimum duration and your user visits multiple pages (causing full page refreshes), the in-memory buffer may be cleared by navigation. When the session reaches the minimum age, we'll start sending data, but you might miss the beginning of the session because the buffer was cleared by the page refresh.
-
-For example, with a 12 second minimum:
-
-- User visits page A for 6 seconds, then navigates to page B
-- After 6 more seconds on page B (12 seconds total session age), we start sending the recording
-- Result: You get 6 seconds of recording from page B, but miss the 6 seconds from page A
-
-#### Strict mode (available in 1.291.0+)
+#### Strict mode (default)
 
 In strict mode (`strictMinimumDuration: true`), the minimum duration is checked against the **actual buffered recording data** (from first to last timestamp), not the session age. We only start sending the recording once we have the minimum duration of continuous data in the buffer.
 
-**Note**: This will become the default behavior in a future release. To opt in now, add to your config:
+Strict mode is the default on posthog-js 1.291.0+ for any `defaults` of `2025-11-30` or later. Projects on an earlier `defaults`, or none at all, get [legacy mode](#legacy-minimum-duration-mode). To set it explicitly:
 
 ```js-web
 posthog.init('<ph_project_token>', {
@@ -271,11 +208,6 @@ For example, with a 12 second minimum:
 Once a session has passed the minimum duration threshold on any page, subsequent page navigations in the same session will continue to send recordings **immediately**.
 
 This mode is **more accurate** for filtering out short sessions, especially on sites with full page refreshes, but may result in missing more session data if users **bounce quickly** across multiple pages.
-
-#### Choosing the right mode
-
-- **Use legacy mode** if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes
-- **Use strict mode** if you want to ensure you only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users
 
 #### Mobile behavior
 
@@ -304,6 +236,35 @@ For example, take one group with an event trigger for exception events and a URL
 - **With ALL matching**, you'll capture only sessions that threw an exception while on checkout.
 
 To record both patterns independently at different rates, use two groups rather than one.
+
+## Programmatic start and stop controls
+
+<Tab.Group tabs={["Web", "iOS", "Android", "React Native", "Flutter"]}>
+  <Tab.List>
+    <Tab>Web</Tab>
+    <Tab>iOS</Tab>
+    <Tab>Android</Tab>
+    <Tab>React Native</Tab>
+    <Tab>Flutter</Tab>
+  </Tab.List>
+  <Tab.Panels>
+    <Tab.Panel>
+      <WebManualReplayControl />
+    </Tab.Panel>
+    <Tab.Panel>
+      <IOSManualReplayControl />
+    </Tab.Panel>
+    <Tab.Panel>
+      <AndroidManualReplayControl />
+    </Tab.Panel>
+    <Tab.Panel>
+      <ReactNativeManualReplayControl />
+    </Tab.Panel>
+    <Tab.Panel>
+      <FlutterManualReplayControl />
+    </Tab.Panel>
+  </Tab.Panels>
+</Tab.Group>
 
 ## Legacy controls
 
@@ -354,6 +315,35 @@ To fix this, either lower your sample rate or switch to "all" matching.
 </CalloutBox>
 
 This trap does not apply to trigger groups, where the sample rate is applied after a group's conditions match rather than as another condition alongside them.
+
+</details>
+
+<details>
+
+<summary id="legacy-minimum-duration-mode">Legacy minimum duration mode</summary>
+
+In legacy mode (`strictMinimumDuration: false` or not set), the minimum duration is checked against the **total session age**. When a session starts, the browser records the start time. If the minimum duration has passed since the session start time, the recording data is sent to the backend.
+
+This is what you get when your [`defaults`](/docs/libraries/js/config) config is earlier than `2025-11-30`, or is not set. To opt in explicitly:
+
+```js-web
+posthog.init('<ph_project_token>', {
+  api_host: '<ph_client_api_host>',
+  session_recording: {
+    strictMinimumDuration: false // +
+  }
+})
+```
+
+**Limitation**: If you set a high minimum duration and your user visits multiple pages (causing full page refreshes), the in-memory buffer may be cleared by navigation. When the session reaches the minimum age, we'll start sending data, but you might miss the beginning of the session because the buffer was cleared by the page refresh.
+
+For example, with a 12 second minimum:
+
+- User visits page A for 6 seconds, then navigates to page B
+- After 6 more seconds on page B (12 seconds total session age), we start sending the recording
+- Result: You get 6 seconds of recording from page B, but miss the 6 seconds from page A
+
+Use legacy mode if you want to capture as much session data as possible and are okay with potentially missing early parts of sessions after page refreshes. Use [strict mode](#strict-mode-default) if you want to only record sessions where users actually spend the minimum duration on a single page, accepting that you may miss more bouncing users.
 
 </details>
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -142,7 +142,7 @@ There are a few common reasons that you may not see recordings appear in your pr
 
 **1. Authorized domains for recordings**
 
-Authorized domains for recordings is deprecated, you should use URL triggers instead. [Read more in our replay controls doc](/docs/session-replay/how-to-control-which-sessions-you-record#with-url-trigger-conditions).
+Authorized domains for recordings is deprecated, you should use URL triggers instead. [Read more in our replay controls doc](/docs/session-replay/how-to-control-which-sessions-you-record#url-triggers).
 
 In your [project replay settings](https://app.posthog.com/settings/environment-replay#replay-authorized-domains), for older projects, there is a section for 'Authorized domains for replay'. This is the list of domains where PostHog will capture recordings. You should make sure it's not too restrictive.
 


### PR DESCRIPTION
Updates session replay controls to match current settings + defaults.

Here are things I inferred from looking at code:

* Regrouped everything under trigger groups
* Each trigger group has its own minimum duration. When more than one group starts a recording, **the shortest minimum duration wins.**
* A group first checks its conditions. It then applies the sample rate to the sessions that matched
* Because of this, a sample rate of 100% cannot make the other conditions stop working. The old warning about this only applies to the legacy controls.
* A group with no conditions matches every session.
* A session is recorded if any one of your groups matches.
* Strict minimum duration is now the default. You get it with a `defaults` value of `2025-11-30` or later.

I could not check one thing in code: the name of the feature flag field in the settings screen. I wrote it as the trigger group's **Feature flag** condition. Please correct me if the screen says something else.