### PR TITLE
docs: fix broken iOS push notifications links in configure-channels

### DIFF
--- a/contents/docs/workflows/configure-channels.mdx
+++ b/contents/docs/workflows/configure-channels.mdx
@@ -94,7 +94,7 @@ Push is the newest workflows channel and is in beta. It's rolling out gradually,
 
 <CalloutBox icon="IconInfo" title="Device tokens come from the mobile SDK" type="fyi">
 
-Push delivery requires your app to register each user's device token with PostHog through the mobile SDK ([iOS](/docs/libraries/ios/push-notifications), [Android](/docs/libraries/android#push-notifications)), which is also where you implement identity verification if you enable it below. Connecting a channel here sets up the credentials PostHog sends with. It doesn't collect tokens on its own.
+Push delivery requires your app to register each user's device token with PostHog through the mobile SDK ([iOS](/docs/workflows/push-notifications/ios), [Android](/docs/libraries/android#push-notifications)), which is also where you implement identity verification if you enable it below. Connecting a channel here sets up the credentials PostHog sends with. It doesn't collect tokens on its own.
 </CalloutBox>
 
 **Firebase Cloud Messaging (FCM)**
@@ -123,7 +123,7 @@ A device token says *where* to deliver a notification, not *who* the device belo
 | **Optional** | Tokens are verified and recorded, but devices can still register without one. Use this to confirm your app sends valid tokens before you require them. |
 | **Required** | Devices without a valid token can't register or unregister. Switch to this only once your app sends tokens, otherwise registration stops working. |
 
-When you enable Optional or Required, paste your backend's EC (P-256) **public key** into the field below the mode. Your backend signs each token with the matching private key (ES256), and PostHog verifies it with the public key you paste here, so the private key never leaves your control. Leave the field blank to verify against your project's Feature flags secure API key instead. Either way, you implement the signing in the mobile SDK ([iOS](/docs/libraries/ios/push-notifications#identity-verification), [Android](/docs/libraries/android#identity-verification)).
+When you enable Optional or Required, paste your backend's EC (P-256) **public key** into the field below the mode. Your backend signs each token with the matching private key (ES256), and PostHog verifies it with the public key you paste here, so the private key never leaves your control. Leave the field blank to verify against your project's Feature flags secure API key instead. Either way, you implement the signing in the mobile SDK ([iOS](/docs/workflows/push-notifications/ios#identity-verification), [Android](/docs/libraries/android#identity-verification)).
 
 Once configured, add a **Push** step in the [workflow builder](/docs/workflows/workflow-builder), set the notification title and body (with variables like `{{ person.name }}`), and optionally set platform-specific overrides.
 


### PR DESCRIPTION
## Changes

The iOS links in the Workflows push notifications channel docs pointed at `/docs/libraries/ios/push-notifications`, which does not exist, so readers setting up push on iOS got a 404. A customer hit this while following the setup guide.

- Repoint both iOS links in `configure-channels.mdx` to `/docs/workflows/push-notifications/ios` (the page that exists).
- The identity-verification link keeps its `#identity-verification` anchor, which that page has.
- Android links are unchanged (their target page exists).

The dead path was left behind when #16177 (which would have created `/docs/libraries/ios/push-notifications`) was closed unmerged.

## 🤖 Agent context

I (Claude) found the dead links while handling a support ticket where a customer reported the 404, verified the target page and its `#identity-verification` anchor exist on master, and made the two link edits. No content changed beyond the two URLs.
