### PR TITLE
Add QR mogging link to moderator tools nav

### DIFF
--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -16,6 +16,7 @@ import {
     IconPeople,
     IconPinFilled,
     IconBadge,
+    IconShare,
 } from '@posthog/icons'
 import { useAppActions, useAppSettings } from '../../context/App'
 
@@ -246,6 +247,13 @@ function TaskBarMenu() {
                                     label: 'Image annotation',
                                     link: '/image-annotator',
                                     icon: <IconPinFilled className="opacity-50 group-hover/item:opacity-75 size-4" />,
+                                },
+                                {
+                                    type: 'item' as const,
+                                    label: 'QR mogging',
+                                    link: 'https://qr-mogging.hosthog.dev',
+                                    external: true,
+                                    icon: <IconShare className="opacity-50 group-hover/item:opacity-75 size-4" />,
                                 },
                             ]
                           : []),

--- a/src/navs/internalTools.ts
+++ b/src/navs/internalTools.ts
@@ -7,4 +7,5 @@ export const internalToolsNav = [
     { name: 'Community directory', url: '/community/directory' },
     { name: 'HogWatch 3000', url: '/hogwatch' },
     { name: 'Image annotation', url: '/image-annotator' },
+    { name: 'QR mogging', url: 'https://qr-mogging.hosthog.dev' },
 ]


### PR DESCRIPTION
## Changes

Adds the QR code generator at qr-mogging.hosthog.dev to the moderator tools nav, so people can find it without a link from chat.

- `src/components/TaskBarMenu/index.tsx` – new "QR mogging" item at the end of the moderator tools group in the avatar menu. It is an external link, so it opens in a new tab, the same as the "PostHog app" item.
- `src/navs/internalTools.ts` – the same entry in the shared internal tools sidebar. `TreeMenu` finds `http(s)` URLs and shows the external cue automatically.

No new components and no styling changes: the item uses the existing menu item shape and `IconShare`.

**Why:** the tool was announced in chat only. The moderator tools menu is where the other internal tools are, so this makes it findable later.

⚠️ **Screenshots missing.** This environment has no dependencies installed and no browser, so I could not start the dev server or capture the before/after grid (narrow/wide, light/dark) that a visual change needs. Please add the screenshots before review.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AP5NXF8D7/p1788556092675409?thread_ts=1788556092.675409&cid=C0AP5NXF8D7)*