### PR TITLE
Page headings

### DIFF
--- a/contents/about.mdx
+++ b/contents/about.mdx
@@ -6,7 +6,7 @@ title: We're here to help you build successful products
 
 <LottieAnimation variant="kendrick" />
 
-## We're here to help make your product self-driving
+<h1 class="!text-2xl !font-bold !leading-snug !tracking-tight !mt-8 !mb-4">We're here to help make your product self-driving</h1>
 
 Literally every piece of software that a product engineer needs.
 

--- a/src/components/Community/Layout.tsx
+++ b/src/components/Community/Layout.tsx
@@ -13,7 +13,7 @@ interface IProps {
 }
 
 export const SectionTitle = ({ children }: { children: React.ReactNode }) => {
-    return <h2 className="m-0 mb-6">{children}</h2>
+    return <h1 className="m-0 mb-6">{children}</h1>
 }
 
 const Community = ({ children, title, tableOfContents, menu, contentWidth }: IProps) => {

--- a/src/components/Hub/index.tsx
+++ b/src/components/Hub/index.tsx
@@ -8,7 +8,7 @@ export default function Hub({ folder, sidebar, title }: { folder: string; sideba
             <div className="flex gap-8 h-full">
                 <section className="flex-1">
                     <ScrollArea>
-                        <h2 className="mb-4">{title}</h2>
+                        <h1 className="mb-4">{title}</h1>
                         <CategoryGrid folder={folder} />
                     </ScrollArea>
                 </section>

--- a/src/components/Products/ReaderViewProduct/templates/Overview.tsx
+++ b/src/components/Products/ReaderViewProduct/templates/Overview.tsx
@@ -67,7 +67,7 @@ const Overview = ({ id, productData }: SectionComponentProps) => {
                         )}
                     </div>
                     <div>
-                        <h2 className="text-4xl font-bold leading-tight">{overview?.title || name}</h2>
+                        <h1 className="!text-4xl font-bold !leading-tight">{overview?.title || name}</h1>
                         <p className="leading-relaxed">{overview?.description}</p>
                     </div>
                     <div>

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -41,7 +41,8 @@ function CopyRSSButton({ placement }: { placement: string }): JSX.Element {
 }
 
 /** The PostHog logomark (light/dark pair) with "Blog" beside it. */
-function BlogWordmark(): JSX.Element {
+function BlogWordmark({ asHeading = false }: { asHeading?: boolean }): JSX.Element {
+    const labelClass = 'text-3xl font-bold leading-none m-0'
     return (
         <div className="flex items-center gap-3">
             <Logo layout="logomark" className="h-8 w-[59px] dark:hidden" width="auto" title="PostHog" />
@@ -53,7 +54,7 @@ function BlogWordmark(): JSX.Element {
                 width="auto"
                 title="PostHog"
             />
-            <span className="text-3xl font-bold leading-none">Blog</span>
+            {asHeading ? <h1 className={labelClass}>Blog</h1> : <span className={labelClass}>Blog</span>}
         </div>
     )
 }
@@ -63,10 +64,18 @@ function BlogWordmark(): JSX.Element {
  * and again as the footer (wordmark + CTA). `placement` tags the copy event so
  * header and footer convert separately.
  */
-function BlogHeader({ placement, includeCTA = true }: { placement?: string; includeCTA?: boolean }): JSX.Element {
+function BlogHeader({
+    placement,
+    includeCTA = true,
+    asHeading = false,
+}: {
+    placement?: string
+    includeCTA?: boolean
+    asHeading?: boolean
+}): JSX.Element {
     return (
         <div className="flex flex-row items-center justify-between gap-4 py-2 flex-wrap">
-            <BlogWordmark />
+            <BlogWordmark asHeading={asHeading} />
             {includeCTA && placement ? <CopyRSSButton placement={placement} /> : null}
         </div>
     )
@@ -90,7 +99,7 @@ export default function BlogPage({ data }: { data: { posts: { nodes: PostSummary
                 hideMarkdownActions
             >
                 <div className="@container not-prose text-pretty text-primary">
-                    <BlogHeader placement="blog-header" includeCTA={false} />
+                    <BlogHeader placement="blog-header" includeCTA={false} asHeading />
                     <div className="relative mx-auto w-full max-w-6xl px-4 pb-12 @2xl:pb-20 @xl:px-8">
                         <div className="mt-2 @lg:mt-10 flex @2xl:flex-row flex-col items-center gap-8 @2xl:gap-16">
                             {/* <BlogHero className="mt-2 @2xl:mt-0" /> */}

--- a/src/pages/demo/index.tsx
+++ b/src/pages/demo/index.tsx
@@ -12,6 +12,7 @@ export default function Demo(): JSX.Element {
                 description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
                 image={`/images/og/default.png`}
             />
+            <h1 className="sr-only">Demo</h1>
             <MediaPlayer videoId="nnp7k9r717" source="wistia" borderRadius={false} />
         </>
     )

--- a/src/pages/ko/_KoreanHome.tsx
+++ b/src/pages/ko/_KoreanHome.tsx
@@ -31,7 +31,6 @@ import { motion } from 'framer-motion'
 import KoreanMDXViewer from '../../components/Korean/KoreanMDXViewer'
 import KoreanHeroCarousel from '../../components/Korean/KoreanHeroCarousel'
 import { KoreanCustomers, getKoreanSharedDescriptors } from '../../components/Korean/KoreanHomeShared'
-import Hero from 'components/Home/Sections/Hero'
 
 type TranslateFn = (value: string) => string
 type ProductSummary = {
@@ -292,7 +291,6 @@ function HeroImage(): JSX.Element {
 }
 
 const jsxComponentDescriptors: JsxComponentDescriptor[] = [
-    { name: 'Hero', kind: 'flow', props: [], Editor: () => <Hero /> },
     { name: 'Tagline', kind: 'flow', props: [], Editor: () => <Tagline /> },
     { name: 'AppCount', kind: 'flow', props: [], Editor: () => <AppCount /> },
     { name: 'CompanyStageTabs', kind: 'flow', props: [], Editor: () => <CompanyStageTabs /> },
@@ -347,7 +345,6 @@ const jsxComponentDescriptors: JsxComponentDescriptor[] = [
 ]
 
 const getJsxComponentDescriptors = (t: TranslateFn): JsxComponentDescriptor[] => [
-    { name: 'Hero', kind: 'flow', props: [], Editor: () => <Hero /> },
     { name: 'Tagline', kind: 'flow', props: [], Editor: () => <Tagline t={t} /> },
     { name: 'AppCount', kind: 'flow', props: [], Editor: () => <AppCount t={t} /> },
     { name: 'CompanyStageTabs', kind: 'flow', props: [], Editor: () => <CompanyStageTabs t={t} /> },

--- a/src/pages/ko/_KoreanHome.tsx
+++ b/src/pages/ko/_KoreanHome.tsx
@@ -31,6 +31,7 @@ import { motion } from 'framer-motion'
 import KoreanMDXViewer from '../../components/Korean/KoreanMDXViewer'
 import KoreanHeroCarousel from '../../components/Korean/KoreanHeroCarousel'
 import { KoreanCustomers, getKoreanSharedDescriptors } from '../../components/Korean/KoreanHomeShared'
+import Hero from 'components/Home/Sections/Hero'
 
 type TranslateFn = (value: string) => string
 type ProductSummary = {
@@ -291,6 +292,7 @@ function HeroImage(): JSX.Element {
 }
 
 const jsxComponentDescriptors: JsxComponentDescriptor[] = [
+    { name: 'Hero', kind: 'flow', props: [], Editor: () => <Hero /> },
     { name: 'Tagline', kind: 'flow', props: [], Editor: () => <Tagline /> },
     { name: 'AppCount', kind: 'flow', props: [], Editor: () => <AppCount /> },
     { name: 'CompanyStageTabs', kind: 'flow', props: [], Editor: () => <CompanyStageTabs /> },
@@ -345,6 +347,7 @@ const jsxComponentDescriptors: JsxComponentDescriptor[] = [
 ]
 
 const getJsxComponentDescriptors = (t: TranslateFn): JsxComponentDescriptor[] => [
+    { name: 'Hero', kind: 'flow', props: [], Editor: () => <Hero /> },
     { name: 'Tagline', kind: 'flow', props: [], Editor: () => <Tagline t={t} /> },
     { name: 'AppCount', kind: 'flow', props: [], Editor: () => <AppCount t={t} /> },
     { name: 'CompanyStageTabs', kind: 'flow', props: [], Editor: () => <CompanyStageTabs t={t} /> },

--- a/src/pages/talk-to-a-human.tsx
+++ b/src/pages/talk-to-a-human.tsx
@@ -106,6 +106,7 @@ export default function TalkToAHuman() {
                 description="PostHog is self-serve, but our team is here if you need us. Book a demo to get setup help, discuss your technical requirements, or see features in action."
                 image={`/images/og/talk-to-a-human.png`}
             />
+            <h1 className="sr-only">Talk to a human</h1>
             <ScrollArea>
                 <div data-scheme="primary" className="bg-accent text-primary h-full pt-2" data-default-form-id="509041">
                     <ContactSales formConfig={formConfig as any} />

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -630,7 +630,7 @@ export default function ApiEndpoint({ data }: { data: ApiEndpointData }): JSX.El
                 <div ref={contentContainerRef} className="p-4">
                     <SEO title={`${title} API Reference - PostHog`} />
 
-                    <h2 className="!mt-0">{title}</h2>
+                    <h1 className="!mt-0">{title}</h1>
                     <blockquote className="p-6 mb-4 rounded bg-accent">
                         <p>
                             For instructions on how to authenticate to use this endpoint, see{' '}

--- a/src/templates/Pagination.tsx
+++ b/src/templates/Pagination.tsx
@@ -21,6 +21,7 @@ const Pagination = ({
             <SEO title={`All ${title} posts - PostHog`} />
 
             <PostLayout article={false} title={title} hideSidebar hideSurvey menu={menu}>
+                <h1 className="sr-only">{title}</h1>
                 <Posts
                     title="All posts"
                     action={

--- a/src/templates/merch/Collection.tsx
+++ b/src/templates/merch/Collection.tsx
@@ -423,7 +423,7 @@ export default function Collection(props: CollectionProps): React.ReactElement {
             <HeaderBar
                 showBack
                 showForward
-                showCustomLeft={<h2 className="text-primary">Merch store</h2>}
+                showCustomLeft={<h1 className="text-primary">Merch store</h1>}
                 onCartOpen={handleCartOpen}
                 onCartClose={handleCartClose}
                 isCartOpen={cartIsOpen}


### PR DESCRIPTION
## Changes

**Adds a page `<h1>` on indexable templates that were missing one.** Closes #19897 for the listed high-traffic pages.

- Product overviews: hero is now `<h1>`; `hideTitle` stays so `ReaderView` does not add a second one
- API docs, merch, community section titles: existing visible titles promoted from `<h2>` to `<h1>`
- `/product-engineers`: `Hub` title is now `<h1>`, same classes as the old `<h2>`
- `/blog`: header wordmark is the `<h1>`; footer wordmark stays a `<span>`
- `/about`: lead heading is an `<h1>` with the same Tailwind size classes as the old `<h2>`
- `/demo`, `/talk-to-a-human`, `/blog/all` and the other `/…/all` listings: visually hidden `<h1>`

**Left alone on purpose**

- `/questions/*` — `return null` is a window-router hack. Gatsby still builds the pages; `Inbox` already sets the document title. Not `noindex`, and not empty HTML
- `/founders` — the live redesign already has an `<h1>` in `CategorySidebar`. The `Hub` change only applies there if the redesign kill-switch is off