### PR TITLE
fix: repair broken DigitalOcean IP screenshot path

### DIFF
--- a/contents/docs/self-host/_snippets/do-ip-address.mdx
+++ b/contents/docs/self-host/_snippets/do-ip-address.mdx
@@ -2,7 +2,7 @@ import GetInstallationAddress from './get-installation-address'
 
 1. In the DigitalOcean console, go to the `Resources` tab of your Kubernetes cluster and click on the load balancer assigned to the cluster. This will bring you to the ([networking tab](https://cloud.digitalocean.com/networking/load_balancers)) where you can get the IP address of the load balancer created by Kubernetes:
 
-    ![DigitalOcean External IP location](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents//..images/do-ip-location.png)
+    ![DigitalOcean External IP location](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/do-ip-location.png)
 
 2. If you have [configured `kubectl` access to your cluster](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/), run the following commands:
 


### PR DESCRIPTION
## Changes

The screenshot in `contents/docs/self-host/_snippets/do-ip-address.mdx` never loads. Its Cloudinary path is `posthog.com/contents//..images/do-ip-location.png`, which 404s. The asset is served at `posthog.com/contents/images/do-ip-location.png`, so this drops the stray `/..` segment. That URL returns 200.

I checked the other 862 Cloudinary assets referenced from `contents/docs` and the 37 `posthog.com` links in there. Two more are broken, but I could not find the real assets, so I left them alone rather than guess:

- `contents/docs/product-analytics/person-properties.mdx` has `featuredImage: .../contents/docs/product-analytics/images/docs-properties.png`
- `contents/docs/billing/estimating-usage-costs.mdx` has `featuredImage: .../contents/docs/billing/images/docs-groups.png`

Both 404. The path shape is right, since the three `getting-started` featured images use the same shape and load fine, so it looks like the two assets were never uploaded under those names. Those pages get no social card until someone with Cloudinary access fixes it.

## Checklist

- [x] I have read the docs style guide
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links (no internal page links changed; this is a Cloudinary asset URL)
- [ ] I have checked the pages added or changed in the Vercel preview build (I cannot see the preview until CI runs; happy to confirm once it is up)
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

## Agent context

Written with AI assistance: Claude, via Claude Code, driven by me. The broken path was found by a link check over `contents/docs` and every URL above was verified with a request rather than inferred.