### PR TITLE
Document applying the internal user filter to existing insights

### DIFF
--- a/contents/tutorials/filter-internal-users.mdx
+++ b/contents/tutorials/filter-internal-users.mdx
@@ -90,28 +90,28 @@ You can also create filters based on pre-prepared cohorts of users, which is esp
 
 The internal and test user filter is controlled with a simple toggle whenever you create a new insight, or edit an existing one. Turn it on and everything in your filter group will be sifted out; turn it off and you’ll see results from all users together.
 
-Defining your filters doesn't switch them on by itself, so that toggle is the setting that decides what each insight shows. Two controls in project settings write to it for you.
+Defining your filters doesn't switch them on, so this toggle decides whether an insight excludes internal users. You can also set it from project settings, without opening each insight.
 
-### Turn the filter on for new insights
+### Set the default for new insights
 
 **Enable this filter on all new insights** sets the starting value for insights created from then on. It doesn't change insights that already exist.
 
-### Turn the filter on for insights you already have
+### Change every insight you already have
 
-Under **Existing insights**, use **Turn on for existing insights** or **Turn off for existing insights** to apply your choice to every insight in the project, including insights other people created. This is the quickest way to clean up your existing dashboards and insights after you set up your filters for the first time. You need to be a project admin to run it.
+Under **Existing insights**, **Turn on for existing insights** and **Turn off for existing insights** set the toggle for every insight in the project, including insights other people created. Run this after setting up your filters for the first time, so your existing dashboards and insights stop counting internal traffic. You need to be a project admin.
 
 Some insights are left as they are:
 
-- **SQL insights**, which have no such toggle. Write the exclusion into the query itself if you need it.
-- **Insights you can't edit.** An organization admin can run it to cover those, or you can ask for [edit access](/docs/settings/access-control).
+- **SQL insights.** These have no such toggle, so write the exclusion into the query itself if you need it.
+- **Insights you can't edit.** An organization admin can cover those, or you can ask for [edit access](/docs/settings/access-control).
 - **Insights saved in an older format.** These keep whatever they were set to. Open one and save it to convert it, then run this again.
 
 After each run, PostHog tells you how many insights it changed, how many already matched, and how many it left alone.
 
-Dashboards show whatever their insights are set to. The exception is a dashboard with its own override for this filter, which keeps that override and ignores the change to the insight underneath.
+Dashboards show whatever their insights are set to. A dashboard with its own override for this filter keeps that override.
 
-> **Note:** There's no bulk undo. Running it the other way sets every insight to the opposite value, rather than restoring the mix that was there before. To get a single insight back, open its activity log. Each change records the insight's previous query, so you can see what it was set to and set it again by hand.
+You can also run this over the API. See [internal and test users](/docs/data/test-accounts) for the endpoint.
 
-For the full reference, including how to apply the filter to existing insights over the API, see [internal and test users](/docs/data/test-accounts).
+> **Note:** There's no bulk undo. Running it the other way sets every insight to the opposite value, rather than restoring what each one had before. To recover a single insight, open its activity log: each change records the previous query, so you can see what it was set to and set it back by hand.
 
 <NewsletterForm />

--- a/contents/tutorials/filter-internal-users.mdx
+++ b/contents/tutorials/filter-internal-users.mdx
@@ -25,7 +25,7 @@ export const step3Light =
 export const step3Dark =
   "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/filter-internal-users/step3-dark-mode.png";
 
-_Estimated reading time: 4 minutes_ ☕
+_Estimated reading time: 5 minutes_ ☕
 
 When you’re investigating an insight, it’s important to make sure you’re looking at the best possible data and that your findings aren’t skewed. That means checking you understand the definition of events or actions you’re using and, if need be, filtering out groups such as internal users, beta testers and contractors or agencies.
 
@@ -79,7 +79,7 @@ You can create filters which include more than one value by separating values wi
 
 You can also create filters based on pre-prepared cohorts of users, which is especially useful if you’re using cohorts with [Feature Flags](/docs/user-guides/feature-flags) or to run [Experiments](/docs/user-guides/experimentation). To do this, simply select the cohort you wish to add to your internal and test user list.
 
-## Step 4: Apply the filter to an insight
+## Step 4: Apply the filter to your insights
 
 <ProductScreenshot
   imageLight={step3Light}
@@ -88,6 +88,30 @@ You can also create filters based on pre-prepared cohorts of users, which is esp
   alt="Filter Internal Users Step 3"
 />
 
-The internal and test user filter is controlled with a simple toggle whenever you create a new insight, or edit an existing one. Turn it on and everything in your filter group will be sifted out; turn it off and you’ll see results from all users together. Simple!
+The internal and test user filter is controlled with a simple toggle whenever you create a new insight, or edit an existing one. Turn it on and everything in your filter group will be sifted out; turn it off and you’ll see results from all users together.
+
+Defining your filters doesn't switch them on by itself, so that toggle is the setting that decides what each insight shows. Two controls in project settings write to it for you.
+
+### Turn the filter on for new insights
+
+**Enable this filter on all new insights** sets the starting value for insights created from then on. It doesn't change insights that already exist.
+
+### Turn the filter on for insights you already have
+
+Under **Existing insights**, use **Turn on for existing insights** or **Turn off for existing insights** to apply your choice to every insight in the project, including insights other people created. This is the quickest way to clean up your existing dashboards and insights after you set up your filters for the first time. You need to be a project admin to run it.
+
+Some insights are left as they are:
+
+- **SQL insights**, which have no such toggle. Write the exclusion into the query itself if you need it.
+- **Insights you can't edit.** An organization admin can run it to cover those, or you can ask for [edit access](/docs/settings/access-control).
+- **Insights saved in an older format.** These keep whatever they were set to. Open one and save it to convert it, then run this again.
+
+After each run, PostHog tells you how many insights it changed, how many already matched, and how many it left alone.
+
+Dashboards show whatever their insights are set to. The exception is a dashboard with its own override for this filter, which keeps that override and ignores the change to the insight underneath.
+
+> **Note:** There's no bulk undo. Running it the other way sets every insight to the opposite value, rather than restoring the mix that was there before. To get a single insight back, open its activity log. Each change records the insight's previous query, so you can see what it was set to and set it again by hand.
+
+For the full reference, including how to apply the filter to existing insights over the API, see [internal and test users](/docs/data/test-accounts).
 
 <NewsletterForm />


### PR DESCRIPTION
## Changes

Step 4 of the [filter out internal users tutorial](https://posthog.com/tutorials/filter-internal-users) only described the per-insight toggle. It now covers all three controls:

- The per-insight toggle, which is what the other two write to.
- **Enable this filter on all new insights**, which sets the default for insights created from then on.
- **Turn on / off for existing insights**, which applies your choice across every insight in the project, plus what it leaves alone (SQL insights, insights you can't edit, insights in an older format), how dashboard overrides behave, and the fact that there is no bulk undo.

Also links to the [internal and test users](https://posthog.com/docs/data/test-accounts) reference page for the API.

**Why:** we shipped the option to retroactively apply the internal and test user filter to existing insights, and the tutorial still told people to toggle it one insight at a time.

Content-only change, so no PR tour or reviewer's guide, and no visual diff to screenshot.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*