### PR TITLE
docs(workflows): document canceling in-flight runs and stopping batch runs

### DIFF
--- a/contents/docs/workflows/best-practices.mdx
+++ b/contents/docs/workflows/best-practices.mdx
@@ -78,7 +78,7 @@ Ensure that failures (e.g. email bounce, webhook error) are captured and surface
 
 Email delivery failures like bounces and complaints are automatically logged as entries on individual invocations, so you can debug specific issues. You can also click the **Bounced** and **Blocked** metric tiles to jump directly to the **Invocations** tab filtered to invocations that experienced those failures.
 
-For long-running workflows (with delays), track user state (which step they are in), and provide a way to debug or abort if something goes wrong.
+For long-running workflows (with delays), track user state (which step they are in). If something goes wrong, you can [cancel in-flight runs](/docs/workflows/editing-live-workflows#stopping-runs) from the **Invocations** tab.
 Periodically review metrics: how many messages sent, how many workflows triggered, bounce/failure rate, conversion rate (if you've configured a conversion goal), etc.
 
 <ProductScreenshot

--- a/contents/docs/workflows/editing-live-workflows.mdx
+++ b/contents/docs/workflows/editing-live-workflows.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 You can edit a workflow while it's enabled and people are moving through it. PostHog uses a **follow-live** model: every step of every run reads the current published configuration, so your edits reach people who are already mid-workflow, not just people who enter afterwards.
 
-This page explains exactly what happens to people already in a workflow when you change it, so you can edit live workflows with confidence.
+This page explains exactly what happens to people already in a workflow when you change it, so you can edit live workflows with confidence. It also covers how to [stop runs](#stopping-runs) entirely.
 
 ## The general model
 
@@ -65,6 +65,46 @@ The tables below break behavior down by where a person is relative to the step y
 - **A step that reads a variable set by a newly added upstream step sees it empty** for people who were already past that point when you published.
 
 </CalloutBox>
+
+## Stopping runs
+
+Editing a workflow changes what happens next for people in it. To stop their runs instead, cancel them from the workflow's **Invocations** tab.
+
+Canceling stops a run before its next step. A run parked in a delay or wait stops within moments. A run that is mid-step finishes that step first, then stops. Steps that already ran, like sent emails, are not undone or recalled.
+
+### Cancel one run
+
+On the **Invocations** tab, every in-flight run (status **Running**) has a **Cancel** button.
+
+### Cancel all in-flight runs
+
+**Cancel in-flight runs** at the top of the **Invocations** tab stops every in-flight run of the workflow at once.
+
+One pass covers a large but bounded number of runs. If the workflow still has runs in flight after a pass, PostHog tells you, and you can run it again to catch the rest.
+
+### Stop a batch run
+
+Canceling in-flight runs doesn't stop a [batch trigger](/docs/workflows/workflow-builder#batch-triggers) that is still enrolling its audience: new runs keep starting until the audience is exhausted. To stop the batch itself, click **Stop** on the batch run in the **Invocations** tab. The button is available while the batch is waiting, queued, or active.
+
+Stopping a batch run halts enrollment, so no more of the audience enters the workflow, and cancels every run the batch already started. Messages already sent are not recalled, and batch runs that already finished are unaffected.
+
+### The canceled status
+
+Canceled is a terminal status with its own filter on the **Invocations** tab. A canceled run:
+
+- doesn't count as succeeded in the workflow's metrics, and is tracked as a separate canceled series
+- keeps its logs, so you can still see how far it got and why it stopped
+- can be rerun later with **Rerun**, like any other finished run
+
+### Disabling a workflow doesn't cancel runs
+
+Disabling an enabled workflow (or archiving it) stops new runs from starting, but runs already in flight aren't canceled right away:
+
+- Runs waiting in a delay or wait step stay parked where they are.
+- If you re-enable the workflow before a parked run wakes, the run continues as normal.
+- If a run comes up for its next step while the workflow is still disabled, it's canceled at that point, and its log records that the workflow was no longer active.
+
+To stop in-flight runs right away, use **Cancel in-flight runs** instead of waiting for their timers to fire.
 
 ## Related
 

--- a/contents/docs/workflows/surfaces/api.mdx
+++ b/contents/docs/workflows/surfaces/api.mdx
@@ -19,6 +19,7 @@ Workflows are stored as **hog flows**, and every one of them is available over t
 - **Keep the suppression list current.** `/api/projects/:project_id/messaging_suppressions/` lists, adds, and removes [suppressed addresses](/docs/workflows/opt-outs#the-suppression-list). Full details in the [messaging suppressions API reference](/docs/api/messaging-suppressions).
 - **Check blast radius before you publish.** The API can report how many people a workflow's audience filters would match, so you don't accidentally message everyone.
 - **Inspect runs.** Batch job status endpoints report on workflows triggered against a batch audience.
+- **Cancel runs.** `/api/projects/:project_id/hog_flows/:id/invocations/cancel` cancels a workflow's in-flight runs, by id or all at once. `/api/projects/:project_id/hog_flows/:id/batch_jobs/:batch_job_id/cancel` stops a batch run: enrollment halts and its in-flight runs are canceled. Both are asynchronous and report when another pass is needed.
 
 A workflow's graph is validated on write. If a trigger, action, or template reference is invalid, the API rejects it with a message naming the offending action rather than saving a broken workflow.
 

--- a/contents/docs/workflows/surfaces/api.mdx
+++ b/contents/docs/workflows/surfaces/api.mdx
@@ -19,7 +19,7 @@ Workflows are stored as **hog flows**, and every one of them is available over t
 - **Keep the suppression list current.** `/api/projects/:project_id/messaging_suppressions/` lists, adds, and removes [suppressed addresses](/docs/workflows/opt-outs#the-suppression-list). Full details in the [messaging suppressions API reference](/docs/api/messaging-suppressions).
 - **Check blast radius before you publish.** The API can report how many people a workflow's audience filters would match, so you don't accidentally message everyone.
 - **Inspect runs.** Batch job status endpoints report on workflows triggered against a batch audience.
-- **Cancel runs.** `/api/projects/:project_id/hog_flows/:id/invocations/cancel` cancels a workflow's in-flight runs, by id or all at once. `/api/projects/:project_id/hog_flows/:id/batch_jobs/:batch_job_id/cancel` stops a batch run: enrollment halts and its in-flight runs are canceled. Both are asynchronous and report when another pass is needed.
+- **Cancel runs.** `/api/projects/:project_id/hog_flows/:id/invocations/cancel` cancels a workflow's in-flight runs, by ID or all at once. `/api/projects/:project_id/hog_flows/:id/batch_jobs/:batch_job_id/cancel` stops a batch run: enrollment halts and its in-flight runs are canceled. Both are asynchronous and report when another pass is needed.
 
 A workflow's graph is validated on write. If a trigger, action, or template reference is invalid, the API rejects it with a message naming the offending action rather than saving a broken workflow.
 

--- a/contents/docs/workflows/troubleshooting.mdx
+++ b/contents/docs/workflows/troubleshooting.mdx
@@ -18,6 +18,12 @@ When an email bounces, is rejected, or receives a complaint, the failure details
 
 To find affected invocations, go to the workflow's **Metrics** tab and click a metric tile like **Bounced** or **Blocked**. This navigates to the **Invocations** tab with a log filter applied, showing all invocations that experienced that failure type within the selected timeframe.
 
+## Need to stop runs that are already in flight?
+
+Cancel them from the workflow's **Invocations** tab. Each in-flight run has a **Cancel** button, and **Cancel in-flight runs** stops all of them at once. A batch run has a **Stop** button that also halts audience enrollment. Canceling doesn't undo steps that already ran or recall sent messages.
+
+Disabling a workflow doesn't cancel in-flight runs: parked runs stay parked, and each one is canceled only when it next wakes while the workflow is still disabled. See [stopping runs](/docs/workflows/editing-live-workflows#stopping-runs) for the full behavior.
+
 ## Variables not populating?
 
 Confirm the property exists on the person profile (e.g. `person.name`).

--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -39,6 +39,8 @@ Draft workflows can also be archived, even if they contain invalid configuration
 
 You can edit a workflow after it's enabled, and your changes reach people who are already moving through it. See [Editing a live workflow](/docs/workflows/editing-live-workflows) for exactly what happens to in-flight runs when you change a live workflow.
 
+Disabling an enabled workflow stops new runs from starting, but doesn't cancel runs already in flight. To stop those, cancel them from the **Invocations** tab. See [stopping runs](/docs/workflows/editing-live-workflows#stopping-runs).
+
 ## Triggers
 
 Every workflow starts with a trigger. Triggers define what kicks off the workflow.
@@ -117,6 +119,10 @@ Configure the recurrence with the schedule picker:
 | Ends      | Never, on a specific date, or after a set number of occurrences                                                                       |
 
 You can also type the recurrence in plain English (e.g. "every week on Monday and Wednesday"), and the picker shows a preview of the next occurrences so you can confirm the schedule before enabling the workflow.
+
+#### Stopping a batch run
+
+You can stop a batch run while it's waiting, queued, or active: click **Stop** on the run in the **Invocations** tab. No more of the audience enters the workflow, and runs the batch already started are canceled. Messages already sent are not recalled. See [stop a batch run](/docs/workflows/editing-live-workflows#stop-a-batch-run) for details.
 
 ### Tracking pixel triggers
 


### PR DESCRIPTION
## Changes

Workflows now let operators cancel in-flight runs ([PostHog/posthog#83342](https://github.com/PostHog/posthog/pull/83342)) and stop batch runs mid-enrollment ([PostHog/posthog#83638](https://github.com/PostHog/posthog/pull/83638)). Both PRs deferred user-facing docs to a posthog.com follow-up; this is it.

- Editing a live workflow gains a "Stopping runs" section: cancel one run, cancel all in-flight runs, stop a batch run, the canceled status, and what disabling a workflow does to runs already in flight.
- Troubleshooting gains a "Need to stop runs that are already in flight?" entry.
- The Workflows API page lists the two cancel endpoints.
- Mechanical: the workflow builder and best practices pages link to the new section.

No screenshots were added: the edited sections are text-only today, and no existing workflows screenshot shows the Invocations tab, so none went stale.

**Why:** the cancel capability was requested through support ([ticket 66051](https://us.posthog.com/project/2/support/tickets/019fcee4-9508-0000-b16f-c57c23a8b6ad)), and both feature PRs promised this docs follow-up.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page was moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*