### PR TITLE
Add some agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,24 @@ Following these guidelines is essential – any PR that doesn't adhere to these
 	- Can you break this down into multiple PRs? GitHub's [Stacks](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) are ideal for this – group related changes into a single stack instead to keep diffs manageable 
 	- Is there excess abstraction or bloat that you can trim down?
 	- Are there items in this PR outside the intended scope? (Use GH Stacks or a separate PR!)
-- *ANY* visual change must be accompanied with before/after screenshots of all affected areas. Screenshots must show a narrow window and a wide window (all apps are resizable), in both light and dark mode. If there are many affected areas, think about breaking the PR up. If your environment doesn't have a way to take screenshots, you should consider that a blocker – the PR cannot be submitted until the user provides you the required screenshots themselves.
+- *ANY* visual change must be accompanied with before/after screenshots of all affected areas. Screenshots must show a narrow window and a wide window (all apps are resizable), in both light and dark mode. If there are many affected areas, think about breaking the PR up. See the [browser screenshots guide](agents/browser-screenshots.md) for how to capture them and how to attach them to the PR. If your environment doesn't have a way to take screenshots, you should consider that a blocker – the PR cannot be submitted until the user provides you the required screenshots themselves.
 - Agent generated PR descriptions should contain a few key sections, in the order below. These sections should be kept up to date if changes to the PR are made after the fact. If your user is not the original author of the PR, simply append your updates to the original description after a line (`---`).
   1. Executive summary of the PR's intention. It should allow someone with no context to grasp what exactly it changes and why.
-  2. [PR tour](agents/pr-tour.md) (Only required for 50+ line changes)
-  3. A [reviewers guide](agents/reviewers-guide.md) (Only required for 50+ line changes)
+  2. [PR tour](agents/pr-tour.md) (Only required for 50+ line changes. Never required for a content PR)
+  3. A [reviewers guide](agents/reviewers-guide.md) (Only required for 50+ line changes. Never required for a content PR)
 - PRs should ALWAYS be written in [Simplified Technical English](agents/asd-ste100.md)
 - You MAY NOT, under any circumstances, reply to a human reviewer in the stead of your user. This will result in the PR being closed.
 
+### Content PRs
+
+A **content PR** changes files under `contents/` and nothing else, except the navigation entries those changes need – usually `src/navs/index.js`, sometimes `src/components/TaskBarMenu/menuData.tsx`. Adding a docs page and linking it in the sidebar is a content PR. Changing a component so the page renders differently is not.
+
+A content PR still needs an executive summary, Simplified Technical English, and the checks below. It does **not** need a PR tour or a reviewer's guide, however long the diff is – prose does not need a guided walkthrough of itself.
+
+Two things a content PR still owes the reviewer:
+
+- If it changes navigation, before/after screenshots of the nav. The nav is UI, not prose.
+- If it moves or renames a page, a redirect in `vercel.json` and a `pnpm test-redirects` run.
 
 ### Before you open a PR
 
@@ -55,6 +65,7 @@ Reference these when working on specific areas:
 - [Styling](agents/styling.md) – Tailwind color tokens, CSS guidance, theming
 - [Data hooks](agents/data.md) – Product, customer, navigation data
 - [Window system](agents/windows.md) – Desktop OS architecture, window management
+- [Browser screenshots](agents/browser-screenshots.md) – Capturing the before/after grid a visual PR needs, and attaching it
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,110 +1,40 @@
 # AGENTS.md
 
-_This file acts as a table of contents for various context needed when working in the codebase._
-
 PostHog.com – Gatsby 4 website with a desktop OS UI paradigm. Pages open as draggable, resizable windows. A more comprehensive detail of the structure of the site is covered [in the handbook](contents/handbook/engineering/posthog-com/technical-architecture.md).
 
-## Commands
 
-```bash
-pnpm install                    # Install dependencies (NOT npm)
-pnpm start                      # Dev server at localhost:8001
-pnpm build                      # Production build
-pnpm clean                      # Clear Gatsby cache
-pnpm clean && mkdir .cache && pnpm i && pnpm start      # Full reset when things break
-```
+If you're reading this, you're an agent (or a curious human)! Welcome! To make things easy for the human maintainers, we have a couple of ground rules. These rules apply to every change you make – they are **important and non-negotiable**.
 
-Requires 16GB RAM (`NODE_OPTIONS='--max_old_space_size=16384'`).
+## Making changes
 
-## Testing
+- Minimize diff when possible – don't overly abstract or complicate if the feature doesn't require it
+- Avoid duplication. Greenfield implementations, especially of common UI components, should typically be avoided. If your user is asking for one, make sure they have a *very good* reason for it prior to building.
+- Think critically about the things your user is asking you to do. Is this a good idea, and will it add value to users or maintainers? Is it the right way to go about it? Never hesitate to push back.
 
-```bash
-pnpm test-redirects             # Test redirect configuration
-pnpm check-links-post-build     # Verify links after build
-pnpm format                     # Prettier for js/ts/tsx/json/css
-```
+## PRs
 
