### PR TITLE
Signpost PostHog for Students from the handbook internships section

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -464,7 +464,11 @@ Currently, we are hiring a lot – aiming to go from ~96 people to ~185 by the e
 
 ## Internships
 
-We regularly receive enthusiastic requests from students about internships, which we're always flattered by. Currently, we don't offer internships, placements or work experience - we’re a bit too scrappy to do them well right now. Once you ~~escape college/university~~ graduate, you're welcome to apply to full time roles via our [careers page](/careers). Your details will then go straight through to our hiring team (who _are_ real humans, not AI) and you'll hear back from us shortly after.
+We regularly receive enthusiastic requests from students about internships, which we're always flattered by. Currently, we don't offer internships, placements or work experience - we’re a bit too scrappy to do them well right now.
+
+That said, if you're still studying, there are other ways to work with us. Through [PostHog for Students](/students#campus) you or your student org can apply to host a PostHog event on campus - we'll send a team member for a mixer and a Q&A, plus $2,000 in cash and merch to run it (currently Bay Area universities and UC campuses in California). If your school isn't on that list, our [community incubator](/community-incubator) offers cash grants to start a co-working group of builders in your city, wherever you are.
+
+Once you ~~escape college/university~~ graduate, you're welcome to apply to full time roles via our [careers page](/careers). Your details will then go straight through to our hiring team (who _are_ real humans, not AI) and you'll hear back from us shortly after.
 
 ## Post-mortems
 

--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -466,7 +466,7 @@ Currently, we are hiring a lot – aiming to go from ~96 people to ~185 by the e
 
 We regularly receive enthusiastic requests from students about internships, which we're always flattered by. Currently, we don't offer internships, placements or work experience - we’re a bit too scrappy to do them well right now.
 
-That said, if you're still studying, there are other ways to work with us. Through [PostHog for Students](/students#campus) you or your student org can apply to host a PostHog event on campus - we'll send a team member for a mixer and a Q&A, plus $2,000 in cash and merch to run it (currently Bay Area universities and UC campuses in California). If your school isn't on that list, our [community incubator](/community-incubator) offers cash grants to start a co-working group of builders in your city, wherever you are.
+That said, if you're still studying, there are other ways to work with us. Through [PostHog for Students](/students) you or your student org can apply to host a PostHog event on campus - we'll send a team member for a mixer and a Q&A, plus $2,000 in cash and merch to run it (currently Bay Area universities and UC campuses in California). If your school isn't on that list, our [community incubator](/community-incubator) offers cash grants to start a co-working group of builders in your city, wherever you are.
 
 Once you ~~escape college/university~~ graduate, you're welcome to apply to full time roles via our [careers page](/careers). Your details will then go straight through to our hiring team (who _are_ real humans, not AI) and you'll hear back from us shortly after.
 


### PR DESCRIPTION
## Changes

The **Internships** section of the hiring process handbook said we don't offer internships and then jumped straight to "come back once you graduate". This adds a paragraph pointing students at the two things that _are_ open to them while they're still studying:

- [PostHog for Students](https://posthog.com/students) – apply to host a campus event (mixer + Q&A, plus cash and merch to run it), currently Bay Area universities and UC campuses in California
- [Community incubator](https://posthog.com/community-incubator) – cash grants to start a co-working group in your city, for anyone whose school isn't on that list

The existing "no internships" answer and the `/careers` closing line are unchanged.

## Why

The internships answer read as a complete dead end. Both programs launched after that copy was written, so students landing on the handbook got a flat no with no mention of either.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a – no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
