### PR TITLE
chore(pocket-guides): docs menu experiment

### DIFF
--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -9,6 +9,7 @@ import { IconGraph, IconWarning, IconRewindPlay  } from '@posthog/icons'
 import LLMsInstallationPlatforms from './_snippets/llms-installation-platforms.tsx'
 import OSButton from 'components/OSButton'
 import WizardCommand from 'components/WizardCommand'
+import GuidesForProduct from 'components/PocketGuides/GuidesForProduct'
 
 
 <QuestLog firstSpeechBubble="Let's get started!" lastSpeechBubble="Time to integrate AI Observability!">
@@ -180,6 +181,18 @@ Reports land in your [inbox](/docs/self-driving/inbox), where one click turns th
 <OSButton variant="primary" asLink to="/docs/self-driving">
   Set up Self-driving
 </OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+  title="Learn it by use case"
+  subtitle="Recommended"
+  icon="IconCompass"
+>
+
+The reference tells you what everything does. The pocket guide walks you through real problems, end to end.
+
+<GuidesForProduct product="ai-observability" />
 
 </QuestLogItem>
 

--- a/contents/docs/ai-observability/start-here.mdx
+++ b/contents/docs/ai-observability/start-here.mdx
@@ -192,7 +192,9 @@ Reports land in your [inbox](/docs/self-driving/inbox), where one click turns th
 
 The reference tells you what everything does. The pocket guide walks you through real problems, end to end.
 
-<GuidesForProduct product="ai-observability" />
+<div>
+  <GuidesForProduct product="ai-observability" />
+</div>
 
 </QuestLogItem>
 

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -12,6 +12,7 @@ import OSButton from 'components/OSButton'
 import WizardCommand from 'components/WizardCommand'
 import LiveSelfDrivingLoop from 'components/LiveSelfDrivingLoop'
 import { IconMessage, IconLaptop, IconMagic, IconCode, IconTerminal } from '@posthog/icons'
+import GuidesForProduct from 'components/PocketGuides/GuidesForProduct'
 
 PostHog makes your product self-driving. It watches how people actually use your product, finds what's worth fixing, opens a pull request, and measures whether the change worked. You review and merge. Turning it on takes one command:
 
@@ -133,9 +134,7 @@ We hold it to a simple standard: you pay a flat **$15 per pull request**, your f
 
 The [pocket guides](/pocket-guides) teach self-driving through real scouts: each use case walks through the report a scout files, the pull request it becomes, and the scout file itself – ending in a one-click way to add it to your own product.
 
-<OSButton variant="primary" asLink to="/pocket-guides">
-  Open the pocket guides
-</OSButton>
+<GuidesForProduct product="self-driving" />
 
 </QuestLogItem>
 

--- a/contents/docs/self-driving/index.mdx
+++ b/contents/docs/self-driving/index.mdx
@@ -134,7 +134,9 @@ We hold it to a simple standard: you pay a flat **$15 per pull request**, your f
 
 The [pocket guides](/pocket-guides) teach self-driving through real scouts: each use case walks through the report a scout files, the pull request it becomes, and the scout file itself – ending in a one-click way to add it to your own product.
 