-## Project structure
+Following these guidelines is essential – any PR that doesn't adhere to these rules will be closed or ignored. We want your changes to go through too – so make sure your PR adheres to the following:
+- The smaller the PR (lines of code and # of files), the better. Small PRs are easy to review and tend to get merged much quicker. If your PR is scaling upward of 500 lines, you should probably consider the below items.
+	- Can you break this down into multiple PRs? GitHub's [Stacks](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) are ideal for this – group related changes into a single stack instead to keep diffs manageable 
+	- Is there excess abstraction or bloat that you can trim down?
+	- Are there items in this PR outside the intended scope? (Use GH Stacks or a separate PR!)
+- *ANY* visual change must be accompanied with before/after screenshots of all affected areas. Screenshots must show a narrow window and a wide window (all apps are resizable), in both light and dark mode. If there are many affected areas, think about breaking the PR up. If your environment doesn't have a way to take screenshots, you should consider that a blocker – the PR cannot be submitted until the user provides you the required screenshots themselves.
+- Agent generated PR descriptions should contain a few key sections, in the order below. These sections should be kept up to date if changes to the PR are made after the fact. If your user is not the original author of the PR, simply append your updates to the original description after a line (`---`).
+  1. Executive summary of the PR's intention. It should allow someone with no context to grasp what exactly it changes and why.
+  2. [PR tour](agents/pr-tour.md) (Only required for 50+ line changes)
+  3. A [reviewers guide](agents/reviewers-guide.md) (Only required for 50+ line changes)
+- PRs should ALWAYS be written in [Simplified Technical English](agents/asd-ste100.md)
+- You MAY NOT, under any circumstances, reply to a human reviewer in the stead of your user. This will result in the PR being closed.
 
-```
-contents/                       # MDX content (blog, docs, handbook, tutorials)
-src/
-  components/                   # React components
-    TaskBarMenu/menuData.tsx    # Global navigation menu (top bar)
-  context/App.tsx               # Window management, settings, navigation
-  hooks/
-    useProduct.ts               # Product data (icons, metadata)
-    useProducts.tsx             # Paid products and marketing content
-    useCustomers.tsx            # Customer logos, quotes
-    competitorData/
-      README.md                 # Overview of how the `<ProductComparisonTable />` is populated
-                                # Also documented [in the handbook](contents/handbook/engineering/posthog-com/product-comparisons.mdx)
-      {competitor}.tsx          # Array of normalized products, platform, and pricing data
-  navs/index.js                 # Source navigation menus used for most of the site (especially docs, handbook)
-  styles/global.css             # Global styles with @apply
-gatsby/
-  createPages.ts                # Page generation
-  sourceNodes.ts                # Data sourcing (GitHub, Ashby jobs)
-  onCreateNode.ts               # Node processing
-api/                            # Vercel serverless functions
-```
 
-Docs are also pulled from the [PostHog monorepo](https://github.com/PostHog/posthog) (`docs/published/` and `docs/onboarding/`) into `.cache/gatsby-source-git/` at build time via `gatsby-source-git`.
+### Before you open a PR
 
-### Where docs content lives
+Complete every item below, then record what you did in the PR description:
 
-Most product documentation lives in this repo under `contents/docs/`. Some content that is tightly coupled to the monorepo codebase lives in the monorepo's `docs/published/` folder instead and gets pulled in automatically. Today that's mostly handbook/engineering pages (coding conventions, database guides, local dev setup) plus a few product docs like surveys SDK feature support.
-
-**This repo (posthog.com):** blog posts, tutorials, handbook (non-engineering), marketing pages, product landing pages, and the majority of product docs.
-
-**Monorepo (`docs/published/`):** engineering handbook pages and product docs that are tightly coupled to the monorepo codebase. URL mapping: `docs/published/docs/foo/bar.md` becomes `/docs/foo/bar` on the site.
-
-When writing new docs, ask: does this content describe something internal to the monorepo codebase? If yes, it likely belongs in the monorepo's `docs/published/` folder, not here.
-
-## Apps and pages
-
-PostHog.com replicates a desktop-style OS. All pages should use an app template:
-
-- `<Editor />`
-- `<Reader />`
-- `<Presentation />`
-- `<Explorer />`
-- `<Inbox />`
-- `<Wizard />`
-- `<MediaPlayer />`
-
-See [Apps guide](agents/apps.md) for templates, creating pages, and shared components.
-
-For working on product pages/presentations, reference [Apps guide](agents/apps.md) for important details about slide templates.
-
-## Code style
-
-### TypeScript/React
-
-```tsx
-// Radix UI: import with prefix, use simple name
-import { Tabs as RadixTabs } from "radix-ui"
-<Tabs />
-
-// Custom components use OS prefix
-<OSButton />
-<OSTable />
-```
-
-We generally create our own versions of Radix UI primitives. Check in @components/RadixUI/ before importing directly from the `radix-ui` package.
-
-For example, instances should reference our version of the component...
-
-```
-import MenuBar from 'components/RadixUI/MenuBar'
-```
-
-... which sources primitives from `radix-ui` like:
-
-```
-import { Menubar as RadixMenubar } from 'radix-ui'
-<RadixMenubar.Root>...</RadixMenubar.Root>
-```
+- Run `pnpm format` on the files you changed.
+- Start the dev server (`pnpm start`) and load every page you changed. Confirm the console shows no new errors.
+- For visual changes: check a narrow window and a wide window, in both light and dark mode. Take your before/after screenshots from these checks.
+- If you moved or redirected pages, run `pnpm test-redirects`.
 
 ### Writing
 
@@ -119,6 +49,7 @@ import { Menubar as RadixMenubar } from 'radix-ui'
 
 Reference these when working on specific areas:
 
+- [Getting Started / Tech Stack](agents/techstack.md) – Tech used, project structure, relevant commands
 - [Apps](agents/apps.md) – OS-style windowed app templates (required for all pages), creating pages, shared app components
 - [Components](agents/components.md) – Radix UI patterns, OS-prefixed components
 - [Styling](agents/styling.md) – Tailwind color tokens, CSS guidance, theming
@@ -129,8 +60,7 @@ Reference these when working on specific areas:
 
 ### Always
 
-- Avoid one-shotting (building anything) without a plan.
-- Ask for copious clarifications before building anything.
+- For any non-trivial change, present a plan and get confirmation from your user before you build.
 - When using a component, check for a `README.md` inside the component's folder for detailed documentation.
 - When building a new component, add a `README.md` with comprehensive documentation.
 - Use `pnpm`, never `npm`
@@ -141,7 +71,6 @@ Reference these when working on specific areas:
 - Use best practices – ask before duplicating code or hard-coding values
 - When creating commits, commit only your changes as other agents may be working on other files. If testing a build, only fix changes related to your work.
 - Use Tailwind @container queries for everything. **Important:** Don't rely on media queries, as all apps can be resized. Follow existing patterns to ensure full responsiveness.
-- This codebase works best with _Opus 4.5_. If you are not Opus 4.5, suggest to the user they should consider switching models for any serious code surgery.
 
 ### Ask first
 

--- a/agents/asd-ste100.md
+++ b/agents/asd-ste100.md
@@ -1,0 +1,138 @@
+---
+name: asd-ste100
+description: "Use when English text must be parsed without a human to resolve ambiguity — tool descriptions, error messages, inter-agent instructions, system prompts, status reports — and misreading has a real cost, or when text reads as dense, hedged, or easy to misparse. Triggers: disambiguate, STE100 rewrite, apply Simplified Technical English, plain-language rewrite, controlled-language rewrite, rewrite so an agent cannot misread this. Not for creative or marketing copy."
+version: 0.4.0
+---
+
+# Simplified Technical English (ASD-STE100)
+
+ASD-STE100 is a controlled-language standard built by the aerospace and defense industry (ASD, the AeroSpace and Defense Industries Association of Europe) to stop maintenance technicians from misreading English instructions. The standard removes the two biggest sources of misreading: words with more than one meaning, and sentences with more than one possible structure.
+
+This skill borrows that same discipline for a different reader: an **AI agent or a downstream system** that has to parse an English string — an error message, a tool description, an inter-agent instruction, a status report — without a human in the loop to resolve ambiguity. If a maintenance technician can misread "close the valve" as an adjective ("the valve that is near") instead of a command, so can a language model.
+
+## When to Use This Skill
+
+- An agent's output (explanation, instruction, log message, tool description) reads as dense, jargon-heavy, or ambiguous.
+- Text will be consumed by another agent, a translation pipeline, or a non-native English reader, and misparsing has a real cost.
+- You are writing a prompt, system message, or tool description and want to remove ambiguity before a model ever sees it.
+- You want a **before/after** comparison showing exactly which rule was violated and how the rewrite fixes it. Ask for it — the default output is the rewritten text alone (see Output Format).
+
+This skill is not for creative or marketing copy — STE is deliberately flat and literal. Do not apply it to text where voice, nuance, or persuasion is the point.
+
+## Two Modes
+
+Pick a mode before rewriting. If the user does not say which, infer from the text type and state the choice in one line.
+
+**Strict** — procedures, error messages, tool and function descriptions, inter-agent instructions, safety text. Anywhere a wrong reading has a cost. Apply every rule below, including the hard length caps and one-word-one-meaning discipline.
+
+**STE-flavored** — READMEs, PR descriptions, changelogs, explanatory prose. Apply the structural rules in full and treat the lexical rules as advisory (see Core Rewrite Rules for that split). In practice that means keeping the sentence length caps, active voice, simple tenses, no phrasal verbs, no semicolons, no nominalization and no marketing adjectives, while dropping the one-word-one-meaning lockdown: prose needs some range, and a strict rewrite of prose reads as a personality transplant rather than a clarification.
+
+The two modes and the structural/lexical split are the same distinction seen from two directions. The split says which rules this skill can verify without ASD's dictionary; the modes say which of them to enforce for a given kind of text.
+
+## Source and Scope
+
+This skill encodes the **rule categories** of ASD-STE100 Issue 9 (Jan 2025): 53 writing rules across 9 sections covering word choice, grammar, sentence structure, and style, backed by a dictionary of ~900 approved words (one meaning, one part of speech each) and ~1,200 words to avoid with suggested replacements. See `references/writing-rules.md` for the full rule summary and citations.
+
+It does **not** reproduce ASD's ~900-word approved dictionary verbatim. ASD-STE100 is free to obtain, but it is not free to redistribute: Issue 9, page 2 states that "no reproduction or publication of it, in whole or in part, shall be made without the written authority of an officer of ASD," and grants free reproduction rights only to eight listed categories (ASD/AIA/AIAC member associations and their member companies and customers, member-state defence ministries, A4A, airworthiness authorities, and universities and research institutes for educational purposes). This project is in none of them, so the dictionary stays out of this repo.
+
+Instead, this skill applies the *underlying principle* (pick the plainest, most common word available and use it the same way every time) rather than checking against a fixed word list. When exact ASD-approved wording matters (e.g. actual aircraft maintenance documentation), get the standard and check word-by-word against the real dictionary. Request it from the [official downloads page](https://www.asd-ste100.org/STE_downloads.html) — note that this is a request form that emails you a link, not a direct download.
+
+## Core Rewrite Rules
+
+STE's rules divide into two kinds, and this skill can only fully deliver one of them. **Structural rules** are self-contained: they describe sentence shape, and you can apply them from the description alone. **Lexical rules** are defined entirely by the official ~900-word dictionary, which this skill deliberately does not reproduce (see Source and Scope). Without that dictionary, the lexical rules degrade from a checkable standard into a preference for plain words.
+
+Apply the structural rules with confidence. Apply the lexical rules as a direction of travel, and say so in your output rather than implying dictionary compliance you cannot verify.
+
+### Structural rules — apply these
+
+| Rule | Do | Don't |
+|---|---|---|
+| Active voice | "The agent deletes the file." | "The file is deleted (by the agent)." — unless the actor is genuinely unknown or irrelevant |
+| No phrasal verbs (Rule 9.3) | "Remove the panel." / "Start the job." | "Take off the panel." / "Spin up the job." — a two-word verb has meanings the parts do not predict |
+| One instruction per sentence | "Open the file. Read line 3." | "Open the file and read line 3, then check if it matches." |
+| Sentence length | ≤20 words for instructions/procedures, ≤25 words for descriptions | Long compound/subordinate-clause sentences |
+| No semicolons (Rule 8.1) | Split into separate sentences | Any semicolon at all — STE bans the mark outright, not only as a clause join. (Rule 8.1 permits every other standard punctuation mark; the em dash is *not* banned by STE, though it often signals a sentence that should be split.) |
+| Noun clusters | ≤3 words stacked as a noun phrase ("fuel pump valve") | 4+ word noun stacks ("high pressure fuel pump inlet valve assembly") |
+| No ellipsis | Keep the subject, verb, and article explicit even if it reads longer | Drop words to save space ("Files not backed up will be lost" → ambiguous which files) |
+| Keep modality | "The request **may have** failed." stays "may have" | Promote a hedge to a fact ("The request failed.") or invent a certainty the source did not state |
+| Paragraph limits | One topic per paragraph, ≤6 sentences | Multi-topic paragraphs |
+| Lists for sequences | Use a numbered or bulleted list for 3+ steps or conditions | Bury a sequence inside one prose sentence |
+
+### Lexical rules — direction of travel only
+
+| Rule | Do | Don't | Why it is weaker here |
+|---|---|---|---|
+| One word, one meaning | Pick one verb for one action and reuse it every time (e.g. always "check", never mix "check"/"verify"/"confirm" for the same action) | Rotate synonyms for the same idea across a document | Consistency within a document is checkable. Which word is the *approved* one is not, without the dictionary. |
+| One part of speech per word | "Apply oil to the valve" (oil = noun) | "Oil the valve" (oil = verb) | Whether "oil" is approved as a noun only is a dictionary fact. Prefer the noun form when both read equally well; do not claim compliance. |
+| Verb, not noun (Rule 3.7) | "Analyze the log." | "Perform an analysis of the log." — a noun form of an action makes the sentence longer and hides who acts | Rule 3.7 says "use an **approved** verb to describe an action." Preferring the verb form is safe to apply anywhere; knowing which verb is the approved one needs the dictionary. |
+| Domain terms | Keep necessary technical nouns/verbs, but define them once if not common English (STE allows a project-specific glossary beyond its base dictionary) | Use jargon without ever defining it | The glossary allowance is real STE, but the base dictionary it extends is absent. |
+
+### Simple tenses — apply with one exception
+
+STE permits infinitive, imperative, simple present, simple past, simple future, and past participle as adjective. It excludes present perfect and other compound forms: "we received the report", not "we have received the report".
+
+Aircraft manuals never need present perfect, so the exclusion costs the standard nothing. Other text is not always so lucky. "The job has completed" (and its output is available now) and "the job completed" (at some past point) are different statements, and status text frequently needs the first. **Where the compound form carries information the simple form cannot — current relevance, or a hedge as in "may have failed" — keep it and flag the departure.** Elsewhere, follow the rule.
+
+## Scan Checklist
+
+These six habits cover most of what makes machine-written English hard to parse. Each one is mechanical: you can point at the exact word or punctuation mark that breaks the rule, with no judgment call. Scan for all six before you rewrite anything.
+
+1. **Synonym rotation** — the same thing gets several names in one document ("the user", "the customer", "the client"). The reader cannot tell whether they are one thing or three. Fix: pick one name, use it every time.
+2. **Hedge stacking** — helper verbs and qualifiers pile up until the sentence asserts nothing ("it is important to note that this may potentially help to improve"). Fix: state the claim, or delete it.
+3. **Nominalization** — an action frozen into a noun ("perform an analysis of", "provides assistance to"). Fix: use the verb ("analyze", "helps").
+4. **Marketing adjectives** — words that claim quality instead of showing it: seamless, robust, powerful, cutting-edge, effortless, blazing-fast. Fix: delete, or replace with the measurement that earns the claim.
+5. **Run-on sentences** — several ideas joined by semicolons or em dashes. Fix: one idea per sentence.
+6. **Soft phrasal verbs** — spin up, reach out, dive into, kick off. Fix: use the single plain verb (start, contact, read, begin).
+
+## Process
+
+1. Pick the mode (Strict or STE-flavored). Say which only when the user asked for the rule table — see Output Format.
+2. Read the input text once for meaning — do not start rewriting before you understand what it must still say afterward.
+3. Walk it sentence by sentence. Flag every rule violation from the Core Rewrite Rules tables and every habit from the Scan Checklist. In STE-flavored mode, flag the lexical rules but do not enforce them.
+4. Rewrite each flagged sentence to fix the violation while preserving the original meaning exactly. If a rewrite would drop necessary precision (a safety condition, a scope qualifier, a number), keep the longer phrasing and flag it instead of silently simplifying.
+   - **Check modality before you commit to a rewrite.** Hedges ("may", "could", "sometimes", "is likely to") carry the author's confidence, and confidence is content. A shorter sentence that upgrades a hedge to a fact is not a simplification — it is a different claim. This is the most common way a well-intentioned STE rewrite goes wrong, because hedges are exactly what a length cap tempts you to cut.
+   - Never add a fact the source did not state. A rewrite that reads better because it supplies a cause, a frequency, or a mechanism has stopped being a rewrite.
+5. Output the rewritten text (see Output Format). Keep the mode choice and the rule analysis internal unless the user asked to see them.
+6. If the input already complies, say so — do not force changes onto compliant text.
+
+## Output Format
+
+**Default: the rewritten text, and nothing else.** Most callers want a result they can paste straight into a tool description, an error string, or a prompt. Print the simplified text on its own. Do not add a preamble about this skill, a mode announcement, a violation count, a summary of what changed, a rule table, or a closing offer to explain further.
+
+The one permitted addition: if step 4 kept a longer phrasing on purpose, add a single line after the text, prefixed `Kept as-is:`, naming the phrase and the precision that would have been lost. Omit the line when there is nothing to report.
+
+**On request: the rule table.** When the user asks to see the reasoning — "show the diff", "which rules did it break", "explain the changes", "before/after" — output this table instead:
+
+```markdown
+| Rule violated | Original | Simplified |
+|---|---|---|
+| Present perfect tense | "We have received your request." | "We received your request." |
+| Noun cluster (4+ words) | "the agent task queue priority handler" | "the handler that sets task-queue priority" |
+
+Mode: Strict. 7 violations found.
+```
+
+Follow the table with a one-line note on anything you deliberately did **not** simplify, and why (usually: simplifying would lose required precision).
+
+## Boundaries
+
+**Will:**
+- Rewrite ambiguous or dense English into short, single-meaning, active-voice sentences.
+- Return the rewritten text alone by default, and name the rules it applied when the user asks.
+- Preserve every fact, condition, and scope qualifier in the original.
+- Preserve the strength of every hedge, and add no claim the source did not make.
+- Suggest a one-line glossary entry for domain terms that must stay.
+
+**Will not:**
+- Reproduce ASD's official ~900-word dictionary as if it were memorized verbatim — always treat the official download as the source of truth for exact approved wording.
+- Simplify creative, marketing, or persuasive copy where voice and nuance are the point.
+- Silently drop a safety condition, exception, or scope qualifier to shorten a sentence — it will flag the trade-off instead.
+- Convert "may have failed" into "failed", or "could be caused by X" into "X is the cause" — losing a hedge changes the claim.
+- Guarantee an aerospace/defense-grade STE-compliant document; this is a general-purpose clarity tool inspired by STE, not a certified STE authoring tool.
+- Make weak content true or useful. STE fixes the *form* of a text, not its substance. A hollow paragraph rewritten under these rules becomes a clean, short, well-punctuated hollow paragraph. If the text has nothing to say, no rewrite fixes that — say so instead of polishing it.
+- Shorten past the point of clarity. Cutting words is not the goal; removing ambiguity is. Past a certain point compression starts costing the reader time rather than saving it, so stop when the sentence is unambiguous, not when it is shortest.
+
+## Additional Resources
+
+- **`references/writing-rules.md`** — fuller summary of the 9 rule sections and dictionary structure, with citations to the official standard and secondary sources.
+- **`examples/before-after.md`** — worked examples, including official STE examples and agent-output examples built for this skill.

--- a/agents/browser-screenshots.md
+++ b/agents/browser-screenshots.md
@@ -92,22 +92,46 @@ The PR must state that the console shows no **new** errors. Do not compare again
 
 ## Putting the images in the PR
 
-`gh` cannot attach an image to a PR body on its own. GitHub's uploader is a web endpoint, not part of the REST API. Use the `gh attach` extension, which is listed with the other CLI tools in the [tech stack guide](techstack.md#github-cli):
+**If you have your own skill or tooling for uploading an image to a PR, use that instead.** This section is the fallback for when you have nothing.
+
+`gh` has no command for this, but the endpoint its web UI uses is reachable with `curl`:
 
 ```bash
-gh attach upload <path> --target PostHog/posthog.com#<pr> --format url
+FILE=before-nav-light-wide.png
+MIME=image/png                                  # image/jpeg for a .jpg
+REPO=PostHog/posthog.com
+TOKEN=$(gh auth token)
+
+curl -s "https://uploads.github.com/user-attachments/assets?name=$FILE&content_type=$MIME&repository_id=$(gh api "repos/$REPO" --jq .id)" \
+  -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/json" --data-binary "@$FILE"
 ```
 
-It prints a URL you embed in the PR body:
+It returns the attachment URL:
+
+```json
+{ "url": "https://github.com/user-attachments/assets/8203f673-85b5-4d46-9fa8-f5e1e160e8f5" }
+```
+
+Put that URL in an `<img>` tag in the PR body:
 
 ```markdown
-<img src="https://github.com/PostHog/posthog.com/releases/download/_gh-attach-assets/before-nav-light-wide.png" width="380">
+<img src="https://github.com/user-attachments/assets/8203f673-85b5-4d46-9fa8-f5e1e160e8f5" width="380">
 ```
 
-Two things to know:
+These are the same attachment URLs the web UI creates when a human drags an image into a comment. GitHub rewrites them at render time into a signed `private-user-images.githubusercontent.com` URL and wraps them in a link.
 
-- The command uploads to a release named `_gh-attach-assets` on the target repo, and creates that release the first time it runs. Never delete that release – it would break the images in every PR that uses it.
-- Upload the files, then edit the whole body in one pass with `gh pr edit <pr> --body-file <file>`. Keep the body in a file so you can regenerate it.
+Three things to know:
+
+- **The asset 404s until the PR body references it.** Upload, embed, and only then check the URL. A 404 straight after upload is normal and does not mean the upload failed.
+- **Do not follow the redirect with the auth header attached.** `curl -L` forwards `Authorization` to S3, which rejects the signature with a 403. Once the asset is public, plain `curl -L` with no header works.
+- **Upload everything first, then edit the body once.** Keep the body in a file and apply it with `gh pr edit <pr> --body-file <file>`, so you can regenerate it without hand-patching.
+
+To confirm an image really renders, compare the served byte count against the local file:
+
+```bash
+curl -sL -o /dev/null -w '%{http_code} %{size_download}\n' "<attachment-url>"
+```
 
 ## Checklist
 

--- a/agents/browser-screenshots.md
+++ b/agents/browser-screenshots.md
@@ -1,0 +1,118 @@
+# Browser screenshots
+
+Every visual change needs before/after screenshots in four states: light and dark, narrow window and wide window. This guide explains how to capture them, and how to put them in the PR.
+
+Read [the reviewer's guide](reviewers-guide.md) for the grid the images go into.
+
+## Two ways to drive a browser
+
+| Tool | Use it for | Weakness |
+|---|---|---|
+| Claude Chrome extension | Hover states, nested menus, anything a real browser must paint | The window will not always resize, so you cannot control the viewport width |
+| Headless puppeteer (`puppeteer` is a devDependency) | Exact viewport widths, scripted before/after runs, reading console errors | Old bundled Chromium. It does not paint nested menus |
+
+Neither tool covers every case. Expect to use both: puppeteer for the narrow and wide grid, the extension for menus and hover states.
+
+## Capture the before state first
+
+The dev server hot-reloads, so you can move between the two states with `git stash`:
+
+```bash
+git stash push -m "wip" <your changed files>   # before state
+# ... capture ...
+git stash pop                                  # after state
+# ... capture ...
+```
+
+Wait for the rebuild between the two. Name the files so the pair is obvious: `before-<area>-<mode>-<width>.png`.
+
+## Open the page you changed
+
+Most pages open as a window on the desktop. **Do not navigate straight to the URL** – for a windowed page that renders the bare desktop with no window. Use the keyboard shortcut instead:
+
+| Page | Shortcut |
+|---|---|
+| Display options | `,` |
+| Keyboard shortcuts | `.` |
+| Wallpaper cycle | `\` |
+
+Other pages list their shortcut in the `shortcut` field in `src/components/TaskBarMenu/menuData.tsx`. If a page has no shortcut, open it the way a user does: click through from the desktop or the nav.
+
+## Headless puppeteer
+
+The bundled browser has a few traps. This recipe avoids all of them:
+
+```js
+const puppeteer = require('puppeteer')
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const page = await browser.newPage()
+page.on('dialog', (d) => d.accept().catch(() => {}))   // an unhandled beforeunload hangs the run
+page.on('console', (m) => m.type() === 'error' && errors.push(m.text()))
+page.on('pageerror', (e) => errors.push(e.message))
+
+await page.setViewport({ width: 640, height: 860 })    // 640 narrow, 1440 wide
+
+// Seed both keys. Set only one and the page theme and the color-mode control disagree.
+await page.evaluateOnNewDocument((mode) => {
+    localStorage.setItem('theme', mode)
+    localStorage.setItem('siteSettings', JSON.stringify({ colorMode: mode, theme: mode }))
+}, 'dark')
+
+await page.goto('http://localhost:8001/', { waitUntil: 'domcontentloaded', timeout: 60000 })
+await sleep(9000)                                       // hydration; see the note below
+```
+
+Four rules for this recipe:
+
+1. **Use `domcontentloaded`, never `networkidle2`.** The site never goes idle, so `networkidle2` times out every time. Follow the navigation with a sleep of about 9 seconds to let the app hydrate.
+2. **Open a fresh page for every screenshot.** A second `goto` in a page that already hydrated hangs on `beforeunload`.
+3. **Dismiss the cookie banner** before you shoot, or it covers the bottom right of every image.
+4. **Do not paint nested menus with this tool.** The submenu opens – `data-state` reads `open` and the element reports a real bounding box – but it never appears in the image. Use the extension for those.
+
+## The Chrome extension
+
+Hover, do not click, to open a submenu. A click on the sub-trigger toggles it shut again.
+
+```
+1. click the parent menu       (for example "More" in the menubar)
+2. wait ~2s
+3. hover the sub-trigger row   (for example "Things that spark joy")
+4. wait ~2s
+5. screenshot with save_to_disk
+```
+
+Give each step time. A click that lands before the app hydrates does nothing, and the menu stays shut.
+
+`resize_window` reports success but may leave the viewport unchanged, because page zoom decouples the window width from `innerWidth`. Check `innerWidth` in the page before you trust a narrow capture from this tool. When it does not move, take the narrow captures with puppeteer instead.
+
+## Console errors
+
+The PR must state that the console shows no **new** errors. Do not compare against a memorized list of known warnings – that list goes stale. Capture the console on both sides of the `git stash` and compare the two sets. Anything on both sides is pre-existing. Report only what your change added.
+
+## Putting the images in the PR
+
+`gh` cannot attach an image to a PR body on its own. GitHub's uploader is a web endpoint, not part of the REST API. Use the `gh attach` extension, which is listed with the other CLI tools in the [tech stack guide](techstack.md#github-cli):
+
+```bash
+gh attach upload <path> --target PostHog/posthog.com#<pr> --format url
+```
+
+It prints a URL you embed in the PR body:
+
+```markdown
+<img src="https://github.com/PostHog/posthog.com/releases/download/_gh-attach-assets/before-nav-light-wide.png" width="380">
+```
+
+Two things to know:
+
+- The command uploads to a release named `_gh-attach-assets` on the target repo, and creates that release the first time it runs. Never delete that release – it would break the images in every PR that uses it.
+- Upload the files, then edit the whole body in one pass with `gh pr edit <pr> --body-file <file>`. Keep the body in a file so you can regenerate it.
+
+## Checklist
+
+- [ ] Before and after, for every affected area
+- [ ] Light and dark, narrow and wide – four states per area
+- [ ] Console compared before and after, not against a remembered list
+- [ ] Images uploaded and embedded, not described in words
+- [ ] Any state you could not capture named in the "Not tested" line, with the reason

--- a/agents/pr-tour.md
+++ b/agents/pr-tour.md
@@ -1,0 +1,97 @@
+# PR tour
+
+Every PR description must contain a PR tour. A PR tour is a guided walkthrough of the diff. It moves through the change feature by feature, in the order a reviewer should read it. A reviewer who follows the tour from top to bottom must understand every hunk in the diff before they open the "Files changed" tab.
+
+Writing a good tour costs real effort. That is the point. The burden of explaining a change sits with the submitter, not the reviewer.
+
+## When to write one
+
+- Required for every PR that touches more than two files or more than ~50 changed lines.
+- Optional for trivial PRs (a typo fix, a one-line copy edit). If you skip the tour, say so in one line: "No tour: single-line copy fix."
+- Update the affected stops every time you push a change that alters the diff. A stale tour is worse than no tour.
+
+## Placement and fold
+
+Put the tour after the PR summary and before the [reviewer's guide](reviewers-guide.md), inside a fold:
+
+```markdown
+<details>
+<summary>🗺️ PR tour</summary>
+
+... tour content ...
+
+</details>
+```
+
+Keep a blank line after the `<summary>` line and before `</details>`. Without those blank lines, GitHub does not render the markdown inside the fold.
+
+## Structure
+
+1. Order the stops by how a reviewer should read the change, not alphabetically. Start at the entry point (the page, the data source, the config change). End with consumers, tests, and cleanup.
+2. Group stops by feature. One stop is one `###` heading. A stop usually covers one file. Small related files can share a stop.
+3. At each stop, write:
+   - What changed, in one or two sentences.
+   - Why it changed, when the diff alone does not show the reason.
+   - A link to the file in the diff (see "Linking into the diff").
+   - An embedded code permalink for the hunks that matter most (see below).
+4. Cover every changed file. Mechanical changes (renames, import updates, formatting) can share one final stop: list the files and label them "mechanical only". Never leave a file out – an untoured file reads as an unreviewed file.
+5. Call out surprises at the stop where they appear: deleted code, changed behavior, a new dependency, or a decision a reviewer would question. Do not bury them.
+6. Write the tour in [Simplified Technical English](asd-ste100.md), like the rest of the PR.
+
+## Linking into the diff
+
+Generate all links after your final push. Use the head commit SHA, never a branch name – branch links go stale when the branch moves.
+
+1. Get the head SHA: `git rev-parse HEAD`.
+2. **Embedded code (preferred).** Paste a permalink with a line range on its own line, surrounded by blank lines:
+
+   ```
+   https://github.com/PostHog/posthog.com/blob/<full-sha>/src/components/Example.tsx#L12-L24
+   ```
+
+   GitHub expands this into an inline code snippet in the PR body. It must use the full 40-character SHA, and it must sit alone on its line. Use one embed per stop for the hunk that carries the change. Do not embed every hunk – embed the ones a reviewer must see.
+3. **Link to a file in the "Files changed" tab.** The anchor is the SHA-256 hash of the file path:
+
+   ```bash
+   printf '%s' 'src/components/Example.tsx' | shasum -a 256
+   ```
+
+   Then link: `https://github.com/PostHog/posthog.com/pull/<number>/files#diff-<hash>`. This needs the PR number, so add these links in an edit right after you open the PR.
+4. If you amend or force-push, regenerate every SHA-based link with the new head SHA.
+
+## Template
+
+```markdown
+<details>
+<summary>🗺️ PR tour</summary>
+
+### Stop 1: <feature or file> ([diff](<files-changed-anchor>))
+
+<What changed and why, one or two sentences.>
+
+<permalink-with-line-range on its own line>
+
+<Callout for anything surprising at this stop.>
+
+### Stop 2: ...
+
+### Stop N: Mechanical changes
+
+These files only have import updates and formatting: `<file>`, `<file>`.
+
+</details>
+```
+
+## Example stop
+
+```markdown
+### Stop 2: Reading time calculation ([diff](https://github.com/PostHog/posthog.com/pull/1234/files#diff-ab12...))
+
+The blog index now shows an estimated reading time on each card. The estimate
+comes from the post body's word count at 265 words per minute.
+
+https://github.com/PostHog/posthog.com/blob/f8da1bc04c1c.../src/components/Blog/index.tsx#L41-L52
+
+⚠️ Note: this reads `post.rawBody`, which is only available after the
+`onCreateNode` change in Stop 1. The two stops must land together.
+```

--- a/agents/pr-tour.md
+++ b/agents/pr-tour.md
@@ -1,12 +1,13 @@
 # PR tour
 
-Every PR description must contain a PR tour. A PR tour is a guided walkthrough of the diff. It moves through the change feature by feature, in the order a reviewer should read it. A reviewer who follows the tour from top to bottom must understand every hunk in the diff before they open the "Files changed" tab.
+Nearly every PR description must contain a PR tour – see "When to write one" below for the exceptions. A PR tour is a guided walkthrough of the diff. It moves through the change feature by feature, in the order a reviewer should read it. A reviewer who follows the tour from top to bottom must understand every hunk in the diff before they open the "Files changed" tab.
 
 Writing a good tour costs real effort. That is the point. The burden of explaining a change sits with the submitter, not the reviewer.
 
 ## When to write one
 
 - Required for every PR that touches more than two files or more than ~50 changed lines.
+- Never required for a [content PR](../AGENTS.md#content-prs) – a change under `contents/` plus the navigation entries it needs. Prose does not need a guided walkthrough of itself, however long the diff is.
 - Optional for trivial PRs (a typo fix, a one-line copy edit). If you skip the tour, say so in one line: "No tour: single-line copy fix."
 - Update the affected stops every time you push a change that alters the diff. A stale tour is worse than no tour.
 

--- a/agents/reviewers-guide.md
+++ b/agents/reviewers-guide.md
@@ -1,0 +1,102 @@
+# Reviewer's guide
+
+Every PR description must contain a "Reviewer's guide" section. This section is written for the reviewer, and it has three jobs:
+
+1. Prove the testing that was done.
+2. Show the visual evidence.
+3. Point the reviewer at the risk.
+
+Place the guide at the end of the PR description, after the [PR tour](pr-tour.md), inside a fold:
+
+```markdown
+<details>
+<summary>🔍 Reviewer's guide</summary>
+
+... guide content ...
+
+</details>
+```
+
+Keep a blank line after the `<summary>` line and before `</details>`. Without those blank lines, GitHub does not render the markdown inside the fold.
+
+Update the guide every time the PR changes – a guide that describes an old revision will get the PR closed.
+
+## Section 1: Testing done
+
+Record every check you ran, as a table. Only record what you actually ran and observed. Never write "tested" or "works" without the command and the result. If a claim in this table turns out to be false, that is worse than an empty table.
+
+```markdown
+### Testing done
+
+| Check | Command / method | Result |
+|---|---|---|
+| Formatting | `pnpm format` on changed files | No changes needed |
+| Dev server | `pnpm start`, loaded `/blog` and `/blog/some-post` | Pages render, no new console errors |
+| Redirects | `pnpm test-redirects` | 0 failures |
+| Window resize | Resized the Blog app from 400px to full width | Layout reflows, no overflow |
+```
+
+List anything you did **not** test in a "Not tested" line below the table, with the reason. An honest gap is acceptable. A hidden gap is not.
+
+```markdown
+**Not tested:** production build (`pnpm build`) — exceeds this environment's memory. Needs a CI pass before merge.
+```
+
+## Section 2: Screenshots
+
+Required for any visual change. Provide before/after screenshots for every affected area, following the grid below. All apps are resizable, so a single desktop-width capture proves nothing.
+
+```markdown
+### Screenshots
+
+#### <Affected area, e.g. "Blog index card">
+
+| State | Before | After |
+|---|---|---|
+| Light, narrow window | <img src="..." width="300"> | <img src="..." width="300"> |
+| Light, wide window | <img src="..." width="300"> | <img src="..." width="300"> |
+| Dark, narrow window | <img src="..." width="300"> | <img src="..." width="300"> |
+| Dark, wide window | <img src="..." width="300"> | <img src="..." width="300"> |
+```
+
+If your environment cannot take screenshots, that is a blocker. Ask your user to supply them. Do not open the PR without them.
+
+## Section 3: What to look at
+
+Name the most risky or most controversial parts of the PR. This is the part of the guide reviewers read first, so make it count:
+
+- List zero to three items, ordered by risk, highest first. No need to make anything up just to fill a bullet point.
+- For each item, give: a link to the code, why it is risky, and what a mistake there would break (the blast radius).
+- Never write "low risk, nothing to look at". Every PR has a most dangerous line. Name it, even in a small PR.
+- Controversial counts as risky. If you made a judgment call the reviewer could reasonably disagree with (an abstraction, a dependency, a naming choice), list it here instead of hoping nobody notices.
+
+```markdown
+### What to look at
+
+1. **[`gatsby/onCreateNode.ts:88`](<permalink>)** — I add `rawBody` to every MDX
+   node. This runs for all ~4,000 content files at build time. A mistake here
+   breaks the whole build, not one page. Check the null guard on line 90.
+2. **[`src/components/Blog/index.tsx:41`](<permalink>)** — the 265 words-per-minute
+   constant is my judgment call, not a product decision. Push back if you want a
+   different number or a shared constant.
+```
+
+## Full skeleton
+
+```markdown
+<details>
+<summary>🔍 Reviewer's guide</summary>
+
+### Testing done
+<table>
+
+**Not tested:** <gaps, with reasons — or omit the line if there are none>
+
+### Screenshots
+<grids per affected area — omit for non-visual PRs>
+
+### What to look at
+<0–3 risk items, highest first>
+
+</details>
+```

--- a/agents/reviewers-guide.md
+++ b/agents/reviewers-guide.md
@@ -48,7 +48,7 @@ List anything you did **not** test in a "Not tested" line below the table, with 
 
 Required for any visual change. Provide before/after screenshots for every affected area, following the grid below. All apps are resizable, so a single desktop-width capture proves nothing.
 
-Read the [browser screenshots guide](browser-screenshots.md) before you start. It covers how to drive a browser, which tool paints what, and how to upload the images with `gh attach` – `gh` cannot attach an image to a PR body on its own.
+Read the [browser screenshots guide](browser-screenshots.md) before you start. It covers how to drive a browser, which tool paints what, and how to get the images into the PR body – `gh` has no command for attaching an image, so use your own tooling for that if you have any, and the guide's `curl` fallback if you do not.
 
 ```markdown
 ### Screenshots

--- a/agents/reviewers-guide.md
+++ b/agents/reviewers-guide.md
@@ -1,10 +1,12 @@
 # Reviewer's guide
 
-Every PR description must contain a "Reviewer's guide" section. This section is written for the reviewer, and it has three jobs:
+Nearly every PR description must contain a "Reviewer's guide" section. This section is written for the reviewer, and it has three jobs:
 
 1. Prove the testing that was done.
 2. Show the visual evidence.
 3. Point the reviewer at the risk.
+
+Two PRs do not need one: a trivial PR (a typo fix, a one-line copy edit), and a [content PR](../AGENTS.md#content-prs) – a change under `contents/` plus the navigation entries it needs. A content PR that touches navigation still owes the reviewer before/after screenshots of the nav.
 
 Place the guide at the end of the PR description, after the [PR tour](pr-tour.md), inside a fold:
 
@@ -46,6 +48,8 @@ List anything you did **not** test in a "Not tested" line below the table, with 
 
 Required for any visual change. Provide before/after screenshots for every affected area, following the grid below. All apps are resizable, so a single desktop-width capture proves nothing.
 
+Read the [browser screenshots guide](browser-screenshots.md) before you start. It covers how to drive a browser, which tool paints what, and how to upload the images with `gh attach` – `gh` cannot attach an image to a PR body on its own.
+
 ```markdown
 ### Screenshots
 
@@ -59,7 +63,7 @@ Required for any visual change. Provide before/after screenshots for every affec
 | Dark, wide window | <img src="..." width="300"> | <img src="..." width="300"> |
 ```
 
-If your environment cannot take screenshots, that is a blocker. Ask your user to supply them. Do not open the PR without them.
+If your environment cannot take screenshots, that is a blocker. Ask your user to supply them. Do not open the PR without them. A state you tried to capture and could not – a menu the tool will not paint, a width you cannot set – goes in the "Not tested" line with the reason. Never leave a cell of the grid silently empty.
 
 ## Section 3: What to look at
 

--- a/agents/techstack.md
+++ b/agents/techstack.md
@@ -20,6 +20,18 @@ pnpm check-links-post-build     # Verify links after build
 pnpm format                     # Prettier for js/ts/tsx/json/css
 ```
 
+## GitHub CLI
+
+PR work needs [`gh`](https://cli.github.com/) v2.0+, authenticated (`gh auth status`), plus two extensions:
+
+```bash
+gh extension install github/gh-stack     # stacked PRs
+gh extension install Addono/gh-attach    # image upload for PR bodies
+```
+
+- **`gh stack`** – create and manage [stacked PRs](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs). Note that `gh pr merge` does not work on a stacked PR; use `gh stack merge --yes`. Run every command non-interactively: `gh stack view --json`, `gh stack submit --auto`, and always pass branch names to `init`, `add`, and `checkout`.
+- **`gh attach`** – upload an image and get a URL you can embed in a PR body. `gh` has no other way to do this. See [browser screenshots](browser-screenshots.md#putting-the-images-in-the-pr).
+
 ## Project structure
 
 ```

--- a/agents/techstack.md
+++ b/agents/techstack.md
@@ -22,15 +22,17 @@ pnpm format                     # Prettier for js/ts/tsx/json/css
 
 ## GitHub CLI
 
-PR work needs [`gh`](https://cli.github.com/) v2.0+, authenticated (`gh auth status`), plus two extensions:
+PR work needs [`gh`](https://cli.github.com/) v2.0+, authenticated (`gh auth status`).
+
+For stacked PRs, add the `gh stack` extension:
 
 ```bash
-gh extension install github/gh-stack     # stacked PRs
-gh extension install Addono/gh-attach    # image upload for PR bodies
+gh extension install github/gh-stack
 ```
 
-- **`gh stack`** – create and manage [stacked PRs](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs). Note that `gh pr merge` does not work on a stacked PR; use `gh stack merge --yes`. Run every command non-interactively: `gh stack view --json`, `gh stack submit --auto`, and always pass branch names to `init`, `add`, and `checkout`.
-- **`gh attach`** – upload an image and get a URL you can embed in a PR body. `gh` has no other way to do this. See [browser screenshots](browser-screenshots.md#putting-the-images-in-the-pr).
+Use it to create and manage [stacked PRs](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs). Note that `gh pr merge` does not work on a stacked PR; use `gh stack merge --yes`. Run every command non-interactively: `gh stack view --json`, `gh stack submit --auto`, and always pass branch names to `init`, `add`, and `checkout`.
+
+`gh` has no command for attaching an image to a PR body, which every visual PR needs. If you have your own skill or tooling for that, use it. Otherwise see the `curl` fallback in [browser screenshots](browser-screenshots.md#putting-the-images-in-the-pr) – no extension required.
 
 ## Project structure
 

--- a/agents/techstack.md
+++ b/agents/techstack.md
@@ -1,0 +1,103 @@
+# Getting started / tech stack
+
+## Commands
+
+```bash
+pnpm install                    # Install dependencies (NOT npm)
+pnpm start                      # Dev server at localhost:8001
+pnpm build                      # Production build
+pnpm clean                      # Clear Gatsby cache
+pnpm clean && mkdir .cache && pnpm i && pnpm start      # Full reset when things break
+```
+
+Requires 16GB RAM (`NODE_OPTIONS='--max_old_space_size=16384'`).
+
+## Testing
+
+```bash
+pnpm test-redirects             # Test redirect configuration
+pnpm check-links-post-build     # Verify links after build
+pnpm format                     # Prettier for js/ts/tsx/json/css
+```
+
+## Project structure
+
+```
+contents/                       # MDX content (blog, docs, handbook, tutorials)
+src/
+  components/                   # React components
+    TaskBarMenu/menuData.tsx    # Global navigation menu (top bar)
+  context/App.tsx               # Window management, settings, navigation
+  hooks/
+    useProduct.ts               # Product data (icons, metadata)
+    useProducts.tsx             # Paid products and marketing content
+    useCustomers.tsx            # Customer logos, quotes
+    competitorData/
+      README.md                 # Overview of how the `<ProductComparisonTable />` is populated
+                                # Also documented [in the handbook](contents/handbook/engineering/posthog-com/product-comparisons.mdx)
+      {competitor}.tsx          # Array of normalized products, platform, and pricing data
+  navs/index.js                 # Source navigation menus used for most of the site (especially docs, handbook)
+  styles/global.css             # Global styles with @apply
+gatsby/
+  createPages.ts                # Page generation
+  sourceNodes.ts                # Data sourcing (GitHub, Ashby jobs)
+  onCreateNode.ts               # Node processing
+api/                            # Vercel serverless functions
+```
+
+Docs are also pulled from the [PostHog monorepo](https://github.com/PostHog/posthog) (`docs/published/` and `docs/onboarding/`) into `.cache/gatsby-source-git/` at build time via `gatsby-source-git`.
+
+### Where docs content lives
+
+Most product documentation lives in this repo under `contents/docs/`. Some content that is tightly coupled to the monorepo codebase lives in the monorepo's `docs/published/` folder instead and gets pulled in automatically. Today that's mostly handbook/engineering pages (coding conventions, database guides, local dev setup) plus a few product docs like surveys SDK feature support.
+
+**This repo (posthog.com):** blog posts, tutorials, handbook (non-engineering), marketing pages, product landing pages, and the majority of product docs.
+
+**Monorepo (`docs/published/`):** engineering handbook pages and product docs that are tightly coupled to the monorepo codebase. URL mapping: `docs/published/docs/foo/bar.md` becomes `/docs/foo/bar` on the site.
+
+When writing new docs, ask: does this content describe something internal to the monorepo codebase? If yes, it likely belongs in the monorepo's `docs/published/` folder, not here.
+
+## Apps and pages
+
+PostHog.com replicates a desktop-style OS. All pages should use an app template:
+
+- `<Editor />`
+- `<Reader />`
+- `<Presentation />`
+- `<Explorer />`
+- `<Inbox />`
+- `<Wizard />`
+- `<MediaPlayer />`
+
+See [Apps guide](apps.md) for templates, creating pages, and shared components.
+
+For working on product pages/presentations, reference [Apps guide](apps.md) for important details about slide templates.
+
+## Code style
+
+### TypeScript/React
+
+```tsx
+// Radix UI: import with prefix, use simple name
+import { Tabs as RadixTabs } from "radix-ui"
+<Tabs />
+
+// Custom components use OS prefix
+<OSButton />
+<OSTable />
+```
+
+We generally create our own versions of Radix UI primitives. Check in @components/RadixUI/ before importing directly from the `radix-ui` package.
+
+For example, instances should reference our version of the component...
+
+```
+import MenuBar from 'components/RadixUI/MenuBar'
+```
+
+... which sources primitives from `radix-ui` like:
+
+```
+import { Menubar as RadixMenubar } from 'radix-ui'
+<RadixMenubar.Root>...</RadixMenubar.Root>
+```


### PR DESCRIPTION
This description was entirely human-written

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`


---

## Agent-written update: `9aab965`, `fcdae78`

Everything above this line is Ian's. This section covers the two commits below it.

The rules had three gaps that made agents fail the PR requirements:

1. **Nothing said how to take a screenshot.** The rules demand a four-state before/after grid for every visual change, but no guide said how to drive a browser, and `gh` cannot attach an image to a PR body at all. Agents skipped the screenshots or described them in prose.
2. **Nothing said which `gh` extensions the workflow needs.** Stacked PRs need `gh stack`; screenshots need `gh attach`.
3. **The PR tour and the reviewer's guide read as required for every PR.** A guided walkthrough of a blog post is nonsense.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: The screenshot guide (new file: `agents/browser-screenshots.md`)

The bulk of the commit. It compares the two ways to drive a browser and names what each one cannot do — the Chrome extension for hover states and nested menus, headless puppeteer for exact viewport widths — because neither covers the whole grid on its own.

The traps it records are ones I hit taking the screenshots for #19619: `networkidle2` never settles on this site, a second `goto` in a hydrated page hangs on `beforeunload`, a windowed page opened by direct URL renders the bare desktop instead of the window, headless Chromium reports a nested submenu as open and then does not paint it, and `resize_window` through the extension can report success while `innerWidth` never moves.

It ends with the upload step and a checklist.

⚠️ The console-errors section tells agents to diff the console across a `git stash`, rather than compare against a list of known warnings. A hard-coded list of "expected" warnings would go stale and start hiding real regressions.

### Stop 2: Getting the images into the PR (`agents/browser-screenshots.md`, `fcdae78`)

`gh` has no command for attaching an image to a PR body, so the guide carries a `curl` recipe against GitHub's own endpoint:

```
POST https://uploads.github.com/user-attachments/assets
```

It returns the same `github.com/user-attachments/assets/<uuid>` URL the web UI produces when a human drags an image into a comment. No extension, no side effect.

The first version of this guide used the `gh-attach` extension instead. That extension uploads to a GitHub release named `_gh-attach-assets` on the target repo and creates that release on first use, so every image in every PR ends up depending on a release that looks like junk to anyone tidying up releases. `fcdae78` replaces it.

Both the guide and the tech-stack section now say the same thing first: if you have your own image-upload tooling, use that. The `curl` recipe is the fallback.

⚠️ The recipe records two traps that cost me time. The asset returns 404 until the PR body references it, so a 404 straight after upload looks like a failed upload and is not one. And `curl -L` forwards the `Authorization` header to S3, which rejects the signature with a 403.

### Stop 3: GitHub CLI tooling (`agents/techstack.md`)

A `## GitHub CLI` section under Commands: the `gh` version floor, the `gh stack` install line, and the non-obvious constraints — `gh pr merge` does not work on a stacked PR, and every `gh stack` command needs its non-interactive flag or it hangs waiting for a TUI.

### Stop 4: The content PR exemption (`AGENTS.md`, `agents/pr-tour.md`, `agents/reviewers-guide.md`)

`AGENTS.md` gains a `### Content PRs` section that defines the term: files under `contents/`, plus the navigation entries those changes need, and nothing else. The tour and reviewer's-guide docs link to that definition and drop their "every PR" opening claim.

⚠️ I did not make the exemption total. A content PR that touches navigation still owes before/after screenshots of the nav, and one that moves a page still owes a redirect. Without those two carve-outs, "add a nav item" becomes a way to ship an unreviewed UI change. Say so if you want the exemption clean instead.

⚠️ Note the scope: this PR is **not** itself a content PR under the new definition. `AGENTS.md` and `agents/*.md` sit at the repo root, not under `contents/`, so the tour you are reading is required.

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Markdown lint | `markdownlint-cli2 --fix` on all five files, plus the `lint-staged` commit hook | 0 errors |
| Formatting | `prettier --write` | No-op — `.prettierignore` excludes `*.md` and `*.mdx`, so markdownlint is the only formatter for these files |
| Link and anchor check | Script resolving every relative `.md` link and `#anchor` in `AGENTS.md` and `agents/*.md` against the real headings | All links and anchors in the changed files resolve |
| Instructions | Every command in the new guide was run for real while taking the #19619 screenshots | The recipes are transcribed from working runs, not written from memory |
| Upload recipe | Uploaded all 13 screenshots on #19619 through the `curl` endpoint, then fetched each URL anonymously | 13/13 returned 200 and matched the local file byte-for-byte |

**Not tested:** the rendered markdown on GitHub. I checked the fold syntax by rule (blank line after `<summary>`, blank line before `</details>`), not by eye. Two pre-existing broken links in `agents/apps.md` point at README files that do not exist (`src/components/Products/Slides/README.md`, `src/components/Products/ReaderViewProduct/CarouselSlide.README.md`); I left them alone as out of scope.

### What to look at

1. **`AGENTS.md`, the `### Content PRs` section** — this is the only change with teeth. It decides which PRs escape review scaffolding, and a definition that is too loose lets real UI changes through unreviewed. The line to argue about is the boundary: "adding a docs page and linking it in the sidebar is a content PR. Changing a component so the page renders differently is not."
2. **`agents/browser-screenshots.md`, the tool comparison table** — I claim headless Chromium will not paint nested menus and that the extension will not always resize. Both are true on my machine today, and both could be version-specific. If they are fixed upstream, this table sends agents down the slower path for no reason.
3. **`agents/browser-screenshots.md`, the `curl` recipe** — `uploads.github.com/user-attachments/assets` is the endpoint GitHub's web UI uses, not a documented API. It works today and the screenshots on #19619 all go through it, but GitHub owes us no stability promise here. If it breaks, the fix is to fall back to asking the user to drag the images in.
</details>
