### PR TITLE
docs(error-tracking): regenerate ngsw.json after Angular source map injection

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/angular.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/angular.mdx
@@ -89,6 +89,29 @@ You should see a comment like this in your minified JS files, for example `main-
 
 </Step>
 
+<Step title="Regenerate the service worker manifest" subtitle="Your goal in this step: Keep the Angular service worker's asset hashes in sync with the injected files." badge="required">
+
+<CalloutBox icon="IconWarning" title="Only needed if you use the Angular service worker" type="caution">
+
+Skip this step if your app doesn't use `@angular/service-worker`.
+
+</CalloutBox>
+
+`ng build` writes a SHA-1 hash of every bundle into `ngsw.json`. `posthog-cli sourcemap inject` rewrites those bundles afterwards, so the recorded hashes no longer match the files. When the service worker detects the mismatch, it rejects the new version and keeps serving the previously cached app, so your deploys silently stop reaching users.
+
+Fix this by regenerating `ngsw.json` after injecting, using the [`ngsw-config`](https://angular.dev/ecosystem/service-workers/config) tool that ships with `@angular/service-worker`:
+
+```bash
+ng build --configuration production
+posthog-cli sourcemap inject --directory ./dist/<your-app-name>/browser
+posthog-cli sourcemap upload --directory ./dist/<your-app-name>/browser
+npx ngsw-config ./dist/<your-app-name>/browser ./ngsw-config.json /
+```
+
+Run `ngsw-config` as the last command that touches the build output. `--delete-after` also rewrites your bundles when it strips the source map comments, so it must run before `ngsw-config` too. The last argument is your app's base href (usually `/`).
+
+</Step>
+
 <Step checkpoint title="Verify source map upload" subtitle="Confirm source maps are successfully uploaded">
 
 Before proceeding, confirm that source maps are successfully uploaded to PostHog. 

--- a/contents/docs/error-tracking/upload-source-maps/angular.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/angular.mdx
@@ -99,12 +99,11 @@ Skip this step if your app doesn't use `@angular/service-worker`.
 
 `ng build` writes a SHA-1 hash of every bundle into `ngsw.json`. `posthog-cli sourcemap inject` rewrites those bundles afterwards, so the recorded hashes no longer match the files. When the service worker detects the mismatch, it rejects the new version and keeps serving the previously cached app, so your deploys silently stop reaching users.
 
-Fix this by regenerating `ngsw.json` after injecting, using the [`ngsw-config`](https://angular.dev/ecosystem/service-workers/config) tool that ships with `@angular/service-worker`:
+Fix this by regenerating `ngsw.json` after processing, using the [`ngsw-config`](https://angular.dev/ecosystem/service-workers/config) tool that ships with `@angular/service-worker`:
 
 ```bash
 ng build --configuration production
-posthog-cli sourcemap inject --directory ./dist/<your-app-name>/browser
-posthog-cli sourcemap upload --directory ./dist/<your-app-name>/browser
+posthog-cli sourcemap process --directory ./dist/<your-app-name>/browser
 npx ngsw-config ./dist/<your-app-name>/browser ./ngsw-config.json /
 ```
 


### PR DESCRIPTION
## Summary

`posthog-cli sourcemap inject` rewrites the built bundles after `ng build` has already recorded their SHA-1 hashes in `ngsw.json`. The Angular service worker then rejects the new app version and keeps serving the cached one — deploys silently stop reaching users (PostHog/posthog#86046).

This adds a step to the Angular source maps guide: run `ngsw-config` (the tool that ships with `@angular/service-worker`) as the last command touching the build output, so the manifest is regenerated from the injected files. Same guidance Sentry gives for the identical problem with their CLI. Skippable for apps without the service worker.

Fixes the documentation part of PostHog/posthog#86046.

## Verification

Reproduced in a fresh Angular 22.1 service-worker app (`web-angular-sw` in the error-tracking-examples sandbox):

- After `sourcemap inject`, the `main-*.js` entry in `ngsw.json` no longer matches the file's SHA-1; after `ngsw-config <dist> ngsw-config.json /` every entry matches again.
- Headless Chrome end to end: a v2 build injected without regeneration is rejected with `VERSION_INSTALLATION_FAILED`, and after a worker restart new visits are still served v1 from cache. With the regenerated manifest the same v2 installs (`VERSION_READY`) and a reload shows v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)