### PR TITLE
fix(handbook): remove broken TAE Lead profile link from sales onboarding

### DIFF
--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -113,7 +113,6 @@ By the end of month 3:
  - Read all of the Sales section in the Handbook, and update it as you learn more.
  - Meet with [Ben](/community/profiles/30205), the lead responsible for Sales, CS, and Onboarding.
  - Meet with [Simon](/community/profiles/28895), CSM Lead
- - Meet with [Alex](community/profiles/33387), TAE Lead
  - PostHog integration exercise - by the end of week 1:
    - Find/build a blank app which doesn’t yet have PostHog integrated.  You should be able to vibe code something simple with React using Cursor or Lovable.dev
    - Once you’ve got your app up and running get PostHog deployed and capturing events and replays.  Default config is fine.


### PR DESCRIPTION
## Summary
- Remove a broken relative community profile link from the sales new-hire onboarding handbook
- `community/profiles/33387` resolved to `/handbook/growth/sales/community/profiles/33387` instead of a real profile page

## Test plan
- [ ] Confirm the "Meet with Alex, TAE Lead" line is gone from `/handbook/growth/sales/new-hire-onboarding`
- [ ] Confirm `/handbook/growth/sales/community/profiles/33387` is no longer linked from that page


Made with [Cursor](https://cursor.com)