### PR TITLE
chore(pocket-guides): show on tool pages

### DIFF
--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -9,6 +9,7 @@ import { IconGraph, IconWarning, IconRewindPlay  } from '@posthog/icons'
 import LLMsInstallationPlatforms from './_snippets/llms-installation-platforms.tsx'
 import OSButton from 'components/OSButton'
 import WizardCommand from 'components/WizardCommand'
+import GuidesForProduct from 'components/PocketGuides/GuidesForProduct'
 
 
 <QuestLog firstSpeechBubble="Let's get started!" lastSpeechBubble="Time to integrate AI Observability!">
@@ -180,6 +181,18 @@ Reports land in your [inbox](/docs/self-driving/inbox), where one click turns th
 <OSButton variant="primary" asLink to="/docs/self-driving">
   Set up Self-driving
 </OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+  title="Learn it by use case"
+  subtitle="Recommended"
+  icon="IconCompass"
+>
+
+The reference tells you what everything does. The pocket guide walks you through real problems, end to end.
+
+<GuidesForProduct product="ai-observability" />
 
 </QuestLogItem>
 

--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -192,7 +192,9 @@ Reports land in your [inbox](/docs/self-driving/inbox), where one click turns th
 
 The reference tells you what everything does. The pocket guide walks you through real problems, end to end.
 
-<GuidesForProduct product="ai-observability" />
+<div>
+  <GuidesForProduct product="ai-observability" />
+</div>
 
 </QuestLogItem>
 

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -12,6 +12,7 @@ import OSButton from 'components/OSButton'
 import WizardCommand from 'components/WizardCommand'
 import LiveSelfDrivingLoop from 'components/LiveSelfDrivingLoop'
 import { IconMessage, IconLaptop, IconMagic, IconCode, IconTerminal } from '@posthog/icons'
+import GuidesForProduct from 'components/PocketGuides/GuidesForProduct'
 
 PostHog makes your product self-driving. It watches how people actually use your product, finds what's worth fixing, opens a pull request, and measures whether the change worked. You review and merge. Turning it on takes one command:
 
@@ -133,9 +134,7 @@ We hold it to a simple standard: you pay a flat **$15 per pull request**, your f
 
 The [pocket guides](/pocket-guides) teach self-driving through real scouts: each use case walks through the report a scout files, the pull request it becomes, and the scout file itself – ending in a one-click way to add it to your own product.
 
-<OSButton variant="primary" asLink to="/pocket-guides">
-  Open the pocket guides
-</OSButton>
+<GuidesForProduct product="self-driving" />
 
 </QuestLogItem>
 

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -134,7 +134,9 @@ We hold it to a simple standard: you pay a flat **$15 per pull request**, your f
 
 The [pocket guides](/pocket-guides) teach self-driving through real scouts: each use case walks through the report a scout files, the pull request it becomes, and the scout file itself – ending in a one-click way to add it to your own product.
 
