### PR TITLE
docs: capitalize product names in installation page titles

### DIFF
--- a/contents/docs/error-tracking/installation/android.mdx
+++ b/contents/docs/error-tracking/installation/android.mdx
@@ -1,5 +1,5 @@
 ---
-title: Android error tracking installation
+title: Android Error Tracking installation
 platformLogo: android
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/angular.mdx
+++ b/contents/docs/error-tracking/installation/angular.mdx
@@ -1,5 +1,5 @@
 ---
-title: Angular error tracking installation
+title: Angular Error Tracking installation
 platformLogo: angular
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/flutter.mdx
+++ b/contents/docs/error-tracking/installation/flutter.mdx
@@ -1,5 +1,5 @@
 ---
-title: Flutter error tracking installation
+title: Flutter Error Tracking installation
 platformLogo: flutter
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/go.mdx
+++ b/contents/docs/error-tracking/installation/go.mdx
@@ -1,5 +1,5 @@
 ---
-title: Go error tracking installation
+title: Go Error Tracking installation
 platformLogo: go
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/hono.mdx
+++ b/contents/docs/error-tracking/installation/hono.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hono error tracking installation
+title: Hono Error Tracking installation
 platformLogo: hono
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/index.mdx
+++ b/contents/docs/error-tracking/installation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install error tracking with PostHog
+title: Install Error Tracking with PostHog
 ---
 
 import InstallationPlatforms from './_snippets/installation-platforms'

--- a/contents/docs/error-tracking/installation/ios.mdx
+++ b/contents/docs/error-tracking/installation/ios.mdx
@@ -1,5 +1,5 @@
 ---
-title: iOS error tracking installation
+title: iOS Error Tracking installation
 platformLogo: ios
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/manual.mdx
+++ b/contents/docs/error-tracking/installation/manual.mdx
@@ -1,5 +1,5 @@
 ---
-title: Manual error tracking installation
+title: Manual Error Tracking installation
 platformIconName: IconCode
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/nextjs.mdx
+++ b/contents/docs/error-tracking/installation/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js error tracking installation
+title: Next.js Error Tracking installation
 platformLogo: nextjs
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/node.mdx
+++ b/contents/docs/error-tracking/installation/node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Node.js error tracking installation
+title: Node.js Error Tracking installation
 platformLogo: nodejs
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/nuxt-3-6.mdx
+++ b/contents/docs/error-tracking/installation/nuxt-3-6.mdx
@@ -1,5 +1,5 @@
 ---
-title: Nuxt error tracking installation (v3.6 and below)
+title: Nuxt Error Tracking installation (v3.6 and below)
 platformLogo: nuxt
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/python.mdx
+++ b/contents/docs/error-tracking/installation/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Python error tracking installation
+title: Python Error Tracking installation
 platformLogo: python
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/react-native.mdx
+++ b/contents/docs/error-tracking/installation/react-native.mdx
@@ -1,5 +1,5 @@
 ---
-title: React Native error tracking installation
+title: React Native Error Tracking installation
 platformLogo: react
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/react.mdx
+++ b/contents/docs/error-tracking/installation/react.mdx
@@ -1,5 +1,5 @@
 ---
-title: React error tracking installation
+title: React Error Tracking installation
 platformLogo: react
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/roblox.mdx
+++ b/contents/docs/error-tracking/installation/roblox.mdx
@@ -1,5 +1,5 @@
 ---
-title: Roblox error tracking installation
+title: Roblox Error Tracking installation
 platformLogo: roblox
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/ruby-on-rails.mdx
+++ b/contents/docs/error-tracking/installation/ruby-on-rails.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ruby on Rails error tracking installation
+title: Ruby on Rails Error Tracking installation
 platformLogo: rails
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/ruby.mdx
+++ b/contents/docs/error-tracking/installation/ruby.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ruby error tracking installation
+title: Ruby Error Tracking installation
 platformLogo: ruby
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/rust.mdx
+++ b/contents/docs/error-tracking/installation/rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rust error tracking installation
+title: Rust Error Tracking installation
 platformLogo: rust
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/svelte.mdx
+++ b/contents/docs/error-tracking/installation/svelte.mdx
@@ -1,5 +1,5 @@
 ---
