### PR TITLE
docs(mcp-analytics): document the Python custom-dispatcher path properly

### DIFF
--- a/contents/docs/mcp-analytics/custom-servers.mdx
+++ b/contents/docs/mcp-analytics/custom-servers.mdx
@@ -15,6 +15,8 @@ For those servers, use **`PostHogMCP`** instead. It's a subclass of the [`postho
 | Built on `@modelcontextprotocol/sdk`'s `Server` / `McpServer` | [`instrument(server, posthog, options?)`](/docs/mcp-analytics/installation) |
 | A custom HTTP/Hono/edge dispatcher with no server object to wrap | `new PostHogMCP(apiKey, options?)` |
 
+The examples below are TypeScript. Python has the same helper with the same methods in snake_case — skip to [Python](#python).
+
 ## Set up
 
 `PostHogMCP` takes the exact same constructor arguments as `posthog-node`'s `PostHog`, so swap the class and you keep one client for your whole app:
@@ -110,45 +112,81 @@ ctx.waitUntil(posthog.flush())
 The Python SDK ships the same custom-dispatcher path as `PostHogMCP`, a subclass of the [`posthog`](/docs/libraries/python) client. Method names are snake_case and arguments are keyword args rather than an options object:
 
 ```python
+import time
 from posthog.mcp import PostHogMCP, get_more_tools_result
 
 posthog = PostHogMCP("phc_your_project_api_key", host="https://us.i.posthog.com")
 
-# Decorate your tools/list response so agents state their intent (and, optionally,
-# advertise the get_more_tools virtual tool):
+# Advertise your tools with the injected `context` intent argument (and, optionally,
+# the get_more_tools virtual tool):
 tools = posthog.prepare_tool_list(my_tools, report_missing=True)
 
-# On an inbound tools/call, pull the intent and strip the injected `context`:
-prepared = posthog.prepare_tool_call(name, arguments)
-if prepared.is_missing_capability:
-    posthog.capture_missing_capability(context=prepared.intent, distinct_id=user_id)
-    return get_more_tools_result()
+def handle_tools_call(request, name, arguments):
+    # Pull the agent's intent off the call and strip the injected `context`:
+    prepared = posthog.prepare_tool_call(name, arguments)
 
-result = run_tool(name, prepared.args)
+    # Pass these on every capture — see "Attributing the caller" below:
+    common = dict(
+        distinct_id=user_id,
+        session_id=mcp_session_id,
+        client_user_agent=request.headers.get("user-agent"),
+        vendor_client=request.headers.get("x-anthropic-client"),
+        groups={"organization": org_id},
+    )
 
-# Capture the call (fire-and-forget, like posthog.capture):
-posthog.capture_tool_call(
-    name,
-    intent=prepared.intent,
-    intent_source=prepared.intent_source,
-    parameters=arguments,
-    response=result,
-    duration_ms=elapsed_ms,
-    is_error=False,
-    distinct_id=user_id,
-    session_id=mcp_session_id,
-    groups={"organization": org_id},
-)
+    if prepared.is_missing_capability:
+        posthog.capture_missing_capability(context=prepared.intent, **common)
+        return get_more_tools_result()
 
-# On the handshake:
-posthog.capture_initialize(client_name="claude-code", client_version="1.2.3", distinct_id=user_id)
+    start = time.monotonic()
+    try:
+        result = run_tool(name, prepared.args)
+    except Exception as exc:
+        posthog.capture_tool_call(
+            name,
+            parameters=prepared.args,
+            duration_ms=(time.monotonic() - start) * 1000,
+            is_error=True,
+            error=exc,  # → $mcp_error_message, $mcp_error_type, and the $exception sibling
+            **common,
+        )
+        raise
+
+    posthog.capture_tool_call(
+        name,
+        intent=prepared.intent,
+        intent_source=prepared.intent_source,
+        parameters=prepared.args,
+        response=result,
+        duration_ms=(time.monotonic() - start) * 1000,
+        **common,
+    )
+    return result
+```
+
+Capture the handshake and the tool listing the same way:
+
+```python
+posthog.capture_initialize(client_name="claude-code", client_version="1.2.3", **common)
+posthog.capture_tools_list(tool_names=[t["name"] for t in tools], **common)
 
 posthog.flush()  # PostHogMCP is a posthog client — flush/shutdown it yourself
 ```
 
-`PostHogMCP(api_key, missing_capability_tool_name="get_more_tools", mcp_exception_autocapture=True, **posthog_kwargs)` accepts the standard `posthog` client kwargs (e.g. `host`). Set `mcp_exception_autocapture=False` to stop a failed tool call from emitting a `$exception` sibling. As in TypeScript, the wrapping-path hooks (`identify`, `context`, `intent_fallback`, `event_properties`) don't apply here — pass identity and properties on each `capture_*` call.
+`PostHogMCP(api_key, missing_capability_tool_name="get_more_tools", mcp_exception_autocapture=True, **posthog_kwargs)` accepts the standard `posthog` client kwargs — `host`, and [`before_send`](/docs/mcp-analytics/privacy#python) if you need to drop or rewrite payloads. Set `mcp_exception_autocapture=False` to stop a failed tool call from emitting a `$exception` sibling. As in TypeScript, the wrapping-path hooks (`identify`, `context`, `intent_fallback`, `event_properties`) don't apply here — pass identity and properties on each `capture_*` call.
 
-The `capture_*` methods also take `error_type` (a low-cardinality failure label for `$mcp_error_type`), `client_user_agent`, and `vendor_client` — the same fields documented in the [event reference](/docs/mcp-analytics/events#core-properties).
+### Failed calls
+
+Pass `error=exc` with `is_error=True` and the SDK reads `$mcp_error_message` and `$mcp_error_type` off the exception, so the failures view shows *why* a call failed instead of an empty row. The message is sanitized and capped at 2048 characters. Add `error_type="timeout"` (or any low-cardinality label) to override the thrown class name with your own category. Requires `posthog>=7.41`; upgrade to `7.45.3` or later, which also unwraps the generic `ToolError` that `mcp>=2.1` raises in place of your exception.
+
+### Attributing the caller
+
+`clientInfo.name` reports `claude-code` from the CLI, the Agent SDK, the VS Code extension and the desktop app alike, so on its own it collapses every surface into one bucket and the harness breakdown reads mostly "Other". The distinguishing detail is in the raw transport headers, which a custom dispatcher has to pass itself (`instrument()` reads them off the request for you):
+
+- `client_user_agent` → `$mcp_client_user_agent` — the parenthetical carries the build (`claude-code/2.1.0 (cli)` vs `(sdk-ts)`).
+- `vendor_client` → `$mcp_vendor_client` — from vendor headers like `x-anthropic-client`, the only thing that separates Anthropic's pooled surfaces (Claude.ai, Cowork, Claude Design) from each other.
+
+Both are captured raw and classified at query time, so labels improve without an SDK release. Requires `posthog>=7.42`. stdio and in-memory transports carry no headers, so leave them unset there.
 
 ### Stateless / multi-pod dispatchers
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -346,7 +346,9 @@ await analytics.flush()   # drain in-flight auto-capture events
 posthog.shutdown()        # flush + stop the posthog client
 ```
 
-No server object to wrap (a custom HTTP/edge dispatcher)? Use `PostHogMCP`, a `posthog` client subclass (needs nothing beyond `posthog` — no MCP SDK) with `capture_tool_call()`, `capture_initialize()`, `capture_tools_list()`, `capture_missing_capability()`, `prepare_tool_list()`, and `prepare_tool_call()` — the Python equivalent of [Custom servers](/docs/mcp-analytics/custom-servers).
+### Custom dispatchers (no server object to wrap)
+
+If you hand-rolled your own dispatcher, there's nothing for `instrument()` to patch. Use `PostHogMCP` instead — a `posthog` client subclass (needs nothing beyond `posthog`, no MCP SDK) that lets you build the events yourself: `capture_tool_call()`, `capture_initialize()`, `capture_tools_list()`, `capture_missing_capability()`, plus `prepare_tool_list()` and `prepare_tool_call()` for intent capture. Same events, same redaction and truncation as `instrument()`. See [Custom servers](/docs/mcp-analytics/custom-servers#python) for a full dispatcher example.
 
 <CalloutBox icon="IconInfo" title="Python SDK is beta" type="fyi">
 

--- a/contents/docs/mcp-analytics/privacy.mdx
+++ b/contents/docs/mcp-analytics/privacy.mdx
@@ -31,8 +31,9 @@ The SDK runs a deterministic sanitizer:
 - **Long base64-looking strings (≥10KB)** → replaced with `"[binary data redacted...]"`.
 - **Keys matching the sensitive-key pattern** — `authorization`, `cookie`, `password`, `token`, `secret`, `api_key`, `private_key`, and similar — have their values replaced with `"[redacted]"`.
 - **PostHog API key patterns** (`ph[a-z]_…`) in any string value → replaced with `"[redacted]"`.
+- **Credential-looking words** — detected by entropy and known key formats (`sk-…`, PEM markers) — replaced word by word, in `$mcp_parameters`, `$mcp_response`, the captured intent, and exception messages. A message like `auth failed for sk-…` keeps its diagnostic text and loses only the key.
 
-This stage is not configurable. It's safety net behavior — if you have stricter requirements, encode them in `beforeSend`.
+This stage is not configurable, and it is a safety net rather than a general-purpose credential scrubber: it catches known key formats and obviously sensitive keys, not every secret your tools might echo. Free text your server writes — exception messages especially — is passed through as-is once those patterns are gone. If you have stricter requirements, encode them in `beforeSend`.
 
 ### 2. Truncation
 
@@ -94,6 +95,41 @@ beforeSend: (event) => {
 You own the `posthog-node` client's lifecycle. Call `posthog.shutdown()` (or `posthog.flush()`) from your `SIGTERM` / `beforeExit` handler — or explicitly at the end of each serverless invocation — so in-flight events aren't dropped. See [Installation](/docs/mcp-analytics/installation#graceful-shutdown) for the snippet.
 
 </CalloutBox>
+
+## Python
+
+The pipeline is identical in Python — same sanitizer, same truncation caps, same `$exception` fan-out — and `before_send` is the same final say. Exception messages are sanitized and capped at 2048 characters from `posthog>=7.41`.
+
+On the `instrument()` path it's an `MCPAnalyticsOptions` field. On the `PostHogMCP` path it's the standard `posthog` client kwarg, which MCP events run through like any other capture:
+
+```python
+from posthog.mcp import instrument, PostHogMCP
+from posthog.mcp.types import MCPAnalyticsOptions
+
+def before_send(event):
+    if event["event"] == "$exception":
+        return None  # drop
+    return event
+
+instrument(server, posthog, MCPAnalyticsOptions(before_send=before_send))
+
+# custom dispatchers:
+posthog = PostHogMCP("phc_your_project_api_key", before_send=before_send)
+```
+
+The callback receives the built payload — `event`, `distinct_id`, `properties`, `timestamp` — may be sync or async, and runs once per emitted event, including the `$exception` sibling. Return the event to send it, or `None` to drop it. A raised exception drops it too and is routed to the logger.
+
+For zero payload retention, strip the payload keys and keep the timing and attribution metadata:
+
+```python
+def before_send(event):
+    event["properties"].pop("$mcp_parameters", None)
+    event["properties"].pop("$mcp_response", None)
+    event["properties"].pop("$mcp_error_message", None)
+    return event
+```
+
+Set `enable_exception_autocapture=False` (`MCPAnalyticsOptions`) or `mcp_exception_autocapture=False` (`PostHogMCP`) to suppress the `$exception` sibling entirely.
 
 ## Buffering and back-pressure
 


### PR DESCRIPTION
## Why

A Python-SDK user hand-rolled their own MCP dispatcher and concluded that `instrument()` was the only option — that they'd have to reimplement capture themselves and that there was no documented redaction contract for Python. Both already exist in the SDK. The docs just didn't lead them there, and the Python examples that were on the page skipped the arguments that make the product work.

## What changed

**`custom-servers.mdx`** — the Python section had a partial snippet: no error path, no transport headers, no `capture_tools_list`, and a stale note passing raw `arguments` (which re-captures the injected `context` into `$mcp_parameters`). It's now a complete dispatcher handler, plus two short sections:

- **Failed calls** — `error=exc` with `is_error=True` populates `$mcp_error_message` / `$mcp_error_type`, so the failures view shows why a call failed instead of an empty row. Notes the `posthog>=7.41` floor and that 7.45.3 unwraps the generic `ToolError` `mcp>=2.1` raises.
- **Attributing the caller** — `client_user_agent` and `vendor_client` have to be passed by a custom dispatcher (`instrument()` reads them off the request). Without them `clientInfo.name` collapses every Anthropic surface into one bucket and the harness breakdown reads mostly "Other", which is exactly what the user hit.

**`privacy.mdx`** — was TypeScript-only, so Python implementers had no redaction contract to point at for zero-retention review. Adds a Python section covering `before_send` on both paths (`MCPAnalyticsOptions(before_send=...)` and the `PostHogMCP` client kwarg), the strip-the-payload recipe, and how to suppress the `$exception` sibling. Also makes the sanitizer's scope honest: it catches known key formats and sensitive keys, not every secret a tool might echo, and free text is passed through once those patterns are gone.

**`installation.mdx`** — the `PostHogMCP` pointer was the last paragraph of the "Flushing on exit" subsection, so it never appeared as a scannable heading. Promoted to `### Custom dispatchers (no server object to wrap)`.

## Verification

Every Python snippet was executed against `posthog` 7.45.3 with a `before_send` collector, confirming: each `capture_*` call accepts the documented keyword arguments and emits the expected event (`$mcp_missing_capability`, `$mcp_tool_call`, `$exception`, `$mcp_initialize`, `$mcp_tools_list`); `prepare_tool_call` strips `context` and returns the intent; `error=exc` yields `$mcp_error_message` with a credential-looking token redacted (`"boom [redacted]"`) plus `$mcp_error_type`; the zero-retention recipe leaves `$mcp_duration_ms`, `$mcp_error_type`, `$mcp_is_error` and `$mcp_tool_name` intact.

`markdownlint` wasn't run locally (`node_modules` isn't installed in this checkout); the changes use only constructs already present in these three files, and nearly every rule is disabled in `.markdownlint-cli2.jsonc`.

## Follow-ups (not in this PR)

- Harness resolution reads the server-stamped `mcp_vendor_client` but not the SDK-emitted `$mcp_vendor_client` (shipped in `posthog` 7.42.0), so self-hosted servers still fall to "Other" even when they send it. Needs a fix in `products/mcp_analytics/backend/mcp_harness.py` plus a `taxonomy.py` entry.
- The failures view's "Not captured (event predates error message capture)" copy asserts a cause it can't know; it should name the missing property and the SDK version that emits it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
