### PR TITLE
chore(docs): drop claims about the removed session summaries

### DIFF
--- a/contents/docs/experiments/analyze-experiments-ai.mdx
+++ b/contents/docs/experiments/analyze-experiments-ai.mdx
@@ -34,7 +34,6 @@ Select a prompt to try it out in the PostHog app:
 - **Name your goal metric** – "with conversion on `purchase_completed`" helps PostHog AI configure the right success metric
 - **Specify split percentages** – "70/30 split" or "equal split across three variants" tells PostHog AI exactly how to allocate traffic
 - **Ask about significance** – "Is this result statistically significant?" prompts PostHog AI to interpret the confidence intervals
-- **Combine with session summaries** – "Summarize replays for users in the control group" reveals behavioral differences that metrics alone might miss
 - **Ask for recommendations** – "Should I ship this?" prompts PostHog AI to weigh the evidence and suggest next steps
 
 ## Get started

--- a/contents/docs/session-replay/surfaces/api.mdx
+++ b/contents/docs/session-replay/surfaces/api.mdx
@@ -20,7 +20,6 @@ Authenticate with a [personal API key](/docs/api#authentication) scoped to `sess
 - **Update recordings** – mark a recording as viewed, or update its metadata.
 - **Delete recordings** – remove a recording, or delete a batch of them for privacy and compliance requests. Deletion is permanent.
 - **Manage playlists** – create, read, update, and delete collections and saved filter playlists, and add or remove recordings from them.
-- **Read session summaries** – list and fetch AI summaries that have already been generated for a session.
 
 Full request and response details live in the [session recordings API reference](/docs/api/session-recordings).
 


### PR DESCRIPTION
## Changes

PostHog/posthog#80312 removed the legacy session summarization. Two docs pages still tell readers it exists.

- `session-replay/surfaces/api.mdx` listed "Read session summaries – list and fetch AI summaries that have already been generated for a session" among the API's capabilities. Those endpoints are gone, so a reader following this hits nothing.
- `experiments/analyze-experiments-ai.mdx` suggested combining experiment analysis with session summaries.

Both bullets are removed rather than reworded, because nothing replaces them at the same level: summarizing a recording is now a Replay Vision summarizer scanner, not a session replay API call.

Left alone, with reasoning:

- `experiments/analyzing-results.mdx` and the example prompt in `analyze-experiments-ai.mdx` describe the **Summarize session replays** button, which still exists. It is worth knowing that the tool behind it (`experiment_session_replays_summary`) only counts recordings and builds filters, and never generated summaries even before the removal. The copy oversells it, but that is a product decision rather than a stale reference, so I did not rewrite it.
- `mcp-analytics/surfaces/web-app.mdx` mentions "generated session summaries". I checked: MCP analytics has its own intent summarization in `products/mcp_analytics/backend/intent_generation.py` and never depended on the removed feature. Accurate as written.

## How did you test this code?

I am an agent. This is a two-bullet deletion from MDX prose, so there is nothing to run. I verified against posthog master that the endpoints named in the API bullet no longer exist, and that MCP analytics summarization is a separate implementation.

Not run: no local build or link check. No links were added or changed, and no page was moved, so no redirect is needed.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