-title: SvelteKit error tracking installation
+title: SvelteKit Error Tracking installation
 platformLogo: svelte
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/unity.mdx
+++ b/contents/docs/error-tracking/installation/unity.mdx
@@ -1,5 +1,5 @@
 ---
-title: Unity error tracking installation
+title: Unity Error Tracking installation
 platformLogo: unity
 showStepsToc: true
 ---

--- a/contents/docs/error-tracking/installation/web.mdx
+++ b/contents/docs/error-tracking/installation/web.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web error tracking installation
+title: Web Error Tracking installation
 platformLogo: javascript
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/android.mdx
+++ b/contents/docs/experiments/installation/android.mdx
@@ -1,5 +1,5 @@
 ---
-title: Android experiments installation
+title: Android Experiments installation
 platformLogo: android
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/angular.mdx
+++ b/contents/docs/experiments/installation/angular.mdx
@@ -1,5 +1,5 @@
 ---
-title: Angular experiments installation
+title: Angular Experiments installation
 platformLogo: angular
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/astro.mdx
+++ b/contents/docs/experiments/installation/astro.mdx
@@ -1,5 +1,5 @@
 ---
-title: Astro experiments installation
+title: Astro Experiments installation
 platformLogo: astro
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/bubble.mdx
+++ b/contents/docs/experiments/installation/bubble.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bubble experiments installation
+title: Bubble Experiments installation
 platformLogo: bubble
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/django.mdx
+++ b/contents/docs/experiments/installation/django.mdx
@@ -1,5 +1,5 @@
 ---
-title: Django experiments installation
+title: Django Experiments installation
 platformLogo: django
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/dotnet.mdx
+++ b/contents/docs/experiments/installation/dotnet.mdx
@@ -1,5 +1,5 @@
 ---
-title: .NET experiments installation
+title: .NET Experiments installation
 showStepsToc: true
 platformLogo: dotnet
 ---

--- a/contents/docs/experiments/installation/flutter.mdx
+++ b/contents/docs/experiments/installation/flutter.mdx
@@ -1,5 +1,5 @@
 ---
-title: Flutter experiments installation
+title: Flutter Experiments installation
 platformLogo: flutter
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/framer.mdx
+++ b/contents/docs/experiments/installation/framer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Framer experiments installation
+title: Framer Experiments installation
 platformLogo: framer
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/go.mdx
+++ b/contents/docs/experiments/installation/go.mdx
@@ -1,5 +1,5 @@
 ---
-title: Go experiments installation
+title: Go Experiments installation
 platformLogo: go
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/index.mdx
+++ b/contents/docs/experiments/installation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install experiments with PostHog
+title: Install Experiments with PostHog
 ---
 
 import ExperimentInstallationPlatforms from './_snippets/installation-platforms.tsx'

--- a/contents/docs/experiments/installation/ios.mdx
+++ b/contents/docs/experiments/installation/ios.mdx
@@ -1,5 +1,5 @@
 ---
-title: iOS experiments installation
+title: iOS Experiments installation
 platformLogo: ios
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/kmp.mdx
+++ b/contents/docs/experiments/installation/kmp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kotlin Multiplatform experiments installation
+title: Kotlin Multiplatform Experiments installation
 platformLogo: kmp
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/laravel.mdx
+++ b/contents/docs/experiments/installation/laravel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Laravel experiments installation
+title: Laravel Experiments installation
 platformLogo: laravel
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/nextjs.mdx
+++ b/contents/docs/experiments/installation/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js experiments installation
+title: Next.js Experiments installation
 platformLogo: nextjs
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/node.mdx
+++ b/contents/docs/experiments/installation/node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Node.js experiments installation
+title: Node.js Experiments installation
 platformLogo: nodejs
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/nuxt.mdx
+++ b/contents/docs/experiments/installation/nuxt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Nuxt experiments installation
+title: Nuxt Experiments installation
 platformLogo: nuxt
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/php.mdx
+++ b/contents/docs/experiments/installation/php.mdx
@@ -1,5 +1,5 @@
 ---
