### PR TITLE
docs(replay-vision): document the replay-vision wizard command

### DIFF
--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -78,6 +78,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
 | `wizard mcp-analytics` | Instrument your own MCP server with [MCP Analytics](/docs/mcp-analytics) |
 | `wizard ai-observability` | Instrument your LLM calls with [AI Observability](/docs/ai-observability) |
+| `wizard replay-vision` | Create [Replay Vision](/docs/replay-vision) scanners written for your product, from your codebase |
 | `wizard migrate` | Migrate from another analytics or feature-flag vendor |
 | `wizard upload-source-maps` | Upload source maps to PostHog Error Tracking |
 | `wizard mcp add` / `wizard mcp remove` / `wizard mcp tutorial` | Manage the PostHog MCP server for your AI agent, or explore the MCP tutorial |

--- a/contents/docs/replay-vision/creating-scanners.mdx
+++ b/contents/docs/replay-vision/creating-scanners.mdx
@@ -3,6 +3,7 @@ title: Creating scanners
 ---
 
 import { ProductScreenshot } from "components/ProductScreenshot";
+import WizardCommand from 'components/WizardCommand'
 
 A scanner is made up of six things you author:
 
@@ -35,6 +36,16 @@ The shipping templates are:
 | **Create from scratch** | –          | Blank scanner – pick a type yourself                                     |
 
 Picking a template just pre-fills the form. You can change anything before saving.
+
+## Let the wizard write them
+
+Templates are generic by design. If you'd rather start from scanners that already know your product, run the wizard in your project directory:
+
+<WizardCommand command="replay-vision" />
+
+It reads your codebase and creates three scanners: a breakage monitor scoped to the URLs of your key flow, a frustration monitor gated on rage clicks, and a low-sampled summarizer that uses your product's own vocabulary. The prompts name the things that actually break in your app rather than generic web copy.
+
+These are ordinary scanners, so everything below still applies. Edit the prompt, retune the filters, or delete them.
 
 ## Writing the prompt
 

--- a/contents/docs/replay-vision/index.mdx
+++ b/contents/docs/replay-vision/index.mdx
@@ -46,6 +46,7 @@ Each of these maps to a [scanner type](/docs/replay-vision/scanner-types).
 
 ## Where to go next
 
