### PR TITLE
chore(handbook): add #skiing and #barcelona to onboarding channel list

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -280,10 +280,12 @@ We encourage you to join and create channels focused around different types of h
 -   `#cycling`
 -   `#listening-to`
 -   `#design-inspiration`
+-   `#skiing`
 
 ### Location specific channels
 
 -   `#london`
 -   `#germany`
 -   `#sf-bay-area`
+-   `#barcelona`
     etc.


### PR DESCRIPTION
## Changes

New hires reading the onboarding page now see two more channels they can join: `#skiing` under social channels, and `#barcelona` under location specific channels.

Both channels exist and are active in Slack.
