### PR TITLE
docs: Add links to PR and Charles in sponsorship request

### DIFF
--- a/contents/handbook/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/marketing/open-source-sponsorship.mdx
@@ -113,6 +113,6 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 
 ### Request sponsorship
 
-If you know of a project that is fundamentally important to PostHog, add the project to this page via a PR and tag Charles. If we decide to sponsor, we can set up the sponsorship via either Open Collective or GitHub. To get an invite to Open Collective, create an account first with your posthog.com email address and then ask Charles to invite you. 
+If you know of a project that is fundamentally important to PostHog, add the project to this [page via a PR](https://github.com/PostHog/posthog.com/edit/master/contents/handbook/marketing/open-source-sponsorship.mdx) and tag [Charles](https://github.com/charlescook-ph). If we decide to sponsor, we can set up the sponsorship via either Open Collective or GitHub. To get an invite to Open Collective, create an account first with your posthog.com email address and then ask Charles to invite you. 
 
 Anyone on the PostHog team can do this!


### PR DESCRIPTION
Updated the request sponsorship section to include links to the PR and Charles' profile.

## Changes

Simplify access to 'Request sponsorship' process doc
Avoid having to find the right doc in the right repo manually 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
