### PR TITLE
Lead with the agent path on context warehouse pocket guides

### DIFF
--- a/contents/pocket-guides/context-warehouse/acquisition-channels-retention/index.mdx
+++ b/contents/pocket-guides/context-warehouse/acquisition-channels-retention/index.mdx
@@ -37,17 +37,6 @@ The Skill looks for patterns like <SeeFig n={1} />: paid social brought in the m
 but organic search and content brought in more *retained* revenue at a fraction of the CAC, the
 real signal for where budget belongs.
 
-## Doing this by hand
-
-1. **Connect [Stripe](/docs/cdp/sources/stripe), and [Google Ads](/docs/cdp/sources/google-ads) or
-   [Meta Ads](/docs/cdp/sources/meta-ads)**, via
-   [Data pipeline > Sources](/docs/data-warehouse/sources).
-2. **Build a [Trends](/docs/product-analytics/trends/overview) insight of signups broken down by
-   [`$initial_utm_source`](/docs/data/utm-segmentation)**: native to PostHog, no join needed for
-   this part.
-3. **Pull revenue and spend per channel separately** from Stripe's and your ad platform's own
-   reports, then match them up using the [SQL editor](/docs/data-warehouse/sql) or PostHog AI.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent attributes each person to a channel from first-touch UTM properties, pulls revenue and
@@ -62,6 +51,17 @@ specific rollout's revenue impact, that's
 [Feature revenue impact](/pocket-guides/context-warehouse/feature-revenue-impact).
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **Connect [Stripe](/docs/cdp/sources/stripe), and [Google Ads](/docs/cdp/sources/google-ads) or
+   [Meta Ads](/docs/cdp/sources/meta-ads)**, via
+   [Data pipeline > Sources](/docs/data-warehouse/sources).
+2. **Build a [Trends](/docs/product-analytics/trends/overview) insight of signups broken down by
+   [`$initial_utm_source`](/docs/data/utm-segmentation)**: native to PostHog, no join needed for
+   this part.
+3. **Pull revenue and spend per channel separately** from Stripe's and your ad platform's own
+   reports, then match them up using the [SQL editor](/docs/data-warehouse/sql) or PostHog AI.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/feature-revenue-impact/index.mdx
+++ b/contents/pocket-guides/context-warehouse/feature-revenue-impact/index.mdx
@@ -36,18 +36,6 @@ The Skill looks for patterns like <SeeFig n={1} />: the exposed cohort earned $6
 after exposure and retained six points better. This shows the experiment was successful, and reporting both cohort sizes
 makes clear the gap reflects a large sample, not noise from a handful of accounts.
 
-## Doing this by hand
-
-1. **If this was a formal [PostHog Experiment](/docs/experiments)**, open its
-   [results page](/docs/experiments/analyzing-results) directly and add a Stripe revenue metric
-   there. PostHog computes exposed-vs-control for you natively, no SQL needed.
-2. **If it was a plain feature flag** instead, connect [Stripe](/docs/cdp/sources/stripe) via
-   [Data pipeline > Sources](/docs/data-warehouse/sources), then build a
-   [Trends](/docs/product-analytics/trends/overview) insight of `$feature_flag_called` broken down
-   by `$feature_flag_response` to see the exposure split.
-3. **Join to revenue** using the [SQL editor](/docs/data-warehouse/sql) or asking PostHog AI to compare
-   post-exposure revenue and retention between variants in one query.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent finds each person's variant from `$feature_flag_called` exposure events and their
@@ -62,6 +50,18 @@ features high-revenue customers already use, with no rollout involved, that's
 [Features & revenue](/pocket-guides/context-warehouse/features-drive-revenue) instead.
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **If this was a formal [PostHog Experiment](/docs/experiments)**, open its
+   [results page](/docs/experiments/analyzing-results) directly and add a Stripe revenue metric
+   there. PostHog computes exposed-vs-control for you natively, no SQL needed.
+2. **If it was a plain feature flag** instead, connect [Stripe](/docs/cdp/sources/stripe) via
+   [Data pipeline > Sources](/docs/data-warehouse/sources), then build a
+   [Trends](/docs/product-analytics/trends/overview) insight of `$feature_flag_called` broken down
+   by `$feature_flag_response` to see the exposure split.
+3. **Join to revenue** using the [SQL editor](/docs/data-warehouse/sql) or asking PostHog AI to compare
+   post-exposure revenue and retention between variants in one query.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/features-drive-revenue/index.mdx
+++ b/contents/pocket-guides/context-warehouse/features-drive-revenue/index.mdx
@@ -38,18 +38,6 @@ The Skill looks for patterns like <SeeFig n={1} />: `exported_data` isn't the mo
 but the accounts that use it are worth nearly eight times as much per account as the ones using the most popular feature
 `viewed_onboarding_tips`.
 
