### PR TITLE
docs: describe the provisioning API rate limit tiers and limits endpoint

### DIFF
--- a/contents/blog/embedded-analytics-provisioning-api.md
+++ b/contents/blog/embedded-analytics-provisioning-api.md
@@ -27,7 +27,7 @@ The code is [on GitHub](https://github.com/Brooker-Fam/hogfarm) and there's a [l
 
 ## Registering your OAuth client
 
-To register my OAuth client, I added a small JSON file. The first time I called the API, PostHog fetched the file and registered my OAuth app. It's called a [Client ID Metadata Document](/docs/api/oauth#client-id-metadata-document-cimd), or CIMD.
+To register my OAuth client, I added a small JSON file to my site and pointed PostHog at it. It's called a [Client ID Metadata Document](/docs/api/oauth#client-id-metadata-document-cimd), or CIMD, and the URL it's served from is my `client_id`.
 
 It looks like this:
 
@@ -40,12 +40,25 @@ It looks like this:
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
   "com.posthog": {
+    "provisioning": true,
     "scopes": ["endpoint:read", "endpoint:write", "query:read", "session_recording:read", "sharing_configuration:write", "project:write"]
   }
 }
 ```
 
-The `client_id` has to be the exact URL the file is served from, or it won't register. The `com.posthog.scopes` list is a ceiling: tokens can never go above it, whatever an individual request asks for. These scopes are everything the dashboard needs later: reading the analytics back and embedding a session recording. More on both below.
+The `client_id` has to be the exact URL the file is served from, or it won't register. `com.posthog.provisioning` is the opt-in for the provisioning API: a `client_id` is a public URL, so PostHog only hands provisioning access to a client whose own document asks for it. The `com.posthog.scopes` list is a ceiling: tokens can never go above it, whatever an individual request asks for. These scopes are everything the dashboard needs later: reading the analytics back and embedding a session recording. More on both below.
+
+With the file live, one call registers it:
+
+```ts
+await fetch(`${HOST}/api/agentic/provisioning/client_registration`, {
+  method: "POST",
+  headers: { "API-Version": "0.1d", "Content-Type": "application/json" },
+  body: JSON.stringify({ client_id: clientId }),
+})
+```
+
+The response reports each check it ran on its own: whether the document could be fetched and validated, whether provisioning is on, and which keys my JWKS serves if I published one. Nothing else works until this succeeds, so it's the first thing to re-run when something further down looks wrong.
 
 Because HogFarm holds no secret (`token_endpoint_auth_method` is `"none"`), I use PKCE to prove the token exchange. I generate a random verifier and send only its SHA-256 hash with the first call. The verifier gets replayed at token exchange.
 
@@ -79,7 +92,7 @@ There are a few cases to handle for this response:
 
 - **A new email** comes back as `{ type: "oauth", oauth: { code } }`. The account gets created and linked quietly, I get a code on the spot, and the farmer gets a welcome email to set their password.
 - **An email that's already a PostHog user** comes back as `{ type: "requires_auth", requires_auth: { url } }`. They have to consent in the browser first, so I send them to `url` and PostHog redirects back to my `redirect_uri` with a code.
-- **The very first call from a new CIMD client** comes back as a `202` with `{ type: "registering" }`. PostHog fetches the metadata document in the background, so I wait the `retry_after` seconds and call again. This happens once per deployment, and it caught me off guard the first time (see below).
+- **A `client_id` that hasn't been registered** comes back as a `401` naming the registration endpoint, which is the reminder to run the call above after shipping a new metadata URL.
 
 ## Getting the farmer's project key
 
@@ -207,7 +220,7 @@ I drop that URL in an iframe and the farmer watches real visitors move through t
 
 These are the things that weren't obvious until I hit them:
 
-- **Your CIMD URL has to be reachable.** I deployed behind Vercel's default deployment protection and the first call just failed. PostHog couldn't fetch the metadata document through the SSO gate. If registration never finishes, open the `.well-known` URL in an incognito window and make sure it loads.
+- **Your CIMD URL has to be reachable.** I deployed behind Vercel's default deployment protection and registration failed: PostHog couldn't fetch the metadata document through the SSO gate. If it fails, open the `.well-known` URL in an incognito window and make sure it loads.
 - **Don't reach for `historical_migration` to seed backdated events.** I seed a week of demo pageviews so a new farm's dashboard isn't empty on day one, and my first instinct was the `historical_migration` flag since the timestamps are in the past. That flag routes the batch to a throttled ingestion pipeline that can take many minutes to become queryable, so the dashboard sat empty right after provisioning, the opposite of what I wanted. The regular capture pipeline takes backdated timestamps fine (it stores the event timestamp, not arrival time) and they show up in seconds. For a week-old seed, skip the flag.
 
 ## Give the gift of PostHog to your users

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -84,7 +84,7 @@ Requirements:
 - **`client_id`** must exactly match the URL where this document is hosted.
 - **`redirect_uris`** is required and must contain at least one HTTPS URI. This is where PostHog redirects existing users during the consent flow.
 - **`logo_uri`** (optional) must be HTTPS if provided.
-- **`token_endpoint_auth_method`** must be `"none"` (CIMD clients are public clients, no client secret).
+- **`token_endpoint_auth_method`** must be `"none"` (a public client, no client secret) or `"private_key_jwt"` with an HTTPS `jwks_uri`. With `private_key_jwt`, your app authenticates by signing an assertion with your own key, which also raises your [rate limits](#rate-limits).
 - The document must be served with `Content-Type: application/json` and be under 5 KB.
 - The URL must use HTTPS, include a path component, and must not contain query parameters or fragments.
 
@@ -95,8 +95,8 @@ Once your metadata document is live, you can start calling the API. The first re
 
 ### Link your partner app to a PostHog organization (optional)
 
-By default, a CIMD partner app is unverified and capped at 10 account requests per hour.
-You can link the app to a PostHog organization with a verification token to raise that to 100/hour and surface the partner integration to that org's admins.
+By default, a CIMD partner app is unverified.
+You can link the app to a PostHog organization with a verification token, which raises your [rate limits](#rate-limits) and surfaces the partner integration to that org's admins.
 
 1. In PostHog, go to **Organization settings → CIMD verification tokens** and click **Create token**. Copy the `phvt_…` value – it's only shown once.
 2. Add the token inside a `com.posthog` namespace in your CIMD metadata document:
@@ -116,7 +116,7 @@ You can link the app to a PostHog organization with a verification token to rais
    }
    ```
 
