### PR TITLE
feat(seo): describe PostHog with JSON-LD on the homepage

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -136,6 +136,27 @@ export const SEO = ({
 export default SEO
 
 /**
+ * PostHog as a schema.org Organization. Shared so the homepage and every product page
+ * describe the same entity rather than drifting copies of it.
+ */
+const POSTHOG_ORGANIZATION = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'PostHog',
+    url: 'https://posthog.com',
+    logo: 'https://posthog.com/brand/posthog-logo-stacked.png',
+    sameAs: ['https://twitter.com/PostHog', 'https://github.com/PostHog', 'https://www.linkedin.com/company/posthog'],
+    address: {
+        '@type': 'PostalAddress',
+        streetAddress: '2261 Market Street #4008',
+        addressLocality: 'San Francisco',
+        addressRegion: 'CA',
+        postalCode: '94114',
+        addressCountry: 'US',
+    },
+}
+
+/**
  * Build schema.org JSON-LD for a product/app page: a SoftwareApplication, the PostHog
  * Organization, and (optionally) a FAQPage. Pass the result to <SEO structuredData={...} />.
  * FAQ entries without an `answer` are skipped, so FAQPage only renders once answers exist.
@@ -170,18 +191,7 @@ export const buildProductStructuredData = ({
             },
             publisher: { '@type': 'Organization', name: 'PostHog', url: 'https://posthog.com' },
         },
-        {
-            '@context': 'https://schema.org',
-            '@type': 'Organization',
-            name: 'PostHog',
-            url: 'https://posthog.com',
-            logo: 'https://posthog.com/images/og/default.png',
-            sameAs: [
-                'https://twitter.com/PostHog',
-                'https://github.com/PostHog',
-                'https://www.linkedin.com/company/posthog',
-            ],
-        },
+        POSTHOG_ORGANIZATION,
     ]
     const faqEntities = (faq || [])
         .filter((q) => q && q.question && q.answer)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import SEO from 'components/seo'
+import SEO, { buildProductStructuredData } from 'components/seo'
 import Test from '../components/Home/Test'
 
 export default function Home() {
@@ -15,6 +15,12 @@ export default function Home() {
                     { hrefLang: 'ko', href: '/ko' },
                     { hrefLang: 'x-default', href: '/' },
                 ]}
+                structuredData={buildProductStructuredData({
+                    name: 'PostHog',
+                    description:
+                        'PostHog automatically diagnoses problems, fixes bugs, and generates pull requests – all without you having to prompt it.',
+                    slug: '',
+                })}
             />
             <Test />
         </>


### PR DESCRIPTION
## Summary

The homepage shipped no structured data at all, so anything trying to resolve what PostHog is had to infer it from prose. `buildProductStructuredData` already existed and was wired into seven pages — cdp, slack, desktop, startups, students, incubator and slides — but not the homepage, which is the page most likely to be asked about.

This wires it in, lifts the Organization object into a shared constant, adds a postal address, and fixes the logo.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: the shared Organization constant

`buildProductStructuredData` built its Organization inline, so every product page carried its own copy. Lifting it to a module constant means the homepage and every product page describe one entity instead of drifting copies, and there is one place to add fields.

Two changes to the object itself:

- **`logo` was wrong.** It pointed at `images/og/default.png`, which is the social share card, not a logo: it carries a headline and a screenshot. Anything consuming this markup would have shown that as the PostHog company mark. It now points at the brand asset, which is 480x430 and clears the 112x112 floor Google sets for an Organization logo. Caught in review by @rafaeelaudibert.
- **`address` added**, so a consumer can verify the business.

https://github.com/PostHog/posthog.com/blob/d6d668428153d1c039862bc053d23a45f93f4c5e/src/components/seo.tsx#L138-L154

### Stop 2: the homepage

Passes `structuredData` to the existing `<SEO>`. `slug: ''` resolves to `https://posthog.com/`. The description is the one the page already uses for its meta description, so the two cannot disagree.

https://github.com/PostHog/posthog.com/blob/d6d668428153d1c039862bc053d23a45f93f4c5e/src/pages/index.tsx#L1-L28

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --write` on both files | Clean |
| Before | Loaded `/` in Chrome against `pnpm start`, counted ld+json | **0 blocks** |
| After | Same | **2 blocks**, both parse |
| Content | Read the parsed blocks | SoftwareApplication + Organization, with address, no contactPoint |
| Logo resolves | `curl` the brand asset on production | 200 `image/png`, 480x430 |
| Console | Compared the error set before and after | No new errors |

**Not tested:** Google's Rich Results Test, which needs a public URL. The JSON parses and follows schema.org shapes, but a validator pass before merge would not hurt.

### Screenshots

Not applicable. JSON-LD is a `<script type="application/ld+json">` in `<head>` and renders nothing.

### What to look at

1. **The postal address.** This is the one thing here that is a factual claim about the company, published to search engines and assistants. It came from @rafaeelaudibert rather than from this repo, because the registered address is not public anywhere in the codebase — `contents/handbook/people/spending-money.md:41` points at a private sheet. Worth confirming it is the address PostHog wants indexed.
2. **The refactor's reach.** Moving Organization into a constant changes the output of all seven pages already calling `buildProductStructuredData`, not just the homepage. They all gain the address and the corrected logo. That is intended, but it is a wider blast radius than the title suggests. It also means the wrong logo was being published on those seven pages already, and this fixes them too.

</details>
