### PR TITLE
Document the self-driving PR generation toggle

### DIFF
--- a/contents/docs/self-driving/faq.mdx
+++ b/contents/docs/self-driving/faq.mdx
@@ -84,10 +84,20 @@ If you need guaranteed handling of a specific stream, use a [signal source](/doc
 Everything is a toggle, and every dollar has a ceiling:
 
 - Turn individual [signal sources](/docs/self-driving/inbox/sources) and [scouts](/docs/self-driving/scouts) on or off per project.
+- Turn **PR generation** off entirely, or set the priority it starts at, in your [inbox](/docs/self-driving/inbox) settings.
+- Cap how much arrives with a daily report limit, also in your inbox settings.
 - You pay a flat $15 per pull request. Reports are free, and your first three PRs each month are free.
 - A default $150 billing limit is set for you, and you can lower it. When you hit the limit, PR generation pauses until the next billing period.
 
 See [pricing](/docs/self-driving/pricing) for the full picture.
+
+## Can I get the findings without the pull requests?
+
+Yes. Turn off **PR generation** in your [inbox](/docs/self-driving/inbox) settings and nothing opens a PR – reports still arrive, still notify your team, and you decide what to do with them. Reports are free, so this costs nothing.
+
+If you want PRs for the urgent things only, leave it on and set the threshold instead: agents start work on reports at or above the priority you pick, and a teammate can set their own threshold for reports that suggest them as reviewer.
+
+Either way, a report is written for a human to read rather than as a spec another agent can execute. If you want your own coding agents working from the same context, give them the [PostHog MCP](/docs/model-context-protocol).
 
 ## Convinced, or at least curious?
 

--- a/contents/docs/self-driving/pricing.mdx
+++ b/contents/docs/self-driving/pricing.mdx
@@ -55,6 +55,7 @@ You can control your self-driving spend on both the usage and billing side.
 
 * Disable [signal sources](/docs/self-driving/inbox/sources) with limited usefulness to you
 * Disable types of [scouts](/docs/self-driving/scouts) with limited usefulness to you
+* Turn **PR generation** off in your [inbox](/docs/self-driving/inbox) settings, or set the priority threshold agents start work at – reports keep arriving either way, and they're free
 
 <CalloutBox icon="IconInfo" title="Coming soon" type="fyi">
 


### PR DESCRIPTION
## Changes

Documents the **PR generation** toggle in inbox settings. It exists in the product (`autostart_enabled` on `SignalTeamConfig`, rendered by `SelfDrivingSection`), along with the priority threshold and the daily report limit, but no docs page mentions any of them — so "can I get the findings without the pull requests?" currently reads as a no when the answer is yes.

- FAQ: adds the toggle and the daily report limit to the "how do I control what it watches, and what it costs?" list
- FAQ: adds "Can I get the findings without the pull requests?", which is the question people actually ask, and points anyone wanting to drive the implementation themselves at the PostHog MCP
- Pricing: lists turning off PR generation as a usage lever alongside disabling sources and scouts

**Why:** the question came up externally — a user asked whether they could get the finding and recommended fix without PostHog opening a PR, because they'd rather their own agents do the implementation. The feature already supports it; only the docs were missing.

Related: PostHog/posthog#86588 (a spec-shaped output for the same audience).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787237496271179?thread_ts=1787237496.271179&cid=C09SK2PAGKF)*
