### PR TITLE
chore(startups): document the company email domain requirement

### DIFF
--- a/contents/founder-lab.mdx
+++ b/contents/founder-lab.mdx
@@ -177,7 +177,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
             <td className="text-center">Free plan only</td>
             <td className="text-center">&lt;$5m in funding and &lt;20 staff members</td>
             <td className="text-center">&lt;$8m in funding and less than 5 years old</td>
-            <td className="bg-accent text-center">&lt;$5m in funding and less than 2 years old</td>
+            <td className="bg-accent text-center">&lt;$5m in funding, less than 2 years old, and a company email domain</td>
         </tr>
         <tr class="border-b border-primary">
             <td><strong>Limitations</strong></td>
@@ -239,12 +239,17 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 <div class="max-w-screen-md mx-auto space-y-1">
 <details>
 <summary>How do I apply?</summary>
-<p>Just sign up to a paid plan in PostHog (you're only charged for usage) and then fill in this <a href="https://app.posthog.com/startups">form</a>. We will review and apply the credit if you're eligible. If you're accepted into the program, we will notify you by email. </p>
+<p>Just sign up to a paid plan in PostHog (you're only charged for usage) and then fill in this <a href="https://app.posthog.com/startups">form</a>. Apply from a PostHog account that uses your company email address. We will review and apply the credit if you're eligible. If you're accepted into the program, we will notify you by email. </p>
 </details>
 
 <details> 
 <summary>Who's eligible? </summary>
-<p>Your company needs to be less than 2 years old and have raised less than $5m funding. You need to have signed up any time from Jan 1st 2023 onwards. </p>
+<p>Your company needs to be less than 2 years old and have raised less than $5m funding. You need to have signed up any time from Jan 1st 2023 onwards, and your PostHog account needs to use your company's email domain. Applications from personal email addresses, like gmail.com or outlook.com, are not accepted.</p>
+</details>
+
+<details>
+<summary>What if we don't have a company email domain yet?</summary>
+<p>You need one to apply, but you don't need credits to start. Every PostHog product has a <a href="/pricing">monthly free allowance</a>, so you can build on PostHog for free and apply for the program once you have a company domain.</p>
 </details>
 
 <details>

--- a/contents/handbook/marketing/startups.md
+++ b/contents/handbook/marketing/startups.md
@@ -10,7 +10,7 @@ We run two special programs for early-stage teams, plus external partnerships wi
 
 | Feature                     | Startups                                              | Y Combinator                                          |
 | --------------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
-| Eligibility                 | <2 years old, <$5M raised, not acquired               | Must be in YC, <$25m raised                           |
+| Eligibility                 | <2 years old, <$5M raised, not acquired, company email domain | Must be in YC, <$25m raised, company email domain     |
 | Credit                      | $50,000 for 12 months                                 | $50k per year, whilst eligible                        |
 | Can use credit for add-ons? | ⚠️ Yes, but cannot use credit for BAA in Boost package | ✅ Yes, and can use credit for BAA in Boost package    |
 | Can use credit for AI tools? | ❌ No, from September 14, 2026 (PostHog Desktop, Replay Vision, PostHog AI, Inbox) | ❌ No, from September 14, 2026 (PostHog Desktop, Replay Vision, PostHog AI, Inbox) |
@@ -20,7 +20,7 @@ We run two special programs for early-stage teams, plus external partnerships wi
 
 ## PostHog for Startups
 
-Any company that is <2 years old and has raised less than $5M in funding is eligible to apply and claim the following:
+Any company that is <2 years old and has raised less than $5M in funding is eligible to apply, from a PostHog account that uses the company's email domain, and claim the following:
 
 -   $50,000 in PostHog credits (valid for 12 months)
 -   One unique welcome pack for founders
@@ -34,6 +34,8 @@ Any company that is <2 years old and has raised less than $5M in funding is elig
 > ⭐ **Small open source projects** without corporate backing and less than $200k annual revenue can contact support to have the 12-month credit expiry waived.
 
 All applications are **automatically approved**, then **manually reviewed** for eligibility.
+
+Applications from free or disposable email domains (gmail.com, outlook.com, and similar) are rejected automatically at submission. This applies to both programs. Founders who don't have a company domain yet can still use the monthly free allowance on every product and apply once they have one.
 
 We track all PostHog for Startups applications in [this Zapier table](http://tables.zapier.com/app/tables/t/01JRARGWTSDYCGNS12HXN3B6DY) and [this Zap](https://zapier.com/editor/291861515/published?conversationId=6e76ea6b-ef2d-4851-9520-55be39df1232).
 
@@ -55,7 +57,7 @@ You can find the copy for the latest deal on Bookface in this [doc](https://docs
 
 > ✅ Credits **can** be used to claim a BAA under the Boost plan.
 
-YC teams must apply via [our secret YC page](https://app.posthog.com/startups/yc), where we ask for a screenshot from Bookface to prove their eligibility.
+YC teams must apply via [our secret YC page](https://app.posthog.com/startups/yc), from a PostHog account that uses the company's email domain, and we ask for a screenshot from Bookface to prove their eligibility.
 
 We track all PostHog for YC applications in [this Zapier table](https://tables.zapier.com/app/tables/t/01JRCYMWYAJNP3K0B6GTYKKBQB).
 

--- a/src/components/Startups/StartupProgram.tsx
+++ b/src/components/Startups/StartupProgram.tsx
@@ -283,8 +283,9 @@ const faqItems = [
                 <Link to="https://app.posthog.com/startups" external className="underline font-semibold">
                     form
                 </Link>
-                . We will apply the credit automatically if you're eligible. If you're accepted into the startups
-                program, we will notify you by email.
+                . Apply from a PostHog account that uses your company email address. We will apply the credit
+                automatically if you're eligible. If you're accepted into the startups program, we will notify you by
+                email.
             </p>
         ),
     },
@@ -293,7 +294,21 @@ const faqItems = [
         content: (
             <p>
                 Your company needs to be less than 2 years old and have raised less than $5m funding. You need to have
-                signed up any time from Jan 1st 2023 onwards.
+                signed up any time from Jan 1st 2023 onwards, and your PostHog account needs to use your company's
+                email domain. Applications from personal email addresses, like gmail.com or outlook.com, are not
+                accepted.
+            </p>
+        ),
+    },
+    {
+        trigger: "What if we don't have a company email domain yet?",
+        content: (
+            <p>
+                You need one to apply, but you don't need credits to start. Every PostHog product has a{' '}
+                <Link to="/pricing" state={{ newWindow: true }} className="underline font-semibold">
+                    monthly free allowance
+                </Link>
+                , so you can build on PostHog for free and apply for the program once you have a company domain.
             </p>
         ),
     },
@@ -413,11 +428,15 @@ const faqStructuredData = [
     },
     {
         question: 'How do I apply to PostHog for Startups?',
-        answer: 'Sign up to a paid plan in PostHog (you are only charged for usage) and complete the startups application form. We apply the credit automatically if you are eligible and notify you by email once accepted.',
+        answer: 'Sign up to a paid plan in PostHog (you are only charged for usage) and complete the startups application form from an account that uses your company email address. We apply the credit automatically if you are eligible and notify you by email once accepted.',
     },
     {
         question: 'Who is eligible for PostHog for Startups?',
-        answer: 'Your company needs to be less than 2 years old and have raised less than $5m in funding, and you need to have signed up any time from Jan 1st 2023 onwards.',
+        answer: 'Your company needs to be less than 2 years old and have raised less than $5m in funding, you need to have signed up any time from Jan 1st 2023 onwards, and your PostHog account needs to use your company email domain. Applications from personal email addresses, like gmail.com or outlook.com, are not accepted.',
+    },
+    {
+        question: 'What if my startup does not have a company email domain yet?',
+        answer: 'You need a company email domain to apply, but you do not need credits to start. Every PostHog product has a monthly free allowance, so you can build on PostHog for free and apply for the program once you have a company domain.',
     },
     {
         question: 'How far does $50,000 in PostHog credits go?',
@@ -750,6 +769,7 @@ export default function StartupProgram({ partnerSlug = null }: StartupProgramPro
                                                 <ul className="pl-0 list-none ml-0">
                                                     <li>&lt;$5m in funding</li>
                                                     <li>&lt;2 years old</li>
+                                                    <li>Company email domain</li>
                                                 </ul>
                                             ),
                                             className: 'bg-[#FFF6DE] dark:bg-yellow/10 !border-l-2 !border-l-yellow',


### PR DESCRIPTION
## Related PRs

- [PostHog/billing#2158](https://github.com/PostHog/billing/pull/2158): the server-side block and the `blocked_at: "api"` event (merge first)
- [PostHog/posthog#83072](https://github.com/PostHog/posthog/pull/83072): the in-app form gate and the `blocked_at: "form"` event
- PostHog/posthog.com#19486: this PR, the eligibility copy on posthog.com and the handbook

## Changes

Startup program applications now require a PostHog account on a company email domain (enforced by [PostHog/billing#2158](https://github.com/PostHog/billing/pull/2158), with an in-app gate in [PostHog/posthog#83072](https://github.com/PostHog/posthog/pull/83072)). This PR states the requirement on the pages where eligibility is described:

- `/startups`: the "Who's eligible?" FAQ and the eligibility comparison table now list the company email domain requirement, and "How do I apply?" says to apply from an account with your company email address. A new FAQ tells teams without a company domain yet that they can build on the monthly free allowance for every product and apply later. The structured-data FAQ mirror matches.
- `/founder-lab`: the same eligibility, apply, and new-FAQ updates on the legacy page.
- `/handbook/marketing/startups`: the eligibility table and program sections note the requirement for both the startup and YC programs, plus a line that free and disposable email domains are rejected automatically at submission.

No screenshots: text-only changes to existing FAQ entries, table cells, and handbook copy.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