-## Doing this by hand
-
-1. **Connect [Stripe](/docs/cdp/sources/stripe).** In PostHog, go to
-   [Data pipeline > Sources](/docs/data-warehouse/sources) and connect Stripe if it isn't already
-   connected; you'll need a restricted API key with read access to Billing.
-2. **Find your feature [events](/docs/data/events).** Check Data management > Events for the
-   events that represent feature use.
-3. **Write the join.** Open the [SQL editor](/docs/data-warehouse/sql) and join `events` to
-   `stripe_invoice` or `stripe_customer` on email. The schema tab on the left shows your
-   project's real column names. You can also ask PostHog AI to do this part for you.
-4. **Save it as an insight** so you don't have to re-run the query by hand next time.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The Skill enables your agent to find your feature-usage events, confirming with you which ones count as
@@ -63,6 +51,18 @@ a specific rollout's revenue impact, see
 [Feature revenue impact](/pocket-guides/context-warehouse/feature-revenue-impact) instead.
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **Connect [Stripe](/docs/cdp/sources/stripe).** In PostHog, go to
+   [Data pipeline > Sources](/docs/data-warehouse/sources) and connect Stripe if it isn't already
+   connected; you'll need a restricted API key with read access to Billing.
+2. **Find your feature [events](/docs/data/events).** Check Data management > Events for the
+   events that represent feature use.
+3. **Write the join.** Open the [SQL editor](/docs/data-warehouse/sql) and join `events` to
+   `stripe_invoice` or `stripe_customer` on email. The schema tab on the left shows your
+   project's real column names. You can also ask PostHog AI to do this part for you.
+4. **Save it as an insight** so you don't have to re-run the query by hand next time.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/lead-scoring/index.mdx
+++ b/contents/pocket-guides/context-warehouse/lead-scoring/index.mdx
@@ -37,16 +37,6 @@ The Skill looks for patterns like <SeeFig n={1} />: Priya was seen 6 hours ago a
 listed as a trial, not yet a marketing-qualified lead: exactly the kind of engaged, uncontacted
 account this list exists to surface before someone else notices.
 
-## Doing this by hand
-
-1. **Connect [HubSpot](/docs/cdp/sources/hubspot) or [Salesforce](/docs/cdp/sources/salesforce)**
-   via [Data pipeline > Sources](/docs/data-warehouse/sources).
-2. **Define your key [events](/docs/data/events)** under Data management > Events: define what
-   signals real intent for you.
-3. **For a ranked list**, check each lead's activity in the [Persons](/docs/data/persons) 
-   explorer, or use the [SQL editor](/docs/data-warehouse/sql), or ask PostHog AI to score every lead
-   in one query.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent defines, with you, the handful of events that signal real intent. Then it scores each
@@ -59,6 +49,16 @@ trial-to-paid conversion in aggregate instead, that's
 [Onboarding conversion](/pocket-guides/context-warehouse/onboarding-conversion).
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **Connect [HubSpot](/docs/cdp/sources/hubspot) or [Salesforce](/docs/cdp/sources/salesforce)**
+   via [Data pipeline > Sources](/docs/data-warehouse/sources).
+2. **Define your key [events](/docs/data/events)** under Data management > Events: define what
+   signals real intent for you.
+3. **For a ranked list**, check each lead's activity in the [Persons](/docs/data/persons) 
+   explorer, or use the [SQL editor](/docs/data-warehouse/sql), or ask PostHog AI to score every lead
+   in one query.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/onboarding-conversion/index.mdx
+++ b/contents/pocket-guides/context-warehouse/onboarding-conversion/index.mdx
@@ -38,6 +38,18 @@ The Skill looks for patterns like <SeeFig n={1} />: only 9% of non-payers ever c
 project, versus 52% of payers, the biggest gap in the funnel. Inviting a teammate looks
 important on its own, but the gap between payers and non-payers is smaller. This tells you to focus on closing the gap for people who don't create a second project.
 
+## Get an agent to do the work
+
+Copy the Skill below and add it to your agent. The agent finds your signup-to-activation events and each user's first successful Stripe
+payment, joined on email. From there it either builds a funnel broken down by paid vs unpaid, or
+computes the completion-rate lift of each step among payers versus non-payers, whichever fits
+what you asked.
+
+The agent looks at the onboarding *path* in aggregate. For scoring which individual leads sales should
+call right now instead, that's [Lead scoring](/pocket-guides/context-warehouse/lead-scoring).
+
+<SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
 ## Doing this by hand
 
 1. **Build the [funnel](/docs/product-analytics/funnels) natively.** Go to Product analytics >
@@ -50,18 +62,6 @@ important on its own, but the gap between payers and non-payers is smaller. This
    breakdown.
 4. **Compare completion rates**, open the [SQL editor](/docs/data-warehouse/sql), or ask PostHog AI if you
    want the lift computed for you in one query instead of reading two funnels side by side.
