### PR TITLE
Improve the map at `CountriesWeHireIn`

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -28,6 +28,7 @@ This has resulted in the highest number of qualified and motivated candidates re
 <CountriesWeHireIn
     excludedCountries={[
         'Afghanistan',
+        'Antarctica',
         'Armenia',
         'Australia',
         'Azerbaijan',
@@ -505,4 +506,3 @@ Once agreed the second half should be focused on agreeing one or two fixes to th
 #### post post-mortem call
 
 The talent partner should write up the post-mortem and share it in the #team-talent channel cross-posting to #tell-posthog-anything. They should then update any handbook pages about the process and be sure to share any findings with the relevant interviewing channels like #technical-interviewers. 
-

--- a/src/components/AMCharts/CountriesWeHireIn/index.tsx
+++ b/src/components/AMCharts/CountriesWeHireIn/index.tsx
@@ -4,6 +4,7 @@ type ExclusionReason = 'sanctions' | 'high-cost' | 'contractors' | 'timezone'
 interface CountryRestriction {
     code: string
     reason: ExclusionReason
+    reasonLabel?: string
 }
 
 // Map of country names to ISO2 codes and exclusion reasons
@@ -29,6 +30,13 @@ const countryRestrictions: { [key: string]: CountryRestriction } = {
     // Contractors only
     Brazil: { code: 'BR', reason: 'contractors' },
     Uruguay: { code: 'UY', reason: 'contractors' },
+
+    // Outside timezone rage (Antarctica as special case)
+    Antarctica: {
+        code: 'AQ',
+        reason: 'timezone',
+        reasonLabel: 'We don’t currently hire in Antarctica. Sorry penguins we’re a hedgehog company 🦔.',
+    },
 
     // Outside timezone range (UTC+3 and beyond, or UTC-9 and beyond)
     Afghanistan: { code: 'AF', reason: 'timezone' },
@@ -212,7 +220,6 @@ export default function CountriesWeHireIn({
         const polygonSeries = chart.series.push(
             am5map.MapPolygonSeries.new(root, {
                 geoJSON: am5geodata_worldLow,
-                exclude: ['AQ'], // Antarctica
             })
         )
 
@@ -274,7 +281,7 @@ export default function CountriesWeHireIn({
                 const icon = restriction.reason === 'contractors' ? '' : xIcon
                 const marginStyle = restriction.reason === 'contractors' ? '' : 'margin-left: 28px;'
                 return `${icon}<strong>${name}</strong><br/><span style="${marginStyle}">${
-                    reasonLabels[restriction.reason]
+                    restriction.reasonLabel ?? reasonLabels[restriction.reason]
                 }</span>`
             }
             return `${checkIcon} We hire from ${name}!`

--- a/src/components/AMCharts/CountriesWeHireIn/index.tsx
+++ b/src/components/AMCharts/CountriesWeHireIn/index.tsx
@@ -158,12 +158,12 @@ export default function CountriesWeHireIn({
 
         const chart = root.container.children.push(
             am5map.MapChart.new(root, {
-                projection: am5map.geoEqualEarth(),
+                projection: am5map.geoOrthographic(),
                 panX: 'rotateX',
-                panY: 'translateY',
+                panY: 'rotateY',
                 wheelY: 'zoom',
                 homeGeoPoint: { latitude: 20, longitude: 0 },
-                zoomLevel: 1.2,
+                zoomLevel: 1,
             })
         )
 


### PR DESCRIPTION
## Changes

Hi, I was looking at the hiring-process page of the handbook, and this PR suggests two improvements of the map shown in `CountriesWeHireIn`:

- replace the flat map with a rotatable globe along all axes
- show Antarctica with an easter egg message instead of excluding it completely

These changes are independent proposals. I separated them into two commits so maintainers can easily decide whether to keep either, both, or neither. Happy to receive feedback!

### Before

<img width="909" height="532" alt="Screenshot 2026-09-01 at 12 38 45" src="https://github.com/user-attachments/assets/75f69511-5585-4f18-b84e-791e1265b76f" />


### After

<img width="825" height="536" alt="Screenshot 2026-09-01 at 12 43 16" src="https://github.com/user-attachments/assets/16e38feb-e4af-4128-8172-4041069a3338" />

<img width="840" height="541" alt="Screenshot 2026-09-01 at 12 43 27" src="https://github.com/user-attachments/assets/9ffbeb75-37b2-4668-bc3c-e39bb7e53aa2" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
