### PR TITLE
docs(browser): document configurable request paths

### DIFF
--- a/contents/docs/advanced/proxy/proxy-reference.mdx
+++ b/contents/docs/advanced/proxy/proxy-reference.mdx
@@ -49,6 +49,12 @@ posthog.init('<ph_project_token>', {
 
 Without `ui_host`, the toolbar and session recordings player won't work correctly.
 
+#### Configure custom request paths
+
+The JavaScript Web SDK can expose custom paths with `rewriteRequestPath`. Keep `api_host` and `ui_host` configured as shown above. The path option does not replace either host option.
+
+Your proxy routes must match every rewritten path and restore the standard PostHog path. Preserve query parameters when you forward requests. Route rewritten `/array/*` and `/static/*` paths to the regional asset host. Route rewritten API and Feature Flags paths to the regional ingestion host. See [customize reverse proxy request paths](/docs/libraries/js/config#customize-reverse-proxy-request-paths) for an SDK example.
+
 ## Troubleshooting
 
 ### 401 Unauthorized

--- a/contents/docs/libraries/js/config.mdx
+++ b/contents/docs/libraries/js/config.mdx
@@ -62,6 +62,7 @@ Some of the most relevant options are:
 | `strict_script_versioning`<br/><br/>**Type:** Boolean<br/>**Default:** `false`                                                                                                            | Loads external dependency scripts from versioned asset paths, such as `/static/1.370.0/recorder.js`, instead of legacy query-string URLs like `/static/recorder.js?v=1.370.0`. Recommended whenever your setup can serve versioned `/static/*` asset paths, so feature scripts load from the same SDK version as `array.js`.                                                                  |
 | `asset_host`<br/><br/>**Type:** String or null<br/>**Default:** `null`                                                                                                                    | Optional host override for static assets loaded by PostHog, such as `recorder.js`, `surveys.js`, or `toolbar.js`. Only applies to `/static/*` assets.                                                                                         |
 | `flags_api_host`<br/><br/>**Type:** String<br/>**Default:** `null`                                                                                                                        | A separate reverse proxy host for feature flag requests. If set, all feature flag evaluation requests will use this host instead of `api_host`. This requires setting up your own [reverse proxy](/docs/advanced/proxy) and creates a logical separation between feature flags and analytics, which can help prevent feature flags from being blocked by ad blockers. See [preventing feature flags from being blocked](/tutorials/flags-adblock-prevention) for more details. |
+| [`rewriteRequestPath`](#customize-reverse-proxy-request-paths)<br/><br/>**Type:** `(url: URL) => URL`<br/>**Default:** `undefined` | Rewrites fully resolved PostHog API, Feature Flags, remote config, and asset request URLs. Use it when your reverse proxy exposes custom paths. UI links are not rewritten. |
 | [`tracing_headers`](#tracing-headers)<br/><br/>**Type:** Array of strings<br/>**Default:** `undefined`                                                                                                        | Hostnames for which PostHog should add tracing headers to `fetch` and `XMLHttpRequest` calls. Use hostnames only (for example, `api.example.com` or `localhost`), not full URLs. Matching requests include `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID`, which lets backend events, logs, errors, and LLM traces link back to frontend sessions and replays. Deprecated aliases: `addTracingHeaders` and `__add_tracing_headers`. |
 | `loaded`<br/><br/>**Type:** Function<br/>**Default:** `function () {}`                                                                                                                    | A function to be called once the PostHog scripts have loaded successfully.                                                                                                                                                                                                                                     |
 | `mask_all_text`<br/><br/>**Type:** Boolean<br/>**Default:** `false`                                                                                                                       | Prevent PostHog autocapture from capturing any text from your elements.                                                                                                                                                                                                                                        |
@@ -85,6 +86,55 @@ Some of the most relevant options are:
 | `surveys`<br/><br/>**Type:** Object<br/>**Default:** `undefined` | [Survey](/docs/surveys)-specific configuration: `prefillFromUrl` (prefill responses from URL parameters), `autoSubmitIfComplete`, and `autoSubmitDelay`. |
 | `xhr_headers`<br/><br/>**Type:** Object<br/>**Default:** `{}` | Any additional headers you wish to pass with the XHR requests to the PostHog API. |
 | `rageclick`<br/><br/>**Type:** Boolean or RageclickConfig<br/>**Default:** `true` | Determines if PostHog should automatically capture rage click events when users rapidly click on non-responsive elements. When `defaults: '2025-11-30'` or later is set, `content_ignorelist` is enabled by default to ignore elements with navigation-related text. [See below for `RageclickConfig`](#configuring-rageclick). |
+
+## Customize reverse proxy request paths
+
+Use `rewriteRequestPath` when your reverse proxy exposes different paths from the standard PostHog paths. This option requires `posthog-js` version `1.416.0` or later.
+
+The function receives a fully resolved `URL` after the SDK selects `api_host`, `flags_api_host`, or the asset host. If a host setting includes a path, such as `api_host: '/ingest'`, `url.pathname` includes that prefix. Mutate this object or return a new `URL`.
+
+```js
+const pathRewrites = [
+  ['/i/v0/e/', '/a1/'],
+  ['/e/', '/a2/'],
+  ['/s/', '/a3/'],
+  ['/flags/', '/a4/'],
+  ['/array/', '/a5/'],
+  ['/static/', '/a6/'],
+]
+
+posthog.init('<ph_project_token>', {
+  api_host: 'https://e.yourdomain.com',
+  ui_host: 'https://us.posthog.com', // Use https://eu.posthog.com for EU projects.
+  rewriteRequestPath: (url) => {
+    const rewrite = pathRewrites.find(([posthogPath]) => url.pathname.startsWith(posthogPath))
+
+    if (rewrite) {
+      const [posthogPath, proxyPath] = rewrite
+      url.pathname = proxyPath + url.pathname.slice(posthogPath.length)
+    }
+
+    return url
+  },
+})
+```
+
+This example rewrites event API, Session Replay ingestion, Feature Flags, remote config, and static asset paths. Other PostHog API paths keep their standard path on `api_host`. Because the function changes only `url.pathname`, each URL keeps its resolved origin and query parameters.
+
+Configure your proxy to reverse every mapping:
+
+| Browser path | PostHog path | PostHog upstream |
+| --- | --- | --- |
+| `/a1/*` | `/i/v0/e/*` | API host |
+| `/a2/*` | `/e/*` | API host |
+| `/a3/*` | `/s/*` | API host |
+| `/a4/*` | `/flags/*` | API host |
+| `/a5/*` | `/array/*` | Asset host |
+| `/a6/*` | `/static/*` | Asset host |
+
+The proxy routes must preserve query parameters and match every path that the function returns. See the [self-hosted proxy reference](/docs/advanced/proxy/proxy-reference) for upstream hosts and other requirements.
+
+`rewriteRequestPath` does not replace `api_host`, `flags_api_host`, `asset_host`, or `ui_host`. The SDK does not apply it to PostHog UI links.
 
 ## HTML snippet and script versioning
 

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,18 +77,6 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
-**Inviting a product engineer into a customer conversation**
-
-Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
-
-- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
-- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
-- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
-
-**Why not just always invite one?**
-
-CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
-
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,6 +77,18 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
+**Inviting a product engineer into a customer conversation**
+
+Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
+
+- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
+- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
+- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
+
+**Why not just always invite one?**
+
+CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
+
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**


### PR DESCRIPTION
## Changes

Documents the browser SDK's `rewriteRequestPath` option for custom reverse proxy paths.

- Add the option type, minimum SDK version, and URL behavior to the JavaScript configuration reference.
- Provide an example for analytics, replay, feature flag, remote config, and asset paths.
- Explain the matching reverse proxy routes and how they interact with `api_host`, `ui_host`, and regional upstreams.

## Validation

- Verified the example against the browser request router implementation and tests.
- Executed assertions for each documented mapping and query parameter preservation.
- Ran focused formatting and `git diff --check`.
- Completed an independent documentation review with no findings.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
