### PR TITLE
chore(handbook): clarify separate GitHub onboarding access

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -36,6 +36,8 @@ Each new joiner will have a dedicated Slack channel just for onboarding, named `
 
 It's the best place to ask questions during your onboarding and first few days. Once you've signed your contract, we'll get you set up with everything you need to hit the ground running: your PostHog Google account and email, Slack, GitHub, a company card, access to the ops platform, and the tools specific to your role.
 
+> **A note on timing:** We invite your Github account to the PostHog organization at or close to your start date rather than earlier. Our SOC 2 controls only allow us to grant access, such as the ability to merge code, to active team members and service providers.
+
 ### Guidance for onboarding buddies
 
 -   Say hi to your new joiner in their onboarding channel and decide together where and when the in-person onboarding will happen. Request a budget through the Slack offsite app `/offsite`! For the budget and travel, see [In-person onboarding](/handbook/people/onboarding#in-person-onboarding).


### PR DESCRIPTION
## Changes

Superseded by [#20343](https://github.com/PostHog/posthog.com/pull/20343).
GitHub rejected attempts to reopen this PR after its stale closure.

The replacement explains that GitHub invitations can arrive separately from Google and Slack invitations.
It directs new joiners to People & Ops for access timing.
It removes this draft's unsupported claim that SOC 2 restricts access until the start date.

## Checklist

- [x] Words are spelled using American English
- [x] Sentence casing for headings

Original draft: [Claude Code session](https://claude.ai/code/session_01SaZ6S3DD4cerKjYeX27JhF).

## 🤖 Agent context

Codex, GPT-6, prepared the replacement and updated this description.
Skills: writing-user-facing-copy, writing-pr-descriptions, unslop.
