### PR TITLE
Add cooling application period for reapplicants

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -310,6 +310,13 @@ If a candidate hasn't customized the application or resume to the role, it is a 
 
 Candidates who are unsuccessful at this stage will receive an automated rejection email. Due to the volume of applications we receive, we usually don't provide personalized feedback.
 
+### 12 month cooling application period
+To ensure a fair and consistent experience for all candidates, we ask that applicants wait 12 months before reapplying for the same or a substantially similar role. This time allows candidates an opportunity to build on their experience, develop new skills, and strengthen areas that may not have fully met the role’s requirements during the interview process.
+
+After 12 months, candidates are welcome to apply again; however, reapplying does not guarantee that the application will be reconsidered or that the candidate will move forward in the process. Our teams and hiring needs are continually evolving, so the requirements of a role may change, and the candidate’s experience may no longer align with what we’re looking for at that time.
+
+We appreciate your interest in joining our team and encourage you to continue growing your skills and experience in the meantime.
+
 ### Interviews
 
 As a rule, all interviews at PostHog are conducted in English. Whilst this might seem obvious to some, we are lucky to have people from multiple different countries, that speak multiple languages. We are hiring for people to be successful at PostHog, and at PostHog we conduct our business in English, so it is important the hiring process is also conducted in English.


### PR DESCRIPTION
Added a section about the 12 month cooling application period for candidates reapplying for the same or similar roles.

## Changes

I've added a blurb about a 12month cooling off period before reapplying

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
