### PR TITLE
Pricing FAQ: ask PostHog AI instead of the community forum

### DIFF
--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -13,6 +13,7 @@ import PricingJourney from 'components/Pricing/Redesign/PricingJourney'
 import Surfaces from 'components/Pricing/Redesign/Surfaces'
 import Philosophy from './philosophy'
 import ShamelessCTA from 'components/Home/ShamelessCTA'
+import AskMax from 'components/AskMax'
 
 /**
  * `/pricing`.
@@ -75,9 +76,18 @@ export default function Pricing(): JSX.Element {
                 <FAQs />
                 <p className="my-6 relative">
                     Have another pricing-related question?{' '}
-                    <Link to="/questions/topic/pricing" state={{ newWindow: true }}>
-                        Ask in our community forum
-                    </Link>{' '}
+                    <AskMax
+                        linkOnly
+                        className="underline font-semibold"
+                        quickQuestions={[
+                            'How much will PostHog cost for my usage?',
+                            'What counts against my free tier each month?',
+                            'How do startup credits work?',
+                            'Can I set a billing limit?',
+                        ]}
+                    >
+                        Ask PostHog AI
+                    </AskMax>{' '}
                     or{' '}
                     <Link to="/talk-to-a-human" state={{ newWindow: true }}>
                         talk to a human


### PR DESCRIPTION
## Changes

The pricing FAQ ended with "Have another pricing-related question? **Ask in our community forum** or talk to a human." That sent pricing questions to a queue where other users must answer them — and pricing details (free tier limits, startup credits, AI credits) are things only we can answer correctly.

The link now says **Ask PostHog AI** and opens the same chat panel as the `?` button in the taskbar. It reuses the existing `AskMax` component in `linkOnly` mode, so it also passes the pricing page as chat context and shows four pricing quick questions. The "talk to a human" link is unchanged, so the path to sales stays.

### Before / after

| | Before | After |
|---|---|---|
| Light, wide | ![before light wide](https://raw.githubusercontent.com/PostHog/pr-assets/b2f6aa2fc3d240f06b63d6ba0870eaada348a600/2026/09/618d7a86-c67f-4e3e-aee7-8f8e30479a64.png) | ![after light wide](https://raw.githubusercontent.com/PostHog/pr-assets/664e5dca6d52860079e1d10d62d0ed78fd9588d9/2026/09/dbef0a25-7848-427d-a995-aad302619440.png) |
| Light, narrow | ![before light narrow](https://raw.githubusercontent.com/PostHog/pr-assets/91c749489ad9f337cd2fb9f74ae8e77f7584dab4/2026/09/83a15ee6-297c-4aed-927c-713dea37fab5.png) | ![after light narrow](https://raw.githubusercontent.com/PostHog/pr-assets/928b9c3a0f4eedd3afa1dd3a547e4d7dea3dd6c1/2026/09/426321e2-6a79-4a53-9555-d961cd8c291a.png) |
| Dark, wide | ![before dark wide](https://raw.githubusercontent.com/PostHog/pr-assets/1873d6f040c262361e7939e55edbe8956559604f/2026/09/d58e55d8-b693-4e3f-89ab-ab1eb9a47420.png) | ![after dark wide](https://raw.githubusercontent.com/PostHog/pr-assets/b46ba3c0a2651bc4c4d8c0ffad3f22991e34dada/2026/09/13179bff-d5d8-4aeb-a34a-9af10b1d51c1.png) |
| Dark, narrow | ![before dark narrow](https://raw.githubusercontent.com/PostHog/pr-assets/0018694a20e44510a0bf5e16d6ef627dc998086e/2026/09/c268dc30-5bc5-41e2-949b-583bf3be48f7.png) | ![after dark narrow](https://raw.githubusercontent.com/PostHog/pr-assets/ab7dd343aec9de631711c50d6b38d603b9fc6911/2026/09/0e84b8b7-90eb-4c84-b5c2-b769ef5bddb7.png) |

The link keeps the styling of the "talk to a human" link next to it. This is what a click gives you — the chat panel, with `/pricing` as context and the pricing quick questions:

![chat open](https://raw.githubusercontent.com/PostHog/pr-assets/850201f7147dcad01420be0cf6dc59e104e6d731/2026/09/59487f73-2461-4fae-b080-01a39dbc223a.png)

### Checks

- `pnpm format` on the changed file.
- Loaded `/pricing` on the dev server in all four states. The console shows no new errors against `master`.
- Clicked the link in the browser: the "Chat with PostHog AI" panel opens with the page context attached.
- No page moved or was renamed, so no redirect is needed.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (not applicable)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1788373845625569?thread_ts=1788373845.625569&cid=C01V9AT7DK4)*
