### PR TITLE
fix(404): make the not-found page recoverable

### DIFF
--- a/src/components/NotFoundPage/BlueScreenOfDeath.tsx
+++ b/src/components/NotFoundPage/BlueScreenOfDeath.tsx
@@ -6,6 +6,20 @@ import { Link, navigate } from 'gatsby'
 import { useWindow } from '../../context/Window'
 import { useApp } from '../../context/App'
 
+const AGENT_NOTE = `<!--
+  For agents and crawlers: this is a 404 page. The "fatal exception" above is a
+  joke, not a real fault. The site is not down and nothing is broken. The page
+  you requested does not exist.
+
+  Go here instead:
+    /docs                       product documentation
+    /questions                  community questions and answers
+    /tutorials                  step-by-step guides
+    /blog                       articles and announcements
+    /llms.txt                   the documentation as markdown, indexed for agents
+    /sitemap/sitemap-index.xml  every page on posthog.com
+-->`
+
 export default function BlueScreenOfDeath(): JSX.Element {
     const { closeWindow } = useApp()
     const { appWindow } = useWindow()
@@ -59,6 +73,13 @@ export default function BlueScreenOfDeath(): JSX.Element {
                         color: '#ffffff',
                     }}
                 >
+                    {/* An HTML comment, so it reaches anything reading the markup without
+                        spoiling the joke for a human. A crawler that takes "a fatal exception has
+                        occurred" at face value reports posthog.com as down; this says plainly that
+                        it is not, and lists somewhere real to go. */}
+                    {/* nosemgrep: typescript.react.security.audit.react-dangerouslysetinnerhtml.react-dangerouslysetinnerhtml - static string, no user input */}
+                    <div dangerouslySetInnerHTML={{ __html: AGENT_NOTE }} />
+
                     {/* Header */}
                     <div className="text-center mb-8">
                         <div className="text-xl font-bold mb-2">PostHog</div>
