### PR TITLE
fix(wizard): make the supported framework list match the wizard

### DIFF
--- a/contents/docs/product-analytics/installation/index.mdx
+++ b/contents/docs/product-analytics/installation/index.mdx
@@ -11,6 +11,7 @@ availability:
 import ProductAnalyticsInstallationPlatforms from './_snippets/installation-platforms'
 import ProductAnalyticsInstallationFrameworks from './_snippets/installation-frameworks'
 import WizardCommand from 'components/WizardCommand'
+import WizardSupportedFrameworks from 'components/WizardSupportedFrameworks'
 import DetailSetUpReverseProxy from '../../integrate/_snippets/details/set-up-reverse-proxy.mdx'
 import DetailGroupProductsInOneProject from '../../integrate/_snippets/details/group-products-in-one-project.mdx'
 import DetailPostHogIPs from '../../integrate/_snippets/details/posthog-ips.mdx'
@@ -23,7 +24,9 @@ Install PostHog in seconds with our wizard by running this command in your proje
 
 Wait for it to finish and test the setup once the wizard is complete.
 
-The wizard supports React, Next.js, Svelte, and React Native. We've got more on the way.
+The wizard supports the following frameworks and languages:
+
+<WizardSupportedFrameworks className="grid gap-4 grid-cols-2 not-prose" />
 
 Check out the wizard's [GitHub repo](https://github.com/PostHog/wizard) for more details.
 

--- a/contents/docs/product-analytics/installation/index.mdx
+++ b/contents/docs/product-analytics/installation/index.mdx
@@ -11,7 +11,6 @@ availability:
 import ProductAnalyticsInstallationPlatforms from './_snippets/installation-platforms'
 import ProductAnalyticsInstallationFrameworks from './_snippets/installation-frameworks'
 import WizardCommand from 'components/WizardCommand'
-import WizardSupportedFrameworks from 'components/WizardSupportedFrameworks'
 import DetailSetUpReverseProxy from '../../integrate/_snippets/details/set-up-reverse-proxy.mdx'
 import DetailGroupProductsInOneProject from '../../integrate/_snippets/details/group-products-in-one-project.mdx'
 import DetailPostHogIPs from '../../integrate/_snippets/details/posthog-ips.mdx'
@@ -23,10 +22,6 @@ Install PostHog in seconds with our wizard by running this command in your proje
 <WizardCommand />
 
 Wait for it to finish and test the setup once the wizard is complete.
-
-The wizard supports the following frameworks and languages:
-
-<WizardSupportedFrameworks className="grid gap-4 grid-cols-2 not-prose" />
 
 Check out the wizard's [GitHub repo](https://github.com/PostHog/wizard) for more details.
 

--- a/src/constants/installation-taxonomy.ts
+++ b/src/constants/installation-taxonomy.ts
@@ -176,7 +176,6 @@ export const TAXONOMY: InstallCategory[] = [
                 librarySlug: 'elixir',
                 wizard: true,
                 wizardOrder: 20,
-                status: 'wip',
             },
             {
                 slug: 'go',
@@ -184,7 +183,6 @@ export const TAXONOMY: InstallCategory[] = [
                 librarySlug: 'go',
                 wizard: true,
                 wizardOrder: 22,
-                status: 'wip',
             },
             {
                 slug: 'java',
@@ -192,7 +190,6 @@ export const TAXONOMY: InstallCategory[] = [
                 librarySlug: 'java',
                 wizard: true,
                 wizardOrder: 23,
-                status: 'wip',
             },
             { slug: 'php', name: 'PHP', librarySlug: 'php' },
             {
@@ -201,7 +198,6 @@ export const TAXONOMY: InstallCategory[] = [
                 librarySlug: 'rust',
                 wizard: true,
                 wizardOrder: 24,
-                status: 'wip',
             },
         ],
     },

--- a/src/constants/installation-taxonomy.ts
+++ b/src/constants/installation-taxonomy.ts
@@ -94,6 +94,15 @@ export const TAXONOMY: InstallCategory[] = [
                 wizardLogoKey: 'tanstack',
             },
             {
+                slug: 'tanstack-router',
+                name: 'TanStack Router',
+                librarySlug: 'tanstack-router',
+                wizard: true,
+                wizardOrder: 27,
+                wizardDocsUrl: WIZARD_GITHUB_REPO_URL,
+                wizardLogoKey: 'tanstack',
+            },
+            {
                 slug: 'vue',
                 name: 'Vue.js',
                 librarySlug: 'vue-js',
@@ -153,7 +162,15 @@ export const TAXONOMY: InstallCategory[] = [
         title: 'Backend languages',
         splitPopular: true,
         items: [
-            { slug: 'nodejs', name: 'Node.js', librarySlug: 'node', popular: true },
+            {
+                slug: 'nodejs',
+                name: 'Node.js',
+                librarySlug: 'node',
+                popular: true,
+                wizard: true,
+                wizardOrder: 26,
+                wizardLogoKey: 'nodejs',
+            },
             {
                 slug: 'python',
                 name: 'Python',

--- a/src/hooks/productData/replay_vision.tsx
+++ b/src/hooks/productData/replay_vision.tsx
@@ -168,6 +168,7 @@ const WIZARD_PLATFORM_SLUGS = new Set([
     'svelte',
     'react-router',
     'tanstack-start',
+    'tanstack-router',
     'django',
     'flask',
     'fastapi',


### PR DESCRIPTION
Elixir, Go, Java and Rust no longer need WIP tags. TanStack Router and Node.js were missing entirely. The Product Analytics install page still named four frameworks.

All confirmed against `FRAMEWORK_REGISTRY` in `@posthog/wizard` v2.67.0 — 27 entries, and the site now lists all 27.