### PR TITLE
Handbook: two-week notice for art requests, brand.posthog.com, chasing on the issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+    - name: 🎨 Art, brand, or merch request
+      url: https://github.com/PostHog/marketing/issues/new/choose
+      about: Art, brand, and merch requests live in the PostHog/marketing repo — please don't open them here.

--- a/contents/handbook/brand/art-requests.md
+++ b/contents/handbook/brand/art-requests.md
@@ -22,21 +22,21 @@ They can help you with things like:
 
 They get a lot of work requests, so they use two separate project boards to organize work – [one for merch](https://github.com/orgs/PostHog/projects/178) and [one for other art projects](https://github.com/orgs/PostHog/projects/65/views/2). This reflects that merch projects often have much longer timelines and need to be handled differently. 
 
-Whenever you want to request a new merch design or other artwork, you should [use the relevant design request templates in the marketing repo](https://github.com/PostHog/marketing/issues/new/choose) – one template for merch, one for other art requests. Each template automatically assigns work to the correct project board. 
+Whenever you want to request a new merch design or other artwork, you should [use the relevant design request templates in the marketing repo](https://github.com/PostHog/marketing/issues/new/choose) – one template for merch, one for other art requests. The templates assign the right people and apply the right labels, but they do **not** add the issue to a project board – see below for how issues get onto the board.
 
 ### Art board automations
 
-The Art & Brand Planning board uses GitHub Actions to keep work moving:
+The Art & Brand Planning board uses automations to keep work moving. Each behavior below names the thing that controls it, so you know where to look when something misbehaves. Everything except the first item is a GitHub Actions workflow living in the [marketing repo](https://github.com/PostHog/marketing/tree/main/.github/workflows); the board is org-level, so the workflows act on board issues wherever those issues live.
 
-- **Reminders** — A daily job (9 AM UTC) posts one-time comments on issues that have been stuck in...
+- **Getting on the board** — controlled by the board itself, not by the Actions workflows or the issue templates. Items are added via the board's built-in auto-add workflow (board → **⋯** → **Workflows** → "Auto-add to project") or by hand, and land in the **No Status** column by default. Every automation below only applies to issues that are on the board – an issue that never gets added is invisible to all of them.
+- **Done → closed** — controlled by `art-board-status-change.yml`. It polls the board every 30 minutes and closes (as completed) any issue whose Status is **Done**, so expect up to ~30 minutes' delay after moving a card.
+- **Assignee sync** — also `art-board-status-change.yml`. When an issue is moved to **"Assigned: Daniel"**, **"Assigned: Lottie"**, or **"Assigned: Heidi"**, the other default assignees are removed so only the owner remains. It only ever removes assignees, never adds them, and it is driven by the board column – not the labels. Requests filed by the Graphics team themselves keep all assignees, and other columns (like "Assigned: Cleo") are untouched, as Cleo has a different workload.
+- **Artist labels** — controlled by `sync-artist-labels.yml`. Every 30 minutes, open issues in an "Assigned: ..." column get the matching `Lottie` / `Heidi` / `Daniel` label (and lose it when moved elsewhere), so work can be filtered per person. The label mirrors the column, never the other way around.
+- **Reminders** — controlled by `art-board-reminders.yml` (via the reusable `art-board-reminder.yml`). Daily at 9 AM UTC it posts a comment on issues stuck in...
   - **Feedback/Review** for 10+ days: asks if any feedback is needed to move the task forward.
   - **No Status** for 7+ days: asks someone to pick it up or assign it to a column.
-- **Status changes** — A job polls the board every 30 minutes and reacts to Status changes:
-  - **Moved to "Done"** → the issue is automatically closed (as completed).
-  - **Moved to "Assigned: Daniel", "Assigned: Lottie", or "Assigned: Heidi"** → other default assignees are removed so only the assigned person is on the issue. Internal requests (from the design team) keep all assignees.
-  - These changes do not impact the "Assigned: Cleo" column, as Cleo has a different workload.
-- **Artist labels** — Every 30 minutes, open issues in an "Assigned: ..." column get a matching label for that artist, so the work can be filtered per person.
-- Workflows run under the **Art Board Bot** GitHub App and live in the [marketing repo](https://github.com/PostHog/marketing) under `.github/workflows/` (`art-board-reminder.yml`, `art-board-reminders.yml`, `art-board-status-change.yml`, `sync-artist-labels.yml`). The board is org-level, so they act on art board issues wherever those issues live.
+  - Each issue only ever gets one reminder of each type, and snoozed items are skipped.
+- **Credentials** — the workflows authenticate as the **Art Board Bot** GitHub App. Its credentials are org-level Actions secrets scoped to the marketing repo, and the app installation needs access to every repo that holds board issues. If all the workflows suddenly start failing at the "Get app token" step, one of those two things is the cause.
 
 To establish a clear connection between the task and the working file, designers will create a frame containing a link to the task. They should then add a link to that frame within the task for easy reference.
 

--- a/contents/handbook/brand/art-requests.md
+++ b/contents/handbook/brand/art-requests.md
@@ -18,6 +18,8 @@ They can help you with things like:
 - Branded merch 
 - Animated UI elements
 
+> 💡 **You might not need a request at all.** [brand.posthog.com](https://brand.posthog.com) has ready-made brand assets — logos, colors, hedgehogs, and crests — that any team can use without filing an issue. The [hedgehog library](#hedgehog-library) below covers approved hogs too.
+
 They get a lot of work requests, so they use two separate project boards to organize work – [one for merch](https://github.com/orgs/PostHog/projects/178) and [one for other art projects](https://github.com/orgs/PostHog/projects/65/views/2). This reflects that merch projects often have much longer timelines and need to be handled differently. 
 
 Whenever you want to request a new merch design or other artwork, you should [use the relevant design request templates in the marketing repo](https://github.com/PostHog/marketing/issues/new/choose) – one template for merch, one for other art requests. Each template automatically assigns work to the correct project board. 
@@ -38,7 +40,9 @@ The Art & Brand Planning board uses GitHub Actions to keep work moving:
 
 To establish a clear connection between the task and the working file, designers will create a frame containing a link to the task. They should then add a link to that frame within the task for easy reference.
 
-Lottie and Daniel usually ask for two weeks minimum notice, but can often work faster on things if needed. If your request is genuinely urgent, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie, Daniel, and/or [Cory](https://posthog.com/community/profiles/30200).
+Please give **two weeks notice** for new briefs — this is the preferred minimum, and more time is always better. For reference, the team receives roughly 25-30 new art requests a month, so new briefs are rarely picked up the day they land. A **one-week turnaround is only possible for actual emergencies.** If your request is a genuine emergency, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie, Daniel, and/or [Cory](/community/profiles/30200).
+
+If you need to chase for an update on a request, the best place to do it is a comment on the issue itself, not a Slack DM. Comments keep the context with the brief, notify the assigned artist, and the team triages from the project board.
 
 ## Hedgehog library
 

--- a/contents/handbook/brand/art-requests.md
+++ b/contents/handbook/brand/art-requests.md
@@ -5,7 +5,7 @@ showTitle: true
 hideAnchor: false
 ---
 
-> 🎨 **Need artwork or merch?** Please request it using the [request templates](https://github.com/PostHog/marketing/issues/new/choose). Do not request art or merch over Slack or email.
+> 🎨 **Need artwork or merch?** Please request it using the [request templates in the PostHog/marketing repo](https://github.com/PostHog/marketing/issues/new/choose) — this is the only place art and brand request issues should be opened. Do not open them in the posthog.com repo, and do not request art or merch over Slack or email.
 
 All artwork and merch requests are handled by <TeamMember name="Lottie Coxon" />, <TeamMember name="Heidi Berton" />, and <TeamMember name="Daniel Hawkins" /> on the Graphics team.
 


### PR DESCRIPTION
## Changes

Updates `handbook/brand/art-requests`:

- **Two weeks notice is now the preferred minimum** for new briefs (was "two weeks minimum... but can often work faster"); a one-week turnaround is only possible for actual emergencies.
- **Art and brand request issues should only be opened in `PostHog/marketing`** — the handbook intro now says so explicitly, and this PR also adds an issue-chooser contact link (`.github/ISSUE_TEMPLATE/config.yml`) so anyone starting an issue in this repo gets pointed to the marketing templates.
- **Rewrites the "Art board automations" section to match how the automations actually behave**, with each behavior naming the workflow file or board setting that controls it. Notably: getting onto the board is controlled by the board's built-in auto-add workflow (or done by hand) — the issue templates do *not* add issues to any board, which the page previously claimed. Also documents that assignee sync only removes assignees (driven by the board column, not labels), that reminders fire once per issue, and where the bot app's credentials live for troubleshooting.
- Adds [brand.posthog.com](https://brand.posthog.com) as a self-serve resource (logos, colors, hedgehogs, crests) that may remove the need for a request.
- States that the best place to chase updates on a request is a comment on the issue itself, not Slack DMs.
- Cites current volume for context: roughly 25-30 new art requests a month (based on template-created issues over the last 30 days).
- Changes the Cory profile link to a relative URL per the style guide.

## Why

The old wording undercut the two-week ask by promising the team "can often work faster", and the automations section described intended behavior rather than actual behavior — in particular, the claim that templates auto-add issues to the board is wrong, which left recent requests stranded off-board and invisible to every automation. The request templates moved to PostHog/marketing in #19300, but nothing in this repo redirects people who still file art requests here out of habit. A companion PR updates the issue template in PostHog/marketing to match.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*