-<GuidesForProduct product="self-driving" />
+<div>
+  <GuidesForProduct product="self-driving" />
+</div>
 
 </QuestLogItem>
 

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -1,0 +1,51 @@
+import { CallToAction } from 'components/CallToAction'
+import React from 'react'
+
+import { WINDOW_BG } from '../../constants/frostedSurfaces'
+import { volumeForProduct } from '../../constants/pocketGuides'
+import usePocketGuideCounts from '../../hooks/usePocketGuideCounts'
+import Cover from './Cover'
+
+interface GuidesForProductProps {
+    /** Docs slug of the product, e.g. "ai-observability". Matched against `docsProduct` on a volume. */
+    product: string
+    /** Optional heading. Omit it when the surrounding block already has one, e.g. a `QuestLogItem`. */
+    heading?: string
+}
+
+/** The pocket guide for one product, on its docs page. Renders nothing when the product has none. */
+export default function GuidesForProduct({ product, heading }: GuidesForProductProps): JSX.Element | null {
+    const volume = volumeForProduct(product)
+    const counts = usePocketGuideCounts()
+
+    // Most products have no volume – returning null is what makes this safe to drop on any page.
+    if (!volume) {
+        return null
+    }
+
+    return (
+        <div className={`not-prose ${heading ? 'my-12' : ''}`}>
+            {heading && <h3 className="my-6 text-2xl font-bold @md/reader-content:text-3xl">{heading}</h3>}
+            <div
+                className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
+            >
+                <div className="w-[200px] shrink-0">
+                    <Cover volume={volume} count={counts[volume.id] ?? 0} />
+                </div>
+                <div className="min-w-0">
+                    <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
+                    <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">{volume.description}</p>
+                    <CallToAction
+                        to={`/pocket-guides/${volume.id}`}
+                        state={{ newWindow: true }}
+                        type="secondary"
+                        size="md"
+                        className="mt-4"
+                    >
+                        Read the pocket guide
+                    </CallToAction>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -19,7 +19,6 @@ export default function GuidesForProduct({ product }: GuidesForProductProps): JS
         return null
     }
 
-    // A `div`, not a `section`: MDX v1 wraps a component that follows prose in a `p`.
     return (
         <div className="not-prose">
             <VolumeCard volume={volume} count={counts[volume.id] ?? 0} />

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -21,7 +21,7 @@ export default function GuidesForProduct({ product }: GuidesForProductProps): JS
 
     return (
         <div className="not-prose">
-            <VolumeCard volume={volume} count={counts[volume.id] ?? 0} />
+            <VolumeCard volume={volume} count={counts[volume.id] ?? 0} placement="product_docs" />
         </div>
     )
 }

--- a/src/components/PocketGuides/GuidesForProduct.tsx
+++ b/src/components/PocketGuides/GuidesForProduct.tsx
@@ -1,20 +1,16 @@
-import { CallToAction } from 'components/CallToAction'
 import React from 'react'
 
-import { WINDOW_BG } from '../../constants/frostedSurfaces'
 import { volumeForProduct } from '../../constants/pocketGuides'
 import usePocketGuideCounts from '../../hooks/usePocketGuideCounts'
-import Cover from './Cover'
+import VolumeCard from './VolumeCard'
 
 interface GuidesForProductProps {
     /** Docs slug of the product, e.g. "ai-observability". Matched against `docsProduct` on a volume. */
     product: string
-    /** Optional heading. Omit it when the surrounding block already has one, e.g. a `QuestLogItem`. */
-    heading?: string
 }
 
 /** The pocket guide for one product, on its docs page. Renders nothing when the product has none. */
-export default function GuidesForProduct({ product, heading }: GuidesForProductProps): JSX.Element | null {
+export default function GuidesForProduct({ product }: GuidesForProductProps): JSX.Element | null {
     const volume = volumeForProduct(product)
     const counts = usePocketGuideCounts()
 
@@ -23,29 +19,10 @@ export default function GuidesForProduct({ product, heading }: GuidesForProductP
         return null
     }
 
+    // A `div`, not a `section`: MDX v1 wraps a component that follows prose in a `p`.
     return (
-        <div className={`not-prose ${heading ? 'my-12' : ''}`}>
-            {heading && <h3 className="my-6 text-2xl font-bold @md/reader-content:text-3xl">{heading}</h3>}
-            <div
-                className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
-            >
-                <div className="w-[200px] shrink-0">
-                    <Cover volume={volume} count={counts[volume.id] ?? 0} />
-                </div>
-                <div className="min-w-0">
-                    <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
-                    <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">{volume.description}</p>
-                    <CallToAction
-                        to={`/pocket-guides/${volume.id}`}
-                        state={{ newWindow: true }}
-                        type="secondary"
-                        size="md"
-                        className="mt-4"
-                    >
-                        Read the pocket guide
-                    </CallToAction>
-                </div>
-            </div>
+        <div className="not-prose">
+            <VolumeCard volume={volume} count={counts[volume.id] ?? 0} />
         </div>
     )
 }

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -159,6 +159,7 @@ shows after the `.mdx` file itself changes (or `pnpm clean`).
 |---|---|
 | `Cover.tsx` | The series cover on the shelf: spine, masthead, specimen, volume number |
 | `Book.tsx` | The volume as a coloured spine for the `/docs` library column, plus the `BookShelf` it sits in |
+| `GuidesForProduct.tsx` | The volume for one product, on that product's docs page. Renders nothing when there is none |
 | `BookReader.tsx` | The full-window page: edge book tabs, popovers, turn zones, foot nav |
 | `BookPage.tsx` | Renders one MDX page into the reader |
 | `bookComponents.tsx` | Assembles the MDX vocabulary from the files below |
@@ -195,6 +196,16 @@ rather than as an object. Both are `motion-safe:`.
 `BookShelf` is layout only: a `max-w-[420px]` column. The cap is what keeps a spine spine-shaped –
 when the docs index stacks into one column the library gets the full window width, and without it
 the volumes stretch into wall-wide slivers.
+
+`GuidesForProduct` is the tool-docs entry point: `<GuidesForProduct product="ai-observability" />`,
+imported into whichever page owns that product's syllabus – `start-here.mdx` for AI Observability,
+`index.mdx` for Self-driving. It matches the slug against `docsProduct` on a volume via `volumeForProduct`
+and **returns `null` when nothing matches** – most products have no volume, so dropping it on a page
+is always safe. Adding a product to the mechanism is one line: set `docsProduct` on its volume in
+`src/constants/pocketGuides.ts`.
+
+It renders the same `Cover` and the same shape as the "Learn it by use case" block on
+`/self-driving` (`src/pages/self-driving/index.tsx`) – one look for the same idea in both places.
 
 Volume metadata lives in `src/constants/pocketGuides.ts` (data-only so `gatsby/` can import it).
 The report frontmatter contract and the `.md` agent-mirror constraints are documented in

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -159,7 +159,8 @@ shows after the `.mdx` file itself changes (or `pnpm clean`).
 |---|---|
 | `Cover.tsx` | The series cover on the shelf: spine, masthead, specimen, volume number |
 | `Book.tsx` | The volume as a coloured spine for the `/docs` library column, plus the `BookShelf` it sits in |
-| `GuidesForProduct.tsx` | The volume for one product, on that product's docs page. Renders nothing when there is none |
+| `VolumeCard.tsx` | One volume pitched as a card: cover, pitch, button. Shared by the docs pages and `/self-driving` |
+| `GuidesForProduct.tsx` | Looks up the volume for a docs slug and renders a `VolumeCard`. Renders nothing when there is none |
 | `BookReader.tsx` | The full-window page: edge book tabs, popovers, turn zones, foot nav |
 | `BookPage.tsx` | Renders one MDX page into the reader |
 | `bookComponents.tsx` | Assembles the MDX vocabulary from the files below |
@@ -204,8 +205,13 @@ and **returns `null` when nothing matches** – most products have no volume, so
 is always safe. Adding a product to the mechanism is one line: set `docsProduct` on its volume in
 `src/constants/pocketGuides.ts`.
 
-It renders the same `Cover` and the same shape as the "Learn it by use case" block on
-`/self-driving` (`src/pages/self-driving/index.tsx`) – one look for the same idea in both places.
+Both it and the "Learn it by use case" block on `/self-driving` (`src/pages/self-driving/index.tsx`)
+render `VolumeCard`, so the card is defined once. `VolumeCard` takes the pitch, the link, and the
+button label as props, because those are the only things the two surfaces disagree on – the docs
+pages send a reader to the volume, `/self-driving` sends them to the whole shelf.
+
+`VolumeCard` deliberately has no `overflow-hidden`: the cover's hover tilt lifts a drop shadow, and
+clipping the card would cut it off.
 
 Volume metadata lives in `src/constants/pocketGuides.ts` (data-only so `gatsby/` can import it).
 The report frontmatter contract and the `.md` agent-mirror constraints are documented in

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -213,6 +213,9 @@ pages send a reader to the volume, `/self-driving` sends them to the whole shelf
 `VolumeCard` deliberately has no `overflow-hidden`: the cover's hover tilt lifts a drop shadow, and
 clipping the card would cut it off.
 
+In `.mdx`, wrap the component in a `<div>`. On its own line MDX treats it as a paragraph and emits
+`<p>`, which cannot legally hold the cover's `<article>` and `<header>`.
+
 Volume metadata lives in `src/constants/pocketGuides.ts` (data-only so `gatsby/` can import it).
 The report frontmatter contract and the `.md` agent-mirror constraints are documented in
 `components/SelfDrivingInbox/README.md`.

--- a/src/components/PocketGuides/VolumeCard.tsx
+++ b/src/components/PocketGuides/VolumeCard.tsx
@@ -1,0 +1,55 @@
+import { CallToAction } from 'components/CallToAction'
+import React from 'react'
+
+import { WINDOW_BG } from '../../constants/frostedSurfaces'
+import type { PocketGuideVolume } from '../../constants/pocketGuides'
+import Cover from './Cover'
+
+interface VolumeCardProps {
+    volume: PocketGuideVolume
+    /** Guides printed on the cover. Callers count them, because the sources differ per surface. */
+    count: number
+    /** Which surface this card sits on. Forwarded to `Cover` so every open is attributable. */
+    placement: 'shelf' | 'self_driving_page' | 'product_docs'
+    /** The pitch. Defaults to the volume's own one-liner. */
+    description?: React.ReactNode
+    /** Where the button goes. Defaults to the volume itself. */
+    to?: string
+    ctaLabel?: string
+}
+
+/** One volume pitched as a card: cover, pitch, button. Shared by the docs pages and `/self-driving`. */
+export default function VolumeCard({
+    volume,
+    count,
+    placement,
+    description,
+    to,
+    ctaLabel = 'Read the pocket guide',
+}: VolumeCardProps): JSX.Element {
+    return (
+        // No `overflow-hidden`: the cover's hover tilt lifts a drop shadow that clipping would cut off.
+        <div
+            className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
+        >
+            <div className="w-[200px] shrink-0">
+                <Cover volume={volume} count={count} placement={placement} />
+            </div>
+            <div className="min-w-0">
+                <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
+                <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">
+                    {description ?? volume.description}
+                </p>
+                <CallToAction
+                    to={to ?? `/pocket-guides/${volume.id}`}
+                    state={{ newWindow: true }}
+                    type="secondary"
+                    size="md"
+                    className="mt-4"
+                >
+                    {ctaLabel}
+                </CallToAction>
+            </div>
+        </div>
+    )
+}

--- a/src/components/PocketGuides/VolumeCard.tsx
+++ b/src/components/PocketGuides/VolumeCard.tsx
@@ -28,18 +28,18 @@ export default function VolumeCard({
     ctaLabel = 'Read the pocket guide',
 }: VolumeCardProps): JSX.Element {
     return (
+        // Always stacked: side by side squeezed the copy at ordinary widths (#19713 review).
         // No `overflow-hidden`: the cover's hover tilt lifts a drop shadow that clipping would cut off.
         <div
-            className={`flex flex-col items-center gap-8 rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
+            className={`flex flex-col items-center gap-6 rounded-md border border-primary p-6 text-center @md/reader-content:p-8 ${WINDOW_BG}`}
         >
-            <div className="w-[200px] shrink-0">
+            {/* Caps at 200px but shrinks into narrow cards, which `shrink-0` would not. */}
+            <div className="w-full max-w-[200px]">
                 <Cover volume={volume} count={count} placement={placement} />
             </div>
-            <div className="min-w-0">
+            <div className="max-w-xl">
                 <p className="m-0 text-base font-bold text-primary">The pocket guide to {volume.title}</p>
-                <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">
-                    {description ?? volume.description}
-                </p>
+                <p className="m-0 mt-2 text-base leading-relaxed text-secondary">{description ?? volume.description}</p>
                 <CallToAction
                     to={to ?? `/pocket-guides/${volume.id}`}
                     state={{ newWindow: true }}

--- a/src/components/RadixUI/MenuBar.tsx
+++ b/src/components/RadixUI/MenuBar.tsx
@@ -29,6 +29,9 @@ export type MenuType = {
     link?: string // Direct link for the menu trigger instead of opening a menu
     mobileLink?: string // Direct link for the menu trigger on mobile
     hideChevron?: boolean // Hide the chevron down icon for this menu in website mode
+    onOpen?: () => void // Fired when this menu opens. Opt-in per menu, so nothing else pays for it.
+    /** Fired when an item in this menu is clicked. Opt-in per menu, like `onOpen`. */
+    onItemClick?: (detail: { label: string; href: string | null }) => void
 }
 
 const RootClasses = 'flex gap-px py-0.5 h-full'
@@ -361,7 +364,13 @@ const MenuBar: React.FC<MenuBarProps> = ({ menus, className, triggerAsChild, cus
             data-scheme="tertiary"
             className={`${RootClasses} ${className || ''}`}
             value={openMenuIndex !== null ? String(openMenuIndex) : ''}
-            onValueChange={(value) => setOpenMenuIndex(value ? Number(value) : null)}
+            onValueChange={(value) => {
+                const nextIndex = value ? Number(value) : null
+                setOpenMenuIndex(nextIndex)
+                if (nextIndex !== null) {
+                    processedMenus[nextIndex]?.onOpen?.()
+                }
+            }}
         >
             {processedMenus.map((menu, menuIndex) => {
                 const triggerLink = menu.link || (isMobile && menu.mobileLink) || null
@@ -394,6 +403,23 @@ const MenuBar: React.FC<MenuBarProps> = ({ menus, className, triggerAsChild, cus
                         </RadixMenubar.Trigger>
                         <RadixMenubar.Portal container={portalContainer || undefined}>
                             <RadixMenubar.Content
+                                onClickCapture={
+                                    menu.onItemClick
+                                        ? (event) => {
+                                              // Links only – submenu triggers and padding aren't navigations.
+                                              const anchor = (event.target as HTMLElement)?.closest?.(
+                                                  'a[href]'
+                                              ) as HTMLAnchorElement | null
+                                              const label = anchor?.textContent?.trim()
+                                              if (label) {
+                                                  menu.onItemClick?.({
+                                                      label,
+                                                      href: anchor.getAttribute('href'),
+                                                  })
+                                              }
+                                          }
+                                        : undefined
+                                }
                                 collisionBoundary={appContainer}
                                 className={`${ContentClasses} max-h-[calc(var(--radix-menubar-content-available-height)-0.75rem)] overflow-hidden flex flex-col`}
                                 align="start"

--- a/src/components/TaskBarMenu/docsNavVariants.ts
+++ b/src/components/TaskBarMenu/docsNavVariants.ts
@@ -8,7 +8,7 @@ export const DOCS_NAV_VARIANTS: DocsNavVariantId[] = ['control', 'goals']
 
 export const DEFAULT_DOCS_NAV_VARIANT: DocsNavVariantId = DOCS_NAV_VARIANTS[0]
 
-/** Control covers SSR, ad-blocked visitors, absent flags, and any key we don't recognise. */
+/** Control covers SSR, ad-blocked visitors, absent flags, and any key we don't recognize. */
 export function resolveDocsNavVariant(value: string | boolean | null | undefined): DocsNavVariantId {
     if (!value || typeof value !== 'string') {
         return DEFAULT_DOCS_NAV_VARIANT

--- a/src/components/TaskBarMenu/docsNavVariants.ts
+++ b/src/components/TaskBarMenu/docsNavVariants.ts
@@ -1,0 +1,18 @@
+/** Docs drop-down experiment: does grouping the menu by reader goal get more people into a pocket guide? */
+export const DOCS_NAV_FLAG = 'docs-nav-goals'
+
+export type DocsNavVariantId = 'control' | 'goals'
+
+/** Index 0 is control, and control is the fallback for every failure mode. */
+export const DOCS_NAV_VARIANTS: DocsNavVariantId[] = ['control', 'goals']
+
+export const DEFAULT_DOCS_NAV_VARIANT: DocsNavVariantId = DOCS_NAV_VARIANTS[0]
+
+/** Control covers SSR, ad-blocked visitors, absent flags, and any key we don't recognise. */
+export function resolveDocsNavVariant(value: string | boolean | null | undefined): DocsNavVariantId {
+    if (!value || typeof value !== 'string') {
+        return DEFAULT_DOCS_NAV_VARIANT
+    }
+    const normalized = value.trim().toLowerCase() as DocsNavVariantId
+    return DOCS_NAV_VARIANTS.includes(normalized) ? normalized : DEFAULT_DOCS_NAV_VARIANT
+}

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -273,7 +273,7 @@ const TemplatesItem = {
     icon: <Icons.IconMagic className="size-4 text-purple" />,
 }
 
-/** Goals arm of DOCS_NAV_FLAG: same entries as DOCS_GROUPS, regrouped; a name dropped here falls into `More tools` instead. */
+/** Goals arm of DOCS_NAV_FLAG: DOCS_GROUPS regrouped by reader goal. A name dropped here lands in `More tools`. */
 const DOCS_GROUPS_GOALS: DocsGroup[] = [
     {
         label: 'New to PostHog',
@@ -354,8 +354,7 @@ export const getDocsMenuItems = (groups: DocsGroup[] = DOCS_GROUPS): MenuItemTyp
         return IconComponent ? <IconComponent className={`text-${source.color || 'gray'} size-4`} /> : undefined
     }
 
-    // A name matching no docsMenu entry is dropped by the filters below, so a typo quietly
-    // shortens the menu. Warn in development rather than let it pass unseen.
+    // A name matching nothing is dropped below, so warn rather than let a typo shorten the menu.
     const claim = (label: string): MenuItemType | undefined => {
         const item = byLabel.get(label)
         if (!item && process.env.NODE_ENV !== 'production') {
@@ -507,7 +506,7 @@ export function useMenuData(): MenuType[] {
             trigger: 'Docs',
             // The docs tree is too deep to browse inside a hamburger; mobile goes to the homepage instead
             mobileLink: '/docs',
-            // Read on open, not on render: reading the flag enrols, and most visitors never open this.
+            // Read on open, not on render: reading the flag enrolls, and most visitors never open this.
             onOpen: () => setDocsNavVariant(resolveDocsNavVariant(posthog?.getFeatureFlag?.(DOCS_NAV_FLAG))),
             // What DOCS_NAV_FLAG is measured on; the variant rides along so arms compare without a join.
             onItemClick: ({ label, href }) =>

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -273,7 +273,7 @@ const TemplatesItem = {
     icon: <Icons.IconMagic className="size-4 text-purple" />,
 }
 
-/** The `goals` arm of DOCS_NAV_FLAG: same entries as DOCS_GROUPS, grouped by what a reader wants to do. */
+/** Goals arm of DOCS_NAV_FLAG: same entries as DOCS_GROUPS, regrouped; a name dropped here falls into `More tools` instead. */
 const DOCS_GROUPS_GOALS: DocsGroup[] = [
     {
         label: 'New to PostHog',
@@ -354,9 +354,19 @@ export const getDocsMenuItems = (groups: DocsGroup[] = DOCS_GROUPS): MenuItemTyp
         return IconComponent ? <IconComponent className={`text-${source.color || 'gray'} size-4`} /> : undefined
     }
 
+    // A name matching no docsMenu entry is dropped by the filters below, so a typo quietly
+    // shortens the menu. Warn in development rather than let it pass unseen.
+    const claim = (label: string): MenuItemType | undefined => {
+        const item = byLabel.get(label)
+        if (!item && process.env.NODE_ENV !== 'production') {
+            console.warn(`[docs menu] "${label}" matches no docs entry, so it will not appear.`)
+        }
+        return item
+    }
+
     const resolve = (entry: string | DocsSubGroup): MenuItemType | undefined => {
-        if (typeof entry === 'string') return byLabel.get(entry)
-        const children = entry.items.map((label) => byLabel.get(label)).filter(Boolean) as MenuItemType[]
+        if (typeof entry === 'string') return claim(entry)
+        const children = entry.items.map(claim).filter(Boolean) as MenuItemType[]
         if (children.length === 0) return undefined
         return { type: 'submenu' as const, label: entry.label, icon: iconFor(entry), items: children }
     }

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -5,6 +5,8 @@ import * as Icons from '@posthog/icons'
 import { Logo } from '@posthog/brand/logo'
 import SearchableProductMenu from './SearchableProductMenu'
 import useProduct from '../../hooks/useProduct'
+import usePostHog from '../../hooks/usePostHog'
+import { DEFAULT_DOCS_NAV_VARIANT, DOCS_NAV_FLAG, DocsNavVariantId, resolveDocsNavVariant } from './docsNavVariants'
 import {
     IconXNotTwitter,
     IconSubstack,
@@ -193,6 +195,8 @@ type DocsSubGroup = {
 type DocsGroup = {
     label: string
     items: (string | DocsSubGroup)[]
+    /** Links that aren't in docsMenu and so can't be referenced by name. */
+    extraItems?: MenuItemType[]
     overflow?: string
     collapse?: boolean
     catchAll?: boolean
@@ -246,7 +250,92 @@ const DOCS_GROUPS: DocsGroup[] = [
     },
 ]
 
-export const getDocsMenuItems = (): MenuItemType[] => {
+const PocketGuidesItem = {
+    type: 'item' as const,
+    label: 'Pocket guides',
+    link: '/pocket-guides',
+    // Orange matches volume one's token in src/constants/pocketGuides.ts.
+    icon: <Icons.IconCompass className="size-4 text-orange" />,
+}
+
+const TutorialsItem = {
+    type: 'item' as const,
+    label: 'Tutorials',
+    link: '/tutorials',
+    icon: <Icons.IconGraduationCap className="size-4 text-purple" />,
+}
+
+const TemplatesItem = {
+    type: 'item' as const,
+    label: 'Templates',
+    link: '/templates',
+    // Matches the Templates entry in src/navs/index.js.
+    icon: <Icons.IconMagic className="size-4 text-purple" />,
+}
+
+/** The `goals` arm of DOCS_NAV_FLAG: same entries as DOCS_GROUPS, grouped by what a reader wants to do. */
+const DOCS_GROUPS_GOALS: DocsGroup[] = [
+    {
+        label: 'New to PostHog',
+        items: ['Self-driving'],
+        extraItems: [PocketGuidesItem, TutorialsItem],
+    },
+    {
+        label: 'Get started',
+        items: [
+            'Install PostHog',
+            'SDKs & frameworks',
+            'PostHog Web',
+            'PostHog Desktop',
+            'PostHog Slack',
+            'PostHog MCP',
+            'PostHog CLI',
+        ],
+    },
+    {
+        label: 'Tools',
+        items: [
+            {
+                label: 'Analytics',
+                icon: 'IconGraph',
+                color: 'blue',
+                items: [
+                    'Product Analytics',
+                    'Web Analytics',
+                    'Customer Analytics',
+                    'Revenue Analytics',
+                    'MCP Analytics',
+                ],
+            },
+            'Session Replay',
+            'AI Observability',
+            'Error Tracking',
+        ],
+        overflow: 'More tools',
+        icon: 'IconApps',
+        color: 'blue',
+    },
+    { label: 'Context', items: ['Data Warehouse', 'Data pipelines', 'Semantic layer'] },
+    {
+        label: 'Reference',
+        collapse: true,
+        icon: 'IconBook',
+        color: 'lilac',
+        items: [
+            'API',
+            'New to PostHog',
+            'AI engineering',
+            'Toolbar & features',
+            'Self-host & deploy',
+            'Billing',
+            'Privacy & GDPR',
+            'How PostHog works',
+            'Glossary',
+        ],
+    },
+]
+
+export const getDocsMenuItems = (groups: DocsGroup[] = DOCS_GROUPS): MenuItemType[] => {
     const items = groupBySectionDividers((docsMenu as DocsMenu).children)
         // Remove any item (submenu or section divider) with label 'Docs'
         .filter((item) => !(item.type === 'submenu' && item.label === 'Docs'))
@@ -255,9 +344,7 @@ export const getDocsMenuItems = (): MenuItemType[] => {
 
     const byLabel = new Map<string, MenuItemType>(items.map((item) => [item.label as string, item]))
     const explicitlyGrouped = new Set(
-        DOCS_GROUPS.flatMap((group) => group.items).flatMap((entry) =>
-            typeof entry === 'string' ? entry : entry.items
-        )
+        groups.flatMap((group) => group.items).flatMap((entry) => (typeof entry === 'string' ? entry : entry.items))
     )
     const byLabelAsc = (a: MenuItemType, b: MenuItemType) =>
         (a.label as string).localeCompare(b.label as string, undefined, { sensitivity: 'base' })
@@ -278,7 +365,7 @@ export const getDocsMenuItems = (): MenuItemType[] => {
 
     const unclaimed = () => items.filter((item) => !explicitlyGrouped.has(item.label as string)).sort(byLabelAsc)
 
-    DOCS_GROUPS.forEach((group) => {
+    groups.forEach((group) => {
         const named = group.catchAll ? unclaimed() : (group.items.map(resolve).filter(Boolean) as MenuItemType[])
 
         if (group.collapse) {
@@ -288,7 +375,7 @@ export const getDocsMenuItems = (): MenuItemType[] => {
             return
         }
 
-        const groupItems = [...named]
+        const groupItems = [...named, ...(group.extraItems ?? [])]
 
         if (group.overflow) {
             const rest = unclaimed()
@@ -316,10 +403,11 @@ export const getDocsMenuItems = (): MenuItemType[] => {
     return grouped.map((item) => (item.items ? { ...item, items: stripIcons(item.items) } : item))
 }
 
-const mergedDocsMenu = (allProducts: any[]) => {
-    const docsItems = getDocsMenuItems()
+const mergedDocsMenu = (allProducts: any[], variant: DocsNavVariantId = DEFAULT_DOCS_NAV_VARIANT) => {
+    const goals = variant === 'goals'
+    const docsItems = getDocsMenuItems(goals ? DOCS_GROUPS_GOALS : DOCS_GROUPS)
     const itemsWithMobileDestinations = addDocsMenuMobileDestinations(docsItems, allProducts)
-    return [...DocsItemsStart, ...itemsWithMobileDestinations, ...DocsItemsEnd]
+    return [...DocsItemsStart, ...itemsWithMobileDestinations, ...(goals ? DocsItemsEndGoals : DocsItemsEnd)]
 }
 
 // Build Products menu items
@@ -390,6 +478,8 @@ export function useMenuData(): MenuType[] {
     const smallTeamsMenuItems = useSmallTeamsMenuItems()
     const allProducts = useProduct() as any[]
     const { isMobile } = useAppSettings()
+    const posthog = usePostHog()
+    const [docsNavVariant, setDocsNavVariant] = React.useState<DocsNavVariantId>(DEFAULT_DOCS_NAV_VARIANT)
 
     // Define main navigation items (excluding logo menu)
     const mainNavItems: MenuType[] = [
@@ -407,7 +497,17 @@ export function useMenuData(): MenuType[] {
             trigger: 'Docs',
             // The docs tree is too deep to browse inside a hamburger; mobile goes to the homepage instead
             mobileLink: '/docs',
-            items: mergedDocsMenu(allProducts),
+            // Read on open, not on render: reading the flag enrols, and most visitors never open this.
+            onOpen: () => setDocsNavVariant(resolveDocsNavVariant(posthog?.getFeatureFlag?.(DOCS_NAV_FLAG))),
+            // What DOCS_NAV_FLAG is measured on; the variant rides along so arms compare without a join.
+            onItemClick: ({ label, href }) =>
+                posthog?.capture('docs_nav_clicked', {
+                    label,
+                    href,
+                    variant: docsNavVariant,
+                    is_pocket_guide: href?.startsWith('/pocket-guides') ?? false,
+                }),
+            items: mergedDocsMenu(allProducts, docsNavVariant),
         },
         {
             trigger: 'Community',
@@ -912,29 +1012,10 @@ export const DocsItemsStart = [
     },
 ]
 
-export const DocsItemsEnd = [
-    { type: 'separator' as const },
-    {
-        type: 'item' as const,
-        label: 'Tutorials',
-        link: '/tutorials',
-        icon: <Icons.IconGraduationCap className="size-4 text-purple" />,
-    },
-    {
-        type: 'item' as const,
-        label: 'Pocket guides',
-        link: '/pocket-guides',
-        // Orange matches volume one's token in src/constants/pocketGuides.ts.
-        icon: <Icons.IconCompass className="size-4 text-orange" />,
-    },
-    {
-        type: 'item' as const,
-        label: 'Templates',
-        link: '/templates',
-        // Matches the Templates entry in src/navs/index.js.
-        icon: <Icons.IconMagic className="size-4 text-purple" />,
-    },
-]
+/** Goals arm: guides lead the menu, so only Templates is left to trail it. */
+export const DocsItemsEndGoals = [{ type: 'separator' as const }, TemplatesItem]
+
+export const DocsItemsEnd = [{ type: 'separator' as const }, TutorialsItem, PocketGuidesItem, TemplatesItem]
 
 import type { AppIconName } from 'components/OSIcons/AppIcon'
 

--- a/src/constants/pocketGuides.ts
+++ b/src/constants/pocketGuides.ts
@@ -13,6 +13,8 @@ export interface PocketGuideVolume {
     token: PocketGuideToken
     /** Printed on the cover. Order on the shelf follows it. */
     volume: number
+    /** Docs slug of the product this volume teaches. Omit when it teaches no single product. */
+    docsProduct?: string
     /** A hand-written src/pages file owns this route, so don't generate one. */
     hasStaticPage?: boolean
     /** Announced but unwritten – renders as a cover with a sash and no link. */
@@ -32,6 +34,7 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         description: 'Scouts that watch your product and open a pull request when something breaks.',
         token: 'orange',
         volume: 1,
+        docsProduct: 'self-driving',
         hasStaticPage: true,
     },
     {
@@ -40,6 +43,7 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         description: 'Tracing every LLM call, scoring what comes back, and seeing what users do with it.',
         token: 'purple',
         volume: 2,
+        docsProduct: 'ai-observability',
     },
     {
         id: 'context-warehouse',
@@ -57,6 +61,11 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         volume: 4,
     },
 ]
+
+/** The volume that teaches a product, if one does. Drives `GuidesForProduct` on tool docs pages. */
+export function volumeForProduct(docsProduct: string): PocketGuideVolume | undefined {
+    return POCKET_GUIDE_VOLUMES.find((v) => v.docsProduct === docsProduct && !v.comingSoon)
+}
 
 export function volumeById(id: string): PocketGuideVolume | undefined {
     return POCKET_GUIDE_VOLUMES.find((v) => v.id === id)

--- a/src/pages/self-driving/index.tsx
+++ b/src/pages/self-driving/index.tsx
@@ -12,7 +12,7 @@ import { WINDOW_BG } from '../../constants/frostedSurfaces'
 import useProduct from 'hooks/useProduct'
 import { useApp } from '../../context/App'
 import { GetStarted } from 'components/Home/Test'
-import Cover from 'components/PocketGuides/Cover'
+import VolumeCard from 'components/PocketGuides/VolumeCard'
 import { useSelfDrivingTemplates } from 'components/SelfDrivingInbox'
 import { volumeById } from '../../constants/pocketGuides'
 import { CatalogLayers } from 'components/ContextWarehouseCatalog'
@@ -722,30 +722,14 @@ const PocketGuidesSection = (): JSX.Element | null => {
     return (
         <section className="not-prose my-12">
             <h3 className={sectionHeadingClassName}>Learn it by use case</h3>
-            <div
-                className={`flex flex-col items-center gap-8 overflow-hidden rounded-md border border-primary p-6 @md/reader-content:flex-row @md/reader-content:items-start @md/reader-content:p-8 ${WINDOW_BG}`}
-            >
-                <div className="w-[200px] shrink-0">
-                    <Cover placement="self_driving_page" volume={volume} count={guides.length} />
-                </div>
-                <div className="min-w-0">
-                    <p className="m-0 text-base font-bold text-primary">The pocket guide to self-driving</p>
-                    <p className="m-0 mt-2 max-w-xl text-base leading-relaxed text-secondary">
-                        A quick overview of self-driving, plus real use cases. Each one walks through the report a scout
-                        files, the pull request it becomes, and the scout itself. You can also add each use case as a
-                        custom scout to your own product.
-                    </p>
-                    <CallToAction
-                        to="/pocket-guides"
-                        state={{ newWindow: true }}
-                        type="secondary"
-                        size="md"
-                        className="mt-4"
-                    >
-                        Read the pocket guides
-                    </CallToAction>
-                </div>
-            </div>
+            <VolumeCard
+                placement="self_driving_page"
+                volume={volume}
+                count={guides.length}
+                to="/pocket-guides"
+                ctaLabel="Read the pocket guides"
+                description="A quick overview of self-driving, plus real use cases. Each one walks through the report a scout files, the pull request it becomes, and the scout itself. You can also add each use case as a custom scout to your own product."
+            />
         </section>
     )
 }


### PR DESCRIPTION
> still WIP :)))) will mark as ready when done

adds an experiment to the docs drop-down. the `goals` arm carries the same entries as the control, just regrouped by what a reader is trying to do (called out by @gewenyu99)

also lifts pocket guides from second-to-last into "New to PostHog" group at the top

## what I'm actually asking for here

merging this for the **instrumentation only** – I'm not running the experiment yet

the flag stays at 0%, so everyone gets control and nothing changes for a single visitor. what I want first is `docs_nav_clicked` flowing from real traffic, because there's one thing I can't answer locally:

**does anyone actually open this menu?** nothing measures that today. if it's a few hundred opens a week the experiment would take a year and isn't worth running

a week of real data answers it. then I either ramp it or bin it – and if I bin it, better to find that out before wiring up metrics and a split

the event itself **is** verified (I'd said earlier it couldn't be checked locally – that was wrong). stubbing `window.posthog` before the page loads, rather than after it hydrates, means `usePostHog()` picks it up on the first render:

- clicking **Pocket guides** in the menu → fires with `label`, `href`, `variant: control`, `is_pocket_guide: true` ✅
- clicking **Analytics** (a submenu trigger, expands rather than navigates) → fires nothing ✅

that second one matters – without it every submenu expand would count as a nav click and inflate the denominator of the only metric this experiment has

**both are parked and ready:**
- flag → https://us.posthog.com/project/2/feature_flags/845159 (0% rollout)
- experiment → https://us.posthog.com/project/2/experiments/450016 (draft, no metrics yet)

deliberately no metric on the experiment yet – `docs_nav_clicked` has never been ingested, and PostHog's validation that catches typo'd event names is the one thing standing between me and a metric that silently returns nothing forever. adding it once the event is real

## before it can actually launch (not in this PR)

- [x] ~~confirm `docs_nav_clicked` fires~~ – verified locally, see above
- [ ] check the volume is worth it
- [ ] variant split is currently **100/0**, needs to be 50/50 – rollout and split are separate dials and both are shut right now
- [ ] add the primary metric (`docs_nav_clicked` where `is_pocket_guide`)

current nav:
<img width="1122" height="1546" alt="CleanShot 2026-08-25 at 14 59 31@2x" src="https://github.com/user-attachments/assets/83c5dff6-74e2-437d-b1b1-52dc9e757df3" />

new nav:
<img width="676" height="1504" alt="CleanShot 2026-08-25 at 14 58 10@2x" src="https://github.com/user-attachments/assets/50391000-b8c2-466c-9c41-0a2f8f79830f" />

<details>
<summary>🗺️ PR tour</summary>

### 1. `src/components/TaskBarMenu/docsNavVariants.ts` – the flag

new. flag key, the two variant ids, and a resolver. control is the fallback for everything that can go wrong – SSR, ad blockers, a flag that never arrives, a variant key we don't recognize. follows the house pattern in `src/components/Pricing/Experiment`

### 2. `src/components/RadixUI/MenuBar.tsx` – two optional hooks

⚠️ **this is the shared component behind every menu on the site**, so worth a proper look

`onOpen` fires when a menu opens, `onItemClick` when an item in it is clicked. both opt-in per menu, and only the Docs menu sets them, so nothing else changes behavior

`onItemClick` is one `onClickCapture` on the menu content – that covers portaled submenus too, since React events follow the component tree not the DOM. it only reports clicks that land on an actual link, because submenu triggers and padding aren't navigations and counting them would inflate the metric

### 3. `src/components/TaskBarMenu/menuData.tsx` – the arm and the event

`DOCS_GROUPS_GOALS` is the regrouped list. `getDocsMenuItems` takes the groups as an argument now so one function serves both arms. `extraItems` carries links that aren't in `docsMenu` and so can't be referenced by name

the flag is read when the menu **opens**, not on render – reading it is what enrolls someone, and this menu is on every page while barely anyone opens it. enrolling every visitor would bury the result

also fixes a pre-existing bug while I was in here: a name matching no `docsMenu` entry used to get silently dropped, so a typo quietly shortened the menu. it warns in dev now. that bug is in `DOCS_GROUPS` too, which outlives the experiment

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
| --- | --- | --- |
| Formatting | `pnpm exec prettier --write` on changed files | clean |
| Types | `pnpm exec tsc --noEmit` | no errors in project files |
| Control arm unchanged | opened the Docs menu on this branch and on the base | identical, still ends Tutorials → Pocket guides → Templates |
| Goals arm | forced the variant locally, opened the menu | renders the regrouped list, all entries present |
| Nothing dropped | loaded pages with the new warning active, both arms | zero warnings, so neither arm loses a name |
| Warning actually fires | injected a fake entry called "Nonexistent Thing" | `[docs menu] "Nonexistent Thing" matches no docs entry, so it will not appear.` then removed it |
| `docs_nav_clicked` fires | stubbed `window.posthog` before page load, real mouse click on **Pocket guides** in the menu | fires with `label`, `href`, `variant`, `is_pocket_guide` |
| submenu triggers stay quiet | same, but clicked **Analytics** (expands, doesn't navigate) | no event, which is the point of the links-only check |

**Not tested:** production build (`pnpm build`)

### What to look at

1. **`src/components/RadixUI/MenuBar.tsx`** – biggest blast radius here by far. every menu on the site renders through it. the additions are optional and only Docs sets them, but if the `onClickCapture` is wrong it's wrong everywhere
2. **`DOCS_GROUPS_GOALS` restates the control structure by hand** – two lists that have to agree with nothing enforcing it. I didn't build sync machinery on purpose, since one arm gets deleted when the experiment resolves, and the new dev warning catches the failure that actually matters (a name resolving to nothing). push back if you'd rather derive one arm from the other
3. **"New to PostHog" is both a group label and an entry under Reference** – deliberate, we're keeping the section title while the content under it gets rewritten this week. reads like a mistake, isn't

</details>

## Testing
- formatting/type checks clear
- control arm is unchanged, tested locally
- goals arm tested locally, forced the variant
