### PR TITLE
docs(mcp-analytics): document which properties resolve the harness label

### DIFF
--- a/contents/docs/mcp-analytics/events.mdx
+++ b/contents/docs/mcp-analytics/events.mdx
@@ -52,6 +52,16 @@ Present on most `mcp_*` events.
 | `$mcp_response`          | object                              | Sanitized tool result                                                                                                                                                                                 |
 | `$mcp_conversation_id`   | string                              | Present when `enableConversationId` is on. See [Conversation IDs](/docs/mcp-analytics/conversation-id).                                                                                               |
 
+### How the harness label is resolved
+
+The **harness** — the friendly client label on the dashboard's breakdown ("Claude Code", "Cursor", "ChatGPT", …) — is resolved at query time from exactly three of the properties above, checked in priority order:
+
+1. **`$mcp_vendor_client`** — the vendor header (e.g. `x-anthropic-client`), the only signal separating Anthropic's pooled surfaces (Claude.ai, Cowork, Claude Design) from each other, since they all report the same `clientInfo.name`.
+2. **`$mcp_client_user_agent`** — carries the build surface for Claude Code (`(cli)` vs `(sdk-ts)` vs `(claude-vscode)` vs `(claude-desktop)`), and acts as the generic fallback when no client name arrived.
+3. **`$mcp_client_name`** — the `clientInfo.name` the client reported.
+
+A call carrying none of the three shows as unattributed, and an unrecognized client collapses into "Other". If your breakdown reads mostly "Other", check that these properties are populated — on HTTP transports the SDK captures the headers automatically (TypeScript ≥ 0.11.0, Python ≥ 7.42.0); a [custom dispatcher](/docs/mcp-analytics/custom-servers#attributing-the-caller) has to pass them itself, and stdio/in-memory transports carry no headers at all, so there the client name is the only signal.
+
 ## Exception properties
 
 Present on `$exception` events emitted alongside any failed tool call. The SDK reuses `@posthog/core`'s error-tracking parser, so these are the same `$exception_list` properties every other PostHog SDK emits — they slot straight into [Error tracking](/docs/error-tracking). Set `enableExceptionAutocapture: false` (default `true`) to stop a failed tool call from emitting the `$exception` sibling.


### PR DESCRIPTION
Adds a "How the harness label is resolved" section to the MCP analytics events reference. Customers were confused why their harness breakdown reads mostly "Other" — the docs never said which properties drive it.

The label is resolved at query time from exactly three properties, in priority order:

1. `$mcp_vendor_client` — the vendor header, the only signal separating Anthropic's pooled surfaces
2. `$mcp_client_user_agent` — the Claude Code build surface + generic fallback
3. `$mcp_client_name` — `clientInfo.name`

Also explains what to check when a breakdown is mostly "Other" (SDK version floors for the header capture, custom dispatchers passing headers themselves, stdio having no headers).

Companion to PostHog/posthog#93189, which makes harness resolution actually read the SDK-emitted `$mcp_vendor_client` (the existing line promising query-time resolution of the vendor header becomes true with that PR).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*