### PR TITLE
docs(next): document route template pageviews

### DIFF
--- a/contents/docs/libraries/next-js/_snippets/posthog-next-app-provider.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-app-provider.mdx
@@ -8,7 +8,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <html lang="en">
             <body>
                 <PostHogProvider clientOptions={{ api_host: '/ingest' }} bootstrapFlags>
-                    <PostHogPageView />
+                    <PostHogPageView captureRouteTemplate />
                     {children}
                 </PostHogProvider>
             </body>

--- a/contents/docs/libraries/next-js/_snippets/posthog-next-pages-provider.mdx
+++ b/contents/docs/libraries/next-js/_snippets/posthog-next-pages-provider.mdx
@@ -10,7 +10,7 @@ export default function App({ Component, pageProps }: AppProps) {
             apiKey={process.env.NEXT_PUBLIC_POSTHOG_KEY!}
             clientOptions={{ api_host: '/ingest' }}
         >
-            <PostHogPageView />
+            <PostHogPageView captureRouteTemplate />
             <Component {...pageProps} />
         </PostHogProvider>
     )

--- a/contents/docs/libraries/next-js/posthog-next.mdx
+++ b/contents/docs/libraries/next-js/posthog-next.mdx
@@ -169,6 +169,16 @@ Setting `proxy: true` routes PostHog API calls through your domain at `/ingest`,
     </Tab.Panels>
 </Tab.Group>
 
+### Capture route templates
+
+Pass `captureRouteTemplate` to `PostHogPageView` to add the normalized Next.js route template to each `$pageview` event as `$route`. For example, a visit to `/posts/123` keeps its concrete `$current_url` and `$pathname` values, and adds `$route: '/posts/[id]'`.
+
+Dynamic segments use `[param]`. Catch-all segments and populated optional catch-all segments use the normalized `[...param]` form. For an empty optional catch-all, the Pages Router normalizes `[[...param]]` to `[...param]`, while the App Router uses the concrete base pathname.
+
+The Pages Router reads the route template from `router.pathname`. The App Router uses `useParams()` to infer the template from the current pathname, so this inference is best effort. If a parameter value matches more than one path segment, PostHog captures the pageview without `$route` because the match is ambiguous.
+
+App Router route-template capture requires Next.js 13.3 or later. On earlier versions, PostHog captures the pageview without `$route`. This requirement does not apply to the Pages Router.
+
 </Step>
 
 <Step checkpoint title="Verify events are captured" subtitle="Confirm that you can see events in your PostHog project">

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,18 +77,6 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
-**Inviting a product engineer into a customer conversation**
-
-Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
-
-- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
-- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
-- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
-
-**Why not just always invite one?**
-
-CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
-
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,6 +77,18 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
+**Inviting a product engineer into a customer conversation**
+
+Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
+
+- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
+- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
+- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
+
+**Why not just always invite one?**
+
+CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
+
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**


### PR DESCRIPTION
## Changes

Documents opt-in route template capture for `@posthog/next` pageviews.

- Enable `captureRouteTemplate` in the App Router and Pages Router provider examples.
- Explain the `$route` property while preserving concrete URL and pathname properties.
- Document dynamic segments, catch-all routes, ambiguity handling, router differences, and the App Router Next.js 13.3 requirement.

> [!IMPORTANT]
> This documentation must not be deployed before the pending `@posthog/next` route-template changeset is released. The current published package does not contain this API yet.

## Validation

- Verified the behavior against both router implementations and their existing tests.
- Ran Prettier, Markdown lint, MDX compilation, and `git diff --check`.
- Completed an independent content review with no findings. The unpublished SDK release remains the only deployment gate.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
