### PR TITLE
feat: students page with image carousel and ambassador quote

### DIFF
--- a/src/components/Students/CampusSpotlightCarousel.tsx
+++ b/src/components/Students/CampusSpotlightCarousel.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react'
+import 'keen-slider/keen-slider.min.css'
+import { useKeenSlider } from 'keen-slider/react'
+import { cn } from '../../utils'
+
+const AUTOPLAY_MS = 5000
+
+const PHOTOS = [
+    {
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/ucd_0_da36c8b7ef.jpeg',
+        alt: 'UC Davis students at a PostHog event',
+    },
+    {
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/ucd_1_c842b31c89.png',
+        alt: 'UC Davis students at a PostHog event',
+    },
+    {
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/ucd_2_08264c97eb.JPG',
+        alt: 'UC Davis students at a PostHog event',
+    },
+    {
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/ucd_3_cdb463452a.JPG',
+        alt: 'UC Davis students at a PostHog event',
+    },
+]
+
+// Container queries, not media queries, since this lives in the resizable ReaderView window.
+const aspectClasses = 'aspect-[4/3] @xl/reader-content:aspect-[16/9] @3xl/reader-content:aspect-[21/9]'
+
+export default function CampusSpotlightCarousel(): JSX.Element {
+    const [currentSlide, setCurrentSlide] = useState(0)
+    const [loaded, setLoaded] = useState(false)
+    const [paused, setPaused] = useState(false)
+    const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
+        loop: true,
+        slides: { perView: 1 },
+        slideChanged: (slider) => setCurrentSlide(slider.track.details.rel),
+        created: () => setLoaded(true),
+    })
+
+    // Self-contained interval so container-query resizes can't stall autoplay. Pauses on hover.
+    useEffect(() => {
+        if (!loaded || paused) return
+        const id = setInterval(() => instanceRef.current?.next(), AUTOPLAY_MS)
+        return () => clearInterval(id)
+    }, [loaded, paused, instanceRef])
+
+    return (
+        <div className="relative" onMouseEnter={() => setPaused(true)} onMouseLeave={() => setPaused(false)}>
+            <div ref={sliderRef} className="keen-slider overflow-hidden rounded-2xl shadow-2xl">
+                {PHOTOS.map((photo) => (
+                    <div key={photo.image} className={cn('keen-slider__slide relative', aspectClasses)}>
+                        <img
+                            src={photo.image}
+                            alt={photo.alt}
+                            className="absolute inset-0 w-full h-full object-cover"
+                        />
+                    </div>
+                ))}
+            </div>
+
+            {loaded && instanceRef.current && (
+                <>
+                    <button
+                        type="button"
+                        aria-label="Previous photo"
+                        onClick={() => instanceRef.current?.prev()}
+                        className="hidden @md/reader-content:flex absolute left-4 top-1/2 -translate-y-1/2 z-10 size-11 items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-sm hover:bg-white/30 transition-colors"
+                    >
+                        <svg className="size-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z" />
+                        </svg>
+                    </button>
+                    <button
+                        type="button"
+                        aria-label="Next photo"
+                        onClick={() => instanceRef.current?.next()}
+                        className="hidden @md/reader-content:flex absolute right-4 top-1/2 -translate-y-1/2 z-10 size-11 items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-sm hover:bg-white/30 transition-colors"
+                    >
+                        <svg className="size-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z" />
+                        </svg>
+                    </button>
+
+                    <div className="absolute bottom-4 left-0 w-full flex justify-center gap-2 z-10">
+                        {PHOTOS.map((_, idx) => (
+                            <button
+                                key={idx}
+                                type="button"
+                                aria-label={`Go to photo ${idx + 1}`}
+                                onClick={() => instanceRef.current?.moveToIdx(idx)}
+                                className={cn(
+                                    'h-2 rounded-full transition-all duration-300',
+                                    currentSlide === idx ? 'w-8 bg-white' : 'w-2 bg-white/40 hover:bg-white/70'
+                                )}
+                            />
+                        ))}
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/src/components/Students/StudentProgram.tsx
+++ b/src/components/Students/StudentProgram.tsx
@@ -8,9 +8,10 @@ import { RoughAnnotation } from 'components/Code/RoughAnnotation'
 import Input from 'components/OSForm/input'
 import Textarea from 'components/OSForm/textarea'
 import OSSelect from 'components/OSForm/select'
+import CampusSpotlightCarousel from 'components/Students/CampusSpotlightCarousel'
 import usePostHog from 'hooks/usePostHog'
-import { HedgehogPartyHog, HedgehogCodingGroup } from '@posthog/brand/hoggies'
-import { IconCheck, IconConfetti, IconGraduationCap } from '@posthog/icons'
+import { HedgehogSurfer, HedgehogCodingGroup } from '@posthog/brand/hoggies'
+import { IconCheck, IconConfetti, IconGraduationCap, IconQuote } from '@posthog/icons'
 
 type IconComponent = React.ComponentType<{ className?: string }>
 
@@ -19,14 +20,14 @@ const Highlight = ({ children }: { children: React.ReactNode }) => (
     <span className="bg-highlight p-0.5 font-bold text-red dark:text-yellow">{children}</span>
 )
 
-// Eligible schools for the dropdown. Selecting one (anything but OTHER) personalizes the page copy,
-// swapping the generic "campus" for the school's name.
+// todo: move to a feature flag
 const OTHER = 'Other'
 const SCHOOLS = [
     'Stanford',
     'UC Berkeley',
     'Caltech',
     'UCLA',
+    'USC',
     'UC San Diego',
     'UC Davis',
     'UC Irvine',
@@ -270,7 +271,7 @@ export default function StudentProgram(): JSX.Element {
 
     const steps = [
         // Eligibility scope – stays generic even when a school is selected.
-        "You're a Bay Area or a University of California student",
+        "You're a Bay Area or a California student",
         `You or your student org apply to host an event`,
         'We pair you with a PostHog team member and schedule your event',
         'We cover food and merch, you bring the builders',
@@ -331,14 +332,14 @@ export default function StudentProgram(): JSX.Element {
                                         Bring PostHog to {campusTarget}
                                     </CallToAction>
                                     <span className="text-xs text-secondary italic">
-                                        * Currently Bay Area universities and UC campuses across California
+                                        * Currently Bay Area universities and campuses across California
                                     </span>
                                 </div>
                             </div>
 
                             <div className="w-full flex justify-center self-center @2xl/reader-content:w-auto @2xl/reader-content:flex-[0_0_240px] @4xl/reader-content:flex-[0_0_300px]">
-                                <HedgehogPartyHog
-                                    title="A hedgehog at a party"
+                                <HedgehogSurfer
+                                    title="A hedgehog surfing"
                                     className="w-full max-w-[240px] @2xl/reader-content:max-w-none"
                                 />
                             </div>
@@ -379,6 +380,31 @@ export default function StudentProgram(): JSX.Element {
                             </div>
                         ))}
                     </div>
+
+                    <h3>
+                        Campus <Highlight>spotlight</Highlight>
+                    </h3>
+                    <p>See what past PostHog for Students events have looked like on campus.</p>
+                    <div className="not-prose my-6">
+                        <CampusSpotlightCarousel />
+                    </div>
+                    <figure className="not-prose mb-8 max-w-2xl">
+                        <IconQuote className="mb-1 size-6 text-secondary/40" />
+                        <blockquote className="m-0 border-0 p-0 text-lg font-light italic leading-relaxed text-secondary @md/reader-content:text-xl">
+                            Crazy to think that a cold email led to a university event at UC Davis. It feels very much
+                            like PostHog showed up for student builders.
+                        </blockquote>
+                        <figcaption className="mt-3 text-sm text-secondary/70">
+                            <Link
+                                to="https://www.linkedin.com/in/samarv/"
+                                externalNoIcon
+                                className="font-normal text-red/90 hover:text-red dark:text-yellow/90 dark:hover:text-yellow"
+                            >
+                                Samar Varma
+                            </Link>
+                            , UC Davis campus ambassador
+                        </figcaption>
+                    </figure>
 
                     {/* Startup School callout – bordered accent card, matching the /startups CTA blocks. */}
                     <div


### PR DESCRIPTION
## Changes

Changes to the `/students` page per comments in #19072
* Added an image carousel (from UC Davis)
* Added a testimonial quote from our campus ambassador Samar
* Changed the party hog to a surfer hog (currently only California schools)

<img width="1170" height="477" alt="image" src="https://github.com/user-attachments/assets/ea490ef6-356f-415f-9b89-c6c133ebb1a7" />
<img width="1174" height="660" alt="image" src="https://github.com/user-attachments/assets/ec278c46-15d6-4a50-b15e-78e536649809" />



Note: not requesting a review from @smallbrownbike and @ianmatson since diffs only pertain to the content of the `/students` page


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.

- [x] Words are spelled using American English

- [x] Use relative URLs for internal links

- [ ] I've checked the pages added or changed in the Vercel preview build

- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)