-title: PHP experiments installation
+title: PHP Experiments installation
 platformLogo: php
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/python.mdx
+++ b/contents/docs/experiments/installation/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Python experiments installation
+title: Python Experiments installation
 platformLogo: python
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/react-native.mdx
+++ b/contents/docs/experiments/installation/react-native.mdx
@@ -1,5 +1,5 @@
 ---
-title: React Native experiments installation
+title: React Native Experiments installation
 platformLogo: react
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/react.mdx
+++ b/contents/docs/experiments/installation/react.mdx
@@ -1,5 +1,5 @@
 ---
-title: React experiments installation
+title: React Experiments installation
 platformLogo: react
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/remix.mdx
+++ b/contents/docs/experiments/installation/remix.mdx
@@ -1,5 +1,5 @@
 ---
-title: Remix experiments installation
+title: Remix Experiments installation
 platformLogo: remix
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/ruby.mdx
+++ b/contents/docs/experiments/installation/ruby.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ruby experiments installation
+title: Ruby Experiments installation
 platformLogo: ruby
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/rust.mdx
+++ b/contents/docs/experiments/installation/rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rust experiments installation
+title: Rust Experiments installation
 showStepsToc: true
 platformLogo: rust
 ---

--- a/contents/docs/experiments/installation/svelte.mdx
+++ b/contents/docs/experiments/installation/svelte.mdx
@@ -1,5 +1,5 @@
 ---
-title: Svelte experiments installation
+title: Svelte Experiments installation
 platformLogo: svelte
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/vue.mdx
+++ b/contents/docs/experiments/installation/vue.mdx
@@ -1,5 +1,5 @@
 ---
-title: Vue experiments installation
+title: Vue Experiments installation
 platformLogo: vue
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/web.mdx
+++ b/contents/docs/experiments/installation/web.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web experiments installation
+title: Web Experiments installation
 platformLogo: javascript
 showStepsToc: true
 ---

--- a/contents/docs/experiments/installation/webflow.mdx
+++ b/contents/docs/experiments/installation/webflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: Webflow experiments installation
+title: Webflow Experiments installation
 platformLogo: webflow
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/datadog.mdx
+++ b/contents/docs/logs/installation/datadog.mdx
@@ -1,5 +1,5 @@
 ---
-title: Datadog logs installation
+title: Datadog Logs installation
 platformIconName: IconCode
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/dotnet.mdx
+++ b/contents/docs/logs/installation/dotnet.mdx
@@ -1,5 +1,5 @@
 ---
-title: .NET logs installation
+title: .NET Logs installation
 platformLogo: dotnet
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/go.mdx
+++ b/contents/docs/logs/installation/go.mdx
@@ -1,5 +1,5 @@
 ---
-title: Go logs installation
+title: Go Logs installation
 platformLogo: go
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/java.mdx
+++ b/contents/docs/logs/installation/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Java logs installation
+title: Java Logs installation
 platformLogo: java
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/javascript.mdx
+++ b/contents/docs/logs/installation/javascript.mdx
@@ -1,5 +1,5 @@
 ---
-title: JavaScript web logs installation
+title: JavaScript web Logs installation
 platformLogo: javascript
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/nextjs.mdx
+++ b/contents/docs/logs/installation/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js logs installation
+title: Next.js Logs installation
 platformLogo: nextjs
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/nodejs.mdx
+++ b/contents/docs/logs/installation/nodejs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Node.js logs installation
+title: Node.js Logs installation
 platformLogo: nodejs
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/other.mdx
+++ b/contents/docs/logs/installation/other.mdx
@@ -1,5 +1,5 @@
 ---
