### PR TITLE
docs(metrics): add log-based metrics page

### DIFF
--- a/contents/docs/logs/best-practices.mdx
+++ b/contents/docs/logs/best-practices.mdx
@@ -350,6 +350,8 @@ Match rules by service name, severity, or any log attribute. Rules run top to bo
 
 Because drop rules apply before storage, they're the fastest way to cut volume without shipping a code change. Pair them with the client-side practices above: sample at the source where you can, and use drop rules to catch the noise you can't.
 
+Dropping a log line doesn't have to mean losing its signal. [Log-based metrics](/docs/metrics/log-based-metrics) are computed at ingestion *before* drop rules run, so you can keep a trend on the lines you're dropping.
+
 ## Add trace and session context
 
 Isolated logs are hard to correlate. Adding trace IDs and session IDs connects individual log events to the broader request journey.

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -14,6 +14,8 @@ There are three ways to send metrics:
 2. **Using OpenTelemetry?** Point any standard OpenTelemetry library or Collector at [PostHog's OTLP endpoint](#set-up-metrics-with-opentelemetry), with no PostHog-specific packages.
 3. **Already exposing Prometheus metrics?** Run the metrics agent with [Docker](/docs/metrics/installation/docker) or [Kubernetes](/docs/metrics/installation/kubernetes) to scrape your existing `/metrics` endpoints, with no code changes.
 
+Already capturing logs? You can also [generate a metric from your logs](/docs/metrics/log-based-metrics) at ingestion time, with no new instrumentation.
+
 ## Already have PostHog installed? Use posthog.metrics
 
 If [posthog-js](/docs/libraries/js) is already running on your site, you can record metrics immediately: no OpenTelemetry setup, no new dependencies, and no extra authentication beyond the project API key you already configured:

--- a/contents/docs/metrics/log-based-metrics.mdx
+++ b/contents/docs/metrics/log-based-metrics.mdx
@@ -1,0 +1,66 @@
+---
+title: Log-based metrics
+---
+
+> **Note:** Metrics is in alpha. Log-based metrics are part of metrics, so they follow the same alpha status and may change before general availability.
+
+**Log-based metrics** generate a metric from your logs at ingestion time. Log lines matching a filter are tallied as they arrive and emitted as a metric you can chart, query, and alert on in [Application metrics](/docs/metrics).
+
+This is the cheapest way to keep a long-term trend on something you already log. Metrics are computed *before* [drop rules](/docs/logs/best-practices) run, so you can drop noisy log lines to cut storage costs and still keep the trend they would have told you.
+
+## When to use a log-based metric
+
+A log line tells you about one event. A log-based metric summarizes all of them, so it's the right tool when you want:
+
+- **A trend over time**: error count per service, signups per minute, jobs processed per worker
+- **A value aggregated from a log attribute**: average or total `duration_ms` from request logs
+- **A trend you can keep while dropping the logs behind it**: the metric is computed before drop rules, so you can drop high-volume `INFO` logs and still see their rate
+
+If you need to see the individual log lines behind a number, that's a job for [log search](/docs/logs/search), not a metric.
+
+## Create a log-based metric
+
+Log-based metrics are managed under [**Settings** > **Environment** > **Logs** > **Log-based metrics**](https://app.posthog.com/settings/environment-logs#logs-metric-rules).
+
+1. Click **New metric rule**.
+2. Give the rule a descriptive name (e.g. "API errors").
+3. Set the **metric name** the generated metric appears under in the metrics viewer (e.g. `log.api_errors`).
+4. Add [filters](#configure-filters) to decide which log lines feed the metric. Leave empty to match all logs.
+5. (Optional) Set a **value attribute** to aggregate a numeric log attribute instead of counting lines.
+6. (Optional) Add **group by** dimensions to split the metric into one series per value.
+7. Toggle the rule **enabled** and save.
+
+The filter preview shows how many recent log lines would have matched, so you can sanity-check the rule before enabling it.
+
+You can also create a rule from any log line: hover the line in the [logs viewer](/docs/logs/search) and click the **Create log-based metric** button, which pre-fills the rule with that line's service and severity.
+
+## Configure filters
+
+Filters use the same shape as [log search](/docs/logs/search) filters, so you can match on severity, service name, and log or resource attributes. Only matching lines feed the metric. Leave filters empty to match every ingested log line.
+
+## Count lines or aggregate a value
+
+With no value attribute, the rule **counts matching log lines**, emitted as a counter you chart with `rate` or `increase`.
+
+Set a **value attribute** (e.g. `attributes.duration_ms`) and the rule instead aggregates that numeric attribute into a distribution, so you can chart how the value's count and sum change over time. The attribute must be numeric; address nested attributes with the `attributes.` or `resource_attributes.` prefix.
+
+The metric name and value attribute can't be changed after creation, because changing either starts a brand-new series and orphans the old one. Create a new rule instead.
+
+## Group by
+
+Add group-by dimensions to split the metric into one series per distinct value combination, for example per `service_name` or `severity_text`. Top-level keys `service_name`, `severity_text`, and `event_name` are available directly; anything else is addressed through the `attributes.` / `resource_attributes.` prefixes.
+
+As with any metric, keep group-by cardinality low: each distinct value combination is its own series, so avoid user or request IDs. A rule can have at most 5 group-by keys.
+
+## Limits and behavior
+
+- A project can have at most **10 enabled** log-based metrics. Every enabled rule is evaluated against every ingested log line, so the cap bounds ingestion cost.
+- Metrics are computed at ingestion, **before** drop rules. Dropping a log line never removes its contribution to a metric.
+- Rules start **disabled** by default; toggle one on when its filters look right in the preview.
+- The generated metric lives in your project like any other metric, so it's queryable in the [metrics viewer](/docs/metrics), through SQL as `posthog.metrics`, and via the [PostHog MCP server](/docs/model-context-protocol).
+
+## Next steps
+
+- [Get started with metrics](/docs/metrics/start-here)
+- [Why you need metrics](/docs/metrics/basics)
+- [Logging best practices](/docs/logs/best-practices)

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -8308,6 +8308,12 @@ export const docsMenu = {
                     ],
                 },
                 {
+                    name: 'Log-based metrics',
+                    url: '/docs/metrics/log-based-metrics',
+                    icon: 'IconFilter',
+                    color: 'orange',
+                },
+                {
                     name: 'Why you need metrics',
                     url: '/docs/metrics/basics',
                     icon: 'IconBook',


### PR DESCRIPTION
## Changes

Adds a docs page for **log-based metrics**, the feature that generates a metric from logs at ingestion time (before drop rules). The metrics docs covered instrumented metrics (the `posthog.metrics` API, OTLP, and the metrics agent) but said nothing about generating metrics from logs, even though the feature lives in the product under **Settings → Environment → Logs → Log-based metrics**.

**Why:** the metrics docs needed to catch up to what is actually in the product. Log-based metrics were undocumented, so a user had no page explaining that they can keep a trend on logs they drop.

The new page covers:

- what a log-based metric is and when to use one
- how to create a rule (filters, count vs value-attribute aggregation, group-by)
- limits and behavior (10 enabled rules per project, computed before drop rules, starts disabled)

It also links the new page from the metrics overview and from the logs drop-rules docs, and registers it in the docs sidebar under **Application metrics**.

Log-based metrics are part of metrics, which is in **alpha** — the page says so and notes details may change before general availability.

### Screenshots

Nav change (new "Log-based metrics" entry under Application metrics) — Vercel preview build below.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*