### PR TITLE
Update expansion-strategies.md

### DIFF
--- a/contents/handbook/growth/sales/expansion-strategies.md
+++ b/contents/handbook/growth/sales/expansion-strategies.md
@@ -143,6 +143,7 @@ You've built strong usage and advocacy at the IC and team lead level. Now you en
 - Trying to go upward before you have bottom-up proof. If leadership asks "do our teams actually use this?" and the answer is weak, you've wasted the meeting and it's very hard to get a second one.
 - Treating the executive meeting as a product demo. Executives don't want a tour of features. They want to understand business impact and cost.
 - Moving upward too early in the relationship. If you're still establishing trust with the IC team, forcing an executive conversation feels pushy and premature.
+- Mistaking a coach for a champion. A champion spends their own credibility on you, while a coach tells you useful things but won't put their name to it internally. Coaches are still valuable, but an account with only coaches has no path upward. Asking for an introduction is how you find out which you have.
 
 ## Choosing the right strategy
 


### PR DESCRIPTION
I've wasted a lot of time in my career on champions who turned out to be coaches. The difference only shows up when you ask for something that costs them something, like an introduction to their VP, a slot in a team meeting, their logo on a case study. If they're consistently helpful in private and consistently unavailable in public, you have a coach. That's still valuable. Coaches give you the org chart, the budget cycle, and the politics. But an account with only coaches has no path upward, and mistaking one for the other means you find out at renewal rather than in month two. "This one trick all coaches hate!": ask for an introduction. What happens next tells you which you have.

## Changes

*Please describe.*
I've added one common mistake under Expansion Strategy of Moving Upwards. The reason is explained above.

*Add screenshots or screen recordings for visual / UI-focused changes.*
<img width="699" height="381" alt="Screenshot From 2026-08-18 18-04-02" src="https://github.com/user-attachments/assets/9accc269-0b9b-476d-9ea8-96639e0366de" />



## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
