### PR TITLE
feat(handbook): agree the feature trailer example before storyboarding

### DIFF
--- a/contents/handbook/content/feature-trailer-process.md
+++ b/contents/handbook/content/feature-trailer-process.md
@@ -31,9 +31,23 @@ Drop a message in [Team YouTube on Slack](https://posthog.slack.com/archives/C01
 
 The team will advise on what else is in progress and whether your timeline is realistic. If it's a yes, you'll move on to a storyboard.
 
-### 3. Create a storyboard
+### 3. Agree on the example
 
-As the requester, you'll put together a short storyboard of what you want the video to cover. This is especially useful for 30–90 second feature trailers.
+Decide which example the video will show before you write the storyboard, and agree on it with both the product manager and the product marketer for that feature.
+
+Product marketing knows which framing lands with the audience. The product manager knows which examples are real, current, and representative of what the product is best at. Getting both views up front takes a day. Discovering later that the example undersells the product costs the whole video.
+
+Changing the example after the script is written means starting over. That is the most expensive change you can make, it delays your video, and it pushes back every other video in the queue.
+
+A good example usually:
+
+- Comes from our own use of the product, with something real you can put on screen, like a PR, a report, or a session recording.
+- Shows what only this product can do. If another PostHog product could have surfaced the same thing, the example isn't making the case.
+- Is recognizable to someone outside PostHog. Viewers should see their own problem in it without knowing how we work.
+
+### 4. Create a storyboard
+
+As the requester, you'll put together a short storyboard of what you want the video to cover, built around the example you agreed on. This is especially useful for 30–90 second feature trailers.
 
 Use [this storyboard template](https://docs.google.com/document/d/1ONoytWmzDFMTN61KhVdtLCVA6_0SYuUf_eSmkj33mhU/edit?tab=t.3a3la71j8gql) as a starting point – copy it and adapt it for your video.
 
@@ -41,11 +55,11 @@ Also note any existing assets for the product – webpage, blog post, social pos
 
 > **The storyboard doesn't need to be polished.** It doesn't need a creative vision or production-quality assets. All it needs to do is convey the narrative beats you want the video to hit. For example, the storyboard for [PostHog self-driving](/self-driving) laid out: show the before and after, show a user solving the problem, ship the fix, then reveal that it was actually fixed autonomously using PostHog self-driving. Each beat just needs a note and a screenshot or rough screen recording.
 
-### 4. Review the storyboard together
+### 5. Review the storyboard together
 
 You'll meet with Jordo and Andy to talk through the storyboard and make any changes. Once everyone's happy with it, Jordo will turn it into a scratch edit – a rough moving version of the storyboard with a draft voiceover and script. It'll have plenty of missing pieces, but it gives you something to react to.
 
-### 5. Iterate on the script and visuals
+### 6. Iterate on the script and visuals
 
 From here, you'll go back and forth refining the script and wording, then refining the visuals.
 

--- a/contents/handbook/content/feature-trailer-process.md
+++ b/contents/handbook/content/feature-trailer-process.md
@@ -33,9 +33,7 @@ The team will advise on what else is in progress and whether your timeline is re
 
 ### 3. Agree on the example use case
 
-Decide which example or use case the video will show before you write the storyboard. Product marketer should lead this and collaborate with product manager / product team.
-
-A good example use case:
+Product marketer should lead this and collaborate with product manager / product team. A good example use case:
 
 - Comes from our own use of the product, with something real you can put on screen, like a PR, a report, or a session recording.
 - Shows what only this product can do. If another PostHog product could have surfaced the same thing, the example isn't making the case.

--- a/contents/handbook/content/feature-trailer-process.md
+++ b/contents/handbook/content/feature-trailer-process.md
@@ -31,15 +31,11 @@ Drop a message in [Team YouTube on Slack](https://posthog.slack.com/archives/C01
 
 The team will advise on what else is in progress and whether your timeline is realistic. If it's a yes, you'll move on to a storyboard.
 
-### 3. Agree on the example
+### 3. Agree on the example use case
 
-Decide which example the video will show before you write the storyboard, and agree on it with both the product manager and the product marketer for that feature.
+Decide which example or use case the video will show before you write the storyboard. Product marketer should lead this and collaborate with product manager / product team.
 
-Product marketing knows which framing lands with the audience. The product manager knows which examples are real, current, and representative of what the product is best at. Getting both views up front takes a day. Discovering later that the example undersells the product costs the whole video.
-
-Changing the example after the script is written means starting over. That is the most expensive change you can make, it delays your video, and it pushes back every other video in the queue.
-
-A good example usually:
+A good example use case:
 
 - Comes from our own use of the product, with something real you can put on screen, like a PR, a report, or a session recording.
 - Shows what only this product can do. If another PostHog product could have surfaced the same thing, the example isn't making the case.


### PR DESCRIPTION
## Changes

- Adds step 3, "Agree on the example", to the feature trailer process. Requesters now pick the example the video will show and agree on it with the product manager and the product marketer for that feature before writing the storyboard.
- Explains why the timing matters: changing the example after the script is written means restarting the video, which delays that video and pushes back everything else in the queue.
- Lists what a strong example looks like, so the conversation has something to judge against: drawn from our own use of the product with a real artifact to show on screen, specific to what only that product can do, and recognizable to someone who doesn't know how PostHog works internally.
- Mechanical: renumbers the following steps and points the storyboard step at the agreed example.

**Why:** Feature trailers should be really good and quick to produce. Discovering late that the chosen example undersells the product forces a restart, which costs both. Agreeing on the example up front is a day of work instead.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1787660485916729?thread_ts=1787660485.916729&cid=C0B7TE4R8GH)*
