### PR TITLE
Reply points

### DIFF
--- a/src/components/Points/TransactionTitle.tsx
+++ b/src/components/Points/TransactionTitle.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { IconPresent, IconReceipt, IconBadge, IconCheck, IconCopy } from '@posthog/icons'
+import { IconPresent, IconReceipt, IconBadge, IconCheck, IconCopy, IconMessage } from '@posthog/icons'
 import CloudinaryImage from 'components/CloudinaryImage'
 import dayjs from 'dayjs'
 import type { TransactionMetadata } from './types'
@@ -9,6 +9,26 @@ const transactionTypeIcons: Record<string, React.ReactNode> = {
     gift: <IconPresent className="size-5 text-purple" />,
     redemption: <IconReceipt className="size-5 text-red" />,
     achievement: <IconBadge className="size-5 text-yellow" />,
+    reply: <IconMessage className="size-5 text-blue" />,
+}
+
+const getDescription = (type: string, metadata?: TransactionMetadata) => {
+    switch (type) {
+        case 'reply':
+            return (
+                <>
+                    Replied to{' '}
+                    <Link
+                        to={`/questions/${metadata?.question?.permalink || ''}`}
+                        className="text-red dark:text-yellow font-semibold"
+                    >
+                        {metadata?.question?.subject}
+                    </Link>
+                </>
+            )
+        default:
+            return metadata?.description || metadata?.redemption?.title || metadata?.achievement?.title
+    }
 }
 
 export default function TransactionTitle({
@@ -29,8 +49,9 @@ export default function TransactionTitle({
     const typeKey = type.toLowerCase().replace(/_/g, '')
     const fallbackIcon = transactionTypeIcons[typeKey]
     const isRedemption = typeKey === 'redemption'
-    const description = metadata?.description || metadata?.redemption?.title || metadata?.achievement?.title
+    const description = getDescription(type, metadata)
     const code = metadata?.redemption?.code
+    const formattedType = type.toLowerCase().replace(/_/g, ' ')
 
     const [showCode, setShowCode] = useState(false)
     const [copied, setCopied] = useState(false)
@@ -54,10 +75,8 @@ export default function TransactionTitle({
                 ) : null}
             </span>
             <div className="min-w-0 flex-1">
-                <div className="flex items-baseline gap-1 leading-none">
-                    <p className="text-sm capitalize m-0 font-semibold truncate">
-                        {type.replace(/_/g, ' ').toLowerCase()}
-                    </p>
+                <div className="flex items-center gap-1 leading-none">
+                    <p className="text-sm capitalize m-0 font-semibold truncate">{formattedType}</p>
                     {link ? (
                         <Link
                             to={link.url}

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { graphql, useStaticQuery } from 'gatsby'
-import { IconShieldLock } from '@posthog/icons'
+import { IconShieldLock, IconWarning } from '@posthog/icons'
 import { Fieldset } from 'components/OSFieldset'
 import Link from 'components/Link'
 import Tooltip from 'components/RadixUI/Tooltip'
@@ -129,14 +129,26 @@ export default function Points({ wallet: walletProp, readOnly = false, firstName
                                                 <div className="flex-1 min-w-0">
                                                     <TransactionTitle type={type} metadata={metadata} date={date} />
                                                 </div>
-                                                <span
-                                                    className={`font-mono font-bold text-base text-right shrink-0 whitespace-nowrap ${
-                                                        amount > 0 ? 'text-green' : 'text-red'
-                                                    }`}
-                                                >
-                                                    {amount > 0 ? '+' : ''}
-                                                    {amount.toLocaleString()}
-                                                </span>
+                                                <div className="flex items-center gap-1 shrink-0">
+                                                    {metadata?.capped ? (
+                                                        <Tooltip
+                                                            delay={0}
+                                                            className="inline-flex cursor-help"
+                                                            trigger={<IconWarning className="size-4 text-yellow" />}
+                                                        >
+                                                            Daily {type.replace(/_/g, ' ').toLowerCase()} points limit
+                                                            reached
+                                                        </Tooltip>
+                                                    ) : null}
+                                                    <span
+                                                        className={`font-mono font-bold text-base text-right whitespace-nowrap ${
+                                                            amount > 0 ? 'text-green' : 'text-red'
+                                                        }`}
+                                                    >
+                                                        {amount > 0 ? '+' : ''}
+                                                        {amount.toLocaleString()}
+                                                    </span>
+                                                </div>
                                             </div>
                                         ))}
                                     </div>

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -107,6 +107,11 @@ export interface TransactionMetadata {
         iconURL?: string
         title?: string
     }
+    reply?: {
+        title?: string
+    }
+    question?: { id: number; subject: string; permalink: string }
+    capped?: boolean
 }
 
 export type Transaction = {


### PR DESCRIPTION
## Changes

- Adds `reply` type to community points
- Shows custom transaction title for reply points including a link to the question the reply was made on, and a warning when the user reaches their daily reply points limit

<img width="856" height="249" alt="image" src="https://github.com/user-attachments/assets/133bb9c0-900a-4a9c-967a-8897bd878ce3" />

To be shipped alongside https://github.com/PostHog/squeak-strapi/pull/215

