### PR TITLE
Add PostHog Slack app to startup credit AI exclusions

### DIFF
--- a/contents/handbook/marketing/startups.md
+++ b/contents/handbook/marketing/startups.md
@@ -13,7 +13,7 @@ We run two special programs for early-stage teams, plus external partnerships wi
 | Eligibility                 | <2 years old, <$5M raised, not acquired, company email domain | Must be in YC, <$25m raised, company email domain     |
 | Credit                      | $50,000 for 12 months                                 | $50k per year, whilst eligible                        |
 | Can use credit for add-ons? | ⚠️ Yes, but cannot use credit for BAA in Boost package | ✅ Yes, and can use credit for BAA in Boost package    |
-| Can use credit for AI tools? | ❌ No, from September 14, 2026 (PostHog Desktop, Replay Vision, PostHog AI, Inbox) | ❌ No, from September 14, 2026 (PostHog Desktop, Replay Vision, PostHog AI, Inbox) |
+| Can use credit for AI tools? | ❌ No, from September 14, 2026 (PostHog Desktop, PostHog Slack app, Replay Vision, PostHog AI, Inbox) | ❌ No, from September 14, 2026 (PostHog Desktop, PostHog Slack app, Replay Vision, PostHog AI, Inbox) |
 | Founder merch               | Welcome pack (max 1)                                  | Different welcome pack (max 4)                        |
 | Community                   | —                                                     | Tim's Whatsapp, priority support                      |
 | Apply via…                  | [Startup page](/startups)                             | [Secret YC page](https://app.posthog.com/startups/yc) |
@@ -29,7 +29,7 @@ Any company that is <2 years old and has raised less than $5M in funding is elig
 
 > ❗Credits **cannot** be used toward a BAA under the Boost plan.
 
-> ❗From September 14, 2026, credits **cannot** be used toward AI tools such as PostHog Desktop, Replay Vision, PostHog AI, and Inbox, due to the prohibitive and unpredictable nature of token-based pricing. Teams that joined before that date can still pay for usage incurred before the cut-off with credits.
+> ❗From September 14, 2026, credits **cannot** be used toward AI tools such as PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and Inbox, due to the prohibitive and unpredictable nature of token-based pricing. Teams that joined before that date can still pay for usage incurred before the cut-off with credits.
 
 > ⭐ **Small open source projects** without corporate backing and less than $200k annual revenue can contact support to have the 12-month credit expiry waived.
 
@@ -73,7 +73,7 @@ Subscribers with [Lenny's Newsletter](https://www.lennysnewsletter.com/) Product
 -   The Scale add-on for free
 -   Valid for one year
 
-Product exclusions are the same as for the PostHog for Startups plan, including PostHog Desktop, Inbox, and Replay Vision. See [posthog.com/startups](/startups) for more detail.
+Product exclusions are the same as for the PostHog for Startups plan, including PostHog Desktop, the PostHog Slack app, Inbox, and Replay Vision. See [posthog.com/startups](/startups) for more detail.
 
 ### Every.to
 
@@ -128,7 +128,7 @@ Credits can be used for most PostHog tools and add-ons, including [platform pack
 
 -   **Startups**: ❌ Cannot use credits toward a BAA due to legal risk.
 -   **YC teams**: ✅ Can use credits for a BAA under the Boost plan.
--   **AI tools**: ❌ From September 14, 2026, credits cannot be used toward AI tools such as PostHog Desktop, Replay Vision, PostHog AI, and Inbox, due to the prohibitive and unpredictable nature of token-based pricing. Usage incurred before the cut-off can still be paid with credits.
+-   **AI tools**: ❌ From September 14, 2026, credits cannot be used toward AI tools such as PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and Inbox, due to the prohibitive and unpredictable nature of token-based pricing. Usage incurred before the cut-off can still be paid with credits.
 
 Credits are valid are not transferable, and don’t carry over or convert to cash. They are valid for 12 months and that timer begins at application. Once expired or fully used, teams are moved to standard billing.
 

--- a/src/components/Startups/StartupProgram.tsx
+++ b/src/components/Startups/StartupProgram.tsx
@@ -245,9 +245,9 @@ const faqItems = [
         content: (
             <p>
                 Almost all of them. From September 14, 2026, startup credits can no longer be used towards bills
-                incurred on AI tools such as PostHog Desktop, Replay Vision, PostHog AI, and Inbox. This is due to the
-                prohibitive and unpredictable nature of token-based pricing. Credits still cover everything else,
-                including AI observability and the context warehouse.
+                incurred on AI tools such as PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and
+                Inbox. This is due to the prohibitive and unpredictable nature of token-based pricing. Credits still
+                cover everything else, including AI observability and the context warehouse.
             </p>
         ),
     },
@@ -269,9 +269,10 @@ const faqItems = [
         content: (
             <p>
                 From September 14, 2026, startup credits can no longer be used towards bills incurred on AI tools such
-                as PostHog Desktop, Replay Vision, PostHog AI, and Inbox. Token-based pricing makes the cost of these
-                tools prohibitive and unpredictable, which makes them harder for us to subsidize. If you joined PostHog
-                for Startups before September 14, 2026, usage before this cut-off can still be paid with credits.
+                as PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and Inbox. Token-based pricing
+                makes the cost of these tools prohibitive and unpredictable, which makes them harder for us to
+                subsidize. If you joined PostHog for Startups before September 14, 2026, usage before this cut-off can
+                still be paid with credits.
             </p>
         ),
     },
@@ -423,7 +424,7 @@ const faqStructuredData = [
     },
     {
         question: 'Can I use my PostHog for Startups credits on all PostHog products?',
-        answer: 'Almost all of them. From September 14, 2026, startup credits can no longer be used towards bills incurred on AI tools such as PostHog Desktop, Replay Vision, PostHog AI, and Inbox, due to the prohibitive and unpredictable nature of token-based pricing. Credits still cover everything else, including AI observability and the context warehouse.',
+        answer: 'Almost all of them. From September 14, 2026, startup credits can no longer be used towards bills incurred on AI tools such as PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and Inbox, due to the prohibitive and unpredictable nature of token-based pricing. Credits still cover everything else, including AI observability and the context warehouse.',
     },
     {
         question: 'How do I apply to PostHog for Startups?',
@@ -439,7 +440,7 @@ const faqStructuredData = [
     },
     {
         question: 'How far does $50,000 in PostHog credits go?',
-        answer: 'A long way. It covers roughly 950 million events, more than 6 million session recordings, over 840 million LLM analytics events, or 396 million error tracking events. Credits cannot be used towards AI tools such as PostHog Desktop, Replay Vision, PostHog AI, and Inbox.',
+        answer: 'A long way. It covers roughly 950 million events, more than 6 million session recordings, over 840 million LLM analytics events, or 396 million error tracking events. Credits cannot be used towards AI tools such as PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and Inbox.',
     },
 ]
 
@@ -605,8 +606,8 @@ export default function StartupProgram({ partnerSlug = null }: StartupProgramPro
                     <p>
                         A <em>very</em> long way. Here's what your credits are worth if you spent them all in one place,
                         but you can mix and match them across most PostHog products. The exceptions are AI tools such as
-                        PostHog Desktop, Replay Vision, PostHog AI, and Inbox, which credits can't be used for.
-                        Otherwise we're not fussy. We just want you to spend the money.
+                        PostHog Desktop, the PostHog Slack app, Replay Vision, PostHog AI, and Inbox, which credits
+                        can't be used for. Otherwise we're not fussy. We just want you to spend the money.
                     </p>
                     <div className="not-prose grid grid-cols-2 @2xl/reader-content:grid-cols-4 gap-4 my-6">
                         {creditBreakdown.map(({ Icon, color, amount, unit }) => (


### PR DESCRIPTION
## Changes

The PostHog Slack app bills under PostHog AI, so startup credits already can't be used for it — but it wasn't named on [/startups](https://posthog.com/startups) or the [startups handbook page](https://posthog.com/handbook/marketing/startups). It's now listed alongside PostHog Desktop, Replay Vision, PostHog AI, and Inbox in every place those exclusions appear (FAQ answers, credit-value copy, FAQPage structured data, handbook table and bullets, plus the Lenny's Product Pass exclusions note which inherits the same list).

Copy-only change, no visual/layout changes.

**Why:** The exclusion was already decided internally, but never made it onto the pages founders actually read, so it looked like credits could cover the Slack app.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08ERRQT41E/p1788254771017189?thread_ts=1788254771.017189&cid=C08ERRQT41E)*