### PR TITLE
fix: resolve the docs sidebar to the section that owns the URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "update-sprite": "svg-sprite -s --symbol-dest src/components/productFeature/images/icons --symbol-sprite sprited-icons.svg src/components/productFeature/images/icons/*.svg",
         "test-redirects": "jest scripts",
         "test:bundle": "node --test scripts/bundle/check-eager-graph.test.mjs",
+        "test:navs": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/navs/activeMenu.test.ts",
         "check-links-post-build": "node scripts/check-links-post-build.js",
         "check-src-links": "node scripts/check-src-links.js",
         "check-product-changelogs": "node scripts/check-product-changelogs.js",

--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -240,8 +240,15 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
     const internalMenu = parent?.children || []
 
     const getActiveInternalMenu = useCallback(() => {
+        const currentURL = item?.path
+        // A URL can be the root of its own section and also a link inside an earlier section. Match the
+        // section that owns the URL first, so the earlier link does not shadow it. A section without
+        // children has no sidebar of its own, so it stays out of this pass.
+        const owner = internalMenu?.find(
+            (menuItem: MenuItem) => menuItem.children?.length && currentURL === menuItem.url?.split('?')[0]
+        )
+        if (owner) return owner
         return internalMenu?.find((menuItem: MenuItem) => {
-            const currentURL = item?.path
             return currentURL === menuItem.url?.split('?')[0] || recursiveSearch(menuItem.children, currentURL)
         })
     }, [internalMenu, item])

--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -36,27 +36,7 @@ import Modal from 'components/RadixUI/Modal'
 import { ToggleGroup } from 'components/RadixUI/ToggleGroup'
 import FloatingModal from 'components/FloatingModal'
 import { MOTION_LAYER, WINDOW_BG } from '../../constants/frostedSurfaces'
-
-const recursiveSearch = (array: MenuItem[] | undefined, value: string): boolean => {
-    if (!array) return false
-
-    for (let i = 0; i < array.length; i++) {
-        const element = array[i]
-
-        if (element.url?.split('?')[0] === value) {
-            return true
-        }
-
-        if (element.children) {
-            const found = recursiveSearch(element.children, value)
-            if (found) {
-                return true
-            }
-        }
-    }
-
-    return false
-}
+import { containsURL, getActiveMenuSection } from '../../navs/activeMenu'
 
 const snapThreshold = -50
 
@@ -232,7 +212,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
     const parent =
         (appMenu as Menu).find(({ children, url }) => {
             const currentURL = item?.path
-            return currentURL === url?.split('?')[0] || recursiveSearch(children, currentURL)
+            return currentURL === url?.split('?')[0] || containsURL(children, currentURL)
         }) ||
         appMenu.find(({ url }) => url === `/${item?.path?.split('/')[1]}`) ||
         appMenu.find(({ name }) => name === 'Docs')
@@ -240,17 +220,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
     const internalMenu = parent?.children || []
 
     const getActiveInternalMenu = useCallback(() => {
-        const currentURL = item?.path
-        // A URL can be the root of its own section and also a link inside an earlier section. Match the
-        // section that owns the URL first, so the earlier link does not shadow it. A section without
-        // children has no sidebar of its own, so it stays out of this pass.
-        const owner = internalMenu?.find(
-            (menuItem: MenuItem) => menuItem.children?.length && currentURL === menuItem.url?.split('?')[0]
-        )
-        if (owner) return owner
-        return internalMenu?.find((menuItem: MenuItem) => {
-            return currentURL === menuItem.url?.split('?')[0] || recursiveSearch(menuItem.children, currentURL)
-        })
+        return getActiveMenuSection<MenuItem>(internalMenu, item?.path)
     }, [internalMenu, item])
 
     const [activeInternalMenu, setActiveInternalMenu] = useState<MenuItem | undefined>(getActiveInternalMenu())

