### PR TITLE
Add icon notification badge for merch

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -28,6 +28,7 @@ import HedgeHogModeEmbed from 'components/HedgehogMode'
 import ReactConfetti from 'react-confetti'
 import { useToast } from '../../context/Toast'
 import { navigate } from 'gatsby'
+import useDesktopBadges from '../../hooks/useDesktopBadges'
 
 interface Product {
     name: string
@@ -189,8 +190,14 @@ function Desktop() {
                   }
                 : app
         )
-    const leftApps = applyGlow(productLinks)
-    const rightApps = applyGlow(apps)
+    // Notification badges come from app state (see useDesktopBadges), so they are
+    // merged in here rather than baked into the static `apps` array above.
+    const badges = useDesktopBadges()
+    const applyBadges = (items: AppItem[]) =>
+        items.map((app) => (app.url && badges[app.url] ? { ...app, badge: badges[app.url] } : app))
+
+    const leftApps = applyBadges(applyGlow(productLinks))
+    const rightApps = applyBadges(applyGlow(apps))
 
     // Mobile: one continuous wrapping grid (avoids a gap when left apps don't fill a row).
     // sm+: classic left/right desktop columns that wrap into extra columns when short on height.

--- a/src/components/NotificationBadge/README.md
+++ b/src/components/NotificationBadge/README.md
@@ -1,0 +1,77 @@
+# NotificationBadge
+
+An iOS-style unread badge: a small red mark that sits on the top-right corner of an icon.
+
+`count` is optional. Without it the badge is empty; with it the badge shows the number. Both are the same size — a 12px circle that only grows wider for a 2+ digit number — so adding or dropping the count never moves the badge.
+
+## Usage
+
+The badge positions itself with `absolute`, so its nearest positioned ancestor must be a box the size of the icon:
+
+```tsx
+import NotificationBadge from 'components/NotificationBadge'
+;<span className="relative inline-flex">
+    <SomeIcon />
+    <NotificationBadge />
+</span>
+```
+
+Desktop and taskbar icons have a `badge` slot on their `AppItem`. It takes the element itself, so the badge's own props stay the only place they are declared:
+
+```tsx
+{
+    label: 'Store',
+    Icon: <GlassIcon path={STORE_SILHOUETTE} />,
+    url: '/merch',
+    source: 'desktop',
+    badge: <NotificationBadge count={3} />,
+}
+```
+
+`AppLink` renders whatever it is given into a wrapper it makes `inline-flex`, which is the positioning context the badge needs. It does not know about `NotificationBadge` itself.
+
+### Desktop icons
+
+Do **not** hard-code `badge` in the `apps` array in `components/Desktop` — that array is module-level data and cannot react to state. Add the rule to [`hooks/useDesktopBadges.tsx`](../../hooks/useDesktopBadges.tsx) instead, keyed by the app's `url`. It returns rendered badges, and `Desktop` merges them into each `AppItem` at render time. The Store icon works this way: its badge is the number of items in the merch cart.
+
+## Props
+
+| Prop        | Type     | Default | Description                                                                    |
+| ----------- | -------- | ------- | ------------------------------------------------------------------------------ |
+| `count`     | `number` | –       | Unread count. Omit it for an empty badge. The component renders `null` at 0 or less. |
+| `max`       | `number` | `99`    | Highest number shown. Above it, the badge shows `{max}+`.                       |
+| `color`     | `NotificationBadgeColor` | `'red'` | Background color. See the swatch list below.                  |
+| `className` | `string` | `''`    | Extra classes, e.g. to nudge the position.                                      |
+
+## Colors
+
+`color` picks a background from the project's color tokens:
+
+| `color`   | Token     | Text color |
+| --------- | --------- | ---------- |
+| `red`     | `bg-red`  | white      |
+| `orange`  | `bg-orange` | dark     |
+| `yellow`  | `bg-yellow` | dark     |
+| `green`   | `bg-green`  | white    |
+| `blue`    | `bg-blue`   | white    |
+| `purple`  | `bg-purple` | white    |
+| `teal`    | `bg-teal`   | dark     |
+| `salmon`  | `bg-salmon` | white    |
+
+Text color is paired with the background, not chosen separately — the light swatches (`yellow`, `orange`, `teal`) take dark text because white on them is unreadable at 8px.
+
+To add a swatch, add a row to the `COLORS` map in `index.tsx`. Write the whole class name (`bg-lilac text-white`). Tailwind scans source for literal classes, so a built-up `bg-${color}` is never generated.
+
+## Animation
+
+The badge springs in (scale + fade) and leaves quickly without the overshoot — an arrival is worth noticing, a dismissal is not. Under `prefers-reduced-motion` it fades only, so nothing moves.
+
+`AnimatePresence` lives **inside** the component, so the exit plays when `count` drops to 0. It cannot help when a parent stops rendering the badge altogether — that unmounts the element outright and the exit is skipped. This is why [`useDesktopBadges`](../../hooks/useDesktopBadges.tsx) keeps the Store badge mounted at `count={0}` rather than removing its entry from the map.
+
+If you render this component conditionally yourself, do the same: keep it mounted and let `count` fall to 0.
+
+## Notes
+
+- The number is `aria-hidden`; a `sr-only` sibling reads out "3 unread" (or just "unread" with no count) so the count is not announced as a bare digit next to the link label.
+- The `ring-[1.5px] ring-white` outline keeps the badge readable on dark wallpapers and on top of a glyph.
+- An **inline** wrapper does not work: absolute children of an inline element anchor to the text line box, so the badge lands near the baseline instead of the icon's top corner. Use `inline-flex` (or `block`) on the wrapper.

