### PR TITLE
Update side-projects alum language and screenshot sizes

### DIFF
--- a/src/components/SideProjects/index.tsx
+++ b/src/components/SideProjects/index.tsx
@@ -571,7 +571,7 @@ export const SideProjectForm = ({
                     <label className="text-[15px] font-semibold">Featured image</label>
                     <p className="m-0 mb-2 text-sm text-secondary">
                         Optional – a screenshot or artwork for the gallery card. Leave it out and we generate one for
-                        you.
+                        you. 1280 × 720 (16:9) format is best.
                     </p>
                     <ImageDrop
                         image={featuredImage}

--- a/src/pages/side-projects.tsx
+++ b/src/pages/side-projects.tsx
@@ -563,7 +563,9 @@ function SideProjectsPage({ location }: { location: { search: string } }): JSX.E
                                                     showAlumni ? '' : '-rotate-90'
                                                 }`}
                                             />
-                                            <h2 className="m-0 text-xl">PostHog Alums...</h2>
+                                            <h2 className="m-0 text-xl">
+                                                Side projects and startups from PostHog alums...
+                                            </h2>
                                             <span className="text-sm text-secondary">
                                                 {filteredAlumni.length} project
                                                 {filteredAlumni.length === 1 ? '' : 's'}
@@ -582,8 +584,8 @@ function SideProjectsPage({ location }: { location: { search: string } }): JSX.E
                                                     >
                                                         be your first investor
                                                     </Link>
-                                                    ! Here are some projects from PostHog alumni that we especially
-                                                    like...
+                                                    ! Here are some side projects and startups from PostHog alumni that
+                                                    we especially like...
                                                 </p>
                                                 <div className="grid grid-cols-1 gap-6 @xl:grid-cols-2 @3xl:grid-cols-3 @5xl:grid-cols-4">
                                                     {filteredAlumni.map((project) => (


### PR DESCRIPTION
## Changes

Making it clearer that not all of the alum projects are side-projects. Also adding a tag to Ellie's and Yakko's listing. 

Also adds some guidance on screenshot sizes. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
