### PR TITLE
Remove commenting on community profile pages

### DIFF
--- a/src/components/Squeak/components/EditProfile.tsx
+++ b/src/components/Squeak/components/EditProfile.tsx
@@ -8,7 +8,6 @@ import { useUser } from 'hooks/useUser'
 import getAvatarURL from '../util/getAvatar'
 import usePostHog from 'hooks/usePostHog'
 import { Avatar as DefaultAvatar } from 'components/Community/Sidebar'
-import Toggle from 'components/Toggle'
 import { IconInfo } from '@posthog/icons'
 import Tooltip from 'components/Tooltip'
 
@@ -106,21 +105,6 @@ const fields = {
             />
         ),
         className: 'w-full',
-    },
-    amaEnabled: {
-        hideLabel: true,
-        component: ({ values, setFieldValue }) => {
-            return (
-                <div className="flex space-x-2 mb-6">
-                    <Toggle
-                        label="Ask me anything"
-                        checked={values.amaEnabled}
-                        onChange={() => setFieldValue('amaEnabled', !values.amaEnabled)}
-                        tooltip="Allows community members to ask you questions directly on your profile page"
-                    />
-                </div>
-            )
-        },
     },
 }
 
@@ -225,7 +209,6 @@ export const EditProfile: React.FC<EditProfileProps> = ({ onSubmit }) => {
         location,
         country,
         pronouns,
-        amaEnabled,
         height,
     } = user?.profile || {}
 
@@ -315,7 +298,6 @@ export const EditProfile: React.FC<EditProfileProps> = ({ onSubmit }) => {
                 pronouns,
                 height,
                 biography,
-                amaEnabled,
             }}
             validationSchema={ValidationSchema}
             onSubmit={handleSubmit}

--- a/src/pages/community/profile/edit.tsx
+++ b/src/pages/community/profile/edit.tsx
@@ -7,7 +7,6 @@ import { Avatar as DefaultAvatar } from 'components/Community/Sidebar'
 import Layout from 'components/Layout'
 import { communityMenu } from '../../../navs'
 import Link from 'components/Link'
-import Switch from 'components/Toggle'
 import { CallToAction } from 'components/CallToAction'
 import { useToast } from '../../../context/Toast'
 import { navigate } from 'gatsby'
@@ -415,25 +414,6 @@ const formSections = [
                 label: 'Height',
                 className: 'w-full',
                 component: HeightField,
-            },
-            amaEnabled: {
-                className: 'w-full',
-                component: ({ values, setFieldValue }) => {
-                    return (
-                        <div className="flex space-x-2 space-between w-full">
-                            <div className="flex-grow">
-                                <p className="font-bold m-0">Show comments</p>
-                                <p className="m-0">
-                                    Let visitors comment on your profile. You'll get comment notifications via email.
-                                </p>
-                            </div>
-                            <Switch
-                                checked={values.amaEnabled}
-                                onChange={() => setFieldValue('amaEnabled', !values.amaEnabled)}
-                            />
-                        </div>
-                    )
-                },
             },
         },
     },

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -756,22 +756,6 @@ const ModeratorFields = ({ setFieldValue, values, errors }) => {
                 </div>
             </div>
             <div>
-                <label className="text-[15px]">Show comments</label>
-                <p className="text-xs text-secondary m-0 mb-2">
-                    Let visitors comment on your profile. You'll get comment notifications via email.
-                </p>
-                <ToggleGroup
-                    title="Show comments"
-                    hideTitle
-                    options={[
-                        { label: 'Yes', value: 'yes' },
-                        { label: 'No', value: 'no' },
-                    ]}
-                    value={values.amaEnabled === null ? undefined : values.amaEnabled ? 'yes' : 'no'}
-                    onValueChange={(value) => setFieldValue('amaEnabled', value === 'yes' ? true : false)}
-                />
-            </div>
-            <div>
                 <ToggleGroup
                     title="T-shirt fit"
                     options={[
@@ -1361,7 +1345,6 @@ export default function ProfilePage({ params }: PageProps) {
             color: profile?.color,
             backgroundImage: profile?.backgroundImage,
             companyRole: profile?.companyRole,
-            amaEnabled: profile?.amaEnabled,
             tShirt: profile?.tShirt || { fit: null, size: null, additionalInfo: null },
         },
         onSubmit: async ({ avatar, images, ...values }) => {
@@ -1699,21 +1682,6 @@ export default function ProfilePage({ params }: PageProps) {
                                     />
                                 </div>
                             ) : null}
-
-                            {profile.amaEnabled && (
-                                <div className="mt-6">
-                                    <Block title="Comments">
-                                        <Questions
-                                            initialView={'question-form'}
-                                            slug={window?.location?.pathname}
-                                            profileId={undefined}
-                                            showForm
-                                            disclaimer={false}
-                                            autoFocus={false}
-                                        />
-                                    </Block>
-                                </div>
-                            )}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
> This isn't being monitored actively (im pretty sure it doesnt even notify the person unless theyre tagged), and people are able to find [deactivated employees and comment on their profiles](https://posthog.com/community/profiles/30200), and then [that turns into a new post in /questions](https://posthog.com/questions/how-i-can-contribute-to-posthog-as-a-product-designer). I think its cleaner to remove this for now similar to what we did with /docs .

## Changes

Removes the AMA-style **Comments** block from community profile pages, following the same move we made for `/docs` pages in #17558.

Profile pages had two comment-related surfaces. Only one of them was actually "commenting on the profile":

| Surface | What it is | This PR |
| --- | --- | --- |
| **"Comments" block** — `<Questions slug={pathname} showForm />`, gated by `profile.amaEnabled` | AMA-style comments left *on* someone's profile | **Removed** |
| **"Discussions" tab** — `<Questions profileId={id} showForm={false} />` | Read-only list of forum threads the person authored or replied to | **Kept** |

The Discussions tab stays because it's the person's community activity history, not comments left on them.

### Files touched

- **`src/pages/community/profiles/[id].tsx`** — deleted the `<Block title="Comments">` block, the "Show comments" `ToggleGroup` in `ModeratorFields`, and `amaEnabled` from the Formik `initialValues`.
- **`src/pages/community/profile/edit.tsx`** — deleted the `amaEnabled` field from `formSections` (which also drops it from the derived `initialValues`) and the now-unused `Switch` import.
- **`src/components/Squeak/components/EditProfile.tsx`** — deleted the "Ask me anything" `Toggle` field, `amaEnabled` from the profile destructure and `initialValues`, and the now-unused `Toggle` import.

All three toggles go together so there's no orphaned setting left in profile settings that does nothing.

### Deliberately unchanged

- **`amaEnabled: boolean | null` in `src/lib/strapi.ts`** — the Strapi field still exists and the API still returns it, so the type is still accurate. Removing the field itself needs a Strapi admin schema change.
- **Existing comment records** — not deleted, just no longer rendered. Reversible.
- **The shared `Squeak` component stack** (`Questions` / `Question` / `Replies` / `Reply` / `QuestionForm`) — also used by the forum, blog comments, and the Discussions tab.

## Testing

Prettier clean on all three files. Worth a local pass on:

- A profile that previously had `amaEnabled: true` with comments — Comments block gone, Discussions tab and the other tabs still render.
- `/community/profile/edit` — "Show comments" toggle gone, and saving the form still succeeds (confirms the `initialValues` change didn't break the submit payload).
- Moderator fields on a profile page — "Show comments" gone, Height and T-shirt fit still save.

Anyone who had comments enabled loses them from view with no notice — flagging in case that warrants a heads-up somewhere.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*