### PR TITLE
docs(data-warehouse): clarify managed warehouse rollout

### DIFF
--- a/contents/docs/data-warehouse/managed-warehouse/setup.mdx
+++ b/contents/docs/data-warehouse/managed-warehouse/setup.mdx
@@ -14,6 +14,8 @@ Setup requires beta access. Not in yet? [Join the waitlist](/context-warehouse/m
 
 Setting up the warehouse takes a few minutes: you pick a name, PostHog provisions the infrastructure, and then historical data starts loading. Everything happens in the **Data ops** section of the app, which appears in your navigation once your organization has beta access.
 
+During the beta, PostHog enables the Data ops UI and imported-source loading separately. The **Overview** tab shows **Not configured** until imported-source loading is enabled for the current project.
+
 ## Before you start
 
 - You need to be an **organization admin** to provision, deprovision, or manage credentials. Other members can see status but can't change anything.
@@ -50,7 +52,7 @@ You don't need to wait for backfills to finish before connecting – data that's
 
 ## Add sources
 
-Anything you connect as a [source](/docs/cdp/sources) syncs into the warehouse automatically alongside its regular imports – there's no separate warehouse configuration per source. Manage sources as usual in [Data pipelines > Sources](https://app.posthog.com/data-management/sources).
+After imported-source loading is enabled for the project, anything you connect as a [source](/docs/cdp/sources) syncs into the warehouse alongside its regular imports. There's no separate warehouse configuration per source. Manage sources as usual in [Data pipelines > Sources](https://app.posthog.com/data-management/sources).
 
 ## Add more projects
 


### PR DESCRIPTION
## Changes

Managed warehouse beta users can now tell when Data ops access arrives before imported-source loading.

- Explain that PostHog can enable Data ops and imported-source loading separately during beta.
- Promise automatic source syncing only after PostHog enables imported-source loading for the project.
- [PostHog PR #91781](https://github.com/PostHog/posthog/pull/91781) restores the independent workflow gate.
- No screenshot: this changes documentation text only.

## Checklist

- [x] I have read the docs and content style guides.
- [x] Words use American English spelling.
- [x] Internal links use relative URLs.
- [ ] I have checked the changed page in the Vercel preview build.
- [x] No page moved, so no redirect is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex prepared the change with the writing-user-facing-copy, writing-pr-descriptions, and signed-git-publish skills. The change contains no customer or private operational data.