### PR TITLE
Clarify coworking food and drink spend

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -214,6 +214,9 @@ You can ask for access to team/company tools by submitted a request in Slack. Fi
 
 ### Coworking
 - If there's a WeWork where you are, use it – we have a company All Access account, so default to that rather than paying for another coworking space. Ask [Kendal](https://posthog.com/community/profiles/28628) in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) for access.
+- We pay for _one_ place to work from, not two. Either we cover a coworking space, or we cover what you buy to work from a cafe – not both. If you have a coworking space, your own food and drink there is a personal expense.
+- Some coworking spaces bundle food and drink into a flat daily fee. Opt out of that fee if it is optional. If you cannot separate it from the day rate, ask in [#team-people-and-ops](https://posthog.slack.com/archives/C017WDX3BFZ) before you expense it.
+- This is different from a meal with colleagues or a customer, which we do cover – see [Travel](#travel).
 
 ### Travel
 - We travel in economy by default and do not pay for business class


### PR DESCRIPTION
## Summary

The Coworking section of the spending money handbook page did not say whether food and drink you buy at a coworking space is a company expense. This came up because some coworking spaces charge a flat daily fee that bundles all food and drink, and it was not clear whether that fee falls under the personal User Limit.

This change adds three lines to that section:

- We pay for one place to work from, not two. Either a coworking space, or what you buy to cowork from a cafe – not both.
- If a coworking space bundles food and drink into an optional daily fee, opt out of it. If the fee is not separable from the day rate, ask in `#team-people-and-ops` first.
- A pointer to the Travel section, which already covers meals with colleagues and customers, so the two rules are not confused.

**Why:** a team member asked whether this spend is acceptable, and the answer was not in the handbook. Writing it down means the next person does not have to ask.

Content-only change to `contents/handbook/people/spending-money.md`. No navigation or component changes, so no screenshots and no redirects.

> [!IMPORTANT]
> The wording follows the stricter of the two answers given in the discussion. Please confirm it says what you want before this comes out of draft.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C017WDX3BFZ/p1788171042569619?thread_ts=1788171042.569619&cid=C017WDX3BFZ)*