### PR TITLE
docs(ai-research): rename the image fetcher bot

### DIFF
--- a/contents/docs/ai-research/image-fetcher-bot.mdx
+++ b/contents/docs/ai-research/image-fetcher-bot.mdx
@@ -1,10 +1,10 @@
 ---
-title: Session replay image bot
+title: Image fetcher bot
 ---
 
 PostHog runs a bot that downloads images referenced by session recordings. This page explains what it does, how to identify it, and how to block it.
 
-The bot is called `PostHogSessionReplayBot`.
+The bot is called `PostHogImageFetcherBot`.
 
 ## What it does
 
@@ -23,7 +23,7 @@ If nobody records PostHog sessions on your site, the bot has no reason to visit 
 Look for this user agent:
 
 ```
-PostHogSessionReplayBot/1.0 (+https://posthog.com/docs/session-replay/image-bot)
+PostHogImageFetcherBot/1.0 (+https://posthog.com/docs/ai-research/image-fetcher-bot)
 ```
 
 The user agent is the way to identify the bot. We don't publish a list of IP addresses, because the addresses can change and a list you can't rely on is worse than no list. If you need a stable range to add to an allowlist, [contact us](/talk-to-a-human) and tell us what you need it for.
@@ -42,7 +42,7 @@ The user agent is the way to identify the bot. We don't publish a list of IP add
 To block it in `robots.txt`:
 
 ```
-User-agent: PostHogSessionReplayBot
+User-agent: PostHogImageFetcherBot
 Disallow: /
 ```
 

--- a/vercel.json
+++ b/vercel.json
@@ -193,6 +193,11 @@
     ],
     "redirects": [
         {
+            "source": "/docs/session-replay/image-bot:ext(\\.md)?",
+            "destination": "/docs/ai-research/image-fetcher-bot:ext?",
+            "statusCode": 301
+        },
+        {
             "source": "/docs/session-replay/session-summaries-ai:ext(\\.md)?",
             "destination": "/docs/replay-vision:ext?",
             "statusCode": 301


### PR DESCRIPTION
## Changes

- Moves the image fetcher bot documentation to `/docs/ai-research/image-fetcher-bot`.
- Renames the bot and user agent to `PostHogImageFetcherBot`.
- [PostHog/posthog#85308](https://github.com/PostHog/posthog/pull/85308) updates the outbound user agent.
- Redirects the previous Session Replay URL, including its `.md` form.
- The redirect generator, Markdown lint, and JSON formatting checks pass.
- The source-link scan still reports one unrelated existing broken link in `src/pages/trash/index.tsx`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words use American English.
- [x] Internal links use relative URLs.
- [ ] I've checked the changed page in the Vercel preview build.
- [x] The moved page has a redirect in `vercel.json`.