### PR TITLE
docs: correct push-notification open coverage for iOS, Android and Flutter

### DIFF
--- a/contents/docs/workflows/push-notifications/android.mdx
+++ b/contents/docs/workflows/push-notifications/android.mdx
@@ -51,7 +51,20 @@ Registration and unregistration are durable. If the device is offline or the req
 
 ## Capturing opens
 
-Automatic open capture detects cold-start taps on a notification from the system tray. Warm-start taps (handled in `onNewIntent`) and notifications you display yourself from a foreground data message need the manual API:
+Automatic open capture detects cold-start taps on a notification from the system tray, recognized by the `google.message_id` extra that Firebase puts on the intent.
+
+Android gives libraries no way to observe `Activity.onNewIntent`, so a tap that arrives while your app is already running needs one line in your activity:
+
+```kotlin
+override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    PostHogAndroid.capturePushNotificationOpened(intent)
+}
+```
+
+Your launcher activity needs `android:launchMode="singleTop"`, or the system resumes the task instead of delivering the tap here. Requires Android SDK 3.62.0 or newer. `PostHogAndroid.capturePushNotificationOpened` is deduplicated against the automatic path by message id, so it can't double-count with it — unlike `PostHog.capturePushNotificationOpened` below, which isn't.
+
+Notifications you display yourself from a foreground data message, and push delivered outside FCM, aren't detected at all — capture those with the fully manual API:
 
 ```kotlin
 PostHog.capturePushNotificationOpened(

--- a/contents/docs/workflows/push-notifications/android.mdx
+++ b/contents/docs/workflows/push-notifications/android.mdx
@@ -62,9 +62,9 @@ override fun onNewIntent(intent: Intent) {
 }
 ```
 
-Your launcher activity needs `android:launchMode="singleTop"`, or the system resumes the task instead of delivering the tap here. Requires Android SDK 3.62.0 or newer. `PostHogAndroid.capturePushNotificationOpened` is deduplicated against the automatic path by message id, so it can't double-count with it — unlike `PostHog.capturePushNotificationOpened` below, which isn't.
+Your launcher activity needs `android:launchMode="singleTop"`, or the system resumes the task instead of delivering the tap here. Requires Android SDK 3.62.0 or newer. `PostHogAndroid.capturePushNotificationOpened` is deduplicated against the automatic path by message ID, so it can't double-count. `PostHog.capturePushNotificationOpened` below isn't deduplicated.
 
-Notifications you display yourself from a foreground data message, and push delivered outside FCM, aren't detected at all — capture those with the fully manual API:
+Notifications you display yourself from a foreground data message, and push delivered outside FCM, aren't detected at all. Capture those with the fully manual API:
 
 ```kotlin
 PostHog.capturePushNotificationOpened(

--- a/contents/docs/workflows/push-notifications/flutter.mdx
+++ b/contents/docs/workflows/push-notifications/flutter.mdx
@@ -25,7 +25,31 @@ await Posthog().setup(config);
 
 On iOS the native SDK hooks the app delegate's remote-notification registration callback, so it picks up the APNs token once your app registers for remote notifications. On Android it fetches the FCM token at startup when `firebase-messaging` is on the classpath. The token is registered under the current distinct ID, so it follows the user across `identify()`.
 
-Open coverage differs per platform. On iOS every tap on a remote notification is captured whatever the app state; locally-scheduled notifications are ignored. On Android only cold-start taps are captured. Capture the rest manually (below).
+Every tap on a remote notification is captured on both platforms, whether the notification cold-launched the app or it was already running. Locally-scheduled notifications are ignored — capture those manually (below).
+
+Cold-start capture needs posthog-ios 3.72.0 on iOS and posthog-android 3.62.0 on Android, which the plugin's version floors bring in. On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
+
+<CalloutBox icon="IconWarning" title="iOS needs a notification delegate" type="caution">
+
+iOS only reports a notification tap to your app through `UNUserNotificationCenter.current().delegate`. A stock Flutter app sets none, and `flutter_local_notifications` doesn't set one either — so without this, iOS reports the tap to nobody and `$push_notification_opened` is never captured, in any app state.
+
+Set it in `ios/Runner/AppDelegate.swift`:
+
+```swift
+import UserNotifications
+
+override func application(
+  _ application: UIApplication,
+  didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+) -> Bool {
+  UNUserNotificationCenter.current().delegate = self
+  return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+}
+```
+
+The SDK logs a warning when the delegate is still missing shortly after setup, if you set `debug = true` on `PostHogConfig`.
+
+</CalloutBox>
 
 The Android startup fetch doesn't see later token refreshes, so forward those yourself to keep the registered token current:
 
@@ -61,21 +85,17 @@ Registration and unregistration are durable. If the device is offline or the req
 
 ## Capturing opens
 
-For the opens automatic capture misses (locally-scheduled notifications on either platform, plus warm-start taps and foreground messages on Android), call the manual API:
+Taps on remote notifications are captured for you. Call the manual API only for opens automatic capture can't see — locally-scheduled notifications, notifications you display yourself from a foreground message, and push delivered outside FCM on Android:
 
 ```dart
