### PR TITLE
chore(vercel): drop Content-Type for a file that no longer exists

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,15 +7,6 @@
     },
     "headers": [
         {
-            "source": "/.well-known/http-message-signatures-directory",
-            "headers": [
-                {
-                    "key": "Content-Type",
-                    "value": "application/http-message-signatures-directory+json"
-                }
-            ]
-        },
-        {
             "source": "/(.*\\.md)",
             "headers": [
                 {


### PR DESCRIPTION
## Summary

`posthog.com/.well-known/http-message-signatures-directory` returns a 404 that still claims to be `application/http-message-signatures-directory+json`.

This is leftover config rather than a live feature. #19479 added the header so Vercel would serve the Web Bot Auth key directory with the right type, because the file has no extension. #19496 then deleted the file:

> Cloudflare uses a key only when the directory response carries a signature made with that key, covering the authority of the request and expiring minutes later. A stored file cannot carry one, so this file registers nothing. The app serves the directory instead.

The header outlived the file. Nothing has served that path on posthog.com since.

**Web Bot Auth is unaffected.** The real directory is served, correctly, from the app:

```
us.posthog.com/.well-known/http-message-signatures-directory   200  application/http-message-signatures-directory+json
app.posthog.com/.well-known/http-message-signatures-directory  200  application/http-message-signatures-directory+json
posthog.com/.well-known/http-message-signatures-directory      404  (with the stale Content-Type)
```

> **Stacked on #19774** — it edits adjacent lines in the same `headers` array, so this targets that branch to avoid a conflict. It is otherwise independent.

No tour: one deletion in one config file.

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| The path is dead | `curl -D -` on posthog.com | 404, carrying the stale `Content-Type` |
| The app still serves it | `curl` both cloud regions | 200 with the correct type on `us.` and `app.` |
| File is gone deliberately | `git log --diff-filter=ADR -- '*http-message-signatures*'` | Added in #19479, deleted in #19496 with the reason quoted above |
| JSON valid | Parsed `vercel.json` after the edit | Valid; headers 3 → 2, routes 1456 → 1455 |

### Screenshots

Not applicable. Config only.

### What to look at

1. **Confirm nothing is about to re-add the file.** This is safe precisely because responsibility moved to the app. If anyone plans to serve a signed directory from posthog.com, they would want this header back — though per #19496 a static file cannot carry a valid signature, so that seems unlikely.
2. **`eu.posthog.com` returns 404 for this path.** Out of scope here, but #19479 noted "EU gets its own key, which is a second entry in this list when it exists," so it may simply be pending. Flagging in case it is not.

</details>
