### PR TITLE
Remove stale /wizard redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6365,11 +6365,6 @@
             "statusCode": 301
         },
         {
-            "source": "/wizard",
-            "destination": "/docs/ai-engineering/ai-wizard",
-            "statusCode": 301
-        },
-        {
             "source": "/product-analytics-explorer/pricing",
             "destination": "/product-analytics/pricing",
             "statusCode": 301


### PR DESCRIPTION
## Changes

`posthog.com/wizard` sometimes opened the wizard page and sometimes went to `/docs/ai-engineering/ai-wizard`. The cause is a leftover 301 in `vercel.json` (`/wizard` → `/docs/ai-engineering/ai-wizard`), although `/wizard` has its own page: `src/pages/wizard/index.tsx` with `contents/wizard.mdx`.

Vercel applies the redirect only to server requests. Thus a direct load or refresh went to the doc, but a click on an in-site link (for example from the startup program page or the platform install schema, which both point to `/wizard`) stayed in the Gatsby client router and showed the real page. The result was the intermittent behavior.

This PR deletes that redirect entry. No other change.

**Why:** `/wizard` is a live page that many links on the site point to, so the redirect sent people away from it.

No visual change to any component — the wizard page itself is unchanged; it is only reachable again on a direct load.

`pnpm test-redirects` runs `jest scripts`, and there are no test files in `scripts/`, so it has nothing to execute. `vercel.json` was validated as JSON after the edit.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1788715202278509)*