### PR TITLE
docs(mcp-analytics): document MCP SDK v2

### DIFF
--- a/contents/docs/mcp-analytics/conversation-id.mdx
+++ b/contents/docs/mcp-analytics/conversation-id.mdx
@@ -25,7 +25,7 @@ instrument(server, posthog, {
 With this on, the SDK does three things:
 
 1. **Injects an optional `conversation_id` argument** into every tool's JSON Schema, with a description telling the agent to reuse the value the server returns.
-2. **Mints a UUID** when the agent calls a tool without `conversation_id` and **appends a text block** to the tool's response that asks the agent to echo the same id on subsequent calls.
+2. **Mints a UUID** when the agent calls a tool without `conversation_id`, and returns it on the tool's response as a `{"conversation_id":"…"}` text block — data, not an instruction.
 3. **Captures the supplied or minted value** on every event as `$mcp_conversation_id`, distinct from `$session_id`.
 
 The agent's `conversation_id` (when present) always wins. The SDK only mints when the agent doesn't supply one.
@@ -62,9 +62,17 @@ LIMIT 50
 
 ## Caveats
 
-<CalloutBox icon="IconWarning" title="The prompt-back leaks into agent UIs" type="caution">
+<CalloutBox icon="IconWarning" title="Some tools can't take the injection" type="caution">
 
-The "please echo this `conversation_id`" message is appended as a regular `text` content block — the only channel MCP currently offers for server-to-agent communication. Consumers that surface raw tool-call content to end users will see `[SERVER]: Reuse conversation_id=…` in their UI. If the MCP spec grows a dedicated server-directives channel (e.g. on `_meta`), the SDK will move there.
+The `conversation_id` parameter can't be added to a schema built from `oneOf` / `allOf` / `anyOf` / `$ref`, or to a tool with no input schema. Those tools log a warning and get no handle, so their calls won't correlate. [`identify`](/docs/mcp-analytics/identifying-users) covers them.
+
+A client working from a **stale cached tool listing** won't know to send the parameter either — `ttlMs` caching on `tools/list` makes that more likely over time.
+
+</CalloutBox>
+
+<CalloutBox icon="IconInfo" title="The handle is visible in tool output" type="fyi">
+
+It's returned as a `{"conversation_id":"…"}` text block, so consumers that surface raw tool-call content to end users will show that JSON. It's deliberately data rather than an instruction — an imperative sentence in tool output is indistinguishable from prompt injection, and hardened clients block it.
 
 </CalloutBox>
 

--- a/contents/docs/mcp-analytics/custom-events.mdx
+++ b/contents/docs/mcp-analytics/custom-events.mdx
@@ -9,14 +9,18 @@ Sometimes the events the SDK emits out of the box aren't enough. You might want 
 Pass an `eventProperties` callback to attach extra properties to every event the SDK emits. The callback runs per request, so values can depend on the current call (request id, transport, headers, env, region, deploy SHA, etc).
 
 ```ts
+import { instrument, getRequestHeaders } from "@posthog/mcp"
+
 const analytics = instrument(server, posthog, {
   eventProperties: async (request, extra) => ({
     $app_version: process.env.GIT_SHA ?? "unknown",
     $mcp_region: process.env.FLY_REGION ?? "unknown",
-    request_id: extra?.requestInfo?.headers?.["x-request-id"],
+    request_id: getRequestHeaders(extra)?.["x-request-id"],
   }),
 })
 ```
+
+`getRequestHeaders` reads headers on both MCP SDK majors — see [MCP SDK v2](/docs/mcp-analytics/sdk-v2#if-your-callbacks-read-headers-change-them).
 
 The returned object is spread flat onto the event's properties alongside the built-in `$mcp_*` keys:
 

--- a/contents/docs/mcp-analytics/identifying-users.mdx
+++ b/contents/docs/mcp-analytics/identifying-users.mdx
@@ -25,11 +25,11 @@ Events for sessions with **no** resolved identity are sent with `$process_person
 `identify` is an async callback that returns either a `UserIdentity` or `null`. The SDK calls it on each request and caches the result per session, so a stable identity isn't re-resolved on every tool call.
 
 ```ts
-import { instrument } from "@posthog/mcp"
+import { instrument, getRequestHeaders } from "@posthog/mcp"
 
 instrument(server, posthog, {
   identify: async (request, extra) => {
-    const token = extra?.requestInfo?.headers?.authorization
+    const token = getRequestHeaders(extra)?.["authorization"]
     if (!token) return null
 
     const user = await resolveUserFromToken(token)
@@ -50,6 +50,8 @@ instrument(server, posthog, {
   },
 })
 ```
+
+Read headers with `getRequestHeaders`, not by reaching into `extra` — the two MCP SDK majors put them in different places, and a hand-written read that works on one returns `undefined` on the other, sending every event out anonymous. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2#if-your-callbacks-read-headers-change-them).
 
 This is the same shape as posthog-node's [`identify({ distinctId, properties })`](/docs/libraries/node) — just returned from a per-request callback instead of called imperatively. The fields map to PostHog as follows:
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -65,7 +65,7 @@ If you use the typed `McpServer` wrapper, pass it in directly — the SDK will u
 
 <MultiLanguage>
 
-```ts file="MCP SDK v1"
+```ts file=SDK-v1
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
@@ -83,7 +83,7 @@ server.tool("search_events", { /* ... */ }, async (args) => {
 })
 ```
 
-```ts file="MCP SDK v2"
+```ts file=SDK-v2
 import { McpServer } from "@modelcontextprotocol/server"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -13,8 +13,8 @@ import WizardCommand from 'components/WizardCommand'
 
 ## Requirements
 
-- Node.js 18 or later (TypeScript/JavaScript), or Python 3.10+ — see [Python](#python) below
-- An MCP server built on `@modelcontextprotocol/sdk` (TS) or the `mcp` package (Python). (Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers).)
+- Node.js 20.20+ or 22.22+ (TypeScript/JavaScript), or Python 3.10+ — see [Python](#python) below
+- An MCP server built on the MCP TypeScript SDK — either major, `@modelcontextprotocol/sdk` (v1) or `@modelcontextprotocol/{core,server,client}` (v2), see [MCP SDK v2](/docs/mcp-analytics/sdk-v2) — or the `mcp` package (Python). (Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers).)
 - A PostHog [project API key](/docs/getting-started/project-token) (`phc_…`)
 
 ## AI wizard
@@ -61,9 +61,11 @@ const analytics = instrument(server, posthog)
 
 ### High-level `McpServer`
 
-If you use the typed `McpServer` wrapper from `@modelcontextprotocol/sdk/server/mcp.js`, pass it in directly — the SDK will unwrap it and also install a proxy on `_registeredTools`, so any tool you register *after* `instrument()` is also wrapped:
+If you use the typed `McpServer` wrapper, pass it in directly — the SDK will unwrap it and also install a proxy on `_registeredTools`, so any tool you register *after* `instrument()` is also wrapped:
 
-```ts
+<MultiLanguage>
+
+```ts file="MCP SDK v1"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
@@ -80,6 +82,28 @@ server.tool("search_events", { /* ... */ }, async (args) => {
   // your handler runs untouched
 })
 ```
+
+```ts file="MCP SDK v2"
+import { McpServer } from "@modelcontextprotocol/server"
+import { PostHog } from "posthog-node"
+import { instrument } from "@posthog/mcp"
+
+const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
+
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com",
+})
+
+const analytics = instrument(server, posthog)
+
+server.registerTool("search_events", { /* ... */ }, async (args) => {
+  // your handler runs untouched
+})
+```
+
+</MultiLanguage>
+
+Everything past this point — options, callbacks, events — is identical on both majors. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2) for the two places they differ.
 
 ### Next.js / Vercel (`mcp-handler`)
 
@@ -181,6 +205,12 @@ serverMutator: (server) => {
 A stateless server keeps nothing between requests — a fresh server instance each time, often on a different pod. Left alone, every request becomes its own `$session_id`, and `$mcp_client_name` / `$mcp_client_version` (only sent at `initialize`) go missing from every event after the handshake.
 
 The SDK handles this with no session store and no sticky routing. At `initialize` it mints the `Mcp-Session-Id` response header as a token carrying the session id and client metadata. Clients replay that header on every subsequent request, so any pod reads the same values back — nothing changes on the client side.
+
+<CalloutBox icon="IconInfo" title="This applies to 2025-11-25 traffic" type="fyi">
+
+The `2026-07-28` revision has no `initialize` and no `Mcp-Session-Id`, so none of this section reaches it. See [Sessions on 2026-07-28](/docs/mcp-analytics/sdk-v2#sessions-on-2026-07-28).
+
+</CalloutBox>
 
 ### Streamable HTTP needs `enableJsonResponse: true`
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -347,6 +347,8 @@ No server object to wrap (a custom HTTP/edge dispatcher)? Use `PostHogMCP`, a `p
 
 The Python SDK is in beta (pre-1.0); the API may still change before `v1`, and some TypeScript-only features may land first. It emits the identical `$mcp_*` events documented on the [events](/docs/mcp-analytics/events) page.
 
+It doesn't support the `2026-07-28` protocol revision yet — that's in progress. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2) for what that revision changes.
+
 </CalloutBox>
 
 ## Configuration

--- a/contents/docs/mcp-analytics/intent.mdx
+++ b/contents/docs/mcp-analytics/intent.mdx
@@ -91,11 +91,15 @@ instrument(server, posthog, {
 `extra` carries MCP transport details — useful when the agent's user-agent or auth context hints at intent:
 
 ```ts
+import { getRequestHeaders } from "@posthog/mcp"
+
 intentFallback: (request, extra) => {
-  const ua = extra?.requestInfo?.headers?.["user-agent"]
+  const ua = getRequestHeaders(extra)?.["user-agent"]
   return `${ua ?? "unknown client"} invoked ${request.params?.name}`
 }
 ```
+
+`getRequestHeaders` reads headers on both MCP SDK majors — see [MCP SDK v2](/docs/mcp-analytics/sdk-v2#if-your-callbacks-read-headers-change-them).
 
 ### LLM-derived intent
 

--- a/contents/docs/mcp-analytics/sdk-v2.mdx
+++ b/contents/docs/mcp-analytics/sdk-v2.mdx
@@ -13,6 +13,12 @@ The MCP TypeScript SDK has two majors. `@posthog/mcp` supports both, and detects
 
 Use `@posthog/mcp` 0.11.2 or later on v2. Earlier versions captured nothing, silently.
 
+<CalloutBox icon="IconFlask" title="TypeScript today, Python soon" type="fyi">
+
+This page covers the MCP **TypeScript** SDK. The [Python SDK](/docs/mcp-analytics/installation#python) is still in active development: it emits the same `$mcp_*` events, but doesn't support the `2026-07-28` revision yet. That support is on the way.
+
+</CalloutBox>
+
 ## Setup
 
 Same call as v1. The only difference is where `McpServer` comes from, and that v2 registers tools with `registerTool()` instead of the removed `server.tool()`:

--- a/contents/docs/mcp-analytics/sdk-v2.mdx
+++ b/contents/docs/mcp-analytics/sdk-v2.mdx
@@ -1,0 +1,81 @@
+---
+title: MCP SDK v2
+---
+
+import CalloutBox from 'components/Docs/CalloutBox'
+
+The MCP TypeScript SDK has two majors. `@posthog/mcp` supports both, and detects which one you're on at runtime — neither is a dependency of the package.
+
+| Your imports | Major | Protocol revisions it serves |
+| --- | --- | --- |
+| `@modelcontextprotocol/sdk` | **v1** | `2025-11-25` and earlier |
+| `@modelcontextprotocol/core`, `/server`, `/client` | **v2** | `2025-11-25` and `2026-07-28` |
+
+Use `@posthog/mcp` 0.11.2 or later on v2. Earlier versions captured nothing, silently.
+
+## Setup
+
+Same call as v1. The only difference is where `McpServer` comes from, and that v2 registers tools with `registerTool()` instead of the removed `server.tool()`:
+
+```ts
+import { McpServer } from "@modelcontextprotocol/server"
+import { PostHog } from "posthog-node"
+import { instrument } from "@posthog/mcp"
+
+const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY)
+
+instrument(server, posthog)
+
+server.registerTool("search_events", { /* ... */ }, async (args) => { /* ... */ })
+```
+
+The low-level `Server` works the same way. If you previously called `instrument(server.server)` to get past the old compatibility check, you can go back to `instrument(server)`.
+
+## If your callbacks read headers, change them
+
+<CalloutBox icon="IconWarning" title="This fails silently" type="caution">
+
+v1 puts headers at `extra.requestInfo.headers`. v2 puts the request at `extra.http.req`, a WHATWG `Request` whose headers only answer to `.get()`. A v1-shaped read returns `undefined` on v2 — so `identify()` returns `null` and **every event goes out anonymous, with no error anywhere.**
+
+</CalloutBox>
+
+Use the exported helper in `identify`, `intentFallback`, `eventProperties` and `beforeSend`. It handles both majors and returns a plain lowercase-keyed object:
+
+```ts
+import { instrument, getRequestHeaders } from "@posthog/mcp"
+
+instrument(server, posthog, {
+  identify: async (request, extra) => {
+    const token = getRequestHeaders(extra)?.["authorization"]
+    return token ? { distinctId: await resolveUserId(token) } : null
+  },
+})
+```
+
+## Sessions on `2026-07-28`
+
+That revision removed the `initialize` handshake and the `Mcp-Session-Id` header, so the [stateless session token](/docs/mcp-analytics/installation#stateless-and-multi-pod-servers) doesn't apply to it — and left alone, **every request becomes its own `$session_id`**:
+
+- **[`enableConversationId: true`](/docs/mcp-analytics/conversation-id)** — the only way to get a shared `$session_id` on this revision. The SDK injects a `conversation_id` parameter, mints one when the agent doesn't send it, and derives `$session_id` from it, so a conversation's calls land in one session. Off by default; turn it on if you want sessions.
+- **[`identify`](/docs/mcp-analytics/identifying-users)** — attributes calls to a person via `distinct_id`. Worth wiring up either way, but note it groups by **user**, not by session, and doesn't give you a `$session_id`.
+
+Note that revision is a property of each **request**, not of your server: a v2 server serves `2025-11-25` traffic too, and most clients still negotiate it.
+
+<CalloutBox icon="IconInfo" title="Missing client name on 2025-11-25 traffic?" type="fyi">
+
+On that revision the client sends its name and version only at `initialize`. If your server builds a fresh instance per request, the SDK bridges this with a session token — but the token only reaches the client if the transport writes response headers *after* your handler runs. `@rekog/mcp-nest` with `enableJsonResponse: true` does; `createMcpHandler`'s legacy path doesn't, so expect `$mcp_client_name` and `$mcp_client_version` to be absent there. `$mcp_protocol_version` still arrives.
+
+</CalloutBox>
+
+## Not instrumented yet
+
+| `2026-07-28` feature | What you get today |
+| --- | --- |
+| **Tasks** (`io.modelcontextprotocol/tasks`) | A tool returning a task handle records an instant success, so task-based tools look fast and always-succeeding. |
+| **Multi round-trip** (`resultType: "input_required"`) | Each round counts as its own `$mcp_tool_call`, inflating call counts and durations. |
+| `server/discover` | Not captured — no session-start event on this revision. |
+| `Mcp-Method` / `Mcp-Name` headers | Not read. |
+| `clientCapabilities` in `_meta` | Not captured. `clientInfo` and protocol version are. |
+
+The first two make numbers wrong rather than missing, so check them before trusting a dashboard for task-based or multi-round-trip tools.

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -33,7 +33,7 @@ MCP Analytics gives you visibility into how AI agents actually use the MCP serve
 - 🧵 The full session, end to end
 - 🚧 Capabilities the agent wished existed (with `reportMissing`)
 
-The SDK supports any TypeScript MCP server built on `@modelcontextprotocol/sdk`. The fastest way to get set up is our wizard, which installs the package and wires up `instrument()` for you (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt):
+The SDK supports any TypeScript MCP server, on [either major](/docs/mcp-analytics/sdk-v2) of the MCP SDK. The fastest way to get set up is our wizard, which installs the package and wires up `instrument()` for you (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt):
 
 <WizardCommand command="mcp-analytics" />
 
@@ -163,9 +163,11 @@ Copy-paste queries
 By default each event is attributed to the MCP connection's session ID. To attribute calls to a real user – for per-user retention, group analytics, and person properties – wire an `identify` callback:
 
 ```ts
+import { instrument, getRequestHeaders } from "@posthog/mcp"
+
 instrument(server, posthog, {
   identify: async (request, extra) => {
-    const token = extra?.requestInfo?.headers?.authorization
+    const token = getRequestHeaders(extra)?.["authorization"]
     const user = token ? await resolveUserFromToken(token) : null
     return user ? { distinctId: user.id, properties: { name: user.name } } : null
   },

--- a/contents/tutorials/mcp-analytics.mdx
+++ b/contents/tutorials/mcp-analytics.mdx
@@ -4,6 +4,7 @@ date: 2026-07-07
 author:
   - arda-eren
   - lucas-faria
+  - georgis
 showTitle: true
 tags:
   - product analytics
@@ -32,7 +33,7 @@ The full source code for the manual approach is available in this [GitHub reposi
 
 ## The quick way: the `@posthog/mcp` SDK
 
-[`@posthog/mcp`](/docs/mcp-analytics) wraps your MCP server and captures analytics automatically – no per-tool instrumentation. It supports any TypeScript MCP server built on `@modelcontextprotocol/sdk`.
+[`@posthog/mcp`](/docs/mcp-analytics) wraps your MCP server and captures analytics automatically – no per-tool instrumentation. It supports any TypeScript MCP server, on [either major](/docs/mcp-analytics/sdk-v2) of the MCP SDK.
 
 The fastest way to set it up is our wizard, which installs the package, adds your `posthog-node` client, and wires up the `instrument()` call for you (it also works with [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor):
 
@@ -46,7 +47,9 @@ npm install @posthog/mcp posthog-node
 
 Then call `instrument(server, posthog)` once at startup. You bring your own `posthog-node` client and pass it in as the second argument:
 
-```typescript
+<MultiLanguage>
+
+```typescript file="MCP SDK v1"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
@@ -61,7 +64,24 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
 instrument(server, posthog)
 ```
 
-That's it. From the first tool call, the SDK emits PostHog events automatically, all prefixed with `$mcp_*` so they never collide with your other data and all sharing a `$session_id` derived from the MCP protocol session:
+```typescript file="MCP SDK v2"
+import { McpServer } from "@modelcontextprotocol/server"
+import { PostHog } from "posthog-node"
+import { instrument } from "@posthog/mcp"
+
+const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
+
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
+})
+
+// Register your tools with registerTool() – their handlers run untouched.
+instrument(server, posthog)
+```
+
+</MultiLanguage>
+
+That's it. From the first tool call, the SDK emits PostHog events automatically, all prefixed with `$mcp_*` so they never collide with your other data and all sharing a `$session_id` derived from the MCP protocol session (on `2026-07-28` there is no protocol session – see [sessions on SDK v2](/docs/mcp-analytics/sdk-v2#sessions-on-2026-07-28)):
 
 - `$mcp_tool_call` for every tool invocation (with parameters, response, duration, and error status)
 - `$mcp_tools_list` for every `tools/list` response, so you can compare advertised vs. called tools
@@ -73,10 +93,13 @@ It also unlocks signals the manual approach can't easily capture, each a one-lin
 - **[Agent intent](/docs/mcp-analytics/intent)** – the *why* behind each call, captured as `$mcp_intent`
 - **[Identifying users](/docs/mcp-analytics/identifying-users)** – attribute calls to a real user behind the agent
 - **[Missing capabilities](/docs/mcp-analytics/missing-capability)** – a queryable feed of things agents wished your server supported
+- **[Conversation IDs](/docs/mcp-analytics/conversation-id)** – `enableConversationId: true`, which is how you get a shared `$session_id` on MCP SDK v2 serving `2026-07-28`, since that revision has no protocol session of its own
 
 Remember to drain queued events on shutdown by calling `posthog.shutdown()` (or `posthog.flush()`) from your `SIGTERM` handler, since you own the client's lifecycle.
 
 > **Note:** `@posthog/mcp` is in beta (pre-1.0). The API may still change – including breaking changes in minor `0.x` releases – so pin a specific version while we iterate. Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers).
+
+On MCP SDK v2, one thing does need changing: if your `identify`, `intentFallback`, `eventProperties` or `beforeSend` callbacks read HTTP headers, read them through the exported `getRequestHeaders(extra)`. The two majors put headers in different places, and a v1-shaped read returns `undefined` on v2 – so `identify()` returns `null` and every event goes out anonymous. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2).
 
 To go deeper, see the [getting started guide](/docs/mcp-analytics/start-here), the [installation docs](/docs/mcp-analytics/installation), and the [event reference](/docs/mcp-analytics/events).
 

--- a/contents/tutorials/mcp-analytics.mdx
+++ b/contents/tutorials/mcp-analytics.mdx
@@ -49,7 +49,7 @@ Then call `instrument(server, posthog)` once at startup. You bring your own `pos
 
 <MultiLanguage>
 
-```typescript file="MCP SDK v1"
+```typescript file=SDK-v1
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
@@ -64,7 +64,7 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
 instrument(server, posthog)
 ```
 
-```typescript file="MCP SDK v2"
+```typescript file=SDK-v2
 import { McpServer } from "@modelcontextprotocol/server"
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -768,5 +768,13 @@
         "link_type": "github",
         "link_url": "https://github.com/willwearing",
         "profile_id": 41941
+    },
+    {
+        "handle": "georgis",
+        "name": "Georgis Andonis",
+        "role": "Product Engineer",
+        "link_type": "linkedin",
+        "link_url": "https://www.linkedin.com/in/georgis-andonis/",
+        "profile_id": 35171
     }
 ]

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7123,6 +7123,12 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
+                    name: 'MCP SDK v2',
+                    url: '/docs/mcp-analytics/sdk-v2',
+                    icon: 'IconCode',
+                    color: 'purple',
+                },
+                {
                     name: 'Custom servers',
                     url: '/docs/mcp-analytics/custom-servers',
                     icon: 'IconServer',


### PR DESCRIPTION
`@posthog/mcp` has supported both MCP TypeScript SDK majors since 0.11.1, but the docs still described a v1-only package — and taught a header read that silently breaks on v2.

## The one that matters

Four pages showed `identify` / `intentFallback` / `eventProperties` reading `extra.requestInfo.headers`. That's `undefined` on SDK v2, so `identify()` returns `null` and **every event goes out anonymous, with no error anywhere**. All four now use the exported `getRequestHeaders`, which handles both majors.

This is the failure an external reporter hit in [posthog-js#4449](https://github.com/PostHog/posthog-js/issues/4449) — our own getting-started page was teaching it.

## What's here

**New page — [MCP SDK v2](https://posthog.com/docs/mcp-analytics/sdk-v2)** (~80 lines): which package is which major, setup, the header helper, sessions on `2026-07-28`, and what the revision has that we don't instrument yet (tasks, multi round-trip).

**Corrections to existing pages:**

| | |
|---|---|
| Requirements | Named `@modelcontextprotocol/sdk` only; said Node 18 against an `engines` floor of `^20.20.0 \|\| >=22.22.0` |
| Stateless sessions | Presented as universal; it's `2025-11-25` only, since `2026-07-28` removed `initialize` and `Mcp-Session-Id`. Names `enableConversationId` as what gives you a `$session_id` there |
| Conversation IDs | Described the imperative prompt-back removed in 0.11.7. Now documents the data-only handle, and the schemas it can't be injected into |
| Event reference | Missing `$mcp_client_user_agent`, `$mcp_vendor_client`, `$mcp_tool_category`; `$mcp_protocol_version` described as handshake-only |

**Tabs, not duplication.** Installation and the tutorial show v1/v2 setup as `<MultiLanguage>` tabs — the delta is the import path and `registerTool()`. Everything past that (options, callbacks, events) is identical on both majors, so there's one set of examples rather than a parallel v2 tree.

## Checked

All nine pages render locally, and a script over every internal `/docs/mcp-analytics/*` link and `#anchor` confirms they resolve.

Draft because it wants a docs review — particularly whether the tutorial's `date` should stay at its original publish date (I left it) given the v2 tabs are new material.