### PR TITLE
fix(seo): always emit html lang and og:type

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -112,7 +112,7 @@ export const SEO = ({
             )}
 
             {seo.url && <meta property="og:url" content={seo.url} />}
-            {article ? <meta property="og:type" content="article" /> : null}
+            <meta property="og:type" content={article ? 'article' : 'website'} />
             {seo.title && <meta property="og:title" content={seo.title} />}
             {seo.description && <meta property="og:description" content={seo.description} />}
             {seo.image && <meta property="og:image" content={seo.image} />}

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -11,7 +11,8 @@ export interface HTMLProps {
 
 export default function HTML(props: HTMLProps): JSX.Element {
     return (
-        <html {...props.htmlAttributes}>
+        // `lang` is a default: pages that set their own (e.g. /ko) override it via htmlAttributes.
+        <html lang="en" {...props.htmlAttributes}>
             <head>
                 <meta charSet="utf-8" />
                 <meta httpEquiv="x-ua-compatible" content="ie=edge" />


### PR DESCRIPTION
## Summary

Two attributes were missing from almost every page on posthog.com.

`<html lang>` was only written when a page passed an explicit `lang` prop to `<SEO>`. Only `/ko` and translated blog posts do that, so every other page shipped an `<html>` element with no language at all. Screen readers pick a voice from that attribute, and search engines use it to decide who a page is for. This sets `en` as the default in the HTML template. A page that declares its own still wins, because Helmet spreads `htmlAttributes` after the default.

`og:type` had the same shape: it was written only for articles, so the homepage, every product page and every docs page shipped Open Graph tags with no type. It now defaults to `website`.

No tour: two one-line defaults.

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --write` on both files | Clean |
| `lang` default | Rendered the real `src/html.tsx` through `react-dom/server` | `<html lang="en">` |
| `lang` override | Same, with `htmlAttributes={{ lang: 'ko' }}` | `<html lang="ko">` — `/ko` is unaffected |
| `og:type` | Loaded `/` in Chrome against `pnpm start`, read the meta tag | `website` |
| Console | Compared the error set before and after the change on `/` | Identical, no new errors |

**Not tested:** a production build. `gatsby build` on this site is long, and `src/html.tsx` is only used at build time, so I rendered the component directly instead — which tests the same code with less waiting.

### Screenshots

Not applicable. Both changes are `<head>`/`<html>` attributes with no visual surface.

### What to look at

1. **`src/html.tsx`** — `lang="en"` sits before `{...props.htmlAttributes}`, and that order is the whole change. Reversed, `/ko` and every translated blog post would silently claim to be English. The direct render above covers exactly this case.
2. **`src/components/seo.tsx`** — `og:type` is now always written. If a page should be something other than `website` or `article` (a video or a profile), it now needs a prop rather than being absent. I do not think any page needs that today.

</details>
