### PR TITLE
docs: give runtime detection its own section on the flags API page

### DIFF
--- a/contents/docs/api/flags.mdx
+++ b/contents/docs/api/flags.mdx
@@ -10,6 +10,8 @@ It is a POST-only public endpoint that uses your [project token](https://app.pos
 
 > **Note:** Make sure to send API requests to the correct domain. These are `https://us.i.posthog.com` for US Cloud, `https://eu.i.posthog.com` for EU Cloud, and your self-hosted domain for self-hosted instances. Confirm yours by checking your URL from your PostHog instance.
 
+`/flags` does not return all the flags in your project. PostHog filters the response by each flag's [evaluation runtime](#runtime-detection) and by the [evaluation contexts](#evaluation-contexts) that you send. PostHog detects the runtime from your request headers and user-agent, not from the request body. If a flag that you expect is missing from the response, examine these two filters first.
+
 import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx'
 
 <APIFeatureFlagsCode />

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -96,172 +96,7 @@ sendFlagsRequest();
 
 > **Note:** The `groups` key is only required for group-based feature flags. If you use it, replace `group_type` and `group_id` with the values for your group such as `company: "Twitter"`.
 
-#### Using evaluation context tags and runtime filtering without SDKs
-
-When making direct API calls to the `/flags` endpoint, you can control which flags are evaluated using evaluation context tags and runtime filtering.
-
-##### Evaluation contexts
-
-To filter flags by evaluation context, include the `evaluation_contexts` field in your request body:
-
-> **Note:** The legacy parameter `evaluation_environments` is also supported for backward compatibility.
-
-<MultiLanguage>
-
-```shell
-curl -v -L --header "Content-Type: application/json" -d '  {
-    "api_key": "<ph_project_token>",
-    "distinct_id": "distinct_id_of_your_user",
-    "evaluation_contexts": ["production", "web"]
-}' "<ph_client_api_host>/flags?v=2"
-```
-
-```python
-import requests
-import json
-
-url = "<ph_client_api_host>/flags?v=2"
-headers = {
-    "Content-Type": "application/json"
-}
-payload = {
-    "api_key": "<ph_project_token>",
-    "distinct_id": "user distinct id",
-    "evaluation_contexts": ["production", "web"]
-}
-response = requests.post(url, headers=headers, data=json.dumps(payload))
-print(response.json())
-```
-
-```javascript
-const response = await fetch("<ph_client_api_host>/flags?v=2", {
-    method: "POST",
-    headers: {
-        "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-        api_key: "<ph_project_token>",
-        distinct_id: "user-distinct-id",
-        evaluation_contexts: ["production", "web"]
-    }),
-});
-const data = await response.json();
-```
-
-</MultiLanguage>
-
-Only flags where at least one evaluation tag matches (or flags with no tags at all) will be returned. For example:
-- Flag with evaluation context tags `["production", "api", "backend"]` + request with `["production", "web"]` = ✅ Flag evaluates ("production" matches)
-- Flag with evaluation context tags `["staging", "api"]` + request with `["production", "web"]` = ❌ Flag doesn't evaluate (no tags match)
-- Flag with evaluation context tags `["web", "mobile"]` + request with `["production", "web"]` = ✅ Flag evaluates ("web" matches)
-- Flag with no evaluation context tags = ✅ Always evaluates (backward compatibility)
-
-##### Runtime detection
-
-Evaluation runtime (server vs. client) is automatically detected based on your request headers and user-agent. This determines which flags are available based on their runtime setting (server-only, client-only, or all).
-
-**How runtime is detected:**
-
-1. **User-Agent patterns** - The system analyzes the User-Agent header:
-   - **Client-side patterns**: `Mozilla/`, `Chrome/`, `Safari/`, `Firefox/`, `Edge/` (browsers), or mobile SDKs like `posthog-android/`, `posthog-ios/`, `posthog-react-native/`, `posthog-flutter/`
-   - **Server-side patterns**: `posthog-python/`, `posthog-ruby/`, `posthog-php/`, `posthog-java/`, `posthog-go/`, `posthog-node/`, `posthog-dotnet/`, `posthog-elixir/`, `python-requests/`, `curl/`
-
-2. **Browser-specific headers** - Presence of these headers indicates client-side:
-   - `Origin` header
-   - `Referer` header  
-   - `Sec-Fetch-Mode` header
-   - `Sec-Fetch-Site` header
-
-3. **Default behavior** - If runtime can't be determined, the system includes flags with no runtime requirement and those set to "all"
-
-**Examples of runtime detection:**
-
-```javascript
-// Browser fetch - Detected as CLIENT runtime
-// Will receive: client-only flags + "all" flags
-// Won't receive: server-only flags
-const response = await fetch("<ph_client_api_host>/flags?v=2", {
-    method: "POST",
-    headers: {
-        "Content-Type": "application/json",
-        // Browser automatically adds Origin, Referer, Sec-Fetch-* headers
-    },
-    body: JSON.stringify({
-        api_key: "<ph_project_token>",
-        distinct_id: "user-id"
-    })
-});
-```
-
-```python
-# Python requests - Detected as SERVER runtime
-# Will receive: server-only flags + "all" flags
-# Won't receive: client-only flags
-import requests
-
-response = requests.post(
-    "<ph_client_api_host>/flags?v=2",
-    json={
-        "api_key": "<ph_project_token>",
-        "distinct_id": "user-id"
-    }
-    # python-requests/ in User-Agent indicates server-side
-)
-```
-
-```shell
-# curl - Detected as SERVER runtime
-# Will receive: server-only flags + "all" flags
-# Won't receive: client-only flags
-curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_token>",
-    "distinct_id": "user-id"
-}' "<ph_client_api_host>/flags?v=2"
-# curl/ in User-Agent indicates server-side
-```
-
-```javascript
-// Node.js with custom User-Agent - Control runtime detection
-const response = await fetch("<ph_client_api_host>/flags?v=2", {
-    method: "POST",
-    headers: {
-        "Content-Type": "application/json",
-        "User-Agent": "posthog-node/3.0.0"  // Explicitly indicates server-side
-    },
-    body: JSON.stringify({
-        api_key: "<ph_project_token>",
-        distinct_id: "user-id"
-    })
-});
-```
-
-##### Combining evaluation context tags and runtime filtering
-
-Both features work together as sequential filters:
-
-```javascript
-// Example: Production web client
-const response = await fetch("<ph_client_api_host>/flags?v=2", {
-    method: "POST",
-    headers: {
-        "Content-Type": "application/json",
-        // Browser headers will trigger client runtime detection
-    },
-    body: JSON.stringify({
-        api_key: "<ph_project_token>",
-        distinct_id: "user-id",
-        evaluation_contexts: ["production", "web"]
-    })
-});
-
-// This request will only receive flags that:
-// 1. Have runtime set to "client" OR "all" (due to browser headers)
-// AND
-// 2. Have evaluation context tags matching "production" OR "web" (or no tags)
-// Note: You can also use the legacy "evaluation_environments" parameter
-```
-
-This allows precise control over which flags are evaluated in different contexts, helping optimize costs and improve security by ensuring flags only evaluate where intended.
+> **Note:** The response only contains the flags that your request can evaluate. If a flag that you expect is missing, see [runtime detection](#runtime-detection) and [evaluation contexts](#evaluation-contexts).
 
 #### Response
 
@@ -389,6 +224,169 @@ Use this endpoint when you need both feature flag evaluation and PostHog configu
 > **Note:** `errorsWhileComputingFlags` will return `true` if we didn't manage to compute some flags (for example, if there's an [ongoing incident involving flag evaluation](https://status.posthog.com/)). 
 > 
 > This enables partial updates to currently active flags in your clients.
+
+#### Evaluation contexts
+
+When you call `/flags` directly, evaluation contexts and [runtime detection](#runtime-detection) control which flags are returned. To filter flags by evaluation context, include the `evaluation_contexts` field in your request body:
+
+> **Note:** The legacy parameter `evaluation_environments` is also supported for backward compatibility.
+
+<MultiLanguage>
+
+```shell
+curl -v -L --header "Content-Type: application/json" -d '  {
+    "api_key": "<ph_project_token>",
+    "distinct_id": "distinct_id_of_your_user",
+    "evaluation_contexts": ["production", "web"]
+}' "<ph_client_api_host>/flags?v=2"
+```
+
+```python
+import requests
+import json
+
+url = "<ph_client_api_host>/flags?v=2"
+headers = {
+    "Content-Type": "application/json"
+}
+payload = {
+    "api_key": "<ph_project_token>",
+    "distinct_id": "user distinct id",
+    "evaluation_contexts": ["production", "web"]
+}
+response = requests.post(url, headers=headers, data=json.dumps(payload))
+print(response.json())
+```
+
+```javascript
+const response = await fetch("<ph_client_api_host>/flags?v=2", {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+        api_key: "<ph_project_token>",
+        distinct_id: "user-distinct-id",
+        evaluation_contexts: ["production", "web"]
+    }),
+});
+const data = await response.json();
+```
+
+</MultiLanguage>
+
+Only flags where at least one evaluation tag matches (or flags with no tags at all) will be returned. For example:
+- Flag with evaluation context tags `["production", "api", "backend"]` + request with `["production", "web"]` = ✅ Flag evaluates ("production" matches)
+- Flag with evaluation context tags `["staging", "api"]` + request with `["production", "web"]` = ❌ Flag doesn't evaluate (no tags match)
+- Flag with evaluation context tags `["web", "mobile"]` + request with `["production", "web"]` = ✅ Flag evaluates ("web" matches)
+- Flag with no evaluation context tags = ✅ Always evaluates (backward compatibility)
+
+#### Runtime detection
+
+Evaluation runtime (server vs. client) is automatically detected based on your request headers and user-agent. This determines which flags are available based on their runtime setting (server-only, client-only, or all).
+
+**How runtime is detected:**
+
+1. **User-Agent patterns** - The system analyzes the User-Agent header:
+   - **Client-side patterns**: `Mozilla/`, `Chrome/`, `Safari/`, `Firefox/`, `Edge/` (browsers), or mobile SDKs like `posthog-android/`, `posthog-ios/`, `posthog-react-native/`, `posthog-flutter/`
+   - **Server-side patterns**: `posthog-python/`, `posthog-ruby/`, `posthog-php/`, `posthog-java/`, `posthog-go/`, `posthog-node/`, `posthog-dotnet/`, `posthog-elixir/`, `python-requests/`, `curl/`
+
+2. **Browser-specific headers** - Presence of these headers indicates client-side:
+   - `Origin` header
+   - `Referer` header  
+   - `Sec-Fetch-Mode` header
+   - `Sec-Fetch-Site` header
+
+3. **Default behavior** - If runtime can't be determined, the system includes flags with no runtime requirement and those set to "all"
+
+**Examples of runtime detection:**
+
+```javascript
+// Browser fetch - Detected as CLIENT runtime
+// Will receive: client-only flags + "all" flags
+// Won't receive: server-only flags
+const response = await fetch("<ph_client_api_host>/flags?v=2", {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/json",
+        // Browser automatically adds Origin, Referer, Sec-Fetch-* headers
+    },
+    body: JSON.stringify({
+        api_key: "<ph_project_token>",
+        distinct_id: "user-id"
+    })
+});
+```
+
+```python
+# Python requests - Detected as SERVER runtime
+# Will receive: server-only flags + "all" flags
+# Won't receive: client-only flags
+import requests
+
+response = requests.post(
+    "<ph_client_api_host>/flags?v=2",
+    json={
+        "api_key": "<ph_project_token>",
+        "distinct_id": "user-id"
+    }
+    # python-requests/ in User-Agent indicates server-side
+)
+```
+
+```shell
+# curl - Detected as SERVER runtime
+# Will receive: server-only flags + "all" flags
+# Won't receive: client-only flags
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_token>",
+    "distinct_id": "user-id"
+}' "<ph_client_api_host>/flags?v=2"
+# curl/ in User-Agent indicates server-side
+```
+
+```javascript
+// Node.js with custom User-Agent - Control runtime detection
+const response = await fetch("<ph_client_api_host>/flags?v=2", {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "posthog-node/3.0.0"  // Explicitly indicates server-side
+    },
+    body: JSON.stringify({
+        api_key: "<ph_project_token>",
+        distinct_id: "user-id"
+    })
+});
+```
+
+#### Combining evaluation context tags and runtime filtering
+
+Both features work together as sequential filters:
+
+```javascript
+// Example: Production web client
+const response = await fetch("<ph_client_api_host>/flags?v=2", {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/json",
+        // Browser headers will trigger client runtime detection
+    },
+    body: JSON.stringify({
+        api_key: "<ph_project_token>",
+        distinct_id: "user-id",
+        evaluation_contexts: ["production", "web"]
+    })
+});
+
+// This request will only receive flags that:
+// 1. Have runtime set to "client" OR "all" (due to browser headers)
+// AND
+// 2. Have evaluation context tags matching "production" OR "web" (or no tags)
+// Note: You can also use the legacy "evaluation_environments" parameter
+```
+
+This allows precise control over which flags are evaluated in different contexts, helping optimize costs and improve security by ensuring flags only evaluate where intended.
 
 #### Quota limiting
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -287,17 +287,17 @@ Evaluation runtime (server vs. client) is automatically detected based on your r
 
 **How runtime is detected:**
 
-1. **User-Agent patterns** - The system analyzes the User-Agent header:
+1. **User-Agent patterns** – The system analyzes the User-Agent header:
    - **Client-side patterns**: `Mozilla/`, `Chrome/`, `Safari/`, `Firefox/`, `Edge/` (browsers), or mobile SDKs like `posthog-android/`, `posthog-ios/`, `posthog-react-native/`, `posthog-flutter/`
    - **Server-side patterns**: `posthog-python/`, `posthog-ruby/`, `posthog-php/`, `posthog-java/`, `posthog-go/`, `posthog-node/`, `posthog-dotnet/`, `posthog-elixir/`, `python-requests/`, `curl/`
 
-2. **Browser-specific headers** - Presence of these headers indicates client-side:
+2. **Browser-specific headers** – Presence of these headers indicates client-side:
    - `Origin` header
    - `Referer` header  
    - `Sec-Fetch-Mode` header
    - `Sec-Fetch-Site` header
 
-3. **Default behavior** - If runtime can't be determined, the system includes flags with no runtime requirement and those set to "all"
+3. **Default behavior** – If runtime can't be determined, the system includes flags with no runtime requirement and those set to "all"
 
 **Examples of runtime detection:**
 


### PR DESCRIPTION
## Changes

On [posthog.com/docs/api/flags](https://posthog.com/docs/api/flags), runtime detection was an `h5` three levels deep, under *Step 1: Evaluate the feature flag value* → *Request* → *Using evaluation context tags and runtime filtering without SDKs*.

Runtime detection is not a detail of the request body. It decides which flags the endpoint returns, and PostHog infers it from your request headers and user-agent. A reader who asks "why is my flag missing from the `/flags` response?" does not find it where it was.

This PR:

- Promotes **Evaluation contexts**, **Runtime detection**, and **Combining evaluation context tags and runtime filtering** from `h5` to `h4`. They are now siblings of *Request* and *Response* instead of children of one of them. The `#evaluation-contexts`, `#runtime-detection`, and `#combining-evaluation-context-tags-and-runtime-filtering` anchors do not change.
- Moves those three sections below *Response*, so that the request and its response stay adjacent.
- Removes the *Using evaluation context tags and runtime filtering without SDKs* wrapper heading, and puts its one sentence of introduction into the *Evaluation contexts* section.
- Adds a short paragraph to the top of the flags API page, and a note in the request section, that tell the reader the response is filtered and where to look.

**Why:** raised in a Slack thread. Runtime detection changes the endpoint's output but is hard to find on the page that documents that endpoint.

The `h5` → `h4` promotion also matters for navigation: `MobileSidebar` drops any heading below `h4`, so runtime detection could not appear in the mobile table of contents at any point.

### Not in this PR

`/docs/api/flags` renders no "On this page" navigation at all. Its `tableOfContents` is `[]`, because `flags.mdx` has no headings of its own and `gatsby-plugin-mdx` reads headings from the file's own AST, not from the `<APIFeatureFlagsCode />` snippet that it imports. This applies to every snippet-driven docs page, `/docs/feature-flags/adding-feature-flag-code` included. The fix belongs in `gatsby/createPages.ts` and is out of scope here.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no page moved

Content-only PR, so no PR tour or reviewer's guide, and no screenshots (no UI change — heading levels and prose only). `pnpm format` is a no-op here: `.mdx` is in `.prettierignore` and the `format` script does not match `.mdx`.

Checked on the deploy preview: `/docs/api/flags` renders *Evaluation contexts*, *Runtime detection*, and *Combining evaluation context tags and runtime filtering* as `h4` siblings of *Request*, *Response*, and *Quota limiting*, and `#runtime-detection` still resolves. Vale went from 3 errors to 0 — a second commit replaces the hyphens in the "How runtime is detected" list with spaced en dashes. The 9 remaining Vale warnings and 2 suggestions are all on pre-existing lines that this PR does not touch.

Affected pages:
- `/docs/api/flags`
- `/docs/feature-flags/adding-feature-flag-code` (shares the same snippet, API tab)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1787332158851609)*
