### PR TITLE
feat(session-replay): publish the image bot signing key

### DIFF
--- a/static/.well-known/http-message-signatures-directory
+++ b/static/.well-known/http-message-signatures-directory
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "crv": "Ed25519",
+      "x": "izz3eTZQw1rtZ1mqSa9KGQI4sVxtzLCx111Agw9u0u8",
+      "kty": "OKP",
+      "kid": "6AGgUdvcCK1XxwUgKQ88vBHurDVP6SXXkWy07zLGwmc",
+      "use": "sig",
+      "alg": "EdDSA"
+    }
+  ]
+}

--- a/static/.well-known/http-message-signatures-directory
+++ b/static/.well-known/http-message-signatures-directory
@@ -1,4 +1,5 @@
 {
+  "//": "Web Bot Auth signing keys for PostHogSessionReplayBot (see https://posthog.com/docs/session-replay/image-bot)",
   "keys": [
     {
       "crv": "Ed25519",

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,15 @@
     },
     "headers": [
         {
+            "source": "/.well-known/http-message-signatures-directory",
+            "headers": [
+                {
+                    "key": "Content-Type",
+                    "value": "application/http-message-signatures-directory+json"
+                }
+            ]
+        },
+        {
             "source": "/docs/:path*",
             "headers": [
                 {


### PR DESCRIPTION
## Problem

- The session replay image bot has no way to prove it is us, so a site that wants to allow it cannot tell it apart from anything else claiming the same user agent.
- Cloudflare blocks unverified AI crawlers by default on domains onboarded since July 2025, and it fronts a large share of the web.
- Its Verified Bots programme accepts three identity methods: a published IP range, reverse DNS, or a signature.
- We ruled out publishing IP ranges. The bot shares egress with the rest of PostHog, so a site that blocked those addresses to stop the crawler would also block its own webhook delivery.
- That leaves the signature, which is what this file enables.

## Changes

- Adds `/.well-known/http-message-signatures-directory`, holding one Ed25519 public key.
- Sets the content type for that path in `vercel.json`, because the file has no extension and Vercel would otherwise guess.

A verifier reads the `Signature-Agent` header on a request, fetches this directory from the origin it names, and checks the signature against the key whose `kid` matches. The `kid` here is the RFC 7638 thumbprint of the key itself, so the document is self-consistent.

> [!NOTE]
> This is the only key, because the crawler runs in one place. If a second deployment ever exists it gets its own key, as a second entry in this list. Publishing a key before anything signs with it is harmless, and Cloudflare's application process needs the directory to be reachable first.

Two follow-ups, neither blocking this file:

- The bot does not send signatures yet. That is application code in `PostHog/posthog`.
- **The directory has to sign its own response, and a static file cannot.** I have now confirmed this against [Cloudflare's documentation](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/). The response needs one signature per key, covering `@authority` with the `req` parameter, tagged `http-message-signatures-directory`, with `created` and `expires` a few seconds apart. Cloudflare's own example uses a ten second window. Cloudflare ignores any key that arrives without such a signature, so this file alone registers nothing.

  What this file did is still needed. The path exists, it serves the right media type, and the key is published. What it cannot do is carry the signature, so registration needs a function on this path with access to the private key. That is the same key the fetch lane signs with, so where it lives is one decision, not two.

## How did you test this code?

- The file parses as JSON. The `kid` matches the RFC 7638 thumbprint computed from `crv`, `kty` and `x`, and the key loads as a 32-byte Ed25519 public key.
- `vercel.json` still parses, and the new rule sits ahead of the catch-all so the specific path wins.
- Not tested: the served response. I cannot check the content type or reachability until this deploys to a preview.

## 🤖 Agent context


I (actually Claude) generated no key material. Robbie created the keypair locally and supplied only the public half, so no private key passed through the agent session.

The route here was research into what makes a crawler verifiable in 2026. That ruled out the IP-range method, because our egress is shared with webhook delivery and other outbound traffic, and publishing it would invite operators to block far more than the crawler.

Skills invoked: `/writing-pr-descriptions`.


