### PR TITLE
docs(elixir): document local flag evaluation

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-elixir.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-elixir.mdx
@@ -1,0 +1,40 @@
+## The interface
+
+The Elixir SDK accepts a `{module, state}` tuple. The module must implement `PostHog.FeatureFlags.FlagDefinitionCacheProvider`:
+
+```elixir
+defmodule MyApp.PostHogDefinitionCache do
+  @behaviour PostHog.FeatureFlags.FlagDefinitionCacheProvider
+
+  @impl true
+  def should_fetch_flag_definitions(state), do: state.fetch_owner?.()
+
+  @impl true
+  def get_flag_definitions(state), do: state.read.()
+
+  @impl true
+  def on_flag_definitions_received(state, definitions), do: state.write.(definitions)
+
+  @impl true
+  def shutdown(_state), do: :ok
+end
+```
+
+`get_flag_definitions/1` must return `nil` when the cache is empty or a map that contains `flags`, `group_type_mapping`, and `cohorts`. The map can use string or atom keys. Store the complete map passed to `on_flag_definitions_received/2` so other instances can read it without changing its shape.
+
+Use `should_fetch_flag_definitions/1` to coordinate which instance fetches definitions from PostHog. Return `true` from the instance that owns the distributed lock and `false` from instances that should read the shared cache.
+
+## Configure the provider
+
+Pass the provider module and its state in `flag_definition_cache_provider`:
+
+```elixir file=config/runtime.exs
+config :posthog,
+  api_host: "<ph_client_api_host>",
+  api_key: "<ph_project_token>",
+  secret_key: System.fetch_env!("POSTHOG_FEATURE_FLAGS_SECURE_API_KEY"),
+  flag_definition_cache_provider: {MyApp.PostHogDefinitionCache, provider_state},
+  flag_definition_cache_provider_timeout_ms: 5_000
+```
+
+The SDK limits each provider callback to `flag_definition_cache_provider_timeout_ms`, which defaults to 5,000 milliseconds. If the initial cache read fails or returns `nil`, the SDK fetches definitions from PostHog. After definitions load, a cache read failure keeps the current in-memory definitions. Provider write and shutdown failures don't stop flag evaluation.

--- a/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-intro.mdx
+++ b/contents/docs/feature-flags/local-evaluation/_snippets/distributed-environments-intro.mdx
@@ -8,7 +8,7 @@ This enables you to:
 - Coordinate fetching so only one worker polls at a time
 - Pre-cache definitions for ultra-low-latency flag evaluation
 
-> **Note:** External cache providers are currently available in the Node.js, Python, PHP, Ruby, and JVM (Java) SDKs.
+> **Note:** External cache providers are currently available in the Node.js, Python, PHP, Ruby, JVM (Java), and Elixir SDKs.
 
 ## When to use an external cache
 

--- a/contents/docs/feature-flags/local-evaluation/distributed-environments.mdx
+++ b/contents/docs/feature-flags/local-evaluation/distributed-environments.mdx
@@ -16,16 +16,18 @@ import LocalEvalDistributedEnvPythonContent from "./_snippets/distributed-enviro
 import LocalEvalDistributedEnvPhpContent from "./_snippets/distributed-environments-php.mdx"
 import LocalEvalDistributedEnvRubyContent from "./_snippets/distributed-environments-ruby.mdx"
 import LocalEvalDistributedEnvJvmContent from "./_snippets/distributed-environments-jvm.mdx"
+import LocalEvalDistributedEnvElixirContent from "./_snippets/distributed-environments-elixir.mdx"
 
 <LocalEvalDistributedEnvIntro />
 
-<Tab.Group tabs={['Node.js', 'Python', 'PHP', 'Ruby', 'JVM (Java)']}>
+<Tab.Group tabs={['Node.js', 'Python', 'PHP', 'Ruby', 'JVM (Java)', 'Elixir']}>
     <Tab.List>
         <Tab>Node.js</Tab>
         <Tab>Python</Tab>
         <Tab>PHP</Tab>
         <Tab>Ruby</Tab>
         <Tab>JVM (Java)</Tab>
+        <Tab>Elixir</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
@@ -42,6 +44,9 @@ import LocalEvalDistributedEnvJvmContent from "./_snippets/distributed-environme
         </Tab.Panel>
         <Tab.Panel>
             <LocalEvalDistributedEnvJvmContent />
+        </Tab.Panel>
+        <Tab.Panel>
+            <LocalEvalDistributedEnvElixirContent />
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>

