### PR TITLE
Change customer case study sidebar label to "Tools used"

### DIFF
--- a/src/components/ReaderView/CustomerMetadata.tsx
+++ b/src/components/ReaderView/CustomerMetadata.tsx
@@ -67,7 +67,7 @@ export default function CustomerMetadata({ customerKey }: CustomerMetadataProps)
             </div>
             {customerData.toolsUsedHandles && customerData.toolsUsedHandles.length > 0 && (
                 <div>
-                    <strong className="text-sm text-secondary">Products used:</strong>
+                    <strong className="text-sm text-secondary">Tools used:</strong>
                     <ul className="not-prose space-y-1 mt-1">
                         {customerData.toolsUsedHandles.map((toolHandle) => {
                             // Check if allProducts is an array


### PR DESCRIPTION
## Changes

The customer metadata sidebar on case studies labelled the list of PostHog products as "Products used:". Changed it to "Tools used:", matching the underlying `toolsUsedHandles` field.

**Why:** "Products used" was flagged as outdated wording on customer case studies.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1787075282491709)*