### PR TITLE
docs(replay-vision): the wizard turns Session Replay on now

### DIFF
--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -78,7 +78,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
 | `wizard mcp-analytics` | Instrument your own MCP server with [MCP Analytics](/docs/mcp-analytics) |
 | `wizard ai-observability` | Instrument your LLM calls with [AI Observability](/docs/ai-observability) |
-| `wizard replay-vision` | Create [Replay Vision](/docs/replay-vision) scanners written for your product, from your codebase |
+| `wizard replay-vision` | Turn on Session Replay and create [Replay Vision](/docs/replay-vision) scanners written for your product |
 | `wizard migrate` | Migrate from another analytics or feature-flag vendor |
 | `wizard upload-source-maps` | Upload source maps to PostHog Error Tracking |
 | `wizard mcp add` / `wizard mcp remove` / `wizard mcp tutorial` | Manage the PostHog MCP server for your AI agent, or explore the MCP tutorial |

--- a/contents/docs/replay-vision/start-here.mdx
+++ b/contents/docs/replay-vision/start-here.mdx
@@ -11,11 +11,9 @@ You should already have [Session Replay](/docs/session-replay) recording session
 
 ## AI wizard
 
-The fastest way to get set up is our wizard. Run it in your project directory and it reads your codebase, installs the PostHog SDK if you don't have it yet, and creates three scanners written for your product: one that watches your key flow for breakage, one that watches for user frustration, and one that summarizes sessions. It also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt:
+The fastest way to get set up is our wizard. Run it in your project directory and it reads your codebase, installs the PostHog SDK if you don't have it yet, turns Session Replay on, and creates three scanners written for your product: one that watches your key flow for breakage, one that watches for user frustration, and one that summarizes sessions. It also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt:
 
 <WizardCommand command="replay-vision" />
-
-The wizard sets up the client side of recording, but it doesn't flip the **Record user sessions** toggle in your project settings. Turn that on yourself if it isn't already, otherwise there are no recordings for the scanners to watch.
 
 The scanners it creates are ordinary scanners. You can edit the prompt, filters, and sampling rate afterwards, or delete them and start over.
 


### PR DESCRIPTION
## Changes

The `replay-vision` wizard can now turn Session Replay on by itself, so the docs no longer need to tell people to do it by hand.

- Removes the caveat on [Getting started with Replay Vision](https://posthog.com/docs/replay-vision/start-here) that said the wizard sets up the client side but leaves **Record user sessions** to you.
- Says instead that the wizard turns Session Replay on, alongside installing the SDK and creating the scanners.
- Restores the same claim in the commands table on the AI wizard page, which was softened for the same reason.

Background: the wizard's enable-replay step calls a `products-enable` MCP tool, but no tool of that name was ever served, so the step degraded to a recorded follow-up telling the user to flip the toggle. PostHog/posthog#86979 exposes it and PostHog/posthog#87089 lets non-admin members use it. Both are merged.

> [!NOTE]
> This describes behavior that is merged but may not have reached production yet. Worth holding until it has deployed.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)
