### PR TITLE
Add coworking and User Limit guidance to spending money handbook

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -24,7 +24,7 @@ If not, think again.
 ## How it works
 - All company expenses (offsites, software/tool subscriptions, merch, etc.) will have common company-wide budgets.
 - You'll be assigned a single `User Limit` of $5,000 per month in Brex from which you can spend money on individual subscriptions, coworking/collaboration, equipment (except laptops and Mac Studio Monitors - ping `#team-people-and-ops` for these), training, etc. If you need an increase in the limit, request it on Brex.
-  - The $5,000 is a ceiling, not a target or an allowance to use up - only spend what you can justify as being in PostHog's best interest.
+  - The $5,000 is a ceiling, not a target or an allowance to use up – only spend what you can justify as being in PostHog's best interest.
 
 ### Transparency & accountability
 - All expenses are visible company-wide
@@ -213,7 +213,7 @@ You can ask for access to team/company tools by submitted a request in Slack. Fi
 - AI coding tools (Cursor, Claude Code, etc.) are encouraged, but usage-based pricing can climb fast. Most engineers' monthly spend lands around a single max-tier subscription (~$200/month). If yours is running several times higher, that's usually a misconfiguration or inefficient workflow rather than a genuine need – compare setups with your teammates and ask in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) if you're unsure. We have a team Claude Code account that you can request to be added to using Zluri in slack.
 
 ### Coworking
-- If there's a WeWork where you are, use it - we have a company All Access account, so default to that rather than paying for another coworking space. Ask [Kendal](https://posthog.com/community/profiles/28628) in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) for access.
+- If there's a WeWork where you are, use it – we have a company All Access account, so default to that rather than paying for another coworking space. Ask [Kendal](https://posthog.com/community/profiles/28628) in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) for access.
 
 ### Travel
 - We travel in economy by default and do not pay for business class

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -24,6 +24,7 @@ If not, think again.
 ## How it works
 - All company expenses (offsites, software/tool subscriptions, merch, etc.) will have common company-wide budgets.
 - You'll be assigned a single `User Limit` of $5,000 per month in Brex from which you can spend money on individual subscriptions, coworking/collaboration, equipment (except laptops and Mac Studio Monitors - ping `#team-people-and-ops` for these), training, etc. If you need an increase in the limit, request it on Brex.
+  - The $5,000 is a ceiling, not a target or an allowance to use up - only spend what you can justify as being in PostHog's best interest.
 
 ### Transparency & accountability
 - All expenses are visible company-wide
@@ -210,6 +211,9 @@ You can ask for access to team/company tools by submitted a request in Slack. Fi
 - IDEs: Visual Studio, VIM and PyCharm are the most popular within our team. IDEs range widely in cost; best in class IDE suites can cost up to $700, which is not a great value proposition for most engineers.
 
 - AI coding tools (Cursor, Claude Code, etc.) are encouraged, but usage-based pricing can climb fast. Most engineers' monthly spend lands around a single max-tier subscription (~$200/month). If yours is running several times higher, that's usually a misconfiguration or inefficient workflow rather than a genuine need – compare setups with your teammates and ask in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) if you're unsure. We have a team Claude Code account that you can request to be added to using Zluri in slack.
+
+### Coworking
+- If there's a WeWork where you are, use it - we have a company All Access account, so default to that rather than paying for another coworking space. Ask [Kendal](https://posthog.com/community/profiles/28628) in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) for access.
 
 ### Travel
 - We travel in economy by default and do not pay for business class


### PR DESCRIPTION
## Changes

Two one-line additions to the spending money handbook page:

- Clarifies the $5,000 monthly `User Limit` is a ceiling, not a target or an allowance to use up.
- Adds a short coworking line: default to our company WeWork All Access account where one is available, rather than paying for other coworking space.

**Why:** coming out of the latest expense review, these were the two recurring patterns worth writing down so people have clear guidance up front.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a - no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BR13GMDGT/p1787234009946399?thread_ts=1787234009.946399&cid=C0BR13GMDGT)*
