### PR TITLE
Move hedgehog mode toggle into display options

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -17,7 +17,6 @@ import {
 } from 'components/OSIcons'
 import { useAppSettings } from '../../context/App'
 import { IconChevronDown } from '@posthog/icons'
-import { useHedgehogMode } from 'components/HedgehogMode'
 import { navigate } from 'gatsby'
 import { useSmallTeamsMenuItems } from './SmallTeamsMenuItems'
 
@@ -391,7 +390,6 @@ export function useMenuData(): MenuType[] {
     const smallTeamsMenuItems = useSmallTeamsMenuItems()
     const allProducts = useProduct() as any[]
     const { isMobile } = useAppSettings()
-    const [hedgehogModeEnabled, setHedgehogModeEnabled] = useHedgehogMode()
 
     // Define main navigation items (excluding logo menu)
     const mainNavItems: MenuType[] = [
@@ -629,33 +627,6 @@ export function useMenuData(): MenuType[] {
                     label: 'Things that spark joy',
                     icon: <IconSparksJoy className="size-4" />,
                     items: [
-                        {
-                            type: 'item',
-                            onClick: () => setHedgehogModeEnabled(!hedgehogModeEnabled),
-                            node: (
-                                <span className="px-2.5 flex w-full justify-between items-center gap-2">
-                                    <span>Hedgehog mode</span>
-                                    {/* Presentational toggle — the whole row is the clickable menu item */}
-                                    <span className="relative inline-flex items-center justify-center h-2 w-8 flex-shrink-0">
-                                        <span
-                                            aria-hidden
-                                            className="pointer-events-none absolute w-full h-full rounded-md bg-[#c4c4c4] dark:bg-[#5A5A5A]"
-                                        />
-                                        <span
-                                            aria-hidden
-                                            className={`pointer-events-none absolute left-0 inline-block h-4 w-4 rounded-full transition-transform ease-in-out duration-200 ${
-                                                hedgehogModeEnabled
-                                                    ? 'translate-x-5 bg-teal'
-                                                    : 'translate-x-0 bg-[#555] dark:bg-[#999]'
-                                            }`}
-                                        />
-                                    </span>
-                                </span>
-                            ),
-                        },
-                        {
-                            type: 'separator',
-                        },
                         {
                             type: 'item',
                             label: 'Browse all',

--- a/src/pages/display-options.tsx
+++ b/src/pages/display-options.tsx
@@ -14,6 +14,7 @@ import Tooltip from 'components/RadixUI/Tooltip'
 import { Screensaver } from '../components/Screensaver'
 import useTheme, { type ThemeOption } from '../hooks/useTheme'
 import KeyboardShortcut from 'components/KeyboardShortcut'
+import { useHedgehogMode } from 'components/HedgehogMode'
 
 const XL_CURSOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 74 28"><g clip-path="url(#a)"><path fill="#000" stroke="#fff" stroke-width="5" d="m44.77 50.196.024.01.025.008c.48.177 1.014.286 1.58.286.665 0 1.28-.147 1.837-.392l.012-.006.013-.006 8.8-3.997.002-.001a4.5 4.5 0 0 0 2.225-5.968v-.001l-10.73-23.395 16.828-1.446.008-.001a4.504 4.504 0 0 0 2.678-7.78L20.073-37.289a4.51 4.51 0 0 0-4.858-.843l-.011.005A4.499 4.499 0 0 0 12.5-34v66a4.503 4.503 0 0 0 2.715 4.133l.01.003a4.505 4.505 0 0 0 4.86-.859L32.01 24.072l10.259 23.717.005.012.005.011a4.527 4.527 0 0 0 2.492 2.384Z"/></g><defs><clipPath id="a"><path fill="#fff" d="M0 0h74v28H0z"/></clipPath></defs></svg>`
 
@@ -198,6 +199,8 @@ const WallpaperSelect = ({ value, onValueChange, title }: WallpaperSelectProps) 
 export default function DisplayOptions() {
     const { siteSettings, updateSiteSettings } = useApp()
     const [previewScreensaver, setPreviewScreensaver] = useState(false)
+    // Hedgehog mode lives in its own localStorage-backed store, not in siteSettings.
+    const [hedgehogModeEnabled, setHedgehogModeEnabled] = useHedgehogMode()
 
     const handleColorModeChange = (value: string) => {
         if (typeof window !== 'undefined' && (window as any).__setPreferredTheme) {
@@ -308,6 +311,27 @@ export default function DisplayOptions() {
                                 updateSiteSettings({ ...siteSettings, reduceTransparency: value === 'true' })
                             }}
                             value={siteSettings.reduceTransparency ? 'true' : 'false'}
+                        />
+                    </div>
+                </div>
+                <div className="bg-primary grid grid-cols-2 gap-2">
+                    <div className="flex items-center gap-1 mb-1">
+                        <span className="text-sm">Hedgehog mode</span>
+                        <Tooltip trigger={<IconInfo className="size-4 inline-block relative -top-px" />} delay={0}>
+                            <p className="max-w-sm my-0 leading-snug">
+                                Hedgehogs walk around the screen, sit on windows, and follow your cursor.
+                            </p>
+                        </Tooltip>
+                    </div>
+                    <div>
+                        <ToggleGroup
+                            title=""
+                            options={[
+                                { label: 'Disabled', value: 'false' },
+                                { label: 'Enabled', value: 'true' },
+                            ]}
+                            onValueChange={(value) => setHedgehogModeEnabled(value === 'true')}
+                            value={hedgehogModeEnabled ? 'true' : 'false'}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
> 📚 **Stacked** on top of [#19613 (Add some agent rules)](https://github.com/PostHog/posthog.com/pull/19613). Review that one first; this PR's diff shows only the hedgehog mode change.

Hedgehog mode is a display preference, but its toggle lived in the **More > Things that spark joy** nav submenu, in a list of games and links. Nothing else in that submenu changes how the site looks — every other item opens a page.

This PR moves the toggle into the display options window (`,`), where it sits with the screensaver and reduce-transparency preferences. The submenu keeps the **Hedgehog mode** playground page under Games; only the toggle row moves.

The toggle keeps its existing behavior. `useHedgehogMode` reads and writes `localStorage`, so the state and the April Fools default are unchanged, and the Spotlight action ("Release the hedgehogs") still works.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: The new row in display options ([diff](https://github.com/PostHog/posthog.com/pull/19619/files#diff-2ccc2aa5b16a6ecf825598b9d05c09a6630f0049d28e283ccadfa9210316fa6c))

Add a **Hedgehog mode** row at the end of the display options window. It copies the reduce-transparency row: a label, an info tooltip, and a Disabled/Enabled `ToggleGroup`.

https://github.com/PostHog/posthog.com/blob/d024f741460d52dead58a2380a985501ed924d86/src/pages/display-options.tsx#L316-L340

The other rows on this page read and write `siteSettings`. This one does not — hedgehog mode has its own `localStorage`-backed external store, and the comment on line 202 says so:

https://github.com/PostHog/posthog.com/blob/d024f741460d52dead58a2380a985501ed924d86/src/pages/display-options.tsx#L202-L203

### Stop 2: The removed row in the nav submenu ([diff](https://github.com/PostHog/posthog.com/pull/19619/files#diff-000fc14ba46488d1a8045495ef5d817257b8106b7eccd36614cf68e363692f38))

Delete the toggle item and the separator below it from the **Things that spark joy** submenu. The submenu now starts with **Browse all**.

https://github.com/PostHog/posthog.com/blob/d024f741460d52dead58a2380a985501ed924d86/src/components/TaskBarMenu/menuData.tsx#L625-L634

The deleted item carried a hand-rolled toggle: 20 lines of spans with hard-coded hex colors (`bg-[#c4c4c4]`, `bg-[#5A5A5A]`, `bg-[#555]`, `bg-[#999]`), because `MenuItemType` has no toggle variant. The `ToggleGroup` on the display options page replaces it, so those hex values leave the codebase.

`useMenuData` no longer needs `useHedgehogMode`, so the import and the hook call go too.

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `prettier --write` on both changed files, plus the `lint-staged` hook on commit | No further changes |
| Lint | `eslint` via the `lint-staged` commit hook | Passed |
| Dev server | `pnpm start`, loaded `/` and the display options window at 640px and 1440px, in light and dark | Renders, no new console errors |
| Console errors | Compared a scripted before/after pass over both widths and both color modes | Same set both sides: one 404 for a missing asset, one `<svg> attribute width: Expected length, "auto"` warning, one duplicate-key warning from `AnimatePresence`. All three pre-date this PR |
| Toggle behavior | Clicked **Enabled** in the display options window | `localStorage['hedgehog-mode-enabled']` flips to `"true"`, the renderer mounts, and a hedgehog walks onto the desktop |
| Nav submenu | Opened **More > Things that spark joy** before and after, in light and dark | The toggle row and its separator are gone; every other item is unchanged |

**Not tested:** production build (`pnpm build`) — it exhausts memory in this environment, so it needs a CI pass. The narrow-window rendering of the **Things that spark joy** submenu — at narrow widths the menubar collapses into the logo menu, and I could not resize the automated browser window to reach it. Both menus read the same `mainNavItems` array, so the removal applies to both, but I did not see the narrow one with my own eyes.

### Screenshots

#### Display options window

The new row sits at the end, below **Reduce transparency**.

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://github.com/user-attachments/assets/25765770-849f-4823-9d40-f902d89f1600" width="380"> | <img src="https://github.com/user-attachments/assets/d1e94ea6-5a99-42ac-87b8-d181bf3be8da" width="380"> |
| Light, wide window | <img src="https://github.com/user-attachments/assets/f204c8c2-a887-4ebf-bd37-3e005eb038f7" width="380"> | <img src="https://github.com/user-attachments/assets/97928c83-2259-492e-9fa6-94460bcc5574" width="380"> |
| Dark, narrow window | <img src="https://github.com/user-attachments/assets/715e1b6e-5bd3-42f0-81a9-631c10b11dec" width="380"> | <img src="https://github.com/user-attachments/assets/ef374f9e-6575-43d8-abb7-2a32bc996a8d" width="380"> |
| Dark, wide window | <img src="https://github.com/user-attachments/assets/4da9c950-965a-4ca2-9d52-a5453c3f5044" width="380"> | <img src="https://github.com/user-attachments/assets/82663314-217c-4bae-80d6-3a2d2f7277f8" width="380"> |

#### More > Things that spark joy submenu

The submenu loses its first row and the separator below it, so it now opens on **Browse all**.

| State | Before | After |
|---|---|---|
| Light, wide window | <img src="https://github.com/user-attachments/assets/6103c19c-9cf7-4fed-96b6-52a849c4c3b8" width="380"> | <img src="https://github.com/user-attachments/assets/c799550c-6439-4323-9cbe-9184f9d85654" width="380"> |
| Dark, wide window | <img src="https://github.com/user-attachments/assets/1825c897-5ead-4aea-b3d5-3eb9592784f2" width="380"> | <img src="https://github.com/user-attachments/assets/eca7d581-9b51-4aaf-8c67-106ba8eed7bc" width="380"> |

#### Hedgehog mode enabled from the new toggle

| State | After |
|---|---|
| Light, wide window | <img src="https://github.com/user-attachments/assets/bd155fe5-1a09-45b2-ae6a-d0e75c860074" width="380"> |

### What to look at

1. **[`src/pages/display-options.tsx:203`](https://github.com/PostHog/posthog.com/blob/d024f741460d52dead58a2380a985501ed924d86/src/pages/display-options.tsx#L202-L203)** — this page now has two sources of truth. Every other row goes through `updateSiteSettings`; this row goes through `useHedgehogMode`. I kept it that way on purpose: folding hedgehog mode into `siteSettings` would need a migration for users who already have the `hedgehog-mode-enabled` key, and it would break the `?hedgehog_mode=true` query param and the Spotlight action, which both use the hook. Push back if you would rather pay that cost now and have one store.
2. **[`src/components/TaskBarMenu/menuData.tsx:625`](https://github.com/PostHog/posthog.com/blob/d024f741460d52dead58a2380a985501ed924d86/src/components/TaskBarMenu/menuData.tsx#L625-L634)** — this removes the only discoverable entry point that a user could stumble on while browsing the nav. What remains is the display options window, the `,` shortcut, Spotlight, and the `?hedgehog_mode=true` param. If discoverability of hedgehog mode matters more than tidy grouping, this is the line to object to.
