### PR TITLE
docs: correct four warehouse source pages that describe fewer tables than they have

### DIFF
--- a/contents/docs/cdp/sources/checkout-com.md
+++ b/contents/docs/cdp/sources/checkout-com.md
@@ -15,32 +15,30 @@ This source is currently in **alpha**. The interface and available tables may ch
 
 </CalloutBox>
 
-The Checkout.com connector syncs your disputes data into the PostHog data warehouse. Checkout.com has no list-all-payments endpoint — bulk payment data only exists via report files — so this source currently syncs disputes.
+The Checkout.com connector syncs your payments, payment actions, customers, instruments, and disputes into the PostHog data warehouse. It also syncs your financial reporting data, where each report type your account generates becomes its own table.
 
 ## Adding a data source
 
 1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
 2. Click **+ New source** and then click **Link** next to Checkout.com.
-3. Create an access key in the [Checkout.com dashboard](https://dashboard.checkout.com/) under **Settings > Access keys** with the `disputes` scope. Note whether your key is for the production or sandbox environment.
+3. Create an access key in the [Checkout.com dashboard](https://dashboard.checkout.com/) under **Settings > Access keys**, with the scopes for the tables you want to sync. See [required scopes](#required-scopes) below. Note whether your key is for the production or sandbox environment.
 4. Back in PostHog, select the **Environment** that matches your access key (Production or Sandbox).
-5. Enter your **Access key ID** and **Access key secret**, then click **Next**.
+5. Enter your **Access key ID** and **Access key secret**. To sync more history than the default, set a **Start date**. Click **Next**.
 6. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
 
 Once the syncs are complete, you can start using Checkout.com data in PostHog.
 
-## Available tables
+## Required scopes
 
-| Table      | Description                      | Sync method |
-| ---------- | -------------------------------- | ----------- |
-| `disputes` | Payment disputes and chargebacks | Incremental |
+Checkout.com grants scopes per endpoint, so a key that reads one table often cannot read another. Grant only the scopes for the tables you want.
 
-**Incremental** tables sync only new or updated records on each run using the `last_update` cursor field.
-
-## Sync limitations
-
-Only the disputes endpoint is available. Bulk payment data (charges, payouts, etc.) is delivered by Checkout.com as generated report files, which aren't supported by this source yet.
-
-Incremental syncs use the `last_update` field as a cursor. Disputes are fetched newest-first, so the watermark is committed at the end of each sync run.
+| Table                           | Checkout.com scope |
+| ------------------------------- | ------------------ |
+| `payments`                      | `payments`         |
+| `payment_actions`               | `gateway`          |
+| `customers` and `instruments`   | `vault`            |
+| `disputes`                      | `disputes`         |
+| `reports` and each report table | `reports`          |
 
 ## Configuration
 
@@ -49,3 +47,19 @@ Incremental syncs use the `last_update` field as a cursor. Disputes are fetched 
 ## Supported tables
 
 <SourceTables />
+
+### Payment tables
+
+Checkout.com has no endpoint that lists every payment, so `payments` comes from the payments search API. `payment_actions`, `customers`, and `instruments` have no list endpoint at all. PostHog reads them one record at a time from the ids that the synced payments refer to. These tables therefore hold only the records a synced payment points to, not your full customer or instrument list. Payment methods that Checkout.com does not store in the vault, such as single-use tokens, have no endpoint to read and are skipped.
+
+Payments search covers about the last 90 days. Set a **Start date** to reach further back. The endpoint serves older payments, and PostHog does not move the date you give it forward.
+
+A large backfill can use up the API budget that PostHog allows a single sync run. The sync then stops with an error, keeps every window it finished, and continues from there on the next run. Repeated runs work through the full range.
+
+### Report tables
+
+Financial reporting data – financial actions, payouts, and balances – comes from the report files your account generates, not from an API you can query directly. Each report type becomes its own table, named after the type. The `FinancialActions` report type becomes `financial_actions_report`, for example.
+
+Every report row carries the report and file it came from in its `report_id`, `report_created_on`, `report_from`, `report_to`, `report_entity_id`, `file_id`, and `file_row_index` columns. The remaining columns come from the report template, which you configure in Checkout.com.
+
+If no report tables appear, set up scheduled reports in your Checkout.com dashboard first. PostHog finds the report tables from the reports your account has already generated, so an account with no reports has none to find. PostHog reads CSV report files only, and skips files in other formats.

--- a/contents/docs/cdp/sources/decagon.md
+++ b/contents/docs/cdp/sources/decagon.md
@@ -16,7 +16,7 @@ import AlphaRelease from "../_snippets/alpha-release.mdx"
 
 <AlphaRelease />
 
-The Decagon connector syncs conversations between your users and your [Decagon](https://decagon.ai/) AI agents into the PostHog Data warehouse, including every message, customer satisfaction (CSAT) ratings, tags, and metadata. Use it to analyze support quality alongside your product data.
+The Decagon connector syncs your [Decagon](https://decagon.ai/) AI agent data into the PostHog Data warehouse. It covers the conversations between your users and your agents – every message, customer satisfaction (CSAT) rating, tag, and piece of metadata – plus the Agent Assist actions your human agents take, the knowledge base articles the AI answers with and how often each one is used, your tag taxonomy, admin logs, team members, and Watchtower QA jobs. Use it to analyze support quality alongside your product data.
 
 ## Prerequisites
 
@@ -34,7 +34,9 @@ When linking Decagon, you'll need:
 
 <SyncModes />
 
-The conversations table syncs as a full refresh. Decagon's export returns conversations oldest first, and a conversation reappears in the export whenever it receives new messages, so each sync picks up the latest version of every conversation.
+`conversations` and `admin_logs` sync incrementally. A conversation reappears in Decagon's export whenever it receives new messages, so each sync picks up the latest version of every conversation it has seen change. `agent_assist_actions` is an append-only event stream, one row per action.
+
+The remaining tables sync as a full refresh. `articles`, `tags`, `team_members`, and `watchtower_jobs` are small dimension tables that resolve the ids other tables reference. `article_usage` is a point-in-time snapshot that PostHog replaces on every sync, so it holds current usage counts rather than a history of them.
 
 ## Configuration
 

--- a/contents/docs/cdp/sources/gladly.md
+++ b/contents/docs/cdp/sources/gladly.md
@@ -9,40 +9,26 @@ availability:
 sourceId: Gladly
 ---
 
+import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
+
 <CalloutBox icon="IconFlask" title="Alpha release" type="action">
 
 This source is currently in **alpha**. The interface and available tables may change.
 
 </CalloutBox>
 
-The Gladly connector pulls your customer service data – customers, conversation items, agents, and topics – into the PostHog data warehouse.
-
-Data comes from Gladly's scheduled export jobs rather than a traditional REST API. Gladly produces JSONL files on an hourly or daily schedule, and PostHog processes them oldest-first to keep your warehouse in sync.
+The Gladly connector pulls your customer service data into the PostHog data warehouse: customers, conversation items, agents, and topics, plus conversations and the lifecycle events behind them.
 
 ## Adding a data source
 
 1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
 2. Click **+ New source** and then click **Link** next to Gladly.
 3. In Gladly, go to **Settings** > **API Tokens** and create an API token for an agent with the **API User** permission. Note the agent's email address and the generated token.
-4. Back in PostHog, enter your **Organization** subdomain (the first part of your Gladly URL – for `myorg.gladly.com` enter `myorg`), the **Agent email**, and the **API token**, then click **Next**.
-5. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+4. Back in PostHog, enter your **Organization**, the **Agent email**, and the **API token**. Your organization is the part of your Gladly URL before `.gladly.com` – for `myorg.gladly.com` enter `myorg`, and for `myorg.us-1.gladly.com` enter `myorg.us-1`.
+5. Leave **Gladly domain** on **Production (gladly.com)** unless you are connecting a Gladly sandbox, which is served on `gladly.qa`. Click **Next**.
+6. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
 
 Once the syncs are complete, you can start using Gladly data in PostHog.
-
-## Available tables
-
-| Table                | Description                                                   | Sync method |
-| -------------------- | ------------------------------------------------------------- | ----------- |
-| `customers`          | Customer profiles from your Gladly instance                   | Incremental |
-| `conversation_items` | Individual items within conversations (messages, notes, etc.) | Incremental |
-| `agents`             | Support agents in your organization                           | Incremental |
-| `topics`             | Topics used to categorize conversations                       | Incremental |
-
-**Incremental** tables sync only new or updated records on each run. Each row includes injected `_job_id` and `_job_updated_at` fields from the export job that produced it. The `_job_updated_at` field is used as the incremental cursor.
-
-## Sync limitations
-
-Gladly retains export job files for **14 days**. The initial sync imports all available data within that window. History older than 14 days isn't accessible unless you ask Gladly support to regenerate past exports.
 
 ## Configuration
 
@@ -51,3 +37,36 @@ Gladly retains export job files for **14 days**. The initial sync imports all av
 ## Supported tables
 
 <SourceTables />
+
+Gladly has no traditional REST API for bulk data, so these tables come from two different places, and each place has its own limits on how far back you can go.
+
+### Export job tables
+
+`customers`, `conversation_items`, `agents`, and `topics` come from Gladly's scheduled export jobs. Gladly produces JSONL files on an hourly or daily schedule, and PostHog processes them oldest first.
+
+Each row carries `_job_id` and `_job_updated_at` columns injected from the export job that produced it. `_job_updated_at` is the incremental cursor.
+
+Gladly retains export job files for **14 days**. The first sync imports everything within that window. To get history older than 14 days, ask Gladly support to regenerate the past exports.
+
+### Report tables
+
+`conversations`, `conversation_timestamps`, and `contact_timestamps` come from Gladly's reports instead, so the 14-day export window does not limit them. PostHog requests the reports one time window at a time, oldest window first.
+
+- `conversations` holds one row per conversation and backfills two years of history.
+- `conversation_timestamps` and `contact_timestamps` hold one row per lifecycle event and backfill 90 days. Both are high volume, so they are unselected by default.
+
+A conversation report row restates in place as the conversation changes – when it closes, for example, or changes assignee. Each incremental sync of `conversations` therefore re-reads a trailing 30 days to pick up those changes. Rows older than that only refresh on a full refresh.
+
+Gladly limits the reports endpoint to 10 requests per minute, so PostHog paces its requests to stay under that. A large backfill takes a while as a result.
+
+Gladly also caps a single report at roughly 100,000 rows and truncates anything past it without saying so. PostHog sizes its report windows to stay clear of that cap, and logs a warning if a window gets close.
+
+The report tables merge on their primary key and cannot run as append only, because PostHog re-reads a report window whenever a sync resumes.
+
+## Troubleshooting
+
+- **"Gladly denied access. Please check that the agent has the API User permission":** the token authenticated, but its agent cannot read the API. Give the agent the **API User** permission under **Settings** > **API Tokens** in Gladly.
+- **"Gladly authentication failed":** the agent email or the API token is wrong. Check both, and confirm the token belongs to the agent whose email you entered.
+- **"Gladly returned a report without the columns this table syncs on":** the report came back malformed, so there was no data to sync. Re-enable the sync to try again, and contact support if it keeps happening.
+
+<TroubleshootingLink />

--- a/contents/docs/cdp/sources/sendgrid.md
+++ b/contents/docs/cdp/sources/sendgrid.md
@@ -16,7 +16,7 @@ import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
 
 <AlphaRelease />
 
-The SendGrid connector pulls your SendGrid data into the PostHog data warehouse, covering suppressions, unsubscribe groups, marketing lists, and email templates.
+The SendGrid connector pulls your SendGrid data into the PostHog data warehouse, covering suppressions, daily email statistics, per-message activity, unsubscribe groups, marketing lists, and email templates.
 
 ## Prerequisites
 
@@ -29,8 +29,10 @@ You need a SendGrid account with permission to create API keys. Marketing lists 
 The only credential this source needs is a SendGrid API key. Create one in your [SendGrid API keys settings](https://app.sendgrid.com/settings/api_keys) under **Settings > API Keys**. Give it **Restricted Access** and grant read access to the areas you want to sync:
 
 - **Suppressions** for bounces, blocks, invalid emails, spam reports, global unsubscribes, and unsubscribe groups
+- **Stats** for daily email statistics
 - **Marketing** for marketing lists
 - **Template Engine** for templates
+- **Email Activity** for message activity
 
 The key value starts with `SG.` and SendGrid shows it only once, so copy it before closing the dialog.
 
@@ -45,9 +47,11 @@ SendGrid grants scopes per endpoint, so a key that reads one table often cannot 
 | `invalid_emails`      | `suppression.invalid_emails.read`   |
 | `spam_reports`        | `suppression.spam_reports.read`     |
 | `global_unsubscribes` | `suppression.unsubscribes.read`     |
+| `stats`               | `stats.read`                        |
 | `unsubscribe_groups`  | `asm.groups.read`                   |
 | `marketing_lists`     | `marketing.read`                    |
 | `templates`           | `templates.read`                    |
+| `message_activity`    | `email_activity.read`               |
 
 You don't have to grant every scope. When you paste the key, PostHog checks each table and flags the ones the key can't read, so you can connect with a narrow key and sync only what you need.
 
@@ -57,11 +61,17 @@ You don't have to grant every scope. When you paste the key, PostHog checks each
 
 </CalloutBox>
 
+<CalloutBox icon="IconWarning" title="Message activity needs the email activity add-on" type="caution">
+
+`message_activity` reads SendGrid's Email Activity feed, which is a paid add-on. Accounts without the additional email activity history add-on return a permission error for this table even with `email_activity.read` granted. The table is unselected by default for that reason. The add-on stores 30 days of history, so the first sync backfills at most the last 30 days.
+
+</CalloutBox>
+
 ## Sync modes
 
 <SyncModes />
 
-The suppression tables filter server side on their immutable `created` timestamp, so they sync incrementally. The remaining tables have no timestamp filter in the SendGrid API and sync as a full refresh.
+The suppression tables filter server side on their immutable `created` timestamp, so they sync incrementally. `stats` filters on its daily aggregate date, and backfills the last year on the first sync. `message_activity` narrows a time window over the Email Activity feed. The remaining tables have no timestamp filter in the SendGrid API and sync as a full refresh.
 
 ## Configuration
 
@@ -83,7 +93,7 @@ The key authenticated but isn't allowed to read that table, so adding the scope 
 
 Allow a few minutes after updating a key before retrying, since SendGrid takes a moment to apply new permissions.
 
-If only `marketing_lists` fails while the other tables sync, check whether your account has Marketing Campaigns before changing scopes. Without it, no scope grant will make that table sync.
+If only `marketing_lists` or `message_activity` fails while the other tables sync, check your account's add-ons before changing scopes. `marketing_lists` needs Marketing Campaigns, and `message_activity` needs the additional email activity history add-on. Without them, no scope grant will make those tables sync.
 
 ### The key is rejected when adding the source
 


### PR DESCRIPTION
## Changes

Four data warehouse source pages describe an older, smaller version of their source than the one that ships today. Each page below states table counts or capabilities that are no longer true, so a reader planning a sync gets the wrong answer.

- **Checkout.com** – the page said the source "currently syncs disputes" and that bulk payment data "aren't supported by this source yet". Payments, payment actions, customers, instruments, and per-type report tables all sync now. Adds a required-scopes table, explains that the customer and instrument tables hold only records a synced payment refers to, and covers the start date field and report discovery.
- **Gladly** – a hardcoded four-table list has become stale. Replaces it with the two data paths the source now has: export jobs, which keep 14 days, and reports, which reach back further and carry their own row cap and rate limit. Also documents the Gladly domain field and the regional organization format.
- **Decagon** – the sync modes section described conversations as the only table. Now describes the incremental, append only, and full refresh tables.
- **SendGrid** – the required-scopes table had no row for `stats` or `message_activity`, and the sync modes paragraph called both a full refresh. Adds the rows and a note about the paid add-on that message activity needs.

Every page already renders `<SourceTables />`, so the table lists themselves come from the source's own metadata. This PR only fixes the prose around them, and removes two hand-maintained table lists that duplicated it.

**Why:** these pages back a batch of source work that shipped over the last two weeks. The code changed, the prose did not, so the docs now describe capabilities the sources have outgrown.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — no pages moved

`pnpm format` is a no-op here: `.prettierignore` excludes `*.md` and `*.mdx`. No navigation or visual changes, so no screenshots. Preview build check is left for the Vercel deployment on this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
