### PR TITLE
chore(pocket-guides): track all CTAs

### DIFF
--- a/contents/handbook/wizard-and-docs/pocket-guides.md
+++ b/contents/handbook/wizard-and-docs/pocket-guides.md
@@ -104,5 +104,27 @@ used before – renders unstyled until the book's component map supports it.
 ## Measuring
 
 Reader interactions emit the `pocket_guide_interaction` event (marker glosses, term hovers,
-contents, font size, scout-file expansion) and both "Add this scout" CTAs emit it with
-`kind: add_scout_click` – that click is the conversion.
+contents, font size, scout-file expansion), and every CTA emits it too. The `kind` property
+names the action:
+
+- `cover_click` – a volume opened from the shelf, with the `volume` id.
+- `add_scout_click` – both "Add this scout" CTAs, with the `scout` name. That click is the
+  conversion for a self-driving guide.
+- `cta_link_click` and `ai_prompt_click` – the `<Action />` button, with the `guide` url.
+- `ai_prompt_copy` – the PostHog AI prompt copied from its code block. For a prompt guide this
+  is the conversion, not the button beside it – a reader who copies the prompt has taken the
+  action whether or not they use the deep link.
+- `skill_file_copy` – a scout or `SKILL.md` file copied from its figure, with the file's name.
+  Volumes that ship a skill rather than a scout have no button at all, so this is their
+  conversion.
+- `guide_link_click` – a link in a guide's prose, with its `href`. Some chapters answer with a
+  link (the skill on GitHub, a docs page), which makes that link the chapter's CTA.
+- `setup_command_copy` – the wizard command copied from a volume's front matter, a CTA
+  prerequisite, or the "Not set up yet?" block.
+
+Every CTA also sends a `placement` (`shelf`, `enable_section`, `action_section`,
+`front_matter`, `figure`, `prose`, or `pinned_bar`), so the pinned bar can be compared against
+the block it shortcuts.
+
+**A new volume needs no tracking work.** The CTA components carry it, so a guide is measured as
+soon as it uses one. Adding a new kind of CTA is the only case that needs a new `kind` here.

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -35,6 +35,8 @@ type CodeBlockProps = {
     showAskAI?: boolean
     focusOnLines?: string
     tooltips?: { lineNumber: number; content: string }[]
+    /** Fired after the code reaches the clipboard, for callers that want to react to a copy. */
+    onCopy?: () => void
 
     onChange?: (language: LanguageOption) => void
     currentLanguage: LanguageOption
@@ -50,6 +52,8 @@ type SingleCodeBlockProps = {
     showAskAI?: boolean
     language: string
     children: string
+    /** Fired after the code reaches the clipboard, for callers that want to react to a copy. */
+    onCopy?: () => void
 }
 
 type MdxCodeBlock = {
@@ -187,6 +191,7 @@ export const CodeBlock = ({
     onChange,
     lineNumberStart = 1,
     tooltips,
+    onCopy,
 }: CodeBlockProps): JSX.Element | null => {
     if (languages.length < 0 || !currentLanguage) {
         return null
@@ -247,6 +252,7 @@ export const CodeBlock = ({
 
     const copyToClipboard = (code: string): void => {
         navigator.clipboard.writeText(replaceProjectInfo(stripAnnotationComments(code)))
+        onCopy?.()
         setTooltipVisible(true)
         setTimeout(() => setTooltipVisible(false), 500)
     }

--- a/src/components/PocketGuides/Action.tsx
+++ b/src/components/PocketGuides/Action.tsx
@@ -35,33 +35,37 @@ export default function Action(): JSX.Element | null {
     }
     const { href, kind } = destination(cta)
 
+    const trackPromptCopy = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'ai_prompt_copy',
+            guide: entry?.url,
+            placement: 'action_section',
+        })
+
+    const trackCtaClick = () =>
+        posthog?.capture('pocket_guide_interaction', { kind, guide: entry?.url, placement: 'action_section' })
+
     return (
         <div>
             {cta.kind === 'prompt' && cta.prompt && (
                 // The prompt is the deliverable, so it's set like the scout file in vol. 1 – same
                 // code block, wrapped locally because `whitespace-pre` scrolls a sentence sideways.
                 <div className="mb-4 [&_.min-w-fit]:min-w-0 [&_.whitespace-pre]:whitespace-pre-wrap [&_.whitespace-pre]:break-words">
-                    <SingleCodeBlock language="text" label="Prompt for PostHog AI" showLabel showCopy showAskAI={false}>
+                    <SingleCodeBlock
+                        language="text"
+                        label="Prompt for PostHog AI"
+                        showLabel
+                        showCopy
+                        showAskAI={false}
+                        onCopy={trackPromptCopy}
+                    >
                         {cta.prompt}
                     </SingleCodeBlock>
                 </div>
             )}
 
             <div className="flex flex-wrap items-center gap-2">
-                <OSButton
-                    asLink
-                    to={href}
-                    external
-                    variant="primary"
-                    size="md"
-                    onClick={() =>
-                        posthog?.capture('pocket_guide_interaction', {
-                            kind,
-                            guide: entry?.url,
-                            placement: 'action_section',
-                        })
-                    }
-                >
+                <OSButton asLink to={href} external variant="primary" size="md" onClick={trackCtaClick}>
                     {cta.label}
                 </OSButton>
                 {cta.note && <span className="text-xs text-secondary">{cta.note}</span>}
@@ -92,8 +96,20 @@ function useWizard() {
  * before anyone reaches a chapter. `<Prerequisite />` repeats it under each CTA.
  */
 export function Setup(): JSX.Element {
+    const posthog = usePostHog()
     const wizard = useWizard()
-    return <CopyableCommand className="my-[0.8em]" command={wizard.displayCommand} copyCommand={wizard.copyCommand} />
+
+    const trackSetupCopy = () =>
+        posthog?.capture('pocket_guide_interaction', { kind: 'setup_command_copy', placement: 'front_matter' })
+
+    return (
+        <CopyableCommand
+            className="my-[0.8em]"
+            command={wizard.displayCommand}
+            copyCommand={wizard.copyCommand}
+            onCopy={trackSetupCopy}
+        />
+    )
 }
 
 /**
@@ -103,11 +119,21 @@ export function Setup(): JSX.Element {
  * no data in this project" is a worse first impression than a sentence saying so up front.
  */
 function Prerequisite({ requires }: { requires: NonNullable<BookPageCta['requires']> }): JSX.Element {
+    const posthog = usePostHog()
+    const entry = useEntry()?.entry
     const wizard = useWizard()
+
+    const trackSetupCopy = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'setup_command_copy',
+            guide: entry?.url,
+            placement: 'action_section',
+        })
+
     return (
         <div className="mt-4 border-t border-light pt-3 dark:border-dark">
             <p className="mb-2 text-xs text-secondary">{requires.label}</p>
-            <CopyableCommand command={wizard.displayCommand} copyCommand={wizard.copyCommand} />
+            <CopyableCommand command={wizard.displayCommand} copyCommand={wizard.copyCommand} onCopy={trackSetupCopy} />
         </div>
     )
 }
@@ -128,17 +154,12 @@ export function ActionBar({
     }
     const { href, kind } = destination(cta)
 
+    const trackCtaClick = () => posthog?.capture('pocket_guide_interaction', { kind, guide, placement: 'pinned_bar' })
+
     return (
         <div className="flex items-center gap-3 border-t border-primary bg-primary px-6 py-3">
             <span className="min-w-0 flex-1 truncate text-sm text-secondary">{title}</span>
-            <OSButton
-                asLink
-                to={href}
-                external
-                variant="primary"
-                size="sm"
-                onClick={() => posthog?.capture('pocket_guide_interaction', { kind, guide, placement: 'pinned_bar' })}
-            >
+            <OSButton asLink to={href} external variant="primary" size="sm" onClick={trackCtaClick}>
                 {cta.label}
             </OSButton>
         </div>

--- a/src/components/PocketGuides/Cover.tsx
+++ b/src/components/PocketGuides/Cover.tsx
@@ -1,6 +1,8 @@
 import Link from 'components/Link'
 import React from 'react'
 
+import usePostHog from '../../hooks/usePostHog'
+
 import { Logo } from '@posthog/brand/logo'
 
 import { PocketGuideVolume } from '../../constants/pocketGuides'
@@ -85,15 +87,25 @@ function CoverBody({ volume, count }: CoverProps): JSX.Element {
 }
 
 export default function Cover({ volume, count }: CoverProps): JSX.Element {
+    const posthog = usePostHog()
+
     // Unwritten volumes aren't links – there's nothing behind them yet.
     if (volume.comingSoon) {
         return <CoverBody volume={volume} count={count} />
     }
 
+    const trackCoverClick = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'cover_click',
+            volume: volume.id,
+            placement: 'shelf',
+        })
+
     return (
         <Link
             to={`/pocket-guides/${volume.id}`}
             state={{ newWindow: true }}
+            onClick={trackCoverClick}
             // Perspective lives on the link so the hover tilt reads as picking the book up.
             className="group block no-underline [perspective:1200px]"
         >

--- a/src/components/PocketGuides/bookPieces.tsx
+++ b/src/components/PocketGuides/bookPieces.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import usePostHog from '../../hooks/usePostHog'
+
 import Link from 'components/Link'
 import { SingleCodeBlock } from 'components/CodeBlock'
 import EnableScout from 'components/SelfDrivingInbox/EnableScout'
@@ -160,6 +162,22 @@ export function SeeAlso({ children }: { children: React.ReactNode }): JSX.Elemen
 const NATIVE_CONTENT =
     'article-content !text-secondary [&_li]:![font-size:1em] [&_p]:![font-size:1em] [&_li]:!leading-relaxed [&_p]:!leading-relaxed [&_li]:![list-style-type:revert] [&_ul]:![list-style-type:revert] [&_ol]:![list-style-type:revert] [&_ul]:[padding-left:revert] [&_ol]:[padding-left:revert]'
 
+/** A prose link, counted like a CTA – some chapters answer with a link, not a button. */
+function BookLink({ href, ...props }: any): JSX.Element {
+    const posthog = usePostHog()
+    const entry = useEntry()?.entry
+
+    const trackLinkClick = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'guide_link_click',
+            href,
+            guide: entry?.url,
+            placement: 'prose',
+        })
+
+    return <Link to={href} state={{ newWindow: true }} className="underline" onClick={trackLinkClick} {...props} />
+}
+
 /** Prose defaults. The page container is `not-prose`, so every tag is styled here. */
 export const proseComponents = {
     // Em-based sizes AND margins: the reading-size control scales type and rhythm together.
@@ -220,7 +238,7 @@ export const proseComponents = {
             {...props}
         />
     ),
-    a: ({ href, ...props }: any) => <Link to={href} state={{ newWindow: true }} className="underline" {...props} />,
+    a: (props: any) => <BookLink {...props} />,
     hr: () => <span aria-hidden="true" className="my-6 block w-16 border-t border-primary" />,
     // A worked-example table inside a <Fig> – illustrative rows, not live data.
     table: (props: any) => <table className="mb-[0.8em] w-full border-collapse text-left text-[0.85em]" {...props} />,

--- a/src/components/SelfDrivingInbox/EnableScout.tsx
+++ b/src/components/SelfDrivingInbox/EnableScout.tsx
@@ -14,6 +14,14 @@ import { Requirement, RequirementLevel, ScoutSpec } from './types'
 /** Pinned shortcut to the enable block, which sits last because the page teaches top-to-bottom. */
 export function EnableScoutBar({ scout, templateTitle }: Pick<EnableScoutProps, 'scout' | 'templateTitle'>) {
     const posthog = usePostHog()
+
+    const trackAddScout = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'add_scout_click',
+            scout: scout?.name,
+            placement: 'pinned_bar',
+        })
+
     return (
         <div className="flex items-center gap-3 border-t border-primary bg-primary px-6 py-3">
             <span className="min-w-0 flex-1 truncate text-sm text-secondary">
@@ -25,13 +33,7 @@ export function EnableScoutBar({ scout, templateTitle }: Pick<EnableScoutProps, 
                 external
                 variant="primary"
                 size="sm"
-                onClick={() =>
-                    posthog?.capture('pocket_guide_interaction', {
-                        kind: 'add_scout_click',
-                        scout: scout?.name,
-                        placement: 'pinned_bar',
-                    })
-                }
+                onClick={trackAddScout}
             >
                 Add this scout
             </OSButton>
@@ -86,6 +88,20 @@ export default function EnableScout({ scout, requires, templateTitle }: EnableSc
     const hasScout = Boolean(scout?.name && scout?.description)
     const selfDrivingCommand = buildSelfDrivingCommand()
 
+    const trackAddScout = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'add_scout_click',
+            scout: scout?.name,
+            placement: 'enable_section',
+        })
+
+    const trackSetupCopy = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'setup_command_copy',
+            scout: scout?.name,
+            placement: 'enable_section',
+        })
+
     // No card chrome or heading of its own: the page hosting it owns the gutter and label.
     return (
         <div>
@@ -117,20 +133,7 @@ export default function EnableScout({ scout, requires, templateTitle }: EnableSc
             )}
 
             <div className="flex flex-wrap items-center gap-2">
-                <OSButton
-                    asLink
-                    to={deepLink}
-                    external
-                    variant="primary"
-                    size="md"
-                    onClick={() =>
-                        posthog?.capture('pocket_guide_interaction', {
-                            kind: 'add_scout_click',
-                            scout: scout?.name,
-                            placement: 'enable_section',
-                        })
-                    }
-                >
+                <OSButton asLink to={deepLink} external variant="primary" size="md" onClick={trackAddScout}>
                     Add this scout
                 </OSButton>
                 <span className="text-xs text-secondary">
@@ -149,6 +152,7 @@ export default function EnableScout({ scout, requires, templateTitle }: EnableSc
                 <CopyableCommand
                     command={selfDrivingCommand.displayCommand}
                     copyCommand={selfDrivingCommand.copyCommand}
+                    onCopy={trackSetupCopy}
                 />
             </div>
         </div>

--- a/src/components/SelfDrivingInbox/ScoutFile.tsx
+++ b/src/components/SelfDrivingInbox/ScoutFile.tsx
@@ -13,6 +13,21 @@ export default function ScoutFile({ scout }: { scout: ScoutSpec }): JSX.Element 
     const posthog = usePostHog()
     const code = (scout.raw ?? '').trim()
 
+    // Only the open direction is a signal – a collapse says nothing about interest.
+    const toggleExpanded = () => {
+        if (!expanded) {
+            posthog?.capture('pocket_guide_interaction', { kind: 'scout_file_expanded' })
+        }
+        setExpanded(!expanded)
+    }
+
+    const trackSkillFileCopy = () =>
+        posthog?.capture('pocket_guide_interaction', {
+            kind: 'skill_file_copy',
+            scout: scout.name,
+            placement: 'figure',
+        })
+
     return (
         <div>
             {/* Wrap locally: `whitespace-pre` scrolls long lines off a pane this narrow. */}
@@ -27,6 +42,7 @@ export default function ScoutFile({ scout }: { scout: ScoutSpec }): JSX.Element 
                     showLabel
                     showCopy
                     showAskAI={false}
+                    onCopy={trackSkillFileCopy}
                 >
                     {code}
                 </SingleCodeBlock>
@@ -40,12 +56,7 @@ export default function ScoutFile({ scout }: { scout: ScoutSpec }): JSX.Element 
             {/* Plus/minus, as RadixUI/Accordion does – the label alone didn't read as a control. */}
             <button
                 type="button"
-                onClick={() => {
-                    if (!expanded) {
-                        posthog?.capture('pocket_guide_interaction', { kind: 'scout_file_expanded' })
-                    }
-                    setExpanded(!expanded)
-                }}
+                onClick={toggleExpanded}
                 className="mt-2 flex items-center gap-1.5 font-sans text-sm font-semibold text-secondary hover:text-primary"
             >
                 {expanded ? (


### PR DESCRIPTION
some CTAs didn't have tracking :) 