### PR TITLE
fix(security): add RFC 9116 Expires field to security.txt

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,4 +1,5 @@
 Contact: mailto:security-reports@posthog.com
+Expires: 2027-08-30T00:00:00.000Z
 Encryption: https://posthog.com/.well-known/pgp-key.txt
 # PGP fingerprint: 35CA 7526 FA8B 9A8A 0254 6EAD F3E0 B94E 3088 9B51
 Preferred-Languages: en


### PR DESCRIPTION
Fixes #18492

## Problem

static/.well-known/security.txt was missing an Expires field, which RFC 9116 §2.5.5 specifies as required. Without an Expires field, some automated security scanners and tools consider the security.txt invalid or stale.

## Fix

Added Expires: 2027-08-30T00:00:00.000Z to static/.well-known/security.txt.