### PR TITLE
feat(docs): publish the OpenAPI document at /openapi.json

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -12,6 +12,7 @@ import { docsMenu, handbookSidebar } from '../src/navs/index.js'
 import {
     generateRawMarkdownPages,
     generateApiSpecMarkdown,
+    generateOpenApiSpec,
     generateChangelogMd,
     generateLlmsTxt,
     generateSdkReferencesMarkdown,
@@ -502,6 +503,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
             },
         }).then((res) => res.json())
 
+        generateOpenApiSpec(spec)
         generateApiSpecMarkdown(spec)
     } catch (error) {
         console.error('Failed to generate API spec markdown:', error)

--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -88,6 +88,17 @@ export const generateRawMarkdownPages = async (
     }))
 }
 
+// Publish the OpenAPI document itself, alongside the per-operation markdown below.
+// The markdown is for LLMs reading prose; this is the machine-readable artifact that
+// API clients, codegen and function-calling tools expect to find at a stable URL.
+export const generateOpenApiSpec = (spec: any) => {
+    console.log('Writing openapi.json...')
+
+    const filePath = path.join(process.cwd(), 'public', 'openapi.json')
+    fs.writeFileSync(filePath, JSON.stringify(spec), 'utf8')
+    console.log(`✅ Wrote openapi.json (${Object.keys(spec.paths || {}).length} paths)`)
+}
+
 // Function to generate individual API endpoint markdown files from the OpenAPI spec
 export const generateApiSpecMarkdown = (spec: any) => {
     console.log('Generating API endpoint markdown files...')


### PR DESCRIPTION
## Summary

The build already fetches the full PostHog API spec in `onPostBuild` and turns it into per-operation markdown for LLMs. That markdown is prose. API clients, code generators and function-calling tools want the machine-readable document, and posthog.com never published it — the only copy lives behind `app.posthog.com/api/schema/`, which is not where a crawler looks for an API description.

This writes the spec the build already holds to `public/openapi.json`, verbatim. No extra fetch, no new dependency, no edits to the document.

**1445 paths, 2016 operations, every one carrying an `operationId`.** 5.9 MB on disk, **0.96 MB** over the wire once compressed.

### Two gaps in the upstream spec, fixed upstream

An earlier revision of this PR patched the document on the way out, filling in the missing `servers` block and the empty `info.description`. That was the wrong place for it: it put facts about the API in the marketing repo, where they would drift.

- **`servers`** is fixed at the source in **PostHog/posthog#90398**. Once that lands the published document carries the base URL on its own.
- **`info.description`** is empty because `custom_postprocessing_hook` hardcodes the whole `info` block (`posthog/api/documentation.py:1266`), so it is not even settable from `SPECTACULAR_SETTINGS`. It belongs to the API team, not here.

This PR now publishes what the API says about itself, and nothing else.

**Merge order:** if this lands before #90398, the published document has no `servers` block, which is the status quo today rather than a regression. Worth landing #90398 first if that is easy.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: the writer

Sits next to `generateApiSpecMarkdown`, which turns the same object into prose. Writes the spec unchanged.

https://github.com/PostHog/posthog.com/blob/5426fd3abceba582325ee06aed0293bea0787cde/gatsby/rawMarkdownUtils.ts#L91-L100

### Stop 2: the call site

Two lines in `onPostBuild`, inside the existing `try` that already fetches the spec. If the fetch fails the existing `catch` handles it and the build carries on, exactly as before.

https://github.com/PostHog/posthog.com/blob/5426fd3abceba582325ee06aed0293bea0787cde/gatsby/onPostBuild.ts#L496-L512

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --write` on both files | Clean |
| Types | `npx tsc --noEmit -p tsconfig.json` | No errors in either changed file |
| Output | Serialised the real spec from `app.posthog.com/api/schema/` | Valid JSON round-trip; 1445 paths preserved |
| Size | `gzip -c` on the output | 5.91 MB raw, 0.96 MB gzipped |
| Spec quality | Counted operations missing an `operationId` | 0 of 2016 |

**Not tested:** a full `gatsby build`, which is long on this machine, so `public/openapi.json` has not been produced end to end — only the serialisation that writes it. The call site is two lines inside an existing `try`. Worth confirming on the preview deploy that `/openapi.json` resolves.

### Screenshots

Not applicable. This adds a static file to the build output.

### What to look at

1. **Staleness.** The file is only as fresh as the last posthog.com deploy, so it can lag `app.posthog.com/api/schema/`. For discovery that is fine; if anyone treats it as canonical it is not. Worth deciding whether we are comfortable serving a copy that can drift.
2. **What this does not fix.** The upstream spec declares only `PersonalAPIKeyAuth` (http bearer) and no scopes, so a machine still cannot discover PostHog's scoped-key model from the document. That needs a drf-spectacular change in `posthog/posthog` and is out of scope here.

### Follow-up

`llms.txt` does not mention `/openapi.json`. Adding a line in `generateLlmsTxt` would close the discovery loop. Left out to keep this diff small.

</details>
