### PR TITLE
docs: note that members can get usage and spend access on request

### DIFF
--- a/contents/docs/billing/common-questions.md
+++ b/contents/docs/billing/common-questions.md
@@ -39,3 +39,9 @@ Non-profits can contact our [sales team](/talk-to-a-human) after signing up to d
 We send billing emails to all owners and administrators in the organization. These are important emails, so we currently don't allow these notification settings to be configured.
 
 If you'd like a specific email address to receive these communications, we recommend inviting that email to your organization and assigning them an administrator role.
+
+## Can someone see usage and spend without being an admin?
+
+By default, billing is only available to organization admins and owners. See our [access control docs](/docs/settings/access-control) for the full list of permissions.
+
+If you want members to see the **Usage** and **Spend** tabs without giving them the rest of billing, [contact support](/questions) and we can enable it for your organization. They get read-only access to usage and spend data for the projects they can already see. They can't change your plan, payment details, or billing limits.

--- a/contents/docs/settings/access-control.mdx
+++ b/contents/docs/settings/access-control.mdx
@@ -39,7 +39,7 @@ The three access levels are: Member, Admin, and Owner. An organization must have
 | Permission                                                                   | Member (base level)                           | Admin                                         | Owner                                         |
 | ---------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------- | --------------------------------------------- |
 | Viewing and querying project data                                            | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> |
-| Accessing billing management                                                 | <span className="text-red text-lg">✖</span>   | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> |
+| Accessing billing management\*\*                                             | <span className="text-red text-lg">✖</span>   | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> |
 | Managing reverse proxies                                                     | <span className="text-red text-lg">✖</span>   | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> |
 | Creating and deleting projects                                               | <span className="text-red text-lg">✖</span>   | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> |
 | Managing project access controls (see more below)                            | <span className="text-red text-lg">✖</span>   | <span className="text-green text-lg">✔</span> | <span className="text-green text-lg">✔</span> |
@@ -53,6 +53,8 @@ The three access levels are: Member, Admin, and Owner. An organization must have
 | Deleting an organization                                                     | <span className="text-red text-lg">✖</span>   | <span className="text-red text-lg">✖</span>   | <span className="text-green text-lg">✔</span> |
 
 \*This permission is configurable and can be disabled for members by organization admins and owners.
+
+\*\*We can give members read-only access to the **Usage** and **Spend** tabs, without the rest of billing. [Contact support](/questions) to set this up for your organization.
 
 Access levels can be viewed and changed in the [Members section](https://app.posthog.com/settings/organization-members) of organization settings.
 


### PR DESCRIPTION
## Changes

Today you have to make someone an organization admin before they can watch usage and spend. That also grants them member management and organization settings. Support can instead open just the **Usage** and **Spend** tabs to members, and the docs never mentioned that this is possible.

- Adds a billing FAQ question on getting usage and spend access without an admin role.
- Adds a footnote to the organization permissions table, which presented billing access as admin-only with no exception.
- Keeps the wording generic and leaves out the flag name, because this is support-gated rather than self-serve.

App and API support ship in [PostHog/posthog#69406](https://github.com/PostHog/posthog/pull/69406).

I (actually Claude) wrote this, using the `/writing-user-facing-copy` and `/writing-pr-descriptions` skills.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

Not checked: the Vercel preview build. No page moved, so no redirect applies.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
