### PR TITLE
docs(error-tracking): rename rule settings

### DIFF
--- a/contents/docs/error-tracking/alerts.mdx
+++ b/contents/docs/error-tracking/alerts.mdx
@@ -9,10 +9,10 @@ To stay on top of issues, you can set up alerts. These enable you to post to Sla
 To alert when an issue is created or reopened, go to [error tracking's configuration page](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-alerting) and click **Alerting**. This shows you a list of existing alerts. Clicking **New notification** brings you to a page to create a new one.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_03_05_339_Z_fce7707d31.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_02_44_265_Z_400e53c07a.png"
-    alt="Error tracking alerting"
-    classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_03_05_339_Z_fce7707d31.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_02_44_265_Z_400e53c07a.png"
+alt="Error tracking alerting"
+classes="rounded"
 />
 
 Choosing an option brings you to a page to configure the alert. This may require setting up the Slack integration or pasting in a webhook URL. Once done, you can test the alert by clicking **Test function** and then finalize by clicking **Create & enable**.
@@ -23,13 +23,13 @@ This will then send alerts to your chosen destination when an issue is created o
 
 ## Issue properties and assignments
 
-You can filter an alert based on the properties of an issue. This is useful for notifying a specific team when they have been auto assigned an issue using [auto assignment rules](/docs/error-tracking/managing-issues#auto-assignment-rules).
+You can filter an alert based on the properties of an issue. This is useful for notifying a specific team when they have been automatically assigned an issue using [assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment).
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_light_e575af6512.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_dark_9a8907af03.png"
-    alt="Error tracking alert assignee filtering"
-    classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_light_e575af6512.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/assignee_filter_dark_9a8907af03.png"
+alt="Error tracking alert assignee filtering"
+classes="rounded"
 />
 
 ## Spike alerts
@@ -51,25 +51,25 @@ To create a real time destination, go to the [data pipelines tab](https://app.po
 On the destination creation screen, make sure to add an event matcher for the `$exception` event, filter for the properties you want, and set the trigger options.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/http_error_alert_light_9898376c56.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/http_error_alert_dark_7705f0e575.png"
-  alt="Real time destination"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/http_error_alert_light_9898376c56.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/http_error_alert_dark_7705f0e575.png"
+alt="Real time destination"
+classes="rounded"
 />
 
 Check out our [real time destinations docs](/docs/cdp/destinations) for more information.
 
 ### Trend alerts
 
-You can also visualize your `$exception` events using [trends](/docs/product-analytics/trends/overview). Once you create a trend insight, click the **Alerts** button at the top of the insight and then **New alert**. 
+You can also visualize your `$exception` events using [trends](/docs/product-analytics/trends/overview). Once you create a trend insight, click the **Alerts** button at the top of the insight and then **New alert**.
 
 Here you can set alerts for event volume value, increase, or decrease.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_04_08_at_14_26_43_2x_4ef6402556.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_04_08_at_14_25_35_2x_f36353143b.png"
-  alt="Insight alert"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_04_08_at_14_26_43_2x_4ef6402556.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_04_08_at_14_25_35_2x_f36353143b.png"
+alt="Insight alert"
+classes="rounded"
 />
 
 This sends an email notification to the user you choose. Check out our [alerts docs](/docs/alerts) for more information.
@@ -78,6 +78,6 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Can't find your alert?" type="fyi">
 
-  If you'd like a destination to be added that we don't yet support, [let us know in-app](https://app.posthog.com/#panel=support%3Afeedback%3Aerror_tracking%3A%3Afalse).
+If you'd like a destination to be added that we don't yet support, [let us know in-app](https://app.posthog.com/#panel=support%3Afeedback%3Aerror_tracking%3A%3Afalse).
 
 </CalloutBox>

--- a/contents/docs/error-tracking/assigning-issues.mdx
+++ b/contents/docs/error-tracking/assigning-issues.mdx
@@ -11,50 +11,50 @@ You can manually assign issues as you triage them in the UI, either from the iss
 From your error tracking [issue list](https://app.posthog.com/error_tracking), click the **Unassigned** selector under any issue to assign it to a role or user.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_52_16_655_Z_b73751c99d.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_52_59_843_Z_d3d394bf7e.png"
-  alt="Assigning an issue from the issue list"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_52_16_655_Z_b73751c99d.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_52_59_843_Z_d3d394bf7e.png"
+alt="Assigning an issue from the issue list"
+classes="rounded"
 />
 
 Alternatively, open an issue and click the **Assignee** selector on its details page.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_53_43_196_Z_4fe353e323.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_54_12_467_Z_35902a2f98.png"
-  alt="Assigning an issue from its details page"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_53_43_196_Z_4fe353e323.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_54_12_467_Z_35902a2f98.png"
+alt="Assigning an issue from its details page"
+classes="rounded"
 />
 
 Want to assign issues to a **team** rather than an individual teammate? You can create a role in [your project settings](https://app.posthog.com/settings/organization-roles).
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_55_26_069_Z_ecff46f618.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_55_55_647_Z_085f6efe19.png"
-  alt="Error tracking role assignees"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_55_26_069_Z_ecff46f618.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_55_55_647_Z_085f6efe19.png"
+alt="Error tracking role assignees"
+classes="rounded"
 />
 
 ## Automatic issue assignment
 
-You can set up automatic issue assignment through a set of rules. This can be configured in the [error tracking settings](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-auto-assignment) using **auto assignment rules**. You can also create assignment rules programmatically using the [PostHog MCP server](/docs/error-tracking/surfaces/mcp).
+You can set up automatic issue assignment through a set of rules. Configure this in the [error tracking settings](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-auto-assignment) using **Assignment rules**. You can also create assignment rules programmatically using the [PostHog MCP server](/docs/error-tracking/surfaces/mcp).
 
 The settings show a list of your existing assignment rules:
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_57_06_125_Z_a7f920a3dc.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_56_47_967_Z_3ddddd1841.png"
-  alt="List of auto assignment rules"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_57_06_125_Z_a7f920a3dc.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_56_47_967_Z_3ddddd1841.png"
+alt="List of assignment rules"
+classes="rounded"
 />
 
 When adding or editing a rule, you can test it before saving. Click **Test** to see how many exceptions matched the rule's conditions over the last 7 days, so you can confirm it behaves as expected.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_30_30_887_Z_7a01202bc4.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_30_54_381_Z_d468514190.png"
-  alt="Adding an auto assignment rule"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_30_30_887_Z_7a01202bc4.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_30_54_381_Z_d468514190.png"
+alt="Adding an assignment rule"
+classes="rounded"
 />
 
 Assignment conditions are evaluated against the properties of the exception event that created the issue. Because assignment rules are evaluated during ingestion, the stack trace (if present) will be unminified, which enables filtering on exception properties such as function name and source file.
@@ -102,10 +102,10 @@ First, set up an [integration](/docs/error-tracking/integrations) with your trac
 From an issue's details page, under **External references**, click **Create issue**.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/create_issue_error_light_b89cd91da1.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/create_issue_error_dark_7d158087f8.png"
-  alt="Error tracking create issue in external tracking system"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/create_issue_error_light_b89cd91da1.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/create_issue_error_dark_7d158087f8.png"
+alt="Error tracking create issue in external tracking system"
+classes="rounded"
 />
 
 The new issue has a partial stack trace and a link to the issue in PostHog.

--- a/contents/docs/error-tracking/grouping-issues.mdx
+++ b/contents/docs/error-tracking/grouping-issues.mdx
@@ -4,7 +4,7 @@ title: Grouping exceptions into issues
 
 import { CalloutBox } from 'components/Docs/CalloutBox'
 
-Issues are created by grouping together similar exception events. When **no custom grouping behavior is configured**, exceptions are grouped together automatically based on their [fingerprint](/docs/error-tracking/fingerprints). 
+Issues are created by grouping together similar exception events. When **no custom grouping behavior is configured**, exceptions are grouped together automatically based on their [fingerprint](/docs/error-tracking/fingerprints).
 
 > We're working on improving our grouping algorithm. If you spot two issues that you think should have been one, or one issue that you think should have been split into two, please [let us know in-app](https://app.posthog.com#panel=support%3Afeedback%3Aerror_tracking%3Alow%3Atrue).
 
@@ -16,33 +16,33 @@ PostHog's default grouping logic may not work for every use case, making custom 
 
 ## Custom issue grouping
 
-PostHog attempts to group similar exceptions into issues automatically. If you want more control over issue grouping, you can use custom grouping rules during ingestion or define a client-side fingerprint.
+PostHog attempts to group similar exceptions into issues automatically. If you want more control over issue grouping, you can use grouping rules during ingestion or define a client-side fingerprint.
 
 ### Option 1: Custom grouping rule
 
-You can group exceptions as a single issue based on their properties using custom grouping rules. As with [auto assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment), you have access to properties of the unminified stack trace because the rules run during ingestion. 
+You can group exceptions as a single issue based on their properties using grouping rules. As with [assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment), you have access to properties of the unminified stack trace because the rules run during ingestion.
 
-The [error tracking settings](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-custom-grouping) show a list of your custom grouping rules:
+The [error tracking settings](https://app.posthog.com/error_tracking/configuration#selectedSetting=error-tracking-custom-grouping) show a list of your grouping rules:
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_03_39_272_Z_a38e139b94.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_03_57_025_Z_128bd9bfe4.png"
-  alt="List of custom grouping rules"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_03_39_272_Z_a38e139b94.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T14_03_57_025_Z_128bd9bfe4.png"
+alt="List of grouping rules"
+classes="rounded"
 />
 
 To create a **custom grouping rule**, click **Add rule** and configure it in the rule editor:
 
 1. Select **Any** to match any of the criteria, or **All** to match all of the criteria.
-2. Click the **+ Add filter** button to add a new filter. These filters can be configured to match any [event property](/docs/data/events) in PostHog. 
+2. Click the **+ Add filter** button to add a new filter. These filters can be configured to match any [event property](/docs/data/events) in PostHog.
 3. Click **Test** to check how many exceptions match the rule's conditions before saving.
 4. Click **Save** to create the rule.
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_35_56_474_Z_03f7bcfafb.png"
-  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_36_15_781_Z_a162179a94.png"
-  alt="Adding a custom grouping rule"
-  classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_35_56_474_Z_03f7bcfafb.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T10_36_15_781_Z_a162179a94.png"
+alt="Adding a custom grouping rule"
+classes="rounded"
 />
 
 Here are some common exception event properties you can filter on:
@@ -108,14 +108,14 @@ Some examples of this could be:
 - A common issue like `ClickHouseTimeout` that occurs in many different places, but are mistakenly labeled as different issues.
 - A specific error message that shouldn't account for any differences in stack traces, such as "Failed to send billing status to SQS for customer".
 
-You should avoid using grouping to address problems that can be otherwise solved by [auto assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment) or filtering by [custom properties](/docs/error-tracking/capture#customizing-exception-properties). When you over-group issues, they lack specificity and become meaningless.
+You should avoid using grouping to address problems that can be otherwise solved by [assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment) or filtering by [custom properties](/docs/error-tracking/capture#customizing-exception-properties). When you over-group issues, they lack specificity and become meaningless.
 
 ## How PostHog prioritizes issue grouping logic
 
 PostHog prioritizes issue grouping logic in the following order:
 
 1. Client-side defined custom fingerprint using `$exception_fingerprint`
-2. Match custom grouping rules defined in PostHog
+2. Match grouping rules defined in PostHog
 3. If no user defined logic, fall back to grouping as issues based on automatic fingerprinting
 
 Read more about how PostHog prioritizes grouping logic in the [issues and exceptions guide](/docs/error-tracking/issues-and-exceptions#how-exceptions-are-grouped-into-issues).

--- a/contents/docs/error-tracking/issues-and-exceptions.mdx
+++ b/contents/docs/error-tracking/issues-and-exceptions.mdx
@@ -6,13 +6,13 @@ This page introduces the concept of issues and exceptions, how they fit into the
 
 ## What is an exception?
 
-Errors are initially captured as individual `$exception` events. Like other [events](/docs/data/events) in PostHog, they contain properties that you can use to filter and group them. You can also use them to create insights, filter recordings, trigger surveys, and more. 
+Errors are initially captured as individual `$exception` events. Like other [events](/docs/data/events) in PostHog, they contain properties that you can use to filter and group them. You can also use them to create insights, filter recordings, trigger surveys, and more.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/exception_activity_light_3fbe98b154.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/exception_activity_dark_57bf2554e0.png"
-    alt="Exception events"
-    classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/exception_activity_light_3fbe98b154.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/exception_activity_dark_57bf2554e0.png"
+alt="Exception events"
+classes="rounded"
 />
 
 <Caption>View recent exception events in the <strong>Activity</strong> tab</Caption>
@@ -30,19 +30,18 @@ These captured properties are used to build a [fingerprint](/docs/error-tracking
 Issues are groups of similar `$exception` events that share common event information, such as the exception type, message, and stack trace. They're the primary way you interact with captured exceptions in error tracking.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_48_22_064_Z_24bedabf5e.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_48_42_304_Z_be037048f5.png"
-    alt="Issues list view"
-    classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_48_22_064_Z_24bedabf5e.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_48_42_304_Z_be037048f5.png"
+alt="Issues list view"
+classes="rounded"
 />
 <Caption>The error tracking dashboard displays a list of issues</Caption>
 
-
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_50_11_322_Z_dfe9b9dd79.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_49_48_664_Z_30d13a2ef1.png"
-    alt="Issue view"
-    classes="rounded"
+imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_50_11_322_Z_dfe9b9dd79.png"
+imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/pasted_image_2026_06_24_T13_49_48_664_Z_30d13a2ef1.png"
+alt="Issue view"
+classes="rounded"
 />
 <Caption>Opening an issue shows detailed information about its exceptions</Caption>
 
@@ -55,7 +54,7 @@ When working in the context of error tracking, PostHog [groups similar exception
 
 ## How exceptions are grouped into issues
 
-PostHog attempts to group similar exceptions into an issue automatically by their exception type, exception message, and [stack traces](/docs/error-tracking/stack-traces). The quality of automatic grouping can vary depending on the data available. 
+PostHog attempts to group similar exceptions into an issue automatically by their exception type, exception message, and [stack traces](/docs/error-tracking/stack-traces). The quality of automatic grouping can vary depending on the data available.
 
 ```mermaid
 flowchart TD
@@ -81,7 +80,7 @@ flowchart TD
 
 ```
 
-You can customize issue grouping logic by using [custom grouping rules](/docs/error-tracking/grouping-issues#option-1-custom-grouping-rule), [merging issues](/docs/error-tracking/grouping-issues), or labeling exceptions with a [custom fingerprint](/docs/error-tracking/grouping-issues#option-2-client-side-fingerprint).
+You can customize issue grouping logic by using [grouping rules](/docs/error-tracking/grouping-issues#option-1-custom-grouping-rule), [merging issues](/docs/error-tracking/grouping-issues), or labeling exceptions with a [custom fingerprint](/docs/error-tracking/grouping-issues#option-2-client-side-fingerprint).
 
 When multiple issue grouping methods apply, PostHog applies them in the following order:
 
@@ -89,8 +88,8 @@ When multiple issue grouping methods apply, PostHog applies them in the followin
 flowchart LR
     A[Exception Event] --> B{Custom fingerprint<br/>set?}
     B -->|Yes| C[Use custom fingerprint]
-    B -->|No| D{Custom grouping rules<br/>match?}
-    D -->|Yes| E[Use custom grouping rules]
+    B -->|No| D{Grouping rules<br/>match?}
+    D -->|Yes| E[Use grouping rules]
     D -->|No| F[Use automatic fingerprinting]
     
     C --> G[Create/update issue]
@@ -99,7 +98,7 @@ flowchart LR
 ```
 
 1. Client-side defined [custom fingerprint](/docs/error-tracking/capture#customizing-exception-capture) using `$exception_fingerprint`
-2. Match [custom grouping rules](/docs/error-tracking/grouping-issues#option-2-custom-grouping-rule) defined in PostHog
+2. Match [grouping rules](/docs/error-tracking/grouping-issues#option-1-custom-grouping-rule) defined in PostHog
 3. If no user defined logic, fall back to [automatic fingerprinting](/docs/error-tracking/fingerprints)
- 
+
 > We're working on improving our grouping algorithm. If you spot two issues that you think should have been one, or one issue that you think should have been split into two, please [let us know in-app](https://app.posthog.com#panel=support%3Afeedback%3Aerror_tracking%3Alow%3Atrue).

--- a/contents/docs/error-tracking/troubleshooting.mdx
+++ b/contents/docs/error-tracking/troubleshooting.mdx
@@ -137,7 +137,7 @@ Rules can become disabled if PostHog encounters a processing error while evaluat
 
 To fix and re-enable a disabled rule:
 
-1. Go to your [custom grouping rules](/docs/error-tracking/grouping-issues#custom-grouping-rule) or [auto assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment) in the **Configuration** tab
+1. Go to your [grouping rules](/docs/error-tracking/grouping-issues#option-1-custom-grouping-rule) or [assignment rules](/docs/error-tracking/assigning-issues#automatic-issue-assignment) in the **Configuration** tab
 2. Find the rule with the disabled banner and review the error message
 3. Edit the rule to correct the configuration issue
 4. Save the rule – this automatically re-enables it
@@ -147,10 +147,10 @@ If the error persists after editing, reach out to support.
 ## Solved community questions
 
 <SolvedQuestions
-  topicLabel="Error Tracking"
-  pinnedQuestions={[
-    "code-variables-for-external-libraries-for-python",
-    "trouble-setting-up-source-map-in-vite-react",
-    "webpack-turbopack-plugin-getting-sourcemaps-uploaded-to-vercel",
-  ]}
+topicLabel="Error Tracking"
+pinnedQuestions={[
+"code-variables-for-external-libraries-for-python",
+"trouble-setting-up-source-map-in-vite-react",
+"webpack-turbopack-plugin-getting-sourcemaps-uploaded-to-vercel",
+]}
 />


### PR DESCRIPTION
## Changes

- Error Tracking docs now use the **Assignment rules** and **Grouping rules** labels shown in the app.
- Existing in-app links keep their stable setting IDs.
- Three stale internal anchors now point to their current headings.
- Companion app change: https://github.com/PostHog/posthog/pull/90004

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
