### PR TITLE
fix(redirects): send two 404 URLs to their real pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -579,6 +579,16 @@
             "statusCode": 301
         },
         {
+            "source": "/docs/mcp/:path*",
+            "destination": "/docs/model-context-protocol/:path*",
+            "statusCode": 301
+        },
+        {
+            "source": "/docs/model-context-protocol/installation:ext(\\.md)?",
+            "destination": "/docs/model-context-protocol:ext?",
+            "statusCode": 301
+        },
+        {
             "source": "/docs/settings/environments:ext(\\.md)?",
             "destination": "/docs/settings/projects:ext?",
             "statusCode": 301
@@ -5206,6 +5216,11 @@
                     "value": "workflows"
                 }
             ]
+        },
+        {
+            "source": "/pricing/:product(ab-testing|ai-observability|endpoints|error-tracking|experiments|feature-flags|llm-analytics|logs|product-analytics|replay-vision|session-replay|surveys|web-analytics|workflows)",
+            "destination": "/:product/pricing",
+            "statusCode": 301
         },
         {
             "source": "/handbook/growth/sales/icp",

--- a/vercel.json
+++ b/vercel.json
@@ -579,11 +579,6 @@
             "statusCode": 301
         },
         {
-            "source": "/docs/mcp/:path*",
-            "destination": "/docs/model-context-protocol/:path*",
-            "statusCode": 301
-        },
-        {
             "source": "/docs/model-context-protocol/installation:ext(\\.md)?",
             "destination": "/docs/model-context-protocol:ext?",
             "statusCode": 301
@@ -5218,8 +5213,8 @@
             ]
         },
         {
-            "source": "/pricing/:product(ab-testing|ai-observability|endpoints|error-tracking|experiments|feature-flags|llm-analytics|logs|product-analytics|replay-vision|session-replay|surveys|web-analytics|workflows)",
-            "destination": "/:product/pricing",
+            "source": "/pricing/product-analytics",
+            "destination": "/product-analytics/pricing",
             "statusCode": 301
         },
         {


### PR DESCRIPTION
## Changes

Two guessable URLs return 404 today, and neither path has ever existed on the site. This adds two redirects in `vercel.json`:

- `/pricing/product-analytics` → `/product-analytics/pricing`
- `/docs/model-context-protocol/installation` → `/docs/model-context-protocol`, which holds the install steps and links to the per-client pages

**Why:** a user looked for these two URLs, found 404s, and asked where the pages went. The per-product pricing URL was always `/pricing?product=<slug>`, and MCP install steps were always on the docs index, so a redirect is the correct fix.

No visual change — this touches redirect configuration only.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D0BNGA70E9W/p1788534261602069?thread_ts=1788534261.602069&cid=D0BNGA70E9W)*
