### PR TITLE
docs(web-analytics): use the recognized project token placeholder

### DIFF
--- a/contents/docs/web-analytics/sending-http-logs.mdx
+++ b/contents/docs/web-analytics/sending-http-logs.mdx
@@ -12,7 +12,7 @@ Send events to the [capture API](/docs/api/capture) like any other event. Here's
 
 ```json
 {
-  "api_key": "<ph_project_api_key>",
+  "api_key": "<ph_project_token>",
   "event": "$http_log",
   "distinct_id": "http_log_5f8ab21c93de4a7b8f0142cc93de4a7b8f01",
   "properties": {


### PR DESCRIPTION
## Changes

- The payload example on the new sending HTTP log events page now uses `<ph_project_token>` instead of `<ph_project_api_key>`, so the code-block renderer substitutes the reader's actual project token instead of showing a literal placeholder.

Addresses the Codex review comment on [#19588](https://github.com/PostHog/posthog.com/pull/19588). Stacked onto that PR's branch; merge this into it before merging #19588.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*