### PR TITLE
fix: display options bug when clicking active toggle

### DIFF
--- a/src/components/RadixUI/ToggleGroup.tsx
+++ b/src/components/RadixUI/ToggleGroup.tsx
@@ -35,6 +35,12 @@ export const ToggleGroup = ({
 }: ToggleGroupProps) => {
     const defaultValue = value ? options.find((option) => option.default)?.value || options[0]?.value : undefined
 
+    // Radix emits '' when the active item is clicked again; ignore that deselect
+    const handleValueChange = (newValue: string) => {
+        if (!newValue) return
+        onValueChange(newValue)
+    }
+
     return (
         <>
             {!hideTitle && <label className="pt-1.5 text-[15px] block mb-1">{title}</label>}
@@ -46,7 +52,7 @@ export const ToggleGroup = ({
                 data-scheme="primary"
                 defaultValue={defaultValue}
                 aria-label={title}
-                onValueChange={onValueChange}
+                onValueChange={handleValueChange}
                 value={value}
             >
                 {options.map((option) => (

--- a/src/pages/display-options.tsx
+++ b/src/pages/display-options.tsx
@@ -200,6 +200,7 @@ export default function DisplayOptions() {
     const [previewScreensaver, setPreviewScreensaver] = useState(false)
 
     const handleColorModeChange = (value: string) => {
+        if (!value) return
         if (typeof window !== 'undefined' && (window as any).__setPreferredTheme) {
             const newTheme = window.__setPreferredTheme(value)
             updateSiteSettings({


### PR DESCRIPTION
## Changes

accidentally clicked the active toggle when I was switching to dark mode and found this bug:

https://github.com/user-attachments/assets/f2c266e2-60e8-40d6-8b2f-436462d6e2de

this fixes it by ignoring the re-select

fix:

https://github.com/user-attachments/assets/884d1f40-ffdf-4a0e-b450-fbf3d2781500

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
