### PR TITLE
docs: point the WAF allowlist snippet at Browserless IPs for heatmaps

### DIFF
--- a/contents/docs/integrate/_snippets/details/posthog-ips.mdx
+++ b/contents/docs/integrate/_snippets/details/posthog-ips.mdx
@@ -9,7 +9,7 @@ import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 
   These are public, stable IPs used by PostHog services.
 
-  Heatmap screenshots are an exception. PostHog renders them with [Browserless](https://www.browserless.io), so the request to your site comes from Browserless IPs, not the PostHog IPs above. If your heatmaps stay blank, add the Browserless IPs to your allowlist too. Browserless publishes the current list, and the API to read it, in their [whitelisting IPs documentation](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips). Read that list at the source each time. Browserless changes these IPs as they scale their fleet.
+  Heatmap screenshots are the exception. PostHog renders them with [Browserless](https://www.browserless.io), so those requests come from Browserless IPs. Allowlist [the IPs Browserless publishes](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips) too. They change as Browserless scales, so read the list at the source.
 
   An allowlist does not help when your app has a private address. For apps on an internal network, see [internal and intranet applications](/docs/session-replay/troubleshooting#internal-and-intranet-applications).
 

--- a/contents/docs/integrate/_snippets/details/posthog-ips.mdx
+++ b/contents/docs/integrate/_snippets/details/posthog-ips.mdx
@@ -9,7 +9,7 @@ import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 
   These are public, stable IPs used by PostHog services.
 
-  Heatmap screenshots are the exception. PostHog renders them with [Browserless](https://www.browserless.io), so those requests come from Browserless IPs. Allowlist [the IPs Browserless publishes](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips) too. They change as Browserless scales, so read the list at the source.
+  Heatmaps need one more step. PostHog screenshots your page through [Browserless](https://www.browserless.io), so that request arrives from a Browserless IP, not a PostHog one. Allowlist [the IPs Browserless publishes](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips) as well, and check that page for changes. Browserless updates the list as it scales its fleet.
 
   An allowlist does not help when your app has a private address. For apps on an internal network, see [internal and intranet applications](/docs/session-replay/troubleshooting#internal-and-intranet-applications).
 

--- a/contents/docs/integrate/_snippets/details/posthog-ips.mdx
+++ b/contents/docs/integrate/_snippets/details/posthog-ips.mdx
@@ -9,7 +9,7 @@ import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 
   These are public, stable IPs used by PostHog services.
 
-  Heatmaps need one more step. PostHog screenshots your page through [Browserless](https://www.browserless.io), so that request arrives from a Browserless IP, not a PostHog one. Allowlist [the IPs Browserless publishes](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips) as well, and check that page for changes. Browserless updates the list as it scales its fleet.
+  PostHog captures heatmap screenshots using [Browserless](https://www.browserless.io), which uses its own IP addresses. Allowlist those too. Browserless [publishes the current list](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips) and updates it as they scale their fleet.
 
   An allowlist does not help when your app has a private address. For apps on an internal network, see [internal and intranet applications](/docs/session-replay/troubleshooting#internal-and-intranet-applications).
 

--- a/contents/docs/integrate/_snippets/details/posthog-ips.mdx
+++ b/contents/docs/integrate/_snippets/details/posthog-ips.mdx
@@ -7,7 +7,9 @@ import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 
   <PostHogIPsInline />
 
-  These are public, stable IPs used by PostHog services (e.g., Celery tasks for snapshots).
+  These are public, stable IPs used by PostHog services.
+
+  Heatmap screenshots are an exception. PostHog renders them with [Browserless](https://www.browserless.io), so the request to your site comes from Browserless IPs, not the PostHog IPs above. If your heatmaps stay blank, add the Browserless IPs to your allowlist too. Browserless publishes the current list, and the API to read it, in their [whitelisting IPs documentation](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips). Read that list at the source each time. Browserless changes these IPs as they scale their fleet.
 
   An allowlist does not help when your app has a private address. For apps on an internal network, see [internal and intranet applications](/docs/session-replay/troubleshooting#internal-and-intranet-applications).
 

--- a/contents/docs/integrate/_snippets/details/posthog-ips.mdx
+++ b/contents/docs/integrate/_snippets/details/posthog-ips.mdx
@@ -9,7 +9,7 @@ import { PostHogIPsInline } from 'components/Docs/PostHogIPs'
 
   These are public, stable IPs used by PostHog services.
 
-  PostHog captures heatmap screenshots using [Browserless](https://www.browserless.io), which uses its own IP addresses. Allowlist those too. Browserless [publishes the current list](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips) and updates it as they scale their fleet.
+  PostHog captures heatmap screenshots using [Browserless](https://www.browserless.io), which has its own IP addresses. Browserless [publishes the current list here](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips).
 
   An allowlist does not help when your app has a private address. For apps on an internal network, see [internal and intranet applications](/docs/session-replay/troubleshooting#internal-and-intranet-applications).
 


### PR DESCRIPTION
## Changes

Our "Add IPs to Firewall/WAF allowlists" snippet names heatmaps as the example feature, then lists only PostHog's egress IPs. Heatmap screenshots are rendered by Browserless, so the request that loads the customer's page comes from Browserless IPs, not ours. A customer who allowlists the documented IPs can still get blank heatmaps, with nothing in the docs to tell them why.

This change:

- Removes the "e.g., Celery tasks for snapshots" example, which pointed at the one thing those IPs do not do.
- Adds a paragraph that explains the Browserless exception and links to the [Browserless whitelisting IPs page](https://docs.browserless.io/baas/troubleshooting/whitelisting-ips), which carries the live list and the API to read it.

The Browserless addresses are deliberately not hardcoded. Browserless changes them as they scale their fleet, so a copy here would go stale silently. Their published GraphQL query is also not copied in, because it enumerates region fields by name and would quietly return an incomplete list if Browserless adds a region.

**Why:** raised in Slack — a customer could not see heatmap data behind their WAF, and our IP allowlist docs gave them no way to find the addresses that were actually blocked.

The snippet is shared, so this text appears in the collapsed allowlist section on the install pages and on [Heatmaps](https://posthog.com/docs/toolbar/heatmaps). Prose only, inside an existing `<details>` block — no layout or navigation change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1787773043260539)*
