### PR TITLE
docs(self-driving): document Ask AI and suggested questions on reports

### DIFF
--- a/contents/docs/self-driving/inbox/index.mdx
+++ b/contents/docs/self-driving/inbox/index.mdx
@@ -29,6 +29,7 @@ Each item is ranked by priority, so you work top-down instead of triaging a flat
 From the inbox you:
 
 - **Review** a report and dig into the evidence.
+- **[Ask AI](/docs/self-driving/reports#ask-ai-about-a-report)** a question about a report, with its evidence already in context.
 - **Steer** the work: approve it, snooze it, or decline what self-driving proposes.
 - **Merge** the pull requests you're happy with, the same as any other PR.
 

--- a/contents/docs/self-driving/reports.mdx
+++ b/contents/docs/self-driving/reports.mdx
@@ -30,6 +30,12 @@ A report is enriched and ranked:
 
 A report also accumulates a history as work happens on it: the commits and pull requests opened against it, the code the investigating agent referenced, CI status and review comments on its PR, related reports, and any notes people left while triaging. You're reading the whole trail, not just the original finding.
 
+## Ask AI about a report
+
+A report is a starting point, not a verdict. Click **Ask AI** on a report to ask a question about what it found – who else is affected, whether the problem is new, what to do next. The agent already has the report and its evidence, so you don't have to re-explain the problem. It works in a task you can follow, and you can keep the conversation going there.
+
+Some reports arrive with suggested questions above the question box. The [scout](/docs/self-driving/scouts) that wrote the report knows which threads it left open, so it offers those as a way in. Click one to fill the box, then send it as written or edit it first – nothing is sent until you click **Ask AI**, so a wrong pick costs you nothing. Not every report suggests questions, and you can always ignore them and write your own.
+
 ## Where reports go
 
 Reports land in your [inbox](/docs/self-driving/inbox), ranked by priority. An agent investigates each one. Actionable reports get a pull request to review and merge – the rest wait in your inbox for your input.


### PR DESCRIPTION
## Changes

The reports page described what a report contains and where it goes, but never mentioned that you can ask AI a question about one. Scout-authored reports can now also offer a few suggested questions in that popover, so a reader can meet the feature in the product with nothing in the docs to explain it.

This adds an **Ask AI about a report** section to `contents/docs/self-driving/reports.mdx`, between "What's in a report" and "Where reports go", and one cross-linking bullet to the inbox page so its list of inbox actions is complete.

The prose is deliberate on two points:

- It does not promise that every report has suggestions, because most do not.
- It says a suggestion fills the box and is not sent until you click **Ask AI**, which is the part that makes a suggestion safe to try.

The authoring limits (how many questions a scout may suggest, and how long each one can be) are left out. They bound what a scout writes, not what a reader does, and no other report-authoring field is documented publicly.

**Why:** the capability shipped and is user-facing, and the public documentation did not cover it.

Behaviour was verified against the component in `posthog/posthog` rather than taken from a summary: clicking a suggestion fills and focuses the textarea without submitting, and submission needs the **Ask AI** button or Cmd/Ctrl + Enter.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — not run locally in this environment; please check the preview
- [x] If I moved a page, I added a redirect in `vercel.json` — n/a, no pages moved

Content-only change (two files under `contents/`), so no PR tour or reviewer's guide, and no visual change to screenshot. Prettier reports both files already conform.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*