### PR TITLE
fix(side-projects): correct modal text in dark mode

### DIFF
--- a/src/components/SideProjects/index.tsx
+++ b/src/components/SideProjects/index.tsx
@@ -516,7 +516,7 @@ export const SideProjectForm = ({
     }
 
     return (
-        <div data-scheme="secondary" className="bg-primary p-4">
+        <div data-scheme="secondary" className="bg-primary p-4 text-primary">
             <form onSubmit={handleSubmit} className="space-y-4">
                 <OSInput
                     label="Project name"


### PR DESCRIPTION
## Changes

The Add project modal inherited black text in dark mode, which made its labels and actions hard to read. It now uses the active secondary scheme's primary text color.

I ran Prettier and `git diff --check`. I could not complete the required visual checks because the local Gatsby server did not finish `createPages` without the site service credentials.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*