### PR TITLE
chore(handbook): add engineering Slack channels to onboarding

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -248,16 +248,35 @@ Below are a list of Slack channels you may find helpful:
 ### Work-related channels
 
 -   `#ask-max` - Max has access to all of our documentation and our handbook, and is a great place to start with many questions
--   `#content-docs-ideas` - for suggesting ideas for the newsletter, tutorials, and docs to be written by the content and docs team
--   `#brand-mentions`
--   `#do-more-weird`
--   `#newsletters`
--   `#team-blitzscale`
--   `#dev`
+-   `#ask-posthog-anything` - ask the team when you cannot find an answer in the handbook, the docs, or `#ask-max`
+-   `#tell-posthog-anything` - company-wide announcements about our people, products, policies, and projects
 -   `#general`
--   `#alerts`
--   `#industry-news`
 -   `#changelog` - keep up with all the cool things we're shipping across the team
+-   `#today-i-learned` - where we share what we learn
+-   `#demo-posthog-anything` - show the team something you built, or see what others are building
+-   `#phishing-attempts` - report suspicious emails, texts, and messages here
+-   `#content-docs-ideas` - for suggesting ideas for the newsletter, tutorials, and docs to be written by the content and docs team
+-   `#newsletters`
+-   `#brand-mentions`
+-   `#industry-news`
+-   `#team-blitzscale`
+
+### Engineering channels
+
+If you are an engineer, join these in addition to the work-related channels above:
+
+-   `#dev` - general engineering discussion
+-   `#dev-ai` - how we use AI tools and coding agents in our own work
+-   `#dev-stamp-exchange` - ask for a quick review when nobody on your team is free. See [how we review](/handbook/engineering/how-we-review)
+-   `#github-rfcs` - all of our [RFCs](/handbook/company/communication#requests-for-comment-rfcs) are posted here
+-   `#flakey-tests` - reports of tests that fail intermittently in CI
+-   `#incidents` - incident declarations and post-mortem summaries. Set this channel to notify you about every message
+-   `#alerts` - company-wide alerts. Teams also have their own `#alerts-[team-name]` channels
+-   `#support-infrastructure` - deployment problems, infrastructure questions, and requests for cloud access
+-   `#aws-access` - use the `/awsaccess` command here to get temporary AWS permissions. See [cloud providers](/handbook/engineering/cloud-providers)
+-   `#papercuts` - small product annoyances that anyone at PostHog can report. Your team's [support hero](/handbook/engineering/support-hero) picks up the ones in your area
+
+Every small team also has a `#team-[team-name]` channel and a `#support-[team-name]` channel, named after the team on the [teams page](/teams). Join the channels for your own team, then add the teams you work with most.
 
 ### Social channels
 
@@ -273,9 +292,13 @@ We encourage you to join and create channels focused around different types of h
 -   `#climbing`
 -   `#coffee-snobs`
 -   `#dad-jokes`
+-   `#do-more-weird`
 -   `#fitness`
 -   `#hoglife`
+-   `#merch`
 -   `#rockets`
+-   `#shitposters-unite`
+-   `#skiing`
 -   `#stonks`
 -   `#cycling`
 -   `#listening-to`
@@ -286,4 +309,6 @@ We encourage you to join and create channels focused around different types of h
 -   `#london`
 -   `#germany`
 -   `#sf-bay-area`
+-   `#barcelona`
+-   `#nyc`
     etc.


### PR DESCRIPTION
## Changes

New engineers had no way to know which Slack channels to join. The onboarding page listed 11 work channels, only two of which said what they were for, and none of the channels an engineer needs day to day.

This adds an **Engineering channels** section covering how we ship code (`#dev`, `#dev-ai`, `#dev-stamp-exchange`, `#github-rfcs`, `#flakey-tests`), how we keep things running (`#incidents`, `#alerts`, `#support-infrastructure`, `#aws-access`, `#papercuts`), and the `#team-[team-name]` / `#support-[team-name]` convention, so people find their neighbouring teams without a hard-coded list that goes stale.

It also gives every work-related channel a description, adds the channels that were missing (`#ask-posthog-anything`, `#tell-posthog-anything`, `#today-i-learned`, `#demo-posthog-anything`, `#phishing-attempts`), moves `#do-more-weird` to the social list where it belongs, and adds `#merch`, `#shitposters-unite`, and `#nyc`.

Each channel description comes from how the handbook already describes that channel elsewhere. This PR does not change any process.

**Why:** A new engineer reported that they kept finding channels by accident, weeks after joining. The onboarding page is where they looked first.

This includes `#skiing` and `#barcelona` from #19873, which changes the same lists. Merging that PR first will cause a conflict here.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BTPHXF7MH/p1788262327744269)*
