### PR TITLE
Handbook: where community bans and grievances go

### DIFF
--- a/contents/handbook/community/channels.mdx
+++ b/contents/handbook/community/channels.mdx
@@ -47,6 +47,17 @@ We don't get the community we want by asking people to behave differently. We ge
 
 - Prompts beat rules. A weekly "what are you working on?" thread does more than a posting guideline ever will.
 
+## Bans and grievances
+
+Send anything community-side – a Discord ban, a moderation decision, or a complaint about how we ran a space – to [community@posthog.com](mailto:community@posthog.com). It's a Gmail alias that goes to the Builder Relations and Marketing teams. Anyone else who wants in can [add themselves](https://groups.google.com/all-groups?pli=1&q=community).
+
+Don't route these to support. Support handles product and account problems, and mail to `support@posthog.com` gets an automated reply that tells the sender to open an in-app ticket, which a banned Discord user may not be able to do.
+
+When you ban someone, always tell them why and how to appeal. Posting the reason in the channel before you swing the hammer is not enough – they can miss it, and then they file a support ticket or sign up again. Both of our ban flows have a place to say it:
+
+- **Discord:** use the reason field in the ban dialog. Choose "Other" to write a freeform reason, and include `community@posthog.com` for appeals. The person sees it if they try to rejoin.
+- **A PostHog organization:** the suspension reason and an appeal address show on login.
+
 ## For PostHog team members
 
 ### Joining Discord


### PR DESCRIPTION
Adds a "Bans and grievances" section to [community channels](https://posthog.com/handbook/community/channels) in the handbook. It records three things:

- Community-side complaints — Discord bans, moderation decisions, how we ran a space — go to community@posthog.com, a Gmail alias reaching the Builder Relations and Marketing teams, with a link for anyone who wants to join it.
- They do not go to support, which handles product and account problems and auto-replies with "open an in-app ticket" — something a banned Discord user may not be able to do.
- A ban must always carry a reason and an appeal path. Both flows have a field for it: the Discord ban dialog ("Other" for a freeform reason), and the organization suspension notice shown on login.

## Why

A recent Discord ban was explained only in a channel post before the ban landed, so we could not be sure the person ever saw it. Bans without a stated reason and an appeal route produce support tickets, repeat signups, and public complaints. This writes down the destination and the expectation so the next one is handled consistently.

## Placement

The request was to put this on the marketing events page, but the handbook already has a community section, and `community/channels` is the page that covers Discord and how we route what arrives there. It fits there instead, and moves with the rest of the community docs as that side of the handbook grows. Happy to relocate it.

## Checks

- Content-only change: one file under `contents/`, no navigation change, no page moved or renamed, so no redirect or `pnpm test-redirects` run needed.
- Formatted with Prettier.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787042843643479?thread_ts=1787042843.643479&cid=C09G8Q32R6F)*