### PR TITLE
docs: explain that heatmap screenshots render from a different set of IPs

### DIFF
--- a/contents/docs/integrate/_snippets/details/posthog-ips.mdx
+++ b/contents/docs/integrate/_snippets/details/posthog-ips.mdx
@@ -3,10 +3,12 @@ import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 <details>
   <summary>Add IPs to Firewall/WAF allowlists (recommended)</summary>
 
-  For certain features like [heatmaps](/docs/toolbar/heatmaps), your Web Application Firewall (WAF) may be blocking PostHog's requests to your site. Add these IP addresses to your WAF allowlist or rules to let PostHog access your site.
+  Your Web Application Firewall (WAF) may be blocking PostHog's requests to your site. Add these IP addresses to your WAF allowlist or rules to let PostHog access your site.
 
   <PostHogIPsInline />
 
-  These are public, stable IPs used by PostHog services (e.g., Celery tasks for snapshots).
+  These are public, stable IPs that PostHog connects from directly.
+
+  [Heatmap screenshots](/docs/toolbar/heatmaps#firewalls-wafs-and-bot-protection) are an exception. A third-party headless browser service renders them, so they reach your site from a different set of addresses that you need to allow separately.
 
 </details>

--- a/contents/docs/toolbar/heatmaps.mdx
+++ b/contents/docs/toolbar/heatmaps.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-import DetailPostHogIPs from "../integrate/_snippets/details/posthog-ips.mdx";
+import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 
 Heatmaps shows you how users are interacting with elements on your website or app.
 
@@ -36,7 +36,7 @@ There are three kinds of heatmaps in the toolbar:
 
 You can also view heatmaps directly in the PostHog. This method is currently in beta and provides almost the same functionality as the toolbar.
 
-<DetailPostHogIPs />
+If your site sits behind a firewall, WAF, or bot protection, see [firewalls, WAFs, and bot protection](#firewalls-wafs-and-bot-protection) before you start. PostHog needs to reach the page to capture it.
 
 To view heatmaps in the app:
 
@@ -188,6 +188,51 @@ For example, if the product pages on an ecommerce site use a URL format of `http
 
 ![Toolbar heatmaps popover menu being used to add a wildcard into the URL](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/products/product-analytics/toolbar-heatmap-wildcard.png)
 
+## Firewalls, WAFs, and bot protection
+
+Capturing a heatmap involves two different sources, and a firewall or bot protection rule can block either one.
+
+**PostHog's own servers** fetch your page to check whether it can be embedded in an `<iframe>`. These requests come from PostHog's fixed IPs:
+
+<PostHogIPsInline />
+
+**A third-party headless browser service** ([Browserless](https://www.browserless.io)) then loads and renders your page for the screenshot. These requests come from that service's worker fleet rather than from PostHog, and they use a default `HeadlessChrome` user agent.
+
+Allowing only PostHog's IPs isn't enough, because the render never comes from them. When a WAF blocks the render, the screenshot ends up showing whatever error page your site returned.
+
+### Allow the request by its header
+
+Every heatmap screenshot request sends this header:
+
+```
+X-PostHog-Heatmap-Screenshot: 1
+```
+
+Matching on it is the most stable option, because it doesn't change when the rendering service rotates its IPs. Write a rule that allows requests carrying this header, rather than allowing headless browsers as a whole.
+
+The header identifies the request, but it doesn't authenticate it. Anyone can send it, so pair it with the IP allowlist below if the rule needs to be tamper-resistant.
+
+### Allow the rendering service's IPs
+
+Browserless publishes the current IPs of its worker fleet. PostHog Cloud US renders from the `sfo` region:
+
+```bash
+curl -s https://api.browserless.io/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ workerIps { sfo lon ams lastUpdate } }"}'
+```
+
+If you aren't sure which region applies to you, allow all three.
+
+Two things to watch:
+
+- Allow the individual addresses, not the blocks that contain them. They sit inside shared DigitalOcean ranges, so allowing a whole `/16` would also admit every other tenant in that range.
+- The fleet changes every few months. Refresh the list on a schedule, and use the `lastUpdate` field to detect when it has drifted.
+
+### Scope the exclusion to one page
+
+If you'd rather not maintain an IP list at all, scope your bot protection exclusion to the specific URL you're capturing. The rest of your site keeps full protection.
+
 ## Troubleshooting
 
 ### Heatmap is captured, but site is not showing
@@ -206,3 +251,5 @@ In app, PostHog overlays the heatmap over your site in an iframe. You can allow 
 If screenshot generation fails or your site blocks iframe embedding (due to auth walls, bot protection, or `Content-Security-Policy` restrictions), PostHog automatically searches for recent session recordings that visited the same page and suggests up to three of them.
 
 Click any suggested recording to open the session player, then click **View heatmap** to view heatmap data overlaid on the recording snapshot. This provides an alternative path to heatmap data when traditional rendering methods don't work.
+
+If the screenshot renders but shows an error page from your own site, a firewall or bot protection rule is blocking the render. See [firewalls, WAFs, and bot protection](#firewalls-wafs-and-bot-protection).

--- a/src/constants/posthogIPs.ts
+++ b/src/constants/posthogIPs.ts
@@ -1,8 +1,11 @@
 // Single source of truth for PostHog's IP addresses: the fixed, public set PostHog
 // connects from when reaching a customer-controlled endpoint (webhook destinations,
-// data warehouse sources, batch exports, and WAF-protected sites for features like
-// heatmaps). These are PostHog's outbound/egress IPs; from the customer's side they
-// arrive as inbound connections to allowlist.
+// data warehouse sources, and batch exports). These are PostHog's outbound/egress IPs;
+// from the customer's side they arrive as inbound connections to allowlist.
+//
+// These cover only what PostHog requests directly. Heatmap screenshots are rendered by a
+// third-party headless browser service that has its own IPs, so allowlisting these is not
+// sufficient for that feature. See contents/docs/toolbar/heatmaps.mdx.
 //
 // If they ever change, update them here only. Every docs surface renders them via
 // the components in components/Docs/PostHogIPs.


### PR DESCRIPTION
## Problem

Someone who allowlists PostHog's published IPs still gets their heatmap screenshot blocked by their WAF, and nothing in the docs explains why.

The render never comes from those IPs. A third-party headless browser service loads the page from its own worker fleet, with a default `HeadlessChrome` user agent. The shared IP snippet described the addresses as "used by PostHog services (e.g., Celery tasks for snapshots)", which reads as covering heatmap screenshots.

## Changes

- The heatmaps page gains a "Firewalls, WAFs, and bot protection" section, naming both origins that reach a customer's site and how to allow each.
- Readers get three options: match the `X-PostHog-Heatmap-Screenshot` header, sync the render service's worker IPs from its API, or scope a bot protection exclusion to a single URL.
- The IP-list snippet drops its heatmap claim and links to the new section. It renders on 16 install and library pages, so it stays generic.
- The heatmaps page renders the IP list directly, instead of the collapsible snippet, so one page no longer shows the list twice.

Mechanical: `posthogIPs.ts` carries the same correction in a comment. The IP values are unchanged and still correct.

## Notes

The header is not live yet. It ships in PostHog/posthog#86049, so this should merge after that one.

The `sfo` region is confirmed for Cloud US. The section tells readers to allow all three regions if unsure, rather than naming a region for Cloud EU that has not been checked against the EU deploy config.

Anchor slugs were verified with `github-slugger`, which the site uses to generate heading links.