-<GuidesForProduct product="self-driving" />
+<div>
+  <GuidesForProduct product="self-driving" />
+</div>
 
 </QuestLogItem>
 

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -1,0 +1,51 @@
+import { CallToAction } from 'components/CallToAction'
+import React from 'react'
+
+import { WINDOW_BG } from '../../constants/frostedSurfaces'
+import { volumeForProduct } from '../../constants/pocketGuides'
+import usePocketGuideCounts from '../../hooks/usePocketGuideCounts'
+import Cover from './Cover'
+
+interface GuidesForProductProps {
+    /** Docs slug of the product, e.g. "ai-observability". Matched against `docsProduct` on a volume. */
+    product: string
+    /** Optional heading. Omit it when the surrounding block already has one, e.g. a `QuestLogItem`. */
+    heading?: string
+}
+
+/** The pocket guide for one product, on its docs page. Renders nothing when the product has none. */
+export default function GuidesForProduct({ product, heading }: GuidesForProductProps): JSX.Element | null {
+    const volume = volumeForProduct(product)
+    const counts = usePocketGuideCounts()
+
+    // Most products have no volume – returning null is what makes this safe to drop on any page.
+    if (!volume) {
+        return null
+    }
+
+    return (
+        <div className={`not-prose ${heading ? 'my-12' : ''}`}>
+            {heading && <h3 className="my-6 text-2xl font-bold @md/reader-content:text-3xl">{heading}</h3>}
+            <div
+                className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
+            >
+                <div className="w-[200px] shrink-0">
+                    <Cover volume={volume} count={counts[volume.id] ?? 0} />
+                </div>
+                <div className="min-w-0">
+                    <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
+                    <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">{volume.description}</p>
+                    <CallToAction
+                        to={`/pocket-guides/${volume.id}`}
+                        state={{ newWindow: true }}
+                        type="secondary"
+                        size="md"
+                        className="mt-4"
+                    >
+                        Read the pocket guide
+                    </CallToAction>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -19,7 +19,6 @@ export default function GuidesForProduct({ product }: GuidesForProductProps): JS
         return null
     }
 
-    // A `div`, not a `section`: MDX v1 wraps a component that follows prose in a `p`.
     return (
         <div className="not-prose">
             <VolumeCard volume={volume} count={counts[volume.id] ?? 0} />

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -21,7 +21,7 @@ export default function GuidesForProduct({ product }: GuidesForProductProps): JS
 
     return (
         <div className="not-prose">
-            <VolumeCard volume={volume} count={counts[volume.id] ?? 0} />
+            <VolumeCard volume={volume} count={counts[volume.id] ?? 0} placement="product_docs" />
         </div>
     )
 }

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -1,20 +1,16 @@
-import { CallToAction } from 'components/CallToAction'
 import React from 'react'
 
-import { WINDOW_BG } from '../../constants/frostedSurfaces'
 import { volumeForProduct } from '../../constants/pocketGuides'
 import usePocketGuideCounts from '../../hooks/usePocketGuideCounts'
-import Cover from './Cover'
+import VolumeCard from './VolumeCard'
 
 interface GuidesForProductProps {
     /** Docs slug of the product, e.g. "ai-observability". Matched against `docsProduct` on a volume. */
     product: string
-    /** Optional heading. Omit it when the surrounding block already has one, e.g. a `QuestLogItem`. */
-    heading?: string
 }
 
 /** The pocket guide for one product, on its docs page. Renders nothing when the product has none. */
-export default function GuidesForProduct({ product, heading }: GuidesForProductProps): JSX.Element | null {
+export default function GuidesForProduct({ product }: GuidesForProductProps): JSX.Element | null {
     const volume = volumeForProduct(product)
     const counts = usePocketGuideCounts()
 
@@ -23,29 +19,10 @@ export default function GuidesForProduct({ product, heading }: GuidesForProductP
         return null
     }
 
+    // A `div`, not a `section`: MDX v1 wraps a component that follows prose in a `p`.
     return (
-        <div className={`not-prose ${heading ? 'my-12' : ''}`}>
-            {heading && <h3 className="my-6 text-2xl font-bold @md/reader-content:text-3xl">{heading}</h3>}
-            <div
-                className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
-            >
-                <div className="w-[200px] shrink-0">
-                    <Cover volume={volume} count={counts[volume.id] ?? 0} />
-                </div>
-                <div className="min-w-0">
-                    <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
-                    <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">{volume.description}</p>
-                    <CallToAction
-                        to={`/pocket-guides/${volume.id}`}
-                        state={{ newWindow: true }}
-                        type="secondary"
-                        size="md"
-                        className="mt-4"
-                    >
-                        Read the pocket guide
-                    </CallToAction>
-                </div>
-            </div>
+        <div className="not-prose">
+            <VolumeCard volume={volume} count={counts[volume.id] ?? 0} />
         </div>
     )
 }

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -159,6 +159,7 @@ shows after the `.mdx` file itself changes (or `pnpm clean`).
 |---|---|
 | `Cover.tsx` | The series cover on the shelf: spine, masthead, specimen, volume number |
 | `Book.tsx` | The volume as a coloured spine for the `/docs` library column, plus the `BookShelf` it sits in |
+| `GuidesForProduct.tsx` | The volume for one product, on that product's docs page. Renders nothing when there is none |
 | `BookReader.tsx` | The full-window page: edge book tabs, popovers, turn zones, foot nav |
 | `BookPage.tsx` | Renders one MDX page into the reader |
 | `bookComponents.tsx` | Assembles the MDX vocabulary from the files below |
@@ -195,6 +196,16 @@ rather than as an object. Both are `motion-safe:`.
 `BookShelf` is layout only: a `max-w-[420px]` column. The cap is what keeps a spine spine-shaped –
 when the docs index stacks into one column the library gets the full window width, and without it
 the volumes stretch into wall-wide slivers.
+
+`GuidesForProduct` is the tool-docs entry point: `<GuidesForProduct product="ai-observability" />`,
+imported into whichever page owns that product's syllabus – `start-here.mdx` for AI Observability,
+`index.mdx` for Self-driving. It matches the slug against `docsProduct` on a volume via `volumeForProduct`
+and **returns `null` when nothing matches** – most products have no volume, so dropping it on a page
+is always safe. Adding a product to the mechanism is one line: set `docsProduct` on its volume in
+`src/constants/pocketGuides.ts`.
+
+It renders the same `Cover` and the same shape as the "Learn it by use case" block on
+`/self-driving` (`src/pages/self-driving/index.tsx`) – one look for the same idea in both places.
 
 Volume metadata lives in `src/constants/pocketGuides.ts` (data-only so `gatsby/` can import it).
 The report frontmatter contract and the `.md` agent-mirror constraints are documented in

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -159,7 +159,8 @@ shows after the `.mdx` file itself changes (or `pnpm clean`).
 |---|---|
 | `Cover.tsx` | The series cover on the shelf: spine, masthead, specimen, volume number |
 | `Book.tsx` | The volume as a coloured spine for the `/docs` library column, plus the `BookShelf` it sits in |
-| `GuidesForProduct.tsx` | The volume for one product, on that product's docs page. Renders nothing when there is none |
+| `VolumeCard.tsx` | One volume pitched as a card: cover, pitch, button. Shared by the docs pages and `/self-driving` |
+| `GuidesForProduct.tsx` | Looks up the volume for a docs slug and renders a `VolumeCard`. Renders nothing when there is none |
 | `BookReader.tsx` | The full-window page: edge book tabs, popovers, turn zones, foot nav |
 | `BookPage.tsx` | Renders one MDX page into the reader |
 | `bookComponents.tsx` | Assembles the MDX vocabulary from the files below |
@@ -204,8 +205,13 @@ and **returns `null` when nothing matches** – most products have no volume, so
 is always safe. Adding a product to the mechanism is one line: set `docsProduct` on its volume in
 `src/constants/pocketGuides.ts`.
 
-It renders the same `Cover` and the same shape as the "Learn it by use case" block on
-`/self-driving` (`src/pages/self-driving/index.tsx`) – one look for the same idea in both places.
+Both it and the "Learn it by use case" block on `/self-driving` (`src/pages/self-driving/index.tsx`)
+render `VolumeCard`, so the card is defined once. `VolumeCard` takes the pitch, the link, and the
+button label as props, because those are the only things the two surfaces disagree on – the docs
+pages send a reader to the volume, `/self-driving` sends them to the whole shelf.
+
+`VolumeCard` deliberately has no `overflow-hidden`: the cover's hover tilt lifts a drop shadow, and
+clipping the card would cut it off.
 
 Volume metadata lives in `src/constants/pocketGuides.ts` (data-only so `gatsby/` can import it).
 The report frontmatter contract and the `.md` agent-mirror constraints are documented in

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -213,6 +213,9 @@ pages send a reader to the volume, `/self-driving` sends them to the whole shelf
 `VolumeCard` deliberately has no `overflow-hidden`: the cover's hover tilt lifts a drop shadow, and
 clipping the card would cut it off.
 
+In `.mdx`, wrap the component in a `<div>`. On its own line MDX treats it as a paragraph and emits
+`<p>`, which cannot legally hold the cover's `<article>` and `<header>`.
+
 Volume metadata lives in `src/constants/pocketGuides.ts` (data-only so `gatsby/` can import it).
 The report frontmatter contract and the `.md` agent-mirror constraints are documented in
 `components/SelfDrivingInbox/README.md`.

--- a/src/components/PocketGuides/VolumeCard.tsx
+++ b/src/components/PocketGuides/VolumeCard.tsx
@@ -1,0 +1,55 @@
+import { CallToAction } from 'components/CallToAction'
+import React from 'react'
+
+import { WINDOW_BG } from '../../constants/frostedSurfaces'
+import type { PocketGuideVolume } from '../../constants/pocketGuides'
+import Cover from './Cover'
+
+interface VolumeCardProps {
+    volume: PocketGuideVolume
+    /** Guides printed on the cover. Callers count them, because the sources differ per surface. */
+    count: number
+    /** Which surface this card sits on. Forwarded to `Cover` so every open is attributable. */
+    placement: 'shelf' | 'self_driving_page' | 'product_docs'
+    /** The pitch. Defaults to the volume's own one-liner. */
+    description?: React.ReactNode
+    /** Where the button goes. Defaults to the volume itself. */
+    to?: string
+    ctaLabel?: string
+}
+
+/** One volume pitched as a card: cover, pitch, button. Shared by the docs pages and `/self-driving`. */
+export default function VolumeCard({
+    volume,
+    count,
+    placement,
+    description,
+    to,
+    ctaLabel = 'Read the pocket guide',
+}: VolumeCardProps): JSX.Element {
+    return (
+        // No `overflow-hidden`: the cover's hover tilt lifts a drop shadow that clipping would cut off.
+        <div
+            className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
+        >
+            <div className="w-[200px] shrink-0">
+                <Cover volume={volume} count={count} placement={placement} />
+            </div>
+            <div className="min-w-0">
+                <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
+                <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">
+                    {description ?? volume.description}
+                </p>
+                <CallToAction
+                    to={to ?? `/pocket-guides/${volume.id}`}
+                    state={{ newWindow: true }}
+                    type="secondary"
+                    size="md"
+                    className="mt-4"
+                >
+                    {ctaLabel}
+                </CallToAction>
+            </div>
+        </div>
+    )
+}

--- a/src/components/PocketGuides/VolumeCard.tsx
+++ b/src/components/PocketGuides/VolumeCard.tsx
@@ -28,18 +28,18 @@ export default function VolumeCard({
     ctaLabel = 'Read the pocket guide',
 }: VolumeCardProps): JSX.Element {
     return (
+        // Always stacked: side by side squeezed the copy at ordinary widths (#19713 review).
         // No `overflow-hidden`: the cover's hover tilt lifts a drop shadow that clipping would cut off.
         <div
-            className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
+            className={`flex flex-col items-center gap-6 rounded-md border border-primary p-6 text-center @md/reader-content:p-8 ${WINDOW_BG}`}
         >
-            <div className="w-[200px] shrink-0">
+            {/* Caps at 200px but shrinks into narrow cards, which `shrink-0` would not. */}
+            <div className="w-full max-w-[200px]">
                 <Cover volume={volume} count={count} placement={placement} />
             </div>
-            <div className="min-w-0">
+            <div className="max-w-xl">
                 <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
-                <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">
-                    {description ?? volume.description}
-                </p>
+                <p className="m-0 mt-2 text-base leading-relaxed text-secondary">{description ?? volume.description}</p>
                 <CallToAction
                     to={to ?? `/pocket-guides/${volume.id}`}
                     state={{ newWindow: true }}

--- a/src/constants/pocketGuides.ts
+++ b/src/constants/pocketGuides.ts
@@ -13,6 +13,8 @@ export interface PocketGuideVolume {
     token: PocketGuideToken
     /** Printed on the cover. Order on the shelf follows it. */
     volume: number
+    /** Docs slug of the product this volume teaches. Omit when it teaches no single product. */
+    docsProduct?: string
     /** A hand-written src/pages file owns this route, so don't generate one. */
     hasStaticPage?: boolean
     /** Announced but unwritten – renders as a cover with a sash and no link. */
@@ -32,6 +34,7 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         description: 'Scouts that watch your product and open a pull request when something breaks.',
         token: 'orange',
         volume: 1,
+        docsProduct: 'self-driving',
         hasStaticPage: true,
     },
     {
@@ -40,6 +43,7 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         description: 'Tracing every LLM call, scoring what comes back, and seeing what users do with it.',
         token: 'purple',
         volume: 2,
+        docsProduct: 'ai-observability',
     },
     {
         id: 'context-warehouse',
@@ -57,6 +61,11 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         volume: 4,
     },
 ]
+
+/** The volume that teaches a product, if one does. Drives `GuidesForProduct` on tool docs pages. */
+export function volumeForProduct(docsProduct: string): PocketGuideVolume | undefined {
+    return POCKET_GUIDE_VOLUMES.find((v) => v.docsProduct === docsProduct && !v.comingSoon)
+}
 
 export function volumeById(id: string): PocketGuideVolume | undefined {
     return POCKET_GUIDE_VOLUMES.find((v) => v.id === id)

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -12,7 +12,7 @@ import { WINDOW_BG } from '../../constants/frostedSurfaces'
 import useProduct from 'hooks/useProduct'
 import { useApp } from '../../context/App'
 import { GetStarted } from 'components/Home/Test'
-import Cover from 'components/PocketGuides/Cover'
+import VolumeCard from 'components/PocketGuides/VolumeCard'
 import { useSelfDrivingTemplates } from 'components/SelfDrivingInbox'
 import { volumeById } from '../../constants/pocketGuides'
 import { CatalogLayers } from 'components/ContextWarehouseCatalog'
@@ -722,30 +722,14 @@ const PocketGuidesSection = (): JSX.Element | null => {
     return (
         <section className="not-prose my-12">
             <h3 className={sectionHeadingClassName}>Learn it by use case</h3>
-            <div
-                className={`flex flex-col items-center gap-8 overflow-hidden rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
-            >
-                <div className="w-[200px] shrink-0">
-                    <Cover placement="self_driving_page" volume={volume} count={guides.length} />
-                </div>
-                <div className="min-w-0">
-                    <p className="m-0 text-base font-bold text-primary">The pocket guide to self-driving</p>
-                    <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">
-                        A quick overview of self-driving, plus real use cases. Each one walks through the report a scout
-                        files, the pull request it becomes, and the scout itself. You can also add each use case as a
-                        custom scout to your own product.
-                    </p>
-                    <CallToAction
-                        to="/pocket-guides"
-                        state={{ newWindow: true }}
-                        type="secondary"
-                        size="md"
-                        className="mt-4"
-                    >
-                        Read the pocket guides
-                    </CallToAction>
-                </div>
-            </div>
+            <VolumeCard
+                placement="self_driving_page"
+                volume={volume}
+                count={guides.length}
+                to="/pocket-guides"
+                ctaLabel="Read the pocket guides"
+                description="A quick overview of self-driving, plus real use cases. Each one walks through the report a scout files, the pull request it becomes, and the scout itself. You can also add each use case as a custom scout to your own product."
+            />
         </section>
     )
 }


### PR DESCRIPTION
## Changes

part 2 of integrating pocket guides into docs. adds `GuidesForProduct` component that looks up the volume for a docs slug and renders its PG cover – added to `start-here` for AIO and self-driving

self-driving already had "Learn by use case" but it pointed at `/pocket-guides` so the reader landed on all three books. now it goes straight to the volume

also pulled the card itself into a shared `VolumeCard`, because `/self-driving` already had a near-identical one and I didn't want two copies drifting apart. that marketing page renders the same card it did before – just from a shared file now

## Why these pages?

I picked it based off traffic. @gewenyu99 brought up some numbers on docs sessions, so I did some more digging. Only 10.2% of docs sessions ever touch `/docs`. Per-tool placement played the better numbers game... and it's where the readers already are:

| Section | Visitors (30d) | Sessions |
| --- | --- | --- |
| `/docs/ai-observability/*` | 16,392 | 18,864 |
| `/docs/self-driving/*` | 6,897 | 8,310 |

> Fun fact: AIO is the second-largest docs section for sessions, behind only `libraries` – with AIO `start-here` being the second-most visited page in ALL of docs (11,115 visitors)

Now most of this traffic comes from paid (93%) - so we need to measure here on installs and signups not guide clicks :) But it will bring it to where the traffic is! 

<img width="3024" height="1530" alt="CleanShot 2026-08-25 at 14 50 07@2x" src="https://github.com/user-attachments/assets/1d58a898-d4fd-4fbc-842d-5f4b17dc6356" />
<img width="3020" height="1524" alt="CleanShot 2026-08-25 at 14 50 20@2x" src="https://github.com/user-attachments/assets/efea52ba-df21-41d4-8034-71fa93f8190e" />

<details>
<summary>🗺️ PR tour</summary>

### 1. `src/constants/pocketGuides.ts` – the mapping

new optional `docsProduct` field on a volume, plus `volumeForProduct()` to look one up by docs slug. set on vol 1 and vol 2. vol 3 (context warehouse) has no docs section so it stays unmapped. data only, so `gatsby/` can still import it at build time

### 2. `src/components/PocketGuides/VolumeCard.tsx` – the card

new. one volume as a card – cover, pitch, button. takes the pitch, the link, and the button label as props, since those are the only three things the two surfaces actually disagree on

no `overflow-hidden` on purpose: the cover tilts on hover and lifts a drop shadow, and clipping cut it off

### 3. `src/components/PocketGuides/GuidesForProduct.tsx` – the docs entry point

matches a product slug against `docsProduct` and hands the volume to `VolumeCard`. returns `null` when nothing matches, which is what makes it safe to drop on any docs page. adding a third product is one line in `pocketGuides.ts`

### 4. `src/pages/self-driving/index.tsx` – the other caller

`PocketGuidesSection` here was a near-copy of the above, so it now renders `VolumeCard` with its own copy and a link to the shelf instead of a volume

⚠️ small copy change: the heading reads "The pocket guide to **S**elf-driving" now instead of lowercase, because the shared card builds that line from `volume.title`. shout if you'd rather keep it lowercase

### 5. the two `.mdx` files

AIO gets a "Learn it by use case" quest item, 7th of 8, right before "Use for free". self-driving swaps its shelf button for the card

⚠️ **both wrap the component in a `<div>` and that's load-bearing** – on its own line MDX treats it as a paragraph and emits `<p>`, which can't legally hold the cover's `<article>`/`<header>`. take the wrapper out and you get 5 React nesting warnings back. noted in the README too

### 6. `src/components/PocketGuides/README.md`

documents `VolumeCard`, `GuidesForProduct`, and the MDX wrapper rule

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
| --- | --- | --- |
| Formatting | `pnpm exec prettier --write` on changed ts/tsx | clean (`.mdx` is in `.prettierignore`) |
| Types | `pnpm exec tsc --noEmit` | no errors in project files – the `node_modules/zod` ones are pre-existing |
| Console before vs after | captured errors on `pocket-guides-landing` and on this branch, all 3 changed pages | 5 unique before, 5 after, same set. **zero new** |
| Both docs pages | `pnpm start`, loaded them | card renders, CTAs resolve to the right volume |
| Null path | `/docs/product-analytics/start-here` | no card, page unchanged |
| Shared card | `/self-driving` | same card, own copy, shelf link intact |
| Counts | compared covers against `/pocket-guides` | vol 1 says "3 guides" on all three surfaces |
| MDX nesting | checked the live DOM for a `<p>` ancestor | none, warnings went 4 → 0 per page |

**Not tested:** production build (`pnpm build`)

### What to look at

1. **`contents/docs/ai-observability/start-here.mdx`** – 93% paid traffic and the handbook calls start-here pages high-converting for ads. a second CTA ahead of "Use for free" could pull people out of the install path. if you want it lower or behind an experiment, say so now
2. **`src/pages/self-driving/index.tsx`** – live marketing page, only touched to kill the duplication. should look identical apart from the capitalized title. if it doesn't, the extraction dropped something
3. **the `<div>` wrappers in the mdx** – they look like noise, they aren't. see tour stop 5

</details>

## Testing
- formatting/types/console checks all clean
- previewed and tested everything locally – card renders, CTAs resolve
- null path tested on pages w/o guides, no card and page unchanged