--- a/src/navs/activeMenu.test.ts
+++ b/src/navs/activeMenu.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Sidebar section matching, against a small fixture and against the real docs nav.
+ *
+ * Run: pnpm test:navs
+ */
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { getActiveMenuSection } from './activeMenu.ts'
+import type { MenuNode } from './activeMenu.ts'
+import { docsMenu } from './index.js'
+
+interface NamedNode extends MenuNode {
+    name: string
+    children?: NamedNode[]
+}
+
+const sectionFor = (url: string): string | undefined =>
+    getActiveMenuSection<NamedNode>(docsMenu.children as NamedNode[], url)?.name
+
+/** Every URL in the tree, with the querystring removed. */
+const collectURLs = (items: NamedNode[] | undefined, found: Set<string> = new Set()): Set<string> => {
+    for (const item of items ?? []) {
+        if (item.url) {
+            found.add(item.url.split('?')[0])
+        }
+        collectURLs(item.children, found)
+    }
+    return found
+}
+
+describe('getActiveMenuSection', () => {
+    test('the section that owns a URL wins over an earlier section that links to it', () => {
+        const sections: NamedNode[] = [
+            {
+                name: 'First',
+                url: '/docs/first',
+                children: [{ name: 'A link to Second', url: '/docs/second' }],
+            },
+            {
+                name: 'Second',
+                url: '/docs/second',
+                children: [{ name: 'Pricing', url: '/docs/second/pricing' }],
+            },
+        ]
+
+        assert.equal(getActiveMenuSection(sections, '/docs/second')?.name, 'Second')
+        assert.equal(getActiveMenuSection(sections, '/docs/second/pricing')?.name, 'Second')
+        assert.equal(getActiveMenuSection(sections, '/docs/first')?.name, 'First')
+    })
+
+    test('a section without children never wins, because it has no sidebar', () => {
+        const sections: NamedNode[] = [
+            {
+                name: 'First',
+                url: '/docs/first',
+                children: [{ name: 'A link to Second', url: '/docs/second' }],
+            },
+            { name: 'Second', url: '/docs/second' },
+        ]
+
+        assert.equal(getActiveMenuSection(sections, '/docs/second')?.name, 'First')
+    })
+
+    test('a querystring on a nav URL does not stop the match', () => {
+        const sections: NamedNode[] = [
+            { name: 'First', url: '/docs/first?tab=web', children: [{ name: 'Child', url: '/docs/first/child' }] },
+        ]
+
+        assert.equal(getActiveMenuSection(sections, '/docs/first')?.name, 'First')
+    })
+
+    test('an unlisted URL matches no section', () => {
+        const sections: NamedNode[] = [{ name: 'First', url: '/docs/first', children: [] }]
+
+        assert.equal(getActiveMenuSection(sections, '/docs/nowhere'), undefined)
+    })
+})
+
+describe('the real docs nav', () => {
+    // Self-driving is the first section and it links to both of these, so before the owner pass
+    // they both rendered the Self-driving sidebar.
+    test('PostHog Desktop pages use the PostHog Desktop sidebar', () => {
+        assert.equal(sectionFor('/docs/posthog-desktop'), 'PostHog Desktop')
+        assert.equal(sectionFor('/docs/posthog-desktop/pricing'), 'PostHog Desktop')
+    })
+
+    test('PostHog Slack pages use the PostHog Slack sidebar', () => {
+        assert.equal(sectionFor('/docs/slack'), 'PostHog Slack')
+    })
+
+    test('Self-driving pages still use the Self-driving sidebar', () => {
+        assert.equal(sectionFor('/docs/self-driving'), 'Self-driving')
+        assert.equal(sectionFor('/docs/self-driving/pricing'), 'Self-driving')
+    })
+
+    test('every docs URL resolves to a section that lists it', () => {
+        const urls = collectURLs(docsMenu.children as NamedNode[])
+        assert.ok(urls.size > 500, `expected the docs nav to hold hundreds of URLs, got ${urls.size}`)
+
+        for (const url of urls) {
+            const section = getActiveMenuSection<NamedNode>(docsMenu.children as NamedNode[], url)
+            assert.ok(section, `${url} resolves to no section`)
+            const listed = section.url?.split('?')[0] === url || collectURLs(section.children).has(url)
+            assert.ok(listed, `${url} resolves to "${section.name}", which does not list it`)
+        }
+    })
+
+    test('every docs URL resolves to a section with a sidebar to render', () => {
+        for (const url of collectURLs(docsMenu.children as NamedNode[])) {
+            const section = getActiveMenuSection<NamedNode>(docsMenu.children as NamedNode[], url)
+            assert.ok(section?.children?.length, `${url} resolves to "${section?.name}", which has no children`)
+        }
+    })
+})

