### PR TITLE
docs(mcp-analytics): document the vendor-gateway harness collapse

### DIFF
--- a/contents/docs/mcp-analytics/custom-servers.mdx
+++ b/contents/docs/mcp-analytics/custom-servers.mdx
@@ -193,7 +193,7 @@ Pass `error=exc` with `is_error=True` and the SDK reads `$mcp_error_message` and
 `clientInfo.name` reports `claude-code` from the CLI, the Agent SDK, the VS Code extension and the desktop app alike, so on its own it collapses every surface into one bucket and the harness breakdown reads mostly "Other". The distinguishing detail is in the raw transport headers, which a custom dispatcher has to pass itself (`instrument()` reads them off the request for you):
 
 - `client_user_agent` → `$mcp_client_user_agent` — the parenthetical carries the build (`claude-code/2.1.0 (cli)` vs `(sdk-ts)`).
-- `vendor_client` → `$mcp_vendor_client` — from vendor headers like `x-anthropic-client`, the only thing that separates Anthropic's pooled surfaces (Claude.ai, Cowork, Claude Design) from each other.
+- `vendor_client` → `$mcp_vendor_client` — from vendor headers like `x-anthropic-client`, the only thing that separates Anthropic's pooled surfaces (Claude.ai, Cowork, Claude Design) from each other. It separates the products, not surfaces within one: claude.ai web, desktop, and mobile connectors all arrive through Anthropic's server-side fetcher with the same header value, so they share the single "Claude.ai" label.
 
 Both are captured raw and classified at query time, so labels improve without an SDK release. Requires `posthog>=7.42`. stdio and in-memory transports carry no headers, so leave them unset there.
 

--- a/contents/docs/mcp-analytics/events.mdx
+++ b/contents/docs/mcp-analytics/events.mdx
@@ -60,6 +60,8 @@ The **harness** — the friendly client label on the dashboard's breakdown ("Cla
 2. **`$mcp_client_user_agent`** — carries the build surface for Claude Code (`(cli)` vs `(sdk-ts)` vs `(claude-vscode)` vs `(claude-desktop)`), and acts as the generic fallback when no client name arrived.
 3. **`$mcp_client_name`** — the `clientInfo.name` the client reported.
 
+One limitation is baked into the wire: traffic proxied through a vendor's server-side gateway carries the gateway's identity, not the end surface's. Claude.ai connectors are the common case — web, desktop, and mobile all reach your server through Anthropic's fetcher with the same `User-Agent` (`Claude-User`) and the same vendor header value, so all three resolve to the single "Claude.ai" label and no signal on the request can tell them apart.
+
 A call carrying none of the three shows as unattributed, and an unrecognized client collapses into "Other". If your breakdown reads mostly "Other", check that these properties are populated — on HTTP transports the SDK captures the headers automatically (TypeScript ≥ 0.11.0, Python ≥ 7.42.0); a [custom dispatcher](/docs/mcp-analytics/custom-servers#attributing-the-caller) has to pass them itself, and stdio/in-memory transports carry no headers at all, so there the client name is the only signal.
 
 ## Exception properties


### PR DESCRIPTION
## Changes

Customer feedback flagged that traffic proxied through vendor gateways collapses into a single harness — claude.ai web, desktop, and mobile connectors all reach an MCP server through Anthropic's server-side fetcher with the same `User-Agent` (`Claude-User`) and the same `x-anthropic-client` value, so all three resolve to the one "Claude.ai" harness label and nothing on the request can tell them apart.

That's a wire-level limitation (Anthropic sends no per-surface discriminator through its gateway), so no SDK or query change can fix it — this documents it where harness resolution is described:

- `events.mdx` — a short paragraph in the new "How the harness label is resolved" section (#19895).
- `custom-servers.mdx` — one clarifying sentence on the `vendor_client` bullet: the vendor header separates Anthropic's *products* from each other, not surfaces within claude.ai.

Header values verified against `services/mcp/src/lib/client-detection.ts` in PostHog/posthog (`Claude-User`, `ClaudeAI`).

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*