### PR TITLE
docs(contribute): describe the current merch code process for contributors

### DIFF
--- a/contents/docs/contribute/recognizing-contributions.md
+++ b/contents/docs/contribute/recognizing-contributions.md
@@ -10,7 +10,7 @@ At PostHog we aim to recognize all contributions made to our open source codebas
 
 Once your pull request is merged, ask the person who reviewed it for a merch code in a comment on the PR. If you have a PostHog account, you can also [open a support request](https://us.posthog.com/#panel=support%3Asupport%3A%3A%3Atrue) with a link to the PR and your GitHub handle. Either way, someone on the PostHog team will send you a code.
 
-We usually give $50 for a code contribution, and more for larger or multiple contributions. Amounts are at our discretion. Codes are single use and don't expire.
+The amount is at our discretion and depends on the size of your contribution. Codes are single use and don't expire.
 
 ## For the PostHog team
 

--- a/contents/docs/contribute/recognizing-contributions.md
+++ b/contents/docs/contribute/recognizing-contributions.md
@@ -8,7 +8,7 @@ At PostHog we aim to recognize all contributions made to our open source codebas
 
 ## How to get your merch code
 
-Once your pull request is merged, email us at [hey@posthog.com](mailto:hey@posthog.com) with a link to the PR and your GitHub handle. Someone on the PostHog team will send you a code. You can also ask the person who reviewed your PR in a comment.
+Once your pull request is merged, [open a support request](https://us.posthog.com/#panel=support%3Asupport%3A%3A%3Atrue) with a link to the PR and your GitHub handle. You don't need a PostHog account to do this. Someone on the PostHog team will send you a code. You can also ask the person who reviewed your PR in a comment.
 
 We usually give $50 for a code contribution, and more for larger or multiple contributions. Amounts are at our discretion. Codes are single use and don't expire.
 

--- a/contents/docs/contribute/recognizing-contributions.md
+++ b/contents/docs/contribute/recognizing-contributions.md
@@ -8,7 +8,7 @@ At PostHog we aim to recognize all contributions made to our open source codebas
 
 ## How to get your merch code
 
-Once your pull request is merged, [open a support request](https://us.posthog.com/#panel=support%3Asupport%3A%3A%3Atrue) with a link to the PR and your GitHub handle. You don't need a PostHog account to do this. Someone on the PostHog team will send you a code. You can also ask the person who reviewed your PR in a comment.
+Once your pull request is merged, ask the person who reviewed it for a merch code in a comment on the PR. If you have a PostHog account, you can also [open a support request](https://us.posthog.com/#panel=support%3Asupport%3A%3A%3Atrue) with a link to the PR and your GitHub handle. Either way, someone on the PostHog team will send you a code.
 
 We usually give $50 for a code contribution, and more for larger or multiple contributions. Amounts are at our discretion. Codes are single use and don't expire.
 

--- a/contents/docs/contribute/recognizing-contributions.md
+++ b/contents/docs/contribute/recognizing-contributions.md
@@ -4,16 +4,14 @@ sidebar: Docs
 showTitle: true
 ---
 
-At PostHog we aim to recognize all contributions made to our open source codebases. We do this largely via automated processes that ensure our contributors are recognized. 
+At PostHog we aim to recognize all contributions made to our open source codebases. If you get a pull request merged into a repository under the `PostHog` organization, we'd like to send you a code for [our merch store](https://merch.posthog.com) as a thank you.
 
-# Pull requests
+## How to get your merch code
 
-If you submit a Pull Request to a repository under the `PostHog` organization, a bot will automatically send you an email to get in touch with us for a merch code. 
+Once your pull request is merged, email us at [hey@posthog.com](mailto:hey@posthog.com) with a link to the PR and your GitHub handle. Someone on the PostHog team will send you a code. You can also ask the person who reviewed your PR in a comment.
 
-We usually give out up to $100 for a product or app-related PR at our discretion, and $25 for something on posthog.com (but we have gone over and above this for particularly large community PRs before!)
+We usually give $50 for a code contribution, and more for larger or multiple contributions. Amounts are at our discretion. Codes are single use and don't expire.
 
-If, after a few days of having had your PR merged, you still didn't get a merch code, you can email us at _[hey@posthog.com](mailto:hey@posthog.com)_ and we'll sort it out! Someone on the PostHog team will send you a code [manually](/handbook/company/merch-store#individuals). 
+## For the PostHog team
 
-
-### Sending out merch
-Follow instructions on [giving away merch for free](/handbook/company/merch-store)
+To send a code, follow the instructions for [merch giveaways](/handbook/company/merch-store#merch-giveaways) in the handbook.


### PR DESCRIPTION
## Changes

- Contributors who read this page expect a bot to email them a merch code after their PR merges. No email arrives, and they end up writing to support to ask where it is.
- The bot behind that promise ([PostHog/contributions-bot](https://github.com/PostHog/contributions-bot)) last acted on a PR in December 2022, and its GitHub App installation was suspended in December 2025.
- The page now tells contributors to ask their PR reviewer for a code, or to open an in-app support request if they have a PostHog account. Both routes reach the team today.
- The page no longer lists an email address.
- The page no longer quotes a dollar amount. It says the amount is at our discretion and depends on the size of the contribution.
- The old page promised up to $100 for a product PR and $25 for a posthog.com PR.
- The team-facing link now points at the handbook's "Merch giveaways" section. The old `#individuals` anchor no longer exists.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`

## Agent context

Drafted with Claude Code from a support ticket where a contributor asked why no merch email arrived after three merged posthog-js PRs. The copy follows the `writing-user-facing-copy` skill, and this description follows `writing-pr-descriptions`. The dollar amount came out in response to review feedback on the first version. Not checked: the deploy preview.
