### PR TITLE
Deep-link the roadmap idea form with /roadmap?idea=new

### DIFF
--- a/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
+++ b/src/components/Roadmap/EarlyAccessFeaturesSection.tsx
@@ -41,6 +41,10 @@ const POPULAR_TOP_N = 10
 // and pinned to the top of the Concept lane. See /research for the tracks behind them.
 const RESEARCH_TEAM_SLUG = 'ai-research'
 
+// Deep link for the idea form: /roadmap?idea=new. The in-app support panel points here.
+const IDEA_PARAM = 'idea'
+const IDEA_PARAM_VALUE = 'new'
+
 const PITCH_SURVEY_ID = '019f8008-6dfe-0000-696a-515c59643b03'
 const PITCH_QUESTION_ID = 'd257defb-d875-42fd-8cb6-80845c2bb26f'
 const PITCH_EMAIL_QUESTION_ID = '794db2f2-7ed4-4cf2-a8a3-d27df1b85530'
@@ -169,12 +173,23 @@ const StageChip = ({ stage, size = 'sm' }: { stage: BoardStage; size?: ChipSize 
     )
 }
 
-const roadmapUrl = (search: string, feature?: string): string => {
+/** What the board has open, reflected in the URL. A feature drawer and the idea form are mutually exclusive. */
+interface RoadmapTarget {
+    feature?: string
+    idea?: boolean
+}
+
+const roadmapUrl = (search: string, target: RoadmapTarget = {}): string => {
     const params = new URLSearchParams(search)
-    if (feature) {
-        params.set('feature', feature)
+    if (target.feature) {
+        params.set('feature', target.feature)
     } else {
         params.delete('feature')
+    }
+    if (target.idea) {
+        params.set(IDEA_PARAM, IDEA_PARAM_VALUE)
+    } else {
+        params.delete(IDEA_PARAM)
     }
     const query = params.toString()
     return `/roadmap${query ? `?${query}` : ''}`
@@ -184,7 +199,7 @@ const CopyLinkButton = ({ flagKey }: { flagKey: string }): JSX.Element => {
     const [copied, setCopied] = useState(false)
 
     const copy = () => {
-        const url = `${window.location.origin}${roadmapUrl('', flagKey)}`
+        const url = `${window.location.origin}${roadmapUrl('', { feature: flagKey })}`
         navigator.clipboard?.writeText(url).then(() => {
             setCopied(true)
             window.setTimeout(() => setCopied(false), 2000)
@@ -795,6 +810,14 @@ export default function EarlyAccessFeaturesSection(): JSX.Element | null {
             setTeamFilter(requestedTeam)
         }
     }, [requestedTeam])
+    // Any value opens the form, so a hand-typed /roadmap?idea works as well as the canonical ?idea=new.
+    const requestedIdea = useMemo(() => new URLSearchParams(location.search).has(IDEA_PARAM), [location.search])
+    useEffect(() => {
+        if (requestedIdea) {
+            setPitchOpen(true)
+            setSelectedFlagKey(undefined)
+        }
+    }, [requestedIdea])
     const requestedFeature = requestedFlagKey
         ? allFeatures.find((feature) => feature.flagKey === requestedFlagKey)
         : undefined
@@ -819,15 +842,15 @@ export default function EarlyAccessFeaturesSection(): JSX.Element | null {
             return
         }
         if (allFeatures.some((feature) => feature.flagKey === legacyFlagKey)) {
-            navigate(roadmapUrl(location.search, legacyFlagKey), { replace: true })
+            navigate(roadmapUrl(location.search, { feature: legacyFlagKey }), { replace: true })
         }
     }, [allFeatures, loading, location.hash, location.search, requestedFlagKey])
 
     useEffect(() => {
         if (!loading && requestedFlagKey && !requestedFeature) {
-            navigate(roadmapUrl(location.search), { replace: true })
+            navigate(roadmapUrl(location.search, { idea: requestedIdea }), { replace: true })
         }
-    }, [loading, location.search, requestedFeature, requestedFlagKey])
+    }, [loading, location.search, requestedFeature, requestedFlagKey, requestedIdea])
 
     useEffect(() => {
         if (!overlayContainer || !drawerOpen) {
@@ -911,12 +934,12 @@ export default function EarlyAccessFeaturesSection(): JSX.Element | null {
     const openFeature = (feature: EarlyAccessFeature) => {
         setSelectedFlagKey(feature.flagKey)
         setPitchOpen(false)
-        navigate(roadmapUrl(location.search, feature.flagKey), { replace: true })
+        navigate(roadmapUrl(location.search, { feature: feature.flagKey }), { replace: true })
     }
     const openPitch = () => {
         setPitchOpen(true)
         setSelectedFlagKey(undefined)
-        navigate(roadmapUrl(location.search), { replace: true })
+        navigate(roadmapUrl(location.search, { idea: true }), { replace: true })
     }
     const closeDrawer = () => {
         setPitchOpen(false)


### PR DESCRIPTION
## Changes

The "Your idea here." form on `/roadmap` could only be opened by clicking the card in the Concept lane. There was no URL that put a person in front of it, so no other surface could send them there.

`/roadmap?idea=new` now opens the idea form when the page loads. The param joins the two the board already reads, `?feature=` and `?team=`. Three details:

- Clicking the card also writes the param, so the address bar always holds a link that is safe to share. Closing the panel removes it.
- Any value opens the form. A hand-typed `/roadmap?idea` works as well as the canonical `/roadmap?idea=new`.
- `roadmapUrl()` now takes an object instead of a positional feature key, because it sets two params.

The in-app support panel picks up this link in [PostHog/posthog#89158](https://github.com/PostHog/posthog/pull/89158).

### Screenshots

The panel itself does not change. What changes is that a URL can open it. Every image below is `/roadmap?idea=new`.

| | Before | After |
|---|---|---|
| **Light, narrow** | ![before light narrow](https://raw.githubusercontent.com/PostHog/pr-assets/4ab5f55330eff3db002f01ea42cd119f44b48f66/2026/08/f55f6f16-907b-499c-9a47-6180d15cddfe.png) | ![after light narrow](https://raw.githubusercontent.com/PostHog/pr-assets/8e6a00c526f975f40b924a04c18066f77fe8ba3f/2026/08/7541b2cf-be4b-40ad-81d0-e10112c40f16.png) |
| **Light, wide** | ![before light wide](https://raw.githubusercontent.com/PostHog/pr-assets/5ff20735caa72f9665787c608bdd2924d1623d1e/2026/08/c198fe30-40aa-4b61-a7f7-fc3e3266a827.png) | ![after light wide](https://raw.githubusercontent.com/PostHog/pr-assets/1cdb03919fcb2fa408df0153c0e49397c2b756ad/2026/08/78c23a32-a418-48a3-8497-5849ee9ec116.png) |
| **Dark, narrow** | ![before dark narrow](https://raw.githubusercontent.com/PostHog/pr-assets/c637676b393a722e1e4db6286940cf0f7070aea5/2026/08/5ac816a0-c51e-407c-9082-c83d9b0b421e.png) | ![after dark narrow](https://raw.githubusercontent.com/PostHog/pr-assets/81cb8bf71af0753800462e29ec1dd9dfb4b09046/2026/08/ffb51a87-772a-449d-8931-50e43c191abd.png) |
| **Dark, wide** | ![before dark wide](https://raw.githubusercontent.com/PostHog/pr-assets/a601cbf0a39e7f6c9684b1c4671b199463a4eb86/2026/08/5463f4b0-19af-48fc-91cb-533c22726b90.png) | ![after dark wide](https://raw.githubusercontent.com/PostHog/pr-assets/946c922d85a9e994e4d581474ad6f6fc8aeda0bd/2026/08/37ea3620-7f5b-47ef-ad68-c46bd28f6789.png) |

Nothing animates differently, so there is no GIF. The panel slides in with the transition it already had.

### Verification

Checked against `gatsby develop` with real roadmap data, driven by headless puppeteer:

- `/roadmap?idea=new` and `/roadmap?idea` open the form. `/roadmap` does not.
- Closing the panel returns the URL to `/roadmap`. Clicking the card returns it to `/roadmap?idea=new`.
- `/roadmap?feature=<key>` still opens that feature, and does not open the idea form.
- `/roadmap?feature=does-not-exist&idea=new` drops the bad key and keeps the form open.
- The console error set is identical with and without the change, captured on both sides of a `git stash`. Nothing new appeared.

`prettier` was run on the changed file.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
