### PR TITLE
Update build-pr-approval-agent.md

### DIFF
--- a/youtube/build-pr-approval-agent.md
+++ b/youtube/build-pr-approval-agent.md
@@ -1,4 +1,4 @@
-Read https://github.com/PostHog/posthog/blob/master/tools/pr-approval-agent/README.md and build the equivalent for the repo at <path>.
+Read https://github.com/PostHog/posthog/blob/master/products/stamphog/packages/pr-approval-agent/README.md and build the equivalent for the repo at <path>.
 
 Copy the architecture; preserve its safety invariants exactly (fail closed, never request changes or merge, LLM can tighten gates but never loosen).
 


### PR DESCRIPTION
## Changes
Links from Youtube are broken. Seems like the target was moved in https://github.com/PostHog/posthog/pull/85567. Updating link.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
