### PR TITLE
fix(docs): clarify how often dynamic cohorts recalculate

### DIFF
--- a/contents/docs/data/cohorts.mdx
+++ b/contents/docs/data/cohorts.mdx
@@ -304,7 +304,11 @@ For more details on activity tracking across PostHog, see the [activity logs](/d
 
 ### How often are dynamic cohorts updated?
 
-Dynamic cohorts are updated once every 24 hours.
+Dynamic cohorts recalculate on a rolling schedule, typically about once a day. A cohort also recalculates as soon as you save a change to its definition.
+
+Membership is a snapshot. An insight filtered by a dynamic cohort uses the membership from the last calculation, not from when the query runs.
+
+If you need a filter that is always current, filter on the person or event property directly instead of putting it in a cohort. Property filters are evaluated when the query runs, so they don't lag. For example, filter on the `Country code` event property rather than building a cohort of visitors in the US and filtering by that.
 
 ### Can you use a dynamic cohort as a feature flag target?
 


### PR DESCRIPTION
## Changes

The cohorts FAQ answered "How often are dynamic cohorts updated?" with a flat "once every 24 hours". Users plan analyses around that number, and it is not a guarantee. Recalculation is throughput-bound: a cohort becomes eligible after a minimum age, then a scheduler takes a fixed number oldest-first per run, so the real interval depends on how many dynamic cohorts the instance holds.

The rewritten answer:

- Describes a rolling schedule that is typically about daily, instead of a fixed cycle.
- States that editing a cohort recalculates it immediately.
- Points users who need always-current filtering at property filters, which are evaluated when the query runs and never lag.

That last point is the useful one. Reaching for a cohort to express something like "visitors in the US" imports a staleness problem that a plain filter on the `Country code` event property does not have.

The same claim appears in the app, on the cohorts list "Last calculated" tooltip. That is corrected in [PostHog/posthog#89730](https://github.com/PostHog/posthog/pull/89730).

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

Not checked: the Vercel preview build. The change is three paragraphs of prose in an existing FAQ section and adds no new links or components.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
