### PR TITLE
Point /security at the security handbook page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -453,7 +453,7 @@
         },
         {
             "source": "/security",
-            "destination": "/.well-known/security.txt",
+            "destination": "/handbook/company/security",
             "statusCode": 301
         },
         {


### PR DESCRIPTION
## Changes

Changes the `/security` redirect target from `/.well-known/security.txt` to `/handbook/company/security`.

Follow-up to [#19696](https://github.com/PostHog/posthog.com/pull/19696), which is already merged, so this is a second PR rather than a change to that branch.

## Why

`security.txt` is the machine-readable standard, but it reads poorly for a person who typed `posthog.com/security` and expected a page. The handbook page is friendlier, and it does not cost researchers anything: `security.txt` stays available at its standard `/.well-known/` location, which is where scanners and researchers look for it.

Note that [#19696](https://github.com/PostHog/posthog.com/pull/19696) shipped a 301, which browsers cache. Anyone who already hit `/security` will continue to land on `security.txt` until their cache clears.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08SCAZ52S3/p1787643932448029?thread_ts=1787643932.448029&cid=C08SCAZ52S3)*