### PR TITLE
docs(sponsorship): add Intlayer to open source sponsorship list

### DIFF
--- a/contents/handbook/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/marketing/open-source-sponsorship.mdx
@@ -68,8 +68,9 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | [SwiftFormat]                  | [nicklockwood]   | A command-line tool and Xcode Extension for formatting Swift code.                    | Directly                                | $10                    |
 | [detekt]                       | [arturbosch]     | Static code analysis for Kotlin                                                       | [GitHub Sponsors][github-sponsors]      | $10                    |
 | [Periphery]                    | [ileitch]        | A tool to identify unused code in Swift projects.                                     | [GitHub Sponsors][github-sponsors]      | $5                     |
-| [Rollup]                       | [Rollup]         | Next-generation ES module bundler.                                                   | [Open Collective][open-collective]      | $5                     |
-| [SeaweedFS]                    | [Chris Lu]         | SeaweedFS is a fast distributed storage system for blobs, objects, files, & data lake | [Patreon](patreon-seaweedfs) | $100 |
+| [Rollup]                       | [Rollup]         | Next-generation ES module bundler.                                                    | [Open Collective][open-collective]      | $5                     |
+| [SeaweedFS]                    | [Chris Lu]       | SeaweedFS is a fast distributed storage system for blobs, objects, files, & data lake | [Patreon](patreon-seaweedfs)            | $100                   |
+| [Intlayer]                     | [aymericzip]     | Open-source i18n library, CMS, and performance insights for multilingual applications | [GitHub Sponsors][github-sponsors]      | $10                    |                                                                                    |
 
 
 
@@ -89,6 +90,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [Rollup]: https://github.com/rollup/rollup
 [SwiftFormat]: https://github.com/nicklockwood/SwiftFormat
 [SeaweedFS]: https://github.com/seaweedfs/seaweedfs
+[Intlayer]: https://github.com/aymericzip/intlayer
 
 <!-- authors -->
 [tailwindlabs]: https://github.com/tailwindlabs
@@ -104,6 +106,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [cpojer]: https://github.com/cpojer
 [nicklockwood]: https://github.com/nicklockwood
 [Chris Lu]: https://github.com/chrislusf
+[aymericzip]: https://github.com/aymericzip
 
 <!-- other links -->
 [github-sponsors]: https://github.com/orgs/PostHog/sponsoring


### PR DESCRIPTION
## Changes

Following the 'request sponsoship' section of https://posthog.com/handbook/marketing/open-source-sponsorship

CC @charlescook-ph

& alignment other rows in table

## Why sponsor Intlayer?

Intlayer is an open-source i18n ecosystem for JavaScript application, combining an i18n library, CMS, and A/B test for multilingual application.

Intlayer already uses PostHog for analytics, and we would like to build a deeper integration with PostHog for **A/B testing localized content**. This could help users test different content variants across languages, identify what performs best, and optimize their copy for conversion and discoverability.

With 30k users, 70k weekly npm downloads, and 820+ GitHub stars, sponsorship would help us maintain the project, scale its infrastructure, and continue developing this integration.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
