### PR TITLE
docs: add AI wizard page for wizard feature-flags

### DIFF
--- a/contents/docs/ai-engineering/ai-wizard.mdx
+++ b/contents/docs/ai-engineering/ai-wizard.mdx
@@ -41,7 +41,9 @@ Running the wizard automatically:
 8. Optionally installs the [PostHog MCP server](/docs/model-context-protocol) for your AI agent
 
 <Caption>
+
 The AI wizard integrating both the JS Web SDK and Node SDK into a Next.js application
+
 </Caption>
 
 ## AI wizard installation
@@ -77,6 +79,7 @@ Running `npx @posthog/wizard` starts the default integration flow. The wizard al
 | `wizard audit <subcommand>` | Audit an existing integration – see [Audit subcommands](#audit-subcommands) |
 | `wizard revenue-analytics` | Wire up Stripe + PostHog revenue analytics |
 | `wizard mcp-analytics` | Instrument your own MCP server with [MCP Analytics](/docs/mcp-analytics) |
+| `wizard feature-flags` | Add feature flags on Next.js App Router (server eval + client bootstrap) – see [AI wizard installation](/docs/feature-flags/installation/ai-wizard) |
 | `wizard ai-observability` | Instrument your LLM calls with [AI Observability](/docs/ai-observability) |
 | `wizard replay-vision` | Turn on Session Replay and create [Replay Vision](/docs/replay-vision) scanners written for your product |
 | `wizard migrate` | Migrate from another analytics or feature-flag vendor |

--- a/contents/docs/feature-flags/installation/ai-wizard.mdx
+++ b/contents/docs/feature-flags/installation/ai-wizard.mdx
@@ -1,0 +1,93 @@
+---
+title: AI wizard feature flags installation
+platformIconName: IconSparkles
+---
+
+import WizardCommand from 'components/WizardCommand'
+import CalloutBox from 'components/Docs/CalloutBox'
+import { Steps, Step } from 'components/Docs/Steps'
+
+`wizard feature-flags` adds the cheap feature flags path to an **existing** PostHog install. It evaluates flags once per request on the server with `evaluateFlags()`, bootstraps those values into the client so the first paint has no flicker and no extra `/flags` fetch, and turns `/flags` polling off in CI.
+
+You still create and target flags in PostHog. This command is the first-hour wiring: one evaluation per request, the same distinct id on server and client, and a kill switch that stays off until you raise rollout. For SDK snippets without the wizard, see [adding feature flag code](/docs/feature-flags/adding-feature-flag-code).
+
+This command is not:
+
+- Default `npx @posthog/wizard` — that installs product analytics. Run it first if PostHog is not initialized.
+- `wizard audit feature-flags` — that is a read-only usage and cost audit after you already have flags.
+- The [PostHog MCP surface](/docs/feature-flags/surfaces/mcp) or [PostHog AI](/docs/feature-flags/manage-flags-ai) — those manage flags from an editor or the app. This command wires evaluation into your Next.js app.
+
+## AI wizard
+
+The fastest way to get this wiring is the wizard (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt):
+
+<WizardCommand command="feature-flags" />
+
+<CalloutBox icon="IconWarning" title="Next.js App Router 15.3+ only" type="caution">
+
+This command instruments **Next.js App Router 15.3 or newer** (`app/` directory). Pages Router, older Next.js, and other frameworks abort. For those stacks, follow [manual installation](/docs/feature-flags/installation) and [bootstrapping](/docs/feature-flags/bootstrapping).
+
+</CalloutBox>
+
+<CalloutBox icon="IconInfo" title="Not on npm @latest yet" type="fyi">
+
+The command ships in [wizard pull request 1192](https://github.com/PostHog/wizard/pull/1192) and [context-mill pull request 378](https://github.com/PostHog/context-mill/pull/378). Until those merge, `npx @posthog/wizard@latest feature-flags` will not find it. Use a local wizard build, or wait for the next npm release.
+
+</CalloutBox>
+
+## What it does
+
+<Steps>
+
+<Step title="Run it in your app repo" badge="required">
+
+From the Next.js project that already has PostHog installed, run the command above. Authenticate if the wizard asks.
+
+If PostHog is not initialized, the run aborts and tells you to run `npx @posthog/wizard` first, then re-run `wizard feature-flags`.
+
+</Step>
+
+<Step title="Confirm one UI path, or skip" badge="required">
+
+The wizard asks once. **Skip is first:** no new flag, no UI change. Confirm: one boolean flag, **active, 0% rollout**, plus one additive UI path (a new, visibly flagged element, not a wrap around existing critical logic). Auth, checkout, payments, and data-mutation handlers stay ungated. Flag-off (including 0%) is current behavior.
+
+</Step>
+
+<Step title="What it changes in code" badge="required">
+
+The wizard:
+
+- Calls `evaluateFlags()` once per request on the server
+- Bootstraps those values into the client `PostHogProvider`
+- Turns `/flags` polling off in CI so tests do not bill you
+
+It does not add local evaluation. See [bootstrapping](/docs/feature-flags/bootstrapping) and [cutting costs](/docs/feature-flags/cutting-costs) for why this path is cheaper.
+
+</Step>
+
+<Step title="Test the kill switch" badge="recommended">
+
+In PostHog, raise the flag's rollout to 100%. Reload the app. The gated UI appears. Set rollout back to 0%. Production users keep seeing today's UI until someone raises rollout in PostHog.
+
+</Step>
+
+</Steps>
+
+## For agents
+
+Paste this page's URL into any coding agent as a prompt:
+
+`https://posthog.com/docs/feature-flags/installation/ai-wizard.md`
+
+Or run the same skill without the TUI:
+
+```bash
+npx @posthog/wizard skill feature-flags-setup
+```
+
+## Related
+
+- [Bootstrapping](/docs/feature-flags/bootstrapping)
+- [Cutting costs](/docs/feature-flags/cutting-costs)
+- [`wizard audit feature-flags`](/docs/ai-engineering/ai-wizard#audit-subcommands)
+- [Manage flags over MCP](/docs/feature-flags/surfaces/mcp)

--- a/contents/docs/feature-flags/installation/index.mdx
+++ b/contents/docs/feature-flags/installation/index.mdx
@@ -8,9 +8,11 @@ import WizardCommand from 'components/WizardCommand'
 
 ## AI wizard
 
-Install PostHog in seconds with our wizard by running this command in your project directory with your terminal (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt):
+On Next.js App Router 15.3+, add the cheap flags path with this command (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt):
 
-<WizardCommand />
+<WizardCommand command="feature-flags" />
+
+This extends an existing PostHog install. It does not replace `npx @posthog/wizard`. Full walkthrough: [AI wizard feature flags installation](/docs/feature-flags/installation/ai-wizard). Other platforms: pick one below.
 
 Wait for it to finish and test the setup once the wizard is complete.
 

--- a/contents/docs/feature-flags/start-here.mdx
+++ b/contents/docs/feature-flags/start-here.mdx
@@ -8,8 +8,25 @@ import FeatureFlagsInstallationPlatforms from './installation/_snippets/installa
 import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 import { IconFlask } from '@posthog/icons'
 import OSButton from 'components/OSButton'
+import WizardCommand from 'components/WizardCommand'
 
 <QuestLog firstSpeechBubble="Let's ship some flags!" lastSpeechBubble="Time to start flagging features!">
+
+<QuestLogItem
+    title="Install with the AI wizard"
+    subtitle="Next.js App Router"
+    icon="IconSparkles"
+>
+
+  On Next.js App Router 15.3+, `wizard feature-flags` adds server `evaluateFlags()`, client bootstrap, and an optional 0% kill switch. It extends an existing PostHog install. Other stacks: skip this step and install an SDK below.
+
+  <WizardCommand command="feature-flags" />
+
+  <OSButton variant="primary" asLink to="/docs/feature-flags/installation/ai-wizard">
+    AI wizard walkthrough
+  </OSButton>
+
+</QuestLogItem>
 
 <QuestLogItem
     title="Create your first flag"

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5161,6 +5161,7 @@ export const docsMenu = {
                     featured: true,
                     children: [
                         { name: 'Overview', url: '/docs/feature-flags/installation' },
+                        { name: 'AI wizard', url: '/docs/feature-flags/installation/ai-wizard' },
                         { name: 'Web', url: '/docs/feature-flags/installation/web' },
                         { name: '.NET', url: '/docs/feature-flags/installation/dotnet' },
                         { name: 'Android', url: '/docs/feature-flags/installation/android' },


### PR DESCRIPTION
## Executive summary

The Feature Flags installation page ran the **default** wizard (`npx @posthog/wizard`). That command installs product analytics. It does not add the cheap flags path.

This PR adds `/docs/feature-flags/installation/ai-wizard` for `npx @posthog/wizard feature-flags`. The URL slot matches Product Analytics and Web Analytics (`/docs/<product>/installation/ai-wizard`). The page is **not** their thin default-wizard wrapper. It documents the specialist command the way MCP Analytics documents `command="mcp-analytics"`.

Paired with [wizard #1192](https://github.com/PostHog/wizard/pull/1192) and [context-mill #378](https://github.com/PostHog/context-mill/pull/378). The command is not on npm `@latest` until those merge. The page says that.

cc @team-wizard-and-docs

## What changed

- New page: `contents/docs/feature-flags/installation/ai-wizard.mdx`
- Nav: Feature Flags → Installation → **AI wizard** (after Overview, same slot as Product Analytics)
- Installation index: `<WizardCommand command="feature-flags" />` plus a pointer at the new page
- Start here: first QuestLog item for Next.js App Router
- AI wizard commands table: `wizard feature-flags` row

Do not add this URL to mill `shared_docs` until `https://posthog.com/docs/feature-flags/installation/ai-wizard.md` returns 200. A 404 fails mill CI.

**No tour:** content PR (`contents/` plus nav).

## Checklist

- [x] Docs / content style guides
- [x] American English
- [x] Relative URLs for internal links
- [ ] Vercel / Cloudflare preview — **fork PRs skip `deploy-preview.yml`**. Review `http://localhost:8001` or the screenshots below
- [x] No page move, no `vercel.json` redirect

<details>
<summary>Reviewer's guide</summary>

### Testing done

| Check | Command / method | Result |
|---|---|---|
| Format | lint-staged on commit (`prettier`, `eslint`, `markdownlint-cli2 --fix`); `scripts/fix-mdx.js` on the new MDX | Commit succeeded |
| Dev server | `pnpm start` (Node 22.12.0, `GATSBY_MINIMAL=true`) at `http://localhost:8001` | `/docs/feature-flags/installation/ai-wizard`, `/docs/feature-flags/installation`, `/docs/feature-flags/start-here` return 200 and render |
| Console | Puppeteer `pageerror` / `console.error` on live posthog.com (before) vs localhost (after) | One **new** warning: `validateDOMNesting: <ul> cannot appear as a descendant of <p>` (MDX list wrapping). SVG `width="auto"` and WizardCommand-in-`<p>` were already on the live installation page |
| Window resize | Viewport 640 (narrow) and 1440 (wide) | Layout reflows. Docs window still usable |

**Not tested:** production build (`pnpm build`) — memory. Cloudflare preview — fork skip. `gh pr-assets` upload to `PostHog/pr-assets` — this fork has no `CreateCommitOnBranch` there. Screenshots are on [fristovic/pr-assets](https://github.com/fristovic/pr-assets) at SHA `e07ed7bcfaca3ba15e55df82612834ccec5069b1`.

### Screenshots

Before = live `posthog.com`. After = `localhost:8001` on this branch.

#### Installation (wrong-command fix + nav child in the platform grid)

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-install-light-narrow.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-install-light-narrow.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-install-light-wide.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-install-light-wide.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-install-dark-narrow.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-install-dark-narrow.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-install-dark-wide.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-install-dark-wide.png" width="300"> |

#### Start here (new first QuestLog item)

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-start-light-narrow.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-start-light-narrow.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-start-light-wide.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-start-light-wide.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-start-dark-narrow.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-start-dark-narrow.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/before-start-dark-wide.png" width="300"> | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-start-dark-wide.png" width="300"> |

#### New page `/docs/feature-flags/installation/ai-wizard`

Live URL is 404 today. After only:

| State | After |
|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-wizard-light-narrow.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-wizard-light-wide.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-wizard-dark-narrow.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/fristovic/pr-assets/e07ed7bcfaca3ba15e55df82612834ccec5069b1/2026/09/feature-flags-wizard-docs/after-wizard-dark-wide.png" width="300"> |

### What to look at

1. **Installation `WizardCommand`** now uses `command="feature-flags"`. Same pattern as AI Observability. Other stacks still have the platform grid.
2. **The new page is a real walkthrough**, not `import WizardInstall`. Product Analytics `ai-wizard.mdx` only wraps the default wizard. Flags needs the specialist command and a pasteable URL.
3. **"Not on npm @latest yet" callout** names wizard #1192 and mill #378. Delete that box after those merge.

</details>
