### PR TITLE
Update Slack app docs and product page for latest features

### DIFF
--- a/contents/docs/slack/commands.mdx
+++ b/contents/docs/slack/commands.mdx
@@ -19,7 +19,13 @@ The full set of commands `@PostHog` accepts, in the same order it lists them whe
 
 For repo selection, the bot checks routing rules first. If nothing matches and you have multiple repos, it opens the in-thread picker. If you only have one repo connected, the task runs against it directly. The `project` commands only matter if your Slack workspace is connected to multiple PostHog projects.
 
-See [Pick a project](/docs/slack/setup #pick-a-project-multi-integration-workspaces).
+See [Pick a project](/docs/slack/setup#pick-a-project).
+
+## The `/posthog` slash command
+
+Every command above is also available as a `/posthog` slash command – `/posthog help`, `/posthog rules list`, `/posthog project <id>`, and so on. Bare `/posthog` shows the command list. Slash commands are for configuration only: to start a task, mention `@PostHog` or [DM the bot](/docs/slack#dm-the-bot). One difference: `/posthog rules add` needs the repo inline (`/posthog rules add "description" org/repo`) since there's no thread to open a picker in.
+
+In a DM with the bot, drop the mention instead: `project <id>`, `rules list`, etc.
 
 ## Routing rules
 
@@ -38,7 +44,8 @@ Before you lean on the Slack app, here's a list of things to know:
 
 - **Ephemeral sandbox.** Each task runs in a fresh sandbox that lives roughly six hours. Long iterations need re-prompting once it recycles.
 - **Personal GitHub auth is per user.** Every teammate who wants to ship a PR has to connect their own GitHub once. First-time setup has known rough edges.
-- **Text input only.** The agent can't read images yet – paste descriptions instead of screenshots.
+- **Attachment limits.** The agent reads images, PDFs, and plain-text attachments (logs, markdown, CSV, JSON, YAML) – up to five per message, 10 MB each. Other file types are skipped with a note.
+- **Runtime is fixed per task.** You can switch models mid-run, but only within the same runtime family (Claude or Codex). Moving to the other family means starting a new thread.
 - **500-repo cap on the picker.** If your team's GitHub install exposes more than 500 repos, the list is truncated. Add a routing rule for repos that fall off the end.
-- **Workflow timeouts.** A single mention has a 10-minute workflow timeout                                                                                              ; the repo picker times out after 15 minutes.
+- **Workflow timeouts.** A single mention has a 10-minute workflow timeout; the repo picker times out after 15 minutes.
 - **Behavior is still moving.** Prompt construction and review-bot trust heuristics are being actively iterated. Expect shifts between beta builds.

--- a/contents/docs/slack/commands.mdx
+++ b/contents/docs/slack/commands.mdx
@@ -45,7 +45,7 @@ Before you lean on the Slack app, here's a list of things to know:
 - **Ephemeral sandbox.** Each task runs in a fresh sandbox that lives roughly six hours. Long iterations need re-prompting once it recycles.
 - **Personal GitHub auth is per user.** Every teammate who wants to ship a PR has to connect their own GitHub once. First-time setup has known rough edges.
 - **Attachment limits.** The agent reads images, PDFs, and plain-text attachments (logs, markdown, CSV, JSON, YAML) – up to five per message, 10 MB each. Other file types are skipped with a note.
-- **Runtime is fixed per task.** You can switch models mid-run, but only within the same runtime family (Claude or Codex). Moving to the other family means starting a new thread.
+- **Runtime is fixed per task.** You can switch models mid-run, but only within the same runtime family (Claude or Codex). Moving to the other family requires starting a new thread.
 - **500-repo cap on the picker.** If your team's GitHub install exposes more than 500 repos, the list is truncated. Add a routing rule for repos that fall off the end.
-- **Workflow timeouts.** A single mention has a 10-minute workflow timeout; the repo picker times out after 15 minutes.
+- **Workflow timeouts.** The 10-minute timeout covers accepting a mention and starting the agent, not the task itself. A running task can keep working well past that, until its sandbox recycles. The repo picker times out after 15 minutes.
 - **Behavior is still moving.** Prompt construction and review-bot trust heuristics are being actively iterated. Expect shifts between beta builds.

--- a/contents/docs/slack/index.mdx
+++ b/contents/docs/slack/index.mdx
@@ -8,7 +8,7 @@ The PostHog Slack app is in beta. Commands, scopes, and behavior are still movin
 
 </CalloutBox>
 
-`@PostHog` brings PostHog into any Slack channel or thread. Mention the bot with a question about your product data and it answers in-thread using the PostHog [MCP](/docs/model-context-protocol). You can also send the bot a direct message – no mention needed – for a private one-on-one conversation.
+`@PostHog` brings PostHog into any Slack channel, thread, or DM. Mention the bot with a question about your product data and it answers in-thread using the PostHog [MCP](/docs/model-context-protocol). You can also send the bot a direct message – no mention needed – for a private one-on-one conversation.
 
 Mention `@PostHog` with a fix, an edit, or a feature idea and it plans the work in a sandboxed environment, edits files, runs your checks, and opens a draft PR. The same agent that powers [PostHog AI](/docs/posthog-ai) and [PostHog Desktop](/desktop), just summoned from where your team already chats.
 
@@ -18,7 +18,7 @@ classes="rounded"
 alt="A PostHog Desktop task running in a Slack thread"
 />
 
-Before you can mention the bot you'll need to [connect the integrations](/docs/slack/setup).You'll need to connect:
+Before you can mention the bot you'll need to [connect the integrations](/docs/slack/setup). You'll need to connect:
 - A Slack workspace connection for each project
 - A personal GitHub connection for each teammate who wants to ship PRs.
 
@@ -44,7 +44,7 @@ to the onboarding flow to lift the drop-off between step 2 and step 3
 
 If you have a single repo connected, the task runs against it immediately. If you have several, the bot opens a repo picker in-thread. Pick one and the task starts. The picker times out after 15 minutes ; after that, re-mention the bot to try again.
 
-Once the agent finishes, it posts a final summary of its work to the thread.
+Once the agent finishes, it posts a final summary of its work to the thread. Every reply from the bot includes a footer with links to the run on web and desktop, the model and reasoning effort used, and a **Configure** link that opens the [App Home tab](#the-app-home-tab).
 
 ## Follow-ups in a thread
 
@@ -54,7 +54,54 @@ Once the agent finishes, you can reply to it by sending a new message in the thr
 
 Anyone in the thread can send follow-ups. Each message is forwarded to the running agent as a new turn in the same conversation, so teammates can steer the run together, drop in extra context, or answer a question the agent asked.
 
-Heads up: the resulting PR is still authored under whoever started the task – their personal GitHub integration is the one wired up – so a teammate's follow-up edits land under the original requester's name. If you want the PR credited to you, start your own task.
+Follow-ups are properly multiplayer: each turn runs under the identity of whoever sent it. The agent switches to the sender's own GitHub and PostHog integrations before the turn runs, so commits and PRs land under the name of the person who actually asked for them – not the person who started the thread.
+
+### Reply without tagging the bot
+
+Once a task is running in a thread, the bot can also pick up replies that don't mention `@PostHog`. Whether it does is up to whoever started the thread – set your preference in the [App Home tab](#the-app-home-tab) under **Thread follow-ups**:
+
+| Option | What happens |
+|---|---|
+| **Leave them alone** (default) | Untagged replies are ignored – mention `@PostHog` to reach the agent |
+| **Ask them first** | If the bot thinks a reply is meant for it, it asks first with a prompt only the replier can see |
+| **Pick them up automatically** | If the bot thinks a reply is meant for it, it answers without asking |
+
+The setting applies to every reply in threads you started, including your own. The bot is deliberately conservative about what counts as "meant for it" – teammates talking to each other are left alone.
+
+## DM the bot
+
+You don't need a channel to talk to the bot – open a DM with **PostHog** and message it directly. Everything that works in a channel mention works in a DM: data questions, coding tasks, follow-ups, and attachments. It's a good place for quick tasks (or embarrassing questions) you'd rather not spam a channel with.
+
+In a DM, drop the mention from commands: `project <id>` instead of `@PostHog project <id>`.
+
+## Pick a model
+
+Tasks run on **Claude Opus 5** by default. To use a different model, just ask for it as part of your message:
+
+```
+@PostHog investigate the checkout drop-off and use fable for it
+```
+
+Any model available in [PostHog Desktop](/desktop) works, and you can request a reasoning effort the same way ("do this with max effort"). To change your default, set a personal preference in the [App Home tab](#the-app-home-tab) under **AI model** – the precedence is: model named in the message → your personal preference → the default.
+
+You can also switch models mid-run from a follow-up message, with one constraint: the runtime (Claude or Codex) is fixed once an agent starts, so moving to a model from the other family means starting a new thread. Each reply's footer shows the model and reasoning effort actually used.
+
+## Attachments, files, and canvases
+
+Attach files to your message and the agent reads them: images (PNG, JPG, GIF, WebP), PDFs, and plain-text files like logs, markdown, CSV, JSON, and YAML. Up to five attachments per message, 10 MB each.
+
+The agent can produce artifacts of its own too – uploading files back to the thread, or creating a Slack canvas when the output is a longer document.
+
+## The App Home tab
+
+Open the PostHog app's **Home** tab in Slack (or click **Configure** in the footer of any bot reply) to manage your setup in one place:
+
+- **Workspace activity** – tasks, PRs opened and merged, merge rate, and most active teammates. Visible to Slack workspace admins and owners only.
+- **Project routing** – your personal default project, plus the workspace-wide default (editable by Slack admins).
+- **AI model** – your personal model and reasoning effort preference.
+- **Thread follow-ups** – how the bot treats [untagged replies](#reply-without-tagging-the-bot) in threads you started.
+- **Linked accounts** – your PostHog account link and personal GitHub connections.
+- **Tasks** – the tasks you've started from Slack, filterable by repo and status, with links to the thread, web, and desktop.
 
 ## See Slack tasks in PostHog Desktop
 

--- a/contents/docs/slack/index.mdx
+++ b/contents/docs/slack/index.mdx
@@ -113,7 +113,6 @@ The bot reacts to your `@PostHog` message as it works through your request, so y
 
 | Emoji | What it means |
 |---|---|
-| 🌱 `:seedling:` | Saw your mention and is spinning up a new task |
 | 🔍 `:mag:` | Picking which repo to run the task against |
 | 👀 `:eyes:` | Forwarding a follow-up to the running agent, or resuming a previous run |
 | 🦔 `:hedgehog:` | The agent finished and posted its reply in the thread |

--- a/contents/docs/slack/index.mdx
+++ b/contents/docs/slack/index.mdx
@@ -10,7 +10,7 @@ The PostHog Slack app is in beta. Commands, scopes, and behavior are still movin
 
 `@PostHog` brings PostHog into any Slack channel, thread, or DM. Mention the bot with a question about your product data and it answers in-thread using the PostHog [MCP](/docs/model-context-protocol). You can also send the bot a direct message – no mention needed – for a private one-on-one conversation.
 
-Mention `@PostHog` with a fix, an edit, or a feature idea and it plans the work in a sandboxed environment, edits files, runs your checks, and opens a draft PR. The PR links back to the Slack thread it came from, so reviewers can find the original context. The same agent that powers [PostHog AI](/docs/posthog-ai) and [PostHog Desktop](/desktop), just summoned from where your team already chats.
+Mention `@PostHog` with a fix, an edit, or a feature idea and it plans the work in a sandboxed environment, edits files, runs your checks, and opens a draft PR. The PR links back to the Slack thread it came from, so reviewers can find the original context. It's the same agent that powers [PostHog AI](/docs/posthog-ai) and [PostHog Desktop](/desktop), summoned to where your team already chats.
 
 <ProductScreenshot
 imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_05_04_at_4_47_08_PM_b8ba794fdc.png"
@@ -42,7 +42,7 @@ to everyone with an @example.com email address
 to the onboarding flow to lift the drop-off between step 2 and step 3
 ```
 
-If you have a single repo connected, the task runs against it immediately. If you have several, the bot opens a repo picker in-thread. Pick one and the task starts. The picker times out after 15 minutes ; after that, re-mention the bot to try again.
+If you have a single repo connected, the task runs against it immediately. If you have several, the bot opens a repo picker in-thread. Pick one and the task starts. The picker times out after 15 minutes; after that, re-mention the bot to try again.
 
 Once the agent finishes, it posts a final summary of its work to the thread. Every reply from the bot includes a footer with links to the run on web and desktop, the model used (plus the reasoning effort, when one is set), and a **Configure** link that opens the [App Home tab](#the-app-home-tab).
 

--- a/contents/docs/slack/index.mdx
+++ b/contents/docs/slack/index.mdx
@@ -10,7 +10,7 @@ The PostHog Slack app is in beta. Commands, scopes, and behavior are still movin
 
 `@PostHog` brings PostHog into any Slack channel, thread, or DM. Mention the bot with a question about your product data and it answers in-thread using the PostHog [MCP](/docs/model-context-protocol). You can also send the bot a direct message – no mention needed – for a private one-on-one conversation.
 
-Mention `@PostHog` with a fix, an edit, or a feature idea and it plans the work in a sandboxed environment, edits files, runs your checks, and opens a draft PR. The same agent that powers [PostHog AI](/docs/posthog-ai) and [PostHog Desktop](/desktop), just summoned from where your team already chats.
+Mention `@PostHog` with a fix, an edit, or a feature idea and it plans the work in a sandboxed environment, edits files, runs your checks, and opens a draft PR. The PR links back to the Slack thread it came from, so reviewers can find the original context. The same agent that powers [PostHog AI](/docs/posthog-ai) and [PostHog Desktop](/desktop), just summoned from where your team already chats.
 
 <ProductScreenshot
 imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_05_04_at_4_47_08_PM_b8ba794fdc.png"
@@ -44,7 +44,7 @@ to the onboarding flow to lift the drop-off between step 2 and step 3
 
 If you have a single repo connected, the task runs against it immediately. If you have several, the bot opens a repo picker in-thread. Pick one and the task starts. The picker times out after 15 minutes ; after that, re-mention the bot to try again.
 
-Once the agent finishes, it posts a final summary of its work to the thread. Every reply from the bot includes a footer with links to the run on web and desktop, the model and reasoning effort used, and a **Configure** link that opens the [App Home tab](#the-app-home-tab).
+Once the agent finishes, it posts a final summary of its work to the thread. Every reply from the bot includes a footer with links to the run on web and desktop, the model used (plus the reasoning effort, when one is set), and a **Configure** link that opens the [App Home tab](#the-app-home-tab).
 
 ## Follow-ups in a thread
 
@@ -55,6 +55,8 @@ Once the agent finishes, you can reply to it by sending a new message in the thr
 Anyone in the thread can send follow-ups. Each message is forwarded to the running agent as a new turn in the same conversation, so teammates can steer the run together, drop in extra context, or answer a question the agent asked.
 
 Follow-ups are properly multiplayer: each turn runs under the identity of whoever sent it. The agent switches to the sender's own GitHub and PostHog integrations before the turn runs, so commits and PRs land under the name of the person who actually asked for them – not the person who started the thread.
+
+If a teammate sends a follow-up without a [personal GitHub connection](/docs/slack/setup), the agent can't fetch, push, or open PRs on their turn. It replies with a link to connect GitHub, and the rest of the conversation carries on as normal.
 
 ### Reply without tagging the bot
 
@@ -72,6 +74,8 @@ The setting applies to every reply in threads you started, including your own. T
 
 You don't need a channel to talk to the bot – open a DM with **PostHog** and message it directly. Everything that works in a channel mention works in a DM: data questions, coding tasks, follow-ups, and attachments. It's a good place for quick tasks (or embarrassing questions) you'd rather not spam a channel with.
 
+Group DMs work too – start one with the bot and your teammates as members. What you can't do is mention the bot in an existing DM it isn't part of: it can't see or join those conversations.
+
 In a DM, drop the mention from commands: `project <id>` instead of `@PostHog project <id>`.
 
 ## Pick a model
@@ -84,7 +88,7 @@ Tasks run on **Claude Opus 5** by default. To use a different model, just ask fo
 
 Any model available in [PostHog Desktop](/desktop) works, and you can request a reasoning effort the same way ("do this with max effort"). To change your default, set a personal preference in the [App Home tab](#the-app-home-tab) under **AI model** – the precedence is: model named in the message → your personal preference → the default.
 
-You can also switch models mid-run from a follow-up message, with one constraint: the runtime (Claude or Codex) is fixed once an agent starts, so moving to a model from the other family means starting a new thread. Each reply's footer shows the model and reasoning effort actually used.
+You can also switch models mid-run from a follow-up message, with one constraint: the runtime (Claude or Codex) is fixed once an agent starts, so moving to a model from the other family requires starting a new thread. For example, you can go from Opus to Fable mid-run, but not from a Claude model to a Codex one. Each reply's footer shows the model and reasoning effort actually used.
 
 ## Attachments, files, and canvases
 

--- a/contents/docs/slack/setup.mdx
+++ b/contents/docs/slack/setup.mdx
@@ -25,7 +25,15 @@ Head to the [**Slack integration page**](https://app.posthog.com/integrations/sl
   alt="The Slack integration section in project settings, with the Add to Slack button"
 />
 
-To talk to the bot in a channel, @-mention it – Slack will prompt you to invite it – or invite it explicitly with `/invite @PostHog`. The first time it sees a mention, it matches your Slack email to your PostHog account, so make sure you're signed in to the same org on both sides.
+To talk to the bot in a channel, @-mention it – Slack will prompt you to invite it – or invite it explicitly with `/invite @PostHog`. When it joins a channel it posts a short welcome with example prompts, and new teammates joining the workspace get a welcome DM introducing the bot. You can also skip channels entirely and [DM the bot directly](/docs/slack#dm-the-bot).
+
+The first time the bot sees a mention, it matches your Slack email to your PostHog account, so make sure you're signed in to the same org on both sides.
+
+<CalloutBox icon="IconInfo" title="Slack email doesn't match your PostHog email?" type="fyi">
+
+Link the accounts instead. When email matching fails, the bot replies with a **Link my PostHog account** button – click it and sign in with Slack to connect the two. You can also link (or unlink) anytime from the App Home tab under **Linked accounts**, or from [Settings → Personal integrations](https://app.posthog.com/settings/user-personal-integrations) in PostHog. A linked account always wins over email matching.
+
+</CalloutBox>
 
 <CalloutBox icon="IconInfo" title="Slack Connect channels require one-time approval" type="fyi">
 
@@ -87,6 +95,8 @@ Pick a project once and the bot remembers it for you across channels and threads
 | `@PostHog project`                | Show which PostHog project your mentions route to in this workspace, and list the alternatives |
 | `@PostHog project <id>`           | Set the PostHog project your mentions route to in this workspace                               |
 | `@PostHog project workspace <id>` | Set the workspace-wide default project (Slack admins/owners only)                              |
+
+The same commands are available as the `/posthog` slash command (e.g. `/posthog project <id>`) – handy in channels where you don't want to ping the bot – and in a DM you drop the mention entirely: `project <id>`. You can also manage your personal default and the workspace default from the App Home tab under **Project routing**.
 
 The bot resolves a target with this precedence: thread context (continuing an existing task) → your personal default → workspace-wide default (set with `@PostHog project workspace <id>` by a Slack admin) → the only connected project → picker. Personal defaults always win over the workspace fallback, so each teammate can route their own mentions independently.
 

--- a/contents/docs/slack/setup.mdx
+++ b/contents/docs/slack/setup.mdx
@@ -25,7 +25,7 @@ Head to the [**Slack integration page**](https://app.posthog.com/integrations/sl
   alt="The Slack integration section in project settings, with the Add to Slack button"
 />
 
-To talk to the bot in a channel, @-mention it – Slack will prompt you to invite it – or invite it explicitly with `/invite @PostHog`. When it joins a channel it posts a short welcome with example prompts, and new teammates joining the workspace get a welcome DM introducing the bot. You can also skip channels entirely and [DM the bot directly](/docs/slack#dm-the-bot).
+To talk to the bot in a channel, @-mention it – Slack will prompt you to invite it – or invite it explicitly with `/invite @PostHog`. When it joins a channel it posts a short greeting with example prompts. When new teammates join your Slack workspace, they get a welcome DM from the bot introducing itself and what it can do. You can also skip channels entirely and [DM the bot directly](/docs/slack#dm-the-bot).
 
 The first time the bot sees a mention, it matches your Slack email to your PostHog account, so make sure you're signed in to the same org on both sides.
 
@@ -96,7 +96,7 @@ Pick a project once and the bot remembers it for you across channels and threads
 | `@PostHog project <id>`           | Set the PostHog project your mentions route to in this workspace                               |
 | `@PostHog project workspace <id>` | Set the workspace-wide default project (Slack admins/owners only)                              |
 
-The same commands are available as the `/posthog` slash command (e.g. `/posthog project <id>`) – handy in channels where you don't want to ping the bot – and in a DM you drop the mention entirely: `project <id>`. You can also manage your personal default and the workspace default from the App Home tab under **Project routing**.
+The same commands are available as the `/posthog` slash command (e.g. `/posthog project <id>`). Unlike an @-mention, a slash command is visible only to you, so you can change your routing without posting a message everyone in the channel sees. In a DM you drop the mention entirely: `project <id>`. You can also manage your personal default and the workspace default from the App Home tab under **Project routing**.
 
 The bot resolves a target with this precedence: thread context (continuing an existing task) → your personal default → workspace-wide default (set with `@PostHog project workspace <id>` by a Slack admin) → the only connected project → picker. Personal defaults always win over the workspace fallback, so each teammate can route their own mentions independently.
 

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -479,7 +479,7 @@ const compareRows: CompareRow[] = [
     {
         label: 'Models',
         ai: "Auto-picked from OpenAI and Anthropic (we tune so you don't have to).",
-        slack: 'Auto-picked from OpenAI and Anthropic.',
+        slack: 'Defaults to Claude Opus 5. Ask for another model right in your message ("use fable for this"), or set a personal default in the App Home tab.',
         code: 'You pick: Claude Code or Codex, with reasoning effort dialed in per task.',
     },
 ]
@@ -596,8 +596,19 @@ const faqItems = [
         trigger: 'Does the PostHog Slack app work in DMs?',
         content: (
             <p>
-                No. But if you want to @PostHog for quick tasks (or embarrassing questions) without spamming your team,
-                you can add it to a private channel with just you and the bot.
+                Yes. DM the bot directly for quick tasks (or embarrassing questions) without spamming your team –
+                everything that works in a channel mention works in a DM: data questions, coding tasks, follow-ups, and
+                attachments.
+            </p>
+        ),
+    },
+    {
+        trigger: 'Do I have to tag the bot on every message?',
+        content: (
+            <p>
+                Only to start. Once a task is running in a thread, the bot can pick up untagged replies too – whoever
+                started the thread chooses between "leave them alone" (the default), "ask them first", and "pick them up
+                automatically" in the App Home tab.
             </p>
         ),
     },
@@ -642,7 +653,8 @@ const faqItems = [
                         is rougher than it should be.
                     </li>
                     <li>
-                        No screenshot input yet – the bot reads text only. Paste descriptions instead of images for now.
+                        Attachments are capped at five per message, 10 MB each – images, PDFs, and plain-text files
+                        only.
                     </li>
                     <li>
                         Prompt construction and review-bot trust heuristics are being actively iterated. Behavior may
@@ -764,7 +776,10 @@ export default function SlackAppPage(): JSX.Element {
                     />
                     <p>You don't need to know any of this to use it. But here's what happens after you hit send:</p>
                     <ol>
-                        <li>The agent scans the thread for relevant content (text only, for now).</li>
+                        <li>
+                            The agent scans the thread for relevant content – including attached images, PDFs, and text
+                            files.
+                        </li>
                         <li>It plans the work, edits files, and runs checks inside a sandboxed environment.</li>
                         <li>It opens a draft PR with a detailed description, and links it back into the thread.</li>
                         <li>

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -596,10 +596,10 @@ const faqItems = [
         trigger: 'Does the PostHog Slack app work in DMs?',
         content: (
             <p>
-                Yes. DM the bot directly for quick tasks (or embarrassing questions) without spamming your team –
-                everything that works in a channel mention works in a DM: data questions, coding tasks, follow-ups, and
-                attachments. You can also start a group DM that includes the bot to work with teammates. The only thing
-                that doesn't work is mentioning it in an existing DM it isn't part of – it can't see or join those.
+                Yes. Everything that works in a channel mention works in a DM: data questions, coding tasks, follow-ups,
+                and attachments. To bring the bot into a DM with one or more colleagues, start a new conversation with
+                @PostHog and one or more of your peers (the agent can't be added to existing DMs). To DM the bot
+                privately, you can do so in the Chat tab of the app.
             </p>
         ),
     },

--- a/src/pages/slack/index.tsx
+++ b/src/pages/slack/index.tsx
@@ -598,7 +598,8 @@ const faqItems = [
             <p>
                 Yes. DM the bot directly for quick tasks (or embarrassing questions) without spamming your team –
                 everything that works in a channel mention works in a DM: data questions, coding tasks, follow-ups, and
-                attachments.
+                attachments. You can also start a group DM that includes the bot to work with teammates. The only thing
+                that doesn't work is mentioning it in an existing DM it isn't part of – it can't see or join those.
             </p>
         ),
     },
@@ -606,9 +607,10 @@ const faqItems = [
         trigger: 'Do I have to tag the bot on every message?',
         content: (
             <p>
-                Only to start. Once a task is running in a thread, the bot can pick up untagged replies too – whoever
-                started the thread chooses between "leave them alone" (the default), "ask them first", and "pick them up
-                automatically" in the App Home tab.
+                Only to start. Once a task is running in a thread, the bot can pick up untagged replies too. In the App
+                Home tab, you can choose how it handles them: "leave them alone" (the default), "ask them first", or
+                "pick them up automatically". The setting of the person who started the thread applies to every reply in
+                it.
             </p>
         ),
     },


### PR DESCRIPTION
## Changes

Updates the Slack app docs (`/docs/slack`) and product page (`/slack`) to cover the features announced internally in #team-self-driving (Aug 5, Aug 11, and Aug 18 updates), verified against the current implementation in `PostHog/posthog` (`products/slack_app/`).

### Docs

**`/docs/slack` (index):**
- Multiplayer: replaced the outdated "PRs are authored by whoever started the task" note – each turn now runs under the sender's own GitHub and PostHog identity.
- New **Reply without tagging the bot** section: the thread creator's Home tab setting with the three modes – *Leave them alone* (default), *Ask them first*, *Pick them up automatically*.
- New **DM the bot** section.
- New **Pick a model** section: default is Claude Opus 5, ask for a model/effort in the message, personal default in the Home tab, runtime (Claude/Codex) fixed per task.
- New **Attachments, files, and canvases** section: readable types (images, PDFs, text files), 5 files / 10 MB limits, plus file and canvas creation.
- New **App Home tab** section: workspace activity (admins), project routing, AI model, thread follow-ups, linked accounts, tasks list.
- Mentioned the reply footer (web/desktop links, model + reasoning, Configure).

**`/docs/slack/setup`:**
- OAuth account linking callout for when the Slack email doesn't match the PostHog email.
- Channel welcome + new-teammate welcome DM mention.
- `/posthog` slash command and DM command form in the project step.
- Fixed the broken "Pick a project" anchor link referenced from the commands page.

**`/docs/slack/commands`:**
- New `/posthog` slash command section (config-only, `rules add` needs repo inline).
- Limitations: removed "text input only" and "DMs coming soon"; added attachment limits and the fixed-runtime-per-task constraint; fixed stray whitespace.

### Product page (`/slack`)

- DM FAQ: "No" → "Yes".
- New FAQ on untagged thread replies.
- Limitations FAQ: "no screenshot input" → attachment limits.
- "A typical run" step 1: no longer text-only.
- Compare table "Models" row: defaults to Claude Opus 5, per-message override, Home tab personal default.

## Notes for review

- Several of these features are behind feature flags (`slack-app-assistant`, `slack-app-home`, `slack-app-oauth`, `slack-app-model-classifier`, `posthog-slack-app-untagged-thread-followups`, `slack-app-canvas-file-artifacts`) that were team-2-only as of Aug 11 with GA planned for the following week. Please confirm rollout status before merging.
- Kept as draft for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)