### PR TITLE
fix(side-projects): show uploaded thumbnails and surface rejected image files

### DIFF
--- a/src/components/SideProjects/README.md
+++ b/src/components/SideProjects/README.md
@@ -20,7 +20,7 @@ Fields (`SideProject`):
 | `teamLink` | no | Fallback creator link when no community profile matches |
 | `githubUrl` | no* | Repo URL |
 | `liveUrl` | no* | Live app URL. *At least one of `githubUrl`/`liveUrl` is required – cards link to `liveUrl \|\| githubUrl`. Use relative URLs for pages on posthog.com |
-| `projectThumbnail` | no | Optional upload stored in Strapi; gallery cards always use `SideProjectGraphic` |
+| `projectThumbnail` | no | Optional upload (PNG, JPG, WebP, or GIF) shown as the card image; cards without one use `SideProjectGraphic` |
 | `tags` | no | Lowercase kebab-case tags (json array); folded through `TAG_ALIASES` for the filter bar |
 
 ## Exports

--- a/src/components/SideProjects/README.md
+++ b/src/components/SideProjects/README.md
@@ -29,6 +29,7 @@ Fields (`SideProject`):
 - `useCreatorProfiles()` – static query for all community (Squeak) profiles.
 - `findCreatorProfile(profiles, { projectAuthor, authorGitHub })` – matches by GitHub username first, then full name.
 - `SideProjectGraphic` – card header adapted from `EventGraphic`: profile color, `font-squeak` title and creator, circular portrait, and a PostHog + job-title bar.
+- `SideProjectThumbnail` – card header for projects with an uploaded image: the image fills the card with a compact identity overlay (title, creator, role, portrait) on a bottom gradient.
 - `normalizeTags(tags)` – dedupes and folds tags through `TAG_ALIASES` so the filter bar stays scannable. Keep raw tags in any search haystack so aliased one-offs stay findable.
 - `isAlumniProject(profiles, project)` – the `alumni` flag wins; otherwise a profile with no small team is treated as alumni.
 - `SideProjectForm` – the add/edit flow (see below).

