### PR TITLE
Say that the Community bot app must be in the community alert channel

### DIFF
--- a/src/pages/teams/[slug].tsx
+++ b/src/pages/teams/[slug].tsx
@@ -687,8 +687,10 @@ export default function TeamPage(props: TeamPageProps) {
                         <Fieldset legend="Community question alerts">
                             <label htmlFor="slackChannel" className="text-sm opacity-75 mb-1">
                                 New questions in this team's subscribed topics get posted to this Slack channel. Use the
-                                channel ID (in Slack: channel name → About → bottom of the panel), not the #name. Leave
-                                blank to stop notifications. Manage which topics this team subscribes to on{' '}
+                                channel ID (in Slack: channel name → About → bottom of the panel), not the #name. You
+                                must also add the Community bot app to the channel. If the app is not a member, Slack
+                                rejects the post and no alert appears. Leave blank to stop notifications. Manage which
+                                topics this team subscribes to on{' '}
                                 <Link to="/community/alerts" state={{ newWindow: true }}>
                                     /community/alerts
                                 </Link>


### PR DESCRIPTION
## Changes

The "Community question alerts" field on a team edit page (`/teams/<slug>`) now says that the Slack channel must also contain the Community bot app.

Before:
> …not the #name. Leave blank to stop notifications.

After:
> …not the #name. **You must also add the Community bot app to the channel. If the app is not a member, Slack rejects the post and no alert appears.** Leave blank to stop notifications.

### Why

A team set a valid channel ID, subscribed to a topic, and still received no alert for a new community question. The channel ID and the topic subscription were both correct. Slack rejected the post because the app was not a member of the channel. squeak-strapi catches that error and only writes it to the server log, so the moderator sees no sign of a problem. The field description is the one place where the moderator can learn the requirement before the first question arrives.

Copy only — 4 lines, no logic change.

### Screenshots

Not attached yet. The field is visible only to a signed-in moderator in edit mode, which I cannot reach in this environment. @brittanyjoiner15 please add the narrow/wide, light/dark before and after images before this leaves draft.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1788471764452739)*