### PR TITLE
Point handbook budget references at the monthly User Limit

### DIFF
--- a/contents/handbook/company/culture.md
+++ b/contents/handbook/company/culture.md
@@ -17,7 +17,7 @@ Being all remote has a bunch of advantages:
 * It creates space for lots of uninterrupted work.
 * We judge performance based on real outcomes, not hours spent in an office.
 
-In addition to all the equipment you'll need, we provide [a budget to help you find coworking space](/handbook/people/spending-money#how-it-works), or to cover coffee shop expenses. There's no fixed travel budget, but you can [use your monthly budget](/handbook/people/spending-money#hub-travel-budget) for ad-hoc meetups.
+In addition to all the equipment you'll need, your monthly [`User Limit`](/handbook/people/spending-money#how-it-works) covers things like coworking space or coffee shop expenses. There's no fixed travel budget either - you can use the same limit for [ad-hoc meetups](/handbook/people/spending-money#hub-travel-budget).
 
 ## We're extremely welcoming
 

--- a/contents/handbook/people/bookhog.mdx
+++ b/contents/handbook/people/bookhog.mdx
@@ -31,4 +31,4 @@ Michael is the organizer and picks the next book to read through a pseudo-democr
 22. Drive Your Plow Over the Bones of the Dead
 23. No Rules Rules
 
-Books can be purchased using your monthly [books budget](/handbook/people/training#books).
+Books can be purchased using your monthly [`User Limit`](/handbook/people/spending-money#how-it-works).

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -237,3 +237,6 @@ If you do decide to come, we ask that you make the trip worthwhile - attend a co
 
 ### Sponsorships
 If you believe an open-source project is fundamentally important to the success of PostHog then we should set up a recurring sponsorship. In this case, see the [open-source sponsorship Marketing initiative](/handbook/marketing/open-source-sponsorship).
+
+#### Open-source sponsorship for individuals
+You can also sponsor open-source projects that have helped you personally, using your monthly `User Limit`. You don't need approval - just apply the guiding principles above, as you would for any other spend.

--- a/contents/handbook/support/support-zero.md
+++ b/contents/handbook/support/support-zero.md
@@ -16,7 +16,7 @@ At times we can really struggle to pull ourselves away from tickets and focus on
 
 Each support team member is given an allocation of *2 support zero weeks in each quarter* (i.e. 10 working days). These are weeks that each team member can book.
 
-Team members are encouraged to consider taking the same zero weeks as someone else working on the same quarterly goal (so it can be done hackathon-style, you can consider using your meetup budget, etc)
+Team members are encouraged to consider taking the same zero weeks as someone else working on the same quarterly goal (so it can be done hackathon-style, you can consider using your monthly [`User Limit`](/handbook/people/spending-money#how-it-works) to meet up, etc)
 
 ### Before the quarter starts
 - [ ] During quarterly goal planning we scope out goals that we think are achievable in our zero time each quarter.


### PR DESCRIPTION
## Changes

- **Spending money:** added an `Open-source sponsorship for individuals` subsection under Sponsorships, saying individual sponsorships come out of your monthly `User Limit`. This also fixes the existing `#open-source-sponsorship-for-individuals` anchor that benefits and the open-source sponsorship page already link to.
- **Culture, BookHog, Support zero:** replaced references to named budgets (coworking budget, books budget, meetup budget) with the monthly `User Limit`, linking to the spending money page.

No change for training — the spending money page already lists training as covered by the `User Limit`, in both "How it works" and "Budget structure on Brex".

**Why:** parts of the handbook still describe spending in terms of specific named budgets, which no longer matches how we actually work — spend comes out of a single monthly user limit.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1786961177425139?thread_ts=1786961177.425139&cid=C017WDX3BFZ)*