### PR TITLE
blog: 7 things I learned in my first two weeks at PostHog

### DIFF
--- a/contents/blog/first-two-weeks-at-posthog.mdx
+++ b/contents/blog/first-two-weeks-at-posthog.mdx
@@ -1,0 +1,72 @@
+---
+title: "7 things I learned in my first two weeks at PostHog"
+date: 2026-08-17
+author:
+  - brittany-joiner
+featuredImage: >-
+  https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/blog/posthog-company-culture-blog.png
+featuredImageType: full
+category: Inside PostHog
+tags:
+  - Culture
+  - People
+---
+
+> **SCAFFOLD — delete everything in blockquotes before this PR leaves draft.**
+>
+> Write in the sections below. Don't touch the frontmatter. Commit and push whenever you like; Vercel rebuilds the preview on every push.
+>
+> **The bar** (from the [style guide](/handbook/content/posthog-style-guide)):
+>
+> - Every item contrasts PostHog with how a normal company does it. If the sentence still makes sense with "PostHog" swapped for "my last job", it isn't one of the 7.
+> - Every item has a concrete anchor: a name, a number, a date, a real Slack thread, a PR you opened, a dollar amount.
+> - No hedging. No "it depends", no "your mileage may vary". Have an opinion.
+> - Intro is 2 to 3 sentences. The style guide says most articles improve by shortening or deleting the intro entirely.
+> - Sentence case headings. American English. Oxford comma.
+>
+> **Candidate angles.** Pick 7 and rewrite the headings in your own words. These are prompts, not headlines — the good version of each is the story, not the principle.
+>
+> 1. **You ship before you ask.** ["Why not now?"](/handbook/values) is a value, but the first time you shipped something without approval is the story. What was it? Who would have had to sign off elsewhere?
+> 2. **The handbook is the org chart.** What did you look up in week one that a normal company would have made you Slack a person for? [Comp bands](/handbook/people/compensation)? Someone's job? [The actual roadmap](/handbook/strategy/roadmap)?
+> 3. **Everyone codes, including you.** Did you open a PR in two weeks? On what? What broke? Non-engineers shipping is the thing outsiders don't believe.
+> 4. **Small teams are smaller than you think.** What surprised you about how few people own a product? Name the team and the headcount. See [small teams](/handbook/company/small-teams).
+> 5. **Onboarding is a rotation, not a slide deck.** What did the first week actually make you do? Support? Customer calls? What did you learn from a real user in week one?
+> 6. **Nobody manages you.** What happened the first time you waited for direction and it didn't come? Be honest about whether that was comfortable. See [management](/handbook/company/management) and [grown-ups](/handbook/company/grown-ups).
+> 7. **Public by default is louder than it sounds.** The first time you posted something in a public channel that you'd have DM'd anywhere else. Or the first time you read a thread you "shouldn't" have had access to.
+> 8. **Do more weird.** What's the weirdest thing you saw in two weeks that turned out to be [a deliberate strategy](/handbook/company/do-more-weird), not a joke?
+> 9. **Feedback is direct and it lands in week one.** Did someone give you real [feedback](/handbook/people/feedback) before you'd finished setting up your laptop?
+> 10. **Something specific to community and events that you did not expect.** The one nobody else could write. This is probably your strongest.
+>
+> **What to cut:** "everyone is really nice and welcoming", "the documentation is great", "there's a lot to learn", "drinking from the firehose". Anything on that list appears in every new-hire post ever written.
+
+> **Intro.** 2 to 3 sentences. Who you are, when you started, and the one sentence that makes someone keep reading. Get to the point.
+
+## 1. Headline goes here
+
+> What specifically happened? Name the person, the number, or the day. What would a normal company have done instead?
+
+## 2. Headline goes here
+
+> Same.
+
+## 3. Headline goes here
+
+> Same.
+
+## 4. Headline goes here
+
+> Same.
+
+## 5. Headline goes here
+
+> Same.
+
+## 6. Headline goes here
+
+> Same.
+
+## 7. Headline goes here
+
+> Same.
+
+> **Closer.** One short paragraph. Optionally link to [careers](/careers) if you want this post to do recruiting work, which is the main reason posts like this earn their place.

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -768,5 +768,11 @@
         "link_type": "github",
         "link_url": "https://github.com/willwearing",
         "profile_id": 41941
+    },
+    {
+        "handle": "brittany-joiner",
+        "name": "Brittany Joiner",
+        "role": "Technical Community Manager",
+        "profile_id": 47334
     }
 ]


### PR DESCRIPTION
## Changes

Draft blog post: **7 things I learned in my first two weeks at PostHog** → `/blog/first-two-weeks-at-posthog`

**Draft on purpose.** This is the scaffold only — frontmatter, section headers, and writing prompts. Britt is writing the body directly on this branch. Opened early so Vercel gives a live preview while drafting.

- `contents/blog/first-two-weeks-at-posthog.mdx` — new post, category `Inside PostHog`, tags Culture + People
- `src/data/authors.json` — adds `brittany-joiner` (first-time author)

### Before this leaves draft

- [ ] Body written, all blockquote scaffolding removed
- [ ] `link_type` / `link_url` added to the `brittany-joiner` author entry
- [ ] Featured image replaced (currently reusing an existing culture image as a placeholder)
- [ ] `date` bumped to actual publish date
- [ ] Style pass against the content style guide

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — n/a, new page

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*