### PR TITLE
docs(python): document asyncio client

### DIFF
--- a/contents/docs/feature-flags/troubleshooting.mdx
+++ b/contents/docs/feature-flags/troubleshooting.mdx
@@ -224,27 +224,13 @@ import PostHogBillableUsageTemplate from "../_snippets/posthog-billable-usage-te
 
 ### Async compatibility (Python / FastAPI)
 
-The `posthog-python` SDK is synchronous — it uses the `requests` library internally. In async Python web frameworks (FastAPI, Starlette), calling SDK methods directly blocks the event loop. Under concurrent load, a single slow PostHog call (e.g., 3-second timeout during an outage) blocks all other requests.
+Version `7.45.0` and later of the Python SDK includes the asyncio-native `AsyncPosthog` client. Use it in FastAPI, Starlette, and other asyncio apps to capture events, evaluate flags, and fetch remote config without blocking the event loop. See the [Python asyncio client guide](/docs/libraries/python#use-the-asyncio-client) for installation and lifecycle examples.
 
-**Fix:** Wrap SDK calls in `asyncio.to_thread()`:
+The synchronous `Posthog` client remains supported. If you keep it in an asyncio app, run network-bound calls in a worker thread with `asyncio.to_thread()` instead of calling them on the event loop.
 
-```python
-import asyncio
-from posthog import Posthog
+### Payload format differs between Python APIs
 
-posthog_client = Posthog('phc_xxx', host='https://us.i.posthog.com')
-
-async def get_flags(distinct_id, properties=None):
-    return await asyncio.to_thread(
-        posthog_client.get_all_flags_and_payloads,
-        distinct_id,
-        person_properties=properties,
-    )
-```
-
-### Payload format differs between SDKs
-
-The Python SDK returns flag payloads as JSON strings — you need to parse them yourself:
+The legacy `Posthog.get_all_flags_and_payloads()` method returns payloads as JSON strings, so you need to parse them:
 
 ```python
 result = posthog_client.get_all_flags_and_payloads('user-123')
@@ -253,7 +239,7 @@ import json
 payload = json.loads(result['featureFlagPayloads']['my-flag'])
 ```
 
-The Node SDK automatically parses payloads into objects — no manual parsing needed.
+`Posthog.evaluate_flags()` and `await AsyncPosthog.evaluate_flags()` return snapshots. Their `get_flag_payload()` accessor returns the parsed payload, so don't pass its result to `json.loads()`.
 
 ## Solved community questions
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -27,6 +27,89 @@ import PythonInstall from '../../integrate/_snippets/install-python.mdx'
 
 <PythonInstall />
 
+## Use the asyncio client
+
+The Python SDK includes an asyncio-native client in version `7.45.0` and later. Continue to use `Posthog` in synchronous apps. For an asyncio app, install the optional async dependencies:
+
+```bash
+pip install "posthog[async]>=7.45.0"
+```
+
+Import `AsyncPosthog`, the customer-facing name for `AsyncClient`. Both names provide the same async context manager and lifecycle methods. Keep one client for the lifetime of your app. For example, use a FastAPI lifespan handler:
+
+```python
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from posthog import AsyncPosthog
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with AsyncPosthog(
+        os.environ["POSTHOG_PROJECT_TOKEN"],
+        host=os.environ["POSTHOG_HOST"],
+        secret_key=os.environ.get("POSTHOG_FEATURE_FLAGS_SECURE_API_KEY"),
+    ) as posthog:
+        app.state.posthog = posthog
+        yield
+
+app = FastAPI(lifespan=lifespan)
+```
+
+Exiting the context calls `shutdown()`. This flushes buffered events, waits for in-flight operations, stops the workers, and closes the HTTP transport. If you don't use the context manager, call `await posthog.shutdown()` during app shutdown. `await posthog.join()` has the same effect.
+
+### Capture events without blocking the event loop
+
+`capture()` queues an event and returns without waiting for a network request. Don't await it:
+
+```python
+posthog.capture(
+    "event_name",
+    distinct_id="user-distinct-id",
+    properties={"source": "fastapi"},
+)
+```
+
+Use `capture_immediate()` when your code must wait for that event's delivery attempt:
+
+```python
+capture_id = await posthog.capture_immediate(
+    "event_name",
+    distinct_id="user-distinct-id",
+)
+```
+
+### Evaluate feature flags
+
+Await `evaluate_flags()` once, then use its snapshot with synchronous in-memory accessors. Pass the same snapshot to `capture()` to attach the exact values used for branching without another feature flag request:
+
+```python
+flags = await posthog.evaluate_flags("user-distinct-id")
+
+if flags.is_enabled("new-checkout"):
+    # Show the new checkout
+    pass
+
+posthog.capture(
+    "checkout started",
+    distinct_id="user-distinct-id",
+    flags=flags,
+)
+```
+
+The snapshot provides synchronous `is_enabled()`, `get_flag()`, and `get_flag_payload()` accessors. The awaited `evaluate_flags()` call also accepts `groups`, `person_properties`, `group_properties`, `disable_geoip`, `flag_keys`, and `device_id` arguments.
+
+### Fetch remote config
+
+Initialize the client with a server-side [feature flags secure API key](/docs/feature-flags/remote-config#step-1-find-your-feature-flags-secure-api-key) as `secret_key`, then await the remote config request:
+
+```python
+config = await posthog.get_remote_config_payload("landing-page-config")
+```
+
+See [Remote config](/docs/feature-flags/remote-config) for setup and security details.
+
 ## Identifying users
 
 import IdentifyBackendCalloutPython from '../../_snippets/identify-backend-callout-python.mdx'
@@ -117,6 +200,8 @@ The `name` is a special property which is used in the PostHog UI for the name of
 
 ## Feature flags
 
+The examples in this section use the synchronous `Posthog` client. For `AsyncPosthog`, use the [awaited feature flag example](#evaluate-feature-flags). The returned snapshot uses the same accessors.
+
 import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
 
 <FeatureFlagsLibsIntro />
@@ -139,7 +224,7 @@ In multi-worker or edge environments, you can implement custom caching for flag 
 
 ## Experiments (A/B tests)
 
-Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code:
+Since [experiments](/docs/experiments/start-here) use feature flags, the code for running an experiment is very similar to the feature flags code. This example uses the synchronous `Posthog` client:
 
 ```python
 flags = posthog.evaluate_flags("user_distinct_id")
@@ -148,6 +233,8 @@ variant = flags.get_flag("experiment-feature-flag-key")
 if variant == "variant-name":
     # Do something
 ```
+
+With `AsyncPosthog`, await the evaluation: `flags = await posthog.evaluate_flags("user_distinct_id")`. The remaining snapshot access is the same.
 
 It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).
 
@@ -319,10 +406,16 @@ import SDKMigration from "../../migrate/_snippets/sdk-migration.mdx"
 
 ## Serverless environments (Render/Lambda/...)
 
-By default, the library buffers events before sending them to the capture endpoint, for better performance. This can lead to lost events in serverless environments, if the Python process is terminated by the platform before the buffer is fully flushed. To avoid this, you can either:
+### Synchronous `Posthog`
 
-- Ensure that `posthog.shutdown()` is called after processing every request by adding a middleware to your server. This allows `posthog.capture()` to remain asynchronous for better performance. `posthog.shutdown()` is blocking.
-- Enable the `sync_mode` option when initializing the client, so that all calls to `posthog.capture()` become synchronous.
+By default, the synchronous `Posthog` client buffers events before sending them to the capture endpoint. This can lead to lost events if the platform terminates the Python process before the buffer is fully flushed. To avoid this, you can either:
+
+- Call `posthog.shutdown()` before the process ends. This blocking call attempts to deliver queued events and cleans up the client.
+- Enable `sync_mode` when initializing the client so each `posthog.capture()` call attempts delivery before it returns.
+
+### Asyncio `AsyncPosthog`
+
+Keep one `AsyncPosthog` client for the lifetime of your application. Use buffered `capture()` by default, or `await capture_immediate()` when one invocation must wait for an event's delivery attempt. Call `await posthog.shutdown()` once during application cleanup. Don't shut down the client after each request.
 
 ## Django
 

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,18 +77,6 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
-**Inviting a product engineer into a customer conversation**
-
-Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
-
-- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
-- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
-- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
-
-**Why not just always invite one?**
-
-CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
-
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,6 +77,18 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
+**Inviting a product engineer into a customer conversation**
+
+Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
+
+- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
+- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
+- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
+
+**Why not just always invite one?**
+
+CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
+
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**


### PR DESCRIPTION
## Changes

Documents the asyncio-native Python client introduced in `posthog-python` 7.45.0.

- Explain how to install the optional `posthog[async]` dependencies and manage `AsyncPosthog` for an application's lifetime.
- Add FastAPI, buffered capture, immediate capture, feature flag, remote config, and shutdown examples.
- Distinguish synchronous and async feature flag and serverless usage.
- Replace the synchronous-only FastAPI troubleshooting advice and clarify payload parsing behavior.

## Validation

- Compiled the Python examples against the released API.
- Verified the documented behavior against `posthog-python` 7.45.0 source and tests.
- Ran focused formatting and `git diff --check`.
- Completed an independent documentation review with no remaining findings.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
