### PR TITLE
docs: deduplicate tile filter override and {filters} docs

### DIFF
--- a/contents/docs/data-warehouse/sql/index.mdx
+++ b/contents/docs/data-warehouse/sql/index.mdx
@@ -112,7 +112,7 @@ WHERE event = '$pageview'
    AND properties.$current_url LIKE '%/blog%'
 ```
 
-To have the insight or dashboard date range and other filters apply to the insight, include [`{filters}` variable](/docs/data-warehouse/sql/variables) in your query like this:
+To have the insight or dashboard date range and other filters apply to the insight, include the [`{filters}` placeholder](/docs/data-warehouse/sql/variables) in your query like this:
 
 ```sql
 SELECT *

--- a/contents/docs/data-warehouse/sql/variables.mdx
+++ b/contents/docs/data-warehouse/sql/variables.mdx
@@ -137,7 +137,7 @@ and timestamp >= {filters.dateRange.from} and timestamp < {filters.dateRange.to}
   classes="rounded"
 />
 
-### How date ranges are resolved
+## How date ranges are resolved
 
 When you use `{filters.dateRange.from}`, `{filters.dateRange.to}`, or `{filters}`, PostHog resolves date values with day-level semantics to match how other insight types handle date ranges:
 

--- a/contents/docs/product-analytics/dashboards.mdx
+++ b/contents/docs/product-analytics/dashboards.mdx
@@ -98,7 +98,7 @@ A few things to keep in mind:
 
 New dashboards are set to _No date range override_ by default. This means all insights use the date range applied in their configuration.
 
-Changing the date range on a dashboard forces all the insights to use the same date range, but this doesn't impact the date range that's shown when viewing an individual insight.
+Changing the date range on a dashboard forces all the insights to use the same date range, unless a tile [overrides or ignores dashboard filters](#overriding-filters-at-the-tile-level). This doesn't impact the date range that's shown when viewing an individual insight.
 
 The date range can be accessed in SQL insights through the [`filters` variable](/docs/data-warehouse/sql/variables) like `filters.dateRange.from` and `filters.dateRange.to`.
 
@@ -143,8 +143,6 @@ To configure tile-level overrides:
 
 Some controls may be disabled depending on the insight type. For example, interval is only available for time-series insights, and breakdown isn't supported by all chart types.
 
-To completely detach a tile from all dashboard filters, enable **Ignore dashboard filters**. The tile-level overrides you configure still apply even when this is enabled.
-
 ### Filter precedence: dashboard vs. tile level
 
 Individual tiles (insights) can have their own filters and date ranges configured separately from dashboard-level overrides. When both are set, **tile-level filters take precedence**:
@@ -157,13 +155,9 @@ The insight card displays a warning when tile filters are merging with or overri
 
 ### Ignoring dashboard filters entirely
 
-If you need a tile to completely ignore all dashboard filters, enable the **Ignore dashboard filters** switch in the tile's filter override modal:
+To completely detach a tile from all dashboard filters, toggle **Ignore dashboard filters** on in the tile's filter override modal (**⋯** → **Override tile filters**).
 
-1. Click the **⋯** menu on the insight card.
-2. Select **Override tile filters**.
-3. Toggle **Ignore dashboard filters** on.
-
-When enabled, the tile uses only its own configured filters and ignores the dashboard's date range, properties, breakdown, interval, and test account filter. The tile's own filter overrides still apply, and [dashboard variables](/docs/data-warehouse/sql/variables) continue to work.
+When enabled, the tile ignores the dashboard's date range, properties, breakdown, interval, and test account filter. Tile-level overrides still apply, and [dashboard variables](/docs/data-warehouse/sql/variables) continue to work.
 
 Tiles ignoring dashboard filters display an **Ignores dashboard filters** indicator in the card heading.
 

--- a/contents/docs/sql/index.mdx
+++ b/contents/docs/sql/index.mdx
@@ -66,7 +66,7 @@ ORDER BY url_count DESC
 
 <ProductScreenshot imageLight={SQLLight} imageDark={SQLDark} alt="SQL insight" />
 
-When a SQL insight's query includes the [`{filters}` variable](/docs/data-warehouse/sql/variables), you can adjust the date range and add property filters directly on the saved insight page without opening the SQL editor. Changes re-run the query immediately but aren't saved until you explicitly save the insight.
+When a SQL insight's query includes the [`{filters}` placeholder](/docs/data-warehouse/sql/variables), you can adjust the date range and add property filters directly on the saved insight page without opening the SQL editor. Changes re-run the query immediately but aren't saved until you explicitly save the insight. Clicking **Edit** carries any unsaved filter changes into the SQL editor where you can save them.
 
 You can use SQL insights within [notebooks](/docs/notebooks) and with external sources using the [data warehouse](/docs/data-warehouse).
 


### PR DESCRIPTION
## TL;DR

Four docs PRs about dashboard and SQL filters merged at once. Together they said the same thing twice in places and used two names for one feature. This PR removes the repeats and makes the naming consistent. No new information added or removed.

## Why

Follow-up cleanup after merging #18948, #19144, #18847, and #18808, which were written independently and overlap.

## Changes

- `dashboards.mdx`: #18847 and #18808 both explained the **Ignore dashboard filters** switch, with the modal steps listed twice. Kept the dedicated section, dropped the duplicate paragraph, and inlined the steps.
- `dashboards.mdx`: "Changing the date range on a dashboard forces all the insights to use the same date range" is no longer true now tiles can override or ignore dashboard filters. Added the exception with a link.
- `variables.mdx`: promoted "How date ranges are resolved" (#19144) from H3 to H2. It covers `{filters}` too, not just the `filters.dateRange.*` variables it was nested under.
- `sql/index.mdx`, `data-warehouse/sql/index.mdx`: renamed "`{filters}` variable" to "`{filters}` placeholder" to match the variables page, where "variable" means `{variables.*}`.
- `sql/index.mdx`: added the "Clicking **Edit** carries unsaved filter changes" sentence so both view-mode paragraphs from #18948 match.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
