### PR TITLE
Add AI plugin to feature ownership, owned by self-driving

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -53,6 +53,11 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         owner: ['ai-gateway'],
         label: false,
     },
+    'ai-plugin': {
+        feature: 'AI plugin (Claude Code, Codex, Cursor, Gemini CLI)',
+        owner: ['self-driving'],
+        label: false,
+    },
     alerts: {
         feature: 'Alerts',
         owner: ['analytics-platform'],

--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -56,6 +56,11 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     'ai-plugin': {
         feature: 'AI plugin (Claude Code, Codex, Cursor, Gemini CLI)',
         owner: ['self-driving'],
+        notes: (
+            <>
+                <TeamMember name="Georgiy Tarasov" /> is the point owner.
+            </>
+        ),
         label: false,
     },
     alerts: {


### PR DESCRIPTION
## Changes

Adds an `AI plugin (Claude Code, Codex, Cursor, Gemini CLI)` entry to the feature ownership table in `src/hooks/useFeatureOwnership.tsx`, owned by the Self-driving team. No `feature/` label exists for it in the monorepo, so `label` is `false`.

**Why:** the [ai-plugin](https://github.com/PostHog/ai-plugin) repo had no listed owner, so contributors had nobody obvious to ask for review. Self-driving is the team that picked it up.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1787065878035849?thread_ts=1787065878.035849&cid=C09G8QA6740)*