### PR TITLE
docs(provisioning): document contacts and that requires_auth is terminal

### DIFF
--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -76,6 +76,7 @@ Create a JSON file at a stable HTTPS URL, for example `https://yourapp.com/.well
   "token_endpoint_auth_method": "none",
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
+  "contacts": ["integrations@yourapp.com"],
   "com.posthog": {
     "provisioning": true
   }
@@ -88,6 +89,7 @@ Requirements:
 - **`com.posthog.provisioning`** must be `true` to use the provisioning API. Your `client_id` is a public URL, so a request that names it proves nothing about who sent it. Declaring the opt-in in the document, which only you can publish, is what grants your app provisioning access. It must be the JSON literal `true`, not the string `"true"`.
 - **`redirect_uris`** is required and must contain at least one HTTPS URI. This is where PostHog redirects existing users during the consent flow.
 - **`logo_uri`** (optional) must be HTTPS if provided.
+- **`contacts`** (optional) is a list of up to 5 email addresses for whoever runs the integration. Add one. It is how PostHog reaches you if your client starts failing, and a shared address such as `integrations@yourapp.com` outlasts any one engineer. Addresses PostHog cannot parse are ignored.
 - **`token_endpoint_auth_method`** must be `"none"` (a public client, no client secret) or `"private_key_jwt"` with an HTTPS `jwks_uri`. With `private_key_jwt`, your app authenticates by signing an assertion with your own key, which also raises your [rate limits](#rate-limits).
 - The document must be served with `Content-Type: application/json` and be under 5 KB.
 - The URL must use HTTPS, include a path component, and must not contain query parameters or fragments.
@@ -306,6 +308,8 @@ The user receives a welcome email with a link to set their password and access t
 ```
 
 When `type` is `requires_auth`, redirect the user to the provided URL. After they approve, PostHog redirects them to your `redirect_uris` with a `code` query parameter that you use in step 2.
+
+> **Note:** `requires_auth` is a final answer, not a retryable error. The email already belongs to a PostHog user, so we cannot link the account until that person approves it. The same request returns `requires_auth` every time until they do, and retrying it makes no progress. In an automated test suite with nobody to approve, use a new email address per run, or complete the consent redirect once and reuse the tokens it returns.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Changes

One partner sent `requires_auth` requests to the account request endpoint in a loop, hundreds of times in one afternoon. The endpoint returned the same answer every time.

The docs caused this. They tell the integrator to redirect the user to the URL in the response, and they stop there. They do not state that the response repeats until a person approves the request, so a retry makes no progress. They also say nothing about an automated test run, where no person is present to approve. A reader of that page can reasonably treat the response as a temporary error.

This PR makes two additions:

- A note under the existing-user response. It states that `requires_auth` is a final answer and not a retryable error. It also states what to do in a test suite that has no user to approve the request.
- The `contacts` field in the metadata document requirements. [feat(provisioning): store contacts from a client's metadata document](https://github.com/PostHog/posthog/pull/87223) makes PostHog read that field.

No page moved, so this PR needs no redirect.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

Authored with Claude Code (Opus 5). Session: https://claude.ai/code/session_018b3WRCLSJaTp567RnzijCW

Skills invoked: `/unambiguous-agent-text`.
