### PR TITLE
docs(api): document the free plan query data limit

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -33,7 +33,7 @@ There are separate limits for different kinds of resources.
 
 - For the `events/values` endpoint, the rate limits are `60/minute` and `300/hour`. When using a personal API key, the `event_name` query parameter is required. For queries without event filters, use the [`query`](/docs/api/queries) endpoint instead.
 
-- The [`query`](/docs/api/queries) endpoint has a rate limit of `2400/hour`. For large or regular exports of events, use [batch exports](/docs/cdp/batch-exports). For data-powered APIs or user-facing dashboards, [reach out to us](https://posthog.com/talk-to-a-human).
+- The [`query`](/docs/api/queries) endpoint has a rate limit of `2400/hour`. Organizations without a paid plan also have a [monthly data-read allowance](/docs/api/queries#free-plan-data-limit) for queries. For large or regular exports of events, use [batch exports](/docs/cdp/batch-exports). For data-powered APIs or user-facing dashboards, [reach out to us](https://posthog.com/talk-to-a-human).
 
 - For [feature flag local evaluation](/docs/feature-flags/local-evaluation) (which is enabled in SDKs when you input a personal API key), the rate limit is `600/minute`.
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -292,6 +292,14 @@ If the project's concurrency quota is exhausted, we put the query in queue and w
 Some customers haven't been migrated to the above limit and are on an old limit of 120 queries/hour.
 </CalloutBox>
 
+### Free plan data limit
+
+Organizations without a paid plan can read up to 50 TB of data per calendar month across all API queries. Past that, queries return a `402` response with the code `api_queries_quota_exceeded` and a message that shows your usage and when the allowance resets (the start of the next month, UTC).
+
+Cached results still work while you are over the limit. Queries made in the PostHog app are not affected.
+
+To remove the limit, [subscribe to a paid plan](/pricing). PostHog is pay-as-you-go with no monthly minimum, and access is restored within moments of subscribing. Trials also lift the limit while active.
+
 ## Further reading
 
 - [Project setup for embedded analytics](/docs/data/embedded-analytics-projects)


### PR DESCRIPTION
## Changes

Documents the new monthly data-read allowance for API queries. PostHog now limits organizations without a paid plan to 50 TB of data read per calendar month through the query API (PostHog/posthog#82372). Over-limit queries return a 402 response. The limit is live, and the docs do not mention it yet.

- Adds a "Free plan data limit" section to the rate limits on /docs/api/queries. It states the limit, the 402 error code, the monthly reset, and how to remove the limit.
- Adds one sentence with a link to that section in the rate limiting list on /docs/api.

Content PR, prose only. Checks done: Prettier passes on both files. Not done: a local dev server render of the two pages, so please confirm the section renders correctly in the Vercel preview.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)