### PR TITLE
docs(metrics): document the metrics viewer and exploration features

### DIFF
--- a/contents/docs/metrics/architecture.mdx
+++ b/contents/docs/metrics/architecture.mdx
@@ -12,6 +12,8 @@ Metrics arrive over the OpenTelemetry Protocol (OTLP) via HTTP at `/i/v1/metrics
 
 Each incoming data point carries a metric name, a metric type, a value (or histogram buckets), a timestamp, resource attributes describing the sender (service name, host), and data point attributes describing the measurement (route, status). Ingestion validates the payload, applies your project's quota, and writes data points to a columnar time series store.
 
+Not every metric arrives over OTLP. A [log-based metric](/docs/logs/metrics) is generated at ingestion from your logs: log lines matching a rule are tallied as they arrive and emitted as a metric into the same store, so it shows up in the metrics viewer like any instrumented metric.
+
 ## The series model
 
 A **series** is one stream of values identified by the combination of:
@@ -44,6 +46,13 @@ Queries resolve over a shared time grid. PostHog picks a bucket size automatical
 Filters match attribute values with equality, negation, or regular expressions, and can target resource attributes, data point attributes, or both. Group by splits the result into one series per attribute value, keeping the largest series when there are too many to chart.
 
 Through the query API you can also combine multiple metrics with a formula, for example an error ratio computed as `errors / requests`, evaluated server side on the shared grid.
+
+## Anomaly detection and samples
+
+Two more things sit between storage and the chart:
+
+- **Anomaly detection.** When you chart a metric, PostHog compares the most recent slice of the window against a baseline and, if they differ statistically, finds the onset and ranks which label values drove the move. That powers the anomaly badge and biggest-movers panel in the [viewer](/docs/metrics/explore).
+- **Raw samples.** Alongside the aggregated series, PostHog keeps the individual emissions. The Samples view in the viewer reads these to show the exact data points behind a chart, and to link each one to the trace it was recorded in when trace context is present.
 
 ## Storage and SQL access
 

--- a/contents/docs/metrics/basics.mdx
+++ b/contents/docs/metrics/basics.mdx
@@ -42,7 +42,7 @@ The same goes for error budgets and latency. A `rate` on an error counter divide
 
 Most teams keep metrics in a separate system from everything else, so answering "did that latency spike affect signups?" means tab switching and timestamp matching. In PostHog, metrics live alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), product analytics, and session replays, in the same project with the same query language.
 
-Everything is queryable as SQL through the `posthog.metrics` table, and the [PostHog MCP server](/docs/model-context-protocol) exposes metrics to AI agents, so your tools can chart, compare, and investigate metrics for you.
+Everything is queryable as SQL through the `posthog.metrics` table, and the [PostHog MCP server](/docs/model-context-protocol) exposes metrics to AI agents, so your tools can chart, compare, and investigate metrics for you. PostHog also watches the metrics you chart: when one moves against its baseline, an anomaly badge surfaces the change and the label values behind it, and the raw samples stay linked to the logs and traces that explain them.
 
 ## Next steps
 

--- a/contents/docs/metrics/basics.mdx
+++ b/contents/docs/metrics/basics.mdx
@@ -42,7 +42,7 @@ The same goes for error budgets and latency. A `rate` on an error counter divide
 
 Most teams keep metrics in a separate system from everything else, so answering "did that latency spike affect signups?" means tab switching and timestamp matching. In PostHog, metrics live alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), product analytics, and session replays, in the same project with the same query language.
 
-Everything is queryable as SQL through the `posthog.metrics` table, and the [PostHog MCP server](/docs/model-context-protocol) exposes metrics to AI agents, so your tools can chart, compare, and investigate metrics for you. PostHog also watches the metrics you chart: when one moves against its baseline, an anomaly badge surfaces the change and the label values behind it, and the raw samples stay linked to the logs and traces that explain them.
+Everything is queryable as SQL through the `posthog.metrics` table, and the [PostHog MCP server](/docs/model-context-protocol) exposes metrics to AI agents, so your tools can chart, compare, and investigate metrics for you. When you chart a metric that has moved against its baseline, an anomaly badge surfaces the change and the label values behind it, and the raw samples stay linked to the logs and traces that explain them.
 
 ## Next steps
 

--- a/contents/docs/metrics/explore.mdx
+++ b/contents/docs/metrics/explore.mdx
@@ -4,12 +4,11 @@ title: Use your metrics
 
 > **Note:** Metrics is in alpha. The views on this page reflect the current product and may change before general availability.
 
-Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has four tabs:
+Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has three tabs:
 
 - **Overview** — is anything arriving, and from which services
 - **Viewer** — chart one metric, break it down, and pivot into logs and traces
 - **SQL** — query your metrics directly as the `posthog.metrics` table
-- **Fundamentals** — the rules a correct chart follows, and a way to check one against real data
 
 ## Overview
 
@@ -39,7 +38,7 @@ From there you can shape the chart itself:
 
 When the metric you're charting moves, the viewer does the first pass of the investigation for you. If the most recent slice of the selected window is statistically different from the rest, an **anomaly badge** appears on the chart showing the percent change against the baseline and when the shift started. Click it to see the **biggest movers** — the label values that drove the change — and pick one to narrow the chart to it.
 
-The **Fundamentals** tab explains the rules a correct chart follows and can take a real bucket apart to show how the number was computed from the raw samples.
+This is investigation, not alerting. The badge is computed when you open a chart — it helps you spot and explain a change you're already looking at. It doesn't watch your metrics around the clock or notify you; for that, set up an [alert](#alerting).
 
 ### Pivot into logs and traces
 
@@ -70,6 +69,18 @@ When a chart is worth keeping, turn it into something durable:
 - **Save as insight** saves the current chart as a reusable insight.
 - **Add to dashboard** drops it onto an existing or new dashboard.
 - **New service dashboard** builds a starter dashboard in one step — pick the metrics (optionally scoped to a service) and PostHog creates one insight per metric, each charted with its recommended aggregation.
+
+## Alerting
+
+Charts and dashboards are for when you're watching; an alert is for when you're not. To get notified when a metric crosses a threshold, save the chart as an insight first — metric alerts are built on insights, so they live alongside your other alerts on the insights and dashboards you already use.
+
+1. In the viewer, click **Save as insight** (or **Add to dashboard**).
+2. Open the saved insight, click **Actions** in the sidebar, and choose **Alerts**.
+3. Click **New alert**, name it, and set the threshold you want to be notified about.
+
+Alerts are threshold-based: you set a bound the metric must stay above or below, and PostHog notifies you (Slack, Microsoft Teams, or webhook) when it crosses. Because a metric alert is just an alert on a metric insight, it uses the same alerting platform and notification channels as every other insight.
+
+See [Alerts](/docs/alerts) for the full setup, including [thresholds](/docs/alerts#thresholds) and [notification channels](/docs/alerts#notifications).
 
 ## Next steps
 

--- a/contents/docs/metrics/explore.mdx
+++ b/contents/docs/metrics/explore.mdx
@@ -1,0 +1,78 @@
+---
+title: Use your metrics
+---
+
+> **Note:** Metrics is in alpha. The views on this page reflect the current product and may change before general availability.
+
+Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has four tabs:
+
+- **Overview** — is anything arriving, and from which services
+- **Viewer** — chart one metric, break it down, and pivot into logs and traces
+- **SQL** — query your metrics directly as the `posthog.metrics` table
+- **Fundamentals** — the rules a correct chart follows, and a way to check one against real data
+
+## Overview
+
+The **Overview** tab is the first place to check whether ingestion is healthy. It shows an ingestion rollup over the last day:
+
+- **Services**, **Metric names**, and **Active series** counts
+- A per-service table with each service's metric count, active series, and **last seen** time. A service that has gone quiet is flagged so you can spot a dropped exporter before it becomes an outage.
+
+Click a service to jump into the viewer scoped to that service. If nothing has arrived yet, the tab links you to the [setup guide](/docs/metrics).
+
+## Viewer
+
+The **Viewer** tab is where you explore a single metric without writing any queries.
+
+- **Pick a metric** by name to chart it over time.
+- **Choose an aggregation** — sum, average, series count, min, max, p95, rate, or increase. The viewer recommends one based on the metric's type: `increase` for counters, `avg` for gauges, `p95` for histograms and summaries.
+- **Group by** an attribute to break the metric into one line per value, for example request rate per route or queue depth per worker.
+- **Filter** with `key=value` chips to focus on one service, environment, or status, and adjust the date range.
+
+From there you can shape the chart itself:
+
+- **Display type** — line, area, or bar.
+- **Chart settings** — add goal lines, switch the Y axis between linear and logarithmic, toggle begin-at-zero, and pin a min or max bound.
+- **Auto-refresh** — refresh the chart every 15 seconds while you watch a deploy or an incident.
+
+### Spot what changed
+
+When the metric you're charting moves, the viewer does the first pass of the investigation for you. If the most recent slice of the selected window is statistically different from the rest, an **anomaly badge** appears on the chart showing the percent change against the baseline and when the shift started. Click it to see the **biggest movers** — the label values that drove the change — and pick one to narrow the chart to it.
+
+The **Fundamentals** tab explains the rules a correct chart follows and can take a real bucket apart to show how the number was computed from the raw samples.
+
+### Pivot into logs and traces
+
+A metric tells you something changed; logs and traces tell you why. The viewer keeps those one click away, scoped to the same service and time window:
+
+- **Exemplar markers** — metrics sent with trace context show clickable dots along the chart baseline, one per traced emission, that open the trace directly.
+- **Samples** — a side panel lists the raw emissions behind the chart. The **Samples** view links each emission to the trace it was recorded in; the **Aggregates** view shows per-series latest and total.
+- **Related** — jump to the **Logs**, **Error logs**, or **Traces** for the chart's service and time window. Filter or group by a service first so the jump lands on the right slice.
+
+### Log-based metrics
+
+A metric generated from your logs by a [log-based metric](/docs/logs/metrics) rule carries a **From logs** tag. Click it to view the source logs the rule matches, or to open the rule in settings.
+
+## Query with SQL
+
+The **SQL** tab gives you direct access to your metrics with [SQL](/docs/sql):
+
+```sql
+SELECT * FROM posthog.metrics LIMIT 10
+```
+
+Use it for anything the viewer doesn't cover: joining metrics against each other, custom math, or ad-hoc exploration of raw data points.
+
+## Save and share
+
+When a chart is worth keeping, turn it into something durable:
+
+- **Save as insight** saves the current chart as a reusable insight.
+- **Add to dashboard** drops it onto an existing or new dashboard.
+- **New service dashboard** builds a starter dashboard in one step — pick the metrics (optionally scoped to a service) and PostHog creates one insight per metric, each charted with its recommended aggregation.
+
+## Next steps
+
+- [Get started with metrics](/docs/metrics/start-here)
+- [Generate a metric from your logs](/docs/logs/metrics)
+- [How metrics works under the hood](/docs/metrics/architecture)

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -207,26 +207,7 @@ Good starting points:
 
 ## Use your metrics
 
-Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog.
-
-### Chart metrics in the viewer
-
-The **Viewer** tab lets you explore metrics without writing any queries:
-
-- **Pick a metric** by name to chart it over time
-- **Choose an aggregation**: sum, average, count, p95, rate, or increase. The viewer recommends one based on the metric's type: increase for counters, average for gauges, p95 for histograms
-- **Group by attributes** to break a metric down into one line per value, like per route or per status code
-- **Filter** to the series you care about, and adjust the date range
-
-### Query metrics with SQL
-
-The **SQL** tab gives you direct access to your metrics with [SQL](/docs/sql):
-
-```sql
-SELECT * FROM posthog.metrics LIMIT 10
-```
-
-Use it for anything the viewer doesn't cover, joining metrics against each other, custom math, or ad-hoc exploration of raw data points.
+Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has four tabs — **Overview** for ingestion health, **Viewer** to chart and break down a metric, **SQL** to query the raw data, and **Fundamentals** to check how a number was computed. Chart any metric over time, group and filter it by attribute, let the anomaly badge point at what changed, and pivot into the logs and traces behind it. See [Use your metrics](/docs/metrics/explore) for the full tour.
 
 ## Troubleshooting
 

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -207,7 +207,7 @@ Good starting points:
 
 ## Use your metrics
 
-Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has four tabs — **Overview** for ingestion health, **Viewer** to chart and break down a metric, **SQL** to query the raw data, and **Fundamentals** to check how a number was computed. Chart any metric over time, group and filter it by attribute, let the anomaly badge point at what changed, and pivot into the logs and traces behind it. See [Use your metrics](/docs/metrics/explore) for the full tour.
+Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has three tabs — **Overview** for ingestion health, **Viewer** to chart and break down a metric, and **SQL** to query the raw data. Chart any metric over time, group and filter it by attribute, let the anomaly badge point at what changed, pivot into the logs and traces behind it, and set an [alert](/docs/metrics/explore#alerting) to get notified when a metric crosses a threshold. See [Use your metrics](/docs/metrics/explore) for the full tour.
 
 ## Troubleshooting
 

--- a/contents/docs/metrics/start-here.mdx
+++ b/contents/docs/metrics/start-here.mdx
@@ -83,7 +83,7 @@ If you need to know what happened for one specific user or request, that's a job
     icon="IconSearch"
 >
 
-Open **Metrics** in the PostHog sidebar. Pick your metric from the name picker and you should see data points within a minute of sending. The viewer recommends an aggregation based on the metric's type, so a counter defaults to `increase` and a gauge to `avg`.
+Open **Metrics** in the PostHog sidebar. The **Overview** tab shows your services, metric names, and active series over the last day, so you can confirm data is landing. In the **Viewer** tab, pick your metric from the name picker and you should see data points within a minute of sending. The viewer recommends an aggregation based on the metric's type, so a counter defaults to `increase` and a gauge to `avg`.
 
 If nothing shows up, check that the endpoint ends in `/i/v1/metrics`, that the token starts with `phc_`, and see the [troubleshooting section](/docs/metrics#troubleshooting).
 
@@ -99,8 +99,10 @@ Once data flows, build the views you'll actually watch:
 
 - **Group by** an attribute to get one line per value, for example request rate per route or queue depth per worker.
 - **Filter** with `key=value` chips to focus on one service, environment, or status.
-- Switch to **stat mode** for a single headline number with an automatic comparison against the baseline.
-- Turn on **live** to refresh the chart every few seconds while you watch a deploy or an incident.
+- Watch for the **anomaly badge** — when the metric moves against its baseline, it shows the change and the label values that drove it.
+- Turn on **auto-refresh** to update the chart every few seconds while you watch a deploy or an incident.
+
+When a chart is worth keeping, **save it as an insight** or add it to a dashboard — or use **New service dashboard** to build one insight per metric in a single step.
 
 </QuestLogItem>
 
@@ -110,9 +112,11 @@ Once data flows, build the views you'll actually watch:
     icon="IconDatabase"
 >
 
-Every metric lands in the `posthog.metrics` table, so the SQL tab in the metrics viewer gives you full query access for anything the chart controls don't cover.
+Every metric lands in the `posthog.metrics` table, so the **SQL** tab in the metrics viewer gives you full query access for anything the chart controls don't cover.
 
 If you use the [PostHog MCP server](/docs/model-context-protocol), your AI tools can query metrics directly: ask your agent to chart a metric, compare error rates between services, or characterize an anomaly, all without leaving your editor.
+
+For the full tour of the viewer — anomaly detection, pivoting into logs and traces, and dashboards — see [Use your metrics](/docs/metrics/explore).
 
 </QuestLogItem>
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -8314,6 +8314,12 @@ export const docsMenu = {
                     ],
                 },
                 {
+                    name: 'Use your metrics',
+                    url: '/docs/metrics/explore',
+                    icon: 'IconTrends',
+                    color: 'blue',
+                },
+                {
                     name: 'Why you need metrics',
                     url: '/docs/metrics/basics',
                     icon: 'IconBook',


### PR DESCRIPTION
## Changes

The application metrics docs covered *sending* metrics (the `posthog.metrics` API, OTLP, and the agent) but almost nothing about *using* them. The metrics scene has grown well past what `/docs/metrics` described — it documented "pick a metric, aggregate, group, filter" and a SQL tab, but the product today has four tabs and a much richer viewer. This PR catches the docs up to what's actually shipped.

**Why:** the metrics docs needed to reflect the product's full functionality, not just ingestion. Log-based metrics were covered separately in #19917; this covers everything else in the metrics scene.

Adds a new page, **`/docs/metrics/explore`** ("Use your metrics"), documenting:

- **Overview tab** — ingestion rollup (services, metric names, active series, last-seen, stale-service flag)
- **Viewer tab** — aggregations, group-by, filters, display types (line/area/bar), chart settings (goal lines, Y-axis scale, begin-at-zero, min/max), and auto-refresh
- **Anomaly detection** — the "vs baseline" badge and biggest-movers panel
- **Pivoting** — exemplar markers, the Samples/Aggregates panel, and the Related menu into logs and traces
- **Log-based metrics** — the "From logs" tag linking a generated metric back to its source
- **SQL tab** and **Save as insight / Add to dashboard / New service dashboard**

It also updates the surrounding pages:

- **index** — replaces the sparse "Use your metrics" section with an overview + link to the new page, and fixes a wrong recommended-aggregation claim
- **start-here** — fixes the "stat mode" bullet (stat has no renderer and isn't in the display picker) and points the verify/chart quests at the Overview tab, anomaly badge, auto-refresh, and dashboards
- **architecture** — adds the anomaly engine and raw-sample storage to "How metrics works," and notes log-based metrics as an ingestion source
- **basics** — mentions automatic anomaly detection as a differentiator

Everything stays flagged **alpha**, matching the existing precedent, and the whole metrics scene sits behind the `metrics` flag (private alpha), so the docs describe alpha features rather than GA.

Log-based metrics themselves are intentionally not re-documented here — they live at `/docs/logs/metrics` (#19917); this page links to them.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*