-3. The next time PostHog refreshes the metadata document, the app is linked to the matching organization and the rate limit is bumped.
+3. The next time PostHog refreshes the metadata document, the app is linked to the matching organization and your rate limits go up.
 
 The token is only used to prove ownership of the partner app – it isn't sent on API requests.
 You can rotate or revoke a token at any time from the same settings page.
@@ -398,6 +398,8 @@ The returned `url` is valid for 10 minutes and can only be opened once, so don't
 
 This endpoint is gated on the `provisioning_can_issue_deep_links` flag on your partner record, which is only enabled for partners admin-onboarded by PostHog. If you get a `deep_links_not_enabled` 403, ask PostHog to enable it for your CIMD app.
 
+Deep links also require `private_key_jwt` client authentication. A public client, identified only by a client_id anyone can send, has no deep-link budget because a deep link mints a full PostHog session.
+
 ### Rotate project credentials
 
 Rotate the project token for an existing provisioned project:
@@ -512,26 +514,84 @@ Common error codes:
 | `invalid_label_prefix` | 400 | `label_prefix` is not a string, is longer than 25 characters after trimming, or contains control or Unicode format characters |
 | `invalid_path` | 400 | Deep-link `path` is not a relative, same-origin in-app path beginning with a single `/` |
 | `invalid_scope` | 400 | Unrecognized scope requested |
