### PR TITLE
fix: match the popover arrow color to the card background

### DIFF
--- a/src/components/RadixUI/Popover.tsx
+++ b/src/components/RadixUI/Popover.tsx
@@ -84,7 +84,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
                                 <ScrollArea className="h-full">{children}</ScrollArea>
                             </div>
                         </div>
-                        <RadixPopover.Arrow className="fill-white" />
+                        <RadixPopover.Arrow className="fill-[rgb(var(--bg))]" />
                     </RadixPopover.Content>
                 </RadixPopover.Portal>
             </RadixPopover.Root>


### PR DESCRIPTION
## Changes

The shared `Popover` painted its arrow white, whatever color the card behind it was. This is a one-line change to that component.

1. **In dark mode the popover arrow stayed pure white, so a bright notch hung off a dark card.** Fixed: the arrow now reads the same color variable as the card, so the two always match.

The arrow follows the card in every theme and color scheme, not only in dark mode. Light mode looks the same as before to the eye. The arrow was a few shades brighter than the card there, and now it is an exact match.

20 files use this component. Nothing else about the popover changed.

### Screenshots

Captured on the wallpaper picker in **Display options**. The window is 640px wide (narrow) and 1440px wide (wide).

#### Popover arrow, full window

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/fb0d2970-cb57-4b03-a018-28ce40837313.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/e6dea4dd-d4b4-447e-a543-45fa8dad17dd.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/e1e09880-f73b-403a-bc24-baeffb4b22fe.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/cd2c9303-2631-4a55-b800-ca664907321a.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/a7b5e50c-0074-4180-a7b2-c378585582f5.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/b1a5a354-5e82-4c05-a423-cda052bd5851.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/33efb2b9-b913-4820-8062-38cd7a8dd5e2.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/bdc6c328d58440d0c564393d2a33c61a621f3e3e/2026/08/41e8523b-4cd3-4b40-b9ca-5d4895afebb1.png" width="300"> |

#### Popover arrow, close up

The arrow is small, so here is the same set cropped to the arrow.

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/64b0639e-7eb7-4222-853f-fa011a96eca6.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/7f24c7bb-2c78-443a-bbd2-eea02ed1695b.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/b4fbc99b-90a2-4ef4-845f-1d1da65c18d1.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/ffbefe81-e300-4e61-8e35-0ed1abd94667.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/d7e459bd-9b5b-4ab0-a368-85a0e200678f.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/98091c45-7b1d-4459-8597-28478adb3ad5.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/e04dddc9-4b49-46c0-8e01-0d2f4c008ef2.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/f2226fdd869051e065ecd8be26a3657259af3e24/2026/08/7bfe768c-b67a-484d-a2c7-e255a37c8214.png" width="300"> |

### Testing done

Ran prettier and ESLint on the changed file, loaded `/` and `/display-options` in both themes at 640px and 1440px, and compared the console error sets before and after – identical, with 40 pre-existing messages on each side. The card background and the arrow fill now measure the same color in all four states: `rgb(37, 38, 43)` in dark mode, and `rgb(238, 239, 233)` in light mode.

Not tested: the other 19 files that use this component were not opened one by one. The arrow now reads the same variable as the card, so it tracks whatever scheme each caller sets.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
