### PR TITLE
fix(tutorials): generate OG images and fall back to the featured image

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -182,8 +182,12 @@ const createOGImages = async (data) => {
         const { title } = post.frontmatter
         const { timeToRead, excerpt, fields, parent } = post
         const lastUpdated = parent && parent.fields && parent.fields.lastUpdated
-        if (!title || !timeToRead || !excerpt || !lastUpdated || !fields?.contributors) continue
-        const contributors = fields?.contributors.map((contributor) => {
+        // Tutorials share this template but have no contributors, and the template already
+        // renders fine without them — so only require contributors for docs and handbook.
+        const isTutorial = fields?.slug?.startsWith('/tutorials/')
+        if (!title || !timeToRead || !excerpt || !lastUpdated) continue
+        if (!isTutorial && !fields?.contributors) continue
+        const contributors = (fields?.contributors || []).map((contributor) => {
             const { avatar, username } = contributor
             return {
                 username,
@@ -802,16 +806,33 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
                     excerpt(pruneLength: 500)
                 }
             }
+            # Tutorials are rendered with the docs/handbook OG template, so they have to select
+            # the same fields it needs — otherwise every tutorial trips the guard in that loop
+            # and gets skipped, leaving the page pointing at an OG image that was never created.
             tutorials: allMdx(filter: { fields: { slug: { regex: "/^/tutorials/" } } }) {
                 nodes {
                     fields {
                         slug
+                        contributors {
+                            username
+                            avatar
+                        }
                     }
                     frontmatter {
+                        title
                         featuredImage {
                             publicURL
                         }
                     }
+                    parent {
+                        ... on File {
+                            fields {
+                                lastUpdated: gitLogLatestDate(formatString: "MMM D, YYYY")
+                            }
+                        }
+                    }
+                    timeToRead
+                    excerpt(pruneLength: 500)
                 }
             }
             customers: allMdx(filter: { fields: { slug: { regex: "/^/customers/" } } }) {

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -71,14 +71,20 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
     const [view, setView] = useState('Article')
     const { fullWidthContent } = useLayoutData()
 
+    // Prefer the tutorial's own featured image for social previews, falling back to the OG image
+    // generated at build time. SEO absolutizes relative paths when imageType isn't 'absolute'.
+    const featuredImageURL = featuredImage?.publicURL
+
     return (
         <article className="@container">
             <SEO
                 title={title + ' - PostHog'}
                 description={description || excerpt}
                 article
-                image={`${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`}
-                imageType="absolute"
+                image={
+                    featuredImageURL || `${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`
+                }
+                imageType={featuredImageURL ? 'relative' : 'absolute'}
             />
             <div className="flex flex-col-reverse items-start @3xl:flex-row gap-8 2xl:gap-12">
                 <div className="flex-1 transition-all pt-8 w-full">


### PR DESCRIPTION
## Changes

Tutorial pages point their `og:image` at a generated OG image on the CDN, but that image is never created — a sample of 60 tutorials found zero present, while docs and handbook pages have theirs.

Two fixes:

- **`gatsby/onPostBuild.ts`** — tutorials are pushed through the docs/handbook OG loop, whose guard requires `title`, `timeToRead`, `excerpt` and `lastUpdated`, but the `tutorials` GraphQL selection only fetched `fields.slug` and the featured image. `title` was always undefined, so every tutorial hit the `continue` and got skipped. The selection now includes the fields the shared template needs, and contributors are no longer required for tutorials (the template already renders fine without them).
- **`src/templates/tutorials/Tutorial.tsx`** — prefer a tutorial's own `featuredImage` for the social preview when one is set, falling back to the generated OG image. This also means tutorials with a featured image get a working preview immediately, without depending on the generator.

**Why:** social previews on tutorial links were falling back to whatever image the crawler could scrape off the page, because the `og:image` URL doesn't resolve. Note there is a separate, unrelated issue affecting blog posts: nothing new has been written to the OG image bucket for a couple of weeks, which is a build/pipeline problem rather than a code one.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1787224960429009?thread_ts=1787224960.429009&cid=C09GU689J1X)*