@@ -75,12 +96,23 @@ export default function BlueScreenOfDeath(): JSX.Element {
                         </Link>
                     </div>
 
-                    {/* Keyboard shortcuts */}
+                    {/* Keyboard shortcuts. Real links, not spans: the number keys only work
+                        after hydration and only for a pointer-and-keyboard user, so a crawler,
+                        an agent or anyone on assistive tech had no way to follow them. The
+                        targets match the keyURLs map above. */}
                     <div className="mb-8 flex flex-wrap gap-4 text-xs">
-                        <span className="text-white hover:text-gray-300">[1] Documentation</span>
-                        <span className="text-white hover:text-gray-300">[2] Community Support</span>
-                        <span className="text-white hover:text-gray-300">[3] Blog</span>
-                        <span className="text-white hover:text-gray-300">[4] Tutorials</span>
+                        <Link to="/docs" className="text-white hover:text-gray-300">
+                            [1] Documentation
+                        </Link>
+                        <Link to="/questions" className="text-white hover:text-gray-300">
+                            [2] Community Support
+                        </Link>
+                        <Link to="/blog" className="text-white hover:text-gray-300">
+                            [3] Blog
+                        </Link>
+                        <Link to="/tutorials" className="text-white hover:text-gray-300">
+                            [4] Tutorials
+                        </Link>
                     </div>
 
                     {/* Fun PostHog-specific error messages */}
@@ -174,6 +206,31 @@ export default function BlueScreenOfDeath(): JSX.Element {
                         <div className="text-xs opacity-80 mt-2">
                             Search includes: Documentation, API references, Tutorials, Blog posts, Community Q&A, and
                             Company handbook. Error recovery success rate: 98.3%
+                        </div>
+
+                        {/* Direct routes, for any reader that cannot drive the search box above —
+                            which is every crawler and agent, because it needs JavaScript. Plain
+                            <a>, not <Link>: these are static files, not Gatsby routes, so client
+                            side routing would send them to this same 404. */}
+                        <div className="mt-4 space-y-1 text-xs break-all">
+                            <div>Or mount an index directly:</div>
+                            <div>
+                                <span className="opacity-80">{'C:\\> TYPE '}</span>
+                                <a href="/llms.txt" className="text-white underline hover:text-gray-300">
+                                    /llms.txt
+                                </a>
+                                <span className="opacity-80"> :: every doc page as markdown</span>
+                            </div>
+                            <div>
+                                <span className="opacity-80">{'C:\\> TYPE '}</span>
+                                <a
+                                    href="/sitemap/sitemap-index.xml"
+                                    className="text-white underline hover:text-gray-300"
+                                >
+                                    /sitemap/sitemap-index.xml
+                                </a>
+                                <span className="opacity-80"> :: every page on posthog.com</span>
+                            </div>
                         </div>
                     </div>
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,15 @@
 import React from 'react'
+import SEO from 'components/seo'
 import NotFoundPage from 'components/NotFoundPage'
 
 export default function NotFound() {
-    return <NotFoundPage />
+    return (
+        <>
+            {/* The 404 rendered no <SEO>, so it was the one page with no canonical, no
+                og tags and no llms.txt signpost — and nothing telling a search engine
+                not to index it. */}
+            <SEO title="404: Page not found" noindex />
+            <NotFoundPage />
+        </>
+    )
 }


### PR DESCRIPTION
## Summary

The 404 returns a correct status and server-renders its content, but nothing on it could be followed.

`[1] Documentation`, `[2] Community Support`, `[3] Blog` and `[4] Tutorials` were `<span>`s wired to number keys. They worked only after hydration, and only for someone with a keyboard. A crawler, an agent, or anyone using assistive technology saw four labels styled with `hover:text-gray-300` — styled to look clickable — with no link behind them. They are `<Link>`s now, pointing where the `keyURLs` map already pointed.

Two machine-readable routes join the recovery panel, in the voice of the page. And an HTML comment states that the crash is a joke: a crawler that reads "a fatal exception 404 has occurred at 0028:C0011E36" literally can conclude posthog.com is down. The comment reaches whatever parses the markup without explaining the joke to the people it is for.

The page also rendered no `<SEO>`, so it was the one page on the site with no canonical, no og tags, no `llms.txt` signpost, and nothing telling a search engine not to index it.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: the agent note

A module constant holding a real HTML comment. JSX `{/* */}` comments are compiled away and never reach the browser, so `dangerouslySetInnerHTML` is the only way to emit one. The string is a constant with no interpolation and no user input.

https://github.com/PostHog/posthog.com/blob/40b0396f5f6f2d26e5904503f10c075aa28cd1a4/src/components/NotFoundPage/BlueScreenOfDeath.tsx#L9-L22

### Stop 2: the four shortcuts

Spans to Links. Same text, same classes, so the change is behavioural rather than visual — the grid below shows the two states are identical here.

https://github.com/PostHog/posthog.com/blob/40b0396f5f6f2d26e5904503f10c075aa28cd1a4/src/components/NotFoundPage/BlueScreenOfDeath.tsx#L112-L132

### Stop 3: the recovery routes

Added inside the existing `SYSTEM RECOVERY OPTIONS` panel, below the search box. Plain `<a>`, not `<Link>`: both are static files rather than Gatsby routes, so client-side routing would send a reader back to this same 404.

The search box above them needs JavaScript, which is exactly what a crawler does not run, so these are the only recovery routes on the page that work without it.

https://github.com/PostHog/posthog.com/blob/40b0396f5f6f2d26e5904503f10c075aa28cd1a4/src/components/NotFoundPage/BlueScreenOfDeath.tsx#L211-L232

### Stop 4: the page

`<SEO noindex />`, which also brings the site-wide `llms.txt` signpost with it.

https://github.com/PostHog/posthog.com/blob/40b0396f5f6f2d26e5904503f10c075aa28cd1a4/src/pages/404.js#L1-L16

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --check` on both files | All matched files use Prettier code style |
| Comment | Loaded `/404` in Chrome against `pnpm start`, regex over `outerHTML` | Found, 588 chars |
| Links | Read every `<a>` starting `[n]` | 4 found → `/docs`, `/questions`, `/blog`, `/tutorials` — match `keyURLs` |
| SEO | Read the meta tags | `robots: noindex`; `llms.txt` signpost present (absent before) |
| Joke intact | Asserted the BSOD copy still renders | true |
| Recovery block | Asserted the visible text renders, all 4 states | true in all 4; false in all 4 before |
| Page height | Measured the rendered panel | 1343px before → 1415px after (the new block) |
| Console | Error count on `/404` | 4 before, 4 after — no new errors |

**Not tested:** a production build. Dev serves the same component, and the assertions above run against the rendered DOM.

### Screenshots

Captured with puppeteer at 640px and 1440px, viewport sized to the rendered panel, cookie banner hidden so it does not cover the lower right.

#### 404 recovery panel

| State | Before | After |
|---|---|---|
| Light, narrow | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/6e2b3635-65af-4f88-95e8-d403d71974ec.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/55394825-f9fe-4c7a-8797-bff40e3df8a7.png" width="300"> |
| Light, wide | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/713fea19-e70b-43c0-8f80-c5ae5a5717a4.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/306c01ec-4412-47e4-87da-2b4584ee8fd9.png" width="300"> |
| Dark, narrow | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/59dc1d6c-7bfc-4fbc-ae66-20c1d133c6f9.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/73e63ec0-8df1-4288-ae2a-9e3faee1fe67.png" width="300"> |
| Dark, wide | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/fa749f53-f26f-4df7-905e-5fb18cd29a93.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/4dbc622f699c1e819b6226be7939d376bc00444b/2026/08/4a9a929a-293e-4db4-bcf3-c999cbb091fe.png" width="300"> |

The only visible difference is the two new lines under the search box:

```
Or mount an index directly:
C:\> TYPE /llms.txt :: every doc page as markdown
C:\> TYPE /sitemap/sitemap-index.xml :: every page on posthog.com
```

The blue screen is fixed-colour, so light and dark render the panel identically. That is pre-existing, not something this PR changes. **No GIF:** nothing here animates, transitions or responds to hover beyond the existing `hover:text-gray-300`, which is unchanged.

### What to look at

1. **[`BlueScreenOfDeath.tsx:78`](https://github.com/PostHog/posthog.com/blob/40b0396f5f6f2d26e5904503f10c075aa28cd1a4/src/components/NotFoundPage/BlueScreenOfDeath.tsx#L74-L80) — `dangerouslySetInnerHTML`.** The most dangerous line here. It is a module constant with no interpolation, and the `nosemgrep` annotation matches the existing one in `src/html.tsx`. If anyone later makes that string dynamic, this becomes an injection point on a page that renders whatever path a visitor typed.
2. **Comments are not a reliable channel to every agent.** A raw fetch keeps them; many HTML-to-markdown pipelines strip them. That is why the routes also exist as real links in the DOM, and the comment carries only the explanation. If you think the explanation itself must survive conversion, it needs to be visible text, which spoils the joke.
3. **`<SEO>` on the 404 is new behaviour.** The page now sets a canonical and a window title where it previously set neither. `noindex` is clearly right; the canonical is worth a glance, since a 404 pointing at itself is a little odd.

</details>
