### PR TITLE
Add icons to the home menu

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -750,11 +750,13 @@ export function useMenuData(): MenuType[] {
             type: 'item' as const,
             label: 'About PostHog',
             link: '/about',
+            icon: getMenuIcon(companyMenu.children, '/about', 'IconLogomark', 'gray'),
         },
         {
             type: 'item' as const,
             label: 'About this website',
             link: '/credits',
+            icon: <Icons.IconInfo className="size-4 text-blue" />,
         },
         {
             type: 'item' as const,
@@ -762,9 +764,17 @@ export function useMenuData(): MenuType[] {
             onClick: () => {
                 navigate('/display-options', { state: { newWindow: true } })
             },
+            icon: <Icons.IconBrightness className="size-4 text-yellow" />,
             shortcut: [','],
         },
     ]
+
+    const homeLogoMenuItem = {
+        type: 'item' as const,
+        label: 'Home',
+        link: '/',
+        icon: <Icons.IconHome className="size-4 text-purple" />,
+    }
 
     // Process main nav items for mobile menu
     const processMobileNavItems = (): MenuItemType[] => {
@@ -845,11 +855,7 @@ export function useMenuData(): MenuType[] {
     // On mobile, include main navigation items in the logo menu
     const logoMenuItems = isMobile
         ? [
-              {
-                  type: 'item' as const,
-                  label: 'Home',
-                  link: '/',
-              },
+              homeLogoMenuItem,
               { type: 'separator' as const },
               // Main navigation items processed for mobile
               ...processMobileNavItems(),
@@ -858,11 +864,7 @@ export function useMenuData(): MenuType[] {
               ...baseLogoMenuItems,
           ]
         : [
-              {
-                  type: 'item' as const,
-                  label: 'Home',
-                  link: '/',
-              },
+              homeLogoMenuItem,
               // Desktop: only show system items
               ...baseLogoMenuItems,
           ]


### PR DESCRIPTION
## Executive summary

This PR adds icons to the menu under the PostHog logo. It covers Home, About PostHog, About this website, and Display options.

The About PostHog item uses the shared Company navigation metadata. The other items use the same semantic icons and color tokens as related navigation items.

## Screenshots

### Light mode

| Width | Before | After |
| --- | --- | --- |
| Narrow | <img src="https://github.com/user-attachments/assets/194c29e3-b5b8-4530-8109-e9cf02a08daa" width="380"> | <img src="https://github.com/user-attachments/assets/45e714c9-033d-4cfb-89f0-d56ddaf5a287" width="380"> |
| Wide | <img src="https://github.com/user-attachments/assets/0b6301f0-5701-49fe-87c0-18a82c584936" width="380"> | <img src="https://github.com/user-attachments/assets/f14841a8-ad3d-4ce9-84e4-37fdd95d69c4" width="380"> |

### Dark mode

| Width | Before | After |
| --- | --- | --- |
| Narrow | <img src="https://github.com/user-attachments/assets/27dd3830-bf3e-4ffe-b3f6-bcb76ba3e43c" width="380"> | <img src="https://github.com/user-attachments/assets/670a91f6-df17-476f-abfc-8c42042f1a13" width="380"> |
| Wide | <img src="https://github.com/user-attachments/assets/9df49baf-e0d0-4930-acb9-b09d2c5182f8" width="380"> | <img src="https://github.com/user-attachments/assets/4993303a-7b85-4712-9dd3-47fd5aa73400" width="380"> |

## Testing

- Ran Prettier on `src/components/TaskBarMenu/menuData.tsx`.
- Ran ESLint on the changed file. It reports no errors and 17 existing warnings.
- Ran `git diff --check`.
- Started the site with `pnpm start` and loaded the home page.
- Opened the logo menu at 640 px and 1440 px in light and dark modes.
- Confirmed that each affected row contains one icon.
- Compared browser console errors before and after. The change adds no new errors.

Not tested: None.