-title: Other languages logs installation
+title: Other languages Logs installation
 platformIconName: IconCode
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/python.mdx
+++ b/contents/docs/logs/installation/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Python logs installation
+title: Python Logs installation
 platformLogo: python
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/react-native.mdx
+++ b/contents/docs/logs/installation/react-native.mdx
@@ -1,5 +1,5 @@
 ---
-title: React Native logs installation
+title: React Native Logs installation
 sidebarTitle: React Native
 platformLogo: react
 showStepsToc: true

--- a/contents/docs/logs/installation/ruby-on-rails.mdx
+++ b/contents/docs/logs/installation/ruby-on-rails.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ruby on Rails logs installation
+title: Ruby on Rails Logs installation
 platformLogo: rails
 showStepsToc: true
 ---

--- a/contents/docs/logs/installation/rust.mdx
+++ b/contents/docs/logs/installation/rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rust logs installation
+title: Rust Logs installation
 platformLogo: rust
 showStepsToc: true
 ---

--- a/contents/docs/product-analytics/installation/ai-wizard.mdx
+++ b/contents/docs/product-analytics/installation/ai-wizard.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI wizard product analytics installation
+title: AI wizard Product Analytics installation
 platformIconName: IconSparkles
 ---
 

--- a/contents/docs/product-analytics/installation/dotnet.mdx
+++ b/contents/docs/product-analytics/installation/dotnet.mdx
@@ -1,5 +1,5 @@
 ---
-title: .NET product analytics installation
+title: .NET Product Analytics installation
 platformLogo: dotnet
 ---
 

--- a/contents/docs/product-analytics/installation/index.mdx
+++ b/contents/docs/product-analytics/installation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Product analytics installation
+title: Product Analytics installation
 sidebar: Docs
 showTitle: true
 availability:

--- a/contents/docs/product-analytics/installation/java.mdx
+++ b/contents/docs/product-analytics/installation/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Java product analytics installation
+title: Java Product Analytics installation
 platformLogo: java
 ---
 

--- a/contents/docs/product-analytics/installation/rust.mdx
+++ b/contents/docs/product-analytics/installation/rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rust product analytics installation
+title: Rust Product Analytics installation
 platformLogo: rust
 ---
 

--- a/contents/docs/session-replay/installation/android.mdx
+++ b/contents/docs/session-replay/installation/android.mdx
@@ -1,5 +1,5 @@
 ---
-title: Android session replay installation
+title: Android Session Replay installation
 platformLogo: android
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/angular.mdx
+++ b/contents/docs/session-replay/installation/angular.mdx
@@ -1,5 +1,5 @@
 ---
-title: Angular session replay installation
+title: Angular Session Replay installation
 platformLogo: angular
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/astro.mdx
+++ b/contents/docs/session-replay/installation/astro.mdx
@@ -1,5 +1,5 @@
 ---
-title: Astro session replay installation
+title: Astro Session Replay installation
 platformLogo: astro
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/bubble.mdx
+++ b/contents/docs/session-replay/installation/bubble.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bubble session replay installation
+title: Bubble Session Replay installation
 platformLogo: bubble
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/flutter.mdx
+++ b/contents/docs/session-replay/installation/flutter.mdx
@@ -1,5 +1,5 @@
 ---
-title: Flutter session replay installation
+title: Flutter Session Replay installation
 platformLogo: flutter
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/framer.mdx
+++ b/contents/docs/session-replay/installation/framer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Framer session replay installation
+title: Framer Session Replay installation
 platformLogo: framer
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/html-snippet.mdx
+++ b/contents/docs/session-replay/installation/html-snippet.mdx
@@ -1,5 +1,5 @@
 ---
-title: HTML snippet session replay installation
+title: HTML snippet Session Replay installation
 platformLogo: html5
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/index.mdx
+++ b/contents/docs/session-replay/installation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Session replay installation
+title: Session Replay installation
 contentMaxWidthClass: max-w-full
 availability:
   free: full

