### PR TITLE
Restore volumes from calculator deep links in every product tab

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
@@ -451,13 +451,22 @@ export default function ProductAnalyticsTab({
         Object.keys(analyticsData).forEach((key) => setAnalyticsVolume(key, analyticsData[key].volume))
         const urlParams = new URLSearchParams(window.location.search)
         const volumes = qs.parse(urlParams.toString())
-        if (volumes['product_analytics']?.types) {
-            Object.keys(volumes['product_analytics'].types).forEach((subtype) => {
-                const volume = volumes['product_analytics'].types[subtype]?.volume
+        const types = volumes['product_analytics']?.types
+        if (types) {
+            Object.keys(types).forEach((subtype) => {
+                const volume = types[subtype]?.volume
                 if (volume) {
                     setAnalyticsVolume(subtype, Number(volume))
                 }
             })
+            return
+        }
+        // A link carrying only a total and no per-type split – anything built outside "Generate
+        // calculator URL". Put the total on identified events so the tab shows the number the
+        // link asked for rather than zero.
+        const total = Number(volumes['product_analytics']?.volume)
+        if (Number.isFinite(total) && total > 0) {
+            setAnalyticsVolume('productAnalyticsEvents', total)
         }
     }, [])
 

--- a/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
@@ -210,6 +210,16 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
         }
     }, [totalCost, mainVolume, billedMainVolume, mainBillingTiers, activeProduct.handle, setProduct])
 
