### PR TITLE
Pricing page: state the events retention policy for new organizations

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -50,7 +50,7 @@ const planSummary = [
             'Generous free tier on all products',
             'Advanced product features',
             '6 projects',
-            '7 year data retention',
+            '2 year data retention',
             'Email support',
             'Pay only for what you use',
             <>
@@ -66,6 +66,7 @@ const planSummary = [
             'Unlimited everything',
             'SAML SSO',
             'Custom MSA',
+            '7 year data retention',
             'Dedicated support',
             'Personalized onboarding & training',
             'Advanced permissions & audit logs',

--- a/src/components/Pricing/Redesign/PricingJourney.tsx
+++ b/src/components/Pricing/Redesign/PricingJourney.tsx
@@ -35,7 +35,7 @@ const freeIncludes = [
 const paidAdds = [
     { name: 'Unlimited usage' },
     { name: '6 projects', detail: 'up from 1' },
-    { name: '7-year data retention', detail: 'up from 1 year' },
+    { name: '2-year data retention', detail: 'up from 1 year' },
     { name: 'Email support', detail: 'or Slack over $2k/mo' },
 ]
 

--- a/src/pages-content/pricing-data.js
+++ b/src/pages-content/pricing-data.js
@@ -74,8 +74,11 @@ const faqs = [
         a: (
             <>
                 <p>
-                    Events and metadata are guaranteed to be retained for 7 years on any paid plan and 1 year on a free
-                    plan. After 1 year, data may be moved into cold storage so queries may run more slowly.
+                    Events and metadata are retained for 1 year on the free plan and 2 years on pay-as-you-go. The Boost
+                    package extends this to 5 years, and Scale and Enterprise to 7 years. Organizations that subscribed
+                    to a paid plan before September 3, 2026 keep 7 years for as long as they stay on a paid plan. See{' '}
+                    <Link to="/docs/privacy/data-storage#data-retention">data retention</Link> for details. After 1
+                    year, data may be moved into cold storage so queries may run more slowly.
                 </p>
                 <p>
                     Recordings on the free plan are retained for 1 month. On the pay-as-you-go plan, recordings are
@@ -88,7 +91,13 @@ const faqs = [
     },
     {
         q: 'What happens after the data retention period elapses?',
-        a: <p>Any data stored for more than the retention period may be permanently deleted from our systems.</p>,
+        a: (
+            <p>
+                Events older than your retention window are hidden from queries. We keep them for at least six months
+                after that, and upgrading to a plan with a longer window restores access. After that, they may be
+                permanently deleted from our systems.
+            </p>
+        ),
     },
     {
         q: 'Is there a free trial on paid plans?',

--- a/src/pages-content/pricing-data.js
+++ b/src/pages-content/pricing-data.js
@@ -77,8 +77,8 @@ const faqs = [
                     Events and metadata are retained for 1 year on the free plan and 2 years on pay-as-you-go. The Boost
                     package extends this to 5 years, and Scale and Enterprise to 7 years. Organizations that subscribed
                     to a paid plan before September 3, 2026 keep 7 years for as long as they stay on a paid plan. See{' '}
-                    <Link to="/docs/privacy/data-storage#data-retention">data retention</Link> for details. After 1
-                    year, data may be moved into cold storage so queries may run more slowly.
+                    <Link to="/docs/product-analytics/data-retention">data retention</Link> for details. After 1 year,
+                    data may be moved into cold storage so queries may run more slowly.
                 </p>
                 <p>
                     Recordings on the free plan are retained for 1 month. On the pay-as-you-go plan, recordings are


### PR DESCRIPTION
## Changes

The pricing page still says pay-as-you-go includes 7-year data retention. From September 3, 2026, organizations that add a paid plan get 2 years, Boost gives 5 years, and Scale and Enterprise give 7. Organizations already on a paid plan keep 7 years. This PR updates the three places on the pricing page that state the old policy. Text only, no layout change.

- Plan cards (`src/components/Pricing/Pricing.tsx`): the Pay-as-you-go card now says "2 year data retention", and the Enterprise card gains "7 year data retention".
- Sign-up journey (`src/components/Pricing/Redesign/PricingJourney.tsx`): step 2 now says "2-year data retention, up from 1 year".
- FAQ (`src/pages-content/pricing-data.js`): the retention answer now lists the window per plan, says that organizations that subscribed before September 3, 2026 keep 7 years, and links to the new [data retention](/docs/privacy/data-storage#data-retention) docs section from [#19927](https://github.com/PostHog/posthog.com/pull/19927). The "what happens after the retention period" answer now says events are hidden first, kept for at least six months, and restored on upgrade.

Source: the [events data retention RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1062). The billing change that makes the new windows real is [PostHog/billing#2243](https://github.com/PostHog/billing/pull/2243). Merge this before that deploys, so the page never promises 7 years to someone who gets 2.


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuyL4asmxXmXTab7VhcZc
