### PR TITLE
Pricing fixes

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -290,7 +290,9 @@ export default function Tabbed() {
             return index === -1 ? Infinity : index
         }
         return initialProducts
-            .filter((product) => !!product.unit && !product.hideFromPricingTableAndCalculator)
+            .filter(
+                (product) => !!product.unit && !product.hideFromPricingTableAndCalculator && !product.hideFromCalculator
+            )
             .sort((a, b) => navOrder(a) - navOrder(b))
     }, [initialProducts])
     const activeProduct = products[activeTab]
@@ -314,21 +316,7 @@ export default function Tabbed() {
         })
     }
 
-    const initialProductAddons = useMemo(() => {
-        const initialAddons = []
-        for (const product of products) {
-            if (product.billingData?.addons?.length > 0) {
-                product.billingData.addons.forEach((addon) => {
-                    initialAddons.push({
-                        type: addon.type,
-                        checked: addonDefaults[addon.type]?.checked || false,
-                        totalCost: 0,
-                    })
-                })
-            }
-        }
-        return initialAddons
-    }, [])
+    const initialProductAddons = useMemo(() => buildProductAddons(products, addonDefaults), [])
     const initialPlatformAddons = useMemo(() => {
         const initialAddons = []
         platform.addons.forEach((addon) => {

--- a/src/hooks/productData/web_analytics.tsx
+++ b/src/hooks/productData/web_analytics.tsx
@@ -34,6 +34,7 @@ export const webAnalytics = {
     wizardSupport: true,
     billedWith: 'Product Analytics',
     billedWithSlug: 'product-analytics',
+    hideFromCalculator: true,
     shortDescription: 'Privacy-focused web analytics',
     pricingDescription:
         'Web Analytics is billed as Product Analytics events, so you get access to both products for the same price. 1 million events free monthly. Anonymous events cost 10x less than identified. Most sites never pay anything. Even high-traffic sites pay way less than GA 360.',


### PR DESCRIPTION
## Changes

- Removes Web Analytics from the pricing calculator's sidebar
- Brings back `buildProductAddons` - accidentally reverted in #19246