--- a/src/components/SideProjects/index.tsx
+++ b/src/components/SideProjects/index.tsx
@@ -391,6 +391,7 @@ export const SideProjectForm = ({
     )
     const [submitting, setSubmitting] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [imageError, setImageError] = useState<string | null>(null)
 
     // The element key must stay "side-project-form" so the window system resolves the fixed
     // modal's appSettings, which means React reuses this instance when one project's form
@@ -400,6 +401,7 @@ export const SideProjectForm = ({
         setValues(toFormValues(project))
         setFeaturedImage(project?.projectThumbnail ? { id: 0, url: project.projectThumbnail } : undefined)
         setError(null)
+        setImageError(null)
         if (appWindow) {
             setWindowTitle(appWindow, project ? 'Edit project' : 'Add a project')
         }
@@ -575,10 +577,26 @@ export const SideProjectForm = ({
                     </p>
                     <ImageDrop
                         image={featuredImage}
-                        onDrop={(image) => setFeaturedImage(image)}
-                        onRemove={() => setFeaturedImage(undefined)}
+                        onDrop={(image) => {
+                            setFeaturedImage(image)
+                            setImageError(null)
+                        }}
+                        onRemove={() => {
+                            setFeaturedImage(undefined)
+                            setImageError(null)
+                        }}
+                        accept={{
+                            'image/png': ['.png'],
+                            'image/jpeg': ['.jpg', '.jpeg'],
+                            'image/webp': ['.webp'],
+                            'image/gif': ['.gif'],
+                        }}
+                        onDropRejected={() =>
+                            setImageError("That file can't be used – upload a single PNG, JPG, WebP, or GIF.")
+                        }
                         className="h-32"
                     />
+                    {imageError && <p className="m-0 mt-2 text-sm text-red">{imageError}</p>}
                 </div>
                 <OSInput
                     label="Tags"

--- a/src/components/SideProjects/index.tsx
+++ b/src/components/SideProjects/index.tsx
@@ -258,6 +258,52 @@ export const SideProjectGraphic = ({
     )
 }
 
+// Card header for projects with an uploaded thumbnail: the image fills the card, with a
+// compact version of the graphic's identity row (title, creator, role, portrait) overlaid
+// on a bottom gradient so that info stays visible.
+export const SideProjectThumbnail = ({
+    src,
+    title,
+    creatorName,
+    creatorRole,
+    avatarUrl,
+    className = '',
+}: {
+    src: string
+    title: string
+    creatorName?: string
+    creatorRole?: string
+    avatarUrl?: string
+    className?: string
+}): JSX.Element => (
+    <div className={`@container relative overflow-hidden ${className}`}>
+        <img src={src} alt="" loading="lazy" className="aspect-video w-full object-cover" />
+        <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-[3%] bg-gradient-to-t from-black/80 via-black/40 to-transparent px-[4%] pb-[3%] pt-[10%] text-white">
+            <div className="min-w-0">
+                {/* The card's only rendering of the title (the thumbnail's alt is empty), so it
+                    must stay in the accessibility tree for the project link's accessible name */}
+                <div className="break-words font-squeak text-[5cqw] font-bold uppercase leading-[0.95]">{title}</div>
+                {creatorName && (
+                    <div className="mt-[1.5%] truncate font-squeak text-[3cqw] font-bold uppercase leading-none">
+                        {creatorName}
+                    </div>
+                )}
+                {creatorRole && (
+                    <div className="mt-[1%] truncate font-rounded text-[2.4cqw] font-bold uppercase leading-none tracking-wide opacity-90">
+                        {creatorRole}
+                    </div>
+                )}
+            </div>
+            <img
+                src={avatarUrl || DEFAULT_HEDGEHOG}
+                alt=""
+                loading="lazy"
+                className="aspect-square w-[13cqw] shrink-0 rounded-full border-[0.4cqw] border-white bg-tan object-cover object-top shadow-xl"
+            />
+        </div>
+    </div>
+)
+
 type StrapiEntry = { id: number; attributes: Record<string, unknown> }
 
 const transformStrapiSideProject = (entry: StrapiEntry): SideProject => ({

--- a/src/pages/side-projects.tsx
+++ b/src/pages/side-projects.tsx
@@ -9,6 +9,7 @@ import SEO from 'components/seo'
 import {
     SideProjectForm,
     SideProjectGraphic,
+    SideProjectThumbnail,
     findCreatorProfile,
     isAlumniProject,
     normalizeTags,
@@ -81,6 +82,15 @@ const ProjectCard = ({
     const projectUrl = liveUrl || githubUrl
     const profile = findCreatorProfile(profiles, { projectAuthor, authorGitHub })
     const tags = normalizeTags(project.tags)
+    const identityProps = {
+        title,
+        creatorName: projectAuthor,
+        creatorRole: showRole ? profile?.companyRole : undefined,
+        avatarUrl:
+            profile?.avatar?.formats?.thumbnail?.url ||
+            profile?.avatar?.url ||
+            (authorGitHub ? `https://github.com/${authorGitHub}.png?size=256` : undefined),
+    }
 
     return (
         <article
@@ -118,24 +128,9 @@ const ProjectCard = ({
             >
                 <div className="border-b border-primary">
                     {projectThumbnail ? (
-                        <img
-                            src={projectThumbnail}
-                            alt={title}
-                            loading="lazy"
-                            className="aspect-video w-full object-cover"
-                        />
+                        <SideProjectThumbnail src={projectThumbnail} {...identityProps} />
                     ) : (
-                        <SideProjectGraphic
-                            title={title}
-                            creatorName={projectAuthor}
-                            creatorRole={showRole ? profile?.companyRole : undefined}
-                            avatarUrl={
-                                profile?.avatar?.formats?.thumbnail?.url ||
-                                profile?.avatar?.url ||
-                                (authorGitHub ? `https://github.com/${authorGitHub}.png?size=256` : undefined)
-                            }
-                            color={profile?.color}
-                        />
+                        <SideProjectGraphic {...identityProps} color={profile?.color} />
                     )}
                 </div>
                 <div className="p-3 pb-3">

--- a/src/pages/side-projects.tsx
+++ b/src/pages/side-projects.tsx
@@ -76,7 +76,7 @@ const ProjectCard = ({
     onDelete: (projectId: number) => void
     showRole?: boolean
 }) => {
-    const { title, description, projectAuthor, authorGitHub, githubUrl, liveUrl } = project
+    const { title, description, projectAuthor, authorGitHub, githubUrl, liveUrl, projectThumbnail } = project
     // Cards link straight to the project itself; prefer the live app over the repo
     const projectUrl = liveUrl || githubUrl
     const profile = findCreatorProfile(profiles, { projectAuthor, authorGitHub })
@@ -117,17 +117,26 @@ const ProjectCard = ({
                 wrapperClassName="flex h-full min-h-0 flex-1 flex-col"
             >
                 <div className="border-b border-primary">
-                    <SideProjectGraphic
-                        title={title}
-                        creatorName={projectAuthor}
-                        creatorRole={showRole ? profile?.companyRole : undefined}
-                        avatarUrl={
-                            profile?.avatar?.formats?.thumbnail?.url ||
-                            profile?.avatar?.url ||
-                            (authorGitHub ? `https://github.com/${authorGitHub}.png?size=256` : undefined)
-                        }
-                        color={profile?.color}
-                    />
+                    {projectThumbnail ? (
+                        <img
+                            src={projectThumbnail}
+                            alt={title}
+                            loading="lazy"
+                            className="aspect-video w-full object-cover"
+                        />
+                    ) : (
+                        <SideProjectGraphic
+                            title={title}
+                            creatorName={projectAuthor}
+                            creatorRole={showRole ? profile?.companyRole : undefined}
+                            avatarUrl={
+                                profile?.avatar?.formats?.thumbnail?.url ||
+                                profile?.avatar?.url ||
+                                (authorGitHub ? `https://github.com/${authorGitHub}.png?size=256` : undefined)
+                            }
+                            color={profile?.color}
+                        />
+                    )}
                 </div>
                 <div className="p-3 pb-3">
                     {description && (


### PR DESCRIPTION
Moderators can upload a featured image for a project on /side-projects. The upload had two problems:

1. The gallery card did not show the uploaded image. The card always showed the generated graphic. 22 projects in Strapi have a stored thumbnail that no page displayed. This contradicts the form copy: "a screenshot or artwork for the gallery card".
2. The form accepted only PNG and JPEG files. When a user selected a different file type, the form gave no feedback. The file was dropped silently, and the project saved without an image.

This PR makes the gallery card show `projectThumbnail` when it is set. The generated graphic stays as the fallback. The form now also accepts WebP and GIF, and shows an error message when it rejects a file.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: Gallery card shows the uploaded thumbnail ([diff](https://github.com/PostHog/posthog.com/pull/PRNUM/files#diff-eb1756ea8a577c0c667ba580c84eedd5961d1e9effef9d4489cf94c79ac1a2f2))

The card image area now renders `projectThumbnail` when it is set. Cards without a thumbnail keep the generated `SideProjectGraphic`.

https://github.com/PostHog/posthog.com/blob/f40391ac3d89a67916d35f534b46b0e08d5173eb/src/pages/side-projects.tsx#L119-L140

⚠️ With a thumbnail, the card no longer renders the title as text. The `alt` attribute on the image keeps the title in the accessibility tree, so the card link keeps its accessible name.

### Stop 2: The form reports rejected files ([diff](https://github.com/PostHog/posthog.com/pull/PRNUM/files#diff-0ccf1f7972e831d6e7ff2ce06d84b86e3da868ed5c61714813240facdfa5f95b))

`SideProjectForm` now passes `onDropRejected` to `ImageDrop` and shows an error message below the drop area. It also widens the accepted types with WebP and GIF. Before this change, a rejected file gave no feedback at all — react-dropzone dropped it silently.

https://github.com/PostHog/posthog.com/blob/f40391ac3d89a67916d35f534b46b0e08d5173eb/src/components/SideProjects/index.tsx#L578-L600

### Stop 3: README ([diff](https://github.com/PostHog/posthog.com/pull/PRNUM/files#diff-76eb33a942aeb3eadce34b0c620f12e43a9e59e2bcaa53eb8d674ba4cb7d401e))

Documentation only. The `projectThumbnail` row in the data contract said "gallery cards always use SideProjectGraphic". It now describes the new behavior.

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `pnpm prettier --write` on the 3 changed files | No changes needed |
| Dev server | `pnpm start`, loaded /side-projects | Page renders |
| Console errors | Puppeteer captured console on master and on this branch, all 4 window states | Same 3 pre-existing errors on both sides, 0 new |
| Card with thumbnail | Puppeteer on /side-projects; checked the Anomstack card (has a stored Strapi thumbnail) | Card shows the uploaded image; cards without a thumbnail keep the generated graphic |
| Accepted file | Puppeteer set a GIF on the dropzone input | Preview renders in the form (rejected silently on master) |
| Rejected file | Puppeteer set a BMP on the dropzone input | Error message shows below the drop area |

**Not tested:** a real Strapi upload with a moderator JWT — this environment has no moderator session. The upload call (`uploadImage`) is unchanged; production entry 69 shows it already works for accepted types. Also not tested: `pnpm build` (exceeds local memory, needs the CI pass). To open the moderator-only form for the screenshots, `canEdit` was forced to `true` locally; that change is not part of this PR.

### Screenshots

#### Gallery card for a project with a stored thumbnail (Anomstack)

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/5de5f52c-e428-4d29-bd9a-11ba1465988f.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/fe6e6838-d8b1-46fd-b733-42a82a7d223f.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/d7bf7271-3f1a-4c02-92ca-ca0ce2131ec7.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/753521e2-2eb4-4233-97c9-630c904f4493.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/d90d0de4-7548-48f1-bb16-270fac8d4c25.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/72f6b07e-a7ce-482d-bf76-9d2ea69dde38.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/942610e8-11c2-43f8-a52a-36c248fb635e.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/d5b42b18-1842-440a-af99-c68f617d99b0.png" width="300"> |

#### Add-project form, GIF selected (rejected silently before, accepted now)

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/d76ed166-4e11-4d2b-89e1-aa56e41f401a.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/4da20896-3d75-45f2-a043-3dee13fe7711.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/11f4edee-f0a8-4be9-806b-0f0a71b41307.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/5146eb04-fba2-4479-a4eb-2a4111e3d5e4.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/173ed63e-aa46-4ce1-9611-c30b595edc57.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/7e27c84a-37a7-4a7d-b97b-aa2fc78bcd65.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/c17c2262-e434-4c7a-8669-e3f6a90eea47.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/e0523a0b-e33c-4def-9869-27fa97bdc487.png" width="300"> |

#### Add-project form, unsupported file selected (BMP)

Before this change every rejected file gave no feedback — the drop area kept the placeholder, exactly as the "Before" column of the GIF grid above shows. After, the form shows an error message:

| State | After |
|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/4768c630-75c6-4e99-a1ad-a99ce0658f17.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/2bfc4746-8741-4110-8c2d-3c87a652b2da.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/10757a6d-6090-4b0c-8b6e-996286759c77.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/a382090da4277efbcad92ccec915b70add977ef6/2026/08/b9035893-a6d6-4cb8-b3f3-59edc77399cc.png" width="300"> |

### What to look at

1. **[`src/pages/side-projects.tsx#L119-L140`](https://github.com/PostHog/posthog.com/blob/f40391ac3d89a67916d35f534b46b0e08d5173eb/src/pages/side-projects.tsx#L119-L140)** — 22 existing projects have a stored thumbnail, so their cards change appearance immediately on merge. If a stored URL is broken, that card shows a broken image instead of the generated graphic. Decide if that trade is acceptable, or if you want an `onError` fallback to the graphic.
2. **[`src/components/SideProjects/index.tsx#L586-L596`](https://github.com/PostHog/posthog.com/blob/f40391ac3d89a67916d35f534b46b0e08d5173eb/src/components/SideProjects/index.tsx#L586-L596)** — the widened accept list (WebP, GIF) is my judgment call. Cloudinary and the Strapi upload route handle both, but push back if uploads must stay PNG/JPEG.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)