### PR TITLE
feat(docs): list supported tables on API-generated source pages

### DIFF
--- a/src/templates/DataWarehouseSource.tsx
+++ b/src/templates/DataWarehouseSource.tsx
@@ -4,6 +4,7 @@ import SEO from 'components/seo'
 import ReactMarkdown from 'react-markdown'
 import ReaderView from 'components/ReaderView'
 import SourceConfiguration from 'components/Product/Sources/Configuration'
+import SourceTables from 'components/Product/Sources/Tables'
 import WarehouseWizardHint from 'components/WarehouseWizardHint'
 import { getProseClasses } from '../constants'
 
@@ -14,6 +15,15 @@ interface SourceField {
     required: boolean
     placeholder: string
     caption: string
+}
+
+interface SourceTable {
+    name: string
+    label: string
+    description: string
+    sync_methods: string[]
+    incremental_fields: string[]
+    primary_keys: string[]
 }
 
 export default function DataWarehouseSource({
@@ -28,10 +38,11 @@ export default function DataWarehouseSource({
             permissionsCaption: string
             beta: boolean
             sourceFields: SourceField[]
+            tables: SourceTable[]
         }
     }
 }): JSX.Element {
-    const { sourceId, name, icon_url, caption, permissionsCaption, beta, sourceFields } = data.postHogSource
+    const { sourceId, name, icon_url, caption, permissionsCaption, beta, sourceFields, tables } = data.postHogSource
 
     return (
         <>
@@ -82,6 +93,9 @@ export default function DataWarehouseSource({
                             <strong>Import</strong>
                         </li>
                     </ol>
+
+                    <h2>Supported tables</h2>
+                    <SourceTables tables={tables} />
                 </div>
             </ReaderView>
         </>
@@ -104,6 +118,14 @@ export const query = graphql`
                 required
                 placeholder
                 caption
+            }
+            tables {
+                name
+                label
+                description
+                sync_methods
+                incremental_fields
+                primary_keys
             }
         }
     }


### PR DESCRIPTION
## Changes

A data warehouse source with no hand-written doc page gets its page from `src/templates/DataWarehouseSource.tsx`. That template renders the source's setup caption, its required permissions, and its config fields — but never its tables. Hand-written pages list tables through `<SourceTables />`, so today the table list exists only for sources somebody wrote a page for.

This renders that same component in the template, from the table metadata the `PostHogSource` node already carries. Sources that discover their tables on connection, such as the SQL sources, fall through to the component's existing empty-state copy.

**Why:** several sources that shipped over the last two weeks have no hand-written page, so the tables they sync are not listed anywhere on the site. Fixing the template covers those sources and every other API-generated page at once, instead of hand-writing a page per source.

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `pnpm format` on the changed file | No changes needed |
| Types | `npx tsc --noEmit` | No errors outside `node_modules` (the `node_modules` errors are pre-existing, from TypeScript 4.9 parsing newer `.d.ts` files) |
| Dev server | `pnpm start`, loaded `/docs/cdp/sources/framer` and `/docs/cdp/sources/dynamodb` | Both render, no new console errors |
| Console | Captured on both sides of the change, four states each | Error sets identical before and after |
| Narrow and wide | Puppeteer at 640px and 1440px, light and dark | See below |
| Redirects | Not run | No page moved or renamed |

### Screenshots

Captured from the local dev server on both sides of the change, so the two columns differ only by this diff.

#### Source page with declared tables (Framer)

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/59f59c49-77e1-4b01-bcf7-5c84ab78dfe0.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/0e0837af-2829-4a09-ad72-4b4943c12f7e.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/cfd055f2-a114-4c81-88c0-25229af08f1b.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/83be0673-b311-4b57-971b-9f3a9a981084.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/8e86d738-b476-42f3-a6f3-954b87c76e4c.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/8c26f3db-31c8-4ddc-9643-812afa295156.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/f5546137-7357-44a7-80b5-505d12aa4144.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/6ecfcc01-c339-439f-9118-b18853c86dc9.png" width="300"> |

#### Source that discovers its tables on connection (DynamoDB)

The empty-state branch, where the component prints its explanatory copy instead of a table.

| State | Before | After |
|---|---|---|
| Light, wide window | Same as the Framer before – the page ends at the linking steps, with no table section of any kind | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/f1bc50c9-6344-4865-bdef-29469684db8d.png" width="300"> |
| Dark, wide window | Same as the Framer before | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/0ff3f2f19728d335ecb0d6655f5ac903f943aa01/2026/08/dd7578eb-30a0-4834-9dda-3fd80ea90e8b.png" width="300"> |

**Not captured:** narrow windows for the DynamoDB empty state. That branch renders a single paragraph, and its before state is identical in shape to Framer's, which is captured at both widths.

### What to look at

- **The `tables` field added to the page query.** If a source node ever carried table metadata in a different shape, this is where a build would break rather than degrade. The field and its subfields are already declared on `PostHogSource` in `gatsby/createSchemaCustomization.ts`, and the same shape already feeds hand-written pages, so the risk is that the schema and this query drift apart later, not today.
- **Placement after the linking steps.** The tables land at the end of the page, right after the step that says to select the tables you want to sync. Moving them above that step would split the config field list from the instructions for filling it in.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build — checked on the local dev server; the preview build was still running
- [x] If I moved a page, I added a redirect in `vercel.json` — no pages moved

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
