### PR TITLE
docs(error-tracking): document custom issue names

### DIFF
--- a/contents/docs/error-tracking/_snippets/exception-properties-table.mdx
+++ b/contents/docs/error-tracking/_snippets/exception-properties-table.mdx
@@ -6,5 +6,7 @@
 | └─ `stacktrace` | Object | Contains a list of stack frames that occurred |
 | └─ `mechanism` | Object | If the stacktrace is handled and if it's synthetic |
 | `$exception_fingerprint` | String | A fingerprint of the exception |
+| `$issue_name` | String | The issue name. PostHog truncates it to 255 bytes and only uses the value from the first event that creates the issue. Without this property, PostHog uses `$exception_list[0].type`. |
+| `$issue_description` | String | The issue description. PostHog truncates it to 255 bytes and only uses the value from the first event that creates the issue. Without this property, PostHog uses `$exception_list[0].value`. |
 | `$exception_level` | String | The level of the severity of the error |
 | `$exception_steps` | List | Breadcrumb-style steps recorded via [`addExceptionStep`](/docs/error-tracking/capture#add-exception-steps) before the exception, each with a `$message`, `$timestamp`, and any custom properties |

--- a/contents/docs/error-tracking/fingerprints.mdx
+++ b/contents/docs/error-tracking/fingerprints.mdx
@@ -67,4 +67,6 @@ You can find details about how issue grouping works in the [issues and exception
 
 Fingerprints can be manually set during exception capture. This is a very useful way to group exceptions that are not related to each other. You can find examples of how to do this in the [custom issue grouping](/docs/error-tracking/grouping-issues#option-2-client-side-fingerprint) section.
 
+The first event with a custom fingerprint sets the issue name. By default, PostHog uses `$exception_list[0].type`. Set `$issue_name` on the first event to use a custom name. Later events with the same fingerprint do not rename the issue.
+
 You can also learn more about grouping issues using rules in the [grouping issues](/docs/error-tracking/grouping-issues) guide.

--- a/contents/docs/error-tracking/grouping-issues.mdx
+++ b/contents/docs/error-tracking/grouping-issues.mdx
@@ -71,6 +71,8 @@ Every captured exception is assigned a [fingerprint](/docs/error-tracking/finger
 posthog.captureException(error, { $exception_fingerprint: "MyCustomGroup" })
 ```
 
+The first event with a custom fingerprint sets the issue name. By default, PostHog uses `$exception_list[0].type`. Set `$issue_name` on the first event to use a custom name. Later events with the same fingerprint do not rename the issue.
+
 If the exception is autocaptured, you need to modify the properties before the event is sent. The PostHog config offers a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook that fires for each event which you can use to alter event and add the property:
 
 ```javascript


### PR DESCRIPTION
## Changes

This PR documents how to set custom error-tracking issue names and descriptions.

- Adds `$issue_name` and `$issue_description` to the shared exception property table.
- Documents the 255-byte limit and first-event-wins behavior.
- Documents the default issue name and description.
- Explains how custom fingerprints determine an issue name.
- Clarifies that later events do not rename an existing issue.

Closes PostHog/posthog#84533.

This is a content-only change. It does not change navigation or UI, so screenshots are not required.

### Validation

- Ran a focused Prettier check on all changed files.
- Started the site locally with `pnpm start`.
- Manually checked `/docs/error-tracking/capture`.
- Manually checked `/docs/error-tracking/issues-and-exceptions`.
- Manually checked `/docs/error-tracking/grouping-issues`.
- Manually checked `/docs/error-tracking/fingerprints`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
