### PR TITLE
docs: fix broken event pipeline source link

### DIFF
--- a/contents/docs/how-posthog-works/ingestion-pipeline.mdx
+++ b/contents/docs/how-posthog-works/ingestion-pipeline.mdx
@@ -97,7 +97,7 @@ In the sections below we will dive deeper into each step:
 4. [Writing to ClickHouse](#4-writing-to-clickhouse)
 5. [CDP destinations](#5-cdp-destinations)
 
-If you would like to dive even deeper the related source code can be found in the [event pipeline implementation](https://github.com/PostHog/posthog/tree/master/nodejs/src/worker/ingestion/event-pipeline).
+If you would like to dive even deeper the related source code can be found in the [event pipeline implementation](https://github.com/PostHog/posthog/tree/master/nodejs/src/ingestion/pipelines/analytics).
 
 ### 1. CDP transformations
 


### PR DESCRIPTION
## Changes

The ingestion pipeline docs linked to a GitHub path that doesn't exist anymore.

- Old: `https://github.com/PostHog/posthog/tree/master/nodejs/src/worker/ingestion/event-pipeline`
- New: `https://github.com/PostHog/posthog/tree/master/nodejs/src/ingestion/pipelines/analytics`

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`