### PR TITLE
fix(docs): point tracing install guides at the real viewer URL

### DIFF
--- a/contents/docs/distributed-tracing/installation/_snippets/tracing-next-steps.mdx
+++ b/contents/docs/distributed-tracing/installation/_snippets/tracing-next-steps.mdx
@@ -7,7 +7,7 @@
 | **Filter spans** | Narrow down by service, status, duration, and attributes |
 | **Propagate context** | Pass trace context across services so spans join the same trace |
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/dotnet.mdx
+++ b/contents/docs/distributed-tracing/installation/dotnet.mdx
@@ -99,7 +99,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/go.mdx
+++ b/contents/docs/distributed-tracing/installation/go.mdx
@@ -125,7 +125,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/java.mdx
+++ b/contents/docs/distributed-tracing/installation/java.mdx
@@ -110,7 +110,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/nextjs.mdx
+++ b/contents/docs/distributed-tracing/installation/nextjs.mdx
@@ -154,7 +154,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/nodejs.mdx
+++ b/contents/docs/distributed-tracing/installation/nodejs.mdx
@@ -108,7 +108,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/php.mdx
+++ b/contents/docs/distributed-tracing/installation/php.mdx
@@ -108,7 +108,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/python.mdx
+++ b/contents/docs/distributed-tracing/installation/python.mdx
@@ -93,7 +93,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 

--- a/contents/docs/distributed-tracing/installation/ruby.mdx
+++ b/contents/docs/distributed-tracing/installation/ruby.mdx
@@ -90,7 +90,7 @@ Once everything is configured, confirm spans are reaching PostHog:
 2. Open the PostHog Tracing interface
 3. Confirm your spans and traces appear
 
-<CallToAction type="primary" to="https://app.posthog.com/traces">
+<CallToAction type="primary" to="https://app.posthog.com/tracing">
 View your traces in PostHog
 </CallToAction>
 


### PR DESCRIPTION
## Changes

Anyone following a distributed tracing install guide hits a 404 when they click the button that should show them their traces. The guides link to `https://app.posthog.com/traces`, which is not a route, so the app renders its "Page not found" scene. The viewer is at `/tracing`.

- The "View your traces in PostHog" button now resolves for all 8 language guides.
- Each guide showed the broken button twice: once in its own "Test your setup" step, once in the shared `_snippets/tracing-next-steps.mdx` block it imports. This fixes both.
- `contents/blog/traces-beta.mdx` already used `/tracing`, so the correct URL was in the repo and the install guides drifted from it.

The change is 9 identical one-line URL edits and nothing else.

The duplicate button is left alone. Collapsing the inline copies onto the snippet is the right cleanup, but it restructures the steps on 8 pages and would conflict with #19837, which already edits `nodejs.mdx` and `nextjs.mdx`.

Nothing looks different apart from where the button goes, so there are no screenshots.

The metrics install guides link to `https://app.posthog.com/metrics`, which is a real route. Those are untouched.

## Verification

- `app.posthog.com/traces` returns the 404 scene, confirmed in the app against a live project.
- The repo has no remaining `app.posthog.com/traces`, and no `us.posthog.com/traces` or `eu.posthog.com/traces` variants.
- Not checked: the Vercel preview build.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

The relative-URL box stays unchecked on purpose. These links point at the PostHog app, not at a posthog.com page, so they have to stay absolute. No page moved, so no redirect is needed.

## 🤖 Agent context

**Autonomy:** Claude Code wrote this change; a human directed it and reviews it.

Found while investigating a support ticket. A customer sent OpenTelemetry logs, metrics and traces, got HTTP 200 for all three, and reported they could not find any trace UI. Their traces had ingested correctly the whole time. They clicked this button, landed on the 404, and concluded the product did not support their data.

Skills invoked: `/writing-pr-descriptions`.

Verified before the edit: `/tracing` is the registered route in `frontend/src/products.tsx`, and no `/traces` route or redirect exists in the app.
