### PR TITLE
docs(metrics): say the viewer is limited to selected teams

### DIFF
--- a/contents/docs/metrics/architecture.mdx
+++ b/contents/docs/metrics/architecture.mdx
@@ -2,7 +2,7 @@
 title: How metrics works
 ---
 
-> **Note:** Metrics is in alpha. The details on this page describe current behavior and may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams. The details on this page describe current behavior and may change before general availability.
 
 This page explains what happens to a metric between your application and a chart: how ingestion works, what a series is, how aggregations are computed, and where the data lives. You don't need any of this to use metrics, but it helps when you're deciding what to instrument or debugging why a chart looks the way it does.
 

--- a/contents/docs/metrics/explore.mdx
+++ b/contents/docs/metrics/explore.mdx
@@ -2,7 +2,7 @@
 title: Use your metrics
 ---
 
-> **Note:** Metrics is in alpha. The views on this page reflect the current product and may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to open the views on this page. They reflect the current product and may change before general availability.
 
 Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has three tabs:
 

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -2,7 +2,11 @@
 title: Application metrics
 ---
 
-> **Note:** Application metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+<CalloutBox icon="IconFlask" title="Metrics is in private alpha" type="action">
+
+The metrics viewer is only turned on for selected teams. You can send metrics now and they are stored against your project, but you won't be able to view them in PostHog until your team is added. Setup details, including the ingestion endpoint, may change before general availability.
+
+</CalloutBox>
 
 **Application metrics** lets you send application and infrastructure metrics (request counts, latencies, queue depths, resource usage) to PostHog and analyze them alongside your [logs](/docs/logs), [traces](/docs/distributed-tracing), and product data.
 

--- a/contents/docs/metrics/installation/docker.mdx
+++ b/contents/docs/metrics/installation/docker.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from "components/Docs/Steps";
 import MetricsNextSteps from "./_snippets/metrics-next-steps.mdx";
 
-> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
 
 If your services already expose Prometheus-format `/metrics` endpoints, the PostHog metrics agent scrapes them and forwards everything to PostHog. One `docker run`, no application changes.
 

--- a/contents/docs/metrics/installation/index.mdx
+++ b/contents/docs/metrics/installation/index.mdx
@@ -2,7 +2,7 @@
 title: Install metrics
 ---
 
-> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
 
 There are three ways to get metrics into PostHog:
 

--- a/contents/docs/metrics/installation/javascript.mdx
+++ b/contents/docs/metrics/installation/javascript.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in alpha. Setup details may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details may change before general availability.
 
 If [posthog-js](/docs/libraries/js) is already running on your site, you can record metrics directly with the `posthog.metrics` API. No new packages, no extra authentication.
 

--- a/contents/docs/metrics/installation/kubernetes.mdx
+++ b/contents/docs/metrics/installation/kubernetes.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from "components/Docs/Steps";
 import MetricsNextSteps from "./_snippets/metrics-next-steps.mdx";
 
-> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
 
 If your Kubernetes workloads already expose Prometheus-format `/metrics` endpoints, the PostHog metrics agent scrapes them and forwards everything to PostHog. One `helm install`, no application changes.
 

--- a/contents/docs/metrics/installation/nodejs.mdx
+++ b/contents/docs/metrics/installation/nodejs.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in alpha. Setup details may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details may change before general availability.
 
 The [posthog-node](/docs/libraries/node) SDK includes the `posthog.metrics` API, so you can record metrics with the same client you use for events and feature flags.
 

--- a/contents/docs/metrics/installation/other.mdx
+++ b/contents/docs/metrics/installation/other.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
 
 PostHog's application metrics work with any OpenTelemetry-compatible client. If your app or infrastructure already exports OTLP metrics, point the exporter at PostHog. No PostHog packages required.
 

--- a/contents/docs/metrics/installation/python.mdx
+++ b/contents/docs/metrics/installation/python.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in alpha. Setup details may change before general availability.
+> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details may change before general availability.
 
 The [posthog-python](/docs/libraries/python) SDK includes the `posthog.metrics` API, so you can record metrics with the same client you use for events and feature flags.
 

--- a/contents/docs/metrics/start-here.mdx
+++ b/contents/docs/metrics/start-here.mdx
@@ -6,7 +6,11 @@ contentMaxWidthClass: max-w-5xl
 
 import { QuestLog, QuestLogItem } from "components/Docs/QuestLog";
 
-> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.
+<CalloutBox icon="IconFlask" title="Metrics is in private alpha" type="action">
+
+The metrics viewer is only turned on for selected teams. You can send metrics now and they are stored against your project, but you won't be able to view them in PostHog until your team is added. Setup details, including the ingestion endpoint, may change before general availability.
+
+</CalloutBox>
 
 <QuestLog firstSpeechBubble="Let's set up metrics!" lastSpeechBubble="Time to chart your metrics!">
 


### PR DESCRIPTION
## Changes

A reader can follow any metrics install guide end to end, send metrics successfully, and then find nothing to look at. The viewer is turned on for selected teams only, and none of the 13 metrics docs pages said so.

All of them carried the same caveat instead:

> **Note:** Metrics is in alpha. Setup details, including the ingestion endpoint, may change before general availability.

That is a statement about maturity. It tells a reader to expect churn, not that they may be unable to view their own data. The in-app gate says something different: "Metrics is available to select teams while we polish it."

- The two entry pages, `index.mdx` and `start-here.mdx`, now open with a `CalloutBox` stating that the viewer is limited and that sent metrics are stored but not viewable until a team is added.
- The nine remaining noted pages state the access limit alongside the existing maturity one, so the note keeps its place on the page and gains the missing half.
- `explore.mdx` gets specific wording, because that page documents the viewer UI itself and most readers cannot open it.

The `CalloutBox` pattern and placement follow `docs/data-warehouse/managed-warehouse/`, which is the closest existing case: a gated product with its own install and setup guides, carrying the notice on every page.

Mechanical: 9 of the 11 files change one line of note text each.

No CTA is included. Asking for access belongs on the gate the reader is already looking at, not in docs, and PostHog/posthog#94218 adds that button.

Untouched on purpose:

- `basics.mdx`, which is conceptual and asks the reader to do nothing.
- `architecture.mdx` line 63, where "while metrics is in alpha" refers to ingestion limits and retention. That is the correct use of the word.
- The `posthog.metrics` SQL references. Documenting SQL as the way to read metrics you cannot view would make a workaround load-bearing.

Nothing renders differently except the notice text and the callout, so there are no screenshots.

## Verification

- `metrics` evaluates true for about 805 people over the last 30 days, against 943,459 false, which is the gap this notice closes.
- No page under `contents/docs/metrics/` mentioned "select teams", "request access", "waitlist", "allowlist", "private alpha", or "early access" before this change.
- Not checked: the Vercel preview build, and how the callout renders in dark mode.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

No page moved, so no redirect is needed.

## 🤖 Agent context

**Autonomy:** Claude Code wrote this change; a human directed it and reviews it.

Found while investigating a support ticket. A customer followed the OpenTelemetry instructions, got HTTP 200 for their metrics, and opened a ticket because nothing appeared. Their data had ingested correctly. They then enabled the feature preview toggle on the metrics page, which writes a person property that no flag condition reads, so it granted nothing.

An earlier draft of this PR added wording about querying `posthog.metrics` from the SQL editor, plus an in-app support link for requesting access. Both were cut: the first documents a workaround that exists only because the viewer is off, and the second belongs on the gate rather than in docs.

Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.
