### PR TITLE
docs(flutter): say screen views and web setup are required steps

### DIFF
--- a/contents/docs/integrate/_snippets/install-flutter.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter.mdx
@@ -144,7 +144,10 @@ Future<void> main() async {
 
 #### Web setup
 
-For Web, add your `Web snippet` (which you can find in [your project settings](https://us.posthog.com/settings/project#snippet)) in the `<header>` of your `web/index.html` file:
+If your project has a `web/` directory, this step is required. `Posthog().setup()`
+is a no-op on web, so a web build without the snippet below captures nothing.
+
+Add your `Web snippet` (which you can find in [your project settings](https://us.posthog.com/settings/project#snippet)) in the `<header>` of your `web/index.html` file. Write your project token into the snippet as a literal string — it is public, the same token ships to every visitor, and no build-time or deploy-time injection is needed:
 
 ```html file=web/index.html
 <!DOCTYPE html>

--- a/contents/docs/integrate/_snippets/install-flutter.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter.mdx
@@ -144,10 +144,9 @@ Future<void> main() async {
 
 #### Web setup
 
-If your project has a `web/` directory, this step is required. `Posthog().setup()`
-is a no-op on web, so a web build without the snippet below captures nothing.
+If your project has a `web/` directory, this step is required. `Posthog().setup()` is a no-op on web, so a web build without the snippet below captures nothing.
 
-Add your `Web snippet` (which you can find in [your project settings](https://us.posthog.com/settings/project#snippet)) in the `<header>` of your `web/index.html` file. Write your project token into the snippet as a literal string — it is public, the same token ships to every visitor, and no build-time or deploy-time injection is needed:
+Add your `Web snippet` (which you can find in [your project settings](https://us.posthog.com/settings/project#snippet)) in the `<header>` of your `web/index.html` file. Write your project token into the snippet as a literal string. It's public, the same token ships to every visitor, and it needs no build-time or deploy-time injection:
 
 ```html file=web/index.html
 <!DOCTYPE html>

--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -37,16 +37,11 @@ PostHog autocapture automatically tracks the following events for you:
 
 ### Capturing screen views
 
-Screen views are **not** captured automatically. Add the `PosthogObserver` to your
-app's `navigatorObservers` — without it, your app sends no `$screen` events at all.
+Screen views aren't captured automatically. Add the `PosthogObserver` to your app's `navigatorObservers`. Without it, your app sends no `$screen` events at all.
 
-This works with any routing package, not just the plain `Navigator` API. Routing
-packages such as `go_router`, `auto_route`, and `routerino` build on `Navigator`,
-so the observer still belongs on your `MaterialApp`.
+This works with any routing package, not just the plain `Navigator` API. Routing packages like `go_router`, `auto_route`, and `routerino` build on `Navigator`, so the observer still belongs on your `MaterialApp`.
 
-> Note: Screen names come from each route's `RouteSettings.name`. Most routing
-> packages set this for you. If yours does not, name your routes so `$screen`
-> events are readable.
+> Note: Screen names come from each route's `RouteSettings.name`. Most routing packages set this for you. If yours doesn't, name your routes so `$screen` events are readable.
 
 #### Using `navigatorObservers`
 

--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -37,9 +37,9 @@ PostHog autocapture automatically tracks the following events for you:
 
 ### Capturing screen views
 
-Screen views aren't captured automatically. Add the `PosthogObserver` to your app's `navigatorObservers`. Without it, your app sends no `$screen` events at all.
+Screen views aren't captured automatically. Add the `PosthogObserver` to your app yourself. Without it, your app sends no `$screen` events at all.
 
-This works with any routing package, not just the plain `Navigator` API. Routing packages like `go_router`, `auto_route`, and `routerino` build on `Navigator`, so the observer still belongs on your `MaterialApp`.
+This works with any routing package, not just the plain `Navigator` API. Add the observer wherever your router takes navigator observers, as shown below for `MaterialApp` and `go_router`.
 
 > Note: Screen names come from each route's `RouteSettings.name`. Most routing packages set this for you. If yours doesn't, name your routes so `$screen` events are readable.
 

--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -32,7 +32,7 @@ PostHog autocapture automatically tracks the following events for you:
 -   **Application Backgrounded** - when the app is sent to the background by the user
 -   **Application Installed** - when the app is installed.
 -   **Application Updated** - when the app is updated.
--   **$screen** - when the user navigates, but only after you add the `PosthogObserver` yourself. Nothing sends a `$screen` event until you do, whatever routing package you use.
+-   **$screen** - when the user navigates, once you add the `PosthogObserver`
 -   **$exception** - when the app throws exceptions.
 
 ### Capturing screen views

--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -32,12 +32,21 @@ PostHog autocapture automatically tracks the following events for you:
 -   **Application Backgrounded** - when the app is sent to the background by the user
 -   **Application Installed** - when the app is installed.
 -   **Application Updated** - when the app is updated.
--   **$screen** - when the user navigates (if using [navigatorObservers](https://docs.flutter.dev/ui/navigation) or [go_router](https://pub.dev/packages/go_router). You'd need to set up the `PosthogObserver` manually.)
+-   **$screen** - when the user navigates, but only after you add the `PosthogObserver` yourself. Nothing sends a `$screen` event until you do, whatever routing package you use.
 -   **$exception** - when the app throws exceptions.
 
 ### Capturing screen views
 
-> Note: Your routes should be named. Otherwise, they won't be recorded.
+Screen views are **not** captured automatically. Add the `PosthogObserver` to your
+app's `navigatorObservers` — without it, your app sends no `$screen` events at all.
+
+This works with any routing package, not just the plain `Navigator` API. Routing
+packages such as `go_router`, `auto_route`, and `routerino` build on `Navigator`,
+so the observer still belongs on your `MaterialApp`.
+
+> Note: Screen names come from each route's `RouteSettings.name`. Most routing
+> packages set this for you. If yours does not, name your routes so `$screen`
+> events are readable.
 
 #### Using `navigatorObservers`
 


### PR DESCRIPTION
Screen views and the Flutter Web snippet are both required and silent when missing, but the docs read as though screen views are automatic and the web snippet is optional.