### PR TITLE
chore(docs): verify reverse proxy upstream TLS

### DIFF
--- a/contents/docs/advanced/proxy/kubernetes-ingress-controller.mdx
+++ b/contents/docs/advanced/proxy/kubernetes-ingress-controller.mdx
@@ -59,6 +59,19 @@ This setup works with the ingress-nginx controller, the most widely used Ingress
 
 <Steps>
 
+<Step title="Create the upstream CA secret">
+
+Create a Secret from your system's trusted certificate authorities so ingress-nginx can verify PostHog's upstream certificates:
+
+```bash
+kubectl create secret generic posthog-upstream-ca \
+  --from-file=ca.crt=/etc/ssl/certs/ca-certificates.crt
+```
+
+Change the file path if your operating system stores its CA bundle elsewhere. The Secret and Ingress resources must use the same namespace. The example below uses the `default` namespace.
+
+</Step>
+
 <Step title="Create a configuration file">
 
 Create a file named `posthog-proxy.yaml`:
@@ -68,14 +81,15 @@ Create a file named `posthog-proxy.yaml`:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: posthog-proxy
+  name: posthog-assets-proxy
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/upstream-vhost: us.i.posthog.com
+    nginx.ingress.kubernetes.io/upstream-vhost: us-assets.i.posthog.com
     nginx.ingress.kubernetes.io/backend-protocol: https
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_name "us.i.posthog.com";
-      proxy_ssl_server_name "on";
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: default/posthog-upstream-ca
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-name: us-assets.i.posthog.com
 spec:
   tls:
   - hosts:
@@ -99,6 +113,29 @@ spec:
             name: posthog-assets-proxy
             port:
               name: https
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: posthog-proxy
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/upstream-vhost: us.i.posthog.com
+    nginx.ingress.kubernetes.io/backend-protocol: https
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: default/posthog-upstream-ca
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-name: us.i.posthog.com
+spec:
+  tls:
+  - hosts:
+    - e.yourdomain.com
+    secretName: your-tls-secret
+  rules:
+  - host: e.yourdomain.com
+    http:
+      paths:
       - pathType: Prefix
         path: /
         backend:
@@ -144,7 +181,11 @@ The annotations in the Ingress configuration above do the following:
 
 - `upstream-vhost` sets the Host header sent to PostHog. Without this, PostHog receives your subdomain as the Host header and can't route the request, causing 401 errors.
 - `backend-protocol` tells the Ingress Controller to use HTTPS when connecting to PostHog's domains.
-- `configuration-snippet` configures SSL settings for the upstream connection. The `proxy_ssl_name` ensures proper SNI handling.
+- `proxy-ssl-secret` supplies the trusted certificate authorities used for upstream verification.
+- `proxy-ssl-verify` requires a valid certificate from the upstream.
+- `proxy-ssl-server-name` and `proxy-ssl-name` send and verify the correct hostname during the TLS handshake.
+
+The API and asset paths use separate Ingress resources because each upstream needs its own Host header and verified TLS hostname. The ExternalName services keep the upstreams as DNS names, allowing ingress-nginx to re-resolve them when their DNS records change.
 
 </Step>
 
@@ -159,7 +200,7 @@ kubectl apply -f posthog-proxy.yaml
 Verify the resources were created:
 
 ```bash
-kubectl get ingress posthog-proxy
+kubectl get ingress posthog-proxy posthog-assets-proxy
 kubectl get service posthog-proxy posthog-assets-proxy
 ```
 

--- a/contents/docs/advanced/proxy/kubernetes-ingress-controller.mdx
+++ b/contents/docs/advanced/proxy/kubernetes-ingress-controller.mdx
@@ -61,14 +61,18 @@ This setup works with the ingress-nginx controller, the most widely used Ingress
 
 <Step title="Create the upstream CA secret">
 
-Create a Secret from your system's trusted certificate authorities so ingress-nginx can verify PostHog's upstream certificates:
+Download the Mozilla CA bundle, then create a Secret from it so ingress-nginx can verify PostHog's upstream certificates:
+
+```bash
+curl --fail --location https://curl.se/ca/cacert.pem --output ca-certificates.crt
+```
 
 ```bash
 kubectl create secret generic posthog-upstream-ca \
-  --from-file=ca.crt=/etc/ssl/certs/ca-certificates.crt
+  --from-file=ca.crt=ca-certificates.crt
 ```
 
-Change the file path if your operating system stores its CA bundle elsewhere. The Secret and Ingress resources must use the same namespace. The example below uses the `default` namespace.
+If you already have a CA bundle locally, you can use its path instead of downloading this file. The Secret and Ingress resources must use the same namespace. The example below uses the `default` namespace.
 
 </Step>
 

