### PR TITLE
Add redirect from /security to /.well-known/security.txt

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -452,6 +452,11 @@
             "statusCode": 301
         },
         {
+            "source": "/security",
+            "destination": "/.well-known/security.txt",
+            "statusCode": 301
+        },
+        {
             "source": "/activity",
             "destination": "/docs/activity",
             "statusCode": 301


### PR DESCRIPTION
## Changes

Adds a permanent redirect from `/security` to `/.well-known/security.txt` in `vercel.json`.

## Why

People (and agents) go looking for `posthog.com/security`, which currently 404s. `security.txt` is the standard location for our security contact and policy info, and it already links out to the security handbook page, so it is the best single destination for that traffic.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08SCAZ52S3/p1787643932448029?thread_ts=1787643932.448029&cid=C08SCAZ52S3)*