### PR TITLE
Remove the posthog-desktop-launch flag and its waitlist fallbacks

### DIFF
--- a/src/components/Code/DesktopDownloadList.tsx
+++ b/src/components/Code/DesktopDownloadList.tsx
@@ -1,54 +1,25 @@
 import List from 'components/List'
-import { FeatureFlagged } from 'components/FeatureFlagged'
 import React from 'react'
-import { DESKTOP_LAUNCH_FLAG } from './flags'
 import { PLATFORMS } from './platforms'
-
-const listClassName = 'grid gap-4 grid-cols-1 @md:grid-cols-2 not-prose'
 
 /**
  * The "Downloads" list on the PostHog Desktop download docs page. Lives in a
- * component rather than inline MDX because the flag-gated variants need
- * multi-line JSX attributes, which MDX v1 doesn't parse reliably.
+ * component rather than inline MDX because it maps over the shared platform
+ * list, which MDX v1 doesn't parse reliably inline.
  */
 export function DesktopDownloadList(): JSX.Element {
     return (
-        <FeatureFlagged
-            flag={DESKTOP_LAUNCH_FLAG}
-            fallback={
-                <List
-                    className={listClassName}
-                    items={[
-                        {
-                            label: 'macOS',
-                            url: '#',
-                            icon: 'IconApple',
-                            badge: 'Coming soon',
-                            description: 'Official app',
-                        },
-                        {
-                            label: 'Windows',
-                            url: '#',
-                            icon: 'IconLaptop',
-                            badge: 'Coming soon',
-                            description: 'Community maintained',
-                        },
-                    ]}
-                />
-            }
-        >
-            <List
-                className={listClassName}
-                items={PLATFORMS.map((platform) => ({
-                    label: platform.label,
-                    url: platform.url,
-                    icon: platform.key.startsWith('mac')
-                        ? 'IconApple'
-                        : platform.key.startsWith('windows')
-                        ? 'IconLaptop'
-                        : 'IconServer',
-                }))}
-            />
-        </FeatureFlagged>
+        <List
+            className="grid gap-4 grid-cols-1 @md:grid-cols-2 not-prose"
+            items={PLATFORMS.map((platform) => ({
+                label: platform.label,
+                url: platform.url,
+                icon: platform.key.startsWith('mac')
+                    ? 'IconApple'
+                    : platform.key.startsWith('windows')
+                    ? 'IconLaptop'
+                    : 'IconServer',
+            }))}
+        />
     )
 }

--- a/src/components/Code/flags.ts
+++ b/src/components/Code/flags.ts
@@ -1,1 +1,0 @@
-export const DESKTOP_LAUNCH_FLAG = 'posthog-desktop-launch'

--- a/src/components/FeatureFlagged/README.md
+++ b/src/components/FeatureFlagged/README.md
@@ -5,7 +5,7 @@ Renders its children only when a PostHog feature flag is enabled for the current
 ```tsx
 import { FeatureFlagged } from 'components/FeatureFlagged'
 
-<FeatureFlagged flag="posthog-desktop-launch" fallback={<WaitlistForm />}>
+<FeatureFlagged flag="my-product-launch" fallback={<WaitlistForm />}>
     <DownloadButtons />
 </FeatureFlagged>
 ```

--- a/src/pages/desktop.tsx
+++ b/src/pages/desktop.tsx
@@ -57,10 +57,7 @@ import Glow from 'components/Glow'
 import WistiaEmbed from 'components/WistiaEmbed'
 import Link from 'components/Link'
 import { IconDiscord } from 'components/OSIcons/Icons'
-import { WaitlistForm } from 'components/WaitlistForm'
 import { DownloadButtons } from 'components/Code/DownloadButtons'
-import { DESKTOP_LAUNCH_FLAG } from 'components/Code/flags'
-import { FeatureFlagged } from 'components/FeatureFlagged'
 import { usePrefersReducedMotion } from 'components/Code/usePrefersReducedMotion'
 
 // ─────────────────────────────────────────────
