### PR TITLE
docs(session-replay): document ph-no-mask for iOS and React Native

### DIFF
--- a/contents/docs/session-replay/_snippets/android-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/android-privacy.mdx
@@ -55,7 +55,7 @@ Text(
 
 ### Precedence and propagation
 
-Both mask and unmask controls apply to all children of the view or composable they are set on. The unmask option (`ph-no-mask` / `postHogUnmask()`) always takes precedence over the mask option (`ph-no-capture` / `postHogMask()`).
+Both mask and unmask controls apply to all children of the view or composable they are set on. The unmask option (`ph-no-mask` / `postHogUnmask()`) always takes precedence over the mask option (`ph-no-capture` / `postHogMask()`). This applies to the whole subtree: a child marked `ph-no-capture` inside an unmasked view is **not** masked, and neither are views that PostHog would otherwise mask automatically. Only unmask a subtree you know contains no sensitive data.
 
 Both `postHogMask()` and `postHogUnmask()` accept an `isEnabled` parameter. When set to `false`, the modifier has no effect (as if it was never applied), allowing dynamic control via global settings or remote config:
 

--- a/contents/docs/session-replay/_snippets/ios-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/ios-privacy.mdx
@@ -1,5 +1,7 @@
 import SensitiveThirdPartyScreens from "./sensitive-third-party-screens.mdx"
 
+### Masking views
+
 To replace any type of `UIView` with a redacted version in the replay, set the [accessibilityIdentifier](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier) to `ph-no-capture`:
 
 ```swift
@@ -8,6 +10,27 @@ imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 ```
 
 > **Note:** For SwiftUI please refer to the [Masking in SwiftUI](#masking-in-swiftui) section below
+
+### Unmasking views
+
+To explicitly prevent a `UIView` and all its subviews from being masked, even when `maskAllTextInputs` or `maskAllImages` is enabled, set the [accessibilityIdentifier](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier) or [accessibilityLabel](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/accessibilitylabel) to `ph-no-mask`:
+
+```swift
+let lblPublicTitle = UILabel(frame: CGRect(x: 50, y: 50, width: 200, height: 40))
+lblPublicTitle.accessibilityIdentifier = "ph-no-mask"
+```
+
+The match is a case-insensitive substring, so `ph-no-mask` can be combined with an identifier you already use:
+
+```swift
+lblPublicTitle.accessibilityIdentifier = "screen-title ph-no-mask"
+```
+
+<CalloutBox title="Requires version 3.71.0" type="info" icon="IconInfo">
+
+Support for the `ph-no-mask` identifier is added in iOS SDK version 3.71.0.
+
+</CalloutBox>
 
 ### Masking in SwiftUI
 
@@ -36,5 +59,9 @@ Apps built with Xcode 26 use a new SwiftUI rendering model that changes how Swif
 **If you're building with Xcode 26**, update to [version 3.36.2](https://github.com/PostHog/posthog-ios/releases/tag/3.36.2) or later to ensure these modifiers work correctly.
 
 </CalloutBox>
+
+### Precedence and propagation
+
+`ph-no-mask` applies to the view it is set on and all of its subviews, and it takes precedence over both `ph-no-capture` and PostHog's default masking heuristics. A view marked with `ph-no-capture` that sits inside a `ph-no-mask` subtree is **not** masked, and neither are sensitive views such as text fields that PostHog would otherwise mask automatically. Only set `ph-no-mask` on a subtree you know contains no sensitive data.
 
 <SensitiveThirdPartyScreens />

--- a/contents/docs/session-replay/_snippets/react-native-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-privacy.mdx
@@ -51,3 +51,27 @@ Alternatively, to replace any type of `React.Component` with a redacted version 
 ```ts
 <Text accessibilityLabel="ph-no-capture">Sensitive!</Text>
 ```
+
+# Unmasking
+
+To explicitly prevent a component and all its children from being masked, even when `maskAllTextInputs` or `maskAllImages` is enabled, set the [accessibilityLabel](https://reactnative.dev/docs/accessibility#accessibilitylabel) to `ph-no-mask`:
+
+```ts
+<Text accessibilityLabel="ph-no-mask">Welcome to PostHog</Text>
+```
+
+The match is a case-insensitive substring, so the token can be combined with a label you already use:
+
+```ts
+<Text accessibilityLabel="Welcome banner ph-no-mask">Welcome to PostHog</Text>
+```
+
+## Precedence and propagation
+
+Unmasking applies to the component and all of its children, and it takes precedence over `ph-no-capture` and over the default masking behavior. A child marked `ph-no-capture` inside an unmasked subtree is **not** masked, and neither are inputs that would otherwise be masked automatically. Only unmask a subtree you know contains no sensitive data.
+
+<CalloutBox title="Native SDK versions" type="info" icon="IconInfo">
+
+`ph-no-mask` support is added in `posthog-ios` version 3.71.0 and `posthog-android` version 3.33.0.
+
+</CalloutBox>


### PR DESCRIPTION
## Changes

Documents the `ph-no-mask` accessibility token, released in iOS SDK [3.71.0](https://github.com/PostHog/posthog-ios/releases/tag/3.71.0) via [posthog-ios#787](https://github.com/PostHog/posthog-ios/pull/787).

iOS (`ios-privacy.mdx`): adds "Unmasking views" and "Precedence and propagation", mirroring the Android snippet so the two platforms read the same.

React Native (`react-native-privacy.mdx`): adds an "Unmasking" section. `PostHogMaskView` is mask-only, so the token is the only way to unmask there.

Android (`android-privacy.mdx`): says the unmask applies to the whole subtree, so a `ph-no-capture` child inside an unmasked view stays unmasked. Already true, just undocumented.

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
