### PR TITLE
docs: add the rokt ads source page

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -235,6 +235,7 @@ Replit
 Revolut
 RevX
 [Rr]ipe
+Rokt
 RudderStack
 [Rr]unway
 Salesforce

--- a/contents/docs/cdp/sources/rokt-ads.md
+++ b/contents/docs/cdp/sources/rokt-ads.md
@@ -15,7 +15,7 @@ This source is currently in **alpha**. The interface and available tables may ch
 
 </CalloutBox>
 
-The Rokt Ads connector pulls your Rokt performance data – campaigns, creatives, audiences, demographics, and partner transactions – into the PostHog data warehouse.
+The Rokt Ads connector pulls your Rokt performance data – campaigns, creatives, audiences, demographics, and partner transactions – into the PostHog Data Warehouse.
 
 The connector reads through the [Rokt Query API](https://docs.rokt.com/developers/api-reference/reporting/query-api/). It covers advertiser reports and partner reports. Rokt tells PostHog which dimensions and metrics your account can request, so the columns you get depend on what your account is entitled to.
 

--- a/contents/docs/cdp/sources/rokt-ads.md
+++ b/contents/docs/cdp/sources/rokt-ads.md
@@ -1,0 +1,69 @@
+---
+title: Linking Rokt Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+sourceId: RoktAds
+---
+
+<CalloutBox icon="IconFlask" title="Alpha release" type="action">
+
+This source is currently in **alpha**. The interface and available tables may change.
+
+</CalloutBox>
+
+The Rokt Ads connector pulls your Rokt performance data – campaigns, creatives, audiences, demographics, and partner transactions – into the PostHog data warehouse.
+
+The connector reads through the [Rokt Query API](https://docs.rokt.com/developers/api-reference/reporting/query-api/). It covers advertiser reports and partner reports. Rokt tells PostHog which dimensions and metrics your account can request, so the columns you get depend on what your account is entitled to.
+
+## Adding a data source
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+2. Click **+ New source** and then click **Link** next to Rokt Ads.
+3. Enter your Rokt credentials:
+   - **App ID** – The app ID from your Rokt profile
+   - **App secret** – The app secret from your Rokt profile
+   - **Account ID** – The Rokt account to read reports from
+4. Set the optional reporting fields, or leave them blank to use your Rokt account's defaults:
+   - **Time zone (Olson name)** – The time zone Rokt groups report days by, for example `America/New_York`
+   - **Currency code** – The currency Rokt reports cost and revenue in, for example `USD`
+5. Click **Next**.
+6. Select the tables you want to sync, set the sync method and frequency, then click **Import**.
+
+To get an app ID and app secret, open the **Profile settings** page in [One Platform](https://my.rokt.com) and generate a pair.
+
+PostHog validates your credentials at connect time. If Rokt rejects them, or if they cannot read the account ID you entered, the connection fails immediately.
+
+Once the syncs are complete, you can start using Rokt Ads data in PostHog.
+
+## Available tables
+
+| Table                    | Description                                                    | Sync method  |
+| ------------------------ | -------------------------------------------------------------- | ------------ |
+| `Accounts`               | Rokt accounts the connected credentials can read               | Full refresh |
+| `CampaignPerformance`    | Daily advertiser spend and outcome metrics per campaign        | Incremental  |
+| `CreativePerformance`    | Daily advertiser metrics per creative within a campaign        | Incremental  |
+| `AudiencePerformance`    | Daily advertiser metrics per targeted audience                 | Incremental  |
+| `CampaignDemographics`   | Daily advertiser metrics split by age range, gender, and device | Incremental  |
+| `TransactionPerformance` | Daily partner transaction and impression metrics               | Incremental  |
+
+`Accounts` is a small dimension table, so it uses full refresh. The five report tables group rows by calendar day and sync incrementally on their `datetime` field.
+
+Each account exposes its own set of dimensions and metrics. If your account cannot serve a metric, that column is dropped from the report instead of failing the sync. If your account cannot serve a dimension, the sync fails with an error naming that dimension, because a dimension sets the row grain and dropping it would collapse rows onto a key that no longer identifies them. Deselect the affected table to continue.
+
+## Incremental syncs
+
+Rokt attributes acquisitions and conversions by conversion time, so it keeps restating recent days after they first land. Each incremental sync re-reads a trailing seven-day window and merges the results on the primary key. A day's numbers can therefore change for about a week after that day ends.
+
+The first sync reaches back up to two years.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />

--- a/contents/docs/cdp/sources/rokt-ads.md
+++ b/contents/docs/cdp/sources/rokt-ads.md
@@ -41,16 +41,16 @@ Once the syncs are complete, you can start using Rokt Ads data in PostHog.
 
 ## Available tables
 
-| Table                    | Description                                                    | Sync method  |
-| ------------------------ | -------------------------------------------------------------- | ------------ |
-| `Accounts`               | Rokt accounts the connected credentials can read               | Full refresh |
-| `CampaignPerformance`    | Daily advertiser spend and outcome metrics per campaign        | Incremental  |
-| `CreativePerformance`    | Daily advertiser metrics per creative within a campaign        | Incremental  |
-| `AudiencePerformance`    | Daily advertiser metrics per targeted audience                 | Incremental  |
-| `CampaignDemographics`   | Daily advertiser metrics split by age range, gender, and device | Incremental  |
-| `TransactionPerformance` | Daily partner transaction and impression metrics               | Incremental  |
+| Table                    | Description                                                     | Sync methods                |
+| ------------------------ | --------------------------------------------------------------- | --------------------------- |
+| `Accounts`               | Rokt accounts the connected credentials can read                | Full refresh                |
+| `CampaignPerformance`    | Daily advertiser spend and outcome metrics per campaign         | Incremental or full refresh |
+| `CreativePerformance`    | Daily advertiser metrics per creative within a campaign         | Incremental or full refresh |
+| `AudiencePerformance`    | Daily advertiser metrics per targeted audience                  | Incremental or full refresh |
+| `CampaignDemographics`   | Daily advertiser metrics split by age range, gender, and device | Incremental or full refresh |
+| `TransactionPerformance` | Daily partner transaction and impression metrics                | Incremental or full refresh |
 
-`Accounts` is a small dimension table, so it uses full refresh. The five report tables group rows by calendar day and sync incrementally on their `datetime` field.
+`Accounts` is a small dimension table, so it only offers full refresh. The five report tables group rows by calendar day. Each one can sync incrementally on its `datetime` field, which is what we recommend, because a full refresh re-reads up to two years of report days on every run.
 
 Each account exposes its own set of dimensions and metrics. If your account cannot serve a metric, that column is dropped from the report instead of failing the sync. If your account cannot serve a dimension, the sync fails with an error naming that dimension, because a dimension sets the row grain and dropping it would collapse rows onto a key that no longer identifies them. Deselect the affected table to continue.
 


### PR DESCRIPTION
## Executive summary

The Rokt Ads warehouse source shipped in PostHog/posthog#82608. Its source config sets `docsUrl` to `/docs/cdp/sources/rokt-ads`, but no page existed at that path, so the "Read the docs" link in the connect wizard returned a 404. This adds the page.

The page follows the structure of the other advertising source pages, such as [Amazon Ads](/docs/cdp/sources/amazon-ads): what the connector pulls, how to connect it, which tables it offers, then the `<SourceParameters />` and `<SourceTables />` blocks.

Two parts of the page describe behavior a person will otherwise be surprised by:

- Numbers for a given day keep moving for about a week. Rokt attributes acquisitions and conversions by conversion time and restates recent days, so each incremental sync re-reads a trailing seven-day window.
- Available columns differ per account. Rokt reports which dimensions and metrics an account may request. A metric the account cannot serve is dropped from the report, but a missing dimension fails the sync with an error naming it, because a dimension sets the row grain.

The alpha callout matches `releaseStatus=ReleaseStatus.ALPHA` on the source config, so the page states the status the product already ships.

## Before you open a PR

- `pnpm format` globs `{html,js,ts,tsx,json,yml,css,scss}` and does not cover `.md`, so it is a no-op for this diff.
- I could not start the dev server locally, because `node_modules` is absent in my environment. Instead I checked the page on the Cloudflare deploy preview this PR builds, which renders the real page.

The preview confirms the page renders correctly:

- The alpha callout, the intro, the connect steps, and the "Available tables" table all render.
- `Configuration` renders the five fields from the source config: App ID, App secret, and Account ID as required, with Time zone and Currency code optional.
- `Supported tables` renders all six tables with their descriptions, sync methods, and incremental fields.

Rendering it found one error that reading the file did not. The generated table reports "Incremental, Full refresh" for the five report tables, but the hand-written table above it named incremental only. That is fixed, and the note underneath now says why incremental is the better choice.

An earlier preview showed an empty `Configuration` heading, because the source had not deployed yet and the build reads source metadata from `/api/public_source_configs`. The source is now live, so the section fills in. No navigation change, because source pages are not listed in `src/navs/index.js`. No page moved or was renamed, so `vercel.json` needs no redirect.

## Vale

The first run reported 15 warnings. Both causes are fixed in this PR, which is why it also touches one file outside `contents/`:

- Fourteen were `'Rokt' is a possible misspelling`. Rokt is a brand name, so it now sits in the `BrandsAndTechnologies` vocabulary alongside HubSpot, Klaviyo, and the other vendors. Without this, every future page that names Rokt repeats the same 14 warnings.
- One was real. `ProductNames` asks for "Data Warehouse" when the phrase names PostHog's product rather than the general industry concept, and that sentence names the product.

Worth flagging for the reviewer: the lowercase form appears in about 106 pages under `contents/docs/` against roughly 12 capitalized, so the corpus has drifted from the rule the linter encodes. I followed the linter here rather than the neighboring pages. Say the word if you would rather match the neighbors, and I will revert that one word.

## Notes

The source logo is a separate PR on the main repo, PostHog/posthog#91320. This page reads `icon_url` from the same source config, so that PR also supplies the icon shown here.