@@ -354,31 +351,6 @@ function PostHogCodeLogomark({ className }) {
 // ─────────────────────────────────────────────
 
 function HeroSection() {
-    const [showDownload, setShowDownload] = useState(false)
-    const [contentVisible, setContentVisible] = useState(true)
-    const prefersReducedMotion = usePrefersReducedMotion()
-
-    // Read the #download hash after mount so SSR and first client render agree (no hydration mismatch).
-    useEffect(() => {
-        if (window.location.hash === '#download') setShowDownload(true)
-    }, [])
-
-    const swapToDownload = () => {
-        if (typeof window !== 'undefined') {
-            window.history.replaceState(null, '', '#download')
-        }
-        if (showDownload) return
-        if (prefersReducedMotion) {
-            setShowDownload(true)
-            return
-        }
-        setContentVisible(false)
-        setTimeout(() => {
-            setShowDownload(true)
-            setContentVisible(true)
-        }, 300)
-    }
-
     return (
         <section className="w-full tracking-[-0.0125em]">
             {/* Top header bar: the page's own title strip (scroller + Discord) with a divider line */}
@@ -395,106 +367,69 @@ function HeroSection() {
                 </Link>
             </div>
 
-            <div
-                style={{
-                    opacity: contentVisible ? 1 : 0,
-                    transition: prefersReducedMotion ? undefined : 'opacity 0.3s ease',
-                }}
-            >
-                {showDownload ? (
-                    <DownloadButtons className="w-full py-8" align="center" />
-                ) : (
-                    <>
-                        <h1 className="!mt-0 mb-4 text-xl font-bold leading-tight @xl:mb-8 @xl:text-3xl">
-                            The{' '}
-                            <RoughAnnotation
-                                type="highlight"
-                                color="rgba(48, 164, 108, 0.2)"
-                                strokeWidth={1}
-                                padding={2}
-                                delay={300}
-                            >
-                                product editor
-                            </RoughAnnotation>
-                            {' for '}
-                            <RoughAnnotation type="underline" color="#F54E00" strokeWidth={2} delay={600}>
-                                <span className="font-bold">product builders</span>
-                            </RoughAnnotation>
-                        </h1>
+            <h1 className="!mt-0 mb-4 text-xl font-bold leading-tight @xl:mb-8 @xl:text-3xl">
+                The{' '}
+                <RoughAnnotation
+                    type="highlight"
+                    color="rgba(48, 164, 108, 0.2)"
+                    strokeWidth={1}
+                    padding={2}
+                    delay={300}
+                >
+                    product editor
+                </RoughAnnotation>
+                {' for '}
+                <RoughAnnotation type="underline" color="#F54E00" strokeWidth={2} delay={600}>
+                    <span className="font-bold">product builders</span>
+                </RoughAnnotation>
+            </h1>
 
-                        <div className="flex flex-col items-start gap-8 @4xl/editor:flex-row">
-                            <div className="@4xl/editor:flex-[0_0_280px]">
-                                <p>
-                                    A multiplayer workspace for you, your team, and your agents – with your product data
-                                    as context, and PostHog tools to ship and measure.
-                                </p>
-                                <ul className="mb-4 list-none space-y-0.5 p-0 text-[15px]">
-                                    {[
-                                        'Build and edit your product',
-                                        'Run a fleet of agents',
-                                        'Turn product signals into PRs',
-                                    ].map((item) => (
-                                        <li key={item} className="relative pl-5">
-                                            <IconCheck className="absolute left-0 top-1 size-4 text-green" />
-                                            {item}
-                                        </li>
-                                    ))}
-                                </ul>
+            <div className="flex flex-col items-start gap-8 @4xl/editor:flex-row">
+                <div className="@4xl/editor:flex-[0_0_280px]">
+                    <p>
+                        A multiplayer workspace for you, your team, and your agents – with your product data as context,
+                        and PostHog tools to ship and measure.
+                    </p>
+                    <ul className="mb-4 list-none space-y-0.5 p-0 text-[15px]">
+                        {['Build and edit your product', 'Run a fleet of agents', 'Turn product signals into PRs'].map(
+                            (item) => (
+                                <li key={item} className="relative pl-5">
+                                    <IconCheck className="absolute left-0 top-1 size-4 text-green" />
+                                    {item}
+                                </li>
+                            )
+                        )}
+                    </ul>
 
-                                <FeatureFlagged
-                                    flag={DESKTOP_LAUNCH_FLAG}
-                                    fallback={
-                                        <div className="@container max-w-sm">
-                                            <WaitlistForm />
-                                            <p className="mt-4 text-sm text-secondary">
-                                                Have an invite code?{' '}
-                                                <Link
-                                                    to="/desktop#download"
-                                                    className="font-bold underline"
-                                                    onClick={(event) => {
-                                                        event.preventDefault()
-                                                        swapToDownload()
-                                                    }}
-                                                >
-                                                    Get started
-                                                </Link>
-                                            </p>
-                                        </div>
-                                    }
-                                >
-                                    <DownloadButtons />
-                                </FeatureFlagged>
-                            </div>
+                    <DownloadButtons />
+                </div>
 
-                            {/* Product shot with the glow + overhanging hog treatment the product pages
-                                use (see Products/ReaderViewProduct/templates/Overview). */}
-                            <div className="w-full min-w-0 @4xl/editor:flex-1">
-                                <Glow color="blue" className="not-prose">
-                                    <CloudinaryImage
-                                        src="https://res.cloudinary.com/dmukukwp6/image/upload/desktop_surveys_canvas_light_160e744e82.png"
-                                        alt="A canvas of survey results open in PostHog Desktop"
-                                        className="w-full dark:hidden"
-                                        imgClassName="w-full h-auto rounded-lg"
-                                    />
-                                    <CloudinaryImage
-                                        src="https://res.cloudinary.com/dmukukwp6/image/upload/desktop_surveys_canvas_dark_085ef34c25.png"
-                                        alt="A canvas of survey results open in PostHog Desktop"
-                                        className="w-full hidden dark:block"
-                                        imgClassName="w-full h-auto rounded-lg"
-                                    />
-                                    <div className="pointer-events-none absolute -bottom-8 -right-4 h-24 @xl/editor:h-32">
-                                        <CloudinaryImage
-                                            src="https://res.cloudinary.com/dmukukwp6/image/upload/multiplayer_hogs_41ec7dc243.png"
-                                            alt="Two hedgehogs building something together"
-                                            className="h-full"
-                                            imgClassName="h-full w-auto"
-                                        />
-                                    </div>
-                                </Glow>
-                            </div>
+                {/* Product shot with the glow + overhanging hog treatment the product pages
+                    use (see Products/ReaderViewProduct/templates/Overview). */}
+                <div className="w-full min-w-0 @4xl/editor:flex-1">
+                    <Glow color="blue" className="not-prose">
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/desktop_surveys_canvas_light_160e744e82.png"
+                            alt="A canvas of survey results open in PostHog Desktop"
+                            className="w-full dark:hidden"
+                            imgClassName="w-full h-auto rounded-lg"
+                        />
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/desktop_surveys_canvas_dark_085ef34c25.png"
+                            alt="A canvas of survey results open in PostHog Desktop"
+                            className="w-full hidden dark:block"
+                            imgClassName="w-full h-auto rounded-lg"
+                        />
+                        <div className="pointer-events-none absolute -bottom-8 -right-4 h-24 @xl/editor:h-32">
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/multiplayer_hogs_41ec7dc243.png"
+                                alt="Two hedgehogs building something together"
+                                className="h-full"
+                                imgClassName="h-full w-auto"
+                            />
                         </div>
-                    </>
-                )}
+                    </Glow>
+                </div>
             </div>
         </section>
     )
@@ -2095,19 +2030,10 @@ const TLDR = () => {
             <div className="grid items-center gap-8 @2xl:grid-cols-2 @2xl:gap-12">
                 <div className="@container bg-blue/10 border border-blue rounded-md px-8 py-6 shadow-xl">
                     <h2 className="mt-0 mb-2 text-2xl font-bold">Try it</h2>
-                    <FeatureFlagged
-                        flag={DESKTOP_LAUNCH_FLAG}
-                        fallback={
-                            <p className="mb-4 text-base leading-loose">PostHog Desktop is launching in Summer 2026.</p>
-                        }
-                    >
-                        <p className="mb-4 text-base leading-loose">
-                            Download PostHog Desktop and sign in with your PostHog account.
-                        </p>
-                    </FeatureFlagged>
-                    <FeatureFlagged flag={DESKTOP_LAUNCH_FLAG} fallback={<WaitlistForm />}>
-                        <DownloadButtons />
-                    </FeatureFlagged>
+                    <p className="mb-4 text-base leading-loose">
+                        Download PostHog Desktop and sign in with your PostHog account.
+                    </p>
+                    <DownloadButtons />
                 </div>
                 <div>
                     <MeepNotification className="mb-5 flex justify-center @2xl:justify-start" />
@@ -2479,9 +2405,7 @@ function FAQ() {
 export function DownloadButton() {
     return (
         <div className="py-6">
-            <FeatureFlagged flag={DESKTOP_LAUNCH_FLAG} fallback={<WaitlistForm />}>
-                <DownloadButtons />
-            </FeatureFlagged>
+            <DownloadButtons />
         </div>
     )
 }

--- a/vercel.json
+++ b/vercel.json
@@ -569,11 +569,11 @@
         },
         {
             "source": "/code/download",
-            "destination": "/desktop#download"
+            "destination": "/desktop"
         },
         {
             "source": "/code/download/",
-            "destination": "/desktop#download"
+            "destination": "/desktop"
         },
         {
             "source": "/slack-app",


### PR DESCRIPTION
## Changes

`posthog-desktop-launch` is at 100% rollout, so the gate around the PostHog Desktop download CTAs is no longer necessary. This PR removes the flag, its waitlist fallbacks, and the pre-launch invite-code path.

The gate is not only redundant, it hides the download CTAs from some visitors. `FeatureFlagged` fails closed, and flags resolve in the browser, so the waitlist form is what the prerendered HTML contains. A visitor whose flag request is blocked or slow keeps the waitlist, and crawlers index the waitlist. This is the cleanup that the [`FeatureFlagged` README](https://github.com/PostHog/posthog.com/blob/master/src/components/FeatureFlagged/README.md) prescribes when a flag reaches 100%.

**Why:** a visitor reported that `/desktop` showed only the waitlist form after launch. The flag is fully rolled out, so the fallback was the cause.

After this change, `/desktop` and the PostHog Desktop docs always show the download CTAs. Delete the flag in PostHog after merge.

<details>
<summary>🗺️ PR tour</summary>

### 1. Hero section on `/desktop`

`src/pages/desktop.tsx` — the largest stop. The `FeatureFlagged` wrapper becomes a plain `<DownloadButtons />`.

This stop also removes the pre-launch escape hatch. The hero held a `showDownload` state, a `#download` hash effect, and a `swapToDownload` fade that replaced the whole hero with only the download buttons. Its only entrance was the "Have an invite code? Get started" link inside the deleted fallback, so the state is now unreachable. The hero content is no longer wrapped in the ternary, which is why the diff for this file is large — most of it is a reindent of unchanged JSX.

https://github.com/PostHog/posthog.com/blob/e21293e1badf1360c55cdf14bdb29012c0a7e2e5/src/pages/desktop.tsx#L353-L370

### 2. "Try it" box

Same file. Two gates collapse into their enabled branch: the "launching in Summer 2026" copy goes, and the waitlist form becomes the download buttons.

https://github.com/PostHog/posthog.com/blob/e21293e1badf1360c55cdf14bdb29012c0a7e2e5/src/pages/desktop.tsx#L2027-L2040

### 3. `DownloadButton`, the docs export

Same file. The docs pages `docs/posthog-desktop/index.mdx` and `docs/posthog-desktop/download-posthog-desktop.mdx` import this component, so the waitlist also showed in the docs.

https://github.com/PostHog/posthog.com/blob/e21293e1badf1360c55cdf14bdb29012c0a7e2e5/src/pages/desktop.tsx#L2405-L2410

### 4. Docs download list

`src/components/Code/DesktopDownloadList.tsx`. The fallback list showed macOS and Windows with a "Coming soon" badge and a `#` URL. The component is now the platform list only. The component comment is updated, because the flag variants were the stated reason for the component.

https://github.com/PostHog/posthog.com/blob/e21293e1badf1360c55cdf14bdb29012c0a7e2e5/src/components/Code/DesktopDownloadList.tsx#L1-L10

### 5. `/code/download` redirect

`vercel.json`. The redirect pointed at `/desktop#download`, which was the escape hatch. No element has that ID, so the hash is now inert. The destination becomes `/desktop`.

**Reviewer decision:** if you want to keep the escape hatch, say so and I will restore the hero swap and this redirect. Nothing else in the PR depends on it.

### 6. Mechanical only

`src/components/Code/flags.ts` is deleted — it held the flag key and nothing else. `src/components/FeatureFlagged/README.md` uses this flag key in its example, so the example moves to a placeholder key.

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier@2 --write` on the changed files, with the repo `.prettierrc` | Reformatted, then clean |
| Parse / transform | `npx esbuild --loader:.tsx=tsx` on both changed TSX files | Both compile, no errors |
| Config validity | `node -e "JSON.parse(...)"` on `vercel.json` | Parses |
| Dead references | `grep` for `DESKTOP_LAUNCH_FLAG`, `Code/flags`, `posthog-desktop-launch`, `WaitlistForm`, `FeatureFlagged`, `showDownload`, `swapToDownload` in `src`, `contents`, and `functions` | No hits remain |
| Unused imports | `grep` for `useEffect`, `useState`, and `usePrefersReducedMotion` in `desktop.tsx` | Each still used by other components in the file, so the imports stay |

**Not tested:** `pnpm install`, `pnpm start`, `pnpm test-redirects`, and the TypeScript project check. This environment has no `node_modules` for this repo, and an install plus a Gatsby dev server is not available here. A CI pass and a Vercel preview check are necessary before merge.

### Screenshots

**Missing, and this PR must stay in draft until they are added.** This environment has no browser, so I cannot capture them. The affected areas need before/after captures in a narrow window and a wide window, in light mode and dark mode:

1. `/desktop` hero — waitlist form and invite-code link, versus download buttons.
2. `/desktop` "Try it" box — waitlist form and "launching in Summer 2026" copy, versus download buttons.
3. `/docs/posthog-desktop` and `/docs/posthog-desktop/download-posthog-desktop` — waitlist form and the "Coming soon" download list, versus download buttons and the platform list.

Note that the "before" state needs the flag disabled for your session, because the flag is at 100%.

### Where the risk is

- **The reindent in `desktop.tsx`.** Most of the diff for that file moves unchanged JSX four levels out. Review it with whitespace hidden (`?w=1`) to confirm that only the gates and the swap state are gone.
- **The escape hatch removal.** `/desktop#download` and `/code/download` no longer show a download-only hero. They show the full page, which always has download buttons. Confirm this is what you want.
- **The docs surface.** The change reaches the docs through the `DownloadButton` export, not only the marketing page. Check both docs pages.

</details>

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — no page moved; the `/code/download` destination is updated

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1787664980526779)*
