### PR TITLE
Fix coloring book PDF scrolling on mobile

### DIFF
--- a/src/components/ColoringBook/index.js
+++ b/src/components/ColoringBook/index.js
@@ -14,9 +14,14 @@ import { useWindow } from '../../context/Window'
 import { useLocation } from '@reach/router'
 import Editor from 'components/Editor'
 
+const PDF_URL = 'https://res.cloudinary.com/dmukukwp6/image/upload/coloring_book_a34bc42c76.pdf'
+const PDF_PAGES = 25
+const pageImage = (page) =>
+    `https://res.cloudinary.com/dmukukwp6/image/upload/pg_${page},w_1200,q_auto,f_auto/coloring_book_a34bc42c76.jpg`
+
 export default function ColoringBook() {
     const posthog = usePostHog()
-    const { closeWindow } = useApp()
+    const { closeWindow, isMobile } = useApp()
     const { appWindow } = useWindow()
 
     return (
@@ -66,13 +71,32 @@ export default function ColoringBook() {
                 `}
             </style>
             <Editor title="Coloring book" type="pdf" hideTitle>
-                <iframe
-                    src="https://res.cloudinary.com/dmukukwp6/image/upload/coloring_book_a34bc42c76.pdf"
-                    width="100%"
-                    height="800px"
-                    style={{ border: 'none' }}
-                    title="Coloring Book PDF"
-                />
+                {isMobile ? (
+                    // Mobile browsers only render the first page of a PDF in an iframe and don't let you
+                    // scroll it, so serve the pages as images instead (with the PDF still downloadable).
+                    <div className="flex flex-col gap-4">
+                        {Array.from({ length: PDF_PAGES }, (_, index) => (
+                            <img
+                                key={index}
+                                src={pageImage(index + 1)}
+                                alt={`Coloring book page ${index + 1} of ${PDF_PAGES}`}
+                                loading={index === 0 ? 'eager' : 'lazy'}
+                                className="w-full h-auto"
+                            />
+                        ))}
+                        <CallToAction to={PDF_URL} externalNoIcon width="full">
+                            Download PDF
+                        </CallToAction>
+                    </div>
+                ) : (
+                    <iframe
+                        src={PDF_URL}
+                        width="100%"
+                        height="800px"
+                        style={{ border: 'none' }}
+                        title="Coloring Book PDF"
+                    />
+                )}
             </Editor>
         </>
     )


### PR DESCRIPTION
## Changes

Mobile browsers only render the first page of a PDF inside an iframe and give you no way to scroll, so `/coloring-book.pdf` was stuck on the cover. On mobile we now render the book’s 25 pages as Cloudinary-generated images stacked in the existing scroll area, with a “Download PDF” button underneath. Desktop keeps the iframe, so the print stylesheet is untouched.

**Why:** raised in Slack — the coloring book was effectively unusable on phones.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1787006466835409)*