+- **Want it set up for you?** Run `npx @posthog/wizard replay-vision` in your project directory. It reads your codebase and creates three scanners written for your product. See [getting started](/docs/replay-vision/start-here#ai-wizard).
 - **New to Replay Vision?** Walk through your [first scanner](/docs/replay-vision/start-here) end-to-end.
 - **Picking the right scanner type?** Read the [scanner types reference](/docs/replay-vision/scanner-types).
 - **Authoring a scanner?** See [creating scanners](/docs/replay-vision/creating-scanners) for prompt patterns, filters, and sampling.

--- a/contents/docs/replay-vision/start-here.mdx
+++ b/contents/docs/replay-vision/start-here.mdx
@@ -3,10 +3,23 @@ title: Getting started with Replay Vision
 ---
 
 import { ProductScreenshot } from "components/ProductScreenshot";
+import WizardCommand from 'components/WizardCommand'
 
 This walkthrough takes you from zero to your first observation in about five minutes. We'll create a scanner from a built-in template, run it on a recording you pick, and then query the result as a regular PostHog event.
 
 You should already have [Session Replay](/docs/session-replay) recording sessions for your project. Replay Vision watches those recordings – without them there's nothing to scan.
+
+## AI wizard
+
+The fastest way to get set up is our wizard. Run it in your project directory and it reads your codebase, installs the PostHog SDK if you don't have it yet, and creates three scanners written for your product: one that watches your key flow for breakage, one that watches for user frustration, and one that summarizes sessions. It also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt:
+
+<WizardCommand command="replay-vision" />
+
+The wizard sets up the client side of recording, but it doesn't flip the **Record user sessions** toggle in your project settings. Turn that on yourself if it isn't already, otherwise there are no recordings for the scanners to watch.
+
+The scanners it creates are ordinary scanners. You can edit the prompt, filters, and sampling rate afterwards, or delete them and start over.
+
+Prefer to create your first scanner by hand, or want to understand each piece? Follow the steps below.
 
 ## 1. Open Replay Vision and pick a template
 

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { getWizardFrameworkRows } from 'constants/installation-taxonomy'
 import {
     IconEye,
     IconWarning,
@@ -153,6 +154,33 @@ const featureComparisonRows = [
     feature('ai_pricing', 'AI pricing model', 'How the AI analysis is billed.'),
 ]
 
+// Platforms the `replay-vision` wizard accepts. It aborts on anything Session
+// Replay cannot record – pure backend targets and KMP – so the install CTAs
+// must not offer them. Mirrors REPLAY_VISION_SUPPORTED in PostHog/wizard.
+const WIZARD_PLATFORM_SLUGS = new Set([
+    'web',
+    'react',
+    'nextjs',
+    'nuxt',
+    'vue',
+    'angular',
+    'astro',
+    'svelte',
+    'react-router',
+    'tanstack-start',
+    'django',
+    'flask',
+    'fastapi',
+    'rails',
+    'laravel',
+    'react-native',
+    'android',
+    'ios',
+    'flutter',
+])
+
+const wizardSupports = getWizardFrameworkRows().filter((row) => WIZARD_PLATFORM_SLUGS.has(row.slug))
+
 export const replayVision = {
     Icon: IconEye,
     name: 'Replay Vision',
@@ -166,6 +194,12 @@ export const replayVision = {
     forumTopicId: 377,
     color: 'yellow',
     colorSecondary: '[#B56C00]',
+    wizardSupport: true,
+    // Wizard subcommand appended to `npx @posthog/wizard` in the hero and Get
+    // started install CTAs – the bare wizard installs the SDK without creating
+    // any scanners.
+    wizardCommand: 'replay-vision',
+    wizardSupports,
     category: 'product_engineering',
     shortDescription: 'Let AI watch your session recordings for you',
     seo: {


### PR DESCRIPTION
## Changes

The `replay-vision` wizard command shipped last week and nothing on posthog.com mentioned it. This documents it the way MCP Analytics and AI Observability document theirs.

- Getting started with Replay Vision gets an `AI wizard` section as the fast path, above the manual walkthrough.
- Creating scanners gets a section after the templates table. Templates are generic, so the pitch is that the wizard's three scanners are scoped to your real routes and vocabulary.
- The Replay Vision landing page gets one pointer in "Where to go next".
- The AI wizard page gets a commands-table row.
- `productData/replay_vision.tsx` sets `wizardSupport` and `wizardCommand`, so the product page install CTAs run the subcommand instead of the bare wizard, and Replay Vision now appears in the wizard page's supported products list.

Two things worth a reviewer's attention.

**`wizardSupports` is not optional here.** The install CTAs otherwise default to the full framework list, which includes Node.js, Ruby, Go, Java, and KMP. The command aborts on exactly those. So this filters the shared taxonomy down to the platforms in the wizard's own `REPLAY_VISION_SUPPORTED`, keeping the 18 web and mobile frameworks and dropping `kmp, python, ruby, elixir, go, java, rust`. It is an allow-list, so a newly added backend framework can never be advertised by accident.

**The docs say the wizard cannot turn on recording, because it can't.** `product-enablement-create` is still `enabled: false` in `services/mcp/definitions/core.yaml`, so the wizard sets up the client side but does not flip **Record user sessions**. On a fresh project the scanners it creates have nothing to watch until someone flips it. If that tool is enabled later, the caveat in `start-here.mdx` is the line to delete.

No screenshots. This adds prose and a rendered `<WizardCommand />` on existing pages, with no visual change beyond that.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)
