### PR TITLE
fix(blog): use the featured image for blog post social previews

### DIFF
--- a/src/templates/BlogPost.tsx
+++ b/src/templates/BlogPost.tsx
@@ -299,6 +299,10 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
     } = postData?.frontmatter
     const lastUpdated = postData?.parent?.fields?.gitLogLatestDate
     const filePath = postData?.parent?.relativePath
+    // The composed OG cards this template used to point at are no longer built, so use the post's
+    // featured image instead. c_limit only scales down, so nothing gets cropped out of the card.
+    // Falls back to the site default image when a post has no featured image.
+    const ogImage = featuredImage?.publicURL?.replace('/image/upload/', '/image/upload/c_limit,w_1200,f_jpg,q_auto/')
     const category = postData?.parent?.category
     const components = {
         h1: (props) => Heading({ as: 'h1', ...props }),
@@ -393,8 +397,7 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
                 title={seo?.metaTitle || title + ' - PostHog'}
                 description={seo?.metaDescription || excerpt}
                 article
-                image={`${process.env.GATSBY_CLOUDFRONT_OG_URL}/${fields.slug.replace(/\//g, '')}.jpeg`}
-                imageType="absolute"
+                image={ogImage}
                 lang={lang || (languageAlternates ? 'en' : undefined)}
                 languageAlternates={languageAlternates}
                 // Standard.site document rkey (only for /blog posts; this template is shared with other sections)


### PR DESCRIPTION
## Changes

Blog posts set `og:image` and `twitter:image` to a pre-rendered card on a CloudFront distribution (`GATSBY_CLOUDFRONT_OG_URL`). That distribution now answers every request with `403 AccessDenied`:

```
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://d36j3rcgc2qfsv.cloudfront.net/blogturning-data-into-content.jpeg
403
```

The cards were written at build time by `createOGImages` in `gatsby/onPostBuild.ts`, which is gated behind `process.env.AWS_CODEPIPELINE === 'true'`. The site no longer builds on AWS CodePipeline, so nothing has written to that bucket for some time. Crawlers that get a 403 fall back to scraping the page, where they can pick the author avatar instead of the post artwork.

This PR points `og:image` at the post's own `featuredImage`, which is already in the template's GraphQL query:

- The Cloudinary transform `c_limit,w_1200,f_jpg,q_auto` scales the image down to a social-friendly size and converts it to JPEG.
- `c_limit` only scales down and never crops, so titles baked into the artwork stay intact. `c_fill` to a 1.91:1 canvas would clip roughly 11% off the top and bottom of these 1.70:1 header cards.
- Posts with no featured image fall through to the sitewide default image, because the `SEO` component already does that when `image` is undefined.

**Why:** A blog author reported that the social preview for one of their posts showed their profile photo instead of the post's featured image. The cause is not specific to that post — it affects every blog post on the site.

### Before and after

`og:image` before this change, for every blog post:

| | |
|---|---|
| URL | `https://d36j3rcgc2qfsv.cloudfront.net/blog<slug>.jpeg` |
| Response | `403 AccessDenied` |
| Result | Crawler falls back to scraping the page |

`og:image` after this change, for `/blog/turning-data-into-content`:

![after - featured image as og image](https://res.cloudinary.com/dmukukwp6/image/upload/c_limit,w_1200,f_jpg,q_auto/placeholder_behind_the_scenes_header_66c0de3f62.png)

### Verification

- Audited all 131 posts served by this template (`contents/blog`, `contents/spotlight`, `contents/founders`, `contents/product-engineers`). Every one has a Cloudinary `featuredImage`, so no post falls back to the default image today.
- Fetched a random sample of 12 transformed URLs. All returned `200 image/jpeg`, between 22 KB and 96 KB, well inside crawler size limits.
- Ran `pnpm format` on the changed file.

I could not load the page in a local dev server. `pnpm start` stalls in `source-nodes` in this environment, because the content sources need API keys that are not available here. Please check the Vercel preview build.

### Known related problem, not fixed here

The same dead CloudFront distribution is the `og:image` source for four more templates, and all of them 403 as well:

| Template | Example |
|---|---|
| `src/templates/Handbook.tsx` | `handbookcompany-culture.jpeg` |
| `src/templates/tutorials/Tutorial.tsx` | `tutorialsfeature-flags.jpeg` |
| `src/templates/Job.tsx` | job slugs |
| `src/pages/careers.tsx` | `careers-og.jpeg` |

Docs, handbook, tutorial, and careers pages have no featured image, so they cannot use the fix in this PR. They need either a revived generation pipeline or a fallback to the default image. That is a separate change, and this PR is deliberately scoped to the reported problem.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — no pages moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9AKT9NTY/p1787933128052439)*
