### PR TITLE
Update MCP Analytics beta status in documentation

### DIFF
--- a/contents/docs/mcp-analytics/index.mdx
+++ b/contents/docs/mcp-analytics/index.mdx
@@ -17,7 +17,7 @@ Every tool invocation lands as a single `$mcp_tool_call` event on your standard 
 
 <CalloutBox icon="IconFlask" title="MCP Analytics is in beta" type="fyi">
 
-The in-app MCP Analytics views are behind a feature preview – [turn on the MCP Analytics preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to enable them. The `@posthog/mcp` SDK is published as a `0.x` release, so event names, properties, and tracing behavior may change before `1.0`. Pin a version and don't depend on it for production reporting yet.
+The in-app MCP Analytics views are in beta. The `@posthog/mcp` SDK is published as a `0.x` release, so event names, properties, and tracing behavior may change before `1.0`. Pin a version and don't depend on it for production reporting yet.
 
 </CalloutBox>
 

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -125,7 +125,7 @@ Learn about intent capture
     icon="IconLineGraph"
 >
 
-Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the [MCP Analytics view](/docs/mcp-analytics) (in beta – [enable the feature preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics)) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
+Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the [MCP Analytics view](/docs/mcp-analytics) (in beta) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
 
 - ### <IconGraph className="text-blue w-7 -mt-1 inline-block"/> Top tools per server
   Where is your agent traffic concentrated? Which tools earn their keep?

--- a/contents/docs/mcp-analytics/surfaces/api.mdx
+++ b/contents/docs/mcp-analytics/surfaces/api.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 <CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
-The MCP Analytics API is in beta and requires the MCP Analytics feature preview to be enabled. Endpoints may change before general availability.
+The MCP Analytics API is in beta. Endpoints may change before general availability.
 
 </CalloutBox>
 

--- a/contents/docs/mcp-analytics/surfaces/mcp.mdx
+++ b/contents/docs/mcp-analytics/surfaces/mcp.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 <CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
-MCP Analytics tools are in beta and require the MCP Analytics feature preview to be enabled.
+MCP Analytics tools are in beta.
 
 </CalloutBox>
 

--- a/contents/docs/mcp-analytics/surfaces/web-app.mdx
+++ b/contents/docs/mcp-analytics/surfaces/web-app.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 <CalloutBox icon="IconFlask" title="Open beta" type="fyi">
 
-The MCP Analytics views are behind a feature preview. [Turn on the MCP Analytics preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics) to enable them.
+The MCP Analytics views are in beta.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Still said `feature preview` with a link to `/settings/user-feature-previews#mcp-analytics` which no longer exists, so Ireplaced `feature preview` with `beta` and removed the settings link.