### PR TITLE
Update most recent pen test date to May 2026

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -96,7 +96,7 @@ We receive data collected by our customers from end-users and allow them to unde
 
 ## Pen tests
 
-We conduct these annually, most recently in May 2025 - you can find the report in [our Trust Center](https://trust.posthog.com/?itemUid=2aafaddd-5329-45e2-a37e-cf6979191ad4&source=search).
+We conduct these annually, most recently in May 2026 - you can find the report in [our Trust Center](https://trust.posthog.com/?itemUid=2aafaddd-5329-45e2-a37e-cf6979191ad4&source=search).
 
 ## Responsible disclosure
 


### PR DESCRIPTION
Our latest third-party security penetration test was conducted on 2026-05-21, but the handbook still said May 2025. This updates the date on `/handbook/company/security`.

Kept the existing `Month YYYY` format and wording. The Trust Center link is unchanged — the report item was refreshed in place under the same `itemUid`, so it already points at the current report.

This is the only *dated* pen test reference in the repo. Other matches are undated ("annual"/"annually" in `security-advisories.md` and the SOC 2 report PDFs), a false positive ("organizational penetration" in a sales page), or generic "security audit" copy unrelated to our own test.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*