### PR TITLE
Fix cart badge border compositing on hover

### DIFF
--- a/src/components/NotificationBadge/README.md
+++ b/src/components/NotificationBadge/README.md
@@ -73,5 +73,5 @@ If you render this component conditionally yourself, do the same: keep it mounte
 ## Notes
 
 - The number is `aria-hidden`; a `sr-only` sibling reads out "3 unread" (or just "unread" with no count) so the count is not announced as a bare digit next to the link label.
-- The `ring-[1.5px] ring-white` outline keeps the badge readable on dark wallpapers and on top of a glyph.
+- The `border-[1.5px] border-white` outline keeps the badge readable on dark wallpapers and on top of a glyph. It is a border rather than a shadow-based Tailwind ring so browsers paint it in the same layer as the badge background during icon hover animations.
 - An **inline** wrapper does not work: absolute children of an inline element anchor to the text line box, so the badge lands near the baseline instead of the icon's top corner. Use `inline-flex` (or `block`) on the wrapper.

--- a/src/components/NotificationBadge/index.tsx
+++ b/src/components/NotificationBadge/index.tsx
@@ -79,7 +79,7 @@ export default function NotificationBadge({ count, max = 99, color = 'red', clas
                     initial="hidden"
                     animate="shown"
                     exit="hidden"
-                    className={`absolute -top-0.5 -right-0.5 z-10 flex items-center justify-center min-w-[12px] h-[12px] px-[2px] rounded-full ring-[1.5px] ring-white text-[8px] font-bold leading-none tabular-nums ${COLORS[color]} ${className}`}
+                    className={`absolute -top-[3.5px] -right-[3.5px] z-10 flex items-center justify-center min-w-[15px] h-[15px] px-[2px] rounded-full border-[1.5px] border-white text-[8px] font-bold leading-none tabular-nums ${COLORS[color]} ${className}`}
                 >
                     {display && <span aria-hidden="true">{display}</span>}
                     <span className="sr-only">{display ? `${display} unread` : 'unread'}</span>


### PR DESCRIPTION
## Executive summary

This change paints the cart badge outline as a border. The browser now paints the outline and the red fill in one layer. This prevents the outline from moving separately during the desktop icon hover animation.

The badge keeps the same red area and total size.

<details>
<summary>🔍 Reviewer’s guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Dependencies | `pnpm install --frozen-lockfile` | Installation completed. The repository reports that Node 24 does not match its Node 22 requirement. |
| Formatting | `pnpm exec prettier --write src/components/NotificationBadge/index.tsx src/components/NotificationBadge/README.md` | Formatting completed with no file changes. |
| Dev server | `NODE_OPTIONS=--max_old_space_size=16384 pnpm start` | The home desktop loaded at `http://localhost:8001/`. Gatsby reported existing local credential and content warnings. |
| Responsive visual check | Headless Chromium at 640 × 860 and 1440 × 900, with a 1.25 device scale factor | The Store badge rendered in its hover state at both widths. |
| Theme visual check | Headless Chromium in light and dark modes | The Store badge rendered in both modes. |
| Browser console | Compared all four before states with all four after states | The error sets matched. This change adds no browser errors. |
| Whitespace | `git diff --check` | No errors. |

**Not tested:** The production build was not run. The local development build completed. The screenshots are captured, but the GitHub attachment endpoint rejects the available GitHub App token. The PR must remain a draft until the eight images are attached.

### Screenshots

The required before/after images exist for light and dark modes at narrow and wide widths. The current GitHub App token cannot upload user attachments. No screenshot cell is included until each image has a public GitHub attachment URL.

### What to look at

1. **[`src/components/NotificationBadge/index.tsx:82`](https://github.com/PostHog/posthog.com/blob/38efbe0549c47473968ff685c898969a8b907262/src/components/NotificationBadge/index.tsx#L82)** — The new border changes the CSS box. Check that the 15 px border box preserves the previous 12 px red area and 15 px total footprint. A mistake changes every `NotificationBadge`, not only the Store badge.

</details>

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*