-if (Platform.isAndroid) {
-  FirebaseMessaging.onMessageOpenedApp.listen((message) {
-    Posthog().capturePushNotificationOpened(
-      title: message.notification?.title,
-      body: message.notification?.body,
-      payload: message.data,
-    );
-  });
-}
+Posthog().capturePushNotificationOpened(
+  title: 'Your order shipped',
+  body: 'Track it in the app',
+  payload: {'order_id': '1234'},
+);
 ```
 
-Only call it for opens automatic capture can't see itself, or the tap is counted twice.
+Don't wire this to `FirebaseMessaging.onMessageOpenedApp` or `getInitialMessage()`. The SDK already captures those taps, and the manual call isn't deduplicated against them, so the open is counted twice.
 
 The `$push_notification_opened` event includes `$notification_title` and `$notification_body` (plus `$notification_subtitle` on iOS), and `$notification_action` for action-button taps. Notification content is only captured for notifications sent by PostHog. Opens of other notifications are still captured, but without title or body.
 
@@ -104,4 +124,5 @@ config.pushIdentityProvider = (distinctId, appId) async {
 | --- | --- |
 | Token never registers | Confirm push is set up in your app and the user granted notification permission. On Android, confirm `firebase-messaging` is on the classpath (`firebase_messaging` sets this up). Any manual `registerPushNotificationToken` call must come after `setup()` completes. |
 | Push doesn't arrive | Confirm the channel's Firebase project (Android) or APNs environment and bundle id (iOS) match your app. |
+| `$push_notification_opened` never fires | On iOS, confirm your `AppDelegate` sets `UNUserNotificationCenter.current().delegate`. On Android, confirm the notification is sent through FCM — detection keys on the `google.message_id` intent extra — and that your launcher activity still has `android:launchMode="singleTop"`, without which the system resumes the task instead of delivering the tap. |
 | Registration rejected on a Required channel | Your `pushIdentityProvider` isn't returning a valid token in time. See [Identity verification](/docs/workflows/push-notifications#identity-verification). |

--- a/contents/docs/workflows/push-notifications/flutter.mdx
+++ b/contents/docs/workflows/push-notifications/flutter.mdx
@@ -25,7 +25,7 @@ await Posthog().setup(config);
 
 On iOS the native SDK hooks the app delegate's remote-notification registration callback, so it picks up the APNs token once your app registers for remote notifications. On Android it fetches the FCM token at startup when `firebase-messaging` is on the classpath. The token is registered under the current distinct ID, so it follows the user across `identify()`.
 
-Cold-start capture on both platforms, and warm-start capture on Android, need an upcoming Flutter SDK release — the one that raises its native floors to posthog-ios 3.72.0 and posthog-android 3.62.0. From that release on, every tap on a remote notification is captured on both platforms, whether the notification cold-launched the app or it was already running.
+Cold-start capture on both platforms, and warm-start capture on Android, arrive with the Flutter SDK release that raises the matching native floor: **posthog-ios 3.72.0** for the iOS half, **posthog-android 3.62.0** for the Android half. The two halves can ship in separate releases, so if only one platform is capturing, check which floors your plugin version declares. Once a platform's floor is in place, every tap on a remote notification is captured there, whether the notification cold-launched the app or it was already running.
 
 Locally-scheduled notifications are ignored — capture those manually (below). On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
 
@@ -85,7 +85,7 @@ Registration and unregistration are durable. If the device is offline or the req
 
 ## Capturing opens
 
-Taps on remote notifications are captured for you. Call the manual API only for opens automatic capture can't see — locally-scheduled notifications, notifications you display yourself from a foreground message, and push delivered outside FCM on Android:
+Taps on remote notifications are captured for you, once your plugin version carries the native floor for that platform (see above). Call the manual API only for opens automatic capture can't see — locally-scheduled notifications, notifications you display yourself from a foreground message, and push delivered outside FCM on Android:
 
 ```dart
 Posthog().capturePushNotificationOpened(

--- a/contents/docs/workflows/push-notifications/flutter.mdx
+++ b/contents/docs/workflows/push-notifications/flutter.mdx
@@ -25,9 +25,9 @@ await Posthog().setup(config);
 
 On iOS the native SDK hooks the app delegate's remote-notification registration callback, so it picks up the APNs token once your app registers for remote notifications. On Android it fetches the FCM token at startup when `firebase-messaging` is on the classpath. The token is registered under the current distinct ID, so it follows the user across `identify()`.
 
-Every tap on a remote notification is captured on both platforms, whether the notification cold-launched the app or it was already running. Locally-scheduled notifications are ignored — capture those manually (below).
+Cold-start capture on both platforms, and warm-start capture on Android, need an upcoming Flutter SDK release — the one that raises its native floors to posthog-ios 3.72.0 and posthog-android 3.62.0. From that release on, every tap on a remote notification is captured on both platforms, whether the notification cold-launched the app or it was already running.
 
-Cold-start capture on both platforms, and warm-start capture on Android, arrive in an upcoming Flutter SDK release — they need posthog-ios 3.72.0 and posthog-android 3.62.0, which that release's version floors bring in. On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
+Locally-scheduled notifications are ignored — capture those manually (below). On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
 
 <CalloutBox icon="IconWarning" title="iOS needs a notification delegate" type="caution">
 

--- a/contents/docs/workflows/push-notifications/flutter.mdx
+++ b/contents/docs/workflows/push-notifications/flutter.mdx
@@ -27,7 +27,7 @@ On iOS the native SDK hooks the app delegate's remote-notification registration 
 
 Every tap on a remote notification is captured on both platforms, whether the notification cold-launched the app or it was already running. Locally-scheduled notifications are ignored — capture those manually (below).
 
-Cold-start capture needs posthog-ios 3.72.0 on iOS and posthog-android 3.62.0 on Android, which the plugin's version floors bring in. On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
+Cold-start capture on both platforms, and warm-start capture on Android, arrive in an upcoming Flutter SDK release — they need posthog-ios 3.72.0 and posthog-android 3.62.0, which that release's version floors bring in. On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
 
 <CalloutBox icon="IconWarning" title="iOS needs a notification delegate" type="caution">
 

--- a/contents/docs/workflows/push-notifications/flutter.mdx
+++ b/contents/docs/workflows/push-notifications/flutter.mdx
@@ -27,13 +27,15 @@ On iOS the native SDK hooks the app delegate's remote-notification registration 
 
 Cold-start capture on both platforms, and warm-start capture on Android, arrive with the Flutter SDK release that raises the matching native floor: **posthog-ios 3.72.0** for the iOS half, **posthog-android 3.62.0** for the Android half. The two halves can ship in separate releases, so if only one platform is capturing, check which floors your plugin version declares. Once a platform's floor is in place, every tap on a remote notification is captured there, whether the notification cold-launched the app or it was already running.
 
-Locally-scheduled notifications are ignored — capture those manually (below). On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
+Locally-scheduled notifications are ignored. Capture those manually (below). On Android a tap is recognized by the `google.message_id` extra that Firebase puts on the intent, so push delivered outside FCM isn't seen.
 
 <CalloutBox icon="IconWarning" title="iOS needs a notification delegate" type="caution">
 
-iOS only reports a notification tap to your app through `UNUserNotificationCenter.current().delegate`. A stock Flutter app sets none, and `flutter_local_notifications` doesn't set one either — so without this, iOS reports the tap to nobody and `$push_notification_opened` is never captured, in any app state.
+iOS only reports a notification tap to your app through `UNUserNotificationCenter.current().delegate`. A stock Flutter app doesn't set one, and neither does `flutter_local_notifications`. Without it, `$push_notification_opened` is never captured on iOS, in any app state.
 
-Set it in `ios/Runner/AppDelegate.swift`:
+</CalloutBox>
+
+Set the delegate in `ios/Runner/AppDelegate.swift`:
 
 ```swift
 import UserNotifications
@@ -48,8 +50,6 @@ override func application(
 ```
 
 The SDK logs a warning when the delegate is still missing shortly after setup, if you set `debug = true` on `PostHogConfig`.
-
-</CalloutBox>
 
 The Android startup fetch doesn't see later token refreshes, so forward those yourself to keep the registered token current:
 
@@ -85,7 +85,7 @@ Registration and unregistration are durable. If the device is offline or the req
 
 ## Capturing opens
 
-Taps on remote notifications are captured for you, once your plugin version carries the native floor for that platform (see above). Call the manual API only for opens automatic capture can't see — locally-scheduled notifications, notifications you display yourself from a foreground message, and push delivered outside FCM on Android:
+Taps on remote notifications are captured for you, once your plugin version carries the native floor for that platform (see above). Automatic capture can't see locally-scheduled notifications, notifications you display yourself from a foreground message, or push delivered outside FCM on Android. Call the manual API only for those:
 
 ```dart
 Posthog().capturePushNotificationOpened(
@@ -124,5 +124,5 @@ config.pushIdentityProvider = (distinctId, appId) async {
 | --- | --- |
 | Token never registers | Confirm push is set up in your app and the user granted notification permission. On Android, confirm `firebase-messaging` is on the classpath (`firebase_messaging` sets this up). Any manual `registerPushNotificationToken` call must come after `setup()` completes. |
 | Push doesn't arrive | Confirm the channel's Firebase project (Android) or APNs environment and bundle id (iOS) match your app. |
-| `$push_notification_opened` never fires | On iOS, confirm your `AppDelegate` sets `UNUserNotificationCenter.current().delegate`. On Android, confirm the notification is sent through FCM — detection keys on the `google.message_id` intent extra — and that your launcher activity still has `android:launchMode="singleTop"`, without which the system resumes the task instead of delivering the tap. |
+| `$push_notification_opened` never fires | On iOS, confirm your `AppDelegate` sets `UNUserNotificationCenter.current().delegate`. On Android, confirm the notification is sent through FCM (detection keys on the `google.message_id` intent extra), and that your launcher activity still has `android:launchMode="singleTop"`, without which the system resumes the task instead of delivering the tap. |
 | Registration rejected on a Required channel | Your `pushIdentityProvider` isn't returning a valid token in time. See [Identity verification](/docs/workflows/push-notifications#identity-verification). |

--- a/contents/docs/workflows/push-notifications/ios.mdx
+++ b/contents/docs/workflows/push-notifications/ios.mdx
@@ -26,6 +26,28 @@ PostHogSDK.shared.setup(config)
 
 With these enabled you only need to register for remote notifications; the SDK picks up the token and open events automatically. The token is registered under the current distinct ID, so it follows the user across `identify()`. Locally-scheduled notifications are ignored. Capture those manually (below).
 
+<CalloutBox icon="IconWarning" title="Your app must set a notification delegate" type="caution">
+
+iOS reports a notification tap through `UNUserNotificationCenter.current().delegate`. If your app never sets one, the system reports the tap to nobody, there's nothing for the SDK to observe, and `$push_notification_opened` is never captured — whatever the app state.
+
+```swift
+import UserNotifications
+
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    UNUserNotificationCenter.current().delegate = self
+    return true
+  }
+}
+```
+
+The SDK logs a warning a few seconds after `setup()` when the delegate is still missing, if you enable `config.debug`.
+
+</CalloutBox>
+
 Automatic registration and open capture require `config.enableSwizzling` to be `true` (the default). If you disable swizzling or manage your own delegates, use the manual APIs below.
 
 ## Manual registration
@@ -92,4 +114,5 @@ config.pushIdentityProvider = { distinctId, appId, completion in
 | --- | --- |
 | Token never registers | Confirm you call `registerForRemoteNotifications()` and the user granted notification permission. If you set `config.enableSwizzling = false`, automatic registration and open capture are off. Use the manual APIs. |
 | Push doesn't arrive | Confirm the channel's APNs environment (Production/Sandbox) matches your build, and the bundle id matches. |
+| Opens are never captured | Confirm your app sets `UNUserNotificationCenter.current().delegate`, and that `config.enableSwizzling` is `true`. In a cross-platform host that configures PostHog from Dart or JavaScript, call `PostHogSDK.prewarmPushNotificationOpenCapture()` (iOS SDK 3.72.0 and newer) from `application(_:didFinishLaunchingWithOptions:)` so a cold-start tap isn't lost before `setup()` runs. The PostHog Flutter plugin already does this for you. |
 | Registration rejected on a Required channel | Your `pushIdentityProvider` isn't returning a valid token in time. See [Identity verification](/docs/workflows/push-notifications#identity-verification). |

--- a/contents/docs/workflows/push-notifications/ios.mdx
+++ b/contents/docs/workflows/push-notifications/ios.mdx
@@ -28,7 +28,11 @@ With these enabled you only need to register for remote notifications; the SDK p
 
 <CalloutBox icon="IconWarning" title="Your app must set a notification delegate" type="caution">
 
-iOS reports a notification tap through `UNUserNotificationCenter.current().delegate`. If your app never sets one, the system reports the tap to nobody, there's nothing for the SDK to observe, and `$push_notification_opened` is never captured — whatever the app state.
+iOS reports a notification tap through `UNUserNotificationCenter.current().delegate`. If your app never sets one, the SDK has nothing to observe and `$push_notification_opened` is never captured, whatever the app state.
+
+</CalloutBox>
+
+Set the delegate when your app launches:
 
 ```swift
 import UserNotifications
