### PR TITLE
Add Google ADK AI observability installation page

### DIFF
--- a/contents/docs/ai-observability/installation/google-adk.mdx
+++ b/contents/docs/ai-observability/installation/google-adk.mdx
@@ -1,0 +1,53 @@
+---
+title: Google ADK observability installation
+platformLabel: Google ADK
+platformIconName: IconGemini
+showStepsToc: true
+tableOfContents: [
+    {
+        url: 'install-dependencies',
+        value: 'Install dependencies',
+        depth: 1,
+    },
+    {
+        url: 'add-the-posthog-plugin',
+        value: 'Add the PostHog plugin',
+        depth: 1,
+    },
+    {
+        url: 'run-your-agent',
+        value: 'Run your agent',
+        depth: 1,
+    },
+    {
+        url: 'plugin-options',
+        value: 'Plugin options',
+        depth: 1,
+    },
+    {
+        url: 'verify-traces-and-generations',
+        value: 'Verify traces and generations',
+        depth: 1,
+    },
+    {
+        url: 'next-steps',
+        value: 'Next steps',
+        depth: 1,
+    },
+]
+---
+
+<!--
+This page imports shared onboarding content from the main PostHog repo.
+Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/ai-observability/google-adk.tsx
+See the docs runbook for more info: https://posthog.com/handbook/wizard-and-docs/onboarding-docs
+-->
+
+import { GoogleADKInstallation } from 'onboarding/ai-observability/google-adk.tsx'
+import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
+import NotableGenerationProperties from '../_snippets/notable-generation-properties.mdx'
+import { addNextStepsStep } from './_snippets/shared-helpers.tsx'
+
+<OnboardingContentWrapper snippets={{ NotableGenerationProperties }}>
+    <GoogleADKInstallation modifySteps={addNextStepsStep} />
+</OnboardingContentWrapper>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6828,6 +6828,11 @@ export const docsMenu = {
                             icon: 'IconGemini',
                         },
                         {
+                            name: 'Google ADK',
+                            url: '/docs/ai-observability/installation/google-adk',
+                            icon: 'IconGemini',
+                        },
+                        {
                             name: 'Vercel AI SDK',
                             url: '/docs/ai-observability/installation/vercel-ai',
                             platformLogo: 'vercel',


### PR DESCRIPTION
## Changes

- Adds the Google ADK page to the AI observability installation docs. It imports the shared onboarding content that landed in [PostHog/posthog#92781](https://github.com/PostHog/posthog/pull/92781), documenting the `PostHogADKPlugin` adapter released in `@posthog/ai` 8.10.0 ([PostHog/posthog-js#4687](https://github.com/PostHog/posthog-js/pull/4687)).
- Adds the "Google ADK" entry to the installation nav (Gemini icon). The installation index grid picks the page up from its frontmatter.

The page rendered correctly on a local Gatsby build against the merged onboarding content: steps, code blocks, step TOC, and nav entry.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
