### PR TITLE
docs(cdp): document file download exports

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -33,7 +33,7 @@ There are separate limits for different kinds of resources.
 
 - For the `events/values` endpoint, the rate limits are `60/minute` and `300/hour`. When using a personal API key, the `event_name` query parameter is required. For queries without event filters, use the [`query`](/docs/api/queries) endpoint instead.
 
-- The [`query`](/docs/api/queries) endpoint has a rate limit of `2400/hour`. Organizations without a paid plan also have a [monthly data-read allowance](/docs/api/queries#free-plan-data-limit) for queries. For large or regular exports of events, use [batch exports](/docs/cdp/batch-exports). For data-powered APIs or user-facing dashboards, [reach out to us](https://posthog.com/talk-to-a-human).
+- The [`query`](/docs/api/queries) endpoint has a rate limit of `2400/hour`. Organizations without a paid plan also have a [monthly data-read allowance](/docs/api/queries#free-plan-data-limit) for queries. For regular exports of events, use [batch exports](/docs/cdp/batch-exports). For large one-off exports, use [file download exports](/docs/cdp/file-download-exports). For data-powered APIs or user-facing dashboards, [reach out to us](https://posthog.com/talk-to-a-human).
 
 - For [feature flag local evaluation](/docs/feature-flags/local-evaluation) (which is enabled in SDKs when you input a personal API key), the rate limit is `600/minute`.
 
@@ -45,7 +45,7 @@ There are separate limits for different kinds of resources.
 
 These limits apply to **the entire team** (i.e. all users within your PostHog organization). For example, if a script requesting feature flag metadata hits the rate limit, and another user, using a different personal API key, makes a single request to the persons API, this gets rate limited as well.
 
-> At this time, we are not offering higher limits than these, but you may wish to try our [endpoints product](/docs/endpoints), which offers query customization and higher limits. Alternatively, you may be able to use our [batch exports product](/docs/cdp/batch-exports) to pull the data that you need from our events or persons tables on a faster cadence.
+> At this time, we are not offering higher limits than these, but you may wish to try our [endpoints product](/docs/endpoints), which offers query customization and higher limits. Alternatively, you may be able to use our [batch exports product](/docs/cdp/batch-exports) to pull the data that you need from our events or persons tables on a faster cadence, or a [file download export](/docs/cdp/file-download-exports) for a one-off export.
 
 ## Responses
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -16,8 +16,8 @@ API queries enable you to query your data in PostHog. This is useful for:
 
 The `/query` endpoint is intended for ad-hoc analytics and embedded use cases. It is **not a supported export mechanism**.
 
-- **Bulk or recurring exports of `events`, `persons`, or `query_log` are not supported** over `/query`. Use [batch exports](/docs/cdp/batch-exports) for ETL, data warehouse syncs, and any integration that pulls more than a few thousand rows on a schedule.
-- **Third-party connectors must use [batch exports](/docs/cdp/batch-exports)**, not `/query`. Connectors built on `/query` are not supported and will be rate-limited or rejected.
+- **Bulk or recurring exports of `events`, `persons`, or `query_log` are not supported** over `/query`. Use [batch exports](/docs/cdp/batch-exports) for ETL, data warehouse syncs, and any integration that pulls more than a few thousand rows on a schedule. For one-off bulk exports, use [file download exports](/docs/cdp/file-download-exports).
+- **Third-party connectors must use [batch exports](/docs/cdp/batch-exports) or [file download exports](/docs/cdp/file-download-exports)**, not `/query`. Connectors built on `/query` are not supported and will be rate-limited or rejected.
 - **`OFFSET` pagination is not supported for programmatic requests** (personal API keys, OAuth tokens, and similar). It currently returns HTTP 400 for personal API keys, and we may reject it for other authentication methods at any time. Use keyset pagination on `timestamp` instead (see [below](#5-use-timestamp-based-pagination-instead-of-offset)).
 - We **reserve the right to rate-limit, restrict, or reject** queries that look like exports, including without prior notice. Pipelines built on `/query` may break at any time.
 - Use [real-time destinations](/docs/cdp/destinations) for sending data to Slack, webhooks, etc.
@@ -40,7 +40,7 @@ To create a query, you make a `POST` request to the `/api/projects/:project_id/q
 
 By default, API queries return up to 100 rows. If you specify your own `LIMIT`, you can return up to 50k rows per query.
 
-For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is not supported for programmatic requests and is currently rejected with HTTP 400 for personal API keys. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) – `/query` is not a supported export path.
+For paginating beyond a single query, you **must** use [keyset pagination on `timestamp`](#5-use-timestamp-based-pagination-instead-of-offset). `OFFSET` is not supported for programmatic requests and is currently rejected with HTTP 400 for personal API keys. For exporting larger volumes, use [batch exports](/docs/cdp/batch-exports) or [file download exports](/docs/cdp/file-download-exports) – `/query` is not a supported export path.
 
 </CalloutBox>
 
@@ -284,7 +284,7 @@ API queries are limited at the project-level to:
   - applies to query execution time, not HTTP request duration
 
 
-At this time, we are not offering higher limits than these, but you may wish to try our [endpoints product](/docs/endpoints), which offers query customization and higher limits. Alternatively, you may be able to use our [batch exports product](/docs/cdp/batch-exports) to pull the data that you need from our events or persons tables on a faster cadence.
+At this time, we are not offering higher limits than these, but you may wish to try our [endpoints product](/docs/endpoints), which offers query customization and higher limits. Alternatively, you may be able to use our [batch exports product](/docs/cdp/batch-exports) to pull the data that you need from our events or persons tables on a faster cadence, or a [file download export](/docs/cdp/file-download-exports) for a one-off export.
 
 If the project's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue before executing, being canceled, or timing out.
 
@@ -302,6 +302,7 @@ To remove the limit, [subscribe to a paid plan](/pricing). PostHog is pay-as-you
 
 ## Further reading
 
+- [File download exports for one-off bulk exports](/docs/cdp/file-download-exports)
 - [Project setup for embedded analytics](/docs/data/embedded-analytics-projects)
 - [How to set up embedded analytics with PostHog, Next.js, and Recharts](/tutorials/embedded-analytics)
 - [How to use Recharts to visualize analytics data (with examples)](/tutorials/recharts)

--- a/contents/docs/cdp/batch-exports/index.mdx
+++ b/contents/docs/cdp/batch-exports/index.mdx
@@ -17,6 +17,8 @@ The key features offered by this platform are:
 
 Batch exports are designed to power any complimentary analytics use cases outside of PostHog.
 
+> Want a one-off export you can download as files, instead of scheduled delivery to a destination? Use a [file download export](/docs/cdp/file-download-exports).
+
 ## Destinations
 
 Every batch export exports data to a destination using the configuration parameters provided when creating a batch export. The following destinations are currently supported:

--- a/contents/docs/cdp/file-download-exports/index.mdx
+++ b/contents/docs/cdp/file-download-exports/index.mdx
@@ -81,7 +81,7 @@ The request body accepts:
 | `file.compression` | Optional. `zstd`, `lz4`, `snappy`, `gzip`, or `brotli` for `Parquet`. Only `gzip` and `brotli` for `JSONLines`. |
 | `file.max_size_mb` | Optional. Splits the output into multiple files of at most this size, instead of one potentially large file. |
 
-Each project can have up to 20 file download exports running at the same time. Requests beyond that return `429 Too Many Requests`.
+Each project can have up to 20 file download exports running at the same time. Requests beyond that return `429 Too Many Requests`. If you hit this limit, wait for a running export to finish, or [cancel](#canceling-an-export) one you no longer need.
 
 ## SQL queries
 
@@ -169,6 +169,8 @@ curl -L -o export.parquet \
 ```
 
 The endpoint responds with a `302` redirect to a temporary signed URL, so make sure your HTTP client follows redirects (`-L` in curl). The signed URL carries its own authentication, so do not send your API key with it. The URL expires after an hour. If it expires, call the download endpoint again for a fresh one. Treat the signed URL as a secret: anyone who has it can download the file while it is valid.
+
+Exported files are kept for one week. After that they are deleted, the download endpoint returns an error, and you need to run the export again.
 
 In place of the file ID, you can use a zero-based index (`.../download/0/`). If the export produced a single file, you can omit the file identifier entirely (`.../download/`). If you set `file.max_size_mb`, remember to download every file in the `files` array, not just the first.
 

--- a/contents/docs/cdp/file-download-exports/index.mdx
+++ b/contents/docs/cdp/file-download-exports/index.mdx
@@ -1,0 +1,189 @@
+---
+title: File download exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+File download exports let you export PostHog data on demand and download the results as Parquet or JSON Lines files. You start an export with an API call, poll until it completes, and download the files – no destination setup, no schedule.
+
+<CalloutBox icon="IconInfo" type="fyi" title="API-only (for now)">
+
+File download exports are currently only available through the API. A UI is coming soon.
+
+</CalloutBox>
+
+## When to use file download exports
+
+Use **file download exports** when you want a one-off copy of your data as files: running some ad-hoc analysis, sharing a dataset with a colleague, or doing a one-time load into another tool.
+
+Use **[batch exports](/docs/cdp/batch-exports)** when you want recurring, scheduled delivery of data to a destination you control, like S3, BigQuery, or Snowflake. This is the right choice for ETL and warehouse syncs.
+
+Use the **[`/query` API](/docs/api/queries)** when you want small, interactive result sets in an API response, like powering embedded analytics. It is not designed to be an export tool.
+
+## What you can export
+
+A file download export can export any of the standard [batch export models](/docs/cdp/batch-exports#models):
+
+- `events`: all events received within a time interval
+- `persons`: all persons that were updated within a time interval
+- `sessions`: all sessions that occurred within a time interval
+
+Exports of these models require a time interval (`data_interval_start` and `data_interval_end`) of at most one week. For longer ranges, run multiple exports.
+
+File download exports write the same files as an S3 batch export, so the schemas are identical. See the [S3 model schemas](/docs/cdp/batch-exports/s3#models) for the fields in each model, and for how the types differ between Parquet and JSON Lines.
+
+You can also export the results of an arbitrary [SQL](/docs/sql) query using the `hogql` model. This is in [closed beta](#sql-queries) (see below).
+
+## Creating an export
+
+Start an export with a `POST` request to the `file_download_batch_exports` endpoint. You need a [personal API key](/docs/api/personal-api-keys) with the `batch_export:write` scope (and `batch_export:read` to poll and download).
+
+For example, to export all `$pageview` events from a single day as zstd-compressed Parquet:
+
+```bash
+curl -X POST \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  <ph_app_host>/api/projects/:project_id/file_download_batch_exports/ \
+  -d '{
+        "model": "events",
+        "include": ["$pageview"],
+        "data_interval_start": "2026-08-18T00:00:00Z",
+        "data_interval_end": "2026-08-19T00:00:00Z",
+        "file": {
+          "format": "Parquet",
+          "compression": "zstd"
+        }
+      }'
+```
+
+A successful request returns `202 Accepted` with the ID of the export run:
+
+```json
+{ "id": "01991f2e-5f8e-7c1a-b3d4-8a2f9c0e1d2b" }
+```
+
+The request body accepts:
+
+| Field | Description |
+| --- | --- |
+| `model` | One of `events`, `persons`, `sessions`, or `hogql` (currently in closed beta). |
+| `data_interval_start`, `data_interval_end` | ISO 8601 datetimes bounding the export. Required for `events`, `persons`, and `sessions`. The range must be at most one week, and the end cannot be in the future. Not supported for `hogql`. |
+| `include`, `exclude` | Optional lists of event names to include or exclude. Only supported for the `events` model. |
+| `hogql_query` | The SQL query to export. Required for (and only supported by) the `hogql` model. |
+| `file.format` | `Parquet` (default) or `JSONLines`. |
+| `file.compression` | Optional. `zstd`, `lz4`, `snappy`, `gzip`, or `brotli` for `Parquet`. Only `gzip` and `brotli` for `JSONLines`. |
+| `file.max_size_mb` | Optional. Splits the output into multiple files of at most this size, instead of one potentially large file. |
+
+Each project can have up to 20 file download exports running at the same time. Requests beyond that return `429 Too Many Requests`.
+
+## SQL queries
+
+<CalloutBox icon="IconInfo" type="fyi" title="This model is in closed beta">
+
+SQL query exports are enabled per team. To get access, message us via the [in-app support form](https://us.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue). We're actively looking for feedback on this feature, and we'd love to hear about the use cases and queries you want to run.
+
+</CalloutBox>
+
+The `hogql` model exports the results of any [SQL](/docs/sql) query, so you aren't limited to the standard models – filter, join, and aggregate whatever you need:
+
+```bash
+curl -X POST \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  <ph_app_host>/api/projects/:project_id/file_download_batch_exports/ \
+  -d '{
+        "model": "hogql",
+        "hogql_query": "SELECT event, timestamp, properties.$current_url AS url FROM events WHERE timestamp > now() - INTERVAL 1 HOUR",
+        "file": {
+          "format": "Parquet"
+        }
+      }'
+```
+
+A few things to know about SQL query exports:
+
+- **Every column needs a name.** Each column in the `SELECT` clause must be a plain field or have an alias, like `count() AS event_count`.
+- **No placeholders.** Placeholder syntax like `{filters}` is not supported yet, so write the query out in full.
+- **No time interval.** The query runs as of the time the export starts, so `data_interval_start` and `data_interval_end` are not accepted. Bound the data in the query itself instead.
+- **Late-arriving events can be missed.** Events can reach PostHog well after their `timestamp`, so a query bounded by `timestamp` may miss events that had not arrived when the export ran. (The standard `events` model reads from an internal table built to avoid this, which SQL queries do not have access to currently.) If completeness matters, leave a margin behind the present or re-run the export later.
+
+### Bound your queries
+
+Since user-supplied queries are more unpredictable in nature, they run under stricter resource limits than the standard models. They are subject to limits on execution time, memory usage, and the volume of data read. A query that exceeds any of them fails with an error.
+
+Always narrow your query with a `WHERE` clause. This keeps you inside the resource limits, and it keeps you from being billed for more rows than you expected. For example, when you query the `events` table, bound the `timestamp` column:
+
+```sql
+SELECT event, timestamp, properties.$current_url AS url
+FROM events
+WHERE timestamp >= '2026-08-18' AND timestamp < '2026-08-19'
+```
+
+If you keep hitting resource limits even with a bounded query, [get in touch](https://us.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue) – we want to hear about it.
+
+## Polling an export
+
+Export runs are asynchronous. Poll the run with a `GET` request:
+
+```bash
+curl \
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  <ph_app_host>/api/projects/:project_id/file_download_batch_exports/:run_id/
+```
+
+The response contains the run's `status`:
+
+| Status | Meaning |
+| --- | --- |
+| `Starting`, `Running` | The export is in progress. Wait and poll again. |
+| `Completed` | The export finished. The response includes a `files` array with the ID of each exported file. |
+| `Cancelled` | The export was canceled. |
+| `Failed`, `FailedBilling` | The export did not finish. The response includes an `error` field with details. |
+
+A completed run looks like this:
+
+```json
+{
+  "status": "Completed",
+  "files": ["01991f30-a2c4-7d5e-9f01-3b4c5d6e7f80"]
+}
+```
+
+Exports usually complete within a few minutes, but large exports can take longer – narrowing the date range or filtering events will help speed things up. To list all of a project's export runs, send a `GET` request to the collection endpoint without a run ID.
+
+## Downloading the files
+
+Once the run is `Completed`, download each file in the `files` array:
+
+```bash
+curl -L -o export.parquet \
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  <ph_app_host>/api/projects/:project_id/file_download_batch_exports/:run_id/download/:file_id/
+```
+
+The endpoint responds with a `302` redirect to a temporary signed URL, so make sure your HTTP client follows redirects (`-L` in curl). The signed URL carries its own authentication, so do not send your API key with it. The URL expires after an hour. If it expires, call the download endpoint again for a fresh one. Treat the signed URL as a secret: anyone who has it can download the file while it is valid.
+
+In place of the file ID, you can use a zero-based index (`.../download/0/`). If the export produced a single file, you can omit the file identifier entirely (`.../download/`). If you set `file.max_size_mb`, remember to download every file in the `files` array, not just the first.
+
+## Canceling an export
+
+Cancel a run that is still `Starting` or `Running` with a `POST` request:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  <ph_app_host>/api/projects/:project_id/file_download_batch_exports/:run_id/cancel/
+```
+
+A canceled run cannot be resumed. Start a new export instead.
+
+## Billing
+
+File download exports are billed the same way as batch exports: based on the number of rows exported. See [our pricing page](/pricing) for details.

--- a/contents/docs/cdp/surfaces/mcp.mdx
+++ b/contents/docs/cdp/surfaces/mcp.mdx
@@ -23,7 +23,9 @@ The [PostHog MCP server](/docs/model-context-protocol) gives AI agents and MCP c
 
 **Control ordering and state.** Reorder transformation execution, and enable or disable a function without deleting it.
 
-**Manage batch exports.** List, create, update, and delete batch exports, and request file downloads for exported data.
+**Manage batch exports.** List, create, update, and delete batch exports.
+
+**Export data as files.** Start a [file download export](/docs/cdp/file-download-exports), check whether it has finished, and cancel one that is still running. Downloading the finished files happens over the API.
 
 ## Example prompts
 
@@ -33,6 +35,7 @@ The [PostHog MCP server](/docs/model-context-protocol) gives AI agents and MCP c
 - `Show me the logs for my HubSpot destination from the last hour.`
 - `Move my PII redaction transformation to run before everything else.`
 - `Disable the destination that's erroring the most.`
+- `Export last week's pageview events as Parquet and tell me when the files are ready.`
 
 ## Install the MCP server
 

--- a/contents/docs/migrate/index.mdx
+++ b/contents/docs/migrate/index.mdx
@@ -22,7 +22,7 @@ Historical migrations refer to ingesting and importing past data into PostHog fo
 
 - Adding past data from a third-party source into PostHog.
 
-> **What about exporting data from PostHog?** Use our [batch export feature](/docs/cdp/batch-exports) to export data from PostHog to external services like [S3](/docs/cdp/batch-exports/s3) or [BigQuery](/docs/cdp/batch-exports/bigquery).
+> **What about exporting data from PostHog?** Use our [batch export feature](/docs/cdp/batch-exports) to export data from PostHog to external services like [S3](/docs/cdp/batch-exports/s3) or [BigQuery](/docs/cdp/batch-exports/bigquery), or a [file download export](/docs/cdp/file-download-exports) to export data as downloadable files.
 
 ## The basics of migrating data into PostHog
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -339,6 +339,13 @@ export const dataPipelines = {
             ],
         },
         {
+            name: 'File download exports',
+            url: '/docs/cdp/file-download-exports',
+            icon: 'IconDownload',
+            color: 'seagreen',
+            featured: true,
+        },
+        {
             name: 'Transformations',
         },
         {


### PR DESCRIPTION
## Summary

Adds documentation for **file download exports**, the on-demand export API that exports PostHog data as downloadable Parquet or JSON Lines files.

The feature runs on the batch export platform, but it is a different thing to use: a batch export delivers data to your own destination on a schedule, while a file download export is a one-off export you trigger, poll, and download. The docs keep the two apart. File download exports get a new top-level section in the Data pipelines sidebar, next to Batch exports, instead of a subsection inside it.

This also paves the way for HogQL-powered file download exports, which is currently in a closed beta.

The new page covers:

- **When to use it** against batch exports (scheduled delivery to your own destination) and the `/query` API (small interactive result sets, not an export path).
- **What you can export** — the standard `events`, `persons`, and `sessions` models, with a link to the S3 model schemas, because file download exports write the same files.
- **SQL queries**, which are in closed beta. The section starts with how to request access and asks for feedback on use cases and queries.
- **The full API flow** — create, poll, download, and cancel, with `curl` examples, the request fields, and the run statuses.
- **Billing**, which works the same way as batch exports and counts exported rows.

The page states that the feature is currently API-only and that a UI is coming.

## Cross-links

Pages that recommend batch exports now also point to file download exports for one-off pulls: the [API overview](contents/docs/api/index.mdx), [API queries](contents/docs/api/queries.mdx), the [batch exports overview](contents/docs/cdp/batch-exports/index.mdx), the [MCP pipelines page](contents/docs/cdp/surfaces/mcp.mdx), and the [migrations overview](contents/docs/migrate/index.mdx).

On the MCP page, the batch exports bullet is split in two. Only create, status, and cancel are available as MCP tools; the download itself goes through the API.

## Checks

- `prettier --check` passes on all changed files.
- Loaded all six changed pages on a local dev server. Console errors are the same before and after on every modified page (8 / 3 / 7 / 3 / 8), so this change adds none. The remaining errors are pre-existing and site-wide.
- Confirmed the in-page anchor still resolves after a heading rename, and that no other file referenced the old anchor.
- No page was moved or renamed, so `vercel.json` needs no redirect.

## Screenshots

Location of the new page in the destinations section

<img width="282" height="253" alt="image" src="https://github.com/user-attachments/assets/bc03848b-9cc9-4cd3-891c-63f2870c1a3f" />


---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
