### PR TITLE
docs: add community skills store documentation

### DIFF
--- a/contents/docs/skills/community.mdx
+++ b/contents/docs/skills/community.mdx
@@ -1,0 +1,95 @@
+---
+title: Community skills
+---
+
+The community skills store is a public catalog of agent skills shared by PostHog users. You can browse it, install skills into your project with one click, and publish your own [skills](/docs/skills) for everyone else to use.
+
+The catalog is backed by the public [PostHog/community-skills](https://github.com/PostHog/community-skills) GitHub repo. Every skill in the catalog lives there as a `SKILL.md` (following the [Agent Skills specification](https://agentskills.io/specification)) plus any bundled files, and every published skill goes through a pull request review before it appears in the store.
+
+## Browse and install skills
+
+Open **[Skills](https://app.posthog.com/skills)** in PostHog and switch to the **Community** tab (or go directly to [`/skills/community`](https://app.posthog.com/skills/community)).
+
+From there you can:
+
+- **Search** by name, description, or tag
+- **Filter** by trust tier (official, verified, or community)
+- **Sort** by most installed, top rated, newest, or name
+- **Upvote** skills you find useful – votes power the "top rated" sort
+- **View the source** – every card links to the skill's directory on GitHub, so you can read exactly what you're installing
+
+Clicking **Install** copies the skill into your project as a regular team skill. From that point on it behaves like any skill you created yourself: you can edit it, version it, and use it from any MCP-connected agent via `skill-get`.
+
+A few things to know about installing:
+
+- **Installing is a copy, not a subscription.** Your installed skill doesn't auto-update when the community version changes. If you want the latest version later, install it again under a new name and compare.
+- **Name conflicts:** if your project already has a skill with the same name, install it under a different name.
+- **Reserved names:** the `signals-scout-` and `review-hog-` prefixes are reserved for PostHog-managed skills that run with elevated permissions, so you can't install a community skill under those names. Install it under a different name instead.
+- **Review before you rely on it.** A skill is instructions your agent will follow. Trust tiers help (see below), but for anything sensitive, read the skill body on GitHub first – the same way you'd review a dependency.
+
+## Trust tiers
+
+Every skill in the catalog carries a trust tier badge:
+
+| Tier          | Meaning                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| **Official**  | Written and maintained by PostHog                                     |
+| **Verified**  | Community-written, reviewed more closely by the catalog's maintainers |
+| **Community** | Community-written, passed the standard review                         |
+
+Tiers are assigned by the maintainers of the community-skills repo when they review a submission – publishers can't set their own tier.
+
+## Templates
+
+Some community skills are **templates**: skills with declared variables that get filled in at install time. They show a `Template` tag on their card, and the install button opens a short form with one field per variable (each with a prompt and an optional default).
+
+The values you provide are substituted into `{{ variable }}` placeholders in the skill body and bundled files. Substitution is plain text replacement – templates can't execute logic or read your data. This is what makes a generic community skill (say, a release-notes writer) adaptable to your repo, product name, or conventions without editing the body by hand after install.
+
+## Publish a skill to the community
+
+If you've built a skill your team finds useful, you can share it with everyone.
+
+### Prerequisites
+
+- You must be an **owner** of the skill. A skill with no owners can't be published – add yourself as an owner first.
+- You must be viewing the **latest version** of the skill.
+
+### Publishing
+
+1. Open the skill in **[Skills](https://app.posthog.com/skills)** and choose **Publish to community** from its **More** menu (it's also in the overflow menu on the skills list)
+2. Fill in the dialog:
+   - **Display name** – how the skill appears in the catalog
+   - **Tags** – comma-separated, used for search and filtering
+   - **Your GitHub handle** (optional) – credited as the author on the skill's card
+3. Click **Publish**
+
+PostHog renders your skill – its instructions, bundled files, and any template variables – into the community-skills repo and opens a pull request for a maintainer to review. You get a link to the PR so you can follow along.
+
+> **The contents are public from the moment you submit**, before any review happens. Don't publish skills that contain credentials, customer data, or internal details.
+
+### Review and sync
+
+A maintainer reviews the PR for safety and quality, and assigns a trust tier. Once merged, the catalog syncs automatically – your skill appears in the community store within about an hour.
+
+If you update your skill and publish again before the first PR is merged, the same PR is updated rather than a new one being opened.
+
+## Limits
+
+- Skill descriptions are capped at 1,024 characters (per the Agent Skills spec)
+- Up to 200 bundled files, 1 MB each, text files only
+- The whole skill (body plus files) must be under 5 MB
+- Publishing is rate-limited per project, so batch your edits locally and publish when the skill is ready
+
+## FAQ
+
+### Do I need MCP to use community skills?
+
+Browsing, installing, and publishing all happen in the PostHog UI. Once a skill is installed, it's a regular team skill – your agents fetch it through the [MCP `skill-*` tools](/docs/skills) like any other.
+
+### What happens if a skill is removed from the catalog?
+
+Nothing changes for you. Installed skills are copies in your project, so they keep working even if the community version is removed.
+
+### Can I publish a skill anonymously?
+
+The GitHub handle field is optional and self-reported. If you leave it out, no author is credited on the card. Either way, the pull request comes from PostHog's publishing bot, not your GitHub account.

--- a/contents/docs/skills/index.mdx
+++ b/contents/docs/skills/index.mdx
@@ -4,7 +4,7 @@ title: Skills
 
 Skills are versioned, reusable instructions for AI agents, stored centrally in PostHog and managed in the **[Skills](https://app.posthog.com/skills)** section of the app. Your team's coding agents (Claude Code, Cursor, Codex, Windsurf, and others) all support [MCP](/docs/model-context-protocol), and skills give you a centralized, versioned place to store and share reusable agent skills – following the [Agent Skills specification](https://agentskills.io/specification) – across any tool, for any team member.
 
-Skills also power the rest of self-driving PostHog: every [scout](/docs/self-driving/scouts) is a skill you can read, edit, or write yourself.
+Skills also power the rest of self-driving PostHog: every [scout](/docs/self-driving/scouts) is a skill you can read, edit, or write yourself. And you don't have to start from scratch – browse the [community skills store](/docs/skills/community) to install skills shared by other PostHog users, or publish your own.
 
 > **Shortcut: install the PostHog AI plugin.**
 >

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -8249,6 +8249,12 @@ export const docsMenu = {
                     icon: 'IconHome',
                     color: 'seagreen',
                 },
+                {
+                    name: 'Community skills',
+                    url: '/docs/skills/community',
+                    icon: 'IconPeople',
+                    color: 'blue',
+                },
             ],
         },
         {


### PR DESCRIPTION
## Executive summary

This PR adds documentation for the community skills store, which rolled out to 100% of users. The community skills store is a public catalog of agent skills at `/skills/community` in the PostHog app. Users can browse the catalog, install skills into their project, and publish their own skills through a pull request to the public `PostHog/community-skills` repo.

The site had no documentation for this feature. This PR adds one page and links it from the navigation:

- **New page:** `contents/docs/skills/community.mdx` (`/docs/skills/community`). It documents how to browse and install skills, trust tiers, templates with variables, the publish flow, limits, and an FAQ.
- **Navigation:** one new entry, "Community skills", in the Skills section of the docs sidebar (`src/navs/index.js`).
- **Cross-link:** one sentence on `/docs/skills` that points to the new page.

This is a content PR. It does not change any component or page template.

## Checks

- Ran `pnpm format` on the changed files.
- Loaded `/docs/skills` and `/docs/skills/community` on the dev server. The console shows no new errors (compared before and after the change, not against a remembered list).
- No pages were moved or renamed, so no redirect is needed.

## Screenshots

### Docs nav (Skills section, wide window)

The nav change adds one entry to the Skills section of the docs sidebar.

| Mode | Before | After |
|---|---|---|
| Light | ![before-nav-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/9fe8fa7b-305f-4360-8acf-d74e3c3f83e1.png) | ![after-nav-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/d906a762-6aa2-4203-a074-2c4850ad115a.png) |
| Dark | ![before-nav-dark-wide](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/dfe981aa-02cb-40dc-b406-d8cdf7c34f1e.png) | ![after-nav-dark-wide](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/15f0cb2f-1c1e-4cfa-9b3b-4546c57179cf.png) |

Not tested: the nav at narrow window widths. The docs window hides the sidebar at narrow widths, so the nav change is not visible there (verified with narrow captures of `/docs/skills`).

### New page: /docs/skills/community (after – the page did not exist before)

| Mode | Narrow | Wide |
|---|---|---|
| Light | ![after-docs-skills-community-light-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/d2b32ee1-ce02-4a9b-a952-9177eb0c4f07.png) | ![after-docs-skills-community-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/1b3a87c5-c6b8-4282-87f5-ef361d2d386c.png) |
| Dark | ![after-docs-skills-community-dark-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/62bcce0e-9277-4b45-9dc5-6198e0e74d6d.png) | ![after-docs-skills-community-dark-wide](https://raw.githubusercontent.com/PostHog/pr-assets/18885f3edbf6ccd477aa221ec585715c379563cb/2026/08/bf9942c5-4b5f-4b4d-813c-c8f08b0e1ad2.png) |

https://claude.ai/code/session_01CzQvyCMSNbVBugbxCec8zx