--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-> **Note:** Local evaluation is only available in the [Node](/docs/libraries/node), [Ruby](/docs/libraries/ruby), [Go](/docs/libraries/go), [Python](/docs/libraries/python), [C#/.NET](/docs/libraries/dotnet), [PHP](/docs/libraries/php), [Java](/docs/libraries/java), and [Rust](/docs/libraries/rust) SDKs. It requires a [feature flags secure API key](#step-1-find-your-feature-flags-secure-api-key), which is secret and must **not** be used in the frontend or exposed to users.
+> **Note:** Local evaluation is only available in the [Node](/docs/libraries/node), [Ruby](/docs/libraries/ruby), [Go](/docs/libraries/go), [Python](/docs/libraries/python), [C#/.NET](/docs/libraries/dotnet), [PHP](/docs/libraries/php), [Java](/docs/libraries/java), [Rust](/docs/libraries/rust), and [Elixir](/docs/libraries/elixir) SDKs. It requires a [feature flags secure API key](#step-1-find-your-feature-flags-secure-api-key), which is secret and must **not** be used in the frontend or exposed to users.
 
 > **Building a frontend, mobile, or CLI app?** Don't use local evaluation or the secure API key on the client. Instead, evaluate flags with a [client-side SDK](/docs/libraries) or by calling the public [`/flags` endpoint](/docs/api/flags) with your [project API key](/docs/feature-flags/installation#where-to-find-your-project-api-key) — the project API key is public and safe to expose to users.
 
@@ -284,6 +284,27 @@ let flags = client.evaluate_flags(
 let flag = flags.get_flag("flag-key");
 ```
 
+```elixir
+{:ok, flags} =
+  PostHog.FeatureFlags.evaluate_flags(%{
+    distinct_id: "distinct_id_of_the_user",
+    # Include any person properties, groups, or group properties required to evaluate the flag
+    person_properties: %{property_name: "value"},
+    groups: %{
+      your_group_type: "your_group_id",
+      another_group_type: "another_group_id"
+    },
+    group_properties: %{
+      your_group_type: %{group_property_name: "value"},
+      another_group_type: %{group_property_name: "another value"}
+    },
+    # Optional. Defaults to false. Set to true to prevent remote fallback.
+    only_evaluate_locally: false
+  })
+
+flag_value = PostHog.FeatureFlags.Evaluations.get_flag(flags, "flag-key")
+```
+
 </MultiLanguage>
 
 ## Reloading flags
@@ -322,6 +343,12 @@ posthog.reloadFeatureFlags()
 // Manual reload is not currently supported.
 ```
 
+```elixir
+# The Elixir SDK automatically reloads flags in the background at the interval
+# specified by feature_flags_poll_interval_ms (default: 30_000).
+# Manual reload is not currently supported.
+```
+
 </MultiLanguage>
 
 ## Restriction on local evaluation
@@ -334,7 +361,7 @@ Local evaluation is not possible for flags that:
 2. Are linked to an [early access feature](/docs/feature-flags/early-access-feature-management)
 3. Depend on [static cohorts](/docs/data/cohorts#static-cohorts)
 4. Use the `is_not_set` property operator, since local evaluation can only check properties you provide — it can't determine whether a property is absent on a person.
-5. Have ["Stop evaluation at first matching condition set"](/docs/feature-flags/creating-feature-flags#stop-evaluation-at-first-matching-condition-set) (early exit) enabled. Local evaluation currently always evaluates all condition groups, even when this setting is enabled. This is a temporary limitation while support is rolled out across SDKs. For now, the setting only takes effect when flags are evaluated through the `/flags` endpoint.
+5. Have ["Stop evaluation at first matching condition set"](/docs/feature-flags/creating-feature-flags#stop-evaluation-at-first-matching-condition-set) (early exit) enabled. This restriction does not apply to v2.15.0 and above of our [Elixir](/docs/libraries/elixir) SDK, which honors early exit during local evaluation. Other SDKs currently evaluate all condition groups locally, even when this setting is enabled. This is a temporary limitation while support is rolled out across SDKs. For those SDKs, the setting only takes effect when flags are evaluated through the `/flags` endpoint.
 
 ### Dynamic cohort restrictions
 
@@ -348,4 +375,4 @@ However, there are a few constraints, and cohorts cannot be evaluated locally if
 2. They have non-person properties.
 3. There's more than one cohort in the feature flag definition.
 4. The cohort in the feature flag is in the same group as another condition.
-5. The cohort has nested AND-OR filters. Only simple cohorts that have a top level OR group, and inner level ANDs will be evaluated locally.
+5. The cohort has nested AND-OR filters. In affected SDKs, only simple cohorts that have a top level OR group, and inner level ANDs can be evaluated locally. This restriction does not apply to v2.15.0 and above of our [Elixir](/docs/libraries/elixir) SDK, which supports nested AND/OR groups and negation during local evaluation.

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -102,4 +102,12 @@ let options = ClientOptionsBuilder::default()
 let client = posthog_rs::client(options).await;
 ```
 
+```elixir file=config/runtime.exs
+config :posthog,
+  api_host: "<ph_client_api_host>",
+  api_key: "<ph_project_token>",
+  secret_key: System.fetch_env!("POSTHOG_FEATURE_FLAGS_SECURE_API_KEY"),
+  feature_flags_poll_interval_ms: 30_000
+```
+
 </MultiLanguage>

--- a/contents/docs/libraries/elixir/index.mdx
+++ b/contents/docs/libraries/elixir/index.mdx
@@ -74,6 +74,32 @@ import ElixirFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets
 
 <ElixirFeatureFlagsCode />
 
+### Local feature flag evaluation
+
+Local evaluation is available in version 2.15.0 and later. Follow the [server-side local evaluation guide](/docs/feature-flags/local-evaluation) to find your secure key and see how to pass the person properties, groups, and group properties that your flag conditions require.
+
+Store the secure key in a server-side environment variable. Don't expose it to client-side applications:
+
+```elixir file=config/runtime.exs
+config :posthog,
+  api_host: "<ph_client_api_host>",
+  api_key: "<ph_project_token>",
+  secret_key: System.fetch_env!("POSTHOG_FEATURE_FLAGS_SECURE_API_KEY")
+```
+
+When `secret_key` is set, the SDK fetches definitions when it starts and polls for updates every 30 seconds. `PostHog.FeatureFlags.evaluate_flags/1` evaluates each flag locally first. If a flag can't be evaluated locally, the SDK makes one `/flags` request to resolve the remaining flags. Set `only_evaluate_locally: true` in the evaluation map to prevent this remote fallback. The SDK then omits unresolved flags from the snapshot.
+
+Use these configuration options to control local evaluation:
+
+| Option | Default | Purpose |
+| :----- | :------ | :------ |
+| `enable_local_evaluation` | `true` | Starts local evaluation when `secret_key` is set. |
+| `feature_flags_poll_interval_ms` | `30_000` | Sets the interval between definition refreshes. |
+| `flag_definition_request_timeout_ms` | `10_000` | Sets the timeout for each definition request. |
+| `flag_definition_cache_provider_timeout_ms` | `5_000` | Sets the timeout for each shared cache provider callback. |
+
+For multiple server instances, you can implement `PostHog.FeatureFlags.FlagDefinitionCacheProvider` and set `flag_definition_cache_provider: {module, state}`. This optional provider shares definitions and coordinates which instance polls PostHog. See [local evaluation in distributed environments](/docs/feature-flags/local-evaluation/distributed-environments?tab=Elixir) for the callback contract and configuration.
+
 ## Error tracking
 
 Error tracking is enabled by default. It will automatically captures exceptions thrown by the application.

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,18 +77,6 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
-**Inviting a product engineer into a customer conversation**
-
-Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
-
-- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
-- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
-- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
-
-**Why not just always invite one?**
-
-CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
-
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,6 +77,18 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
+**Inviting a product engineer into a customer conversation**
+
+Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
+
+- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
+- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
+- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
+
+**Why not just always invite one?**
+
+CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
+
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**


### PR DESCRIPTION
## Changes

Documents local feature flag evaluation in the Elixir SDK 2.15.0.

- Add secure key configuration, local-first evaluation, remote fallback, polling, and timeout guidance to the Elixir SDK page.
- Add Elixir examples and capability notes to the shared local evaluation guide.
- Document the optional distributed flag definition cache provider and add an Elixir tab to the distributed environments guide.
- Clarify the early-exit and nested cohort behavior supported by Elixir 2.15.0.

## Validation

- Verified the APIs and defaults against the Elixir 2.15.0 source and release tag.
- Ran the focused Elixir evaluator tests, Markdown lint, MDX compilation, and `git diff --check`.
- Completed an independent documentation review with no remaining findings.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
