### PR TITLE
Add optional LinkedIn field to student mixer application

### DIFF
--- a/src/components/Students/StudentProgram.tsx
+++ b/src/components/Students/StudentProgram.tsx
@@ -164,6 +164,7 @@ function CampusMixerForm({ school, setSchool, campusTarget }: CampusMixerFormPro
         const form = formRef.current
         const nameInput = form?.elements.namedItem('name') as HTMLInputElement | null
         const emailInput = form?.elements.namedItem('email') as HTMLInputElement | null
+        const linkedinInput = form?.elements.namedItem('linkedin') as HTMLInputElement | null
         const pitchInput = form?.elements.namedItem('pitch') as HTMLTextAreaElement | null
 
         // The school dropdown isn't a native form control, so validate it by hand.
@@ -185,6 +186,8 @@ function CampusMixerForm({ school, setSchool, campusTarget }: CampusMixerFormPro
                 name: nameInput?.value,
                 email: emailInput.value,
                 school,
+                // Optional field, so send the key only when the applicant filled it in.
+                linkedin: linkedinInput?.value || undefined,
                 pitch: pitchInput?.value,
             })
             form?.reset()
@@ -220,6 +223,14 @@ function CampusMixerForm({ school, setSchool, campusTarget }: CampusMixerFormPro
                             }}
                             touched={schoolTouched}
                             error={schoolTouched && !school ? 'Please pick your school' : undefined}
+                        />
+                        <Input
+                            label="Your LinkedIn profile"
+                            name="linkedin"
+                            type="text"
+                            direction="column"
+                            description="Optional"
+                            placeholder="linkedin.com/in/your-profile"
                         />
                         <Textarea
                             label={`Tell us about ${campusTarget} and the event you'd run`}


### PR DESCRIPTION
## Changes

The application form on `/students` now has an optional "Your LinkedIn profile" field. Its value goes out as a `linkedin` property on the existing `student_mixer_application` event, next to `name`, `email`, `school`, and `pitch`. The property is omitted when the applicant leaves the field empty, so downstream automations only see it when there is a value.

The field is not required. It does not change form validation or the submitted state.

**Why:** applicants are easier to review and follow up on when we can see who they are, but a LinkedIn profile must not be a condition of applying.

### Screenshots

| | Before | After |
|---|---|---|
| Light, wide | ![before-form-light-1440](https://raw.githubusercontent.com/PostHog/pr-assets/7bd66fa98ff56d8fa4bee4bd0a6e9e1ded2a0347/2026/08/40a6e264-6b86-40d9-9138-af7d7926a0d7.png) | ![after-form-light-1440](https://raw.githubusercontent.com/PostHog/pr-assets/7bd66fa98ff56d8fa4bee4bd0a6e9e1ded2a0347/2026/08/a319e0df-dc4a-40a0-9be2-7e299fd9d484.png) |
| Dark, wide | ![before-form-dark-1440](https://raw.githubusercontent.com/PostHog/pr-assets/9450ccb79980894ab14a851d7d3cc40c4bd6af0d/2026/08/26cdc6c3-d96c-4c88-9964-96706869739e.png) | ![after-form-dark-1440](https://raw.githubusercontent.com/PostHog/pr-assets/9450ccb79980894ab14a851d7d3cc40c4bd6af0d/2026/08/5be97428-ff52-4d6d-a5cc-f8bfb341fd20.png) |
| Light, narrow | ![before-form-light-640](https://raw.githubusercontent.com/PostHog/pr-assets/9450ccb79980894ab14a851d7d3cc40c4bd6af0d/2026/08/74f88bfc-c8c4-47a6-9e77-3b4e8916f9cf.png) | ![after-form-light-640](https://raw.githubusercontent.com/PostHog/pr-assets/9450ccb79980894ab14a851d7d3cc40c4bd6af0d/2026/08/3fe0e7f5-99fb-423b-9f1f-84c7c3e48af4.png) |
| Dark, narrow | ![before-form-dark-640](https://raw.githubusercontent.com/PostHog/pr-assets/9450ccb79980894ab14a851d7d3cc40c4bd6af0d/2026/08/1d42189b-42e0-45fb-941f-1d9e030be184.png) | ![after-form-dark-640](https://raw.githubusercontent.com/PostHog/pr-assets/9450ccb79980894ab14a851d7d3cc40c4bd6af0d/2026/08/1758b262-9106-4519-ac05-0b2c1c64c17a.png) |

Captured with headless puppeteer at 640px and 1440px, in light and dark mode.

### Checks

- `prettier --write` on the changed file: no changes needed.
- Loaded `/students` on the dev server in all four states. The console error set is identical before and after the change, so the change adds no new errors.
- No page was moved or renamed, so no redirect is necessary.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C088RSQKH2T/p1787113041925379?thread_ts=1787113041.925379&cid=C088RSQKH2T)*
