### PR TITLE
fix(docs): update broken AI costs code link

### DIFF
--- a/contents/docs/ai-observability/calculating-costs.mdx
+++ b/contents/docs/ai-observability/calculating-costs.mdx
@@ -191,4 +191,4 @@ When PostHog calculates costs automatically, it sets the following metadata prop
 
 These properties are useful for debugging cost discrepancies or understanding which pricing was applied when using model aliases or custom configurations.
 
-You can find the code for this on [GitHub](https://github.com/PostHog/posthog/tree/master/plugin-server/src/ingestion/ai-costs).
+You can find the code for this on [GitHub](https://github.com/PostHog/posthog/tree/master/nodejs/src/ingestion/pipelines/ai/costs).


### PR DESCRIPTION
## Changes

The "find the code for this on GitHub" link on the [Calculating costs](https://posthog.com/docs/ai-observability/calculating-costs) docs page pointed to `plugin-server/src/ingestion/ai-costs`, which now 404s. The `plugin-server` directory was renamed to `nodejs` and the AI cost calculation code moved into the ingestion pipelines tree, so the link now points to `nodejs/src/ingestion/pipelines/ai/costs`.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1787664148819199)*