### PR TITLE
docs: add Apple Ads source setup instructions

### DIFF
--- a/contents/docs/cdp/sources/apple-search-ads.md
+++ b/contents/docs/cdp/sources/apple-search-ads.md
@@ -1,0 +1,101 @@
+---
+title: Linking Apple Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: AppleSearchAds
+---
+
+import SourceSetupIntro from "../\_snippets/source-setup-intro.mdx"
+import SyncModes from "../\_snippets/sync-modes.mdx"
+import TroubleshootingLink from "../\_snippets/dw-troubleshooting-link.mdx"
+import AlphaRelease from "../\_snippets/alpha-release.mdx"
+
+<AlphaRelease />
+
+The Apple Ads connector syncs your campaigns, ad groups, keywords, and daily performance reporting into PostHog, so you can analyze ad spend next to your product data. Apple Ads was called Apple Search Ads until Apple renamed it, and it now covers ads on both the App Store and Apple Maps.
+
+PostHog reads version 1.0 of the [Apple Ads Platform API](https://developer.apple.com/documentation/apple-ads-platform-api).
+
+## Prerequisites
+
+Neither PostHog nor Apple generates an API key for you. You generate a key pair yourself, an account administrator uploads the public half to Apple, and Apple then shows you the identifiers to paste into PostHog. Work through the four steps below before you link the source.
+
+### 1. Create an API user
+
+An Apple Ads account administrator signs in to [Apple Ads](https://ads.apple.com), goes to **Account Settings** > **User Management**, and invites or edits a user with one of these roles:
+
+- **API Account Read Only** – read access to the account. This is all PostHog needs.
+- **API Account Manager** – read and write access. This works, but it grants more than PostHog uses.
+
+Apple revokes API access if the user later moves to a non-API role, which makes syncs start to fail. Use a user whose role you don't expect to change.
+
+### 2. Generate a key pair
+
+The API user generates an EC P-256 key pair. OpenSSL is already installed on macOS and Linux:
+
+```bash
+openssl ecparam -genkey -name prime256v1 -noout -out private-key.pem
+openssl ec -in private-key.pem -pubout -out public-key.pem
+```
+
+Keep `private-key.pem` secret. If it leaks, generate a new pair and upload the new public key to Apple.
+
+### 3. Upload the public key
+
+The API user signs in to Apple Ads, goes to **Account Settings** > **API**, pastes the contents of `public-key.pem` into the **Public Key** field, and clicks **Save**.
+
+Apple then shows three identifiers above that field. PostHog needs all three:
+
+```
+clientId SEARCHADS.aeb3ef5f-0c5a-4f2a-99c8-fca83f25a9
+teamId   SEARCHADS.hgw3ef3p-0w7a-8a2n-77c8-scv83f25a7
+keyId    a273d0d3-4d9e-458c-a173-0db8619ca7d7
+```
+
+### 4. Find your ad account ID
+
+The Platform API scopes every request to one ad account, so PostHog needs your ad account ID. This is **not** your organization ID, because one organization can hold several ad accounts.
+
+Apple only serves this value from the API. Follow [Apple's OAuth guide](https://developer.apple.com/documentation/apple-ads-platform-api/implementing-oauth-for-the-apple-ads-platform-api) to sign a client secret with `private-key.pem` and exchange it for an access token, then call the [Get User ACL](https://developer.apple.com/documentation/apple-ads-platform-api/get-user-acls) endpoint:
+
+```bash
+curl -H "Authorization: Bearer $ACCESS_TOKEN" https://api.ads.apple.com/v1/acls
+```
+
+Each entry in the response holds an `adAccount.id`. That value is your ad account ID.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+## Sync modes
+
+<SyncModes />
+
+The `campaigns`, `ad_groups`, `keywords`, and `acls` tables use full refresh, because Apple's query endpoints expose no updated-since cursor.
+
+The three reporting tables sync incrementally by `date`. Each run re-reads a trailing window of recent days, because Apple restates recent reporting as attribution settles. Rows are merged away by primary key, so restatements replace earlier values instead of duplicating them.
+
+Apple serves daily reporting for the **last 90 days only**. PostHog starts a couple of days inside that boundary, because Apple applies it in the ad account's own reporting time zone. If you set a report start date older than the window, PostHog starts from the oldest day Apple still serves rather than failing the sync. To build a longer history, connect the source and let it sync regularly — PostHog keeps the rows it has already imported after they age out of Apple's window.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+## Troubleshooting
+
+- **401 errors** mean Apple rejected the access token. Check that the API client still exists under **Account Settings** > **API**, and that the private key in PostHog matches the public key uploaded there.
+- **403 errors** mean the API user can reach Apple but not this ad account. Check the user's role and the ad account ID.
+- **404 errors** mean Apple can't find the ad account. Re-read the ID from `adAccount.id` rather than using your organization ID.
+- **"The private key isn't a valid unencrypted EC (P-256) PEM"** means the key was pasted in the wrong format. Paste the whole contents of `private-key.pem`, including the `-----BEGIN EC PRIVATE KEY-----` and `-----END EC PRIVATE KEY-----` lines, and make sure the key isn't passphrase-protected.
+- **Reporting tables are empty for older dates** because of the 90-day daily reporting window described above. This is an Apple limit, not a sync failure.
+
+<TroubleshootingLink />


### PR DESCRIPTION
## Changes

The Apple Ads source had no hand-written docs page. Because of this, posthog.com built the page automatically from the source config. That generated page told the reader to create an API user in the Search Ads UI and let Apple generate an API key.

Apple removed that flow. The reader must now generate an EC P-256 key pair, and an account administrator must upload the public half to Apple. Apple then shows the client ID, team ID, and key ID. The reader could not do this correctly from the page as written.

This PR adds `contents/docs/cdp/sources/apple-search-ads.md`. The page gives:

- The four steps to do in Apple Ads before you link the source: create an API user with the correct role, generate the key pair, upload the public key, and read the ad account ID from Apple's Get User ACL endpoint.
- The API version PostHog reads, which is Apple Ads Platform API 1.0.
- The 90-day limit on daily reporting, and what PostHog does when the start date is older than that limit.
- Troubleshooting for the 401, 403, and 404 errors the connector reports.

Each Apple-side instruction agrees with Apple's own documentation. The OpenSSL commands, the **Account Settings** > **API** path, the role names, and the `adAccount.id` field all come from Apple's OAuth guide and Platform API reference.

The file uses `sourceId: AppleSearchAds`. Gatsby therefore uses this page instead of the generated page, at `/docs/cdp/sources/apple-search-ads` and at `/docs/data-warehouse/sources/apple-search-ads`. The `Configuration` and `Supported tables` sections keep the shared components, so both stay correct as the source config changes. The file name does not change the URL, so no redirect is necessary.

**Why:** users reported that they could not set up the source, because the page did not tell them how to get Apple credentials.

### Sequencing

This page describes the credentials of the Apple Ads Platform API. PostHog/posthog#89997 moves the source to that API and adds the **Ad account ID** field. Merge that PR first. If this page goes live first, the `Configuration` table will still show the older **Organization ID** field, and the page will disagree with the connect form.

Refs PostHog/posthog#83942, which asks for the supported API version on the docs page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, this is a new page

**Note on the two unchecked items:** my sandbox has no `node_modules` for this repo, so I could not start the dev server or open a preview. `pnpm format` does not apply here, because its glob covers `html,js,ts,tsx,json,yml,css,scss` and not markdown. The page copies the structure of `contents/docs/cdp/sources/maxio.md`, which builds today. Please confirm the Vercel preview before merge.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
