### PR TITLE
docs: document session recording deletion and crypto-shredding

### DIFF
--- a/contents/docs/data/persons.mdx
+++ b/contents/docs/data/persons.mdx
@@ -128,10 +128,12 @@ Clicking on a person in the [People tab](https://app.posthog.com/persons) opens 
 
 - Search for the person via their unique ID. For example, their email.
 - Click on the person's ID
-- Click **Delete person** to remove them and all their associated data. You will be prompted to confirm this action.
+- Click **Delete person** to remove them and all their associated data. You will be prompted to confirm this action. You can also choose to delete their session recordings at this step.
 
 <DistinctIdReuseWarning />
 
 ### Via the API
 
-You can also delete persons data via the API. See the [Data Deletion docs](/docs/privacy/data-deletion) for more information.
+You can also delete persons data via the API. When deleting a person, you can pass `delete_events=true` to delete their events and `delete_recordings=true` to delete their [session recordings](/docs/session-replay). Recording deletion uses crypto-shredding to permanently destroy encryption keys, making the recordings unrecoverable.
+
+See the [data deletion docs](/docs/privacy/data-storage#data-deletion) for more information.

--- a/contents/docs/privacy/data-storage.mdx
+++ b/contents/docs/privacy/data-storage.mdx
@@ -106,7 +106,7 @@ You can remove unwanted data from PostHog by deleting groups and persons.
 | **Your account**  | [Account settings](https://us.posthog.com/settings/user#user-delete)                      | Account is deleted immediately; all stored data about you is cleared within 30 days. See [deleting your account](/docs/settings/account-settings#deleting-your-account).                                                   |
 | **Projects**      | [Project settings](https://us.posthog.com/settings/project#project-delete)                | All data under the project (including events) are automatically removed                                                                                                                                                    |
 | **Organizations** | [Organization settings](https://us.posthog.com/settings/organization#organization-delete) | Deletion is processed in the background and typically takes a couple of minutes. You'll see a blocking screen while it completes. All data under the organization's projects (including events) are automatically removed. |
-| **Persons**       | [In the persons tab](https://us.posthog.com/persons), [by API](#right-to-be-forgotten)    | When a person is deleted, all events for that person can be deleted                                                                                                                                                        |
+| **Persons**       | [In the persons tab](https://us.posthog.com/persons), [by API](#right-to-be-forgotten)    | When a person is deleted, all events and [session recordings](/docs/session-replay) for that person can be deleted                                                                                                          |
 
 ### Right to be forgotten
 
@@ -151,18 +151,18 @@ response = requests.get(
 
 </MultiLanguage>
 
-To delete persons and their events, use the [DELETE Persons API endpoint](/docs/api/persons-4#post-api-projects-project_id-persons-bulk_delete) with the person's UUID (returned as `id` in the persons API response). To delete the person's corresponding events, add the `delete_events=true` parameter:
+To delete persons and their events, use the [DELETE Persons API endpoint](/docs/api/persons-4#post-api-projects-project_id-persons-bulk_delete) with the person's UUID (returned as `id` in the persons API response). To delete the person's corresponding events, add the `delete_events=true` parameter. To also delete their session recordings, add `delete_recordings=true`:
 
 <MultiLanguage>
 
 ```bash
-curl -X DELETE "https://app.posthog.com/api/projects/<project_id>/persons/<person_uuid>?delete_events=true" \
+curl -X DELETE "https://app.posthog.com/api/projects/<project_id>/persons/<person_uuid>?delete_events=true&delete_recordings=true" \
      -H "Authorization: Bearer <personal_api_key>"
 ```
 
 ```javascript
 fetch(
-  "https://app.posthog.com/api/projects/<project_id>/persons/<person_uuid>?delete_events=true",
+  "https://app.posthog.com/api/projects/<project_id>/persons/<person_uuid>?delete_events=true&delete_recordings=true",
   {
     method: "DELETE",
     headers: {
@@ -182,7 +182,7 @@ api_key = "<personal_api_key>"
 project_id = "<project_id>"
 person_uuid = "<person_uuid>"
 
-url = "https://app.posthog.com/api/projects/{}/persons/{}?delete_events=true".format(
+url = "https://app.posthog.com/api/projects/{}/persons/{}?delete_events=true&delete_recordings=true".format(
     project_id, person_uuid
 )
 headers = {"Authorization": "Bearer {}".format(api_key)}
@@ -193,7 +193,7 @@ print(response.json())
 
 </MultiLanguage>
 
-This request will delete all events of the person(s) that have been captured before the deletion request.
+This request deletes all events of the person(s) captured before the deletion request. When `delete_recordings=true` is set, all session recordings for the person are permanently destroyed using crypto-shredding, which irreversibly deletes the encryption keys making recordings unreadable. This process cannot be undone.
 
 #### Bulk delete response
 

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -41,3 +41,26 @@ PostHog offers a range of controls to limit what data is captured by session rec
 ## Network capture
 
 Session replay also allows you to capture network requests and responses. Headers and bodies can include sensitive information. We scrub some headers automatically, but if your network requests and responses include sensitive information you can provide a function to scrub them. [Read more in our network capture docs](/docs/session-replay/network-recording#sensitive-information)
+
+
+## Data deletion
+
+On PostHog Cloud, session recordings are encrypted using per-session encryption keys. When a recording is deleted, PostHog permanently destroys the encryption key (a process called crypto-shredding), making the recording data unreadable. This is irreversible.
+
+Deletion is a two-phase process:
+
+1. **Key shredding** – the encryption key is permanently destroyed, making the recording unplayable immediately
+2. **Metadata cleanup** – recording metadata is purged from the database after a 10-day grace period via a nightly scheduled job
+
+### When recordings are deleted
+
+Recording deletion happens automatically when:
+
+- **A person is deleted** via the [Persons API](/docs/api/persons) with the `delete_recordings` parameter set to `true`
+- **A team, project, or organization is deleted** – all recordings for each affected team are queued for deletion
+
+### Viewing deleted recordings
+
+If you open a recording that has been deleted, the Session Replay player displays a notice showing when it was deleted and by whom.
+
+For more information on data deletion in PostHog, see [data storage](/docs/privacy/data-storage#data-deletion).

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -42,7 +42,6 @@ PostHog offers a range of controls to limit what data is captured by session rec
 
 Session replay also allows you to capture network requests and responses. Headers and bodies can include sensitive information. We scrub some headers automatically, but if your network requests and responses include sensitive information you can provide a function to scrub them. [Read more in our network capture docs](/docs/session-replay/network-recording#sensitive-information)
 
-
 ## Data deletion
 
 On PostHog Cloud, session recordings are encrypted using per-session encryption keys. When a recording is deleted, PostHog permanently destroys the encryption key (a process called crypto-shredding), making the recording data unreadable. This is irreversible.
@@ -61,6 +60,6 @@ Recording deletion happens automatically when:
 
 ### Viewing deleted recordings
 
-If you open a recording that has been deleted, the Session Replay player displays a notice showing when it was deleted and by whom.
+If you open a recording that has been deleted, the session replay player displays a notice showing when it was deleted and by whom.
 
 For more information on data deletion in PostHog, see [data storage](/docs/privacy/data-storage#data-deletion).


### PR DESCRIPTION
## Changes

Anyone deleting a person had no way to find out what happens to that person's session recordings. These docs answer that.

- `session-replay/privacy.mdx` gains a "Data deletion" section covering crypto-shredding, the two-phase key-then-metadata process, and what triggers a deletion.
- `privacy/data-storage.mdx` documents the `delete_recordings=true` parameter on the persons delete API, in all three language samples.
- `data/persons.mdx` mentions the recordings option in the UI delete flow.
- `data/persons.mdx` repoints a link at `/docs/privacy/data-storage#data-deletion`. The old target `/docs/privacy/data-deletion` does not exist.

Replaces #15324, which cannot be updated in place. Its branch fails the signed-commits rule: master carries nine unsigned commits, and any rebase or merge pulls them into the branch.

The content is the inkeep bot's from #15324. I (actually Claude) rebased it onto master and resolved the conflict in the data deletion table, keeping master's reformatted table and its current link to the bulk delete endpoint.

No preview build checked, so the rendered pages are unverified.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
