### PR TITLE
Remove web_search from the PostHog AI default tools table

### DIFF
--- a/contents/docs/posthog-ai/modes.mdx
+++ b/contents/docs/posthog-ai/modes.mdx
@@ -134,5 +134,4 @@ Regardless of which mode is active, the agent always has access to:
 | `read_data` | Read data warehouse schema, insights, dashboards, notebooks, and billing info |
 | `list_data` | Browse PostHog entities with pagination |
 | `search` | Search insights, dashboards, cohorts, actions, experiments, feature flags, notebooks, and more |
-| `web_search` | Search the web for up-to-date information about your product, company, or industry |
 | `switch_mode` | Switch to a different specialized mode |


### PR DESCRIPTION
## Changes

Removes the `web_search` row from the "Default tools (available in all modes)" table in `docs/posthog-ai/modes.mdx`.

The docs currently contradict themselves: `modes.mdx` listed `web_search` as always available to the agent, while `tools.mdx` lists "Browse the web beyond PostHog documentation" under **Limitations** and omits `web_search` from its tool table entirely. This drops the capability claim so the two pages agree.

Deliberately left alone:

- `docs/posthog-ai/edit-memory.mdx` — the `/init` flow does retrieve your URL or app bundle and search the web to seed memory, so that line stays accurate.
- `docs/ai-observability/calculating-costs.mdx` — the `$ai_web_search_price` / `$ai_web_search_cost_usd` references there are cost properties for customers instrumenting their own LLM apps, unrelated to PostHog AI's own tools.

## Why

Someone went looking for a web search capability they remembered being announced, and found the docs describing it in one place and denying it in another. Fixing the inconsistency in the docs is the immediate change; whether the tool should be documented as a headline capability is a separate product question being followed up outside this PR.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787058627555869?thread_ts=1787058627.555869&cid=C09SK2PAGKF)*
