### PR TITLE
Update newsletter strapline copy

### DIFF
--- a/src/components/BuildMode/Hero.tsx
+++ b/src/components/BuildMode/Hero.tsx
@@ -86,8 +86,7 @@ export default function Hero({ className = '', placement }: { className?: string
                 <span className="box-decoration-clone rounded-xs bg-highlight px-2 text-red">product builders.</span>
             </h1>
             <p className="m-0 max-w-2xl text-lg text-secondary">
-                Advice on building great products, lessons (and mistakes) from building PostHog, and deep dives into the
-                strategies of top startups.
+                Join 80,000+ builders from companies like Vercel, HuggingFace, GitLab, and leading startups.
             </p>
             <SubscribeForm placement={placement} />
         </div>


### PR DESCRIPTION
## Changes

Replaces the /newsletter page strapline (the subtitle under "Tools, tactics, and taste for product builders.") with social-proof copy naming the newsletter's audience, instead of describing its content.

- Before: "Advice on building great products, lessons (and mistakes) from building PostHog, and deep dives into the strategies of top startups."
- After: "Join 80,000+ builders from companies like Vercel, HuggingFace, GitLab, and leading startups."

Verified locally in the dev server across narrow/wide widths and light/dark modes — no new console errors introduced. Screenshots not attached to this PR; available on request.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`
---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*