--- a/contents/docs/session-replay/installation/ios.mdx
+++ b/contents/docs/session-replay/installation/ios.mdx
@@ -1,5 +1,5 @@
 ---
-title: iOS session replay installation
+title: iOS Session Replay installation
 platformLogo: ios
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/kmp.mdx
+++ b/contents/docs/session-replay/installation/kmp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kotlin Multiplatform session replay installation
+title: Kotlin Multiplatform Session Replay installation
 platformLogo: kmp
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/nextjs.mdx
+++ b/contents/docs/session-replay/installation/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js session replay installation
+title: Next.js Session Replay installation
 platformLogo: nextjs
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/nuxt.mdx
+++ b/contents/docs/session-replay/installation/nuxt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Nuxt session replay installation
+title: Nuxt Session Replay installation
 platformLogo: nuxt
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/react-native.mdx
+++ b/contents/docs/session-replay/installation/react-native.mdx
@@ -1,5 +1,5 @@
 ---
-title: React Native session replay installation
+title: React Native Session Replay installation
 platformLogo: react
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/react.mdx
+++ b/contents/docs/session-replay/installation/react.mdx
@@ -1,5 +1,5 @@
 ---
-title: React session replay installation
+title: React Session Replay installation
 platformLogo: react
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/remix.mdx
+++ b/contents/docs/session-replay/installation/remix.mdx
@@ -1,5 +1,5 @@
 ---
-title: Remix session replay installation
+title: Remix Session Replay installation
 platformLogo: remix
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/svelte.mdx
+++ b/contents/docs/session-replay/installation/svelte.mdx
@@ -1,5 +1,5 @@
 ---
-title: Svelte session replay installation
+title: Svelte Session Replay installation
 platformLogo: svelte
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/vue.mdx
+++ b/contents/docs/session-replay/installation/vue.mdx
@@ -1,5 +1,5 @@
 ---
-title: Vue session replay installation
+title: Vue Session Replay installation
 platformLogo: vue
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/web.mdx
+++ b/contents/docs/session-replay/installation/web.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web session replay installation
+title: Web Session Replay installation
 platformLogo: javascript
 showStepsToc: true
 ---

--- a/contents/docs/session-replay/installation/webflow.mdx
+++ b/contents/docs/session-replay/installation/webflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: Webflow session replay installation
+title: Webflow Session Replay installation
 platformLogo: webflow
 showStepsToc: true
 ---


### PR DESCRIPTION
## Problem

Installation page titles disagree with the style guide on whether a PostHog product name is capitalized, and 84 of them are on the wrong side of it.

- The [style guide](https://posthog.com/handbook/content/posthog-style-guide) says to capitalize a product name as a proper noun, and to use lowercase only for the general industry term.
- An installation page for Session Replay names the product, so "Android session replay installation" should be "Android Session Replay installation".
- Vale flags every one of them, which is where I noticed it.

This came out of #19514, where the Kotlin Multiplatform pages inherited the lowercase form from their neighbours.

## Changes

- Capitalizes the product name in 84 installation page titles. One frontmatter line per file, nothing else.

| Product | Titles |
| --- | --- |
| experiments | 27 |
| error-tracking | 21 |
| session-replay | 19 |
| logs | 12 |
| product-analytics | 5 |

I left body prose alone. Vale reports 3,258 product-name warnings across 907 files in `contents/docs`, and most need judgment rather than a sweep: "use feature flags to gate your rollout" is the industry term and should stay lowercase, while "Feature Flags supports local evaluation" is the product. A mechanical pass over those would get a good share of them wrong in exactly the direction the rule exists to prevent.

## How did you test this code?

- Vale product-name warnings across the installation pages drop from 174 to 90. All 84 title warnings are gone; the remaining 90 are body prose, unchanged by this PR.
- The diff is 168 lines and every one of them is a `title:` line, 84 removed and 84 added.
- Not checked: I did not open the preview. The change is frontmatter only, so the effect is the page title and its sidebar entry.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This is the docs update.
