### PR TITLE
Handbook: move Community pages into the Marketing nav section

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1061,6 +1061,32 @@ export const handbookSidebar = [
                 ],
             },
             {
+                name: 'Community',
+                url: '/handbook/community',
+                children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/community',
+                    },
+                    {
+                        name: 'Community channels',
+                        url: '/handbook/community/channels',
+                    },
+                    {
+                        name: 'Answering community questions',
+                        url: '/handbook/community/questions',
+                    },
+                    {
+                        name: 'Profiles',
+                        url: '/handbook/community/profiles',
+                    },
+                    {
+                        name: 'Points & rewards',
+                        url: '/handbook/community/points',
+                    },
+                ],
+            },
+            {
                 name: 'Influencers',
                 url: '/handbook/marketing/influencers',
                 children: [
@@ -1946,32 +1972,6 @@ export const handbookSidebar = [
             {
                 name: 'Editing API docs',
                 url: '/handbook/engineering/posthog-com/api-docs',
-            },
-            {
-                name: 'Community',
-                url: '',
-                children: [
-                    {
-                        name: 'Overview',
-                        url: '/handbook/community',
-                    },
-                    {
-                        name: 'Community channels',
-                        url: '/handbook/community/channels',
-                    },
-                    {
-                        name: 'Answering community questions',
-                        url: '/handbook/community/questions',
-                    },
-                    {
-                        name: 'Profiles',
-                        url: '/handbook/community/profiles',
-                    },
-                    {
-                        name: 'Points & rewards',
-                        url: '/handbook/community/points',
-                    },
-                ],
             },
         ],
     },


### PR DESCRIPTION
Moves the **Community** group in the handbook sidebar from the **Website** section to the **Marketing** section, directly below **Events (IRL)**.

Community and events are both Builder Relations work, and Builder Relations is listed as a marketing team on the [marketing overview](https://posthog.com/handbook/marketing). Having one in Website and the other in Marketing made the community pages hard to find.

This is a navigation-only change. The five pages keep their `/handbook/community/...` URLs, so no redirect is necessary and no link breaks. If we want the URLs to move too, that is a follow-up.

### Screenshots

Handbook sidebar on `/handbook/community`. Before, the group is at the bottom of Website, below "Editing API docs". After, it is inside Marketing, below "Events (IRL)".

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/e6c209b2-f9e3-4f70-aee0-1e1f78dcaa80.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/319994bc-8dc8-4be8-a01a-508fc75e750e.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/b02917a5-34fa-466d-81f6-4a5ecc16d94e.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/5a1986a7-7faf-4ff5-aa5b-dce2660bfe84.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/07e85f55-0170-4465-bbde-ecca5bd5e730.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/5c7bbcf4-c877-458d-8118-9f5e189c585b.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/837cc7e5-2f54-461e-a009-5276c2faf7f6.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/064b197fae8b64eee93d0b282790f47c005bb129/2026/08/a7e0ad5c-cbcb-4ad9-bbc3-d2c69b716e00.png" width="300"> |

### Checks

- Captured on the local dev server at 1600px and 900px viewports, light and dark, before and after, with `git stash` between the two states.
- Console errors collected on `/handbook/community`, `/handbook/community/channels`, and `/handbook/marketing/events` in both states. The two sets are identical, so this change adds none.
- `prettier --write src/navs/index.js` run.
- No page moved or renamed, so `vercel.json` and `pnpm test-redirects` are not affected.
- Not tested: mobile menu and the search index, neither of which reads section membership.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787042843643479?thread_ts=1787042843.643479&cid=C09G8Q32R6F)*