--- a/src/components/NotificationBadge/index.tsx
+++ b/src/components/NotificationBadge/index.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+
+export type NotificationBadgeColor = 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'teal' | 'salmon'
+
+/**
+ * Background + text pairs, written as whole class names. Tailwind scans source for
+ * literal classes, so a built-up `bg-${color}` would never be generated. Light
+ * swatches take dark text; the rest take white.
+ */
+const COLORS: Record<NotificationBadgeColor, string> = {
+    red: 'bg-red text-white',
+    orange: 'bg-orange text-dark',
+    yellow: 'bg-yellow text-dark',
+    green: 'bg-green text-white',
+    blue: 'bg-blue text-white',
+    purple: 'bg-purple text-white',
+    teal: 'bg-teal text-dark',
+    salmon: 'bg-salmon text-white',
+}
+
+export interface NotificationBadgeProps {
+    /**
+     * Unread count. Omit it for a plain badge with no number. A count of 0 or
+     * less hides the badge (with its exit animation) instead of rendering it.
+     */
+    count?: number
+    /** Highest number shown before the badge switches to `{max}+`. Default 99. */
+    max?: number
+    /** Background color, from the project's color tokens. Default `red`. */
+    color?: NotificationBadgeColor
+    className?: string
+}
+
+/**
+ * iOS-style unread badge — a small colored mark pinned to the top-right corner of
+ * an icon.
+ *
+ * `count` is optional: with it you get a number, without it you get an empty
+ * badge. Both are the same size — the badge is a 12px circle that only grows
+ * wider for a 2+ digit number, so adding or dropping the count never moves the
+ * badge or changes its footprint.
+ *
+ * Positioning is absolute, so the nearest positioned ancestor has to match the
+ * icon's box, not the icon + its label. `AppLink` handles that by making its icon
+ * wrapper `inline-flex` whenever a badge is present (an inline wrapper would
+ * anchor the badge to the text line box instead of the 36px glyph).
+ */
+export default function NotificationBadge({ count, max = 99, color = 'red', className = '' }: NotificationBadgeProps) {
+    const shouldReduceMotion = useReducedMotion()
+
+    const hasCount = count !== undefined && count !== null
+    const visible = !hasCount || count >= 1
+    const display = hasCount ? (count > max ? `${max}+` : `${count}`) : null
+
+    // Pops in off a spring, leaves quickly and without the overshoot — an arrival
+    // is worth noticing, a dismissal is not. Reduced motion drops the scale and
+    // fades instead, so nothing moves.
+    const variants = shouldReduceMotion
+        ? {
+              hidden: { opacity: 0, transition: { duration: 0.12 } },
+              shown: { opacity: 1, transition: { duration: 0.12 } },
+          }
+        : {
+              hidden: { opacity: 0, scale: 0.4, transition: { duration: 0.12, ease: 'easeIn' } },
+              shown: { opacity: 1, scale: 1, transition: { type: 'spring', stiffness: 600, damping: 22, mass: 0.6 } },
+          }
+
+    // AnimatePresence lives inside the component so the exit plays whenever `count`
+    // drops to 0. It cannot help if a parent stops rendering the badge altogether —
+    // that unmounts the element outright. See `useDesktopBadges`, which keeps the
+    // Store badge mounted at `count={0}` for exactly this reason.
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.span
+                    key="badge"
+                    variants={variants}
+                    initial="hidden"
+                    animate="shown"
+                    exit="hidden"
+                    className={`absolute -top-0.5 -right-0.5 z-10 flex items-center justify-center min-w-[12px] h-[12px] px-[2px] rounded-full ring-[1.5px] ring-white text-[8px] font-bold leading-none tabular-nums ${COLORS[color]} ${className}`}
+                >
+                    {display && <span aria-hidden="true">{display}</span>}
+                    <span className="sr-only">{display ? `${display} unread` : 'unread'}</span>
+                </motion.span>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/src/components/OSIcons/AppIcon.tsx
+++ b/src/components/OSIcons/AppIcon.tsx
@@ -295,6 +295,7 @@ export interface AppItem {
     orientation?: 'row' | 'column'
     source?: string
     external?: boolean
+    badge?: React.ReactNode
 }
 
 export const AppLink = ({
@@ -312,6 +313,7 @@ export const AppLink = ({
     orientation = 'column',
     source,
     external,
+    badge,
 }: AppItem) => {
     const posthog = usePostHog()
     const { posthogInstance } = useAppSettings()
@@ -413,10 +415,13 @@ export const AppLink = ({
 
     const content = (
         <>
-            <span className="relative">
+            {/* inline-flex only when badged: an inline wrapper anchors the absolutely
+                positioned badge to the text line box instead of the icon's own box. */}
+            <span className={`relative ${badge ? 'inline-flex' : ''}`}>
                 {renderIcon()}
                 {renderChildIcon()}
                 {children}
+                {badge}
             </span>
             <figcaption
                 className={`text-[13px] font-medium leading-tight ${

--- a/src/hooks/useDesktopBadges.tsx
+++ b/src/hooks/useDesktopBadges.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import NotificationBadge from 'components/NotificationBadge'
+import { useCartStore } from '../templates/merch/store'
+
+/** Rendered badges keyed by an `AppItem`'s `url`. */
+export type DesktopBadges = Record<string, React.ReactNode>
+
+const EMPTY: DesktopBadges = {}
+
+export default function useDesktopBadges(): DesktopBadges {
+    const cartCount = useCartStore((state) => state.count)
+    const [mounted, setMounted] = useState(false)
+
+    useEffect(() => {
+        setMounted(true)
+    }, [])
+
+    return useMemo(() => {
+        if (!mounted) return EMPTY
+
+        // The Store badge stays mounted at `count={0}`, where it renders nothing.
+        // Dropping the entry instead would unmount the element outright and skip
+        // NotificationBadge's exit animation when the cart empties.
+        const badges: DesktopBadges = {
+            '/merch': <NotificationBadge count={cartCount ?? 0} />,
+        }
+        return badges
+    }, [mounted, cartCount])
+}


### PR DESCRIPTION
## Changes

Adds generic notification badges for desktop icon as a slot.

Notification Badge component can have different colors, counts, and max numbers.

This PR also moves the badge rendering to a hook so that it can utilize the Zustland store for user carts.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
