### PR TITLE
Fix page count on The Context Gap report page

### DIFF
--- a/src/pages/the-context-gap-report/index.tsx
+++ b/src/pages/the-context-gap-report/index.tsx
@@ -94,7 +94,7 @@ export default function ContextGapReport() {
                                 You don't have to read everyone's reports to know what's important in data infrastructure, just read ours:
                             </p>
                             <ul className="list-disc pl-5 space-y-1">
-                                <li>It's only 2 pages, not 300.</li>
+                                <li>It's only 3 pages, not 300.</li>
                                 <li>It's still a PDF, so it still feels professional.</li>
                                 <li>Not gated behind a form, no need to give us your email</li>
                             </ul>


### PR DESCRIPTION
## Changes

The Context Gap report landing page said the report is "only 2 pages" — it is 3 pages. Corrected the number.

**Why:** Reported in Slack as a typo on the newly released report page.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0351B1DMUY/p1788523210402929?thread_ts=1788523210.402929&cid=C0351B1DMUY)*