### PR TITLE
fix(tutorials): use featured images for social previews

### DIFF
--- a/contents/tutorials/understand-ai-agent-performance.mdx
+++ b/contents/tutorials/understand-ai-agent-performance.mdx
@@ -3,6 +3,8 @@ date: 2026-08-14
 title: How to understand AI agent performance in your product
 author:
   - will-wearing
+featuredImage: >-
+  https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_08_17_T08_50_29_648_Z_c98944d6bd.png
 sidebar: Docs
 showTitle: true
 hideAnchor: true

--- a/contents/tutorials/understand-ai-agent-performance.mdx
+++ b/contents/tutorials/understand-ai-agent-performance.mdx
@@ -4,7 +4,7 @@ title: How to understand AI agent performance in your product
 author:
   - will-wearing
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_08_17_T08_50_29_648_Z_c98944d6bd.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_08_17_T08_50_29_648_Z_c98944d6bd.png
 sidebar: Docs
 showTitle: true
 hideAnchor: true

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -77,7 +77,10 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                 title={title + ' - PostHog'}
                 description={description || excerpt}
                 article
-                image={`${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`}
+                image={
+                    featuredImage?.publicURL ||
+                    `${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`
+                }
                 imageType="absolute"
             />
             <div className="flex flex-col-reverse items-start @3xl:flex-row gap-8 2xl:gap-12">

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -77,10 +77,7 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                 title={title + ' - PostHog'}
                 description={description || excerpt}
                 article
-                image={
-                    featuredImage?.publicURL ||
-                    `${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`
-                }
+                image={`${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`}
                 imageType="absolute"
             />
             <div className="flex flex-col-reverse items-start @3xl:flex-row gap-8 2xl:gap-12">


### PR DESCRIPTION
## Summary

Uses a tutorial’s featured image for its Open Graph and Twitter image, while retaining the generated image for tutorials without one.

Sets the AI agent performance tutorial’s featured image to its improvement-loop graphic.

## Why

LinkedIn currently previews the contributor-based generated image, which includes the author avatar. This change makes the tutorial share the intended graphic.

## Validation

- `pnpm exec prettier --check src/templates/tutorials/Tutorial.tsx`
- Pre-commit ESLint and Markdownlint checks
- `pnpm build` compiled the changed Gatsby code, then stopped while fetching unrelated community data because local service credentials are absent and requests reset.