### PR TITLE
legal: use "Processor" in DPA section 10.3

### DIFF
--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -1224,7 +1224,7 @@ function DpaGenerator() {
                             <p>
                                 10.3. <strong>Data Privacy Framework.</strong> Processor confirms that it participates
                                 in the EU-US Data Privacy Framework, the UK Extension to this Framework and the
-                                Swiss-U.S. Data Privacy Framework (together, the "<strong>DPF</strong>"). The Supplier
+                                Swiss-U.S. Data Privacy Framework (together, the "<strong>DPF</strong>"). The Processor
                                 undertakes to maintain its self-certification to the DPF; to notify Company without
                                 undue delay if Processor determines that it will cease to self-certify to the DPF; and
                                 to notify Company immediately if Processor's participation in the DPF is otherwise


### PR DESCRIPTION
## Summary

Section 10.3 of the DPA (Data Privacy Framework) referred to the party as "The Supplier" in one sentence. Every other reference in the document — including the two later sentences of the same clause — calls that party the "Processor". This changes the one reference so the clause is internally consistent.

Before:
> ... (together, the "DPF"). **The Supplier** undertakes to maintain its self-certification to the DPF; to notify Company without undue delay if Processor determines that it will cease to self-certify to the DPF ...

After:
> ... (together, the "DPF"). **The Processor** undertakes to maintain its self-certification to the DPF; to notify Company without undue delay if Processor determines that it will cease to self-certify to the DPF ...

"Supplier" is not a defined term in this agreement, so the old text pointed at a party the document never defined. This was the only occurrence of the word in the file.

## Checks

- `prettier --write` and `eslint` ran on the changed file through the pre-commit hook, both clean.
- No visual change: the edit is one word inside a paragraph of body text, so no screenshots are included.
- No page moved or was renamed, so no redirect is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)