### PR TITLE
Default product OG images

### DIFF
--- a/src/components/Products/ReaderViewProduct/index.tsx
+++ b/src/components/Products/ReaderViewProduct/index.tsx
@@ -108,7 +108,7 @@ export default function ProductReaderView({
             <SEO
                 title={seoOverrides?.title || productData?.seo?.title}
                 description={seoOverrides?.description || productData?.seo?.description}
-                image={seoOverrides?.image || `/images/og/${productData?.slug}.jpg`}
+                image={seoOverrides?.image || productData?.seo?.image || `/images/og/default.png`}
             />
             <ReaderView
                 title={productData?.name}


### PR DESCRIPTION
## Changes

Product pages used `/images/og/{slug}.jpg` as the OG image. Those files do not exist, so share previews 404 (including Replay Vision).

- Prefer `seoOverrides.image`, then `productData.seo.image` (Product Analytics, Surveys, Feature Flags, Error Tracking)
- Fall back to `/images/og/default.png` for every other product