### PR TITLE
Handbook: billing configurations for customers with organizations in more than one region

### DIFF
--- a/contents/handbook/growth/billing/customer-billing-configurations.md
+++ b/contents/handbook/growth/billing/customer-billing-configurations.md
@@ -7,37 +7,35 @@ showTitle: true
 This document outlines all possible billing configurations for customers at PostHog. The goal is to ensure the team is on the same page with the different configurations we support to ensure things move smoothly as we scale. We want to ensure they support the billing repo, dashboard, usage reports, revenue reporting, etc.
 
 
-Below are the main configurations. Each outlines how the Stripe accounts are setup and billing and how we account for revenue on them. 
+Below are the main configurations. Each one outlines how the Stripe customers are set up and billed, and how we account for revenue on them.
 
 1. Free plan customers
-   - We don't need to worry about these users because they aren't paying anything, even if they have a Stripe account.
+   - We don't need to worry about these users because they aren't paying anything, even if they have a Stripe customer.
 2. Paid plan customers
    - Regular user on a paid plan with no credits.
    - Pay the invoice directly with no funny business
    - Can be with or without tax.
    - Every line item on the invoice is a product with a product key
    - Should be using default products/prices
-   - Should only have 1 stripe account and 1 subscription
+   - Should only have 1 Stripe customer and 1 subscription. Configuration 5 below is the exception.
    - **Details**
      - mrr = sum(mrr products) + tax
 3. Start-up plan customers
    - Startup plan where users receive credits (e.g., $50,000).
    - Credits apply to all charges until the credits run out.
    - Credit usage needs to be tracked.
