### PR TITLE
Handbook: restrict conversion discounts for customers with recurring partner credit grants

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -56,6 +56,8 @@ Beyond optimization, we offer discounts based on three levers:
 - To include the 5% discount on the order form, we require written confirmation by the customer's designated signatory of the customer's intent to sign an order form by a specific, mutually agreed upon date - _this needs to come from the person who will actually sign the order form_
 - This is about creating predictability for both sides, not artificial deadlines
 - This is a one-time discount, which will be offered once during a monthly-to-annual conversion or net new agreement cycle
+- Not available while the customer can claim a further partner-program credit grant (for example, a renewed YC deal grant) during the proposed contract term. This discount buys a firm conversion date, and a customer with another free grant on the way has no single conversion moment for us to secure. Once the customer is no longer eligible to claim the grant again, they count as ordinary net new and the discount is available.
+- Doesn't stack with the [startup plan roll-off offer](#startup-plan-discounts) — a converting customer gets one conversion incentive, not both.
 
 **For renewals:** +5% additional discount
 - Early renewal commitment. Available in the last 6 months of the contract term and 60+ days before it expires. For a standard 12-month term that means months 7-10, up to 60 days out. 
@@ -127,6 +129,8 @@ You might see some customers with a 30% discount on their monthly Stripe subscri
 ### Startup plan discounts
 
 For customers on our [startup plan](/startups), we offer two months free credit when signing a prepaid deal. This encourages startups to use their credits to understand usage, and then commit to a longer term plan with PostHog. This offer is available until the first billing date after the credits expire. If a customer has used up their credits before the expiration date, they still have until the original expiration date to decide and claim the offer. The amount of free credits is determined by how much they purchase on a prepaid plan. By default, we work with customers on prepaid plans that will cover their usage for the next 12 months.
+
+The offer bridges a single expiry cliff: the startup credits expire once, and the free months reward committing to a prepaid plan before they do. It's therefore not available while the customer can claim a further partner-program credit grant (for example, a renewed YC deal grant) during the proposed contract term — with another grant on the way there is no cliff to bridge, and the incentive buys nothing. Once the customer is no longer eligible to claim a grant again, they qualify like any other roll-off. This offer also doesn't stack with the +5% forecast discount for conversions above — a converting customer gets one conversion incentive, not both.
 
 > Important clarification: operationally this is implemented as free credits applied before the contract start date, not as extra credits inside the contract term unless a specific dollar amount for the free credits is explicitly included under Special Terms.
 


### PR DESCRIPTION
## Changes

This PR updates the contract rules page [based on this conversation](https://posthog.slack.com/archives/C08ERRQT41E/p1788429841035899). It restricts the two conversion incentives for customers who can claim repeated partner-program credit grants (for example, the YC deal).

- The +5% forecast discount for monthly-to-annual conversions and net new agreements is not available while the customer can claim a further partner-program grant during the proposed contract term. The discount becomes available again when the customer loses grant eligibility.
- The startup plan two-months-free offer follows the same rule.
- The two incentives do not stack. A converting customer gets one conversion incentive, not both.

## Why

Both incentives pay for a single conversion moment. The two-months-free offer bridges one expiry cliff. The +5% buys a firm signature date. A customer who can claim a fresh grant each year has no cliff and no single conversion moment, so the incentive buys nothing.

The exclusion ends when grant eligibility ends. At that point we want the customer on a contract, so the full conversion incentives return.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*