### PR TITLE
docs: rename metrics product docs to "Application metrics"

### DIFF
--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -1,10 +1,12 @@
 ---
-title: Metrics
+title: Application metrics
 ---
 
-> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Application metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
 
-PostHog Metrics lets you send application and infrastructure metrics (request counts, latencies, queue depths, resource usage) to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
+**Application metrics** lets you send application and infrastructure metrics (request counts, latencies, queue depths, resource usage) to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
+
+We call these *application metrics* to distinguish them from the other kinds of metrics PostHog helps you track — [experiment metrics](/docs/experiments/metrics), [revenue metrics](/docs/revenue-analytics/revenue-metrics), and [usage metrics](/docs/customer-analytics/usage-metrics) measure your product and business, whereas application metrics measure the systems running it.
 
 There are three ways to send metrics:
 

--- a/contents/docs/metrics/installation/other.mdx
+++ b/contents/docs/metrics/installation/other.mdx
@@ -9,7 +9,7 @@ import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
 > **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
 
-PostHog Metrics works with any OpenTelemetry-compatible client. If your app or infrastructure already exports OTLP metrics, point the exporter at PostHog. No PostHog packages required.
+PostHog's application metrics work with any OpenTelemetry-compatible client. If your app or infrastructure already exports OTLP metrics, point the exporter at PostHog. No PostHog packages required.
 
 <Steps>
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "update-sprite": "svg-sprite -s --symbol-dest src/components/productFeature/images/icons --symbol-sprite sprited-icons.svg src/components/productFeature/images/icons/*.svg",
         "test-redirects": "jest scripts",
         "test:bundle": "node --test scripts/bundle/check-eager-graph.test.mjs",
-        "test:navs": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/navs/activeMenu.test.ts",
+        "test:navs": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/navs/activeMenu.test.ts src/navs/applicationMetrics.test.ts",
         "check-links-post-build": "node scripts/check-links-post-build.js",
         "check-src-links": "node scripts/check-src-links.js",
         "check-product-changelogs": "node scripts/check-product-changelogs.js",

--- a/src/navs/applicationMetrics.test.ts
+++ b/src/navs/applicationMetrics.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The metrics product is called out as "Application metrics" in the docs, not plain
+ * "Metrics", so it isn't confused with experiment/revenue/usage/dashboard metrics.
+ *
+ * Run: pnpm test:navs
+ */
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { docsMenu } from './index.js'
+
+interface NamedNode {
+    name?: string
+    url?: string
+    children?: NamedNode[]
+}
+
+const metricsSection = (docsMenu.children as NamedNode[]).find((section) => section.url === '/docs/metrics')
+
+describe('the metrics docs section', () => {
+    test('is named "Application metrics" in the docs nav', () => {
+        assert.equal(metricsSection?.name, 'Application metrics')
+    })
+
+    test('is not named plain "Metrics" anywhere in the section', () => {
+        const walk = (nodes?: NamedNode[]): string[] =>
+            (nodes ?? []).flatMap((node) => [node.name ?? '', ...walk(node.children)])
+        assert.ok(
+            !walk([metricsSection as NamedNode]).includes('Metrics'),
+            'expected no plain "Metrics" name inside the /docs/metrics section'
+        )
+    })
+
+    test('its overview frontmatter uses the "Application metrics" title', () => {
+        const here = dirname(fileURLToPath(import.meta.url))
+        const frontmatter = readFileSync(join(here, '../../contents/docs/metrics/index.mdx'), 'utf8').split(
+            /^---$/m
+        )[1]
+        assert.match(frontmatter ?? '', /title:\s*Application metrics/i)
+    })
+})

--- a/src/navs/applicationMetrics.test.ts
+++ b/src/navs/applicationMetrics.test.ts
@@ -39,6 +39,6 @@ describe('the metrics docs section', () => {
         const frontmatter = readFileSync(join(here, '../../contents/docs/metrics/index.mdx'), 'utf8').split(
             /^---$/m
         )[1]
-        assert.match(frontmatter ?? '', /title:\s*Application metrics/i)
+        assert.match(frontmatter ?? '', /title:\s*Application metrics/)
     })
 })

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -8229,14 +8229,14 @@ export const docsMenu = {
             ],
         },
         {
-            name: 'Metrics',
+            name: 'Application metrics',
             icon: 'IconTrends',
             color: 'green',
             url: '/docs/metrics',
             description: 'Send OpenTelemetry metrics to PostHog and analyze them.',
             children: [
                 {
-                    name: 'Metrics',
+                    name: 'Application metrics',
                 },
                 {
                     name: 'Overview',


### PR DESCRIPTION
## Changes

Renames the `/docs/metrics` product from plain "Metrics" to **Application metrics** to clarify that it covers application/infrastructure metrics (request counts, latencies, queue depths, resource usage) — not the experiment, revenue, usage, or dashboard metrics documented elsewhere in the docs.

- Docs nav section now reads "Application metrics" (its sidebar header too)
- Overview page title updated, with a short note distinguishing application metrics from the other metric kinds
- One straggler "PostHog Metrics" mention in the other-languages install page updated
- Added `src/navs/applicationMetrics.test.ts` (wired into `pnpm test:navs`) covering the nav name and overview title

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*