### PR TITLE
Document experiment flag cleanup PRs

### DIFF
--- a/contents/docs/experiments/managing-lifecycle.mdx
+++ b/contents/docs/experiments/managing-lifecycle.mdx
@@ -32,13 +32,9 @@ Remember, experimentation is an iterative process. Each experiment teaches you s
 
 ### Opening a flag cleanup PR
 
-When ending an experiment, you can ask PostHog to clean up the feature flag code for you. Check **Open a draft PR removing `<flag key>` from your code** in the end experiment dialog. PostHog scans your repository for references to the flag and opens a draft pull request that removes the flag checks. If you shipped a variant, its code path is kept. If the repository contains no references to the flag, no PR is opened.
+When ending an experiment, you can check **Open a draft PR removing `<flag key>` from your code** in the end experiment dialog. PostHog opens a draft pull request in your GitHub repository that removes the flag checks from your code. If you shipped a variant, its code path is kept. Review the PR before merging.
 
-This requires the GitHub integration to be connected in your project settings. If more than one repository is connected, select the repository for the PR in the dialog. Project admins can save the selection as the default for all experiments in the project, or change it later in experiment settings under **Default repository for flag cleanup PRs**.
-
-The PR is a draft, so review it before merging. After the experiment ends, a link to the cleanup task appears next to the experiment's conclusion.
-
-This feature is rolling out gradually. If you don't see the checkbox when ending an experiment, it isn't available on your project yet.
+This requires the GitHub integration to be connected in your project settings. If more than one repository is connected, pick one in the dialog. You can also set a default repository for all experiments in experiment settings.
 
 ### Ending an already rolled out experiment
 

--- a/contents/docs/experiments/managing-lifecycle.mdx
+++ b/contents/docs/experiments/managing-lifecycle.mdx
@@ -22,13 +22,23 @@ Beyond this, we recommend:
 
 2. Documenting conclusions and findings in the description field of your experiment. This helps preserve historical context for future team members.
 
-3. Removing the experiment and losing variant's code.
+3. Removing the experiment and losing variant's code. PostHog can do this for you by [opening a flag cleanup PR](#opening-a-flag-cleanup-pr).
 
 4. Archiving the experiment.
 
 5. Disabling or deleting the feature flag once the winning variant is hardcoded in your application and the flag check has been removed from your code. You can [delete flags linked to non-running experiments](/docs/feature-flags/creating-feature-flags#deleting-flags-linked-to-experiments) without losing the experiment's historical data. Every active flag counts toward your [feature flag billing](/docs/feature-flags/cutting-costs), even if it's rolled out to 100% and no longer doing anything useful.
 
 Remember, experimentation is an iterative process. Each experiment teaches you something about your users, even when results aren't what you expected.
+
+### Opening a flag cleanup PR
+
+When ending an experiment, you can ask PostHog to clean up the feature flag code for you. Check **Open a draft PR removing `<flag key>` from your code** in the end experiment dialog. PostHog scans your repository for references to the flag and opens a draft pull request that removes the flag checks. If you shipped a variant, its code path is kept. If the repository contains no references to the flag, no PR is opened.
+
+This requires the GitHub integration to be connected in your project settings. If more than one repository is connected, select the repository for the PR in the dialog. Project admins can save the selection as the default for all experiments in the project, or change it later in experiment settings under **Default repository for flag cleanup PRs**.
+
+The PR is a draft, so review it before merging. After the experiment ends, a link to the cleanup task appears next to the experiment's conclusion.
+
+This feature is rolling out gradually. If you don't see the checkbox when ending an experiment, it isn't available on your project yet.
 
 ### Ending an already rolled out experiment
 

--- a/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
+++ b/contents/docs/feature-flags/cleaning-up-stale-flags.mdx
@@ -64,6 +64,8 @@ The MCP server calls `feature-flag-get-all` with `active: "STALE"` and returns t
 
 Once you know which flags are stale, you need to decide what happens to the code they gate. This depends on the flag's rollout state:
 
+> **Tip:** For flags backing experiments, PostHog can open the cleanup PR for you when you end the experiment. See [opening a flag cleanup PR](/docs/experiments/managing-lifecycle#opening-a-flag-cleanup-pr).
+
 ### Fully rolled out flags
 
 The flag was at 100% with no targeting conditions. The enabled code path is the one to keep.


### PR DESCRIPTION
## Changes

Experiments can open a draft PR that removes the feature flag from your codebase when you end them, but the docs don't mention the feature.

- Adds an "Opening a flag cleanup PR" section to the experiment lifecycle docs: the end-experiment checkbox, repository selection, and the default repository setting.
- Adds a pointer to it from the stale flag cleanup guide.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`