### PR TITLE
feat(docs): Keep pocket guide contents links in the Learn tab

### DIFF
--- a/src/components/PocketGuides/LearnPage.tsx
+++ b/src/components/PocketGuides/LearnPage.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import { useLocation } from '@reach/router'
 
-import { ProductSwitcher, buildProductMenuTabs } from 'components/Products/ReaderViewProduct'
+import { ProductSwitcher, buildProductMenuTabs, surfaceBasePath } from 'components/Products/ReaderViewProduct'
 import ReaderView from 'components/ReaderView'
 import SEO from 'components/seo'
 import useProduct from 'hooks/useProduct'
@@ -46,7 +46,13 @@ export default function LearnPage({ productHandle, chapter, title, description }
                 productSelect={<ProductSwitcher activeHandle={productHandle} />}
             >
                 <article ref={contentRef}>
-                    {volumeId ? <LearnSurface volumeId={volumeId} chapter={chapter} /> : null}
+                    {volumeId ? (
+                        <LearnSurface
+                            volumeId={volumeId}
+                            chapter={chapter}
+                            basePath={surfaceBasePath(productData.slug, 'learn')}
+                        />
+                    ) : null}
                 </article>
             </ReaderView>
         </>

--- a/src/components/PocketGuides/LearnSurface.tsx
+++ b/src/components/PocketGuides/LearnSurface.tsx
@@ -4,20 +4,10 @@ import { graphql, useStaticQuery } from 'gatsby'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 
 import { EntryProvider, bookMdxComponents } from './bookComponents'
-import { BookPageEntry, FONT_SIZES, normalizeUrl, useBookPages } from './bookModel'
+import { FONT_SIZES, learnChapterSlug, normalizeUrl, useBookPages } from './bookModel'
 
 /** `BookReader`'s starting size, from the book's own scale so they cannot drift. */
 const BOOK_BASE_FONT_SIZE = FONT_SIZES[0]
-
-/** A chapter's url segment. The front matter has none: it is the index. */
-export function learnChapterSlug(entry: BookPageEntry): string {
-    return entry.order === 0 ? '' : normalizeUrl(entry.url).split('/').pop() || ''
-}
-
-export function learnChapterPath(basePath: string, entry: BookPageEntry): string {
-    const slug = learnChapterSlug(entry)
-    return slug ? `${basePath}/${slug}` : basePath
-}
 
 interface LearnBodyNode {
     body: string
@@ -53,10 +43,12 @@ interface LearnSurfaceProps {
     volumeId: string
     /** Empty or unknown falls back to the front matter. */
     chapter?: string
+    /** This surface's route root, so in-page links stay in the Learn tab. */
+    basePath: string
 }
 
 /** One chapter of a volume, rendered in the docs reader. */
-export default function LearnSurface({ volumeId, chapter }: LearnSurfaceProps): JSX.Element | null {
+export default function LearnSurface({ volumeId, chapter, basePath }: LearnSurfaceProps): JSX.Element | null {
     const pages = useBookPages(volumeId)
     const bodies = useBookBodies()
 
@@ -76,7 +68,7 @@ export default function LearnSurface({ volumeId, chapter }: LearnSurfaceProps): 
     return (
         // `not-prose`: the book styles its own. `!p-0`: the docs column already pads.
         <div className="not-prose @container [&>div]:!p-0" style={{ fontSize: BOOK_BASE_FONT_SIZE }}>
-            <EntryProvider value={{ entry, pages }}>
+            <EntryProvider value={{ entry, pages, basePath }}>
                 <MDXProvider components={bookMdxComponents}>
                     <MDXRenderer>{body}</MDXRenderer>
                 </MDXProvider>

--- a/src/components/PocketGuides/bookContext.tsx
+++ b/src/components/PocketGuides/bookContext.tsx
@@ -8,6 +8,11 @@ import { BookPageEntry } from './bookModel'
 export interface BookEntry {
     entry: BookPageEntry
     pages: BookPageEntry[]
+    /**
+     * The Learn tab's route root, when the book is embedded there. Unset in the standalone
+     * reader, where a page's own url is already its route.
+     */
+    basePath?: string
 }
 
 const EntryContext = createContext<BookEntry | null>(null)

--- a/src/components/PocketGuides/bookModel.tsx
+++ b/src/components/PocketGuides/bookModel.tsx
@@ -132,6 +132,16 @@ export function pageCount(pages: BookPageEntry[]): number {
     return pages.reduce((max, entry) => Math.max(max, entry.page ?? 0), 0)
 }
 
+/** A chapter's url segment. The front matter has none: it is the index. */
+export function learnChapterSlug(entry: BookPageEntry): string {
+    return entry.order === 0 ? '' : normalizeUrl(entry.url).split('/').pop() || ''
+}
+
+export function learnChapterPath(basePath: string, entry: BookPageEntry): string {
+    const slug = learnChapterSlug(entry)
+    return slug ? `${basePath}/${slug}` : basePath
+}
+
 /** One tab per page in the book, the current one marked. */
 export function bookTabs(pages: BookPageEntry[], activeUrl: string): BookTab[] {
     return pages.map((entry) => ({

--- a/src/components/PocketGuides/bookPieces.tsx
+++ b/src/components/PocketGuides/bookPieces.tsx
@@ -8,7 +8,7 @@ import EnableScout from 'components/SelfDrivingInbox/EnableScout'
 import { productSource } from 'components/SelfDrivingInbox/sources'
 
 import { useEntry, useTemplate } from './bookContext'
-import { BookPageEntry, volumeIdFromUrl } from './bookModel'
+import { BookPageEntry, learnChapterPath, normalizeUrl, volumeIdFromUrl } from './bookModel'
 import { volumeArt } from './volumeArt'
 
 /** Inline cue to a figure, color only – bold read larger than the surrounding text. */
@@ -77,10 +77,13 @@ export function Enable(): JSX.Element | null {
 }
 
 /** One page's row: a link, a dotted leader, and its folio number. */
-function ContentsRow({ page }: { page: BookPageEntry }): JSX.Element {
+function ContentsRow({ page, basePath }: { page: BookPageEntry; basePath?: string }): JSX.Element {
+    // Inside the Learn tab the contents keep the reader in the tab; the standalone reader's
+    // pages are their own routes.
+    const to = basePath ? learnChapterPath(basePath, page) : page.url
     return (
         <li className="flex items-baseline gap-2">
-            <Link to={page.url} wrapperClassName="min-w-0" className="text-[1em] text-primary hover:underline">
+            <Link to={to} wrapperClassName="min-w-0" className="text-[1em] text-primary hover:underline">
                 {page.title}
             </Link>
             {/* The dotted leader, so the row reads as a ToC line. */}
@@ -108,7 +111,7 @@ export function Contents(): JSX.Element | null {
         return (
             <ul className="m-0 list-none space-y-3 p-0">
                 {pages.map((page) => (
-                    <ContentsRow key={page.url} page={page} />
+                    <ContentsRow key={page.url} page={page} basePath={book.basePath} />
                 ))}
             </ul>
         )
@@ -137,7 +140,7 @@ export function Contents(): JSX.Element | null {
                     )}
                     <ul className="m-0 list-none space-y-3 p-0">
                         {group.pages.map((page) => (
-                            <ContentsRow key={page.url} page={page} />
+                            <ContentsRow key={page.url} page={page} basePath={book.basePath} />
                         ))}
                     </ul>
                 </div>
@@ -165,7 +168,14 @@ const NATIVE_CONTENT =
 /** A prose link, counted like a CTA – some chapters answer with a link, not a button. */
 function BookLink({ href, ...props }: any): JSX.Element {
     const posthog = usePostHog()
-    const entry = useEntry()?.entry
+    const book = useEntry()
+    const entry = book?.entry
+
+    // A link to another chapter of this book: inside the Learn tab it turns the page there,
+    // rather than sending the reader out to the standalone reader in a new window.
+    const basePath = book?.basePath
+    const chapter = basePath ? book?.pages.find((page) => page.url === normalizeUrl(href ?? '')) : undefined
+    const chapterPath = basePath && chapter ? learnChapterPath(basePath, chapter) : undefined
 
     const trackLinkClick = () =>
         posthog?.capture('pocket_guide_interaction', {
@@ -175,7 +185,11 @@ function BookLink({ href, ...props }: any): JSX.Element {
             placement: 'prose',
         })
 
-    return <Link to={href} state={{ newWindow: true }} className="underline" onClick={trackLinkClick} {...props} />
+    return chapterPath ? (
+        <Link to={chapterPath} className="underline" onClick={trackLinkClick} {...props} />
+    ) : (
+        <Link to={href} state={{ newWindow: true }} className="underline" onClick={trackLinkClick} {...props} />
+    )
 }
 
 /** Prose defaults. The page container is `not-prose`, so every tag is styled here. */

--- a/src/components/Products/ReaderViewProduct/buildProductMenuTabs.tsx
+++ b/src/components/Products/ReaderViewProduct/buildProductMenuTabs.tsx
@@ -2,9 +2,8 @@ import React, { useMemo } from 'react'
 import { IconBook, IconGraduationCap, IconPiggyBank, IconPresent } from '@posthog/icons'
 import { TreeMenu } from 'components/TreeMenu'
 import Link from 'components/Link'
-import { learnChapterPath } from 'components/PocketGuides/LearnSurface'
 import { DEFAULT_LEARN_PLACEMENT, type LearnPlacement } from './learnPlacement'
-import { useBookPages } from 'components/PocketGuides/bookModel'
+import { learnChapterPath, useBookPages } from 'components/PocketGuides/bookModel'
 import usePlatformList from 'hooks/docs/usePlatformList'
 import type { MenuTab } from 'components/ReaderView'
 import { docsMenu } from '../../../navs'
@@ -179,7 +178,7 @@ interface BuildProductMenuTabsArgs {
     navStyle?: 'grouped' | 'listed'
 }
 
-const surfaceBasePath = (productSlug: string, surface: ProductSurface): string => {
+export const surfaceBasePath = (productSlug: string, surface: ProductSurface): string => {
     if (surface === 'pricing') return `/${productSlug}/pricing`
     // Under /docs so switching to Learn never leaves the docs sidebar.
     if (surface === 'learn') return `/docs/${productSlug}/learn`

--- a/src/components/Products/ReaderViewProduct/index.tsx
+++ b/src/components/Products/ReaderViewProduct/index.tsx
@@ -11,7 +11,7 @@ import buildProductMenuTabs, { type ProductSurface } from './buildProductMenuTab
 import ProductSwitcher from './ProductSwitcher'
 import { templateRegistry } from './templates'
 
-export { default as buildProductMenuTabs } from './buildProductMenuTabs'
+export { default as buildProductMenuTabs, surfaceBasePath } from './buildProductMenuTabs'
 export type { ProductSurface } from './buildProductMenuTabs'
 export { default as ProductNav } from './ProductNav'
 export { default as ProductSwitcher } from './ProductSwitcher'


### PR DESCRIPTION
## Changes

The Contents list on a pocket guide's introduction page linked to each chapter's own url, which is the standalone reader route (`/pocket-guides/<volume>/<page>`). When the guide is read in a product's Learn tab, the first click therefore threw the reader out of the docs surface and into the reader view.

The entry context now carries the base path of the surface the book is rendered on. Only `LearnSurface` sets it, so:

- In the Learn tab, a Contents row links to `/docs/<product>/learn/<chapter>`.
- In the standalone reader, nothing changes — a page's own url is already its route.

A prose link to another chapter of the same book (the introduction's "start with AI Observability 101") had the same problem, and follows the same rule. Outside links keep their current behavior.

`learnChapterSlug` and `learnChapterPath` move from `LearnSurface` to `bookModel`, so the shared MDX components can import them without an import cycle. The Learn nav in the sidebar already used these helpers and is unchanged.

**Why:** raised in <#C09GTQY5RLZ> — clicking a Contents entry in the Learn tab dropped the reader into the reader view, while clicking the sidebar kept them in the tabbed navigation. The two paths should agree.

### Screenshots

None: nothing renders differently. The Contents list is identical in layout, type, and color — only the link targets change. The Vercel preview is the place to click through: open **AI Observability → Learn**, then a Contents entry, and confirm the tab strip stays.

### Checks

- `npx tsc --noEmit` — clean.
- `pnpm format` on the changed files.
- `pnpm start`, then loaded `/docs/ai-observability/learn`, `/docs/ai-observability/learn/101`, and `/pocket-guides/ai-observability`. All compile and serve; no new errors in the dev log.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — no pages moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1787781595866779?thread_ts=1787781595.866779&cid=C09GTQY5RLZ)*