+    // Adopt a volume written from outside the tab – Tabbed's mount effect restores
+    // `?<product>[volume]=N` via setVolume once this tab has already seeded mainVolume at 0.
+    // Converges: the effect above then reports the same volume back, so the next run bails.
+    useEffect(() => {
+        const external = Number(activeProduct.volume)
+        if (Number.isFinite(external) && external > 0 && external !== mainVolume) {
+            setMainVolume(external)
+        }
+    }, [activeProduct.volume])
+
     // Cost is derived from billedMainVolume in the effect above — the cost SliderRow reports only
     // covers its own volume, which undercounts when an add-on meters through the main product.
     const handleMainVolumeChange = (volume) => {

--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 // import { allProductsData } from 'components/Pricing/Pricing'
 import { calculatePrice } from 'components/Pricing/PricingSlider/pricingSliderLogic'
 import { graphql, useStaticQuery } from 'gatsby'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 // Import individual product data
 import { productAnalytics } from './productData/product_analytics'
@@ -89,25 +89,34 @@ export default function useProducts() {
 
     const monthlyTotal = useMemo(() => products.reduce((acc, product) => acc + (product.cost || 0), 0), [products])
 
-    const setProduct = (handle: string, data: any) => {
-        const target = baseProducts.find((product) => product.handle === handle)
-        if (!target || (target as any).billedWith) return
-        setOverrides((prev) => ({ ...prev, [handle]: { ...(prev[handle] || {}), ...data } }))
-    }
+    // Stable across renders: tabs list these in effect dependencies, and every call writes a new
+    // overrides object. A fresh function each render makes those effects re-run on their own
+    // output, so the tab writes its volume back over anything set from outside it.
+    const setProduct = useCallback(
+        (handle: string, data: any) => {
+            const target = baseProducts.find((product) => product.handle === handle)
+            if (!target || (target as any).billedWith) return
+            setOverrides((prev) => ({ ...prev, [handle]: { ...(prev[handle] || {}), ...data } }))
+        },
+        [baseProducts]
+    )
 
-    const setVolume = (handle: string, volume: number) => {
-        const rounded = Math.round(volume)
-        const product = baseProducts.find((product) => product.handle === handle)
-        const { total, costByTier } = calculatePrice(
-            rounded,
-            product?.billingData?.plans.find((plan: any) => plan.tiers)?.tiers
-        )
-        setProduct(handle, {
-            volume: rounded,
-            cost: total,
-            costByTier,
-        })
-    }
+    const setVolume = useCallback(
+        (handle: string, volume: number) => {
+            const rounded = Math.round(volume)
+            const product = baseProducts.find((product) => product.handle === handle)
+            const { total, costByTier } = calculatePrice(
+                rounded,
+                product?.billingData?.plans.find((plan: any) => plan.tiers)?.tiers
+            )
+            setProduct(handle, {
+                volume: rounded,
+                cost: total,
+                costByTier,
+            })
+        },
+        [baseProducts, setProduct]
+    )
 
     return { products, setVolume, setProduct, monthlyTotal }
 }


### PR DESCRIPTION
## Changes

A shared pricing calculator link does not fill in the volumes it carries. The calculator opens on the correct tab, but the sliders stay at zero and the estimate reads $0.

The restore code in `Tabbed` is correct. It parses the query string and calls `setVolume` for each product. The problem is that only one of the three tab layouts reads that value back:

| Tab layout | Reads restored volume | Products |
|---|---|---|
| Plain slider | Yes | Feature flags, surveys, error tracking, and others |
| `StandaloneAddonsTab` | **No** | Session replay, logs, managed warehouse, workflows, realtime destinations |
| `ProductAnalyticsTab` | **Partially** | Product analytics |

`StandaloneAddonsTab` copies the volume into local state one time, during the first render. Child components initialise before the parent effect runs, so that copy is always zero. Nothing syncs it again.

`ProductAnalyticsTab` reads only the per-type split that the "Generate calculator URL" button writes. A link that carries a total and no split leaves every slider at zero.

**Why this matters:** the pricing page now offers an AI-written estimate, and the link that flow produces carries a total. Product analytics and session replay are the two products people estimate most, and both are in the broken set. A person who follows one of these links sees an empty calculator, which is worse than no link at all.

This PR is the minimum fix for that. It does not change the calculator's design or its math.

<details>
<summary>🗺️ PR tour</summary>

### 1. Make the shared setters stable — `src/hooks/useProducts.tsx`

[`useProducts.tsx`](https://github.com/PostHog/posthog.com/blob/ce1d88ecc7dc1913429bd32b775568a27fc67434/src/hooks/useProducts.tsx#L92-L120)

`setProduct` and `setVolume` were new functions on each render. `StandaloneAddonsTab` lists `setProduct` in the dependencies of the effect that writes its volume to the shared state. A new function on each render makes that effect run again after its own write. The effect then pushes its local volume back over any value set from outside the tab.

`useCallback` stops this. Read this stop first, because the other two stops depend on it.

This is a behavior change, not only a performance change. Do not remove it.

### 2. Adopt an external volume — `Tabs/StandaloneAddonsTab.tsx`

[`StandaloneAddonsTab.tsx`](https://github.com/PostHog/posthog.com/blob/ce1d88ecc7dc1913429bd32b775568a27fc67434/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx#L213-L222)

A new effect watches `activeProduct.volume`. When a volume arrives from outside the tab, the effect copies it into `mainVolume`.

The effect converges. The write-back effect above it reports the same volume to the shared state. The next run of the new effect then finds equal values and does nothing. A volume of zero is ignored, so a person can still drag a slider back to zero.

`ReplayVisionTab` already contains [this same pattern](https://github.com/PostHog/posthog.com/blob/ce1d88ecc7dc1913429bd32b775568a27fc67434/src/components/Pricing/PricingCalculator/Tabs/ReplayVision.tsx#L45-L51). This stop copies it.

### 3. Accept a total with no split — `Tabs/ProductAnalytics.tsx`

[`ProductAnalytics.tsx`](https://github.com/PostHog/posthog.com/blob/ce1d88ecc7dc1913429bd32b775568a27fc67434/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx#L450-L471)

The per-type branch is unchanged. The diff moves the repeated lookup into a `types` variable and adds an early return, so the new branch reads clearly.

The new branch runs when the link has a total and no per-type split. It puts the whole total on identified events. Identified events is the first slider and it is on by default, so the number appears where a person looks first.

</details>

<details>
<summary>🔍 Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Formatting | `npx prettier --write` on the three changed files | Formatted, no further changes |
| Calculator math | `node --test --experimental-strip-types src/components/Pricing/PricingCalculator/calculatorLogic.test.ts` | 14 passed, 0 failed |
| Types | `npx tsc --noEmit` | No errors in the changed files |
| Query parsing | Ran the real `URLSearchParams` → `qs.parse` path against three shared links | Each resolves to the correct `setVolume(product, volume)` calls, which confirms the links are valid and the fault is downstream |

**Not tested:** the browser. `pnpm start` does not finish its bootstrap in the environment this PR was written in, so there are no before/after screenshots and no console comparison yet. Both are required before this leaves draft. Please treat every claim above about rendered output as reasoning from the code, not as an observation.

### What to check

1. Open `/pricing?calculator=session_replay&session_replay[volume]=13223`. The recordings slider must show 13,223.
2. Open `/pricing?calculator=product_analytics&product_analytics[volume]=7600000`. Identified events must show 7,600,000.
3. Use "Generate calculator URL" with a per-type split, then open the result. The split must restore as before, and it must not fall into the new total branch.
4. Open `/pricing?calculator=feature_flags&feature_flags[volume]=17280000`. This path already worked. Confirm it still does.
5. Drag a slider on the Session replay tab down to zero. The value must stay at zero.

### Risk

The `useCallback` in stop 1 changes when effects run across every consumer of `useProducts`, not only the calculator tabs. That is the widest part of this change and the part to read most carefully.

</details>

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no pages moved

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BH6R0RDFX/p1788297473667029)*
