### PR TITLE
docs: list the new aws_ses source IAM permissions

### DIFF
--- a/contents/docs/cdp/sources/aws-ses.md
+++ b/contents/docs/cdp/sources/aws-ses.md
@@ -32,6 +32,16 @@ You also need an IAM user or role with the following permissions:
 - `ses:ListEmailIdentities`
 - `ses:GetEmailIdentity`
 - `ses:ListSuppressedDestinations`
+- `ses:ListEmailTemplates`
+- `ses:GetEmailTemplate`
+- `ses:ListContactLists`
+- `ses:GetContactList`
+- `ses:ListDedicatedIpPools`
+- `ses:GetDedicatedIpPool`
+- `ses:GetDedicatedIps`
+- `ses:ListCustomVerificationEmailTemplates`
+- `ses:GetCustomVerificationEmailTemplate`
+- `ses:ListMultiRegionEndpoints`
 
 SES data is regional. Connect one source per AWS region you send email from.
 
@@ -63,7 +73,17 @@ When linking Amazon SES, you'll need:
         "ses:GetConfigurationSet",
         "ses:ListEmailIdentities",
         "ses:GetEmailIdentity",
-        "ses:ListSuppressedDestinations"
+        "ses:ListSuppressedDestinations",
+        "ses:ListEmailTemplates",
+        "ses:GetEmailTemplate",
+        "ses:ListContactLists",
+        "ses:GetContactList",
+        "ses:ListDedicatedIpPools",
+        "ses:GetDedicatedIpPool",
+        "ses:GetDedicatedIps",
+        "ses:ListCustomVerificationEmailTemplates",
+        "ses:GetCustomVerificationEmailTemplate",
+        "ses:ListMultiRegionEndpoints"
       ],
       "Resource": "*"
     }
@@ -96,7 +116,7 @@ The other tables are small and sync as a full refresh. The `account` table is a 
 
 - If you see "AWS rejected the access key", check that the access key ID and secret access key are correct and that the key is still active in IAM.
 - If you see a signature error, re-enter the secret access key. If you are using temporary credentials, the session token may have expired.
-- If you see "missing SES read permissions", grant the six `ses:` permissions listed above to the IAM user or role.
+- If you see "missing SES read permissions", grant the `ses:` permissions listed above to the IAM user or role.
 - If a sync fails with a region error, check that the region is a valid AWS region code like `us-east-1` and that your SES account sends from that region.
 
 <TroubleshootingLink />


### PR DESCRIPTION
## Changes

- The Amazon SES source doc's prerequisites list and example IAM policy grant ten more read actions, one per API call behind the six tables added in [PostHog/posthog#86839](https://github.com/PostHog/posthog/pull/86839).
- The troubleshooting line no longer hardcodes the permission count, so it stays correct as later table batches land.
- The Supported tables section needs no edit: `<SourceTables />` renders the table list from the source's code.

No visual or layout changes; the page gains list items only.

**Why:** without the wider grant list, users connecting SES after the new tables ship would see the new tables flagged as unreadable in the table picker.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
