### PR TITLE
docs(handbook): split the CS Small Team interview by role

### DIFF
--- a/contents/handbook/people/hiring-process/sales-cs-hiring.md
+++ b/contents/handbook/people/hiring-process/sales-cs-hiring.md
@@ -88,7 +88,15 @@ This is our usual first-round interview with a member of the People & Ops team.
 
 #### Small Team interview
 
-The small team interview with the relevant team lead usually lasts 45 minutes.  For this round, we will use scenario-based questions to assess your technical and customer skills, as well as your knowledge of PostHog. As part of this, we will ask you to give a quick pitch of PostHog (not a full demo).
+The small team interview with the relevant team lead usually lasts 45 minutes. How we run it depends on the role you're interviewing for.
+
+##### Technical Customer Success Manager (TCSM)
+
+For TCSM candidates, this round is scenario-based questions to assess your technical and customer skills. There's no demo or pitch. The focus is on how you reason through account scenarios and technical problems.
+
+##### Forward Deployed Engineer (FDE)
+
+For FDE candidates, this round uses scenario-based questions and includes a quick pitch of PostHog (not a full demo), to assess how you communicate the product to a customer.
 
 #### Culture and motivation interview
 


### PR DESCRIPTION
## Changes

The Small Team interview section for CS and FDE hiring described one generic format for both roles, including "a quick pitch of PostHog (not a full demo)." Going through the Technical CSM round this week, it was scenario-based questions only, no demo or pitch. That's structurally closer to the Sales side's Technical Account Executive round than the Technical Account Manager round, which already gets its own subsection describing its demo component.

This splits Small Team interview into TCSM and FDE subsections, mirroring the existing TAE/TAM structure under Technical interview and demo. The TCSM description reflects what the round actually covered today. The FDE description keeps the original wording unchanged, no firsthand basis to describe that round differently.

This is a fork PR, so the Cloudflare preview build is skipped. Checked with `vale` locally instead, no new errors. The two added headings trip the same pre-existing SentenceCase warning the TAE/TAM headings already trip.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build (skipped, fork PR, see above)
- [x] N/A, no page moved