--- a/src/navs/activeMenu.ts
+++ b/src/navs/activeMenu.ts
@@ -1,0 +1,50 @@
+/**
+ * Picks the sidebar section a URL belongs to.
+ *
+ * `AppWindow` renders the children of the section this returns. The logic lives outside the
+ * React tree so that `activeMenu.test.ts` can run it against the real nav data under
+ * `node --test`. See `pnpm test:navs`.
+ */
+
+export interface MenuNode {
+    url?: string
+    children?: MenuNode[]
+}
+
+const pathOf = (url: string | undefined): string | undefined => url?.split('?')[0]
+
+/** True when `url` matches one of `items` or anything below it. */
+export const containsURL = (items: MenuNode[] | undefined, url: string | undefined): boolean => {
+    if (!items) return false
+
+    for (const item of items) {
+        if (pathOf(item.url) === url) {
+            return true
+        }
+
+        if (containsURL(item.children, url)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/**
+ * A URL can be the root of its own section and also a plain link inside an earlier section.
+ * Match the section that owns the URL first, so the earlier link does not shadow it. A section
+ * without children has no sidebar of its own, so it stays out of that first pass.
+ */
+export function getActiveMenuSection<T extends MenuNode>(
+    sections: T[] | undefined,
+    url: string | undefined
+): T | undefined {
+    if (url) {
+        const owner = sections?.find((section) => section.children?.length && pathOf(section.url) === url)
+        if (owner) {
+            return owner
+        }
+    }
+
+    return sections?.find((section) => pathOf(section.url) === url || containsURL(section.children, url))
+}


### PR DESCRIPTION
## Changes

A docs URL can be the root of its own sidebar section and also a plain link inside an earlier section. The matcher took the first section in array order whose tree contained the current URL, so the earlier link won and the page rendered the wrong sidebar.

The matcher now runs a first pass that matches the section which owns the URL. Sections without children stay out of that pass, because they have no sidebar of their own and would otherwise render an empty tree.

The matcher moves out of `src/components/AppWindow/index.tsx` into `src/navs/activeMenu.ts`, so a test can call it without React. `src/navs/activeMenu.test.ts` runs under `node --test` through `pnpm test:navs`, the same pattern as `calculatorLogic.test.ts`. It covers the shadowing rule on a small fixture, pins the two URLs that change, and sweeps every URL in `docsMenu` for two invariants: each URL resolves to a section that lists it, and each resolved section has children to render. Remove the first pass and 3 of the 9 tests fail.

Two URLs change. `/docs/posthog-desktop` moves from the Self-driving sidebar to the PostHog Desktop sidebar. `/docs/slack` moves from the Self-driving sidebar to the PostHog Slack sidebar. No other URL changes section, and no URL loses its sidebar.

Two related notes, not fixed here:

- `/docs/cli`, `/docs/model-context-protocol`, and `/docs/self-driving/web` still show the Self-driving sidebar. Their own sections have no children, so there is nothing better to show.
- The matcher compares URLs for equality, not by path prefix. A page that no nav lists gets no sidebar.

## Why

On the PostHog Desktop docs, the sidebar belonged to Self-driving. "Pricing" therefore went to `/docs/self-driving/pricing`, and readers had to type the address to reach `/docs/posthog-desktop/pricing`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787060035884629?thread_ts=1787060035.884629&cid=C09G8Q32R6F)*