### PR TITLE
Fix duplicated intro text on silent failure pocket guide

### DIFF
--- a/contents/pocket-guides/self-driving/silent-failure-core-action/index.mdx
+++ b/contents/pocket-guides/self-driving/silent-failure-core-action/index.mdx
@@ -90,9 +90,7 @@ report:
 
 # Silent failure in your core action
 
-Every product has one action that matters more than the rest: checkout, publish, send, or deploy.
-When it fails loudly, you hear about it. When it fails quietly, nobody sees an error and nobody
-Every product has one action that matters more than the rest: checkout, publish, send, or deploy. When it fails loudly, you hear about it. When it fails quietly, nobody sees an error and nobody files a ticket. 
+Every product has one action that matters more than the rest: checkout, publish, send, or deploy. When it fails loudly, you hear about it. When it fails quietly, nobody sees an error and nobody files a ticket.
 
 This scout watches your most important flow and catches the failures nobody reports.
 


### PR DESCRIPTION
## Changes

The intro paragraph on `/pocket-guides/self-driving/silent-failure-core-action` had a truncated duplicate of itself pasted above the complete version, so the rendered page showed a sentence that cut off mid-clause and then restarted. Removed the broken fragment and kept the complete sentence.

**Why:** Reported as a typo on the live page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090NGM3S7M/p1786730643452419)*