### PR TITLE
Fix desktop cart badge hover rendering

### DIFF
--- a/src/components/NotificationBadge/index.tsx
+++ b/src/components/NotificationBadge/index.tsx
@@ -79,7 +79,7 @@ export default function NotificationBadge({ count, max = 99, color = 'red', clas
                     initial="hidden"
                     animate="shown"
                     exit="hidden"
-                    className={`absolute -top-0.5 -right-0.5 z-10 flex items-center justify-center min-w-[12px] h-[12px] px-[2px] rounded-full ring-[1.5px] ring-white text-[8px] font-bold leading-none tabular-nums ${COLORS[color]} ${className}`}
+                    className={`absolute -top-1 -right-1 z-10 box-border flex h-[15px] min-w-[15px] origin-center transform-gpu items-center justify-center rounded-full border-[1.5px] border-white px-[3px] text-[8px] font-bold leading-none tabular-nums will-change-transform ${COLORS[color]} ${className}`}
                 >
                     {display && <span aria-hidden="true">{display}</span>}
                     <span className="sr-only">{display ? `${display} unread` : 'unread'}</span>


### PR DESCRIPTION
## Changes

- Paint the notification badge outline as a real border on the badge element instead of a separate ring shadow.
- Preserve the badge's visual footprint so the red center and white outline move as one layer during desktop icon hover transforms.

**Why**

The cart badge could show a monitor-dependent compositing artifact where the white outline appeared to move separately from the red badge body after hover. Keeping the outline and fill on the same painted element avoids that split rendering path.

## Checklist

- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*