### PR TITLE
fix(docs): make cross-section docs nav links external

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2316,28 +2316,23 @@ export const docsMenu = {
                 },
                 {
                     name: 'Slack',
-                    url: 'https://posthog.com/docs/slack',
-                    external: true,
+                    url: '/docs/slack',
                 },
                 {
                     name: 'Web app',
-                    url: 'https://posthog.com/docs/self-driving/web',
-                    external: true,
+                    url: '/docs/self-driving/web',
                 },
                 {
                     name: 'MCP',
-                    url: 'https://posthog.com/docs/model-context-protocol',
-                    external: true,
+                    url: '/docs/model-context-protocol',
                 },
                 {
                     name: 'CLI',
-                    url: 'https://posthog.com/docs/cli',
-                    external: true,
+                    url: '/docs/cli',
                 },
                 {
                     name: 'Desktop',
-                    url: 'https://posthog.com/docs/posthog-desktop',
-                    external: true,
+                    url: '/docs/posthog-desktop',
                 },
                 {
                     name: 'Concepts',
@@ -3656,71 +3651,58 @@ export const docsMenu = {
                         },
                         {
                             name: 'Model Context Protocol (MCP)',
-                            url: 'https://posthog.com/docs/model-context-protocol',
-                            external: true,
+                            url: '/docs/model-context-protocol',
                             children: [
                                 {
                                     name: 'Overview',
-                                    url: 'https://posthog.com/docs/model-context-protocol',
-                                    external: true,
+                                    url: '/docs/model-context-protocol',
                                 },
                                 {
                                     name: 'Use cases',
-                                    url: 'https://posthog.com/docs/model-context-protocol/use-cases',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/use-cases',
                                 },
                                 {
                                     name: 'MCP tools reference',
-                                    url: 'https://posthog.com/docs/model-context-protocol/tools',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/tools',
                                 },
                                 {
                                     name: 'FAQ and advanced setup',
-                                    url: 'https://posthog.com/docs/model-context-protocol/faq',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/faq',
                                 },
                                 {
                                     name: 'Enterprise auth (ID-JAG)',
-                                    url: 'https://posthog.com/docs/model-context-protocol/enterprise-managed-authorization',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/enterprise-managed-authorization',
                                 },
                                 {
                                     name: 'Code editors',
                                 },
                                 {
                                     name: 'Claude Code',
-                                    url: 'https://posthog.com/docs/model-context-protocol/claude-code',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/claude-code',
                                 },
                                 {
                                     name: 'Claude Desktop',
-                                    url: 'https://posthog.com/docs/model-context-protocol/claude-desktop',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/claude-desktop',
                                 },
                                 {
                                     name: 'Codex',
-                                    url: 'https://posthog.com/docs/model-context-protocol/codex',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/codex',
                                 },
                                 {
                                     name: 'Cursor',
-                                    url: 'https://posthog.com/docs/model-context-protocol/cursor',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/cursor',
                                 },
                                 {
                                     name: 'VS Code',
-                                    url: 'https://posthog.com/docs/model-context-protocol/vscode',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/vscode',
                                 },
                                 {
                                     name: 'Windsurf',
-                                    url: 'https://posthog.com/docs/model-context-protocol/windsurf',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/windsurf',
                                 },
                                 {
                                     name: 'Zed',
-                                    url: 'https://posthog.com/docs/model-context-protocol/zed',
-                                    external: true,
+                                    url: '/docs/model-context-protocol/zed',
                                 },
                                 {
                                     name: 'Platforms',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2316,23 +2316,28 @@ export const docsMenu = {
                 },
                 {
                     name: 'Slack',
-                    url: '/docs/slack',
+                    url: 'https://posthog.com/docs/slack',
+                    external: true,
                 },
                 {
                     name: 'Web app',
-                    url: '/docs/self-driving/web',
+                    url: 'https://posthog.com/docs/self-driving/web',
+                    external: true,
                 },
                 {
                     name: 'MCP',
-                    url: '/docs/model-context-protocol',
+                    url: 'https://posthog.com/docs/model-context-protocol',
+                    external: true,
                 },
                 {
                     name: 'CLI',
-                    url: '/docs/cli',
+                    url: 'https://posthog.com/docs/cli',
+                    external: true,
                 },
                 {
                     name: 'Desktop',
-                    url: '/docs/posthog-desktop',
+                    url: 'https://posthog.com/docs/posthog-desktop',
+                    external: true,
                 },
                 {
                     name: 'Concepts',
@@ -2444,7 +2449,8 @@ export const docsMenu = {
                         },
                         {
                             name: 'Identity resolution',
-                            url: '/docs/product-analytics/identity-resolution',
+                            url: 'https://posthog.com/docs/product-analytics/identity-resolution',
+                            external: true,
                         },
                         {
                             name: 'Deploy a proxy',
@@ -3232,7 +3238,8 @@ export const docsMenu = {
                         },
                         {
                             name: 'Data model',
-                            url: '/docs/how-posthog-works/data-model',
+                            url: 'https://posthog.com/docs/how-posthog-works/data-model',
+                            external: true,
                         },
                     ],
                 },
@@ -3649,58 +3656,71 @@ export const docsMenu = {
                         },
                         {
                             name: 'Model Context Protocol (MCP)',
-                            url: '/docs/model-context-protocol',
+                            url: 'https://posthog.com/docs/model-context-protocol',
+                            external: true,
                             children: [
                                 {
                                     name: 'Overview',
-                                    url: '/docs/model-context-protocol',
+                                    url: 'https://posthog.com/docs/model-context-protocol',
+                                    external: true,
                                 },
                                 {
                                     name: 'Use cases',
-                                    url: '/docs/model-context-protocol/use-cases',
+                                    url: 'https://posthog.com/docs/model-context-protocol/use-cases',
+                                    external: true,
                                 },
                                 {
                                     name: 'MCP tools reference',
-                                    url: '/docs/model-context-protocol/tools',
+                                    url: 'https://posthog.com/docs/model-context-protocol/tools',
+                                    external: true,
                                 },
                                 {
                                     name: 'FAQ and advanced setup',
-                                    url: '/docs/model-context-protocol/faq',
+                                    url: 'https://posthog.com/docs/model-context-protocol/faq',
+                                    external: true,
                                 },
                                 {
                                     name: 'Enterprise auth (ID-JAG)',
-                                    url: '/docs/model-context-protocol/enterprise-managed-authorization',
+                                    url: 'https://posthog.com/docs/model-context-protocol/enterprise-managed-authorization',
+                                    external: true,
                                 },
                                 {
                                     name: 'Code editors',
                                 },
                                 {
                                     name: 'Claude Code',
-                                    url: '/docs/model-context-protocol/claude-code',
+                                    url: 'https://posthog.com/docs/model-context-protocol/claude-code',
+                                    external: true,
                                 },
                                 {
                                     name: 'Claude Desktop',
-                                    url: '/docs/model-context-protocol/claude-desktop',
+                                    url: 'https://posthog.com/docs/model-context-protocol/claude-desktop',
+                                    external: true,
                                 },
                                 {
                                     name: 'Codex',
-                                    url: '/docs/model-context-protocol/codex',
+                                    url: 'https://posthog.com/docs/model-context-protocol/codex',
+                                    external: true,
                                 },
                                 {
                                     name: 'Cursor',
-                                    url: '/docs/model-context-protocol/cursor',
+                                    url: 'https://posthog.com/docs/model-context-protocol/cursor',
+                                    external: true,
                                 },
                                 {
                                     name: 'VS Code',
-                                    url: '/docs/model-context-protocol/vscode',
+                                    url: 'https://posthog.com/docs/model-context-protocol/vscode',
+                                    external: true,
                                 },
                                 {
                                     name: 'Windsurf',
-                                    url: '/docs/model-context-protocol/windsurf',
+                                    url: 'https://posthog.com/docs/model-context-protocol/windsurf',
+                                    external: true,
                                 },
                                 {
                                     name: 'Zed',
-                                    url: '/docs/model-context-protocol/zed',
+                                    url: 'https://posthog.com/docs/model-context-protocol/zed',
+                                    external: true,
                                 },
                                 {
                                     name: 'Platforms',
@@ -4188,7 +4208,8 @@ export const docsMenu = {
                 },
                 {
                     name: 'SQL',
-                    url: '/docs/data-warehouse/sql',
+                    url: 'https://posthog.com/docs/data-warehouse/sql',
+                    external: true,
                     icon: 'IconHogQL',
                     color: 'purple',
                 },


### PR DESCRIPTION
## Changes

The docs sidebar resolves a page's section by finding the **first** top-level entry in `docsMenu` whose subtree contains the current path (`Layout/context.tsx` → `recursiveSearch`). So when a page is linked from a section it doesn't belong to, and that section appears earlier in the list, the page renders under the wrong sidebar.

This converts three such links to absolute `posthog.com` links with `external: true` — the same pattern already used for the AI Observability entry — so the link stays visible in the nav but no longer claims the page:

- `/docs/data-warehouse/sql`, linked from Product Analytics → now renders under Data Warehouse
- `/docs/product-analytics/identity-resolution`, linked from Install PostHog → now renders under Product Analytics
- `/docs/how-posthog-works/data-model`, linked from API → now renders under How PostHog works

Deliberately scoped to these three. Several other cross-section links look like the same bug but point at top-level entries that are link tiles with no `children` of their own, so externalizing them gives the page an empty sidebar or none at all — worse than the current behavior. Notably the MCP subtree under AI engineering: `PostHog MCP` is a childless tile, so AI engineering is the only section that holds those pages.

Two cases are worth a follow-up but aren't fixed here, since it's a content call rather than a mechanical one: `/docs/slack` and `/docs/posthog-desktop` are linked from Self-driving, which wins, even though `PostHog Slack` and `PostHog Desktop` are full sections with their own children.

## Why

Reported in #team-content: docs pages were showing up under the wrong section in the sidebar, and the fix needed to be structural rather than page-by-page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links — intentionally violated here; the absolute URL is exactly what stops the section from matching
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — n/a, no pages moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1786990303887859?thread_ts=1786990303.887859&cid=C01V9AT7DK4)*
