### PR TITLE
Update all-hands topic of the day page

### DIFF
--- a/contents/handbook/exec/all-hands-topics.md
+++ b/contents/handbook/exec/all-hands-topics.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-James presents a topic of the day each week in the company all hands. The main objective of this is to repeat and reinforce key messages:
+Someone from the Blitzscale team presents a topic of the day each week in the company all hands - it isn't always the same person. The main objective of this is to repeat and reinforce key messages:
 
 -   Make sure everyone knows what our mission is, and how their work contributes
 -   Make sure everyone knows what our strategy is, and how their work contributes
@@ -13,7 +13,11 @@ James presents a topic of the day each week in the company all hands. The main o
 
 An element of repetition is important because a) we are regularly adding new people to the team, and b) just hearing a message once is not enough for it to stick. 'Repetition' does not mean literally saying the same words over and over again - it's more about finding examples of things people are doing or working on, and showing how those tie back to the bigger picture of what's important at PostHog.
 
-We generally avoid using the topic of the day to announce new things, as these should be done async. Sometimes he will go deeper on a recent announcement, e.g. why we cut pricing for X.
+We generally avoid using the topic of the day to announce new things, as these should be done async. Sometimes the topic goes deeper on a recent announcement, e.g. why we cut pricing for X.
+
+The format varies week to week. Sometimes it's a talk, sometimes we invite demos - anyone can be asked or volunteer - and sometimes it's more curated around a particular theme. There is always time for anyone to ask any question.
+
+If you have a topic or theme you'd like covered, ask in the [#team-blitzscale](https://posthog.slack.com/archives/C06LMMS3YP4) channel in Slack.
 
 ## Important topics to revisit regularly
 

--- a/contents/handbook/exec/all-hands-topics.md
+++ b/contents/handbook/exec/all-hands-topics.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-Someone from the Blitzscale team presents a topic of the day each week in the company all hands - it isn't always the same person. The main objective of this is to repeat and reinforce key messages:
+Someone from <SmallTeam slug="blitzscale" /> presents a topic of the day each week in the company all hands - it isn't always the same person. The main objective of this is to repeat and reinforce key messages:
 
 -   Make sure everyone knows what our mission is, and how their work contributes
 -   Make sure everyone knows what our strategy is, and how their work contributes


### PR DESCRIPTION
## Changes

The topic of the day is no longer presented by one person - it's hosted by the Blitzscale team, and the format varies week to week (a talk, invited demos, or something more curated around a theme). There's always time for anyone to ask any question.

Also adds a pointer to #team-blitzscale for anyone who wants to request a topic or theme.

**Why:** The page still described the meeting as it used to run, which is out of date and doesn't tell people where to send topic requests.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*