### PR TITLE
docs: clarify evaluation contexts for local evaluation

### DIFF
--- a/contents/docs/feature-flags/evaluation-contexts.mdx
+++ b/contents/docs/feature-flags/evaluation-contexts.mdx
@@ -143,7 +143,9 @@ var posthog = new PostHogClient(new PostHogOptions
 
 ## How evaluation works
 
-When a flag evaluation request is made:
+### Remote evaluation
+
+When your SDK asks PostHog to evaluate a flag:
 
 1. **SDK sends application contexts**: The SDK includes its configured `evaluation_contexts` in the request
 2. **PostHog filters flags**: Only flags matching these criteria are evaluated:
@@ -151,6 +153,14 @@ When a flag evaluation request is made:
    - Flags with empty evaluation contexts
    - Flags where at least one evaluation context matches the SDK's declared contexts
 3. **Results returned**: Only the filtered flags are returned to the SDK
+
+### Local evaluation
+
+Server SDKs that evaluate flags locally poll `/flags/definitions` for flag definitions instead of calling `/flags`. That endpoint accepts no evaluation context parameter. It returns every flag, and each flag carries its own evaluation contexts in the response. The SDK applies the matching rules above to the definitions it polled.
+
+Filtering therefore happens inside the SDK, so it only works on an SDK version that implements it. Check [SDK support](#sdk-support) before relying on it. This matters most with an option like the Node.js `strictLocalEvaluation`, because no remote request is made to fall back on.
+
+Local evaluation downloads the full flag set either way. Evaluation contexts change which flags your SDK evaluates, and they do not reduce the size of the definitions payload.
 
 ### Example scenario
 
@@ -257,7 +267,9 @@ If a flag with evaluation contexts isn't evaluating:
 If you're still seeing all flags despite using evaluation contexts:
 1. Confirm your SDK version supports evaluation contexts
 2. Check that flags have evaluation contexts configured in the **Evaluation Contexts** section (not just tags)
-3. Verify your SDK is sending the `evaluation_contexts` parameter
+3. Verify your SDK is sending the `evaluation_contexts` parameter on its `/flags` requests
+4. Check that flags you expect to be filtered actually have contexts set. A flag with no evaluation contexts always evaluates, whatever contexts your SDK declares.
+5. If you evaluate flags locally, confirm your SDK version filters locally. Node.js does this from 5.51.4+. On earlier versions, evaluation contexts apply only to remote `/flags` requests, so every polled flag still evaluates. See [local evaluation](#local-evaluation).
 
 ### Performance not improved
 
@@ -291,3 +303,12 @@ Evaluation contexts are supported as first-class SDK configuration in the follow
 | [.NET](/docs/libraries/dotnet#evaluation-contexts) | `EvaluationContexts` in `PostHog` 2.8.0+ and `PostHog.AspNetCore` 2.7.0+ | Not supported |
 
 > **Note:** If you're on an older supported SDK version that only supports the legacy option, that will continue to work. We recommend using the current option for new implementations.
+
+The versions above are for remote evaluation. Local evaluation is filtered by the SDK itself, so it needs separate support:
+
+| SDK | Local evaluation support |
+|-----|--------------------------|
+| [Node.js](/docs/libraries/node/) | 5.51.4+ |
+| [.NET](/docs/libraries/dotnet#evaluation-contexts) | Not yet supported |
+
+The other SDKs in the table above evaluate flags remotely, so this doesn't apply to them.


### PR DESCRIPTION
## Changes

- Readers who evaluate flags locally set `evaluationContexts`, saw no filtering, and had no way to tell from this page whether that was expected. The page described only the remote `/flags` path, so the SDK support table read as if it covered every setup.
- "How evaluation works" now has a **Local evaluation** section. `/flags/definitions` takes no context parameter and returns every flag, so the SDK filters the polled definitions itself.
- A second support table gives local evaluation versions separately. Node.js supports it from 5.51.4+ ([posthog-js#4660](https://github.com/PostHog/posthog-js/pull/4660)). .NET sends `evaluation_contexts` on `/flags` only, so local evaluation is not filtered there yet.
- Troubleshooting gains two checks: flags with no contexts always evaluate, and local evaluation needs SDK-side support.

Docs only, no code and no redirects.

Verified against the SDK and server source rather than the changelogs: `posthog-node` 5.49.1 ignores `evaluationContexts` during local evaluation, 5.51.4 filters correctly, and the two match the server's `collect_excluded_by_tags` rules, including keeping untagged flags. Not checked: whether Go, Ruby, PHP, or Python expose the option at all, so the tables are unchanged for them.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a, no page moved)

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored with PostHog Desktop (Claude) while debugging a support ticket about `evaluationContexts` having no effect under `strictLocalEvaluation`.
- Skills invoked: `writing-user-facing-copy`, `writing-pr-descriptions`.
- Ran the published SDK against a mocked `/flags/definitions` on both 5.49.1 and 5.51.4 to confirm the behavior before documenting the version boundary.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