-   - Metadata added to Stripe account (`is_startup_plan_customer`, `credit_expires_at`, etc.).
-     - [There is an RFC](https://github.com/PostHog/product-internal/pull/610) in the works to update this metadata for better tracking.
-     - We are going to revisit this process.
+   - Metadata added to the Stripe customer (`is_startup_plan_customer`, `credit_expires_at`, etc.), as agreed in [this RFC](https://github.com/PostHog/product-internal/pull/610). The [Vitally and Zapier automations](/handbook/growth/sales/automations) read the same metadata.
    - Revenue is not earned until credits are depleted or expired.
    - Can be with or without tax.
    - Should be using default products/prices.
-   - Should only have 1 stripe account and 1 subscription.
+   - Should only have 1 Stripe customer and 1 subscription. Configuration 5 below is the exception.
    - **Details**
      - mrr = 0 while on credits
      - mrr per product = 0 while on credits
 4. Enterprise customers
    - Enterprise customers pay an invoice for credits (before the subscription is created).
    - Once the invoice is paid, the subscription is created by revops.
-   - Much of this is done via Zapier. See the [docs](https://posthog.com/handbook/growth/sales/billing) for more info.
+   - Much of this is done via Zapier. See the [billing docs](/handbook/growth/sales/billing) for more info.
    - Credits apply to their usage.
    - Credits reduce product charges on invoices.
    - Should be using default products/prices.

--- a/contents/handbook/growth/billing/customer-billing-configurations.md
+++ b/contents/handbook/growth/billing/customer-billing-configurations.md
@@ -32,13 +32,15 @@ Below are the main configurations. Each one outlines how the Stripe customers ar
    - **Details**
      - mrr = 0 while on credits
      - mrr per product = 0 while on credits
-4. Enterprise customers
-   - Enterprise customers pay an invoice for credits (before the subscription is created).
+4. Annual plan customers (prepaid credits)
+   - The customer pays an invoice for credits before the subscription is created.
    - Once the invoice is paid, the subscription is created by revops.
+   - Metadata added to the Stripe customer (`annual_plan_starts_at`, `annual_plan_ends_at`) sets the contract term. The billing service reads these dates to decide if the customer is on an annual plan today.
    - Much of this is done via Zapier. See the [billing docs](/handbook/growth/sales/billing) for more info.
    - Credits apply to their usage.
    - Credits reduce product charges on invoices.
    - Should be using default products/prices.
+   - The Enterprise platform and support package is not related to this configuration. It is an add-on that a customer can buy on any configuration. See [contract rules](/handbook/growth/sales/contract-rules).
    - **Details:**
      - mrr comes from the actual usage in that month (minus the credit-discount-percent on the customer)
 

--- a/contents/handbook/growth/billing/customer-billing-configurations.md
+++ b/contents/handbook/growth/billing/customer-billing-configurations.md
@@ -44,5 +44,27 @@ Below are the main configurations. Each outlines how the Stripe accounts are set
    - **Details:**
      - mrr comes from the actual usage in that month (minus the credit-discount-percent on the customer)
 
+5. Customers with organizations in more than one region
+   - A customer can have one organization in the US cloud and one in the EU cloud, usually because their own customers need EU data residency. Data does not move between the regions, and the customer cannot query across them.
+   - Before you choose a configuration, confirm three things with the customer: why they need the second region, the usage split they expect, and if their finance team needs the spend for each organization. Some customers ask for a second region and then use only one organization.
+   - Get the organization ID for each region before contract setup. It is much easier to set the configuration up at the start than to change it later.
+   - There are two configurations. Agree on one with the customer before the order form goes out.
+   - **Option A: one Stripe customer for each organization**
+     - Each organization gets its own Stripe customer, subscription, invoices, and credit pool.
+     - Write the credit split for each organization on the order form.
+     - Each organization operates as usual: separate spend visibility, MRR, forecasts, and billing limits.
+     - The customer pays for each add-on one time for each organization. We can comp the add-ons on the second organization, so the customer pays one time.
+     - Credits are not shared. If the split is incorrect, revops must move credits between the organizations manually.
+     - Use this option when the customer knows the split, or when their finance team needs the spend for each organization.
+   - **Option B: one Stripe customer for all the organizations**
+     - The organizations share one Stripe customer, one subscription, one invoice, and one credit pool.
+     - Usage from all the organizations is added together and reported against the shared subscription.
+     - The customer pays for each add-on one time. No override is necessary.
+     - The customer cannot see a spend breakdown for each organization.
+     - All the organizations show the same combined usage and forecast numbers in the billing UI.
+     - Billing limits for each organization are not reliable. A limit applies to the combined pool, and the organization that reported last wins.
+     - Internally, MRR and invoices attach to the canonical organization, which is the organization with the lowest customer ID. The other organizations show no MRR in our own tools, which include flags, campaigns, and Vitally.
+     - Use this option when the customer does not know the split, and their finance team does not need the spend for each organization.
+
 #### Legacy configuration
 Note: this above list is focused about the creation of new customers going forward – there are many existing configurations not covered directly in this document.

--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -15,6 +15,10 @@ The credit term only extends beyond 12 months (e.g. to 24 months for a two-year 
 -   **Paying all upfront for the full term:** the customer gets the full credit amount added in bulk at the start, with an expiry set to the full length of the term (e.g. a two-year expiry for a two-year deal paid upfront).
 -   **Paying per year (or in tranches):** the extended term does not apply. Credits are granted in tranches allocated on each renewal date, each with a 12-month term. For example, a two-year deal split evenly grants half the credits in the first year and half on the renewal date at the start of the second.
 
+### Customers with organizations in more than one region
+
+If the customer needs an organization in more than one region (for example the US cloud and the EU cloud), agree on the billing configuration before the order form goes out. Read [customer billing configurations](/handbook/growth/billing/customer-billing-configurations) for the two options and their limits. If you keep the credits separate, write the credit split for each organization on the order form. For either option, get the organization ID for each region before contract setup.
+
 ### What about monthly customers?
 
 Anyone on a monthly plan simply agrees to our [terms](/terms) and [privacy policy](/privacy) when they sign up.


### PR DESCRIPTION
## Changes

Sales and CS did not have a written answer for a customer that needs an organization in more than one cloud region (usually US plus EU for data residency). The billing team has answered this question ad hoc more than one time, so this PR puts the answer in the handbook. It also refreshes details on the same page that went stale.

**Why:** the billing configuration must be agreed before the order form goes out, because one of the two options needs a credit split written into the contract and both options need the organization ID for each region at contract setup time. Without a written page, this is discovered late in the deal.

Two files change, all prose:

- `contents/handbook/growth/billing/customer-billing-configurations.md`
  - **Adds a fifth configuration** for a customer with organizations in more than one region. It describes the two options we support (one Stripe customer for each organization, or all organizations linked to one Stripe customer), what each one gives up, and which questions to ask the customer before choosing. The behavior described matches `canonical_customer_for_stripe_customer` in the billing repo, which resolves a shared Stripe customer to the mapped billing customer with the lowest id.
  - **Renames configuration 4** from "Enterprise customers" to "Annual plan customers (prepaid credits)". The customers in this configuration buy prepaid credits on an annual contract, which the billing service identifies with the `annual_plan_starts_at` and `annual_plan_ends_at` metadata (`Customer.is_annual_plan_customer`). "Enterprise" means two different things at PostHog — the Enterprise platform and support package, and a large deal shape — so the old name told the reader nothing about the configuration and suggested two conditions that are not necessary. The item now names the metadata and says that the Enterprise package is not related. The name matches the "Annual Plan" segments we already use in Vitally and Salesforce.
  - **Removes stale text.** The RFC on startup plan Stripe metadata merged in June 2024, but the page still said it was in progress and that we would revisit the process; the metadata keys it describes are in use today in the billing code and in the sales automations. The page also said "Stripe account" where it means "Stripe customer", stated that a customer has only one Stripe customer and one subscription with no exception, and used an absolute internal link.
- `contents/handbook/growth/sales/contracts.md` — a short subsection that sends the reader to the page above before they build the order form.

No navigation, redirect, or component change. This is a content PR, so no PR tour or reviewer's guide.

## Open questions for the billing team

- Is "annual plan" the name you want? The handbook is split: `sales/billing.md` says "Credit-based Plan Automation" and `sales/automations.md` says "Annual Plan Automation" for the same Zapier table. This PR follows the billing code and the CRM segment names. Making the handbook agree everywhere is a separate PR.
- The startup plan bullet gives $50,000 as the example credit amount. Is this still the correct example?
- The paid plan bullet says `mrr = sum(mrr products) + tax`. Does MRR really include tax?

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no page moved

Notes on the pre-PR checks: `pnpm format` does not apply here, because `.prettierignore` excludes `*.md` and the `format` script does not match Markdown. The dev server was not started in this sandbox, so please use the Vercel preview to confirm both pages render.

The technical claims come from the billing team and need a review from them before merge.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C093XHYMGBE/p1788369809335839?thread_ts=1788369809.335839&cid=C093XHYMGBE)*