### PR TITLE
Fix heading anchor links on docs pages built with Steps

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -1466,11 +1466,8 @@ function ReaderViewContent({
                     if (detailsParent) {
                         detailsParent.open = true
                     }
-                    // `offsetTop` is measured from the nearest positioned ancestor, not from the
-                    // scroll viewport. Pages built with <Steps> wrap every heading in a
-                    // `relative` step container, so it reports single-digit pixels and the
-                    // scroll lands at the top of the page. Measure against the viewport instead —
-                    // the same math the table of contents and the text-fragment branch below use.
+                    // Not `offsetTop` — that measures from the nearest positioned ancestor, which
+                    // on a <Steps> page is the step container, not the viewport.
                     const targetRect = targetElement.getBoundingClientRect()
                     const scrollRect = scrollElement.getBoundingClientRect()
                     scrollElement.scrollTo({

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -1466,8 +1466,15 @@ function ReaderViewContent({
                     if (detailsParent) {
                         detailsParent.open = true
                     }
+                    // `offsetTop` is measured from the nearest positioned ancestor, not from the
+                    // scroll viewport. Pages built with <Steps> wrap every heading in a
+                    // `relative` step container, so it reports single-digit pixels and the
+                    // scroll lands at the top of the page. Measure against the viewport instead —
+                    // the same math the table of contents and the text-fragment branch below use.
+                    const targetRect = targetElement.getBoundingClientRect()
+                    const scrollRect = scrollElement.getBoundingClientRect()
                     scrollElement.scrollTo({
-                        top: targetElement.offsetTop || 0,
+                        top: Math.max(0, targetRect.top - scrollRect.top + scrollElement.scrollTop),
                         behavior: 'smooth',
                     })
                     return


### PR DESCRIPTION
## Changes

Anchor links to a heading did not scroll to that heading on docs pages built with `<Steps>`. The page stayed at the top. Reported for [/docs/slack/setup#pick-a-project](https://posthog.com/docs/slack/setup#pick-a-project), but every `<Steps>` page had it.

`ReaderView` scrolled its scroll viewport to `targetElement.offsetTop`. `offsetTop` is measured from the nearest positioned ancestor, not from the scroll viewport. `Steps` wraps each step's content in a `relative` container, so a heading inside a step measured its offset from that container and reported single-digit pixels. The viewport scrolled to 8px, which is the top of the page.

Measured on the affected page, `offsetTop` for every heading against the position the viewport actually needed:

| Heading | `offsetTop` used | Correct position |
| --- | --- | --- |
| `connect-slack-to-your-project` | 8 | 243 |
| `connect-your-personal-github` | 8 | 1395 |
| `pick-a-project` | 8 | 2374 |
| `next-steps` | 8 | 3348 |

This measures against the viewport instead. It is the same calculation that the table of contents (`ElementScrollLink`), the text-fragment branch directly below it, and the shared `scrollToElement` helper already use, so a heading now lands in the same place whether you open its URL or click it in the table of contents.

Only URL and hash navigation was broken. Clicking a heading in the table of contents always worked, because that path never used `offsetTop`.

### Before / after

`/docs/slack/setup#pick-a-project` on load. Before, the viewport sits at 8px and the heading is 2366px below the fold. After, the heading is at the top and the table of contents marks it active.

| | Before | After |
| --- | --- | --- |
| Light, wide | ![before-anchor-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/626a09ee-d0b5-44d9-adb1-9c9522bdf00d.png) | ![after-anchor-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/14b007f2-155a-4611-a246-d146399ced39.png) |
| Dark, wide | ![before-anchor-dark-wide](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/d217ba02-9b92-4c4d-b054-738666d2f7df.png) | ![after-anchor-dark-wide](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/74730379-63fb-4185-9b34-8b6de13482c3.png) |
| Light, narrow | ![before-anchor-light-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/0921072e-3662-40e3-ba94-827039bb2020.png) | ![after-anchor-light-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/25ee86c4-d039-4212-bd23-bc4764a7c5bb.png) |
| Dark, narrow | ![before-anchor-dark-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/cf1a96fc-e08c-430b-a427-cd852099ab18.png) | ![after-anchor-dark-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/eba8a769234ba749fb82b7de2c300a0848be3b3a/2026/08/37cf5b7f-9e7f-4c46-b096-562a9a14eb5e.png) |

Viewport scroll position on load, from the same runs:

| Mode | Width | Before | After | Heading position |
| --- | --- | --- | --- | --- |
| Light | Narrow (640) | 8 | 2434 | Top of viewport |
| Light | Wide (1440) | 8 | 2373 | Top of viewport |
| Dark | Narrow (640) | 8 | 2434 | Top of viewport |
| Dark | Wide (1440) | 8 | 2373 | Top of viewport |

## Testing

- Ran `pnpm format` on the changed file.
- Loaded `/docs/slack/setup#pick-a-project` on `pnpm start` in all four states above. No new console errors — the only messages are pre-existing `validateDOMNesting` warnings from the page's MDX content, present before and after.
- Confirmed the table of contents click path and text-fragment (`#:~:text=`) scrolling still land correctly.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — no pages moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787753330980289?thread_ts=1787753330.980289&cid=C0ACRAMJUAG)*
