### PR TITLE
docs(kmp): add iOS SwiftPM linkage setup

### DIFF
--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -48,6 +48,23 @@ posthog-kmp = { group = "com.posthog", name = "posthog-kmp", version.ref = "post
 
 You can find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.posthog/posthog-kmp).
 
+### Link the iOS Swift package
+
+> **Note:** This setup applies to `posthog-kmp` 0.5.0 and later and requires Kotlin 2.4.10 or later.
+
+On iOS, the SDK uses Kotlin's [Swift Package Manager (SwiftPM) integration](https://kotlinlang.org/docs/multiplatform-spm-import.html) to link the native `posthog-ios` package and copy its resources, including privacy manifests, into your app.
+
+After adding the dependency, run the linkage task once from your project root:
+
+```bash
+XCODEPROJ_PATH="$PWD/iosApp/iosApp.xcodeproj" \
+./gradlew :shared:integrateLinkagePackage
+```
+
+Replace `iosApp/iosApp.xcodeproj` with the path to your Xcode project and `:shared` with the Gradle module that builds your iOS framework.
+
+The task generates a `KotlinMultiplatformLinkedPackage` directory and adds it to the Xcode project. Commit the generated package and Xcode project changes. The package is updated automatically when SwiftPM dependencies change. You don't need to add `posthog-ios` to Xcode separately.
+
 ### Configure the SDK
 
 Initialize PostHog once, early in your app's lifecycle, by calling `PostHog.setup()` with a `PostHogConfig` and a platform `PostHogContext`:

--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -54,6 +54,16 @@ You can find the latest version on [Maven Central](https://central.sonatype.com/
 
 On iOS, the SDK uses Kotlin's [Swift Package Manager (SwiftPM) integration](https://kotlinlang.org/docs/multiplatform-spm-import.html) to link the native `posthog-ios` package and copy its resources, including privacy manifests, into your app.
 
+If your app supports iOS 13 or 14, set the minimum deployment target in the Gradle module that builds your iOS framework:
+
+```kotlin file=shared/build.gradle.kts
+kotlin {
+    swiftPMDependencies {
+        iosMinimumDeploymentTarget.set("13.0")
+    }
+}
+```
+
 After adding the dependency, run the linkage task once from your project root:
 
 ```bash
@@ -653,7 +663,7 @@ Pass a `SessionRecordingConfig` to `PostHogConfig.sessionRecording`. Defaults ma
 | Platform | Status | Backed by |
 | --- | --- | --- |
 | Android | ✅ | [PostHog Android](/docs/libraries/android) (native) |
-| iOS | ✅ | [PostHog iOS](/docs/libraries/ios) (native, via a Swift bridge) |
+| iOS | ✅ | [PostHog iOS](/docs/libraries/ios) (native, via SwiftPM) |
 | Web | ✅ | [PostHog.js](/docs/libraries/js) |
 | JVM (desktop) | ✅ | `com.posthog:posthog`, the [JVM core library](/docs/libraries/java) the Android SDK is built on |
 

--- a/contents/docs/libraries/kmp/index.mdx
+++ b/contents/docs/libraries/kmp/index.mdx
@@ -50,9 +50,9 @@ You can find the latest version on [Maven Central](https://central.sonatype.com/
 
 ### Link the iOS Swift package
 
-> **Note:** This setup applies to `posthog-kmp` 0.5.0 and later and requires Kotlin 2.4.10 or later.
+> **Note:** This setup applies to `posthog-kmp` 0.5.0 and later and requires Kotlin 2.4.0 or later.
 
-On iOS, the SDK uses Kotlin's [Swift Package Manager (SwiftPM) integration](https://kotlinlang.org/docs/multiplatform-spm-import.html) to link the native `posthog-ios` package and copy its resources, including privacy manifests, into your app.
+On iOS, the SDK uses Kotlin's [Swift Package Manager (SwiftPM) integration](https://kotlinlang.org/docs/multiplatform/multiplatform-spm-import.html) to link the native `posthog-ios` package and copy its resources, including privacy manifests, into your app.
 
 If your app supports iOS 13 or 14, set the minimum deployment target in the Gradle module that builds your iOS framework:
 
@@ -73,7 +73,7 @@ XCODEPROJ_PATH="$PWD/iosApp/iosApp.xcodeproj" \
 
 Replace `iosApp/iosApp.xcodeproj` with the path to your Xcode project and `:shared` with the Gradle module that builds your iOS framework.
 
-The task generates a `KotlinMultiplatformLinkedPackage` directory and adds it to the Xcode project. Commit the generated package and Xcode project changes. The package is updated automatically when SwiftPM dependencies change. You don't need to add `posthog-ios` to Xcode separately.
+The task generates a `KotlinMultiplatformLinkedPackage` directory and adds it to the Xcode project. Commit the generated package and Xcode project changes. The package is updated automatically when SwiftPM dependencies change. If the first build after a dependency change stops with `Synthetic project state updated`, run the same build again. You don't need to add `posthog-ios` to Xcode separately.
 
 ### Configure the SDK
 


### PR DESCRIPTION
## Changes

Document the iOS SwiftPM linkage step required by `posthog-kmp` 0.5.0 and later. The new section includes the minimum Kotlin version, the `integrateLinkagePackage` command, the iOS 13 deployment target setting, and the generated files that applications need to commit. It also replaces the old Swift bridge description in the platform support table.

This PR depends on [PostHog/posthog-kmp#65](https://github.com/PostHog/posthog-kmp/pull/65) and should merge when version 0.5.0 is available.

Validated the page with `markdownlint-cli2` and Vale 3.13.1. The new section has no Vale findings.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
