### PR TITLE
Fix #changelog Slack link in sales and CS tools

### DIFF
--- a/contents/handbook/growth/sales/sales-and-cs-tools.md
+++ b/contents/handbook/growth/sales/sales-and-cs-tools.md
@@ -92,7 +92,7 @@ Unless otherwise indicated, you can self-serve access requests to the following 
 - <PrivateLink url='https://posthog.slack.com/archives/C08UNFX75ST'>#closed-won</PrivateLink> - yay!
 - <PrivateLink url='https://posthog.slack.com/archives/C096DC85NH5'>#closed-lost</PrivateLink> - boo!
 - <PrivateLink url='https://posthog.slack.com/archives/C09HKF565MZ'>#customer-churn</PrivateLink> - discussion of potential and actual customer churn.
-- <PrivateLink url='https://posthog.slack.com/archives/C09HKF565MZ'>#changelog</PrivateLink> - product launches.
+- <PrivateLink url='https://posthog.slack.com/archives/C099B0YCULT'>#changelog</PrivateLink> - product launches.
 - <PrivateLink url='https://posthog.slack.com/archives/C0975UEGHT5'>#today-i-learned</PrivateLink> - where we share our learnings.
 - <PrivateLink url='https://posthog.slack.com/archives/C07TQR0V16U'>#ask-max</PrivateLink> - bot focused on internal processes and questions.
 - <PrivateLink url='https://posthog.slack.com/archives/C0AP5NXF8D7'>#demo-posthog-anything</PrivateLink> - show off something cool or see how others are demoing things.


### PR DESCRIPTION
## Problem

In the "Useful Slack channels" list on the sales & CS tools page, the `#changelog` entry links to `C09HKF565MZ` — but that's `#customer-churn`, the channel ID on the line directly above it. Looks like a copy/paste slip when the two lines were added.

Anyone clicking `#changelog` to follow product launches lands in the churn channel instead.

## Fix

Point `#changelog` at its actual channel ID, `C099B0YCULT`. One line changed; `#customer-churn` above it was already correct and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pNSXVDoPbqspLcaKgPXPd