--- a/contents/docs/advanced/proxy/nginx.mdx
+++ b/contents/docs/advanced/proxy/nginx.mdx
@@ -71,25 +71,37 @@ server {
     listen [::]:80;
     server_name e.yourdomain.com;
 
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
+
+    set $posthog_api_host us.i.posthog.com;
+    set $posthog_assets_host us-assets.i.posthog.com;
+
     location /static/ {
-        proxy_pass https://us-assets.i.posthog.com/static/;
-        proxy_set_header Host us-assets.i.posthog.com;
+        proxy_pass https://$posthog_assets_host;
+        proxy_set_header Host $posthog_assets_host;
         proxy_ssl_server_name on;
-        proxy_ssl_name us-assets.i.posthog.com;
+        proxy_ssl_name $posthog_assets_host;
+        proxy_ssl_verify on;
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
     }
 
     location /array/ {
-        proxy_pass https://us-assets.i.posthog.com/array/;
-        proxy_set_header Host us-assets.i.posthog.com;
+        proxy_pass https://$posthog_assets_host;
+        proxy_set_header Host $posthog_assets_host;
         proxy_ssl_server_name on;
-        proxy_ssl_name us-assets.i.posthog.com;
+        proxy_ssl_name $posthog_assets_host;
+        proxy_ssl_verify on;
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
     }
 
     location / {
-        proxy_pass https://us.i.posthog.com/;
-        proxy_set_header Host us.i.posthog.com;
+        proxy_pass https://$posthog_api_host;
+        proxy_set_header Host $posthog_api_host;
         proxy_ssl_server_name on;
-        proxy_ssl_name us.i.posthog.com;
+        proxy_ssl_name $posthog_api_host;
+        proxy_ssl_verify on;
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
     }
 }
 ```
@@ -98,10 +110,14 @@ Replace `e.yourdomain.com` with your subdomain. Replace `us` with `eu` for EU re
 
 Here's what each directive does:
 
-- `proxy_pass`: The upstream URL nginx forwards requests to. The trailing slash is important—it tells nginx to replace the matched location path.
+- `resolver`: Re-resolves PostHog's upstream domains every five minutes so nginx picks up DNS changes without a reload. Use a DNS resolver available from your server if it cannot reach the resolvers shown above.
+- `set`: Stores each upstream hostname in a variable. nginx only re-resolves names used through variables in `proxy_pass`.
+- `proxy_pass`: The upstream URL nginx forwards requests to. Omitting a URI preserves the complete request path.
 - `proxy_set_header Host`: Sets the Host header sent to PostHog. Without this, PostHog receives your domain and can't route the request, causing 401 errors.
 - `proxy_ssl_server_name on`: Enables Server Name Indication (SNI) for the upstream SSL connection. Required because PostHog uses virtual hosting.
 - `proxy_ssl_name`: The hostname to use for SNI. Must match the upstream domain.
+- `proxy_ssl_verify on`: Verifies that the upstream certificate is valid for the hostname in `proxy_ssl_name`.
+- `proxy_ssl_trusted_certificate`: Points nginx to the operating system's trusted certificate authorities. Change this path if your distribution stores its CA bundle elsewhere.
 
 Enable the site by creating a symlink:
 
@@ -231,28 +247,40 @@ http {
         resolver 8.8.8.8 8.8.4.4 valid=300s;
         resolver_timeout 5s;
 
+        set $posthog_api_host "${POSTHOG_CLOUD_REGION}.i.posthog.com";
+        set $posthog_assets_host "${POSTHOG_CLOUD_REGION}-assets.i.posthog.com";
+
         location /static/ {
-            proxy_pass https://${POSTHOG_CLOUD_REGION}-assets.i.posthog.com/static/;
-            proxy_set_header Host "${POSTHOG_CLOUD_REGION}-assets.i.posthog.com";
+            proxy_pass https://$posthog_assets_host;
+            proxy_set_header Host $posthog_assets_host;
             proxy_ssl_server_name on;
+            proxy_ssl_name $posthog_assets_host;
+            proxy_ssl_verify on;
+            proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
 
             proxy_hide_header 'Access-Control-Allow-Origin';
             add_header 'Access-Control-Allow-Origin' '*' always;
         }
 
         location /array/ {
-            proxy_pass https://${POSTHOG_CLOUD_REGION}-assets.i.posthog.com/array/;
-            proxy_set_header Host "${POSTHOG_CLOUD_REGION}-assets.i.posthog.com";
+            proxy_pass https://$posthog_assets_host;
+            proxy_set_header Host $posthog_assets_host;
             proxy_ssl_server_name on;
+            proxy_ssl_name $posthog_assets_host;
+            proxy_ssl_verify on;
+            proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
 
             proxy_hide_header 'Access-Control-Allow-Origin';
             add_header 'Access-Control-Allow-Origin' '*' always;
         }
 
         location / {
-            proxy_pass https://${POSTHOG_CLOUD_REGION}.i.posthog.com;
-            proxy_set_header Host "${POSTHOG_CLOUD_REGION}.i.posthog.com";
+            proxy_pass https://$posthog_api_host;
+            proxy_set_header Host $posthog_api_host;
             proxy_ssl_server_name on;
+            proxy_ssl_name $posthog_api_host;
+            proxy_ssl_verify on;
+            proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
 
             proxy_hide_header 'Access-Control-Allow-Origin';
             add_header 'Access-Control-Allow-Origin' '*' always;
@@ -261,7 +289,7 @@ http {
 }
 ```
 
-The `resolver` directive configures DNS resolution for the upstream domains. This is required in containers because nginx resolves hostnames at startup, and container DNS may not be available immediately.
+The `resolver` directive and hostname variables make nginx refresh the upstream IP addresses every five minutes. The trusted certificate bundle included in the Alpine image lets nginx verify PostHog's upstream certificates.
 
 </Step>
 


### PR DESCRIPTION
## Changes

- Verify PostHog upstream certificates in the nginx and ingress-nginx examples.
- Re-resolve nginx upstream DNS records without requiring a reload.
- Use separate Kubernetes Ingress resources so API and asset traffic verify the correct hostnames.

**Why**

Managed reverse proxies should reject invalid upstream certificates and follow PostHog DNS changes automatically.

Validation: nginx syntax check, Prettier check, and `git diff --check`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*