-| `rate_limited` | 429 | Rate limit exceeded |
+| `rate_limited` | 429 | Rate limit exceeded. The `Retry-After` header says how many seconds to wait. See [rate limits](#rate-limits). |
 | `account_creation_failed` | 500 | Server error during account creation |
 
 ## Rate limits
 
-All provisioning endpoints are rate limited.
+Every provisioning endpoint has a per-partner budget: a burst you can spend at once, refilling continuously at an hourly rate. There is no fixed window, so you never wait for the top of the hour. When you run out, the response is a 429 with a `Retry-After` header saying exactly how many seconds until your next request can succeed.
 
-**CIMD registration** (first request from a new `client_id`):
+Requests that fail validation (4xx errors like `invalid_request`) are refunded, so debugging an integration doesn't spend your budget.
+
+### Your tier
+
+Budgets scale with how strongly your app identifies itself, on two axes:
+
+| Client authentication | Not linked to an org | Linked via a [verification token](#link-your-partner-app-to-a-posthog-organization-optional) |
+| --- | --- | --- |
+| `none` (public, PKCE) | 1x | 2x |
+| `private_key_jwt` | 5x | 10x |
+
+Both upgrades are self-serve and take effect on your next request: declare `private_key_jwt` with a `jwks_uri` in your metadata document, or add a verification token. Nothing to wait for and nobody to ask.
+
+### Budgets
+
+At the 1x tier:
+
+| Endpoints | Burst | Refill |
+| --- | --- | --- |
+| Account requests | 5 | 10/hour |
+| Project provisioning (`/resources`) | 10 | 30/hour |
+| Everything else (token exchange, token refresh, reads, credential rotation, deep links) | 30 | 120/hour |
+
+So account requests, the tightest budget, run at 10/20/50/100 per hour across the four tiers. Token refreshes have their own budget, separate from token exchanges, so keeping many users' tokens alive never competes with onboarding new ones.
+
+Limits are per region: US and EU count separately.
+
+**CIMD registration** (first request from a new `client_id`) is limited separately:
 
 - 5 requests per minute per IP (burst)
 - 10 requests per hour per IP (sustained)
 - 100 new client registrations per hour globally
 - 5 new client registrations per domain per hour
 
-**Account requests** (per partner, per hour):
+If the top tier still isn't enough for production use, open a [support request](https://us.posthog.com/#panel=support%3Asupport%3Alogin%3A%3Atrue) in the app, choosing **Authentication** as the topic. PostHog can set per-endpoint overrides for your app.
 
-- 10/hour for unverified CIMD partners
-- 100/hour for partners linked to a PostHog organization via a [verification token](#link-your-partner-app-to-a-posthog-organization-optional)
+### Check your limits
 
-Open a [support request](https://us.posthog.com/#panel=support%3Asupport%3Alogin%3A%3Atrue) in the app, choosing **Authentication** as the topic, if you need a higher limit for production use.
+Every response that counted against a budget includes `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers, so you can pace requests instead of reacting to 429s.
+
+To see everything at once, call the limits endpoint. It returns your tier, why you have it, and every endpoint's budget with current headroom:
+
+```bash
+# With an access token
+curl https://us.posthog.com/api/agentic/provisioning/limits \
+  -H "Authorization: Bearer pha_abc123..."
+
+# Or with your client_id (public clients)
+curl "https://us.posthog.com/api/agentic/provisioning/limits?client_id=https://yourapp.com/.well-known/posthog-client.json"
+```
+
+`private_key_jwt` clients POST instead, with the signed assertion in the form body, the same way the token endpoint takes it.
+
+**Response:**
+
+```json
+{
+  "tier": "public_attested",
+  "tier_basis": {
+    "client_authentication": "none",
+    "attested": true
+  },
+  "endpoints": {
+    "account_requests": { "per_hour": 20, "burst": 10, "remaining": 9, "reset": 180 },
+    "token_exchanges": { "per_hour": 40, "burst": 20, "remaining": 20, "reset": 0 },
+    "deep_links": { "blocked": true }
+  }
+}
+```
+
+`remaining` is whole tokens available now, and `reset` is seconds until the budget is full again. A `blocked` endpoint is unavailable at your tier; an `unlimited` one has a PostHog-set override.
 
 ## Full example
 

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -208,6 +208,22 @@ If `com.posthog.scopes` is omitted, your app can request any scope a user can gr
 
 CIMD app scopes are managed via the metadata document and are read-only in the PostHog admin UI.
 
+#### Scopes a user can decline
+
+Everything in `scopes` is required, and the user sees it locked on the consent screen. If part of what you ask for is for a feature they may not want, put those scopes in `optional_scopes` instead. Those appear as declinable, and the user can approve the rest without them.
+
+```json
+"com.posthog": {
+  "provisioning": true,
+  "scopes": ["insight:read", "project:read"],
+  "optional_scopes": ["session_recording:read"]
+}
+```
+
+Your ceiling is both lists together, so a token can carry anything in either one, and never anything outside them. Check the scopes on the token you get back before using a feature that depends on a declinable scope, because the user may have said no to it.
+
+`optional_scopes` needs a non-empty `scopes` alongside it: an app offering extras has to declare the base they sit on top of. Both lists are filtered the same way, so an unrecognized or internal scope is dropped from either. Unlike `scopes`, an `optional_scopes` list that ends up empty is fine, and just means you offer no declinable extras.
+
 ## API reference
 
 All endpoints are on `https://us.posthog.com` (US region) or `https://eu.posthog.com` (EU region).

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -75,13 +75,17 @@ Create a JSON file at a stable HTTPS URL, for example `https://yourapp.com/.well
   "logo_uri": "https://yourapp.com/logo.png",
   "token_endpoint_auth_method": "none",
   "grant_types": ["authorization_code"],
-  "response_types": ["code"]
+  "response_types": ["code"],
+  "com.posthog": {
+    "provisioning": true
+  }
 }
 ```
 
 Requirements:
 
 - **`client_id`** must exactly match the URL where this document is hosted.
+- **`com.posthog.provisioning`** must be `true` to use the provisioning API. Your `client_id` is a public URL, so a request that names it proves nothing about who sent it. Declaring the opt-in in the document, which only you can publish, is what grants your app provisioning access. It must be the JSON literal `true`, not the string `"true"`.
 - **`redirect_uris`** is required and must contain at least one HTTPS URI. This is where PostHog redirects existing users during the consent flow.
 - **`logo_uri`** (optional) must be HTTPS if provided.
 - **`token_endpoint_auth_method`** must be `"none"` (a public client, no client secret) or `"private_key_jwt"` with an HTTPS `jwks_uri`. With `private_key_jwt`, your app authenticates by signing an assertion with your own key, which also raises your [rate limits](#rate-limits).
@@ -91,7 +95,60 @@ Requirements:
 PostHog fetches and caches this document automatically.
 Subsequent requests reuse the cached version and refresh it in the background based on your `Cache-Control: max-age` header (clamped between 5 minutes and 24 hours, default 1 hour).
 
-Once your metadata document is live, you can start calling the API. The first request auto-registers your app and returns HTTP 202; retry after a few seconds.
+### Register your app
+
+Once your metadata document is live, register it. PostHog fetches the document, validates it, and turns on provisioning access if it declares `com.posthog.provisioning`.
+
+This call is not authenticated, because an app that hasn't registered yet has no credential to present. That's why the opt-in lives in your document rather than in this request.
+
+```bash
+curl -X POST https://us.posthog.com/api/agentic/provisioning/client_registration \
+  -H "Content-Type: application/json" \
+  -H "API-Version: 0.1d" \
+  -d '{"client_id": "https://yourapp.com/.well-known/posthog-client.json"}'
+```
+
+**Response** (HTTP 200):
+
+```json
+{
+  "client_id": "https://yourapp.com/.well-known/posthog-client.json",
+  "registered": true,
+  "client_type": "public",
+  "token_endpoint_auth_method": "none",
+  "jwks_uri": null,
+  "scopes": ["insight:read", "project:read"],
+  "provisioning": {
+    "active": true,
+    "can_create_accounts": true,
+    "can_provision_resources": true
+  },
+  "capabilities": {
+    "account_requests": true,
+    "github_grants": false,
+    "wizard_runs": false
+  },
+  "checks": [
+    { "name": "metadata_document", "ok": true, "detail": "Fetched and validated" },
+    { "name": "provisioning_enabled", "ok": true, "detail": "Active" },
+    {
+      "name": "jwks",
+      "ok": true,
+      "detail": "No jwks_uri, so this client authenticates with PKCE only and cannot use the GitHub grant endpoints"
+    }
+  ]
+}
+```
+
+`scopes` is your [scope ceiling](#declare-oauth-scopes-for-your-app-optional): the scopes you declared, or every scope a user can grant if you declared none. `capabilities` says which endpoints you can call, including the ones PostHog has to enable for you.
+
+Each check is reported separately, so a setup problem names its own cause instead of arriving as a bare 401 later. If registration fails, you get HTTP 400 with `"registered": false`, the same `checks` array, and an `error` object whose message is the first failed check.
+
+Call this endpoint again whenever you want to re-check your setup. It re-fetches your document and re-reports every check. Registering again never reactivates an app PostHog has deactivated.
+
+You can also verify a signed assertion end to end by sending `client_assertion` and `client_assertion_type`, which is worth doing once before you depend on `private_key_jwt`. Verifying consumes the assertion's `jti`, so mint a fresh one for the check rather than reusing it afterwards.
+
+Until your app is registered, the other endpoints return HTTP 401 with a message pointing back here.
 
 ### Link your partner app to a PostHog organization (optional)
 
@@ -111,6 +168,7 @@ You can link the app to a PostHog organization with a verification token, which 
      "grant_types": ["authorization_code"],
      "response_types": ["code"],
      "com.posthog": {
+       "provisioning": true,
        "verification_token": "phvt_..."
      }
    }
@@ -137,6 +195,7 @@ You can declare which OAuth scopes your partner app needs by adding a `scopes` f
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
   "com.posthog": {
+    "provisioning": true,
     "verification_token": "phvt_...",
     "scopes": ["insight:read", "project:read", "person:read"]
   }
@@ -508,6 +567,7 @@ Common error codes:
 |---|---|---|
 | `invalid_request` | 400 | Missing or invalid field |
 | `unauthorized` | 401 | Authentication failed |
+| `registration_failed` | 400 | [Registration](#register-your-app) did not complete. The `checks` array in the same response says which step failed |
 | `forbidden` | 403 | Partner not authorized for this action |
 | `expired` | 400 | Account request has expired |
 | `invalid_grant` | 400 | Authorization code is invalid or expired (token endpoint) |
@@ -548,10 +608,11 @@ So account requests, the tightest budget, run at 10/20/50/100 per hour across th
 
 Limits are per region: US and EU count separately.
 
-**CIMD registration** (first request from a new `client_id`) is limited separately:
+**[Registration](#register-your-app)** is limited separately, because it fetches your document while you wait:
 
-- 5 requests per minute per IP (burst)
-- 10 requests per hour per IP (sustained)
+- 30 registration calls per hour per `client_id`
+- 120 registration calls per hour per IP
+- 5 requests per minute per IP, and 10 per hour per IP, for a `client_id` PostHog has never seen
 - 100 new client registrations per hour globally
 - 5 new client registrations per domain per hour
 

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -638,18 +638,23 @@ If the top tier still isn't enough for production use, open a [support request](
 
 Every response that counted against a budget includes `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers, so you can pace requests instead of reacting to 429s.
 
-To see everything at once, call the limits endpoint. It returns your tier, why you have it, and every endpoint's budget with current headroom:
+To see everything at once, call the limits endpoint. It returns your tier, why you have it, and every endpoint's budget with current headroom.
+
+The endpoint is `POST` only, and you have to prove the request is yours. Send an access token, or authenticate as your client the same way you do at the token endpoint:
 
 ```bash
-# With an access token
-curl https://us.posthog.com/api/agentic/provisioning/limits \
+# With an access token. Public clients use this after their first token exchange.
+curl -X POST https://us.posthog.com/api/agentic/provisioning/limits \
   -H "Authorization: Bearer pha_abc123..."
 
-# Or with your client_id (public clients)
-curl "https://us.posthog.com/api/agentic/provisioning/limits?client_id=https://yourapp.com/.well-known/posthog-client.json"
+# Or as a private_key_jwt client, with the signed assertion in the form body
+curl -X POST https://us.posthog.com/api/agentic/provisioning/limits \
+  -d "client_id=https://yourapp.com/.well-known/posthog-client.json" \
+  -d "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
+  -d "client_assertion=eyJhbGci..."
 ```
 
-`private_key_jwt` clients POST instead, with the signed assertion in the form body, the same way the token endpoint takes it.
+A `client_id` on its own is not enough. Your `client_id` is published, so accepting it here would let anyone read your limits and spend your budget for this endpoint. Requests that only carry a `client_id` get a 401.
 
 **Response:**
 


### PR DESCRIPTION
## Changes

Rewrites the provisioning API's rate limit section for the new tier-based token buckets shipping in [PostHog/posthog#83935](https://github.com/PostHog/posthog/pull/83935) and its stack:

- Budgets are token buckets (burst + hourly refill) instead of fixed hourly windows, and 429s carry a real `Retry-After`.
- Limits scale with a 2x2 tier: client authentication (`none` vs `private_key_jwt`) x organization verification. Both upgrades are self-serve.
- Documents the budgets per endpoint group, the refund of failed validation requests, per-region counting, and the `RateLimit-*` response headers.
- Documents the new `GET/POST /api/agentic/provisioning/limits` introspection endpoint.
- Updates the CIMD requirements (`private_key_jwt` + `jwks_uri` is supported) and the verification section to point at the tier table instead of hardcoding 10/100 per hour.
- Notes that deep links additionally require `private_key_jwt` client authentication.

Draft until the PostHog/posthog stack (#83934-#83937) merges; the numbers here match those PRs.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)
