### PR TITLE
Remove stale replay summary claims from experiment AI docs

### DIFF
--- a/contents/docs/experiments/analyze-experiments-ai.mdx
+++ b/contents/docs/experiments/analyze-experiments-ai.mdx
@@ -2,7 +2,7 @@
 title: Analyze Experiments with PostHog AI
 ---
 
-[PostHog AI](/docs/posthog-ai) creates [Experiments](/docs/experiments), analyzes results, and summarizes behavioral differences between variants. You can set up A/B tests, check statistical significance, and compare session replays across variants – all through natural language.
+[PostHog AI](/docs/posthog-ai) creates [Experiments](/docs/experiments) and analyzes their results. You can set up A/B tests, check statistical significance, and ask what the data means – all through natural language.
 
 ## How it works
 
@@ -16,8 +16,9 @@ PostHog AI doesn't just show you the numbers, it interprets them. When you ask a
 
 - **Which variant is winning** and by how much
 - **Whether the result is statistically significant** based on the confidence intervals
-- **What behavioral differences exist** between variants by summarizing [session replays](/docs/session-replay) for each group
 - **What to do next** – whether to ship, extend, or stop the Experiment
+
+You can also start a summary from the Experiment itself: on the results page, click the spark button next to the **Primary metrics** header. It opens PostHog AI with your Experiment's results ready to summarize. The button appears once your Experiment is running and has results.
 
 ## Try it
 
@@ -25,8 +26,6 @@ Select a prompt to try it out in the PostHog app:
 
 - [`Set up an A/B test with a 70/30 split for a new checkout flow`](https://app.posthog.com/#panel=max:Set%20up%20an%20A%2FB%20test%20with%20a%2070%2F30%20split%20for%20a%20new%20checkout%20flow)
 - [`Summarize the results of my latest Experiment`](https://app.posthog.com/#panel=max:Summarize%20the%20results%20of%20my%20latest%20Experiment)
-- [`What behavioral differences do you see between variant A and variant B?`](https://app.posthog.com/#panel=max:What%20behavioral%20differences%20do%20you%20see%20between%20variant%20A%20and%20variant%20B%3F)
-- [`Summarize session replays for the control group in my pricing Experiment`](https://app.posthog.com/#panel=max:Summarize%20session%20replays%20for%20the%20control%20group%20in%20my%20pricing%20Experiment)
 - [`Create an Experiment targeting only mobile users`](https://app.posthog.com/#panel=max:Create%20an%20Experiment%20targeting%20only%20mobile%20users)
 
 ## Tips for better results

--- a/contents/docs/experiments/analyzing-results.mdx
+++ b/contents/docs/experiments/analyzing-results.mdx
@@ -117,8 +117,6 @@ Click on any variant in the delta chart to access detailed results. This opens a
 
 Click **View recordings** to see session recordings of experiment participants. By default, all metric events are applied as filters to the playlist meaning you'll only see recordings for users who completed the funnel or fired the trend metric. However, the filters don't map exactly to the statistical calculations ([funnel attribution type](/docs/product-analytics/funnels#attribution-types) isn't applied, for instance), so the recordings don't map exactly to the experiment results.
 
-You can also click **Summarize session replays** to have [PostHog AI](/docs/posthog-ai) analyze recordings across your experiment variants. This identifies behavior patterns, highlighting differences in how users interact with each variant.
-
 ### Time series analysis
 
 The time series chart shows how your experiment results change over time, helping you see if your results are stable or still changing.


### PR DESCRIPTION
## Changes

Session replay summarization was removed from PostHog (PostHog/posthog#80312), and the experiment AI analysis tab was replaced by a spark button next to the primary metrics header (PostHog/posthog#77518). Two experiment docs pages still described the old behavior.

- `analyze-experiments-ai.mdx`: drops the replay summary claims and prompts, adds the spark button as the in-app entry point for result summaries.
- `analyzing-results.mdx`: drops the "Summarize session replays" button paragraph.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`