### PR TITLE
docs(react-native): document full SwiftPM integration

### DIFF
--- a/contents/docs/error-tracking/installation/react-native.mdx
+++ b/contents/docs/error-tracking/installation/react-native.mdx
@@ -16,6 +16,6 @@ import { ErrorTrackingReactNativeInstallationWrapper } from './_snippets/et-inst
 
 ## iOS dependency resolution for native crash capture
 
-The `@posthog/react-native-plugin` package supports CocoaPods, the hybrid CocoaPods and Swift Package Manager path, and React Native's full Swift Package Manager integration. PostHog verifies the full path with an iOS-only React Native 0.87.0 app and React Native Community CLI 20.2.0. This path requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target.
+The `@posthog/react-native-plugin` package supports CocoaPods, the hybrid CocoaPods and Swift Package Manager path, and React Native's full Swift Package Manager integration. PostHog verifies the full path with an iOS-only React Native 0.87.1 app and React Native Community CLI 20.2.0. This path requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target.
 
 See [iOS dependency paths for the React Native native plugin](/docs/libraries/react-native#choose-an-ios-dependency-path-for-the-native-plugin) for the requirements and setup steps. This verification does not cover Expo or other React Native versions. Use CocoaPods or the hybrid path unless you validate full Swift Package Manager for your configuration.

--- a/contents/docs/error-tracking/installation/react-native.mdx
+++ b/contents/docs/error-tracking/installation/react-native.mdx
@@ -13,3 +13,9 @@ See the docs runbook for more info: https://posthog.com/handbook/wizard-and-docs
 import { ErrorTrackingReactNativeInstallationWrapper } from './_snippets/et-installation-wrapper.tsx'
 
 <ErrorTrackingReactNativeInstallationWrapper />
+
+## iOS dependency resolution for native crash capture
+
+The `@posthog/react-native-plugin` package supports CocoaPods, the hybrid CocoaPods and Swift Package Manager path, and React Native's full Swift Package Manager integration. PostHog verifies the full path with an iOS-only React Native 0.87.0 app and React Native Community CLI 20.2.0. This path requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target.
+
+See [iOS dependency paths for the React Native native plugin](/docs/libraries/react-native#choose-an-ios-dependency-path-for-the-native-plugin) for the requirements and setup steps. This verification does not cover Expo or other React Native versions. Use CocoaPods or the hybrid path unless you validate full Swift Package Manager for your configuration.

--- a/contents/docs/error-tracking/upload-source-maps/react-native.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/react-native.mdx
@@ -291,7 +291,7 @@ If you aren't using the Expo config plugin, wire up the uploads manually.
 
 #### iOS
 
-In Xcode, add a **Run Script** build phase to your main app target and place it **last** (so it runs after the dSYM bundle is produced). The `upload-symbols.sh` script ships inside the `PostHog` pod, which is pulled in transitively by `@posthog/react-native-plugin`.
+In Xcode, add a **Run Script** build phase to your main app target and place it **last** so it runs after the dSYM bundle is produced. The `upload-symbols.sh` script ships with the transitive `posthog-ios` dependency. Use the script path that matches your [iOS dependency path](/docs/libraries/react-native#choose-an-ios-dependency-path-for-the-native-plugin).
 
 <MultiLanguage>
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -36,7 +36,7 @@ The optional `@posthog/react-native-plugin` package adds native features such as
 | --- | --- | --- |
 | CocoaPods | A React Native project that uses CocoaPods | CocoaPods resolves the plugin and `posthog-ios`. This remains the default path. |
 | CocoaPods with `posthog-ios` through Swift Package Manager | React Native 0.75 or later and a CocoaPods project with dynamic frameworks | CocoaPods resolves the plugin. Swift Package Manager resolves `posthog-ios`. |
-| Full Swift Package Manager | Verified with an iOS-only React Native 0.87.0 app and React Native Community CLI 20.2.0.<br/><br/>Requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target. | React Native's experimental Swift Package Manager integration resolves the plugin and `posthog-ios`. This path does not use CocoaPods. |
+| Full Swift Package Manager | Verified with an iOS-only React Native 0.87.1 app and React Native Community CLI 20.2.0.<br/><br/>Requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target. | React Native's experimental Swift Package Manager integration resolves the plugin and `posthog-ios`. This path does not use CocoaPods. |
 
 This verification does not cover Expo or other React Native versions. Use CocoaPods or the hybrid path unless you validate the full Swift Package Manager path for your configuration.
 
@@ -88,30 +88,7 @@ npx react-native spm add --deintegrate --yes
 
 The `--deintegrate` option removes the complete CocoaPods integration from the iOS project. React Native then finds the plugin's `ios/Package.swift` manifest. Swift Package Manager resolves the plugin and `posthog-ios`. Do not run `pod install` for this path.
 
-##### React Native 0.87.0 Hermes workaround
-
-React Native 0.87.0's Swift Package Manager tooling can select a Hermes compiler with an incompatible bytecode version. Use the following exact development dependency until React Native ships matching runtime and compiler versions. Install your JavaScript dependencies again after this change:
-
-```json
-{
-  "devDependencies": {
-    "hermes-compiler": "260318099.0.1"
-  }
-}
-```
-
-After the conversion, set the generated project's `HERMES_CLI_PATH` to the pinned compiler. Run this command from the `ios` directory. Replace `YourProjectName` with the Xcode project name:
-
-```bash
-PROJECT_NAME="YourProjectName"
-hermesc="$PWD/../node_modules/hermes-compiler/hermesc/osx-bin/hermesc"
-sed -i '' -E "s#HERMES_CLI_PATH = .*;#HERMES_CLI_PATH = \"$hermesc\";#" \
-  "$PROJECT_NAME.xcodeproj/project.pbxproj"
-```
-
-This command writes a checkout-specific absolute path. Do not commit the generated `HERMES_CLI_PATH` override. Run the command in every checkout and CI job before the Xcode build.
-
-PostHog CI verifies this path with the configuration in the requirements table. It applies the Hermes workaround before Debug and Release builds. The verified app sets its deployment target to iOS 15.1. The plugin package manifest has a separate iOS 15 minimum. The CocoaPods and hybrid paths keep the plugin podspec's iOS 13 minimum.
+PostHog CI verifies this path with the configuration in the requirements table. The verified app sets its deployment target to iOS 15.1. The plugin package manifest has a separate iOS 15 minimum. The CocoaPods and hybrid paths keep the plugin podspec's iOS 13 minimum.
 
 <DetailSetUpReverseProxy />
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -28,6 +28,91 @@ import ReactNativeInstall from '../../integrate/_snippets/install-react-native.m
 
 <ReactNativeInstall />
 
+### Choose an iOS dependency path for the native plugin
+
+The optional `@posthog/react-native-plugin` package adds native features such as session replay and native crash capture. Install it as described in the guide for the feature that you use. Then choose one iOS dependency path:
+
+| Path | Requirements | What it resolves |
+| --- | --- | --- |
+| CocoaPods | A React Native project that uses CocoaPods | CocoaPods resolves the plugin and `posthog-ios`. This remains the default path. |
+| CocoaPods with `posthog-ios` through Swift Package Manager | React Native 0.75 or later and a CocoaPods project with dynamic frameworks | CocoaPods resolves the plugin. Swift Package Manager resolves `posthog-ios`. |
+| Full Swift Package Manager | Verified with an iOS-only React Native 0.87.0 app and React Native Community CLI 20.2.0.<br/><br/>Requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target. | React Native's experimental Swift Package Manager integration resolves the plugin and `posthog-ios`. This path does not use CocoaPods. |
+
+This verification does not cover Expo or other React Native versions. Use CocoaPods or the hybrid path unless you validate the full Swift Package Manager path for your configuration.
+
+#### CocoaPods
+
+Use the standard React Native CocoaPods flow:
+
+```bash
+cd ios
+pod install
+```
+
+The plugin podspec adds `posthog-ios` as a CocoaPods dependency. You do not need to add `posthog-ios` separately.
+
+#### CocoaPods with `posthog-ios` through Swift Package Manager
+
+Add the following property to `ios/Podfile.properties.json`:
+
+```json
+{
+  "posthog.useSpm": "true"
+}
+```
+
+Add dynamic frameworks to your `ios/Podfile`:
+
+```ruby
+use_frameworks! :linkage => :dynamic
+```
+
+Then install the pods:
+
+```bash
+cd ios
+pod install
+```
+
+This setting changes only how the plugin resolves `posthog-ios`. The plugin and other React Native dependencies still use CocoaPods.
+
+#### Full Swift Package Manager
+
+This path uses React Native's experimental CocoaPods-free iOS integration. Every native dependency in your app must support React Native's full Swift Package Manager integration. Use CocoaPods or the hybrid path if a dependency does not support it.
+
+Install your JavaScript dependencies first. Make a clean commit or a backup of your iOS project before the conversion. Then run this command from the `ios` directory:
+
+```bash
+npx react-native spm add --deintegrate --yes
+```
+
+The `--deintegrate` option removes the complete CocoaPods integration from the iOS project. React Native then finds the plugin's `ios/Package.swift` manifest. Swift Package Manager resolves the plugin and `posthog-ios`. Do not run `pod install` for this path.
+
+##### React Native 0.87.0 Hermes workaround
+
+React Native 0.87.0's Swift Package Manager tooling can select a Hermes compiler with an incompatible bytecode version. Use the following exact development dependency until React Native ships matching runtime and compiler versions. Install your JavaScript dependencies again after this change:
+
+```json
+{
+  "devDependencies": {
+    "hermes-compiler": "260318099.0.1"
+  }
+}
+```
+
+After the conversion, set the generated project's `HERMES_CLI_PATH` to the pinned compiler. Run this command from the `ios` directory. Replace `YourProjectName` with the Xcode project name:
+
+```bash
+PROJECT_NAME="YourProjectName"
+hermesc="$PWD/../node_modules/hermes-compiler/hermesc/osx-bin/hermesc"
+sed -i '' -E "s#HERMES_CLI_PATH = .*;#HERMES_CLI_PATH = \"$hermesc\";#" \
+  "$PROJECT_NAME.xcodeproj/project.pbxproj"
+```
+
+This command writes a checkout-specific absolute path. Do not commit the generated `HERMES_CLI_PATH` override. Run the command in every checkout and CI job before the Xcode build.
+
+PostHog CI verifies this path with the configuration in the requirements table. It applies the Hermes workaround before Debug and Release builds. The verified app sets its deployment target to iOS 15.1. The plugin package manifest has a separate iOS 15 minimum. The CocoaPods and hybrid paths keep the plugin podspec's iOS 13 minimum.
+
 <DetailSetUpReverseProxy />
 
 <DetailGroupProductsInOneProject />

--- a/contents/docs/session-replay/installation/react-native.mdx
+++ b/contents/docs/session-replay/installation/react-native.mdx
@@ -20,7 +20,7 @@ The native plugin supports three additive iOS dependency paths:
 
 - CocoaPods for the plugin and `posthog-ios`. This remains the default path.
 - CocoaPods for the plugin, with `posthog-ios` resolved through Swift Package Manager.
-- React Native's experimental full Swift Package Manager integration, with no CocoaPods. PostHog verifies an iOS-only React Native 0.87.0 app with React Native Community CLI 20.2.0. This path requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target.
+- React Native's experimental full Swift Package Manager integration, with no CocoaPods. PostHog verifies an iOS-only React Native 0.87.1 app with React Native Community CLI 20.2.0. This path requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target.
 
 See [iOS dependency paths for the React Native native plugin](/docs/libraries/react-native#choose-an-ios-dependency-path-for-the-native-plugin) for the requirements and setup steps. This verification does not cover Expo or other React Native versions. Use CocoaPods or the hybrid path unless you validate full Swift Package Manager for your configuration.
 

--- a/contents/docs/session-replay/installation/react-native.mdx
+++ b/contents/docs/session-replay/installation/react-native.mdx
@@ -16,17 +16,13 @@ import { SRReactNativeInstallationWrapper } from './_snippets/sr-installation-wr
 
 ## iOS dependency resolution
 
-By default, the optional React Native native plugin resolves `posthog-ios` through CocoaPods.
+The native plugin supports three additive iOS dependency paths:
 
-If your iOS project uses Swift Package Manager for native dependencies, you can opt in to resolving `posthog-ios` through SPM instead. Add the following to `ios/Podfile.properties.json`:
+- CocoaPods for the plugin and `posthog-ios`. This remains the default path.
+- CocoaPods for the plugin, with `posthog-ios` resolved through Swift Package Manager.
+- React Native's experimental full Swift Package Manager integration, with no CocoaPods. PostHog verifies an iOS-only React Native 0.87.0 app with React Native Community CLI 20.2.0. This path requires `@posthog/react-native-plugin` 2.4.0 or later, Xcode 16 or later, and an iOS 15.1 or later app deployment target.
 
-```json
-{
-  "posthog.useSpm": "true"
-}
-```
-
-This path requires `use_frameworks! :linkage => :dynamic` in your `ios/Podfile`. Without `posthog.useSpm`, the default CocoaPods resolution path is unchanged.
+See [iOS dependency paths for the React Native native plugin](/docs/libraries/react-native#choose-an-ios-dependency-path-for-the-native-plugin) for the requirements and setup steps. This verification does not cover Expo or other React Native versions. Use CocoaPods or the hybrid path unless you validate full Swift Package Manager for your configuration.
 
 ## Troubleshooting
 

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,18 +77,6 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
-**Inviting a product engineer into a customer conversation**
-
-Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
-
-- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
-- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
-- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
-
-**Why not just always invite one?**
-
-CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
-
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**

--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -77,6 +77,18 @@ Sometimes an existing or potential customer may ask us to fix an issue or build 
 - We already have [principles](/handbook/how-we-make-money#principles-for-dealing-with-big-customers) for how we build for big customers - if you have a big customer with a niche use case that isn't applicable to anyone else, you should assume we won't build for them (don't be mad!)
 - For any [feature requests](/handbook/cs-and-onboarding/feature-requests) customers care deeply about, we should file and track those in Vitally.
 
+**Inviting a product engineer into a customer conversation**
+
+Separately from product requests, there are moments where it's worth seeing whether a product engineer wants to join a customer conversation - as much for what _they_ get out of it as the customer. Always pitch this as an open invitation ("this might be an interesting call, would anyone like to join?"), never as "we need an engineer on this call." Situations where it's usually worth asking:
+
+- **A customer is moving to or from another tool.** If someone's weighing PostHog feature flags against LaunchDarkly, or shifting their error tracking to Sentry - in either direction - the relevant product engineer often wants in. It's a first-hand look at why a customer picks one platform over another and the trade-offs they weigh, which is useful to us whichever way they're moving.
+- **The customer's on early-access or giving feedback.** For anything in alpha, beta, or just shipped - or a not-yet-GA product they're already using and forming opinions on - engineers get a lot from hearing live first impressions, and the customer gets direct access to the people building it. A customer actively feeding back on pre-release features is exactly the kind of call worth pulling the team into.
+- **You're meeting the customer in person.** An on-site visit is a great chance to bring along a product engineer who's local, if there's one whose area matches what the customer uses (e.g. someone from the experiments team for a heavy experiments customer). This doesn't need to fit the two cases above - a good match nearby is reason enough. Have an agenda, and keep it to topics relevant to whoever's joining.
+
+**Why not just always invite one?**
+
+CSMs here are technical enough to solve real problems without asking our engineers. [You're the expert!](/handbook/cs-and-onboarding/customer-success) Bringing an engineer in is the exception, earned by genuine two-way value (one of the cases above), not a default or a comfort blanket. If you can't say what the engineer would get out of it, that's your answer.
+
 Finally, if you are bringing engineers onto a call, brief them first - what is the call about, who will be there. And then afterwards, summarize what you talked about. This goes a long way to ensuring sales <\> engineering happiness.
 
 **Complicated technical questions**


### PR DESCRIPTION
## Changes

Adds an additive setup guide for the React Native native plugin's full Swift Package Manager integration.

- Keep the existing CocoaPods and hybrid CocoaPods with SwiftPM paths available.
- Document the verified iOS-only React Native 0.87.1 and Community CLI 20.2.0 setup.
- Add the plugin, Xcode, and deployment target requirements.
- Explain that full conversion removes the complete CocoaPods integration and requires every native dependency to support React Native full SwiftPM.
- Clarify that Expo and other React Native configurations are not covered by the current verification.
- Link session replay, native error tracking, and symbol upload guidance to the shared dependency path section.

The React Native 0.87.1 fixture update is in [PostHog/posthog-js#4714](https://github.com/PostHog/posthog-js/pull/4714). React Native 0.87.1 resolves matching Hermes compiler and runtime versions, so these instructions do not include the workaround required by 0.87.0.

## Validation

- Verified the instructions against the plugin manifest, podspec, React Native fixture, and native CI workflow.
- Installed the fixture with React Native 0.87.1 and converted it to full Swift Package Manager without a Hermes override.
- Built Debug and Release for the iOS Simulator, verified the native plugin symbol, and launched the Release app successfully.
- Ran focused formatting, source-to-document assertions, `actionlint`, and `git diff --check`.
- Completed an independent compatibility review with no remaining findings.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`
