### PR TITLE
Add import rate and timestamp ordering guidance to migrations docs

### DIFF
--- a/contents/docs/migrate/index.mdx
+++ b/contents/docs/migrate/index.mdx
@@ -55,3 +55,15 @@ An example `cURL` implementation using the `batch` API endpoint looks like this:
 - Build resumability into your exports and imports, so you can just resume the process from the last successful point if any problems occur. For example, we use a cursor-based approach in our self-hosted migration tool.
 
 - To batch user updates, use the same request but with the `$identify` event. Same for groups and the `$group_identify` event.
+
+### Limit your import rate
+
+Add rate limiting to your import script and keep the total below a few thousand events per second across all workers and processes. A faster import does not land your data sooner. It fills the ingestion queue, which delays your own events and the events of other customers. If your import destabilizes ingestion, we can delay or drop your events to protect the pipeline.
+
+A [managed migration](/docs/migrate/managed-migrations) does this for you, so use one if your source is Amplitude, Mixpanel, or an S3 bucket.
+
+### Send events in timestamp order
+
+Group your events into batches that each cover a short time range, then import the batches from oldest to newest. One day per batch is a good default.
+
+A strict sort is not necessary. What matters is that a single batch does not mix events from across your full history. Scrambled timestamps make ClickHouse write many small data parts instead of a few large ones. This causes `too many parts` errors, which slow your import and can lose events.

--- a/contents/docs/migrate/index.mdx
+++ b/contents/docs/migrate/index.mdx
@@ -66,4 +66,4 @@ A [managed migration](/docs/migrate/managed-migrations) does this for you, so us
 
 Group your events into batches that each cover a short time range, then import the batches from oldest to newest. One day per batch is a good default.
 
-A strict sort is not necessary. What matters is that a single batch does not mix events from across your full history. Scrambled timestamps make ClickHouse write many small data parts instead of a few large ones. This causes `too many parts` errors, which slow your import and can lose events.
+A strict sort is not necessary. What matters is that a single batch does not mix events from across your full history. Scrambled timestamps make ClickHouse write many small data parts instead of a few large ones.


### PR DESCRIPTION
## Changes

The historical migrations overview did not say how fast you can import, or in what order. Customers who write their own import scripts have no guidance, and unthrottled backfills with scrambled timestamps destabilize ingestion.

This adds two subsections to **Best practices for migrations**:

- **Limit your import rate** — keep total throughput below a few thousand events per second across all workers, with a pointer to managed migrations, which handle this for you.
- **Send events in timestamp order** — batch events by a short time range (one day is a good default) and import oldest first. Explains why: mixed timestamps make ClickHouse write many small parts.

Content-only change to `contents/docs/migrate/index.mdx`. No navigation, component, or visual changes, so no screenshots and no redirect needed.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1787877936064599?thread_ts=1787877936.064599&cid=C075D3C5HST)*

