### PR TITLE
Note that the keeper test excludes people in probation

### DIFF
--- a/contents/handbook/company/management.md
+++ b/contents/handbook/company/management.md
@@ -102,6 +102,8 @@ As PostHog grows, it's increasingly important that all team leads help us keep t
 2. Dig in where the answer is 'no' - what would it take for this to be a 'yes'? Is this just temporary, or is there a deeper issue to resolve?
 3. Make sure the manager is sharing all of this feedback with their team to help them improve.
 
+The keeper test is only sent for team members who have passed their [probation period](/handbook/people/compensation#probation-period). New starters are covered by the [30, 60, and 80-day check-ins](/handbook/people/onboarding#306090-day-check-ins) instead, so if you do not get a keeper test form for someone who joined recently, that is expected.
+
 That form will be shared with the relevant team Blitzscale member, so they can help where necessary.
 
 Feedback also flows the other way. Direct reports are periodically asked to give feedback on their manager through an automated form, rating them against what we expect managers to focus on and explaining why. This keeps the bar for managers high too, and gives them honest signal on how they're doing.


### PR DESCRIPTION
## Changes

The handbook did not say who the keeper test form goes out for. A team lead expected a form for a recent starter and did not get one, and it was not possible to tell from the page whether that was correct or a process failure.

This adds two sentences to [The keeper test](https://posthog.com/handbook/company/management#the-keeper-test): the keeper test is only sent for team members who have passed their probation period, and new starters are covered by the 30, 60, and 80-day check-ins instead.

Content change only. No visual or component changes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1787581188211649?thread_ts=1787581188.211649&cid=C017WDX3BFZ)*
