### PR TITLE
docs(notebooks): document executable SQL and Python cells

### DIFF
--- a/contents/docs/notebooks/index.mdx
+++ b/contents/docs/notebooks/index.mdx
@@ -57,41 +57,20 @@ export const surveyDark =
 
 Notebooks enable you to combine the tools of PostHog into a single space for analysis. Rather than jumping between dashboards, insights, replays, experiment results, and more, your chain of analysis exists on a single page.
 
-Notebooks are built out of **cells**. A SQL cell runs [HogQL](/docs/data-warehouse/sql) against your PostHog and [data warehouse](/docs/data-warehouse) data. A Python cell runs in a sandboxed kernel that can read and reshape any previous cell's result. Markdown cells hold prose. Component cells embed insights, replays, feature flags, surveys, and other PostHog objects. It's one page for the query, the analysis, the visualization, and the narrative.
+It provides a flexible interface for doing deeper data analysis, exploring data from different sources, bug investigations, internal documentation, and feature releases by yourself or with your team.
 
-It provides a flexible interface for organizing ad-hoc analysis, bug investigations, internal documentation, and feature releases by yourself or with your team.
+You can write PostHog SQL to query your PostHog specific data or any of your connected warehouse sources.
+Notebooks allow you to write Python code to analyse your data further, and use the output of your queries/analysis in following query nodes for going deeper in your analysis and have a complete analysis.
 
 You can get started with notebooks by going to [the notebook tab](https://app.posthog.com/notebooks) in your PostHog instance and clicking "New notebook."
 
-> **In beta.** Executable SQL and Python cells and the sandbox kernel that powers them are rolling out behind a feature flag. Some features described below (the executable-cell types, the kernel, cross-cell dataframes, and the notebook cell tools over MCP) may not be visible in your project yet. Ask your PostHog contact if you'd like early access.
-
-## Accessing the notebook popover
-
-Critical to combining the functionality of PostHog is being able to access notebooks from anywhere, like a scratchpad for analysis which you can organize and clean up later.
-
-You can access a notebook by clicking it in the sidebar or by clicking and dragging a link anywhere in PostHog.
-
-<ProductVideo
-  videoLight={popoverLight}
-  videoDark={popoverDark}
-  alt="Popover icon"
-  classes="rounded"
-/>
-
-To switch the notebook that opens in the popover, click the title button in the top left of the popover.
-
-<ProductVideo
-  videoLight={switchLight}
-  videoDark={switchDark}
-  alt="Switch popover notebook"
-  classes="rounded"
-/>
+> **In beta.** Python cells are being rolled out behind a feature flag. Some features described related to those (cross-cell dataframes, and the notebook cell tools over MCP) may not be visible in your project yet. Ask your PostHog contact if you'd like early access.
 
 ## Adding content to notebooks
 
 To start adding content to notebooks, start typing. There are three main ways to add content to notebooks:
 
-1. **Slash commands.** Within a notebook, type `/` and a menu will pop up with options for you. For example, `/trend` creates a trend insight.
+1. **Slash commands.** Within a notebook, type `/` and a menu will pop up with options for you. For example, `/trend` adds a trend insight.
 
 <ProductVideo videoLight={slashLight} videoDark={slashDark} alt="Slash command" classes="rounded" />
 
@@ -112,28 +91,26 @@ Every SQL and Python cell has:
 - **Code**, in HogQL for a SQL cell or Python for a Python cell.
 - A **run button** that dispatches the code and streams back the result. Results are stored on the cell, so the notebook still shows the last result when you reopen it.
 - A **result view** below the code, with the table (SQL), rendered figures (Python matplotlib), and any `stdout`/`stderr`.
+- A **dataframe name** given for its output, so that other cells can reference (see below).
 - A **title** in the cell header. Set it to say what the cell shows, so a reader can skim the notebook without reading the code.
-- A **dataframe name** other cells can reference (see below).
 
-Add an executable cell with the slash menu (`/sql`, `/python`) or the `+` button on an empty line. A notebook holds at most 50 cells.
+Add an executable cell with the slash menu (`/sql`, `/python`) or the `+` button on an empty line.
 
 ### SQL cells
 
 SQL cells run HogQL against your events, persons, sessions, and any synced [data warehouse](/docs/data-warehouse) tables. The result renders as a table you can chart.
-
-A SQL cell that references a dataframe another cell created (for example a Python cell's `pandas.DataFrame`) runs on the notebook's local DuckDB engine automatically. The syntax is the same as for a ClickHouse-backed query, so you can join local dataframes with warehouse tables in a single cell.
+A SQL cell that references a dataframe another cell created (for example a Python cell's `pandas.DataFrame`) runs on the notebook's local engine automatically. You can join local dataframes with warehouse tables in a single cell.
 
 ### Python cells
 
-Python cells run in a sandboxed kernel with pandas, numpy, scipy, scikit-learn, and matplotlib preinstalled. Use them for analysis a query can't express: reshaping a SQL result, joining across dataframes, statistics, clustering, forecasting, plotting.
+Python cells run in a sandboxed compute with pandas, numpy, scipy, scikit-learn, and matplotlib preinstalled. Use them for deeper analysis: reshaping a SQL result, joining across dataframes, statistics, clustering, forecasting, plotting.
+The first Python cell in a notebook starts the node, which takes a few seconds. Subsequent cells reuse the same compute, so dataframes stay in memory across runs. SQL-only notebooks never start a compute node.
 
-The first Python cell in a notebook starts the kernel, which takes a few seconds. Subsequent cells reuse the same kernel, so dataframes stay in memory across runs. SQL-only notebooks never start a kernel.
-
-You can configure the kernel's CPU cores, memory, and idle timeout from the **compute menu** at the top of the notebook. Changing these while a kernel is running requires a restart, which clears any materialized dataframes.
+You can choose a pre-set defined compute for your notebook, or configure it manually (CPU cores, memory, timeout) as it fits best to your needs, from the **compute menu** at the top of the notebook. Changing these while a node is running requires a restart, which clears any materialized dataframes.
 
 ### Sharing data between cells
 
-Every SQL and Python cell produces a named **dataframe** (`sql_df`, `df`, or a name you pick). Other cells reference that dataframe by name:
+Every SQL and Python cell produces a named **dataframe** (`top_mrr_clients_df`, `uploads_per_month`, or a name you pick). Other cells reference that dataframe by name:
 
 - A Python cell reads it as a `pandas.DataFrame` variable.
 - A SQL cell reads it as a table via the local DuckDB engine.
@@ -291,8 +268,8 @@ If you've [connected the PostHog MCP server](/docs/model-context-protocol#get-st
 - Updating a cell's code and re-running it, with a list of downstream cells that are now stale.
 - Deleting a cell, with a list of any dataframe references now orphaned.
 - Reading the notebook's current state: title, markdown, cells, dependencies, and which cells are stale.
-- Listing the kernel's live dataframes with columns, types, and row counts.
-- Configuring the kernel's compute (CPU, memory, idle timeout).
+- Listing your node's live dataframes with columns, types, and row counts.
+- Configuring the compute (CPU, memory, idle timeout).
 
 See the [notebook tools in the MCP reference](/docs/model-context-protocol/tools) for the full list, and the [MCP use cases](/docs/model-context-protocol/use-cases#analyze-data-in-a-notebook) for prompt examples.
 
@@ -300,7 +277,8 @@ See the [notebook tools in the MCP reference](/docs/model-context-protocol/tools
 
 ### How much do notebooks cost?
 
-Notebooks are free. [Sign up for free](https://app.posthog.com/signup) to try them out.
+Notebooks are free except the sandboxed compute you attach to them when you're running Python nodes.
+You can choose a pre-set defined compute, or configure it manually as it fits best to your needs.
 
 ### What are the differences between dashboards and notebooks?
 

--- a/contents/docs/notebooks/index.mdx
+++ b/contents/docs/notebooks/index.mdx
@@ -57,9 +57,13 @@ export const surveyDark =
 
 Notebooks enable you to combine the tools of PostHog into a single space for analysis. Rather than jumping between dashboards, insights, replays, experiment results, and more, your chain of analysis exists on a single page.
 
+Notebooks are built out of **cells**. A SQL cell runs [HogQL](/docs/data-warehouse/sql) against your PostHog and [data warehouse](/docs/data-warehouse) data. A Python cell runs in a sandboxed kernel that can read and reshape any previous cell's result. Markdown cells hold prose. Component cells embed insights, replays, feature flags, surveys, and other PostHog objects. It's one page for the query, the analysis, the visualization, and the narrative.
+
 It provides a flexible interface for organizing ad-hoc analysis, bug investigations, internal documentation, and feature releases by yourself or with your team.
 
 You can get started with notebooks by going to [the notebook tab](https://app.posthog.com/notebooks) in your PostHog instance and clicking "New notebook."
+
+> **In beta.** Executable SQL and Python cells and the sandbox kernel that powers them are rolling out behind a feature flag. Some features described below (the executable-cell types, the kernel, cross-cell dataframes, and the notebook cell tools over MCP) may not be visible in your project yet. Ask your PostHog contact if you'd like early access.
 
 ## Accessing the notebook popover
 
@@ -100,6 +104,41 @@ To start adding content to notebooks, start typing. There are three main ways to
 <ProductVideo videoLight={dragLight} videoDark={dragDark} alt="Drag and drop" classes="rounded" />
 
 You can rearrange content in notebooks by dragging and dropping components into a different order.
+
+## Executable cells
+
+Every SQL and Python cell has:
+
+- **Code**, in HogQL for a SQL cell or Python for a Python cell.
+- A **run button** that dispatches the code and streams back the result. Results are stored on the cell, so the notebook still shows the last result when you reopen it.
+- A **result view** below the code, with the table (SQL), rendered figures (Python matplotlib), and any `stdout`/`stderr`.
+- A **title** in the cell header. Set it to say what the cell shows, so a reader can skim the notebook without reading the code.
+- A **dataframe name** other cells can reference (see below).
+
+Add an executable cell with the slash menu (`/sql`, `/python`) or the `+` button on an empty line. A notebook holds at most 50 cells.
+
+### SQL cells
+
+SQL cells run HogQL against your events, persons, sessions, and any synced [data warehouse](/docs/data-warehouse) tables. The result renders as a table you can chart.
+
+A SQL cell that references a dataframe another cell created (for example a Python cell's `pandas.DataFrame`) runs on the notebook's local DuckDB engine automatically. The syntax is the same as for a ClickHouse-backed query, so you can join local dataframes with warehouse tables in a single cell.
+
+### Python cells
+
+Python cells run in a sandboxed kernel with pandas, numpy, scipy, scikit-learn, and matplotlib preinstalled. Use them for analysis a query can't express: reshaping a SQL result, joining across dataframes, statistics, clustering, forecasting, plotting.
+
+The first Python cell in a notebook starts the kernel, which takes a few seconds. Subsequent cells reuse the same kernel, so dataframes stay in memory across runs. SQL-only notebooks never start a kernel.
+
+You can configure the kernel's CPU cores, memory, and idle timeout from the **compute menu** at the top of the notebook. Changing these while a kernel is running requires a restart, which clears any materialized dataframes.
+
+### Sharing data between cells
+
+Every SQL and Python cell produces a named **dataframe** (`sql_df`, `df`, or a name you pick). Other cells reference that dataframe by name:
+
+- A Python cell reads it as a `pandas.DataFrame` variable.
+- A SQL cell reads it as a table via the local DuckDB engine.
+
+PostHog tracks the dependency graph across cells and marks a downstream cell as **stale** when an upstream cell's code changes. Re-run stale cells in dependency order (top-down) to bring the notebook back in sync.
 
 ## Notebook content types
 
@@ -242,6 +281,20 @@ Diagrams render in view mode. In edit mode you see the raw source and can edit i
 ## Canvas
 
 A canvas is like a Notebook whose entire contents is persisted in the URL so that it can be easily shared with members of your organisation. Canvases support all the same content types as Notebooks but do not get persisted to the database or come with any form of history tracking. They are a great way of doing some quick explorations that you may want to share with a colleague but don't necessarily need to save for future use. The shareable link changes as you make edits, so updates to you notebook will require a new link to be shared.
+
+## Editing notebooks over MCP
+
+If you've [connected the PostHog MCP server](/docs/model-context-protocol#get-started-in-30-seconds) to your AI coding agent, it can create notebooks and drive cells on your behalf. The notebook tools cover:
+
+- Creating a markdown notebook with an initial title and body.
+- Adding a cell (SQL, Python, markdown, saved insight, or component). SQL and Python cells run immediately.
+- Updating a cell's code and re-running it, with a list of downstream cells that are now stale.
+- Deleting a cell, with a list of any dataframe references now orphaned.
+- Reading the notebook's current state: title, markdown, cells, dependencies, and which cells are stale.
+- Listing the kernel's live dataframes with columns, types, and row counts.
+- Configuring the kernel's compute (CPU, memory, idle timeout).
+
+See the [notebook tools in the MCP reference](/docs/model-context-protocol/tools) for the full list, and the [MCP use cases](/docs/model-context-protocol/use-cases#analyze-data-in-a-notebook) for prompt examples.
 
 ## Frequently asked questions
 


### PR DESCRIPTION
## Changes

Rewrite the notebooks doc so it describes the revamped executable-cell model, not just the popover and content blocks:

- New intro line naming the cell types (SQL, Python, markdown, saved insight, component).
- A short beta callout at the top, since executable cells are still rolling out behind the `revamped-py-notebooks` feature flag.
- A new **Executable cells** section covering SQL cells (HogQL against PostHog and warehouse data), Python cells (sandboxed kernel with pandas / numpy / scipy / scikit-learn / matplotlib), cell titles, and dataframe names.
- A new **Sharing data between cells** subsection covering the dependency graph and stale-cell tracking.
- A new **Compute and the kernel** subsection covering CPU / memory / idle-timeout config and the SQL-only-notebook fast path.
- A new **Editing notebooks over MCP** section pointing at the notebook tools and use cases so the two docs cross-reference each other.

## Why

We revamped notebooks around executable cells and a per-notebook Python kernel. The current public doc doesn't mention any of it, so readers landing on posthog.com/docs/notebooks have no idea SQL cells, Python cells, dataframes, or the MCP notebook tools exist.

## Overlap

There's an open PR ([#17760](https://github.com/PostHog/posthog.com/pull/17760)) documenting the inline `/ai` mode against the same file. Whichever lands second will need to rebase; both diffs are additive so the resolution is trivial. Happy to rebase either way once #17760's direction is settled.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

## 🤖 Agent context

Drafted from the posthog/products/notebooks source of truth (tools.yaml, `services/mcp/src/tools/notebooks/*.ts`, `products/notebooks/backend/`). Cell types, kernel behavior, dataframe sharing, and the 50-cell limit come from those tool descriptions and handler code. The beta callout is intentional: `revamped-py-notebooks` is not at 100%. If you'd rather ship this as GA copy, remove the callout and the "currently in beta" hedges in the MCP section.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*