-
-## Get an agent to do the work
-
-Copy the Skill below and add it to your agent. The agent finds your signup-to-activation events and each user's first successful Stripe
-payment, joined on email. From there it either builds a funnel broken down by paid vs unpaid, or
-computes the completion-rate lift of each step among payers versus non-payers, whichever fits
-what you asked.
-
-The agent looks at the onboarding *path* in aggregate. For scoring which individual leads sales should
-call right now instead, that's [Lead scoring](/pocket-guides/context-warehouse/lead-scoring).
-
-<SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/pre-cancellation-behavior/index.mdx
+++ b/contents/pocket-guides/context-warehouse/pre-cancellation-behavior/index.mdx
@@ -39,17 +39,6 @@ The Skill looks for patterns like <SeeFig n={1} />: engagement doesn't fall off 
 erodes, roughly halving every week for a month before cancellation. That decay curve is the
 early-warning signal so you can start re-engaging users when their engagement first begins to dip.
 
-## Doing this by hand
-
-1. **Connect [Stripe](/docs/cdp/sources/stripe) or [Chargebee](/docs/cdp/sources/chargebee)** via
-   [Data pipeline > Sources](/docs/data-warehouse/sources) for cancellation dates.
-2. **Pick a handful of recently churned accounts** and open each one in PostHog's
-   [Persons](/docs/data/persons) (or Groups) explorer to read their activity timeline in the weeks
-   before they left.
-3. **Look for the shared pattern**: Use the
-   [SQL editor](/docs/data-warehouse/sql) or ask PostHog AI to
-   average the number of weeks-to-churn across the accounts you've selected.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent finds each account's cancellation timestamp (Stripe's `canceled_at`, or the Chargebee
@@ -62,6 +51,17 @@ support tickets predicting churn, that's
 [Tickets & churn](/pocket-guides/context-warehouse/support-tickets-churn) instead.
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **Connect [Stripe](/docs/cdp/sources/stripe) or [Chargebee](/docs/cdp/sources/chargebee)** via
+   [Data pipeline > Sources](/docs/data-warehouse/sources) for cancellation dates.
+2. **Pick a handful of recently churned accounts** and open each one in PostHog's
+   [Persons](/docs/data/persons) (or Groups) explorer to read their activity timeline in the weeks
+   before they left.
+3. **Look for the shared pattern**: Use the
+   [SQL editor](/docs/data-warehouse/sql) or ask PostHog AI to
+   average the number of weeks-to-churn across the accounts you've selected.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/support-tickets-churn/index.mdx
+++ b/contents/pocket-guides/context-warehouse/support-tickets-churn/index.mdx
@@ -37,14 +37,6 @@ The Skill looks for patterns like <SeeFig n={1} />: "Billing confusion" generate
 than the other topics but cost more in churned revenue than the next two combined. The ranking
 that matters is lost revenue, independent of ticket volume.
 
-## Doing this by hand
-
-1. **Connect [Zendesk](/docs/cdp/sources/zendesk) or [Intercom](/docs/cdp/sources/intercom), and
-   [Stripe](/docs/cdp/sources/stripe)**, via [Data pipeline > Sources](/docs/data-warehouse/sources).
-2. **Pull your churned accounts list** from Stripe, and look each one up in your support tool's
-   own reporting (Zendesk Explore, or Intercom's reports) for their ticket topics.
-3. **Tally revenue by topic**: either in a spreadsheet, with the [SQL editor](/docs/data-warehouse/sql), or by asking PostHog AI to find the answer.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent needs three sources working together: ticket rows with a customer identifier and a
@@ -59,6 +51,14 @@ tickets involved, that's
 [Pre-cancellation behavior](/pocket-guides/context-warehouse/pre-cancellation-behavior) instead.
 
 <SkillFigure n={2} caption="The Skill itself, the file an agent follows to answer this question." />
+
+## Doing this by hand
+
+1. **Connect [Zendesk](/docs/cdp/sources/zendesk) or [Intercom](/docs/cdp/sources/intercom), and
+   [Stripe](/docs/cdp/sources/stripe)**, via [Data pipeline > Sources](/docs/data-warehouse/sources).
+2. **Pull your churned accounts list** from Stripe, and look each one up in your support tool's
+   own reporting (Zendesk Explore, or Intercom's reports) for their ticket topics.
+3. **Tally revenue by topic**: either in a spreadsheet, with the [SQL editor](/docs/data-warehouse/sql), or by asking PostHog AI to find the answer.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/upsell-ready-accounts/index.mdx
+++ b/contents/pocket-guides/context-warehouse/upsell-ready-accounts/index.mdx
@@ -37,18 +37,6 @@ The Skill looks for patterns like <SeeFig n={1} />: Acme Co is running at 94% of
 plan's limit, month after month, a sustained pattern rather than a one-off spike. Globex is
 smaller in absolute terms but just as close to its own ceiling.
 
-## Doing this by hand
-
-1. **Connect [Stripe](/docs/cdp/sources/stripe)** via
-   [Data pipeline > Sources](/docs/data-warehouse/sources) for each account's current plan.
-2. **Write down your own plan limits**: Stripe rarely stores these, so you'll need your pricing
-   page or internal docs.
-3. **Build a usage [Trends](/docs/product-analytics/trends/overview) insight**, broken down by
-   account or group, for the metric your limits apply to.
-4. **Cross-reference** in a spreadsheet, open the
-   [SQL editor](/docs/data-warehouse/sql), or ask PostHog AI to join usage against plan in one query and skip the
-   spreadsheet.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent works out each account's current plan from Stripe, the numeric limit that plan implies
@@ -63,6 +51,18 @@ engagement instead, that's
 [ARR vs engagement](/pocket-guides/context-warehouse/value-vs-engagement).
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **Connect [Stripe](/docs/cdp/sources/stripe)** via
+   [Data pipeline > Sources](/docs/data-warehouse/sources) for each account's current plan.
+2. **Write down your own plan limits**: Stripe rarely stores these, so you'll need your pricing
+   page or internal docs.
+3. **Build a usage [Trends](/docs/product-analytics/trends/overview) insight**, broken down by
+   account or group, for the metric your limits apply to.
+4. **Cross-reference** in a spreadsheet, open the
+   [SQL editor](/docs/data-warehouse/sql), or ask PostHog AI to join usage against plan in one query and skip the
+   spreadsheet.
 
 <SeeAlso>
 

--- a/contents/pocket-guides/context-warehouse/value-vs-engagement/index.mdx
+++ b/contents/pocket-guides/context-warehouse/value-vs-engagement/index.mdx
@@ -36,16 +36,6 @@ PostHog engagement score and flags the high-ARR, low-engagement quadrant.
 The skill looks for patterns like <SeeFig n={1} />: Globex Corp pays more than Acme Co but logged
 activity on only 2 of the last 30 days. The gap between the two numbers is the risk to watch.
 
-## Doing this by hand
-
-1. **Connect [Salesforce](/docs/cdp/sources/salesforce) or [HubSpot](/docs/cdp/sources/hubspot)**
-   via [Data pipeline > Sources](/docs/data-warehouse/sources) for ARR.
-2. **Build an engagement [Trends](/docs/product-analytics/trends/overview) insight**, broken down
-   by group (account): active days or a count of key events.
-3. **Export both and join in a spreadsheet** on account name or domain, sorting by ARR to spot
-   the low-engagement outliers by eye. The [SQL editor](/docs/data-warehouse/sql) does the same
-   join live, or you can ask PostHog AI to analyze the insight, and your list updates itself instead of going stale.
-
 ## Get an agent to do the work
 
 Copy the Skill below and add it to your agent. The agent confirms how you track accounts (a PostHog group, or persons aggregated by email
@@ -60,6 +50,16 @@ This measures CRM-ARR versus engagement health. For expansion candidates based o
 [Upsell-ready accounts](/pocket-guides/context-warehouse/upsell-ready-accounts).
 
 <SkillFigure n={2} caption="The Skill itself, copy and paste this into your agent to answer the question." />
+
+## Doing this by hand
+
+1. **Connect [Salesforce](/docs/cdp/sources/salesforce) or [HubSpot](/docs/cdp/sources/hubspot)**
+   via [Data pipeline > Sources](/docs/data-warehouse/sources) for ARR.
+2. **Build an engagement [Trends](/docs/product-analytics/trends/overview) insight**, broken down
+   by group (account): active days or a count of key events.
+3. **Export both and join in a spreadsheet** on account name or domain, sorting by ARR to spot
+   the low-engagement outliers by eye. The [SQL editor](/docs/data-warehouse/sql) does the same
+   join live, or you can ask PostHog AI to analyze the insight, and your list updates itself instead of going stale.
 
 <SeeAlso>
 


### PR DESCRIPTION
## Summary
- Swaps the order of the "Doing this by hand" and "Get an agent to do the work" sections on all 9 "Ask a quick question" pages in the Context Warehouse pocketbook, so the agent workflow is presented first.
- Pure reorder — no copy changes.

Pages updated:
- features-drive-revenue
- onboarding-conversion
- upsell-ready-accounts
- pre-cancellation-behavior
- support-tickets-churn
- value-vs-engagement
- acquisition-channels-retention
- lead-scoring
- feature-revenue-impact

## Test plan
- [x] Diffed each file to confirm it's a clean section reorder with no content loss or spacing issues