### PR TITLE
Focus onboarding success plans on customer outcomes

### DIFF
--- a/contents/handbook/cs-and-onboarding/onboarding-success-plan.md
+++ b/contents/handbook/cs-and-onboarding/onboarding-success-plan.md
@@ -14,6 +14,12 @@ There are still some best practices we can follow to collaborate with the custom
 - Customize the template with the goals, specific products and commitments that make sense for your customer's use case.
 - Share with customer, ideally as a Slack Canvas
 
+## Focus on the outcomes that matter most 
+Use this plan to align on the customer outcome you want to improve and the milestones that will show progress.
+When customizing the plan, work backwards from the customer's primary goal:
+**Business/product goal → baseline → PostHog use case → expected behavior change → measurable outcome**
+PostHog product adoption should support that goal, rather than become the goal itself. Add products or workflows when they help the customer make progress toward the agreed outcome.
+
 # Template
 ## PostHog 30-Day success plan
 **Customer:** [Customer Name] | **CSM:** CSM or AE NAME | **Start Date:** [Date]
@@ -45,12 +51,12 @@ There are still some best practices we can follow to collaborate with the custom
 **Weekly check-in:** [Day/Time] - 30 minutes
 - What findings have you learned from the first few insights you set up?
 - Have you come across any points of friction in the setup or areas of the product you're struggling to understand?
-- What are the next actions steps for us to follow up with in the next meeting?
+- What are the next action steps for us to follow up with in the next meeting?
 
 ---
 
-### Week 2-3: Feature Adoption & Optimization
-**Goal: Expand usage across your team**
+### Week 2-3: Use Case Adoption & Optimization
+**Goal: Make the customer's primary PostHog workflow repeatable and useful**
 
 #### Together We'll:
 - **Session Replay:** Set up recordings for your key user flows
@@ -97,9 +103,9 @@ There are still some best practices we can follow to collaborate with the custom
 | SDK Validated | Day 2 | Data flowing correctly into PostHog | ⏳ |
 | Custom Events Defined | Day 3 | Business-specific tracking configured | ⏳ |
 | Feature Flags & Groups Setup | Day 5 | B2B tracking and flags operational | ⏳ |
-| Team Trained | Day 7 | 3+ people actively using | ⏳ |
+| Relevant Team Enabled | Day 7 | People responsible for the primary use case can use the required workflow | ⏳ |
 | Actionable Insights | Day 10 | 2+ specific findings identified | ⏳ |
-| Feature Expansion | Day 20 | 2+ products actively used | ⏳ |
+| Use Case Adoption | Day 20 | Customer can use PostHog to support their primary use case by using at least 2 products | ⏳ |
 | Business Impact | Day 28 | Measurable metric improvement | ⏳ |
 
 ---


### PR DESCRIPTION
## Changes

The change updates the 30-day onboarding success plan to focus more explicitly on customer outcomes rather than product adoption as a success metric. The current plan is strongly focused on getting customers to measurable business value, but some of the default success criteria measure PostHog adoption instead - for example, “2+ products actively used” as a success milestone.
I think this can encourage us to treat broader product adoption as evidence of success even when it isn't tied to the customer's original goal.
This change makes the template more outcome-focused: start from the customer's primary business or product goal, define the baseline and desired outcome, then use whichever PostHog products are necessary to get there.
Product adoption and expansion are still useful signals, but they shouldn't be universal success criteria. A customer using one PostHog product to make better decisions may be more successful than one using several products without a clear use case.
This PR also updates the Week 2–3 milestone language so that the focus is on making the customer's primary PostHog workflow repeatable and useful.

*Add screenshots or screen recordings for visual / UI-focused changes.* - handbook content change

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
