### PR TITLE
fix(seo): stop advertising markdown that does not exist

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,8 +11,20 @@ export const MARKDOWN_CONTENT_PATHS = [
     '/pocket-guides',
     '/pricing',
 ] as const
-export const isMarkdownContentPath = (path: string) =>
-    MARKDOWN_CONTENT_PATHS.some((p) => path === p || path.startsWith(`${p}/`))
+
+// Section index pages have no scraped `.md`. generateRawMarkdownPages only sees nodes
+// matching `/^/(docs|handbook|...)/` (onPostBuild.ts) — note the trailing slash, which
+// requires a segment after the section name — so `/docs` and friends are never processed.
+// `/changelog` and `/pricing` are the exceptions: generateChangelogMd and generatePricingMd
+// write those two by hand.
+const SECTION_ROOTS_WITH_MARKDOWN: readonly string[] = ['/changelog', '/pricing']
+
+export const isMarkdownContentPath = (path: string): boolean => {
+    const normalized = path.replace(/\/$/, '')
+    return MARKDOWN_CONTENT_PATHS.some((p) =>
+        normalized === p ? SECTION_ROOTS_WITH_MARKDOWN.includes(p) : normalized.startsWith(`${p}/`)
+    )
+}
 
 // Default avatar fallback (Max the hedgehog)
 export const AVATAR_FALLBACK_URL =


### PR DESCRIPTION
## Summary

`/docs`, `/blog`, `/handbook`, `/newsletter` and `/pocket-guides` each published a `<link rel="alternate" type="text/markdown">` pointing at a URL that returns 404. An agent that follows the link the site advertises gets nothing.

Section index pages never get a scraped `.md`. `generateRawMarkdownPages` only sees nodes matching `` /^/(docs|handbook|...)/ `` (built in `gatsby/onPostBuild.ts:594`) — note the trailing slash, which requires a segment after the section name — so the roots are never processed. `/changelog` and `/pricing` are the two exceptions, written by hand by `generateChangelogMd` and `generatePricingMd`, and those two do resolve.

`isMarkdownContentPath` now knows that difference, and normalises a trailing slash on the way in so `/docs/` and `/docs` agree.

Verified live before writing the fix:

```
/docs.md 404   /blog.md 404   /handbook.md 404   /newsletter.md 404   /pocket-guides.md 404
/changelog.md 200   /pricing.md 200
```

No tour: one predicate, one file.

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --write src/constants/index.ts` | Clean |
| Predicate | 15 cases incl. trailing slashes, `/`, and the near-miss `/docsomething` | All pass |
| Live truth | `curl` each section-root `.md` on production | Matches the table above |
| Browser, before | `pnpm start`, read the alternate link on 4 pages | `/docs` → `/docs.md`, `/blog` → `/blog.md` (both 404) |
| Browser, after | Same 4 pages | `/docs` → none, `/blog` → none, `/changelog` and `/docs/getting-started/install` unchanged |
| Console | Error counts on all 4 pages, before vs after | Identical: 4 / 7 / 6 / 16 both sides |

### Screenshots

Not applicable — the change removes a `<link>` from `<head>`. The one component it touches, `MarkdownActions`, was already invisible on these pages (see below), so nothing that was rendered before stops being rendered.

### What to look at

1. **`src/constants/index.ts` — the `SECTION_ROOTS_WITH_MARKDOWN` list.** This is a hand-maintained exception list, which is the part I like least. It is correct today and the comment explains why, but if someone later teaches `generateRawMarkdownPages` to emit `/docs.md`, this list has to change with it. I could not read the truth at SSR time: the `.md` files are written in `onPostBuild`, which runs after pages render. Push back if you would rather thread the real list through the build.
2. **Blast radius beyond SEO.** `isMarkdownContentPath` is also used by `MarkdownActions` (`src/components/MarkdownActions/index.tsx:109`). On these pages the Copy button already stayed hidden, because it does its own HEAD check and the `.md` 404s. It now returns early instead, so those pages no longer fire a request that is known to fail. Same pixels, one less request.
3. **`hideMarkdownActions` may now be redundant.** `ReaderView` has a prop that pages set by hand for exactly this problem (`src/components/ReaderView/index.tsx:106-112`). I left every usage alone to keep this diff to one file, but it is probably dead weight now.

</details>
