### PR TITLE
fix(docs): compile Desktop pricing API on Vercel

### DIFF
--- a/api/posthog-desktop-pricing.ts
+++ b/api/posthog-desktop-pricing.ts
@@ -1,11 +1,22 @@
-const handler = async (req, res) => {
+import { getPostHogDesktopPricing, PRICING_CACHE_CONTROL } from '../src/lib/posthogDesktopPricing'
+
+interface VercelRequest {
+    method?: string
+}
+
+interface VercelResponse {
+    setHeader(name: string, value: string): void
+    status(statusCode: number): VercelResponse
+    json(body: unknown): void
+}
+
+const handler = async (req: VercelRequest, res: VercelResponse): Promise<void> => {
     if (req.method !== 'GET') {
         res.setHeader('Allow', 'GET')
         return res.status(405).json({ error: 'Method not allowed' })
     }
 
     try {
-        const { getPostHogDesktopPricing, PRICING_CACHE_CONTROL } = await import('../src/lib/posthogDesktopPricing.ts')
         res.setHeader('Cache-Control', PRICING_CACHE_CONTROL)
         return res.status(200).json(await getPostHogDesktopPricing())
     } catch (error) {
@@ -14,4 +25,4 @@ const handler = async (req, res) => {
     }
 }
 
-module.exports = handler
+export default handler


### PR DESCRIPTION
## Problem

`GET /api/posthog-desktop-pricing` returns 502 even though both upstream pricing endpoints return 200.

The Vercel JavaScript function dynamically imported a raw TypeScript source file. Vercel compiles TypeScript function entrypoints and statically imported dependencies, but the runtime import bypassed that build path. The import failed before either upstream request ran, and the broad catch returned `Failed to fetch PostHog Desktop pricing`.

## Fix

- Make the Vercel API route a TypeScript entrypoint.
- Statically import the shared pricing module so Vercel bundles and compiles it.
- Keep the route path, response shape, cache policy, and Cloudflare Pages function unchanged.

## Verification

- Bundled the function and its static dependency with esbuild for Node 22.
- Invoked the bundled handler against the live upstreams: status 200, 14 priced models, expected cache header.
- Ran focused TypeScript checking for the handler and shared pricing module.
- Ran Prettier check and `git diff --check`.

The full `vercel build` command could not run locally because this environment does not have a valid Vercel token.
