### PR TITLE
Handbook: add link to metrics docs on CS Onboarding page

### DIFF
--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -177,7 +177,7 @@ Below is a per-product reading list to work through - the reference you come bac
 
 ### Experiments
 1. [Creating an experiment](/docs/experiments/creating-an-experiment) from PostHog UI
-2. Understanding MDE, primary metrics, secondary metrics, interpreting results
+2. Understanding MDE, [primary metrics, secondary metrics](/docs/experiments/metrics#primary-and-secondary-metrics), interpreting results
 3. [Traffic allocation](/docs/experiments/traffic-allocation) - configuring it and validating it. What are some reasons why 80/20 split may not be an 80/20 split?
 4. Returning users: user sees variant A in session 1, does not convert; user sees variant B in session 2, does convert
     - Does this happen? Can the same user see different variants in different sessions? If so, how does this affect the results?


### PR DESCRIPTION
Added link for primary and secondary metrics in the experiments section of CS Onboarding Handbook

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
