### PR TITLE
Fix the about card background

### DIFF
--- a/src/components/About/v2/TLDR.tsx
+++ b/src/components/About/v2/TLDR.tsx
@@ -3,7 +3,7 @@ import Link from 'components/Link'
 
 export const TLDR = ({ children }: { children: React.ReactNode }) => {
     return (
-        <div className="max-w-sm mx-auto border-2 border-primary px-4 py-3 mt-4 mb-1 mr-1 rotate-1">
+        <div className="max-w-sm mx-auto border-2 border-primary bg-primary px-4 py-3 mt-4 mb-1 mr-1 rotate-1">
             <div className="flex gap-2 items-center mb-2">
                 <div className="w-10">
                     <div className="size-10 rounded-full bg-accent flex justify-center items-center text-xl font-bold text-muted">


### PR DESCRIPTION
## Changes

Set the TLDR newsletter card on `/about` to use the primary background token. This makes the card white in light mode and keeps its theme-aware dark surface in dark mode.

**Why:** The page background was visible through the card, so its light-mode surface did not match the intended design.

| | Before | After |
|---|---|---|
| Light, narrow | ![Before, light, narrow](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/2d06c0f0-f451-491e-b9e5-3ba944599172.png) | ![After, light, narrow](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/89d10996-dc89-42fa-aae0-7ff7d4783fa1.png) |
| Light, wide | ![Before, light, wide](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/1ba4b3f6-707e-48aa-a389-807fdfa06b18.png) | ![After, light, wide](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/bd7427f7-7c31-4e69-a1ce-a907b531be57.png) |
| Dark, narrow | ![Before, dark, narrow](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/b5b5b5c7-a3f9-4816-9291-2d2e63ac26d6.png) | ![After, dark, narrow](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/3f147869-9b61-4140-b24d-e6a0dc1b56a5.png) |
| Dark, wide | ![Before, dark, wide](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/fc6bbe05-e66c-4cf4-b235-40b3fe9b39ad.png) | ![After, dark, wide](https://raw.githubusercontent.com/PostHog/pr-assets/2ef16f9a5b82822be28f26328389fef38b454df4/2026/08/b819c764-a235-4c49-9d33-ccc56510e700.png) |

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable)
- [x] Ran Prettier on the changed file
- [x] Loaded `/about` in narrow and wide windows, in light and dark mode
- [x] Confirmed the change adds no console errors

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
