### PR TITLE
Rename "Escalate to support" button to "Escalate"

### DIFF
--- a/src/components/Squeak/components/Question.tsx
+++ b/src/components/Squeak/components/Question.tsx
@@ -469,8 +469,8 @@ export function Question(props: QuestionProps) {
         })
         setEscalateState('sent')
         addToast({
-            title: 'Escalated to support',
-            description: 'Support has been notified.',
+            title: 'Escalated',
+            description: 'Moderators have been notified.',
             duration: 3000,
         })
     }
@@ -712,7 +712,7 @@ export function Question(props: QuestionProps) {
                                                     onClick={handleEscalateToSupport}
                                                     disabled={escalateState === 'sent'}
                                                 >
-                                                    {escalateState === 'sent' ? 'Escalated ✓' : 'Escalate to support'}
+                                                    {escalateState === 'sent' ? 'Escalated ✓' : 'Escalate'}
                                                 </OSButton>
                                             </p>
                                         </div>
@@ -726,7 +726,7 @@ export function Question(props: QuestionProps) {
                                             onClick={handleEscalateToSupport}
                                             disabled={escalateState === 'sent'}
                                         >
-                                            {escalateState === 'sent' ? 'Escalated ✓' : 'Escalate to support'}
+                                            {escalateState === 'sent' ? 'Escalated ✓' : 'Escalate'}
                                         </OSButton>
                                     </div>
                                 )}


### PR DESCRIPTION
## Changes

The button in the Moderator tools panel on `/questions` now reads **Escalate**. The confirmation toast now says "Escalated" / "Moderators have been notified."

**Why:** The button does not send the question to support. It posts the question to a Slack channel for community moderation, from which a moderator sends it to the correct place. The word "support" was thus not correct.

Text-only change to a button label and a toast. No screenshots are attached because the environment has no dependencies installed to make a build.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*