### PR TITLE
Make WizardCTA customizable from MDX

### DIFF
--- a/src/components/PlatformInstall/buildCommand.ts
+++ b/src/components/PlatformInstall/buildCommand.ts
@@ -11,15 +11,31 @@
  * Inline wizard command. The display is always the clean `npx @posthog/wizard …`; the copy always
  * pins `-y` (auto-confirms the npx prompt) and `@latest` (freshness). There is intentionally no flag
  * to toggle `@latest` — it is always copied, never displayed. The subcommand is appended last, to both.
+ *
+ * `fullCommand` is the escape hatch for call sites that need to state the whole command themselves
+ * (an author writing raw MDX, a non-wizard command). It is shown and copied verbatim — no `-y`, no
+ * `@latest`, no subcommand — because the point is that what you typed is what ships. `copyOverride`
+ * lets those call sites still copy something different from what they display.
  */
-export function buildWizardCommand({ subcommand }: { subcommand?: string }): {
+export function buildWizardCommand({
+    subcommand,
+    fullCommand,
+    copyOverride,
+}: {
+    subcommand?: string
+    fullCommand?: string
+    copyOverride?: string
+}): {
     displayCommand: string
     copyCommand: string
 } {
+    if (fullCommand) {
+        return { displayCommand: fullCommand, copyCommand: copyOverride || fullCommand }
+    }
     const tail = subcommand ? ` ${subcommand}` : ''
     return {
         displayCommand: `npx @posthog/wizard${tail}`,
-        copyCommand: `npx -y @posthog/wizard@latest${tail}`,
+        copyCommand: copyOverride || `npx -y @posthog/wizard@latest${tail}`,
     }
 }
 

--- a/src/components/PlatformInstall/index.tsx
+++ b/src/components/PlatformInstall/index.tsx
@@ -141,6 +141,13 @@ export interface PlatformInstallProps {
     selfDriving?: boolean
     /** Escape hatch to append any other subcommand to the command (display + copy). */
     command?: string
+    /**
+     * Inline only: state the entire command yourself instead of having it built. Shown and copied
+     * verbatim, so `-y`/`@latest` are not added and `command`/`selfDriving` are ignored.
+     */
+    fullCommand?: string
+    /** Clipboard override, if it should differ from what's displayed. */
+    copyCommand?: string
     /** Inline only: hide the "Learn more" tab and fully round the button. */
     slim?: boolean
     /** Inline only: bordered button style. */
@@ -159,6 +166,8 @@ export default function PlatformInstall({
     variant = 'card',
     selfDriving = false,
     command,
+    fullCommand,
+    copyCommand: copyCommandOverride,
     slim = false,
     bordered = false,
     secondaryTo,
@@ -192,7 +201,7 @@ export default function PlatformInstall({
     // Inline variant: the bare command button (consolidated WizardCommand look). Builds the command
     // from flags via the shared builder so display/copy semantics can never drift from the card.
     if (variant === 'inline') {
-        const inline = buildWizardCommand({ subcommand })
+        const inline = buildWizardCommand({ subcommand, fullCommand, copyOverride: copyCommandOverride })
         return (
             <InlineCommand
                 displayCommand={inline.displayCommand}

--- a/src/components/WizardCTA/README.md
+++ b/src/components/WizardCTA/README.md
@@ -42,6 +42,22 @@ Two props, depending on how much of the command you want to own.
 
 Use `copyCommand` alongside it when the clipboard should differ from the display.
 
+## Replacing the image
+
+`image` swaps the wizard hedgehog for any URL:
+
+```mdx
+<WizardCTA image="https://res.cloudinary.com/dmukukwp6/image/upload/some_other_hog.png" />
+```
+
+**It scales, but it does not crop.** The image gets the banner's responsive widths (`w-36` up to `w-48`, tracking the banner's own width rather than the viewport's, since the banner sits inside resizable windows), and the height follows whatever aspect ratio you give it. So:
+
+- A roughly square, transparent PNG — like the hedgehogs — drops straight in and needs nothing.
+- A markedly wider or taller image still fits the width, but its height changes the banner's height with it. Pass `imageClassName` to size it yourself, e.g. `imageClassName="w-24 @lg:w-32"` for something tall, or a fixed `h-*` plus `object-contain`.
+- A photo or an image with a solid background will look wrong against the tan texture. Use a cutout with transparency.
+
+Set `imageAlt` whenever the image conveys meaning. It defaults to the hedgehog's alt text for the default image and to `''` (decorative) for a replacement, so a swapped-in image never inherits a description of a different picture.
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -51,6 +67,9 @@ Use `copyCommand` alongside it when the clipboard should differ from the display
 | `copyCommand` | `string?` | – | Clipboard override, if it should differ from what's displayed |
 | `title` | `string?` | "Install PostHog with one command" | Bold headline |
 | `subtitle` | `string?` | "Paste this into your terminal and make AI do all the work." | Supporting line |
+| `image` | `string?` | wizard hedgehog | Image URL; prefer a transparent PNG on Cloudinary |
+| `imageAlt` | `string?` | hedgehog alt, or `''` for a replacement | Alt text; set it if the image carries meaning |
+| `imageClassName` | `string?` | `w-36 @lg:w-32 @xl:w-40 @2xl:w-48` | Sizing classes, replacing the responsive width defaults |
 | `learnMoreTo` | `string?` | `/wizard` | "Learn more" link target under the command |
 | `className` | `string?` | – | Extra classes on the outer wrapper |
 

--- a/src/components/WizardCTA/README.md
+++ b/src/components/WizardCTA/README.md
@@ -23,34 +23,31 @@ Every prop is optional and defaults to the copy above, so a post can retarget th
 
 ## Setting the command
 
-There are two levels, depending on how much you want to own:
+Two props, depending on how much of the command you want to own.
 
-`command` appends a subcommand to the built command, which keeps the copy-button pinning (`-y` and `@latest`) that stops readers from running a stale wizard:
+**`command` appends a wizard subcommand.** Use this for the normal case — a documented wizard subcommand like `self-driving`, `ai-observability`, or `warehouse` (see [the wizard docs](/docs/ai-engineering/ai-wizard) for the list). You get the copy-button pinning for free: `-y` auto-confirms the npx prompt and `@latest` stops readers running a stale wizard, neither of which clutters the displayed command.
 
 ```mdx
 <WizardCTA command="self-driving" />   →  shows  npx @posthog/wizard self-driving
                                           copies npx -y @posthog/wizard@latest self-driving
 ```
 
-`selfDriving` is shorthand for that same subcommand:
+**`fullCommand` replaces the command outright.** Whatever you type is what shows in the box and what lands on the reader's clipboard — nothing is appended and nothing is pinned, so include `-y`/`@latest` yourself if you want them. It does not have to be a wizard command at all:
 
 ```mdx
-<WizardCTA selfDriving />
+<WizardCTA fullCommand="npx -y @posthog/wizard@latest self-driving --debug" />
+
+<WizardCTA fullCommand="pip install posthog" title="Install the Python SDK" />
 ```
 
-`fullCommand` states the whole thing instead. It is shown and copied verbatim — nothing is appended and nothing is pinned, so add `-y`/`@latest` yourself if you want them. Reach for this when the built form isn't what you need:
-
-```mdx
-<WizardCTA fullCommand="npx @posthog/wizard self-driving --debug" />
-```
+Use `copyCommand` alongside it when the clipboard should differ from the display.
 
 ## Props
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `command` | `string?` | – | Wizard subcommand appended to `npx @posthog/wizard`, e.g. `"ai-observability"` |
-| `selfDriving` | `boolean?` | `false` | Shorthand for `command="self-driving"`; takes precedence over `command` |
-| `fullCommand` | `string?` | – | The entire command, shown and copied verbatim. Overrides `command`/`selfDriving` and skips the `-y`/`@latest` pinning |
+| `command` | `string?` | – | Wizard subcommand appended to `npx @posthog/wizard`, e.g. `"self-driving"` |
+| `fullCommand` | `string?` | – | The entire command, shown and copied verbatim. Overrides `command` and skips the `-y`/`@latest` pinning |
 | `copyCommand` | `string?` | – | Clipboard override, if it should differ from what's displayed |
 | `title` | `string?` | "Install PostHog with one command" | Bold headline |
 | `subtitle` | `string?` | "Paste this into your terminal and make AI do all the work." | Supporting line |

--- a/src/components/WizardCTA/README.md
+++ b/src/components/WizardCTA/README.md
@@ -10,11 +10,9 @@ Bare, for the default "install PostHog" pitch:
 <WizardCTA />
 ```
 
-Every prop is optional and defaults to the copy above, so a single post can retarget the command without touching the component:
+Every prop is optional and defaults to the copy above, so a post can retarget the banner by editing its own markdown — no new component, no code change:
 
 ```mdx
-<WizardCTA selfDriving />
-
 <WizardCTA
     command="ai-observability"
     title="Add LLM observability in one command"
@@ -23,12 +21,37 @@ Every prop is optional and defaults to the copy above, so a single post can reta
 />
 ```
 
+## Setting the command
+
+There are two levels, depending on how much you want to own:
+
+`command` appends a subcommand to the built command, which keeps the copy-button pinning (`-y` and `@latest`) that stops readers from running a stale wizard:
+
+```mdx
+<WizardCTA command="self-driving" />   →  shows  npx @posthog/wizard self-driving
+                                          copies npx -y @posthog/wizard@latest self-driving
+```
+
+`selfDriving` is shorthand for that same subcommand:
+
+```mdx
+<WizardCTA selfDriving />
+```
+
+`fullCommand` states the whole thing instead. It is shown and copied verbatim — nothing is appended and nothing is pinned, so add `-y`/`@latest` yourself if you want them. Reach for this when the built form isn't what you need:
+
+```mdx
+<WizardCTA fullCommand="npx @posthog/wizard self-driving --debug" />
+```
+
 ## Props
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `command` | `string?` | – | Wizard subcommand appended to `npx @posthog/wizard`, e.g. `"ai-observability"` |
 | `selfDriving` | `boolean?` | `false` | Shorthand for `command="self-driving"`; takes precedence over `command` |
+| `fullCommand` | `string?` | – | The entire command, shown and copied verbatim. Overrides `command`/`selfDriving` and skips the `-y`/`@latest` pinning |
+| `copyCommand` | `string?` | – | Clipboard override, if it should differ from what's displayed |
 | `title` | `string?` | "Install PostHog with one command" | Bold headline |
 | `subtitle` | `string?` | "Paste this into your terminal and make AI do all the work." | Supporting line |
 | `learnMoreTo` | `string?` | `/wizard` | "Learn more" link target under the command |

--- a/src/components/WizardCTA/README.md
+++ b/src/components/WizardCTA/README.md
@@ -1,0 +1,40 @@
+# WizardCTA
+
+Wizard install banner (hedgehog, tan texture background, inline copyable command) used in prose — blog posts, docs — and on the `/r/*` landing pages. Rendered as a global MDX shortcode, so `<WizardCTA />` works in any `.mdx`/`.md` file without an import.
+
+## Usage
+
+Bare, for the default "install PostHog" pitch:
+
+```mdx
+<WizardCTA />
+```
+
+Every prop is optional and defaults to the copy above, so a single post can retarget the command without touching the component:
+
+```mdx
+<WizardCTA selfDriving />
+
+<WizardCTA
+    command="ai-observability"
+    title="Add LLM observability in one command"
+    subtitle="The wizard finds your LLM calls and wires them up for you."
+    learnMoreTo="/docs/ai-observability/installation"
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `command` | `string?` | – | Wizard subcommand appended to `npx @posthog/wizard`, e.g. `"ai-observability"` |
+| `selfDriving` | `boolean?` | `false` | Shorthand for `command="self-driving"`; takes precedence over `command` |
+| `title` | `string?` | "Install PostHog with one command" | Bold headline |
+| `subtitle` | `string?` | "Paste this into your terminal and make AI do all the work." | Supporting line |
+| `learnMoreTo` | `string?` | `/wizard` | "Learn more" link target under the command |
+| `className` | `string?` | – | Extra classes on the outer wrapper |
+
+## Related
+
+- `components/PlatformInstall` — owns command building and the inline button. The displayed command is the clean `npx @posthog/wizard …`; the copied one pins `-y` and `@latest`. Don't assemble command strings here.
+- `components/WizardHint` — same visual design, but collapsible and aimed at "there's an automated alternative to this manual setup" moments inside docs.

--- a/src/components/WizardCTA/index.tsx
+++ b/src/components/WizardCTA/index.tsx
@@ -4,6 +4,16 @@ import PlatformInstall from 'components/PlatformInstall'
 
 const DEFAULT_TITLE = 'Install PostHog with one command'
 const DEFAULT_SUBTITLE = 'Paste this into your terminal and make AI do all the work.'
+const DEFAULT_IMAGE = 'https://res.cloudinary.com/dmukukwp6/image/upload/wizard_3f8bb7a240.png'
+const DEFAULT_IMAGE_ALT = 'PostHog Wizard hedgehog'
+
+/**
+ * Container-query widths for the image, so it tracks the banner's own width rather than the
+ * viewport's — the banner lives inside resizable app windows. Height is left to the image's aspect
+ * ratio; a replacement that isn't roughly as wide as it is tall will change the banner's height, so
+ * `imageClassName` can override this wholesale.
+ */
+const DEFAULT_IMAGE_CLASSES = 'w-36 @lg:w-32 @xl:w-40 @2xl:w-48'
 
 /**
  * Wizard install banner for prose (blog posts, docs) and the `/r/*` landing pages.
@@ -28,6 +38,9 @@ export default function WizardCTA({
     copyCommand,
     title = DEFAULT_TITLE,
     subtitle = DEFAULT_SUBTITLE,
+    image = DEFAULT_IMAGE,
+    imageAlt,
+    imageClassName = DEFAULT_IMAGE_CLASSES,
     learnMoreTo,
     className = '',
 }: {
@@ -42,6 +55,16 @@ export default function WizardCTA({
     copyCommand?: string
     title?: string
     subtitle?: string
+    /** Image URL, replacing the wizard hedgehog. Prefer a transparent PNG on Cloudinary. */
+    image?: string
+    /**
+     * Alt text for `image`. Defaults to the hedgehog's alt for the default image and to `''` for a
+     * replacement — a swapped-in image is treated as decorative rather than silently inheriting a
+     * description of a different picture. Set it whenever the image carries meaning.
+     */
+    imageAlt?: string
+    /** Sizing/positioning classes for the image, replacing the responsive width defaults. */
+    imageClassName?: string
     /** "Learn more" link target under the command. Defaults to `/wizard`. */
     learnMoreTo?: string
     className?: string
@@ -73,9 +96,9 @@ export default function WizardCTA({
                     </div>
                     <div className="shrink-0">
                         <img
-                            src="https://res.cloudinary.com/dmukukwp6/image/upload/wizard_3f8bb7a240.png"
-                            alt="PostHog Wizard hedgehog"
-                            className="w-36 @lg:w-32 @xl:w-40 @2xl:w-48"
+                            src={image}
+                            alt={imageAlt ?? (image === DEFAULT_IMAGE ? DEFAULT_IMAGE_ALT : '')}
+                            className={`object-contain ${imageClassName}`}
                         />
                     </div>
                 </div>

--- a/src/components/WizardCTA/index.tsx
+++ b/src/components/WizardCTA/index.tsx
@@ -1,10 +1,39 @@
 import React from 'react'
 import CloudinaryImage from 'components/CloudinaryImage'
-import WizardCommand from 'components/WizardCommand'
+import PlatformInstall from 'components/PlatformInstall'
 
-export default function WizardCTA(): JSX.Element {
+const DEFAULT_TITLE = 'Install PostHog with one command'
+const DEFAULT_SUBTITLE = 'Paste this into your terminal and make AI do all the work.'
+
+/**
+ * Wizard install banner for prose (blog posts, docs) and the `/r/*` landing pages.
+ *
+ * Every piece of copy has a prop defaulting to the value it was previously hard-coded to, so bare
+ * `<WizardCTA />` call sites keep rendering exactly what they always have while an individual post
+ * can retarget the command — e.g. `<WizardCTA selfDriving />` or
+ * `<WizardCTA command="ai-observability" />`. Command building itself stays in
+ * [`PlatformInstall`](../PlatformInstall) so the displayed and copied strings can't drift.
+ */
+export default function WizardCTA({
+    command,
+    selfDriving = false,
+    title = DEFAULT_TITLE,
+    subtitle = DEFAULT_SUBTITLE,
+    learnMoreTo,
+    className = '',
+}: {
+    /** Wizard subcommand appended to the command, e.g. "ai-observability" or "warehouse". */
+    command?: string
+    /** Shorthand for `command="self-driving"`. Takes precedence over `command`. */
+    selfDriving?: boolean
+    title?: string
+    subtitle?: string
+    /** "Learn more" link target under the command. Defaults to `/wizard`. */
+    learnMoreTo?: string
+    className?: string
+}): JSX.Element {
     return (
-        <div className="relative overflow-hidden rounded not-prose my-6 border border-secondary">
+        <div className={`relative overflow-hidden rounded not-prose my-6 border border-secondary ${className}`}>
             <div className="max-w-2xl mx-auto">
                 <CloudinaryImage
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/texture_tan_9608fcca70.png"
@@ -18,11 +47,14 @@ export default function WizardCTA(): JSX.Element {
                 />
                 <div className="relative flex flex-col-reverse @lg:flex-row items-center pl-5 @lg:pl-8 pr-5 py-4 @lg:py-3">
                     <div className="flex-1 text-center @lg:text-left">
-                        <p className="text-lg font-bold !mb-0">Install PostHog with one command</p>
-                        <p className="!mt-1 !mb-3 text-sm opacity-75">
-                            Paste this into your terminal and make AI do all the work.
-                        </p>
-                        <WizardCommand />
+                        <p className="text-lg font-bold !mb-0">{title}</p>
+                        <p className="!mt-1 !mb-3 text-sm opacity-75">{subtitle}</p>
+                        <PlatformInstall
+                            variant="inline"
+                            command={command}
+                            selfDriving={selfDriving}
+                            secondaryTo={learnMoreTo}
+                        />
                     </div>
                     <div className="shrink-0">
                         <img

--- a/src/components/WizardCTA/index.tsx
+++ b/src/components/WizardCTA/index.tsx
@@ -13,8 +13,11 @@ const DEFAULT_SUBTITLE = 'Paste this into your terminal and make AI do all the w
  * post can retarget it inline. Two levels of control, deliberately:
  *
  * - `command="self-driving"` appends a subcommand, keeping the `-y`/`@latest` pinning on copy.
- * - `fullCommand="npx @posthog/wizard self-driving"` states the whole thing, shown and copied
+ * - `fullCommand="npx @posthog/wizard self-driving"` replaces the command outright, shown and copied
  *   verbatim, for when the built form isn't what you want.
+ *
+ * `PlatformInstall`'s `selfDriving` flag is deliberately not re-exposed here — it is just shorthand
+ * for `command="self-driving"`, and two spellings of one thing is a worse API than one.
  *
  * Command assembly itself stays in [`PlatformInstall`](../PlatformInstall) so the displayed and
  * copied strings can't drift.
@@ -23,7 +26,6 @@ export default function WizardCTA({
     command,
     fullCommand,
     copyCommand,
-    selfDriving = false,
     title = DEFAULT_TITLE,
     subtitle = DEFAULT_SUBTITLE,
     learnMoreTo,
@@ -38,8 +40,6 @@ export default function WizardCTA({
     fullCommand?: string
     /** Clipboard override, if it should differ from what's displayed. */
     copyCommand?: string
-    /** Shorthand for `command="self-driving"`. Takes precedence over `command`. */
-    selfDriving?: boolean
     title?: string
     subtitle?: string
     /** "Learn more" link target under the command. Defaults to `/wizard`. */
@@ -68,7 +68,6 @@ export default function WizardCTA({
                             command={command}
                             fullCommand={fullCommand}
                             copyCommand={copyCommand}
-                            selfDriving={selfDriving}
                             secondaryTo={learnMoreTo}
                         />
                     </div>

--- a/src/components/WizardCTA/index.tsx
+++ b/src/components/WizardCTA/index.tsx
@@ -9,13 +9,20 @@ const DEFAULT_SUBTITLE = 'Paste this into your terminal and make AI do all the w
  * Wizard install banner for prose (blog posts, docs) and the `/r/*` landing pages.
  *
  * Every piece of copy has a prop defaulting to the value it was previously hard-coded to, so bare
- * `<WizardCTA />` call sites keep rendering exactly what they always have while an individual post
- * can retarget the command — e.g. `<WizardCTA selfDriving />` or
- * `<WizardCTA command="ai-observability" />`. Command building itself stays in
- * [`PlatformInstall`](../PlatformInstall) so the displayed and copied strings can't drift.
+ * `<WizardCTA />` call sites keep rendering exactly what they always have while an author editing a
+ * post can retarget it inline. Two levels of control, deliberately:
+ *
+ * - `command="self-driving"` appends a subcommand, keeping the `-y`/`@latest` pinning on copy.
+ * - `fullCommand="npx @posthog/wizard self-driving"` states the whole thing, shown and copied
+ *   verbatim, for when the built form isn't what you want.
+ *
+ * Command assembly itself stays in [`PlatformInstall`](../PlatformInstall) so the displayed and
+ * copied strings can't drift.
  */
 export default function WizardCTA({
     command,
+    fullCommand,
+    copyCommand,
     selfDriving = false,
     title = DEFAULT_TITLE,
     subtitle = DEFAULT_SUBTITLE,
@@ -24,6 +31,13 @@ export default function WizardCTA({
 }: {
     /** Wizard subcommand appended to the command, e.g. "ai-observability" or "warehouse". */
     command?: string
+    /**
+     * The entire command, shown and copied verbatim. Overrides `command`/`selfDriving` and skips the
+     * `-y`/`@latest` pinning, so include them yourself if you want them.
+     */
+    fullCommand?: string
+    /** Clipboard override, if it should differ from what's displayed. */
+    copyCommand?: string
     /** Shorthand for `command="self-driving"`. Takes precedence over `command`. */
     selfDriving?: boolean
     title?: string
@@ -52,6 +66,8 @@ export default function WizardCTA({
                         <PlatformInstall
                             variant="inline"
                             command={command}
+                            fullCommand={fullCommand}
+                            copyCommand={copyCommand}
                             selfDriving={selfDriving}
                             secondaryTo={learnMoreTo}
                         />


### PR DESCRIPTION
## Changes

`WizardCTA` took no props — the heading, subheading, and `npx @posthog/wizard` command were all hard-coded, so every one of its ~60 call sites rendered identical copy.

It now accepts optional `command`, `selfDriving`, `title`, `subtitle`, `learnMoreTo`, and `className` props, each defaulting to the value it was previously hard-coded to. Bare `<WizardCTA />` renders exactly what it did before, so no existing call site changes.

```mdx
<WizardCTA selfDriving />

<WizardCTA command="ai-observability" title="Add LLM observability in one command" />
```

Command building goes through `PlatformInstall`'s inline variant rather than being assembled here, so the displayed and copied strings can't drift. Also adds a `README.md` for the component.

## Why

So a writer can retarget the wizard command from inside a blog post — e.g. point it at `wizard self-driving` — without needing a new component or a code change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9AKT9NTY/p1787075140051569)*