### PR TITLE
Align Slack profile etiquette with the onboarding checklist

### DIFF
--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -171,7 +171,7 @@ Slack is used differently in different organizations. Here are some guidelines f
 3. Make use of threads when responding to a post. This allows informal discussion to take place without notifications being sent to everyone in the channel on every reply.
 4. When possible, summarize multiple thoughts into a single message instead of sending multiple messages sequentially.
 5. You don't need to tell people if you're away from your computer, especially on no-meeting days. There's no general expectation people are available to reply to messages in real time, including in Slack.
-6. Keep your Slack profile up to date with the right information, including the appropriate name eg with surname or surname initial if you share a name with a colleauge.
+6. Keep your Slack profile up to date with your timezone, team, start date, and a link to your PostHog community profile. Include your full name in both your Slack handle and display name — even if you're the only one with your name right now, others may soon join with the same first name, and this reduces confusion.
 
 Channel naming conventions so people don't get confused:
 


### PR DESCRIPTION
## Changes

Updates item 6 of the Slack etiquette list in the communication handbook so it matches the wording new starters already get in their onboarding checklist: keep your Slack profile up to date (timezone, team, start date, community profile link) and use your full name in both your Slack handle and display name.

Previously the handbook only asked for a surname or surname initial *if* you shared a name with a colleague, which is weaker than what new starters are actually asked to do. Also fixes the "colleauge" typo.

## Why

Someone asked what the guidance was for new starters on Slack handles and display names, and the handbook and the onboarding checklist gave different answers.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1787126998971619)*