### PR TITLE
Remove the Chrome focus ring from the ScrollArea viewport

### DIFF
--- a/src/components/RadixUI/ScrollArea.tsx
+++ b/src/components/RadixUI/ScrollArea.tsx
@@ -101,7 +101,14 @@ const ScrollArea = ({
                 // are unconditional, so both axes always end up `scroll` anyway — setting them
                 // here (Radix spreads `style` last) makes that true in the SSR'd HTML too.
                 style={{ overflowX: 'scroll', overflowY: 'scroll' }}
-                className={`app-scroll-viewport size-full ${viewportClasses} ${fadeHeight ? `pb-${fadeHeight}` : ''}`}
+                // `outline-none`: Blink is the only engine that paints a focus ring on a scroll
+                // container, so a focused viewport draws a blue rectangle in Chrome and nothing
+                // anywhere else. The ring is never useful here — `tabIndex={-1}` keeps the viewport
+                // out of the tab order, so it only ever holds focus because something put it there
+                // to aim the scroll keys, not because a keyboard user navigated to it.
+                className={`app-scroll-viewport size-full outline-none ${viewportClasses} ${
+                    fadeHeight ? `pb-${fadeHeight}` : ''
+                }`}
             >
                 {fullWidth ? <div>{children}</div> : children}
             </RadixScrollArea.Viewport>

--- a/src/components/RadixUI/ScrollArea.tsx
+++ b/src/components/RadixUI/ScrollArea.tsx
@@ -101,11 +101,6 @@ const ScrollArea = ({
                 // are unconditional, so both axes always end up `scroll` anyway — setting them
                 // here (Radix spreads `style` last) makes that true in the SSR'd HTML too.
                 style={{ overflowX: 'scroll', overflowY: 'scroll' }}
-                // `outline-none`: Blink is the only engine that paints a focus ring on a scroll
-                // container, so a focused viewport draws a blue rectangle in Chrome and nothing
-                // anywhere else. The ring is never useful here — `tabIndex={-1}` keeps the viewport
-                // out of the tab order, so it only ever holds focus because something put it there
-                // to aim the scroll keys, not because a keyboard user navigated to it.
                 className={`app-scroll-viewport size-full outline-none ${viewportClasses} ${
                     fadeHeight ? `pb-${fadeHeight}` : ''
                 }`}


### PR DESCRIPTION
## Changes

Users see blue outlines along the dividers between the main content column and the left nav and right table-of-contents panels. The outlines occur in Chrome only.

The outlines are the Chrome default focus ring. `ScrollArea` gives the Radix viewport `tabIndex={-1}`, which makes the viewport focusable, and no rule sets a focus style on it. Blink is the only engine that paints a focus ring on a scroll container, so the viewport draws a blue rectangle in Chrome and nothing in Firefox or Safari. The rectangle looks like an outline on the dividers because the viewport box fills the content column and the sidebar panels exactly.

`ReaderView` focuses the content viewport after each navigation, so that the scroll keys have a target. This makes the ring visible on almost every docs and handbook page. A click on a nav or table-of-contents link focuses that panel's viewport instead, which moves the ring to the sidebar.

This change adds `outline-none` to the viewport. `tabIndex={-1}` keeps the viewport out of the tab order, so no keyboard user can reach it with Tab, and no focus indicator is lost. Arrow-key scrolling does not change. The same class is already used on the other Radix primitives in `src/components/RadixUI/`.

**Why:** The outlines were reported as a visual defect on posthog.com.

## Screenshots

**Not yet captured — this is a blocker before the PR leaves draft.** The environment for this change has no browser and no installed dependencies, so the dev server could not run. The defect also only occurs in real Chrome, which the bundled headless browser does not reproduce reliably.

The states to capture are the reader window in Chrome, narrow and wide, in light and dark mode:
- Before: a blue rectangle along the content column and the sidebar dividers after a page load.
- After: no rectangle.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no pages moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BH6R0RDFX/p1787948881255709)*
