### PR TITLE
Add print styles for focused app window

### DIFF
--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -672,7 +672,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                 {item.appSettings?.size?.fixed && (
                     <div
                         onClick={handleClose}
-                        className={`fixed inset-0 z-50 bg-black/50 ${
+                        className={`fixed inset-0 z-50 bg-black/50 print:hidden ${
                             closing ? 'animate-overlay-fade-out' : !skipsOpenAnimation ? 'animate-overlay-fade-in' : ''
                         }`}
                     />
@@ -700,6 +700,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                     data-expanded={item.expanded || undefined}
                     data-windowed={item.windowed || undefined}
                     data-snapped={item.snapped || undefined}
+                    data-focused={focusedWindow === item || undefined}
                     data-scheme="tertiary"
                     className={`@container relative overflow-hidden ${
                         item.appSettings?.size?.fixed
@@ -746,7 +747,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             : undefined
                     }
                 >
-                    <div className={`${hasToolbar ? 'bg-primary flex items-center py-0.5 px-1' : ''}`}>
+                    <div className={`print:hidden ${hasToolbar ? 'bg-primary flex items-center py-0.5 px-1' : ''}`}>
                         {hasToolbar && (
                             <>
                                 {!hideTitle && (
@@ -811,6 +812,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                     </div>
                     <div
                         ref={contentRef}
+                        data-app="AppWindowContent"
                         className={`size-full flex-grow ${
                             chrome
                                 ? `${

--- a/src/components/Wrapper/index.tsx
+++ b/src/components/Wrapper/index.tsx
@@ -15,7 +15,7 @@ const WindowList = React.memo(function WindowList() {
     const { windows } = useAppWindows()
 
     return (
-        <div className="flex size-full justify-center items-center">
+        <div data-app="WindowList" className="flex size-full justify-center items-center">
             {windows.map((item) => (
                 <AppWindow item={item} key={item.key} />
             ))}
@@ -30,7 +30,7 @@ export default function Wrapper() {
     return (
         <AppContainer className="h-dvh flex flex-col p-2">
             {!compact && <TaskBarMenu />}
-            <div ref={constraintsRef} className={`flex-grow relative min-h-0 overflow-clip`}>
+            <div data-app="DesktopViewport" ref={constraintsRef} className={`flex-grow relative min-h-0 overflow-clip`}>
                 <Desktop />
                 <WindowList />
             </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3205,3 +3205,68 @@ html.ai-observability-wizard-hint-dismissed .ai-observability-wizard-hint .wizar
 .dark ::highlight(text-fragment-target) {
     background-color: rgb(247 165 1 / 0.3);
 }
+
+/* Print the focused page, not the desktop shell. */
+@media print {
+    html,
+    body,
+    #___gatsby,
+    #gatsby-focus-wrapper,
+    #app-container,
+    [data-app='DesktopViewport'],
+    [data-app='WindowList'] {
+        width: auto !important;
+        height: auto !important;
+        min-height: 0 !important;
+        overflow: visible !important;
+    }
+
+    #app-container {
+        position: static !important;
+        display: block !important;
+        padding: 0 !important;
+    }
+
+    #app-container > :not([data-app='DesktopViewport']),
+    [data-app='DesktopViewport'] > :not([data-app='WindowList']),
+    [data-app='AppWindow']:not([data-focused]) {
+        display: none !important;
+    }
+
+    [data-app='DesktopViewport'],
+    [data-app='WindowList'],
+    [data-app='AppWindow'][data-focused],
+    [data-app='AppWindowContent'],
+    [data-app='AppWindow'][data-focused] .app-scroll-area,
+    [data-app='AppWindow'][data-focused] .app-scroll-viewport {
+        display: contents !important;
+    }
+
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'],
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'] > div:not([aria-hidden]),
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'] > div:not([aria-hidden]) > div,
+    [data-app='AppWindow'][data-focused] [data-app='Editor'],
+    [data-app='AppWindow'][data-focused] [data-app='Viewer'],
+    [data-app='AppWindow'][data-focused] [data-app='Explorer'],
+    [data-app='AppWindow'][data-focused] [data-radix-scroll-area-viewport] > div {
+        position: static !important;
+        display: block !important;
+        width: 100% !important;
+        height: auto !important;
+        min-height: 0 !important;
+        max-width: none !important;
+        max-height: none !important;
+        overflow: visible !important;
+        transform: none !important;
+    }
+
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'] > aside,
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'] > div > div > aside,
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'] > [aria-hidden],
+    [data-app='AppWindow'][data-focused] [data-app='ReaderView'] button[aria-label='Open navigation'],
+    [data-app='AppWindow'][data-focused] .app-scrollbar,
+    [data-app='AppWindow'][data-focused] .scrollarea-fade,
+    [data-app='AppWindow'][data-focused] .scrollarea-fade-x {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
## Changes

Makes pages actually printable:

### Before
<img width="783" height="835" alt="image" src="https://github.com/user-attachments/assets/e294b1a8-27ff-4aae-9800-a34467ccbf8a" />

### After
<img width="694" height="841" alt="image" src="https://github.com/user-attachments/assets/4f497cc5-6983-4380-b368-5ec1fee4173a" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
