### PR TITLE
Document how to get a signed DPA in the privacy docs

### DIFF
--- a/contents/docs/privacy/gdpr-compliance.mdx
+++ b/contents/docs/privacy/gdpr-compliance.mdx
@@ -91,6 +91,8 @@ You will be using PostHog in one of two ways:
 | PostHog Cloud | Hosted and managed by PostHog | PostHog | You |
 | Self-hosted | Hosted on your private cloud or infrastructure | You | You |
 
+If you use PostHog Cloud, PostHog is your data processor. Article 28 of the GDPR requires a contract between a controller and a processor. That contract is the Data Processing Agreement (DPA). See [how to get a signed DPA](/docs/privacy#how-do-i-get-a-signed-dpa).
+
 ### Step 1: Choose a hosting provider
 
 We recommend using [PostHog Cloud EU](/eu) for GDPR compliance, though you can use PostHog Cloud US if you follow additional steps to protect user data. 

--- a/contents/docs/privacy/gdpr-compliance.mdx
+++ b/contents/docs/privacy/gdpr-compliance.mdx
@@ -91,7 +91,7 @@ You will be using PostHog in one of two ways:
 | PostHog Cloud | Hosted and managed by PostHog | PostHog | You |
 | Self-hosted | Hosted on your private cloud or infrastructure | You | You |
 
-If you use PostHog Cloud, PostHog is your data processor. Article 28 of the GDPR requires a contract between a controller and a processor. That contract is the Data Processing Agreement (DPA). See [how to get a signed DPA](/docs/privacy#how-do-i-get-a-signed-dpa).
+If you use PostHog Cloud, PostHog may be considered a data processor. Article 28 of the GDPR and similar data privacy frameworks may require a contract between a controller and a processor. That contract is the Data Processing Agreement (DPA). See [how to get a signed DPA](/docs/privacy#how-do-i-get-a-signed-dpa).
 
 ### Step 1: Choose a hosting provider
 

--- a/contents/docs/privacy/index.mdx
+++ b/contents/docs/privacy/index.mdx
@@ -77,21 +77,25 @@ We also offer [PostHog Cloud EU](https://eu.posthog.com/signup) – a managed ve
 
 ### How do I get a signed DPA?
 
-A Data Processing Agreement (DPA) is the contract between you as the data controller and PostHog as your data processor. All PostHog Cloud customers can get one, on any plan. This includes the free plan.
+A Data Processing Agreement (DPA) is the contract between a data controller and a data processor. If you use PostHog Cloud, PostHog may be considered your data processor. All PostHog Cloud customers can get a DPA, on any plan. This includes the free plan.
 
 To get your signed copy:
 
 1. Open [app.posthog.com/legal](https://app.posthog.com/legal). It sends you to your own cloud region.
-2. Add your company details, then sign the DPA.
-3. Download the copy. PostHog countersigns it in the app.
+2. Click "+ New" and then "Data Processing Agreement (DPA)".
+3. Add your company details, including legal company name, then click "Send for signature".
+4. PandaDoc sends an email to the address in your company details. Open that email and sign the DPA. PostHog has already countersigned it.
+5. The DPA is effective as soon as you sign. You receive an email with the completed document. You can also download it from PandaDoc, or find it on the legal dashboard.
 
-The DPA is self-serve, so you do not wait for a reply from our team. You can also [read the full text of the DPA](/dpa) first. The "Get countersigned DPA" button on that page opens the same legal page in the app. The text on `/dpa` is a preview only. Only the copy that you generate in the app is valid.
+The DPA is self-serve, so you do not wait for our team to approve or sign it. You can also [read the full text of the DPA](/dpa) first. The "Get countersigned DPA" button on that page opens the same legal page in the app. The text on `/dpa` is a preview only. Only the copy that you generate in the app is valid.
 
 If you need changes to the standard DPA, [contact us](/talk-to-a-human) first.
 
 ### Can I use PostHog Cloud under HIPAA?
 
-Yes. A Business Associate Agreement (BAA) permits HIPAA-compliant use of PostHog Cloud. You generate and download a countersigned BAA on the legal page in your PostHog organization, in the same way as the DPA. You can [read the full text of the BAA](/baa) first. PostHog offers a BAA to customers on the [Boost, Scale, or Enterprise package](/platform-packages). [Contact us](/talk-to-a-human) to discuss your requirements. 
+Yes. A Business Associate Agreement (BAA) may be required for HIPAA-compliant use of PostHog Cloud, but a signed BAA does not make your setup compliant on its own. It does not cover every feature, and compliance also depends on how you configure the features you use. Read our [HIPAA guidance](/docs/privacy/hipaa-compliance) to see which features a BAA covers, and check your configuration before you send protected health information to PostHog.
+
+You generate and download a countersigned BAA on the legal page in your PostHog organization, in the same way as the DPA. You can [read the full text of the BAA](/baa) first. PostHog offers a BAA to customers on the [Boost, Scale, or Enterprise package](/platform-packages). [Contact us](/talk-to-a-human) to discuss your requirements. 
 
 ### Is Google Analytics HIPAA compliant?
 

--- a/contents/docs/privacy/index.mdx
+++ b/contents/docs/privacy/index.mdx
@@ -75,9 +75,23 @@ We have [in-depth GDPR guidance documentation](/docs/privacy/gdpr-compliance) fo
 
 We also offer [PostHog Cloud EU](https://eu.posthog.com/signup) – a managed version of PostHog with servers hosted in Frankfurt, ensuring user data never leaves EU jurisdiction. 
 
+### How do I get a signed DPA?
+
+A Data Processing Agreement (DPA) is the contract between you as the data controller and PostHog as your data processor. All PostHog Cloud customers can get one, on any plan. This includes the free plan.
+
+To get your signed copy:
+
+1. Open [app.posthog.com/legal](https://app.posthog.com/legal) in your PostHog organization.
+2. Add your company details, then sign the DPA.
+3. Download the copy. PostHog countersigns it in the app.
+
+The DPA is self-serve, so you do not wait for a reply from our team. You can also [read the full text of the DPA](/dpa) first. That page is a preview only. Only the copy that you generate in the app is valid.
+
+If you need changes to the standard DPA, [contact us](/talk-to-a-human) first.
+
 ### Can I use PostHog Cloud under HIPAA?
 
-Yes, we can provide a Business Associate Agreement (BAA) to enable HIPAA-compliant usage of PostHog Cloud. Please [contact us to arrange a BAA and discuss your requirements](/talk-to-a-human). 
+Yes. A Business Associate Agreement (BAA) permits HIPAA-compliant use of PostHog Cloud. You generate and download a countersigned BAA at [app.posthog.com/legal](https://app.posthog.com/legal), in the same way as the DPA. You can [read the full text of the BAA](/baa) first. PostHog offers a BAA to customers on the [Boost, Scale, or Enterprise package](/platform-packages). [Contact us](/talk-to-a-human) to discuss your requirements. 
 
 ### Is Google Analytics HIPAA compliant?
 

--- a/contents/docs/privacy/index.mdx
+++ b/contents/docs/privacy/index.mdx
@@ -81,17 +81,17 @@ A Data Processing Agreement (DPA) is the contract between you as the data contro
 
 To get your signed copy:
 
-1. Open [app.posthog.com/legal](https://app.posthog.com/legal) in your PostHog organization.
+1. Open the legal page in your PostHog organization. On PostHog Cloud US, go to [app.posthog.com/legal](https://app.posthog.com/legal). On PostHog Cloud EU, go to [eu.posthog.com/legal](https://eu.posthog.com/legal).
 2. Add your company details, then sign the DPA.
 3. Download the copy. PostHog countersigns it in the app.
 
-The DPA is self-serve, so you do not wait for a reply from our team. You can also [read the full text of the DPA](/dpa) first. That page is a preview only. Only the copy that you generate in the app is valid.
+The DPA is self-serve, so you do not wait for a reply from our team. You can also [read the full text of the DPA](/dpa) first. The "Get countersigned DPA" button on that page opens the same legal page in the app. The text on `/dpa` is a preview only. Only the copy that you generate in the app is valid.
 
 If you need changes to the standard DPA, [contact us](/talk-to-a-human) first.
 
 ### Can I use PostHog Cloud under HIPAA?
 
-Yes. A Business Associate Agreement (BAA) permits HIPAA-compliant use of PostHog Cloud. You generate and download a countersigned BAA at [app.posthog.com/legal](https://app.posthog.com/legal), in the same way as the DPA. You can [read the full text of the BAA](/baa) first. PostHog offers a BAA to customers on the [Boost, Scale, or Enterprise package](/platform-packages). [Contact us](/talk-to-a-human) to discuss your requirements. 
+Yes. A Business Associate Agreement (BAA) permits HIPAA-compliant use of PostHog Cloud. You generate and download a countersigned BAA on the legal page in your PostHog organization, in the same way as the DPA. You can [read the full text of the BAA](/baa) first. PostHog offers a BAA to customers on the [Boost, Scale, or Enterprise package](/platform-packages). [Contact us](/talk-to-a-human) to discuss your requirements. 
 
 ### Is Google Analytics HIPAA compliant?
 

--- a/contents/docs/privacy/index.mdx
+++ b/contents/docs/privacy/index.mdx
@@ -81,7 +81,7 @@ A Data Processing Agreement (DPA) is the contract between you as the data contro
 
 To get your signed copy:
 
-1. Open the legal page in your PostHog organization. On PostHog Cloud US, go to [app.posthog.com/legal](https://app.posthog.com/legal). On PostHog Cloud EU, go to [eu.posthog.com/legal](https://eu.posthog.com/legal).
+1. Open [app.posthog.com/legal](https://app.posthog.com/legal). It sends you to your own cloud region.
 2. Add your company details, then sign the DPA.
 3. Download the copy. PostHog countersigns it in the app.
 

--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -6,7 +6,6 @@ import Link from 'components/Link'
 import Tooltip from 'components/Tooltip'
 
 const APP_LEGAL_URL = 'https://app.posthog.com/legal'
-const EU_APP_LEGAL_URL = 'https://eu.posthog.com/legal'
 
 function DpaGenerator() {
     const [mode, setMode] = useState('pretty')
@@ -178,12 +177,7 @@ function DpaGenerator() {
                     </p>
                     <p className="text-sm">
                         It's self-serve and takes a couple of minutes. Nobody has to approve it and there's nothing to
-                        wait for. We countersign it on the spot, on any plan, including the free one. On PostHog Cloud
-                        EU, use{' '}
-                        <Link to={EU_APP_LEGAL_URL} external className="font-semibold underline">
-                            eu.posthog.com/legal
-                        </Link>{' '}
-                        instead.
+                        wait for. We countersign it on the spot, on any plan, including the free one.
                     </p>
                     <p className="text-sm">
                         The version below is the exact same agreement, just rendered here for your reading pleasure (and

--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -6,6 +6,7 @@ import Link from 'components/Link'
 import Tooltip from 'components/Tooltip'
 
 const APP_LEGAL_URL = 'https://app.posthog.com/legal'
+const EU_APP_LEGAL_URL = 'https://eu.posthog.com/legal'
 
 function DpaGenerator() {
     const [mode, setMode] = useState('pretty')
@@ -176,6 +177,15 @@ function DpaGenerator() {
                         DPA — countersigned by us.
                     </p>
                     <p className="text-sm">
+                        It's self-serve and takes a couple of minutes. Nobody has to approve it and there's nothing to
+                        wait for. We countersign it on the spot, on any plan, including the free one. On PostHog Cloud
+                        EU, use{' '}
+                        <Link to={EU_APP_LEGAL_URL} external className="font-semibold underline">
+                            eu.posthog.com/legal
+                        </Link>{' '}
+                        instead.
+                    </p>
+                    <p className="text-sm">
                         The version below is the exact same agreement, just rendered here for your reading pleasure (and
                         choice of font). It's not binding on its own — only the one you generate and countersign through
                         the app counts.
@@ -299,7 +309,8 @@ function DpaGenerator() {
 
                     <div className="bg-yellow/25 py-3 px-4 text-sm text-center -mx-4 @3xl:-mx-8 mt-0 border-b border-light dark:text-black">
                         <strong>Heads up:</strong> This is a preview. To get a countersigned, valid DPA, generate it
-                        inside your PostHog organization at{' '}
+                        inside your PostHog organization. It's self-serve and we countersign it on the spot, so there's
+                        nothing to wait for. Go to{' '}
                         <a
                             href={APP_LEGAL_URL}
                             target="_blank"

--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -172,8 +172,8 @@ function DpaGenerator() {
                         <Link to={APP_LEGAL_URL} external className="font-semibold underline">
                             app.posthog.com/legal
                         </Link>{' '}
-                        inside your PostHog organization. That's where you generate, sign, and download a real, valid
-                        DPA — countersigned by us.
+                        inside your PostHog organization. That's where you generate a real, valid DPA — countersigned by
+                        us.
                     </p>
                     <p className="text-sm">
                         It's self-serve and takes a couple of minutes. Nobody at PostHog has to approve it — you add

--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -176,8 +176,9 @@ function DpaGenerator() {
                         DPA — countersigned by us.
                     </p>
                     <p className="text-sm">
-                        It's self-serve and takes a couple of minutes. Nobody has to approve it and there's nothing to
-                        wait for. We countersign it on the spot, on any plan, including the free one.
+                        It's self-serve and takes a couple of minutes. Nobody at PostHog has to approve it — you add
+                        your company details, we generate the agreement with our signature already on it, and PandaDoc
+                        emails it to you to sign. It's effective the moment you do. Any plan, including the free one.
                     </p>
                     <p className="text-sm">
                         The version below is the exact same agreement, just rendered here for your reading pleasure (and
@@ -303,8 +304,8 @@ function DpaGenerator() {
 
                     <div className="bg-yellow/25 py-3 px-4 text-sm text-center -mx-4 @3xl:-mx-8 mt-0 border-b border-light dark:text-black">
                         <strong>Heads up:</strong> This is a preview. To get a countersigned, valid DPA, generate it
-                        inside your PostHog organization. It's self-serve and we countersign it on the spot, so there's
-                        nothing to wait for. Go to{' '}
+                        inside your PostHog organization. It's self-serve, and we've already signed it before it reaches
+                        you, so all that's left is your signature. Go to{' '}
                         <a
                             href={APP_LEGAL_URL}
                             target="_blank"


### PR DESCRIPTION
## Changes

**Why:** A community member waited 11 days for a countersigned DPA. The DPA is self-serve and instant, but nothing on the site says so, and the docs never explained the flow at all.

- `/dpa`: state that the flow is self-serve, that nobody has to approve it, that we countersign on the spot, and that it works on any plan.
- Docs: add a "How do I get a signed DPA?" FAQ to the privacy overview, and link it from the controller and processor table in the GDPR guide.
- Docs: correct the HIPAA FAQ. It told the reader to contact us, but the BAA is self-serve too.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

**Blocked on screenshots.** The `/dpa` change adds copy, so it changes the page visually. This environment has no dependencies installed and no browser, so I could not capture the before and after grid, or check the Vercel preview. The PR stays a draft until someone adds screenshots of the `/dpa` sidebar and the preview banner, at a narrow and a wide window, in light and dark mode.

**One claim to confirm before merge:** that the DPA needs no paid plan. Nothing in the repo or the handbook gates it, and only the BAA has a documented package requirement. Please confirm against the app before this goes out.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


---

## Legal review update

Commit `8b73831` applies a legal review of the new copy. It changes the same three files, and adds no new ones.

**Hedged the controller and processor language** in the GDPR guide and the privacy FAQ. The docs now say that PostHog *may be considered* a data processor, and that Article 28 and similar data privacy frameworks *may require* a contract. This hedge is deliberate.

**Corrected the DPA steps.** The list has five steps and gives the true flow: click "+ New" and select the DPA, add the company details and the legal company name, then click "Send for signature". PandaDoc sends an email to the address in the company details. PostHog signs the agreement first, so only the customer signature is missing. The DPA is effective when the customer signs.

**Corrected the `/dpa` page.** Both new blocks said that PostHog countersigns on the spot, and that there is nothing to wait for. There is an email round trip, so they now say that PostHog signs the agreement before it reaches the customer.

**Rewrote the HIPAA answer.** A BAA *may be required*, but a signed BAA does not make a setup compliant on its own. It does not cover every feature, and compliance also depends on the configuration. The answer links to the HIPAA guidance, which lists the features that a BAA does not cover.

### Open items

1. `src/pages/dpa.tsx:174` says that app.posthog.com/legal is where you "generate, sign, and download" the DPA. The customer signs in PandaDoc, not in the app. This line is outside the PR diff, so it is unchanged.
2. The HIPAA answer says that the BAA is self-serve "in the same way as the DPA". `contents/handbook/growth/sales/contracts.md:181` says that a salesperson creates the BAA from a PandaDoc template and sends it, and that a platform package is necessary first. One of the two is stale.
3. The `/dpa` copy change is still a visual change, so it still needs the before and after screenshots.
