### PR TITLE
feat(vercel): negotiate raw markdown via Accept header

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+/**
+ * Serve raw markdown to clients that ask for it with `Accept: text/markdown`.
+ *
+ * This has to be middleware rather than a `vercel.json` rewrite. Vercel gives
+ * the filesystem precedence over rewrites, and Gatsby writes an index.html for
+ * every one of these paths, so a rewrite is never reached. Middleware is the
+ * only hook that runs ahead of the filesystem.
+ *
+ * Two costs are worth knowing before this ships — see the PR description:
+ *   1. The matcher is path-only. Vercel's generic (non-Next.js) middleware
+ *      matcher has no `has` header condition, so this runs on every request to
+ *      these prefixes, not only the ones asking for markdown.
+ *   2. It therefore adds a hop ahead of the CDN cache for ordinary readers too.
+ *
+ * Returning `undefined` continues to the normal static response, so anything
+ * this function declines to handle behaves exactly as it does today.
+ */
+export const config = {
+    matcher: ['/docs/:path*', '/handbook/:path*', '/blog/:path*', '/newsletter/:path*', '/changelog'],
+}
+
+export default async function middleware(request: Request): Promise<Response | undefined> {
+    if (!(request.headers.get('accept') || '').includes('text/markdown')) return
+
+    const url = new URL(request.url)
+    const pathname = url.pathname.replace(/\/$/, '')
+    if (!pathname || pathname.endsWith('.md')) return
+
+    // Not every path under these prefixes has a generated `.md` sibling — the
+    // section index pages (/docs, /blog, /handbook, /newsletter) don't. Ask for
+    // it and fall through to the HTML when it isn't there, rather than keeping a
+    // hand-maintained list of exceptions that silently rots.
+    const markdown = await fetch(new URL(`${pathname}.md`, url.origin), {
+        headers: { accept: 'text/plain' },
+    })
+    if (!markdown.ok) return
+
+    return new Response(markdown.body, {
+        status: 200,
+        headers: {
+            'content-type': 'text/markdown; charset=utf-8',
+            'cache-control': markdown.headers.get('cache-control') || 'public, max-age=0, must-revalidate',
+            vary: 'Accept',
+        },
+    })
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,51 @@
     },
     "headers": [
         {
+            "source": "/docs/:path*",
+            "headers": [
+                {
+                    "key": "Vary",
+                    "value": "Accept"
+                }
+            ]
+        },
+        {
+            "source": "/handbook/:path*",
+            "headers": [
+                {
+                    "key": "Vary",
+                    "value": "Accept"
+                }
+            ]
+        },
+        {
+            "source": "/blog/:path*",
+            "headers": [
+                {
+                    "key": "Vary",
+                    "value": "Accept"
+                }
+            ]
+        },
+        {
+            "source": "/newsletter/:path*",
+            "headers": [
+                {
+                    "key": "Vary",
+                    "value": "Accept"
+                }
+            ]
+        },
+        {
+            "source": "/changelog",
+            "headers": [
+                {
+                    "key": "Vary",
+                    "value": "Accept"
+                }
+            ]
+        },
+        {
             "source": "/(.*\\.md)",
             "headers": [
                 {


### PR DESCRIPTION
## Summary

**Draft — this is a costed proposal for the team, not a merge request.** It restores real `Accept: text/markdown` negotiation, which #19774 removes because the `vercel.json` rewrites could never run.

> **Stacked on #19774.** Review that one first; this targets its branch.

Middleware is the only hook that runs ahead of the filesystem, so it is the only place this can work.

## What it costs

Vercel's generic (non-Next.js) middleware matcher supports **paths only** — no `has` header condition, which is a Next.js-only feature. So this runs on every request to `/docs`, `/handbook`, `/blog`, `/newsletter` and `/changelog`, not only the ones asking for markdown.

At ~8M requests/day, invocations dominate at $0.60/million:

| Component | Rate | Per 1M requests |
|---|---|---|
| Invocations | $0.60/M | **$0.60** |
| Active CPU | $0.128–0.221/hr | ~$0.02–0.03 |
| Provisioned memory | $0.0106–0.0183/GB-hr | <$0.01 |

| Share of traffic on these 5 prefixes | Monthly |
|---|---|
| 10% (~24M/mo) | ~$17 |
| 25% (~60M/mo) | ~$39 |
| 50% (~120M/mo) | ~$75 |
| 100% (~240M/mo) | ~$147 |

**Roughly $20–155/month, up to ~$1,850/year.** Enterprise terms may differ, so treat that as a ceiling estimate rather than a quote.

**The money is the smaller cost.** Middleware runs *before* the CDN cache, so this adds an edge-function hop to every docs and blog pageview — including cache hits that are pure static edge serves today — in order to serve markdown to the small fraction of requests that ask for it.

## What we get

Compliance with [acceptmarkdown.com](https://acceptmarkdown.com). Worth weighing against the fact that the capability already exists: `.md` URLs work, are documented in `contents/docs/ai-engineering/markdown-llms-txt.mdx`, are listed in `llms.txt`, and every page advertises its markdown sibling via `<link rel="alternate" type="text/markdown">`. This buys protocol compliance, not a new capability.

**My recommendation is not to merge this** unless the team wants acceptmarkdown.com compliance specifically. Opening it so the option is concrete and costed rather than hypothetical.

<details>
<summary>🗺️ PR tour</summary>

### Stop 1: the middleware

Returns `undefined` to continue the chain, so anything it declines to handle behaves exactly as today.

Rather than keep a hand-maintained list of paths without a `.md` sibling, it requests the sibling and falls through to the HTML when it is absent. Section index pages keep working unchanged, and the list cannot rot. The cost is an internal fetch on negotiated requests only.

**No new dependency.** The documented API is `@vercel/functions` (`rewrite()`/`next()`), but `pnpm add` fails in this repo — `ERR_PNPM_TRUST_DOWNGRADE` on `tailwindcss@3.4.17`, which lost its provenance attestation, against the `trustPolicy: no-downgrade` set in `pnpm-workspace.yaml:16`. Rather than weaken a supply-chain control for convenience, this returns a plain `Response` and uses `undefined` to continue, which needs no package.

https://github.com/PostHog/posthog.com/blob/132e4653f2c6f247fa8d0b30e67686ee4baf812e/middleware.ts#L1-L47

### Stop 2: Vary: Accept restored

#19774 removes these because they described negotiation that never happened. With negotiation real, they are required for cache correctness, and now cover `/blog`, `/newsletter` and `/changelog` too — which the original config missed.

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --write middleware.ts` | Clean |
| Types | `npx tsc --noEmit` on `middleware.ts` | No errors |
| JSON valid | Parsed `vercel.json` after the edit | Valid; routes 1456 → 1461 |
| Mechanism | Vercel docs on Routing Middleware | Runs before the filesystem; works with any framework |
| Matcher limits | Vercel `proxy.matcher` reference | "A path matcher starting with `/`" — no `has` support |

**Not tested — and this is the gap.** No Vercel preview deployment, so the middleware has never actually executed. It cannot be exercised locally: `gatsby develop` does not run Vercel's routing layer. **Before this could merge it needs a preview deploy confirming that `Accept: text/markdown` returns markdown, that ordinary requests are untouched, and what it does to p50/p99 on `/docs`.**

### Screenshots

Not applicable. No visual surface.

### What to look at

1. **The cost and the latency hop, above.** That is the actual decision. The code is the easy part.
2. **[`middleware.ts:36`](https://github.com/PostHog/posthog.com/blob/132e4653f2c6f247fa8d0b30e67686ee4baf812e/middleware.ts#L30-L47) — the internal fetch.** On a negotiated request this fetches the `.md` sibling before responding. It avoids a rotting exception list, but it doubles the origin work for those requests and is a failure mode if that fetch is slow. A hardcoded list would be faster and more brittle; I picked the safer of the two, and would not argue hard against the other.
3. **No `@vercel/functions`.** Returning a bare `Response` and `undefined` is documented behaviour, but it is not the idiomatic path, so it deserves a look. It also means the `ERR_PNPM_TRUST_DOWNGRADE` blocker is unresolved — **that currently blocks `pnpm add` for anyone in this repo**, and is worth its own issue regardless of what happens here.

</details>
