### PR TITLE
Remove the change request prompt from the DPA page

### DIFF
--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -185,14 +185,6 @@ function DpaGenerator() {
                         choice of font). It's not binding on its own — only the one you generate and countersign through
                         the app counts.
                     </p>
-                    <p className="text-sm">
-                        Need changes to this DPA?{' '}
-                        <Link to="/talk-to-a-human" state={{ newWindow: true }} className="font-semibold underline">
-                            Contact us
-                        </Link>{' '}
-                        first.
-                    </p>
-
                     <Link
                         to={APP_LEGAL_URL}
                         external


### PR DESCRIPTION
Removes this block from `/dpa`:

> Need changes to this DPA? [Contact us](/talk-to-a-human) first.

The line invited customers to ask for changes to the standard DPA which we do not entertain by default. We do not want to offer that, so the prompt is removed. The "Generate a DPA in PostHog" button now follows the preview paragraph directly.

Copy deletion only. No other page or file is changed.