### PR TITLE
Add debounced search input to community directory

### DIFF
--- a/src/pages/community/directory.tsx
+++ b/src/pages/community/directory.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import debounce from 'lodash/debounce'
 import SEO from 'components/seo'
 import Editor from 'components/Editor'
 import OSTable from 'components/OSTable'
@@ -14,6 +15,7 @@ import ReaderView from 'components/ReaderView'
 import OSButton from 'components/OSButton'
 import { useApp } from '../../context/App'
 import { Select } from 'components/RadixUI/Select'
+import { OSInput } from 'components/OSForm'
 import Tooltip from 'components/RadixUI/Tooltip'
 import dayjs from 'dayjs'
 
@@ -112,12 +114,22 @@ function downloadProfilesCSV(profiles: Awaited<ReturnType<typeof fetchAllCommuni
 
 export default function CommunityDirectory(): JSX.Element {
     const { user, isModerator, isValidating: userValidating, getJwt } = useUser()
+    // searchInput updates on every keystroke; search (the API filter) follows after a debounce
+    const [searchInput, setSearchInput] = useState('')
     const [search, setSearch] = useState('')
     const [minReputation, setMinReputation] = useState<number | null>(10)
     const [teamMember, setTeamMember] = useState<'any' | 'yes' | 'no'>('no')
     const [sortField, setSortField] = useState<SortField>('reputation')
     const [sortDir, setSortDir] = useState<SortDir>('desc')
     const [exporting, setExporting] = useState(false)
+
+    const debouncedSetSearch = useMemo(() => debounce(setSearch, 300), [])
+
+    useEffect(() => {
+        debouncedSetSearch(searchInput)
+    }, [searchInput, debouncedSetSearch])
+
+    useEffect(() => () => debouncedSetSearch.cancel(), [debouncedSetSearch])
 
     const handleSort = useCallback(
         (field: SortField) => {
@@ -231,7 +243,7 @@ export default function CommunityDirectory(): JSX.Element {
                     title: 'Community directory',
                     description: 'Browse community profiles by reputation',
                 }}
-                onSearchChange={setSearch}
+                onSearchChange={setSearchInput}
             >
                 {error ? (
                     <p className="text-red">Failed to load profiles. Try refreshing.</p>
@@ -247,6 +259,22 @@ export default function CommunityDirectory(): JSX.Element {
                                 {isValidating ? ' · updating…' : ''}
                             </p>
                             <div className="flex flex-wrap items-center gap-2">
+                                <OSInput
+                                    type="text"
+                                    label="Search profiles"
+                                    showLabel={false}
+                                    placeholder="Search name or email…"
+                                    value={searchInput}
+                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                        setSearchInput(e.target.value)
+                                    }
+                                    onClear={() => setSearchInput('')}
+                                    showClearButton
+                                    size="sm"
+                                    width="full"
+                                    name="profile-search"
+                                    containerClassName="w-56"
+                                />
                                 <Select
                                     prefix="Min reputation"
                                     value={minReputation == null ? 'any' : String(minReputation)}


### PR DESCRIPTION
Apparently this existed if you magically knew to type shift + f? Close this if there's a good reason not to do it, but it took me way to long to figure that out and i feel like querying this table should be much easier 😅 

## TL;DR
Added a visible search input field to the community directory that allows users to search profiles by name or email, with debounced API calls to improve performance.

## What changed?
- Added a new `OSInput` search field to the community directory UI that displays prominently in the filters section
- Implemented debounced search behavior: the input updates immediately on keystroke (`searchInput` state), while the actual API filter (`search` state) updates after a 300ms delay using lodash debounce
- Added necessary imports: `useEffect` hook, `debounce` from lodash, and `OSInput` component
- Connected the search input to trigger profile filtering by name or email
- Added a clear button to the search input for easy reset

## Technical details
- The dual state approach (`searchInput` for UI responsiveness, `search` for API calls) prevents excessive API requests while maintaining a snappy user experience
- Proper cleanup of the debounced function is handled via `useEffect` return to prevent memory leaks
- The search field is sized at `w-56` and includes a placeholder hint "Search name or email…"

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*