### PR TITLE
docs(mcp-analytics): standardize on POSTHOG_PROJECT_TOKEN env var

### DIFF
--- a/contents/docs/mcp-analytics/custom-servers.mdx
+++ b/contents/docs/mcp-analytics/custom-servers.mdx
@@ -22,7 +22,7 @@ For those servers, use **`PostHogMCP`** instead. It's a subclass of the [`postho
 ```ts
 import { PostHogMCP } from "@posthog/mcp"
 
-const posthog = new PostHogMCP(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHogMCP(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
   // standard posthog-node options apply, e.g. beforeSend, enableExceptionAutocapture
 })

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -50,7 +50,7 @@ import { instrument } from "@posthog/mcp"
 
 const server = new Server({ name: "my-mcp-server", version: "1.0.0" })
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
 })
 
@@ -72,7 +72,7 @@ import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com",
 })
 
@@ -90,7 +90,7 @@ import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com",
 })
 
@@ -115,7 +115,7 @@ import { createMcpHandler } from "mcp-handler"
 import { PostHog, instrument } from "@posthog/mcp"
 
 // Create the client once at module scope (not per request).
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
 })
 
@@ -172,7 +172,7 @@ import { McpModule } from "@rekog/mcp-nest"
 import { PostHog, instrumentMutator } from "@posthog/mcp"
 
 // Create the client once at module scope.
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
 })
 
@@ -375,7 +375,7 @@ The `posthog-node` client queues and batches events asynchronously, and you own 
 import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY)
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN)
 instrument(server, posthog)
 
 process.on("SIGTERM", async () => {

--- a/contents/docs/mcp-analytics/sdk-v2.mdx
+++ b/contents/docs/mcp-analytics/sdk-v2.mdx
@@ -29,7 +29,7 @@ import { PostHog } from "posthog-node"
 import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY)
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN)
 
 instrument(server, posthog)
 

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -50,7 +50,7 @@ import { instrument } from "@posthog/mcp"
 
 const server = new Server({ name: "my-mcp-server", version: "1.0.0" })
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com",
 })
 

--- a/contents/tutorials/mcp-analytics.mdx
+++ b/contents/tutorials/mcp-analytics.mdx
@@ -56,7 +56,7 @@ import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
 })
 
@@ -71,7 +71,7 @@ import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
 
-const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
   host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
 })
 


### PR DESCRIPTION
## Problem

The mcp-analytics docs section is the only part of the docs that names the SDK env var `POSTHOG_PROJECT_API_KEY` in its code examples. Everywhere else — the official install snippets under `contents/docs/integrate/_snippets/`, library docs, tutorials (40 files) — the convention is `POSTHOG_PROJECT_TOKEN`, as is the entire [context-mill](https://github.com/PostHog/context-mill) repo (lint-enforced), including the mcp-analytics skill that bundles these very pages.

This surfaced in a review follow-up on context-mill [#344](https://github.com/PostHog/context-mill/pull/344): an agent reads the skill (`POSTHOG_PROJECT_TOKEN`) alongside the bundled docs pages (`POSTHOG_PROJECT_API_KEY`) and may emit a mismatched env var name.

## Change

Rename `POSTHOG_PROJECT_API_KEY` → `POSTHOG_PROJECT_TOKEN` in the mcp-analytics code examples only (11 lines, all `new PostHog(...)` / `new PostHogMCP(...)` constructions):

- `contents/docs/mcp-analytics/installation.mdx` (6)
- `contents/docs/mcp-analytics/start-here.mdx` (1)
- `contents/docs/mcp-analytics/custom-servers.mdx` (1)
- `contents/docs/mcp-analytics/sdk-v2.mdx` (1)
- `contents/tutorials/mcp-analytics.mdx` (2)

The env var is user-defined, so this is purely a docs-naming standardization — no functional change. `contents/handbook/engineering/sdks/releases.mdx` intentionally keeps `POSTHOG_PROJECT_API_KEY`: that is a real CI secret name, not a docs example.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*