### PR TITLE
feat(side-projects): rotate gallery order with a daily-seeded shuffle

### DIFF
--- a/src/components/SideProjects/README.md
+++ b/src/components/SideProjects/README.md
@@ -13,7 +13,7 @@ Fields (`SideProject`):
 | `id` | no | Strapi entry id |
 | `title` | yes | Project name |
 | `description` | no | One-liner shown on the card |
-| `date` | no | `YYYY-MM-DD`; drives "newest first" ordering – undated legacy entries sort last |
+| `date` | no | `YYYY-MM-DD`; the date the project was added. Not used for ordering – the gallery rotates in a daily-seeded shuffle |
 | `projectAuthor` | yes | Creator's full name; used to match their community profile |
 | `authorGitHub` | no | GitHub username; preferred profile match key, also used for avatar fallback |
 | `alumni` | no | Overrides the automatic current-team/alumni detection |

--- a/src/pages/side-projects.tsx
+++ b/src/pages/side-projects.tsx
@@ -164,13 +164,29 @@ const ProjectCard = ({
     )
 }
 
-// Newest first by the explicit added date only – undated legacy entries deliberately sort
-// last, alphabetically. Strapi's createdAt is NOT a fallback: after migration it would make
-// every undated seed outrank dated projects with the migration run's timestamp.
-const byMostRecent = (a: SideProject, b: SideProject): number => {
-    const timeA = a.date ? new Date(a.date).getTime() : 0
-    const timeB = b.date ? new Date(b.date).getTime() : 0
-    return timeB - timeA || a.title.localeCompare(b.title)
+// A plain rolling hash keeps near-identical inputs (sequential ids, one-day-apart seeds) in
+// nearly identical order, which defeats a shuffle – the murmur3 finalizer scrambles them apart
+const hashString = (value: string): number => {
+    let hash = 0
+    for (let i = 0; i < value.length; i++) {
+        hash = Math.imul(hash, 31) + value.charCodeAt(i)
+    }
+    hash ^= hash >>> 16
+    hash = Math.imul(hash, 0x85ebca6b)
+    hash ^= hash >>> 13
+    hash = Math.imul(hash, 0xc2b2ae35)
+    hash ^= hash >>> 16
+    return hash
+}
+
+// Shuffle that reseeds daily, keyed on each project's identity (Strapi id, or title for
+// entries not yet migrated) plus today's date: deterministic within a day (stable across
+// re-renders and identical for every visitor) but different tomorrow, so the same cards
+// aren't permanently at the top of the gallery.
+const byDailyRotation = (projects: SideProject[]): SideProject[] => {
+    const daySeed = new Date().toISOString().slice(0, 10)
+    const rotationKey = (project: SideProject) => hashString(daySeed + String(project.id ?? project.title))
+    return [...projects].sort((a, b) => rotationKey(a) - rotationKey(b) || a.title.localeCompare(b.title))
 }
 
 function SideProjectsPage({ location }: { location: { search: string } }): JSX.Element {
@@ -265,7 +281,7 @@ function SideProjectsPage({ location }: { location: { search: string } }): JSX.E
                 current.push(project)
             }
         })
-        return { currentProjects: current.sort(byMostRecent), alumniProjects: alumni.sort(byMostRecent) }
+        return { currentProjects: byDailyRotation(current), alumniProjects: byDailyRotation(alumni) }
     }, [projects, profiles])
 
     // Tags ranked by how many projects use them; one-off tags stay searchable but don't clutter the bar


### PR DESCRIPTION
The /side-projects gallery sorted cards newest first by the added date. The order only changed when someone added a project, so the same cards stayed at the top for weeks, and bulk-imported projects that share one date sat in a fixed alphabetical block.

This PR replaces that sort with a daily-seeded shuffle. Each card's position comes from a hash of the project's identity (Strapi id, with the title as fallback) plus today's date. The order is stable within a day and identical for every visitor, and it changes every day, so each project gets time at the top. The `date` field no longer affects the order.

No PR tour: one sort function in one page file, plus its README row.

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `pnpm prettier --write` on the 2 changed files | No changes needed |
| Rotation logic | Node script with the same hash against the live Strapi data, seeds for 4 different days | 4 distinct full orderings; order within one seed is deterministic |
| Dev server | `pnpm start`, loaded /side-projects on master and on this branch | Master: A Couch Potato, ArtemisCalendar, BaseKit… (static alphabetical block). Branch: proke, Anomaly Agent, Loggl… (rotated) |
| Hash quality | Checked sequential Strapi ids and one-day-apart seeds | A plain rolling hash kept sequential ids in order (no shuffle at all); the murmur3 finalizer fixes this — see "What to look at" |

**Not tested:** production build (`pnpm build`) — exceeds this environment's memory, needs the CI pass. Screenshots come from puppeteer's bundled Chromium, which predates CSS container queries, so the grid shows fewer columns than production; the card order, which is what this PR changes, is unaffected.

### Screenshots

The change is the card order, so the top of the gallery is the affected area. The "after" order is the rotation for 2026-08-25 and will differ on other days.

#### Top of the gallery grid

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/7962f959-b8cb-48a8-8f35-58a56e9dc7db.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/a42fb2fb-47fb-4d83-bf7e-ad78a4b7efe2.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/9fd53948-bdc4-44da-91b1-d8b2f4914cea.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/6601a73e-0b50-4a30-b834-c0eeb9c66200.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/8820e49a-5480-4406-a363-732d9ef3f362.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/9e8b366d-c6be-4739-bf10-993a16dfa13d.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/1d2459f1-a098-46cc-a2c0-20421dd43122.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0e8f51c590d77463bfc493add986f625b0c2abcf/2026/08/270fd3bf-dcc0-4b58-850a-40f3c0f65c7c.png" width="300"> |

### What to look at

1. **[`src/pages/side-projects.tsx#L167-L189`](https://github.com/PostHog/posthog.com/blob/095d8f997f/src/pages/side-projects.tsx#L167-L189)** — the hash must scramble near-identical inputs. My first version was a plain `h*31+c` rolling hash, and it silently degenerated into sort-by-id with the same order every day. The murmur3 finalizer is what prevents that. If you swap the hash, re-check with sequential ids.
2. **Product call: "newest first" is gone.** A freshly added project lands at a random position, not at the top. If new projects should stay visible for a while, say so — a variant that pins recent additions first is a small change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)