### PR TITLE
fix: TeamMember linking to empty duplicate profile

### DIFF
--- a/src/components/BuiltBy/index.tsx
+++ b/src/components/BuiltBy/index.tsx
@@ -1,4 +1,4 @@
-import { TeamMemberLink } from 'components/TeamMember'
+import { findProfileByName, TeamMemberLink } from 'components/TeamMember'
 import { graphql, useStaticQuery } from 'gatsby'
 import React from 'react'
 
@@ -19,6 +19,11 @@ export default function BuiltBy({ people }) {
                     firstName
                     lastName
                     squeakId
+                    teams {
+                        data {
+                            id
+                        }
+                    }
                 }
             }
         }
@@ -29,9 +34,7 @@ export default function BuiltBy({ people }) {
             <span className="text-[13px] md:text-sm opacity-70 flex md:mb-1">Built by:</span>
             <ul className="list-none !m-0 p-0 [&_li:nth-child(2)_img]:bg-blue [&_li:nth-child(3)_img]:bg-yellow [&_li:nth-child(4)_img]:bg-teal space-y-1.5">
                 {people.map((name) => {
-                    const person = nodes.find(
-                        ({ firstName, lastName }) => `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
-                    )
+                    const person = findProfileByName(nodes, name)
                     if (!person) return null
                     return (
                         <li key={name}>

--- a/src/components/Careers/MegaQuote/index.tsx
+++ b/src/components/Careers/MegaQuote/index.tsx
@@ -10,6 +10,7 @@ import { IconCake } from '@posthog/icons'
 import dayjs from 'dayjs'
 import slugify from 'slugify'
 import Link from 'components/Link'
+import { findProfileByName } from 'components/TeamMember'
 
 const TeamMemberLink = (person) => {
     const { firstName, lastName, country, startDate, pineappleOnPizza, squeakId, avatar, teams, leadTeams, color } =
@@ -116,9 +117,7 @@ const TeamMember: React.FC<{ name: string }> = ({ name }) => {
         }
     `)
 
-    const person = nodes.find(
-        ({ firstName, lastName }) => `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
-    )
+    const person = findProfileByName(nodes, name)
 
     return person ? <TeamMemberLink {...person} /> : null
 }

--- a/src/components/Careers/TeamQuotes/index.tsx
+++ b/src/components/Careers/TeamQuotes/index.tsx
@@ -6,6 +6,7 @@ import Stickers from 'components/ProfileStickers'
 import slugify from 'slugify'
 import Link from 'components/Link'
 import Masonry from 'react-masonry-css'
+import { findProfileByName } from 'components/TeamMember'
 
 const TeamMemberLink = (person) => {
     const {
@@ -121,9 +122,7 @@ const TeamMember: React.FC<{ name: string }> = ({ name }) => {
         }
     `)
 
-    const person = nodes.find(
-        ({ firstName, lastName }) => `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
-    )
+    const person = findProfileByName(nodes, name)
 
     return person ? <TeamMemberLink {...person} /> : null
 }

--- a/src/components/Products/Slides/VideosSlide.tsx
+++ b/src/components/Products/Slides/VideosSlide.tsx
@@ -8,6 +8,7 @@ import SmallTeam from 'components/SmallTeam'
 import { useToast } from '../../../context/Toast'
 import OSButton from 'components/OSButton'
 import { Link, graphql, useStaticQuery } from 'gatsby'
+import { findProfileByName } from 'components/TeamMember'
 
 interface VideoChapter {
     title: string
@@ -384,10 +385,7 @@ function AuthorInfo({ name }: { name: string }) {
         }
     `)
 
-    const person = nodes.find(
-        ({ firstName, lastName }: { firstName: string; lastName: string }) =>
-            `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
-    )
+    const person = findProfileByName(nodes, name)
 
     if (!person) return null
 

--- a/src/components/TeamMember/index.tsx
+++ b/src/components/TeamMember/index.tsx
@@ -5,6 +5,20 @@ import React from 'react'
 import ReactCountryFlag from 'react-country-flag'
 import { Link } from 'gatsby'
 
+type ProfileNameFields = {
+    firstName: string
+    lastName?: string
+    teams?: { data?: { id?: string | number }[] | null } | null
+}
+
+// Duplicate profiles can share a name; prefer the one attached to a team
+export function findProfileByName<T extends ProfileNameFields>(nodes: T[], name: string): T | undefined {
+    const matches = nodes.filter(
+        ({ firstName, lastName }) => `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
+    )
+    return matches.find(({ teams }) => (teams?.data?.length ?? 0) > 0) ?? matches[0]
+}
+
 export const TeamMemberLink = ({
     firstName,
     lastName,
@@ -176,15 +190,17 @@ export default function TeamMember({
                     location
                     country
                     color
+                    teams {
+                        data {
+                            id
+                        }
+                    }
                 }
             }
         }
     `)
 
-    const person = nodes.find(
-        ({ firstName, lastName }: { firstName: string; lastName: string }) =>
-            `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
-    )
+    const person = findProfileByName(nodes, name)
 
     return person ? (
         <>


### PR DESCRIPTION
## Changes

`<TeamMember name="..." />` (and the other components that look up a Squeak profile by name — `BuiltBy`, `TeamQuotes`, `MegaQuote`, and the videos slide's `AuthorInfo`) picked the **first** profile whose full name matched. When duplicate profiles share a name, the link could point at a stale profile with no team, role, or avatar — e.g. `<TeamMember name="Brian Young" />` linked to the empty [/community/profiles/33685](https://posthog.com/community/profiles/33685) instead of [/community/profiles/32934](https://posthog.com/community/profiles/32934).

This adds a shared `findProfileByName` helper that prefers the name match attached to a team (the actual current team member), falling back to the first match, and uses it in all five lookups.

**Why:** Brian Young's `TeamMember` mentions (e.g. on the Paid Ads handbook page) directed to an empty profile because a duplicate profile with the same name and a valid `startDate` shadowed his real one in the build data.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
