### PR TITLE
fix(docs): fall back to published Desktop pricing

### DIFF
--- a/src/components/PostHogDesktopPricing/README.md
+++ b/src/components/PostHogDesktopPricing/README.md
@@ -5,3 +5,5 @@
 The component loads a same-origin API route. That route combines and caches the public model-pricing and sandbox-pricing responses from PostHog services.
 
 When no compute rate card is published, the component shows model pricing without a cloud compute section.
+
+If the route fails or returns no models, the component shows its dated pricing snapshot so the documentation remains useful. Update the snapshot when model or compute rates change.

--- a/src/components/PostHogDesktopPricing/index.tsx
+++ b/src/components/PostHogDesktopPricing/index.tsx
@@ -46,9 +46,169 @@ const MODEL_DISPLAY_NAMES: Record<string, string> = {
     'gpt-5.6-luna': 'GPT-5.6 Luna',
     'gpt-5.5': 'GPT-5.5',
     'gpt-5.4': 'GPT-5.4',
+    'zai-org/glm-5.3': 'GLM-5.3',
     '@cf/zai-org/glm-5.2': 'GLM-5.2',
     'moonshotai/kimi-k3': 'Kimi K3',
     'deepseek-ai/deepseek-v4-flash-0731': 'DeepSeek V4 Flash',
+}
+
+const FALLBACK_PRICING: PricingResponse = {
+    models: [
+        {
+            id: 'claude-fable-5',
+            display_name: 'claude-fable-5',
+            pricing: {
+                prompt: '0.00001',
+                completion: '0.00005',
+                input_cache_read: '0.000001',
+                input_cache_write: '0.0000125',
+            },
+        },
+        {
+            id: 'claude-opus-5',
+            display_name: 'claude-opus-5',
+            pricing: {
+                prompt: '0.000005',
+                completion: '0.000025',
+                input_cache_read: '0.0000005',
+                input_cache_write: '0.00000625',
+            },
+        },
+        {
+            id: 'claude-opus-4-8',
+            display_name: 'claude-opus-4-8',
+            pricing: {
+                prompt: '0.000005',
+                completion: '0.000025',
+                input_cache_read: '0.0000005',
+                input_cache_write: '0.00000625',
+            },
+        },
+        {
+            id: 'claude-opus-4-7',
+            display_name: 'claude-opus-4-7',
+            pricing: {
+                prompt: '0.000005',
+                completion: '0.000025',
+                input_cache_read: '0.0000005',
+                input_cache_write: '0.00000625',
+            },
+        },
+        {
+            id: 'claude-sonnet-5',
+            display_name: 'claude-sonnet-5',
+            pricing: {
+                prompt: '0.000002',
+                completion: '0.00001',
+                input_cache_read: '0.0000002',
+                input_cache_write: '0.0000025',
+            },
+        },
+        {
+            id: 'claude-sonnet-4-6',
+            display_name: 'claude-sonnet-4-6',
+            pricing: {
+                prompt: '0.000003',
+                completion: '0.000015',
+                input_cache_read: '0.0000003',
+                input_cache_write: '0.00000375',
+            },
+        },
+        {
+            id: 'moonshotai/kimi-k3',
+            display_name: 'moonshotai/kimi-k3',
+            pricing: {
+                prompt: '0.000003',
+                completion: '0.000015',
+                input_cache_read: '0.0000003',
+                input_cache_write: '0.000003',
+            },
+        },
+        {
+            id: 'deepseek-ai/deepseek-v4-flash-0731',
+            display_name: 'deepseek-ai/deepseek-v4-flash-0731',
+            pricing: {
+                prompt: '0.00000013',
+                completion: '0.00000026',
+                input_cache_read: '0.000000028',
+                input_cache_write: '0.00000013',
+            },
+        },
+        {
+            id: 'gpt-5.6-sol',
+            display_name: 'gpt-5.6-sol',
+            pricing: {
+                prompt: '0.000005',
+                completion: '0.00003',
+                input_cache_read: '0.0000005',
+                input_cache_write: '0.00000625',
+            },
+        },
+        {
+            id: 'gpt-5.6-terra',
+            display_name: 'gpt-5.6-terra',
+            pricing: {
+                prompt: '0.000002',
+                completion: '0.000012',
+                input_cache_read: '0.0000002',
+                input_cache_write: '0.0000025',
+            },
+        },
+        {
+            id: 'gpt-5.6-luna',
+            display_name: 'gpt-5.6-luna',
+            pricing: {
+                prompt: '0.0000002',
+                completion: '0.0000012',
+                input_cache_read: '0.00000002',
+                input_cache_write: '0.00000025',
+            },
+        },
+        {
+            id: 'gpt-5.5',
+            display_name: 'gpt-5.5',
+            pricing: {
+                prompt: '0.000005',
+                completion: '0.00003',
+                input_cache_read: '0.0000005',
+                input_cache_write: '0.000005',
+            },
+        },
+        {
+            id: 'gpt-5.4',
+            display_name: 'gpt-5.4',
+            pricing: {
+                prompt: '0.0000025',
+                completion: '0.000015',
+                input_cache_read: '0.00000025',
+                input_cache_write: '0.0000025',
+            },
+        },
+        {
+            id: 'zai-org/glm-5.3',
+            display_name: 'zai-org/glm-5.3',
+            pricing: {
+                prompt: '0.0000014',
+                completion: '0.0000044',
+                input_cache_read: '0.00000014',
+                input_cache_write: '0.0000014',
+            },
+        },
+        {
+            id: '@cf/zai-org/glm-5.2',
+            display_name: '@cf/zai-org/glm-5.2',
+            pricing: {
+                prompt: '0.0000014',
+                completion: '0.0000044',
+                input_cache_read: null,
+                input_cache_write: null,
+            },
+        },
+    ],
+    compute: {
+        cpu_core_second_usd: '0.000075',
+        memory_gib_second_usd: '0.000008',
+    },
 }
 
 const creditsPerMillionTokens = (rate: string | null): string => {
@@ -64,20 +224,22 @@ const fetchPricing = async (url: string): Promise<PricingResponse> => {
     if (!response.ok) {
         throw new Error(`Pricing request returned ${response.status}`)
     }
-    return response.json() as Promise<PricingResponse>
+    const pricing = (await response.json()) as PricingResponse
+    if (!Array.isArray(pricing.models) || pricing.models.length === 0) {
+        throw new Error('Pricing response contains no models')
+    }
+    return pricing
 }
 
 export const PostHogDesktopPricing = (): React.ReactElement => {
-    const { data: pricing, error } = useSWR<PricingResponse>('/api/posthog-desktop-pricing', fetchPricing)
+    const { data, error } = useSWR<PricingResponse>('/api/posthog-desktop-pricing', fetchPricing)
 
-    if (error) {
-        return <p>Pricing is currently unavailable. Refresh the page to try again.</p>
-    }
-
-    if (!pricing) {
+    if (!data && !error) {
         return <p>Loading current pricing...</p>
     }
 
+    const pricing = data?.models.length ? data : FALLBACK_PRICING
+    const isFallback = pricing === FALLBACK_PRICING
     const rows = pricing.models.map((model) => ({
         key: model.id,
         cells: [
@@ -86,12 +248,9 @@ export const PostHogDesktopPricing = (): React.ReactElement => {
         ],
     }))
 
-    if (rows.length === 0) {
-        return <p>Pricing is currently unavailable. Refresh the page to try again.</p>
-    }
-
     return (
         <>
+            {isFallback && <p>Live pricing is temporarily unavailable. Showing rates published August 21, 2026.</p>}
             <OSTable columns={[{ name: 'Model' }, ...TOKEN_COLUMNS]} rows={rows} width="full" />
             {pricing.compute && (
                 <>


### PR DESCRIPTION
## Problem

The Desktop pricing documentation replaces the entire pricing table with an error whenever `/api/posthog-desktop-pricing` fails. This leaves readers with no pricing information during an API or deployment failure.

This is intentionally separate from #19629. It changes only the client-side documentation component and does not change an API function.

## Fix

- Fall back to a dated pricing snapshot if the route fails or returns no models.
- Snapshot all 15 current Desktop models and their token rates from the live gateway response.
- Include compute rate card v1: `$0.000075` per CPU core-second and `$0.000008` per GiB-second, effective August 21, 2026 at 16:00 UTC.
- Show a visible note when the fallback is active instead of claiming pricing is unavailable.
- Document that the snapshot must be updated when pricing changes.

## Verification

- Compared every fallback model ID and token rate with the current live pricing source.
- Rendered the API-error path and verified 15 model rows plus both v1 compute rates.
- Confirmed the compute rates and effective timestamp against `sandbox_pricing.py` on `PostHog/posthog` master.
- Prettier, Markdownlint, and `git diff --check` pass.
