### PR TITLE
docs(data-warehouse): cross-link to notebooks for SQL+Python analysis

### DIFF
--- a/contents/docs/data-warehouse/surfaces/mcp.mdx
+++ b/contents/docs/data-warehouse/surfaces/mcp.mdx
@@ -164,6 +164,7 @@ See the [MCP server docs](/docs/model-context-protocol) for full setup instructi
 ## Related
 
 - [Use the data warehouse in the web app](/docs/data-warehouse/surfaces/web-app) for the SQL editor, source setup, and insights.
+- Combine warehouse queries with Python analysis in a [notebook](/docs/notebooks). Notebook cells can also be authored through the [notebook tools](/docs/model-context-protocol/tools) on the same MCP connection.
 - [Use the data warehouse over the API](/docs/data-warehouse/surfaces/api) for the same operations from your own scripts.
 - [Use the data warehouse in PostHog Desktop](/docs/data-warehouse/surfaces/desktop) to work through failing models and syncs.
 - [Views](/docs/data-warehouse/views) and [materialized views](/docs/data-warehouse/views/materialize) for what the view tools manage.

--- a/contents/docs/data-warehouse/surfaces/web-app.mdx
+++ b/contents/docs/data-warehouse/surfaces/web-app.mdx
@@ -21,11 +21,13 @@ Open the [SQL editor](https://us.posthog.com/sql) to see the schema browser: you
 - **[Create views](/docs/data-warehouse/views)** – save a query as a view and reference it from other queries.
 - **[Materialize views](/docs/data-warehouse/views/materialize)** – refresh a view on a schedule instead of recomputing it on every read.
 - **[Visualize with insights](/docs/data-warehouse/insights)** – turn any query into a SQL insight and put it on a dashboard.
+- **[Analyze in a notebook](/docs/notebooks)** – drop a warehouse query into a SQL cell, then reshape or model the result in a Python cell with pandas, matplotlib, or scikit-learn, all in one shareable document. Executable cells are currently in beta.
 - **Fix a query with [PostHog AI](/docs/posthog-ai)** – when a query in the SQL editor errors, PostHog AI can [repair it](/docs/data-warehouse/write-sql-ai) with your real schema in context. It's an interaction mode inside the SQL editor, not a separate surface, and it's the only place PostHog AI touches the warehouse.
 
 ## Related
 
 - Start with [Get started with the data warehouse](/docs/data-warehouse/start-here).
+- Turn ad-hoc queries into a shareable investigation in a [notebook](/docs/notebooks) with SQL and Python cells.
 - Run the same queries from your editor over [MCP](/docs/data-warehouse/surfaces/mcp).
 - Automate the same work with the [API](/docs/data-warehouse/surfaces/api).
 - Work through failing models and syncs in [PostHog Desktop](/docs/data-warehouse/surfaces/desktop).

--- a/contents/docs/sql/index.mdx
+++ b/contents/docs/sql/index.mdx
@@ -68,7 +68,7 @@ ORDER BY url_count DESC
 
 When a SQL insight's query includes the [`{filters}` placeholder](/docs/data-warehouse/sql/variables), you can adjust the date range and add property filters directly on the saved insight page without opening the SQL editor. Changes re-run the query immediately but aren't saved until you explicitly save the insight. Clicking **Edit** carries any unsaved filter changes into the SQL editor where you can save them.
 
-You can use SQL insights within [notebooks](/docs/notebooks) and with external sources using the [data warehouse](/docs/data-warehouse).
+You can embed SQL insights inside [notebooks](/docs/notebooks) alongside executable SQL and Python cells for deeper analysis, and query external tables through the [data warehouse](/docs/data-warehouse).
 
 ## Query API
 


### PR DESCRIPTION
## Changes

Point data warehouse readers at notebooks as another surface for the work they're already doing in SQL:

- `contents/docs/data-warehouse/surfaces/web-app.mdx` — a bullet under "What you can do here" for **Analyze in a notebook**, plus a related-link tying the surfaces together.
- `contents/docs/data-warehouse/surfaces/mcp.mdx` — a related-link noting that notebook cells can be authored through the notebook MCP tools on the same connection as the SQL and view tools already covered on the page.
- `contents/docs/sql/index.mdx` — refresh the notebooks cross-link to mention executable SQL and Python cells, not just SQL insights.

## Why

Warehouse SQL work often needs a Python step on top: reshape, model, plot. Notebooks now do that in the same document as the query, but the warehouse docs never mention notebooks at all. This adds discovery without duplicating any content.

The beta hedge on the web-app bullet matches [#19891](https://github.com/PostHog/posthog.com/pull/19891) and can come off when `revamped-py-notebooks` is at 100%.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

## 🤖 Agent context

Independent of [#19891](https://github.com/PostHog/posthog.com/pull/19891) and [#19892](https://github.com/PostHog/posthog.com/pull/19892) — no file overlap. Land in any order.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*