@@ -45,8 +49,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 ```
 
 The SDK logs a warning a few seconds after `setup()` when the delegate is still missing, if you enable `config.debug`.
-
-</CalloutBox>
 
 Automatic registration and open capture require `config.enableSwizzling` to be `true` (the default). If you disable swizzling or manage your own delegates, use the manual APIs below.
 

--- a/contents/docs/workflows/push-notifications/react-native.mdx
+++ b/contents/docs/workflows/push-notifications/react-native.mdx
@@ -31,7 +31,7 @@ Both behaviors are on by default. An app that already has push configured and th
 
 On iOS the native SDK hooks the app delegate's remote-notification registration callback, so it picks up the APNs token once your app registers for remote notifications. On Android it fetches the FCM token at startup when Firebase Messaging is on the classpath (`@react-native-firebase/messaging` sets this up). The token is registered under the current distinct ID, so it follows the user across `identify()`.
 
-Open coverage differs per platform. On iOS every tap on a remote notification is captured whatever the app state; locally-scheduled notifications are ignored. On Android only cold-start taps are captured. Capture the rest manually (below).
+Open coverage differs per platform. On iOS every tap on a remote notification is captured whatever the app state, provided your app sets `UNUserNotificationCenter.current().delegate` — without one iOS reports the tap to nobody; locally-scheduled notifications are ignored. On Android only cold-start taps are captured. Capture the rest manually (below).
 
 The Android startup fetch doesn't see later token refreshes, so forward those yourself to keep the registered token current:
 

--- a/contents/docs/workflows/push-notifications/react-native.mdx
+++ b/contents/docs/workflows/push-notifications/react-native.mdx
@@ -31,7 +31,7 @@ Both behaviors are on by default. An app that already has push configured and th
 
 On iOS the native SDK hooks the app delegate's remote-notification registration callback, so it picks up the APNs token once your app registers for remote notifications. On Android it fetches the FCM token at startup when Firebase Messaging is on the classpath (`@react-native-firebase/messaging` sets this up). The token is registered under the current distinct ID, so it follows the user across `identify()`.
 
-Open coverage differs per platform. On iOS every tap on a remote notification is captured whatever the app state, provided your app sets `UNUserNotificationCenter.current().delegate` — without one iOS reports the tap to nobody; locally-scheduled notifications are ignored. On Android only cold-start taps are captured. Capture the rest manually (below).
+Open coverage differs per platform. On iOS every tap on a remote notification is captured whatever the app state, provided your app sets `UNUserNotificationCenter.current().delegate`. Without one, iOS reports the tap to nobody. Locally-scheduled notifications are ignored. On Android only cold-start taps are captured. Capture the rest manually (below).
 
 The Android startup fetch doesn't see later token refreshes, so forward those yourself to keep the registered token current:
 


### PR DESCRIPTION
## Changes

Corrects the push-notification open-tracking docs for iOS, Android and Flutter. Some of this is wrong today, independent of any SDK change.

**iOS never captures a tap unless the app sets a `UNUserNotificationCenter` delegate.** The page currently says the SDK "picks up the token and open events automatically". The token half is true; the open half is not — PostHog swizzles the app's delegate rather than installing its own, so with no delegate iOS reports the tap to nobody and `$push_notification_opened` is never captured, in any app state. This is the most likely reason a reader sees zero events, and it's what PostHog/posthog-flutter#555 turned out to be. Neither a stock Flutter app nor `flutter_local_notifications` sets one.

**The Flutter page tells users to capture Android warm taps themselves.** Once PostHog/posthog-flutter#557 ships, the plugin captures that tap too, and the manual API isn't deduplicated against it — so anyone following the current snippet double-counts every warm tap. Replaced with an example that can't collide, plus an explicit "don't wire this to `onMessageOpenedApp` / `getInitialMessage()`".

**The Android page points at the manual API for warm taps.** PostHog/posthog-android#753 adds `PostHogAndroid.capturePushNotificationOpened(intent)`, which dedupes against the automatic path. Also documents the `singleTop` requirement — without it the system resumes the task instead of delivering the tap, so the snippet would never fire — and that detection is FCM-specific (`google.message_id`).

**React Native** carries the same iOS overclaim, so that one sentence is corrected. The RN cold-start gap itself is not fixed and is out of scope here.

## Related

| | |
| --- | --- |
| PostHog/posthog-ios#792 | `prewarmPushNotificationOpenCapture()`, and the missing-delegate warning |
| PostHog/posthog-android#753 | `PostHogAndroid.capturePushNotificationOpened(intent)` |
| PostHog/posthog-flutter#556 | iOS cold-start capture — PostHog/posthog-flutter#555 |
| PostHog/posthog-flutter#557 | Android cold and warm start — PostHog/posthog-flutter#558 |
| **PostHog/posthog.com#19905** | **docs for all of the above — ← this PR** |

**Order:** the two native PRs merge and release first → the two Flutter PRs leave draft and go green on their own once the floors publish → this one last, since posthog.com deploys on merge.

## Timing

⚠️ **Do not merge before the remaining SDK releases land.** posthog.com deploys on merge. Status as of 2026-09-09:

| Needed by | Status |
| --- | --- |
| posthog-android 3.62.0 | ✅ released — the Android page is accurate today |
| posthog-ios 3.72.0 | ⏳ PostHog/posthog-ios#792 merged, release pending |
| Flutter release carrying both floors | ⏳ PostHog/posthog-flutter#556 and PostHog/posthog-flutter#557 |

Only the Flutter page still contains statements that are false today, and they are now scoped to a sentence that names the release they need rather than asserted up front. The iOS delegate callout, the FCM-detection note, the `singleTop` requirement and the whole Android page are true right now — if you'd rather ship the correction sooner, everything except `flutter.mdx` could merge today.

**The Flutter page no longer assumes a single release carries both halves.** An earlier draft said cold-start and Android warm-start capture arrive together in "the" release raising both floors, which would be wrong if PostHog/posthog-flutter#556 and PostHog/posthog-flutter#557 ship in different releases — or if only one of them lands. Each half now names the native floor it needs (posthog-ios 3.72.0 for iOS, posthog-android 3.62.0 for Android) and says the two can ship separately, so the page reads correctly under any merge order, including neither.

Draft. The two behavioural statements — Android warm-start capture being automatic, and cold start working at all — only become true when the SDK releases land. The delegate and FCM-detection corrections are true today and could merge sooner if you'd rather split them.

The Flutter SDK version numbers are deliberately not stated: #556 and #557 ship separately with different native gates, so which release carries which half depends on merge order. Native floors (posthog-ios 3.72.0, posthog-android 3.62.0) are certain and are stated.

## Testing

The behaviour described here was verified on device — iPhone 17 Pro simulator and a Pixel 9 emulator — for cold and warm starts on both platforms, in native and Flutter hosts, with each event read out of the `/batch` payload the SDK sent (the example apps were pointed at a local stand-in for the ingestion host). Re-run 2026-09-08; all eight combinations captured, one event each. Details in the linked SDK PRs.

Not verified: the site hasn't been built locally, so the `CalloutBox` rendering is unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd





