### PR TITLE
Iterate on the session replay pocket guide

### DIFF
--- a/contents/docs/session-replay/start-here.mdx
+++ b/contents/docs/session-replay/start-here.mdx
@@ -6,6 +6,7 @@ contentMaxWidthClass: max-w-5xl
 
 import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 import OSButton from 'components/OSButton'
+import GuidesForProduct from 'components/PocketGuides/GuidesForProduct'
 import { IconRewindPlay, IconBolt, IconMagic, IconPerson } from '@posthog/icons'
 
 <QuestLog firstSpeechBubble="Let's record your first session!" lastSpeechBubble="You're ready to watch real users!">
@@ -95,6 +96,16 @@ Session replay isn't just playback – it's a signal source. PostHog looks for t
 </div>
 
 <OSButton variant="primary" asLink to="/docs/session-replay/surfaces/desktop">Session replay and Self-driving</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem title="Learn it by use case" subtitle="Recommended" icon="IconCompass">
+
+The reference tells you what everything does. The pocket guide walks you through real problems, end to end.
+
+<div>
+  <GuidesForProduct product="session-replay" />
+</div>
 
 </QuestLogItem>
 

--- a/contents/pocket-guides/session-replay/101/index.mdx
+++ b/contents/pocket-guides/session-replay/101/index.mdx
@@ -52,7 +52,7 @@ Session Replay enables self-driving by providing you and your agents the context
 - **Observe** - Then, watch a few replays yourself and build collections to share with your team. It's a lot of fun!
 - **Self-drive** - Finally, when you find yourself drowning in replays, get a robot to watch replays for you and even open PRs for improvements and fixes!
 
-The goal is actionable reports landing in your inbox on their own, like this one <SeeFig n={2} />.
+The goals is to get actionable reports based on your session replays automatically in your inbox, like this one <SeeFig n={2} />.
 
 This pocket guide will walk you through each level of autonomy you can achieve with Session Replay.
 

--- a/contents/pocket-guides/session-replay/101/index.mdx
+++ b/contents/pocket-guides/session-replay/101/index.mdx
@@ -3,70 +3,35 @@ title: Session Replay 101
 shortTitle: Session Replay 101
 subtitle: What a replay actually is, where the recording comes from, and what watches them besides you.
 pocketGuideOrder: 1
+section: Instrument
 ---
 
 <LeftPage>
-
-<!-- Marker coordinates are percentages of the image. Grab new ones from /image-annotator. -->
 
 <ScreenshotFigure
     n={1}
     product="session_replay"
     screenshot="player-overview"
-    caption="The replay page: pick a session on the left, watch it in the middle, read what happened on the right."
-    annotations={[
-        {
-            x: 20.5,
-            y: 29.5,
-            title: 'The sessions list',
-            description: 'Recordings to watch based on your filters.',
-        },
-        {
-            x: 55,
-            y: 72,
-            title: 'The player',
-            description:
-                'Plays back sessions like a video, showing scrolling and mouse movement. You can scrub through like a video, too.',
-        },
-        {
-            x: 75,
-            y: 54,
-            title: 'The inspector panel',
-            description:
-                'The right side panel shows you events captured to PostHog, synced with the playback timestamps. This panel also contains network, performance, and other tools. More about them below.',
-        },
-    ]}
+    alt="A session playing back, with the sessions list on the left and the captured events on the right"
+    caption="A replay playing back, with the events PostHog captured beside it."
 />
 
-<ScreenshotFigure
+<AnatomyFigure
     n={2}
-    product="session_replay"
-    screenshot="player-inspector"
-    alt="A session playing back on the left, with the inspector's event list beside it"
-    caption="The player up close: the session on the left, everything PostHog recorded about it on the right."
-    annotations={[
-        {
-            x: 24,
-            y: 40,
-            title: "The session you're watching",
-            description:
-                'The session played back. It is the rendered page, not a video file, which is why it stays sharp and searchable.',
-        },
-        {
-            x: 93.4,
-            y: 4.8,
-            title: 'Flip between Overview, Inspector, Network waterfall, Observations, and create Linked issues',
-            description:
-                'Three views onto the same session, plus two more that appear when they have something to show.',
-        },
-        {
-            x: 72,
-            y: 45,
-            title: 'Follow the events and people in this replay across PostHog',
-            description:
-                'The same events you query everywhere else, in order. Each one seeks the player to that moment, and leads back out to the person, the exception, or the insight it belongs to.',
-        },
-    ]}
+    caption="Where this ends up: a report in your inbox, with the recordings that back it inside."
+    priority="P2"
+    status="Ready"
+    actionability="Actionable"
+    headline="Accounts that left onboarding midway can't get past step two. The workspace they created last time blocks them, and the name it holds is their own"
+    report={{
+        title: "Accounts that left onboarding midway can no longer finish it",
+        source: 'Scout · dead-end pages',
+        receivedAgo: '5h',
+        affected: '~180 accounts stuck, ~40 more each day',
+        body: "Sessions reaching `/onboarding/step-1` now end there 41% of the time, up from 9% across the trailing two weeks. Signup volume is unchanged and nothing threw.\n\nOnboarding creates the workspace at step two and writes `onboarding_complete` at step four. Anyone who left between the two has a workspace but an incomplete account, so the guard sends them back to step one – where step two now returns a 409, because the name is taken by the workspace they made last time. The form shows it as a validation error under the name field.\n\nThe recordings are people trying variations of their own company name against the same wall, four attempts before the tab closes.",
+        suggestedAction: 'Have step two adopt the existing workspace, and resume at the first unfinished step.',
+        actionNote: 'An agent opens the pull request – you review and merge.',
+    }}
 />
 
 </LeftPage>
@@ -75,38 +40,21 @@ pocketGuideOrder: 1
 
 # Session Replay 101
 
-Session Replay records what real users do in your product and plays it back like a DVR, with a synced dev tool panel showing console logs, network requests, and errors at the exact moment they happened.
+Session Replay records what real users do in your product and plays it back like a DVR <SeeFig n={1} />, with a synced dev tool panel showing console logs, network requests, and errors at the exact moment they happened. This is one of the tools that makes your product <Term name="self-driving">self-driving</Term>.
 
-## Anatomy of a replay
+A replay is not a video. The SDK records what changed on the page and the player rebuilds it, alongside the events, errors, and person PostHog already had. We'll take the player apart properly in [Watching replays yourself](/pocket-guides/session-replay/watching-replays).
 
-When you head to [Session Replay](https://us.posthog.com/replay) in PostHog, you'll be greeted with a player <SeeFig n={1} /> with all your recordings. You'll spend a lot of time here, so let's go on a tour.
+## Path to self-driving
 
-Select a session on the left and it plays back in the middle, with everything PostHog knows about it on the right. That context is what makes PostHog's Session Replay powerful.
+Session Replay enables self-driving by providing you and your agents the context they need to make informed decisions. Session Replays let you do this in different levels:
 
-## Session context
+- **Instrument** - First, you need high quality Session replays. You'll want to install Session Replay, filter out noise, configure privacy protection, and set up a reverse proxy.
+- **Observe** - Then, watch a few replays yourself and build collections to share with your team. It's a lot of fun!
+- **Self-drive** - Finally, when you find yourself drowning in replays, get a robot to watch replays for you and even open PRs for improvements and fixes!
 
+The goal is actionable reports landing in your inbox on their own, like this one <SeeFig n={2} />.
 
-The right-hand inspector lets you watch replays in context of your PostHog data. They add context so you can answer the who, what, when, where, and how of each replay. You can follow from replay to persons, events, logs, errors, and more.
-
-- **[Overview](/docs/session-replay/how-to-watch-recordings)** – who this is. The <Term name="person" /> and their <Term name="person property">properties</Term>, the screen they were on, which <Term name="experiment" /> variants they got, and who else on your team has already watched this replay.
-- **[Inspector](/docs/session-replay/how-to-watch-recordings)** – events and errors captured during the session on a synced timeline. Your <Term name="event">events</Term>, <Term name="console log">console logs</Term>, <Term name="network request">network requests</Term>, and <Term name="comment">comments</Term>, filterable down to one kind at a time.
-- **[Network waterfall](/docs/session-replay/network-recording)** – what the page was waiting on. Every request laid out by time, so a slow screen in the replay has something to blame.
-- **[Observations](/docs/replay-vision/observations)** – what <Term name="replay vision">Replay Vision</Term> found in this session without you watching it.
-- **[Linked issues](/docs/session-replay/integrations)** – create or find related issues in your issue tracking tool.
-
-You'll find them all on the right of the player <SeeFig n={2} />.
-
-## What's actually recorded
-
-Recordings come from your PostHog SDKs. Session Replay is supported by the [JavaScript web](/docs/session-replay/installation/web), [React Native](/docs/session-replay/installation/react-native), [iOS](/docs/session-replay/installation/ios), [Android](/docs/session-replay/installation/android), and [Flutter](/docs/session-replay/installation/flutter) SDKs.
-
-These replays are not videos on the web. The SDK takes a full snapshot of the page's DOM, then records only what changes – clicks, scrolls, mutations – and the player rebuilds the page from that stream. This helps keep cost low and minimize performance implications.
-
-| SDK | What it records |
-| --- | --- |
-| JavaScript web | The DOM, rebuilt in the player |
-| Android, iOS | A wireframe of the view hierarchy, rather than the real look and feel, unless you turn on screenshot mode |
-| React Native, Flutter | Always screenshot mode |
+This pocket guide will walk you through each level of autonomy you can achieve with Session Replay.
 
 ## Install and turn it on
 

--- a/contents/pocket-guides/session-replay/101/index.mdx
+++ b/contents/pocket-guides/session-replay/101/index.mdx
@@ -48,11 +48,11 @@ A replay is not a video. The SDK records what changed on the page and the player
 
 Session Replay enables self-driving by providing you and your agents the context they need to make informed decisions. Session Replays let you do this in different levels:
 
-- **Instrument** - First, you need high quality Session replays. You'll want to install Session Replay, filter out noise, configure privacy protection, and set up a reverse proxy.
-- **Observe** - Then, watch a few replays yourself and build collections to share with your team. It's a lot of fun!
-- **Self-drive** - Finally, when you find yourself drowning in replays, get a robot to watch replays for you and even open PRs for improvements and fixes!
+- **Instrument** – First, you need high quality Session replays. You'll want to install Session Replay, filter out noise, configure privacy protection, and set up a reverse proxy.
+- **Observe** – Then, watch a few replays yourself and build collections to share with your team. It's a lot of fun!
+- **Self-drive** – Finally, when you find yourself drowning in replays, get a robot to watch replays for you and even open PRs for improvements and fixes!
 
-The goal is actionable reports landing in your inbox on their own, like this one <SeeFig n={2} />.
+The goals is to get actionable reports based on your session replays automatically in your inbox, like this one <SeeFig n={2} />.
 
 This pocket guide will walk you through each level of autonomy you can achieve with Session Replay.
 

--- a/contents/pocket-guides/session-replay/configure-replays/index.mdx
+++ b/contents/pocket-guides/session-replay/configure-replays/index.mdx
@@ -7,6 +7,7 @@ title: Control which sessions to record
 shortTitle: Which sessions to record
 subtitle: Configure which sessions to record and keep costs low.
 pocketGuideOrder: 2
+section: Instrument
 ---
 
 <RightPage>
@@ -14,6 +15,12 @@ pocketGuideOrder: 2
 # Control which sessions to record
 
 If you get thousands or millions of visitors a day, you can't watch _every_ replay. PostHog gives you a few knobs to keep only the useful sessions and keep costs low.
+
+## What a recording actually is
+
+Recordings come from your PostHog SDKs. Session Replay is supported by the [JavaScript web](/docs/session-replay/installation/web), [React Native](/docs/session-replay/installation/react-native), [iOS](/docs/session-replay/installation/ios), [Android](/docs/session-replay/installation/android), and [Flutter](/docs/session-replay/installation/flutter) SDKs.
+
+These replays are not videos on the web. The SDK takes a full snapshot of the page's DOM, then records only what changes – clicks, scrolls, mutations – and the player rebuilds the page from that stream. This helps keep cost low and minimize performance implications.
 
 ## Trigger groups
 

--- a/contents/pocket-guides/session-replay/configure-replays/index.mdx
+++ b/contents/pocket-guides/session-replay/configure-replays/index.mdx
@@ -16,11 +16,13 @@ section: Instrument
 
 If you get thousands or millions of visitors a day, you can't watch _every_ replay. PostHog gives you a few knobs to keep only the useful sessions and keep costs low.
 
+<ProductVideo videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/Google_Chrome_515d008318.mp4" />
+
 ## What a recording actually is
 
 Recordings come from your PostHog SDKs. Session Replay is supported by the [JavaScript web](/docs/session-replay/installation/web), [React Native](/docs/session-replay/installation/react-native), [iOS](/docs/session-replay/installation/ios), [Android](/docs/session-replay/installation/android), and [Flutter](/docs/session-replay/installation/flutter) SDKs.
 
-These replays are not videos on the web. The SDK takes a full snapshot of the page's DOM, then records only what changes – clicks, scrolls, mutations – and the player rebuilds the page from that stream. This helps keep cost low and minimize performance implications.
+Replays are not videos. The SDK takes a full snapshot of the page's DOM, then records only what changes – clicks, scrolls, mutations – and the player rebuilds the page from that stream. This helps keep cost low and minimize performance implications.
 
 ## Trigger groups
 

--- a/contents/pocket-guides/session-replay/finding-replays/index.mdx
+++ b/contents/pocket-guides/session-replay/finding-replays/index.mdx
@@ -11,6 +11,7 @@ title: Finding the replay you need
 shortTitle: Finding replays
 subtitle: Recording is the easy half. Getting to the one session that explains the problem is the other.
 pocketGuideOrder: 5
+section: Observe
 ---
 
 <LeftPage>

--- a/contents/pocket-guides/session-replay/index.mdx
+++ b/contents/pocket-guides/session-replay/index.mdx
@@ -13,13 +13,11 @@ pocketGuideOrder: 0
 
 Watch how people actually use your product with Session Replay – or let <Term name="replay vision">Replay Vision</Term> watch it for you.
 
+<ProductVideo videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/Google_Chrome_515d008318.mp4" />
+
 ## Where to start
 
-This guide aims to give you a conceptual understanding of Session Replay.
-
-- **Section 1** introduces what Session Replay can do.
-- **Sections 2-4** cover key configurations to make sure you get complete, accurate recordings.
-- **Sections 5 onwards** cover common use cases and patterns to watch and analyze replays.
+Session Replay is one of the tools that makes your product <Term name="self-driving">self-driving</Term>. We'll cover what Session Replay is, how to turn it on, how to watch replays, and eventually get a robot to watch replays for you.
 
 Every page assumes a PostHog SDK is in your app with recording switched on. If it isn't yet, run the wizard first or [install it yourself](/docs/session-replay/installation):
 

--- a/contents/pocket-guides/session-replay/protecting-user-privacy/index.mdx
+++ b/contents/pocket-guides/session-replay/protecting-user-privacy/index.mdx
@@ -8,6 +8,7 @@ title: Protecting user privacy
 shortTitle: Privacy
 subtitle: Masking happens on the device, before anything is sent. Decide it before real traffic arrives.
 pocketGuideOrder: 3
+section: Instrument
 ---
 
 <LeftPage>
@@ -32,15 +33,15 @@ You should never allow captures by default. Trying to mask fields individually b
 
 ## Where each platform starts
 
-Each SDK has different default masking behavior and supports different masking rules.
+Each SDK records something different, and starts from a different default.
 
-| Platform | Masked out of the box | Can you unmask individual elements? |
-| --- | --- | --- |
-| Web | Inputs masked, all other text recorded as it appears | Yes, but through a callback rather than a selector |
-| Android | Text and images masked, recorded as a wireframe | Yes, and revealing beats masking |
-| iOS | Text and images masked, recorded as a wireframe | Yes, and revealing beats masking |
-| React Native | Text, inputs, and images masked, always a screenshot | No – only an app-wide default |
-| Flutter | Text and images masked, always a screenshot | No – only an app-wide default |
+| Platform | What it records | Masked out of the box | Unmask individually? |
+| --- | --- | --- | --- |
+| Web | The DOM, rebuilt in the player | Inputs only | Yes, through a callback rather than a selector |
+| Android | A wireframe, or screenshots if you turn screenshot mode on | Text and images | Yes, and revealing beats masking |
+| iOS | A wireframe, or screenshots if you turn screenshot mode on | Text and images | Yes, and revealing beats masking |
+| React Native | Always screenshots | Text, inputs, and images | No – only an app-wide default |
+| Flutter | Always screenshots | Text and images | No – only an app-wide default |
 
 ## Blocking is not masking
 

--- a/contents/pocket-guides/session-replay/replay-vision/index.mdx
+++ b/contents/pocket-guides/session-replay/replay-vision/index.mdx
@@ -10,6 +10,7 @@ title: Getting a robot to watch for you
 shortTitle: Getting a robot to watch for you
 subtitle: Nobody watches a thousand recordings. Make a robot do it and then tell you what it saw.
 pocketGuideOrder: 7
+section: Self-drive
 ---
 
 <LeftPage>

--- a/contents/pocket-guides/session-replay/reverse-proxy/index.mdx
+++ b/contents/pocket-guides/session-replay/reverse-proxy/index.mdx
@@ -10,6 +10,7 @@ title: Reverse proxy
 shortTitle: Reverse proxy
 subtitle: Ad blockers drop requests to known analytics domains. A reverse proxy routes them through yours instead.
 pocketGuideOrder: 4
+section: Instrument
 ---
 
 <RightPage>

--- a/contents/pocket-guides/session-replay/watching-replays/index.mdx
+++ b/contents/pocket-guides/session-replay/watching-replays/index.mdx
@@ -9,12 +9,13 @@ title: Watching replays yourself
 shortTitle: Watching replays yourself
 subtitle: The player is a DVR with your event stream welded to it. Most of what it does isn't obvious.
 pocketGuideOrder: 6
+section: Observe
 ---
 
 <LeftPage>
 
 <ScreenshotFigure
-    n={1}
+    n={3}
     product="session_replay"
     screenshot="player-controls"
     caption="The foot of the player, in the pinned layout: seek bar above, transport and capture controls below."
@@ -43,6 +44,66 @@ pocketGuideOrder: 6
     ]}
 />
 
+<ScreenshotFigure
+    n={1}
+    product="session_replay"
+    screenshot="player-overview"
+    caption="The replay page: pick a session on the left, watch it in the middle, read what happened on the right."
+    annotations={[
+        {
+            x: 20.5,
+            y: 29.5,
+            title: 'The sessions list',
+            description: 'Recordings to watch based on your filters.',
+        },
+        {
+            x: 55,
+            y: 72,
+            title: 'The player',
+            description:
+                'Plays back sessions like a video, showing scrolling and mouse movement. You can scrub through like a video, too.',
+        },
+        {
+            x: 75,
+            y: 54,
+            title: 'The inspector panel',
+            description:
+                'The right side panel shows you events captured to PostHog, synced with the playback timestamps. This panel also contains network, performance, and other tools. More about them below.',
+        },
+    ]}
+/>
+
+<ScreenshotFigure
+    n={2}
+    product="session_replay"
+    screenshot="player-inspector"
+    alt="A session playing back on the left, with the inspector's event list beside it"
+    caption="The player up close: the session on the left, everything PostHog recorded about it on the right."
+    annotations={[
+        {
+            x: 24,
+            y: 40,
+            title: "The session you're watching",
+            description:
+                'The session played back. It is the rendered page, not a video file, which is why it stays sharp and searchable.',
+        },
+        {
+            x: 93.4,
+            y: 4.8,
+            title: 'Flip between Overview, Inspector, Network waterfall, Observations, and create Linked issues',
+            description:
+                'Three views onto the same session, plus two more that appear when they have something to show.',
+        },
+        {
+            x: 72,
+            y: 45,
+            title: 'Follow the events and people in this replay across PostHog',
+            description:
+                'The same events you query everywhere else, in order. Each one seeks the player to that moment, and leads back out to the person, the exception, or the insight it belongs to.',
+        },
+    ]}
+/>
+
 </LeftPage>
 
 <RightPage>
@@ -53,12 +114,30 @@ Everything on this page is about spending less time per replay. The Session Repl
 
 Just know that you can also get a robot to watch replays for you, so you never have to learn any of this. If that sounds more like you, learn more on [the next section](/pocket-guides/session-replay/replay-vision).
 
+## Anatomy of a replay
+
+When you head to [Session Replay](https://us.posthog.com/replay) in PostHog, you'll be greeted with a player <SeeFig n={1} /> with all your recordings. You'll spend a lot of time here, so let's go on a tour.
+
+Select a session on the left and it plays back in the middle, with everything PostHog knows about it on the right. That context is what makes PostHog's Session Replay powerful.
+
+## Session context
+
+The right-hand inspector lets you watch replays in context of your PostHog data. They add context so you can answer the who, what, when, where, and how of each replay. You can follow from replay to persons, events, logs, errors, and more.
+
+- **[Overview](/docs/session-replay/how-to-watch-recordings)** – who this is. The <Term name="person" /> and their <Term name="person property">properties</Term>, the screen they were on, which <Term name="experiment" /> variants they got, and who else on your team has already watched this replay.
+- **[Inspector](/docs/session-replay/how-to-watch-recordings)** – events and errors captured during the session on a synced timeline. Your <Term name="event">events</Term>, <Term name="console log">console logs</Term>, <Term name="network request">network requests</Term>, and <Term name="comment">comments</Term>, filterable down to one kind at a time.
+- **[Network waterfall](/docs/session-replay/network-recording)** – what the page was waiting on. Every request laid out by time, so a slow screen in the replay has something to blame.
+- **[Observations](/docs/replay-vision/observations)** – what <Term name="replay vision">Replay Vision</Term> found in this session without you watching it.
+- **[Linked issues](/docs/session-replay/integrations)** – create or find related issues in your issue tracking tool.
+
+You'll find them all on the right of the player <SeeFig n={2} />.
+
 ## Playback controls
 
 - Change the playback speed. Most sessions are watchable at 2x or faster.
 - **Skip inactivity** jumps the parts where nobody did anything. It's in the **...** menu.
 - Play, pause, and seek as normal. Hold `alt` to move the seek buttons to 1 millisecond steps.
-- Controls sit in one of two layouts: **floating**, the default, which overlays the recording and appears on hover, or **pinned** <SeeFig n={1} />, which sits below and stays visible. Your choice persists across sessions.
+- Controls sit in one of two layouts: **floating**, the default, which overlays the recording and appears on hover, or **pinned** <SeeFig n={3} />, which sits below and stays visible. Your choice persists across sessions.
 - Take a screenshot, clip a GIF around the current moment, or export a whole session as MP4.
 
 Most of the player is reachable from the keyboard:

--- a/src/components/PocketGuides/bookComponents.tsx
+++ b/src/components/PocketGuides/bookComponents.tsx
@@ -1,3 +1,5 @@
+import { ProductVideo } from '../ProductVideo'
+
 import Term from './terms'
 
 import Action, { Setup } from './Action'
@@ -62,6 +64,7 @@ export const bookMdxComponents = {
     Enable,
     Action,
     Callout,
+    ProductVideo,
     Setup,
     Contents,
     SeeAlso,

--- a/src/constants/pocketGuides.ts
+++ b/src/constants/pocketGuides.ts
@@ -59,6 +59,7 @@ export const POCKET_GUIDE_VOLUMES: PocketGuideVolume[] = [
         description: 'Watch how people actually use your product – or let Replay Vision watch it for you.',
         token: 'yellow',
         volume: 4,
+        docsProduct: 'session-replay',
     },
 ]
 

--- a/src/hooks/productData/session_replay.tsx
+++ b/src/hooks/productData/session_replay.tsx
@@ -26,6 +26,8 @@ export const sessionReplay = {
     type: 'session_replay',
     teamSlug: 'replay',
     forumTopicId: 377,
+    // Volume id in src/constants/pocketGuides.ts – gives the docs a Learn tab.
+    pocketGuideVolume: 'session-replay',
     color: 'yellow',
     colorSecondary: '[#B56C00]',
     wizardSupport: true,

--- a/src/pages/docs/session-replay/learn.tsx
+++ b/src/pages/docs/session-replay/learn.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import LearnPage from 'components/PocketGuides/LearnPage'
+
+export default function SessionReplayLearn(): JSX.Element {
+    return (
+        <LearnPage
+            productHandle="session_replay"
+            title="Learn Session Replay – PostHog"
+            description="Watch how people actually use your product – or let Replay Vision watch it for you."
+        />
+    )
+}

--- a/src/pages/docs/session-replay/learn/[...chapter].tsx
+++ b/src/pages/docs/session-replay/learn/[...chapter].tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useLocation } from '@reach/router'
+
+import LearnPage from 'components/PocketGuides/LearnPage'
+
+const BASE = '/docs/session-replay/learn'
+
+/** Client-only; the indexed copy is /pocket-guides. */
+export default function SessionReplayLearnChapter(): JSX.Element {
+    const location = useLocation()
+    const chapter = (location?.pathname || '').replace(/\/$/, '').slice(BASE.length).replace(/^\//, '')
+
+    return (
+        <LearnPage
+            productHandle="session_replay"
+            chapter={chapter}
+            title="Learn Session Replay – PostHog"
+            description="Watch how people actually use your product – or let Replay Vision watch it for you."
+        />
+    )
+}


### PR DESCRIPTION
K so Sean M sniped me with OODA loops. Here's what comes of it. 

## What changed
- I moved the introduction as -> How to get to self-driving
- I frame each section as a step toward it. 
- I added a video
- I show an example of a report earlier in the pocket guide <3

--- 

Moving video pixels for people's attention


<img width="1000" height="1400" alt="image" src="https://github.com/user-attachments/assets/9f28da7a-584d-4bd6-91d3-16ff6b66ba47" />

Path to self-driving + a preview of the end result of a self-driving report

<img width="875" height="593" alt="Screenshot 2026-09-02 at 6 51 58 PM" src="https://github.com/user-attachments/assets/e60d3980-cd79-4452-9c07-1d12e9ad3499" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: Learn tab and review changes

**The volume is on the docs now.** Session Replay's docs get a Learn tab, the same way AI Observability's do. `/docs/session-replay/learn` shows the book, `/docs/session-replay/learn/<chapter>` shows one chapter, and "Get started" has a "Learn it by use case" card that links the volume. Three small pieces make this work: `docsProduct` on the volume, `pocketGuideVolume` on the product data, and two page files that copy the AI Observability ones. No new components.

**Review changes.** The 101 uses the suggested wording for the goal sentence, and its tier list uses en dashes, which clears the three Vale errors. "Control which sessions to record" uses the suggested wording for what a replay is, and shows the cover's clip above that section.
