### PR TITLE
docs: replay filter semantics troubleshooting + AI-drafted scanner filter

### DIFF
--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -80,7 +80,7 @@ Once the scanner is running, the tuning loop moves to its [calibration tab](/doc
 
 ### Drafting prompts with PostHog AI
 
-Inside the scanner editor, you can ask [PostHog AI](/docs/posthog-ai) to draft a prompt by describing what you want in natural language. It picks a scanner type, drafts the prompt, and fills it into the form for you to edit.
+Inside the scanner editor, you can ask [PostHog AI](/docs/posthog-ai) to draft a prompt by describing what you want in natural language. It picks a scanner type, drafts the prompt, and fills it into the form for you to edit. When your goal targets a specific flow and one of your product's events clearly marks it, the draft also pre-fills a recording filter for that event, which you can review or remove on the filters step.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/posthog_ai_prompt_drafter_7cb9c1fc04.png"

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -227,6 +227,16 @@ Session Replay relies on the `$session_id` property added to events by the web S
 
 To workaround this, you can use the `posthog.onSessionId` method in the web SDK to register a callback that will be called each time the session ID changes. You can send this to your backend and add the `$session_id` property to your backend events.
 
+## Filters return recordings that don't seem to match
+
+Three filter behaviors are intentional but can be surprising when a recording shows up that doesn't look like it matches:
+
+**Person filters match the whole person, including older sessions.** Filtering by a person property (like an email) matches every session belonging to that person, across all of their identifiers. When an anonymous session is later linked to a person via `identify()` or `alias()`, that older session starts matching the person's filters too, even though no event inside it carries the filtered property. To see why a specific recording matched, open it and check the highlighted matching events in the player sidebar.
+
+**"Did not perform event" filters only look within the selected date range.** A filter like "users who did not perform `signed_up`" excludes sessions where that event happened inside the queried date range (plus a day of margin). Someone who performed the event before the range still appears. To exclude people based on their full history, use a [cohort](/docs/data/cohorts) with an event condition instead.
+
+**Group filters match any event in the session.** Filtering recordings by a group matches every session containing at least one event tagged with that group, regardless of who sent it. A single group-tagged event inside an otherwise unrelated session is enough for the recording to match.
+
 ## Recording not found
 
 There are several valid reasons why recordings aren't captured. To keep the site fast we don't actively confirm a recording has been captured before showing the "view recording" button.


### PR DESCRIPTION
Two small replay docs additions:

**`session-replay/troubleshooting.mdx`** – new section "Filters return recordings that don't seem to match", covering three intentional filter behaviors that regularly surprise users:

1. Person filters match the whole person retroactively: once an anonymous session is linked via `identify()`/`alias()`, older sessions start matching person-property filters too.
2. "Did not perform event" filters are scoped to the queried date range (plus a day of margin), so someone who performed the event before the range still appears. Points at cohorts for full-history exclusion.
3. Group filters match any event in the session carrying the group.

All three verified against the recordings query implementation in PostHog/posthog (`posthog/session_recordings/queries/`).

**`replay-vision/creating-scanners.mdx`** – one sentence documenting that the PostHog AI scanner drafter now pre-fills a recording event filter from the goal when a taxonomy event clearly marks the targeted flow (shipped in [PostHog/posthog#83206](https://github.com/PostHog/posthog/pull/83206)).

(generated by claude-fable-5)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
