### PR TITLE
Add metric conventions to RevOps navigation

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1273,6 +1273,10 @@ export const handbookSidebar = [
                 url: '/handbook/growth/revops/overview',
             },
             {
+                name: 'Metric conventions',
+                url: '/handbook/growth/revops/metric-conventions',
+            },
+            {
                 name: 'Revenue adjustments',
                 url: '/handbook/growth/revops/revenue-adjustments',
             },


### PR DESCRIPTION
## Changes

- Add the Metric conventions page to the RevOps handbook navigation.

**Why:** Make the existing metric guidance discoverable from the RevOps handbook overview and sidebar.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable; no page moved)

### Testing

- `git diff --check`
- `pnpm check-src-links` *(blocked by an unrelated existing broken link in `src/pages/trash/index.tsx`)*

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*