### PR TITLE
Fix cart badge hover outline rendering

### DIFF
--- a/src/components/NotificationBadge/README.md
+++ b/src/components/NotificationBadge/README.md
@@ -73,5 +73,5 @@ If you render this component conditionally yourself, do the same: keep it mounte
 ## Notes
 
 - The number is `aria-hidden`; a `sr-only` sibling reads out "3 unread" (or just "unread" with no count) so the count is not announced as a bare digit next to the link label.
-- The `ring-[1.5px] ring-white` outline keeps the badge readable on dark wallpapers and on top of a glyph.
+- The white outline is real badge background + padding, not a CSS ring. This keeps the outline and colored center in the same transformed layer during desktop icon hover animations.
 - An **inline** wrapper does not work: absolute children of an inline element anchor to the text line box, so the badge lands near the baseline instead of the icon's top corner. Use `inline-flex` (or `block`) on the wrapper.

--- a/src/components/NotificationBadge/index.tsx
+++ b/src/components/NotificationBadge/index.tsx
@@ -19,6 +19,8 @@ const COLORS: Record<NotificationBadgeColor, string> = {
     salmon: 'bg-salmon text-white',
 }
 
+const BADGE_OUTLINE_PX = 1.5
+
 export interface NotificationBadgeProps {
     /**
      * Unread count. Omit it for a plain badge with no number. A count of 0 or
@@ -79,9 +81,16 @@ export default function NotificationBadge({ count, max = 99, color = 'red', clas
                     initial="hidden"
                     animate="shown"
                     exit="hidden"
-                    className={`absolute -top-0.5 -right-0.5 z-10 flex items-center justify-center min-w-[12px] h-[12px] px-[2px] rounded-full ring-[1.5px] ring-white text-[8px] font-bold leading-none tabular-nums ${COLORS[color]} ${className}`}
+                    className={`absolute -top-[3.5px] -right-[3.5px] z-10 inline-flex items-center justify-center rounded-full bg-white ${className}`}
+                    style={{
+                        padding: BADGE_OUTLINE_PX,
+                    }}
                 >
-                    {display && <span aria-hidden="true">{display}</span>}
+                    <span
+                        className={`flex min-w-[12px] h-[12px] items-center justify-center rounded-full px-[2px] text-[8px] font-bold leading-none tabular-nums ${COLORS[color]}`}
+                    >
+                        {display && <span aria-hidden="true">{display}</span>}
+                    </span>
                     <span className="sr-only">{display ? `${display} unread` : 'unread'}</span>
                 </motion.span>
             )}


### PR DESCRIPTION
## Changes

Replaces the cart notification badge's CSS ring with a real white outer badge background and inner colored badge body. This keeps the outline and center moving together during desktop icon hover transforms.

**Why**

The cart badge outline could visually drift from the red badge body on some displays when the desktop icon hover animation moved the icon.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in vercel.json

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*