### PR TITLE
Clarify PostHog credits are post-discount on AWS Marketplace offers

### DIFF
--- a/contents/handbook/growth/sales/selling-via-aws.md
+++ b/contents/handbook/growth/sales/selling-via-aws.md
@@ -57,6 +57,7 @@ Since AWS Marketplace can be a pain to navigate, we're using Clazar to manage th
    - Set as **upfront payment** (non-FPS offer)
    - Enter the negotiated price
    - Currency: USD (can do EUR, GBP, JPY if needed)
+   - **PostHog credits are post-discount** – the credit balance we apply equals the discounted amount the customer pays through AWS, not the pre-discount list value
 6. **Choose EULA type:**
    - Use **Standard Contract for AWS Marketplace** unless legal says otherwise
    - If custom EULA needed, upload the PDF (max 5 docs)
@@ -82,6 +83,7 @@ If you need more control or Salesforce isn't cooperating:
    - Add your product dimensions
    - Set prices for each dimension
    - For annual deals, configure as single upfront payment
+   - **PostHog credits are post-discount** – the credit balance we apply equals the discounted amount the customer pays through AWS, not the pre-discount list value
 7. **Legal terms:**
    - Select EULA type (Standard Contract or Custom)
    - Upload any additional documents if needed


### PR DESCRIPTION
## Changes

Adds a line to both private-offer creation paths in the AWS procurement handbook page noting that PostHog credits applied for an AWS Marketplace private offer are post-discount — the credit balance matches the discounted amount the customer pays through AWS, not the pre-discount list value.

**Why:** This came up as a question in Slack and wasn't documented anywhere, so writing it down saves the next person asking.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090RCG671C/p1787216524648039?thread_ts=1787216524.648039&cid=C090RCG671C)*