### PR TITLE
Remove duplicate Fivetran chart in "Mind the context gap"

### DIFF
--- a/contents/blog/mind-the-context-gap.mdx
+++ b/contents/blog/mind-the-context-gap.mdx
@@ -67,7 +67,6 @@ That's most of a data team's week going on work that produces no new answers, on
 
 ## Let's agree on what "data readiness" means
 
-![Fivetran data](https://res.cloudinary.com/dmukukwp6/image/upload/fivetran_screenshot_686e2c07e9.png)
 > 42% of teams say more than half of their AI projects have stalled, and the cause isn't the model. It's a lack of data readiness.
 > ![Fivetran data](https://res.cloudinary.com/dmukukwp6/image/upload/fivetran_screenshot_686e2c07e9.png)
 > 


### PR DESCRIPTION
## Changes

The Fivetran chart showed twice back-to-back in `contents/blog/mind-the-context-gap.mdx`, under the heading "Let's agree on what "data readiness" means". This removes the first copy, which sat on its own above the pull quote, and keeps the copy inside the blockquote. The kept copy agrees with the dbt Labs and Apache quotes elsewhere in the same post, where the chart is part of the blockquote.

**Why:** A reader saw the same chart two times in a row while reading the post.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GU689J1X/p1787687445735379)*
