### PR TITLE
fix(docs): fix dead links to persons bulk_delete API endpoint

### DIFF
--- a/contents/docs/privacy/data-storage.mdx
+++ b/contents/docs/privacy/data-storage.mdx
@@ -151,7 +151,7 @@ response = requests.get(
 
 </MultiLanguage>
 
-To delete persons and their events, use the [DELETE Persons API endpoint](/docs/api/persons-4#post-api-projects-project_id-persons-bulk_delete) with the person's UUID (returned as `id` in the persons API response). To delete the person's corresponding events, add the `delete_events=true` parameter. To also delete their session recordings, add `delete_recordings=true`:
+To delete persons and their events, use the [DELETE Persons API endpoint](/docs/api/persons#post-api-projects-project_id-persons-bulk_delete) with the person's UUID (returned as `id` in the persons API response). To delete the person's corresponding events, add the `delete_events=true` parameter. To also delete their session recordings, add `delete_recordings=true`:
 
 <MultiLanguage>
 
@@ -197,7 +197,7 @@ This request deletes all events of the person(s) captured before the deletion re
 
 #### Bulk delete response
 
-When using the [bulk_delete endpoint](/docs/api/persons-4#post-api-projects-project_id-persons-bulk_delete), the API returns a response with details about the deletion operation:
+When using the [bulk_delete endpoint](/docs/api/persons#post-api-projects-project_id-persons-bulk_delete), the API returns a response with details about the deletion operation:
 
 | Field                            | Type    | Description                                                                  |
 | -------------------------------- | ------- | ---------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

The persons API was consolidated from multiple paginated pages into a single page, which made two links on the [data storage privacy page](/docs/privacy/data-storage) point to the now-nonexistent `/docs/api/persons-4`. Both links now point to `/docs/api/persons` with the same anchor.

## Test plan

- [x] Visit [/docs/privacy/data-storage#data-deletion](/docs/privacy/data-storage#data-deletion) and confirm both bulk_delete links resolve

https://claude.ai/code/session_01P8JX12DyBh9QMCGEZPRHaL