### PR TITLE
Document CSM relationship in the CS handbook

### DIFF
--- a/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
+++ b/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
@@ -47,6 +47,7 @@ If you're inheriting an existing contact:
 - Review the [Sales → CSM Handover](/handbook/growth/sales/account-allocation#handing-over-customers) process.
 - Get introduced in the existing Slack/Teams channel or via email.
 - Coordinate with the previous owner for continuity.
+- Set your own [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-sentiment) rating on the account. Start at 2 — do not keep the rating the previous owner gave it.
 
 ### Cold (no established contact)
 

--- a/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
+++ b/contents/handbook/cs-and-onboarding/getting-started-with-customers.md
@@ -47,7 +47,7 @@ If you're inheriting an existing contact:
 - Review the [Sales → CSM Handover](/handbook/growth/sales/account-allocation#handing-over-customers) process.
 - Get introduced in the existing Slack/Teams channel or via email.
 - Coordinate with the previous owner for continuity.
-- Set your own [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-sentiment) rating on the account. Start at 2 — do not keep the rating the previous owner gave it.
+- Set your own [CSM relationship](/handbook/cs-and-onboarding/health-tracking#csm-relationship) rating on the account. Start at 2 — do not keep the rating the previous owner gave it.
 
 ### Cold (no established contact)
 

--- a/contents/handbook/cs-and-onboarding/health-tracking.md
+++ b/contents/handbook/cs-and-onboarding/health-tracking.md
@@ -8,6 +8,8 @@ We use Vitally as a customer success platform.  You can log in via Google SSO to
 
 ## Health scoring
 
+This section covers the computed score. For the rating you set by hand on your own accounts, see [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-sentiment).
+
 ### Overview
 
 Health scores are a great way to assess whether your customer is at risk of churn or in a good state and are a common pattern in Customer Success tracking.  We compute an overall <PrivateLink url="https://posthog.vitally-eu.io/settings/health/accounts">health score</PrivateLink> out of 10 based on the following factors and weighting.  You can read more about how Vitally health scores work in their docs <PrivateLink url="https://docs.vitally.io/account-health-scores-and-metrics/health-scores">here</PrivateLink>.
@@ -174,3 +176,28 @@ Applied if the Forecasted MRR Change is more than 10%, indicating an increase in
 #### Organization owner recently added
 
 Applied if the Owner role has been added to a user in the last 14 days. This is a good opportunity to reach out to a potential champion if you've not met them before. 
+
+## CSM sentiment
+
+The health score above is computed for you. CSM sentiment is not — it is a rating you set by hand on your own accounts, in <PrivateLink url="https://us.posthog.com/project/2/accounts">Customer analytics</PrivateLink>.
+
+It records the relationship *you personally* have with the account. It does not measure how the account is doing. A large, healthy, fully self-serve account can sit at the bottom of the scale, and that is a correct reading — in a product-led book, "assigned to you" and "known to you" are different things. When the health score and your sentiment disagree, they are usually both right.
+
+| Rating | What it means |
+|--------|---------------|
+| 1 - No relationship | The account is yours on paper only. It is fully self-serve, and you have no two-way contact with anyone there. |
+| 2 - Warm handover | The relationship came to you from another CSM or a teammate. You have an introduction, but no direct trust yet. |
+| 3 - Reactive | They contact you when they need something, and there is no contact between times. |
+| 4 - Working relationship | You have regular two-way contact with a named person who replies to you and takes meetings. |
+| 5 - Trusted advisor | You are multi-threaded in the account. They bring you problems early and include you in their plans. |
+
+To set the rating, add the **CSM sentiment** column to your account view, then click the cell.
+
+### How to use it
+
+- Only the CSM on the account sets the rating. Do not rate an account for somebody else.
+- Change it when the relationship changes. There is no review schedule.
+- On handover, rate your own relationship. Start again at 2 instead of keeping the rating the previous CSM gave. If you keep their rating, the field tells you about the history of the book and not about the relationship the account has today.
+- Be honest. A book of all fives is less useful than an accurate one, and a one is not a failure — it tells us which accounts are self-serve by nature and which ones need a human.
+
+Each label starts with a digit, so the scale sorts in the accounts table and totals in HogQL and PostHog AI. Use `toInt32OrNull(substring(value, 1, 1))` to get the number.

--- a/contents/handbook/cs-and-onboarding/health-tracking.md
+++ b/contents/handbook/cs-and-onboarding/health-tracking.md
@@ -8,7 +8,7 @@ We use Vitally as a customer success platform.  You can log in via Google SSO to
 
 ## Health scoring
 
-This section covers the computed score. For the rating you set by hand on your own accounts, see [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-relationship).
+This section covers the computed score. For the rating you set by hand on your own accounts, see [CSM relationship](/handbook/cs-and-onboarding/health-tracking#csm-relationship).
 
 ### Overview
 

--- a/contents/handbook/cs-and-onboarding/health-tracking.md
+++ b/contents/handbook/cs-and-onboarding/health-tracking.md
@@ -179,7 +179,7 @@ Applied if the Owner role has been added to a user in the last 14 days. This is 
 
 ## CSM sentiment
 
-The health score above is computed for you. CSM sentiment is not — it is a rating you set by hand on your own accounts, in <PrivateLink url="https://us.posthog.com/project/2/accounts">Customer analytics</PrivateLink>.
+The health score above is computed for you. CSM sentiment is a rating you set by hand on your own accounts, in <PrivateLink url="https://us.posthog.com/project/2/accounts">Customer analytics</PrivateLink>.
 
 It records the relationship *you personally* have with the account. It does not measure how the account is doing. A large, healthy, fully self-serve account can sit at the bottom of the scale, and that is a correct reading — in a product-led book, "assigned to you" and "known to you" are different things. When the health score and your sentiment disagree, they are usually both right.
 

--- a/contents/handbook/cs-and-onboarding/health-tracking.md
+++ b/contents/handbook/cs-and-onboarding/health-tracking.md
@@ -198,6 +198,6 @@ To set the rating, add the **CSM sentiment** column to your account view, then c
 - Only the CSM on the account sets the rating. Do not rate an account for somebody else.
 - Change it when the relationship changes. There is no review schedule.
 - On handover, rate your own relationship. Start again at 2 instead of keeping the rating the previous CSM gave. If you keep their rating, the field tells you about the history of the book and not about the relationship the account has today.
-- Be honest. A book of all fives is less useful than an accurate one, and a one is not a failure — it tells us which accounts are self-serve by nature and which ones need a human.
+- Be honest. A book of all fives is less useful than an accurate one, and a one is not a failure — it tells us which accounts might need more focus from the CSM team and beyond.
 
 Each label starts with a digit, so the scale sorts in the accounts table and totals in HogQL and PostHog AI. Use `toInt32OrNull(substring(value, 1, 1))` to get the number.

--- a/contents/handbook/cs-and-onboarding/health-tracking.md
+++ b/contents/handbook/cs-and-onboarding/health-tracking.md
@@ -8,7 +8,7 @@ We use Vitally as a customer success platform.  You can log in via Google SSO to
 
 ## Health scoring
 
-This section covers the computed score. For the rating you set by hand on your own accounts, see [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-sentiment).
+This section covers the computed score. For the rating you set by hand on your own accounts, see [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-relationship).
 
 ### Overview
 
@@ -177,9 +177,9 @@ Applied if the Forecasted MRR Change is more than 10%, indicating an increase in
 
 Applied if the Owner role has been added to a user in the last 14 days. This is a good opportunity to reach out to a potential champion if you've not met them before. 
 
-## CSM sentiment
+## CSM relationship
 
-The health score above is computed for you. CSM sentiment is a rating you set by hand on your own accounts, in <PrivateLink url="https://us.posthog.com/project/2/accounts">Customer analytics</PrivateLink>.
+The health score above is computed for you. CSM relationship is a rating you set by hand on your own accounts, in <PrivateLink url="https://us.posthog.com/project/2/accounts">Customer analytics</PrivateLink>.
 
 It records the relationship *you personally* have with the account. It does not measure how the account is doing from a usage/spend/metrics standpoint. A large, healthy, fully self-serve account can sit at the bottom of the scale, and that is a correct reading in a product-led book, "assigned to you" and "known to you" are different things. 
 
@@ -191,7 +191,7 @@ It records the relationship *you personally* have with the account. It does not 
 | 4 - Working relationship | You have regular two-way contact with a named person who replies to you and takes meetings. |
 | 5 - Trusted advisor | You are multi-threaded in the account. They bring you problems early and include you in their plans. |
 
-To set the rating, add the **CSM sentiment** column to your account view, then click the cell.
+To set the rating, add the **CSM relationship** column to your account view, then click the cell.
 
 ### How to use it
 

--- a/contents/handbook/cs-and-onboarding/health-tracking.md
+++ b/contents/handbook/cs-and-onboarding/health-tracking.md
@@ -181,7 +181,7 @@ Applied if the Owner role has been added to a user in the last 14 days. This is 
 
 The health score above is computed for you. CSM sentiment is a rating you set by hand on your own accounts, in <PrivateLink url="https://us.posthog.com/project/2/accounts">Customer analytics</PrivateLink>.
 
-It records the relationship *you personally* have with the account. It does not measure how the account is doing. A large, healthy, fully self-serve account can sit at the bottom of the scale, and that is a correct reading — in a product-led book, "assigned to you" and "known to you" are different things. When the health score and your sentiment disagree, they are usually both right.
+It records the relationship *you personally* have with the account. It does not measure how the account is doing from a usage/spend/metrics standpoint. A large, healthy, fully self-serve account can sit at the bottom of the scale, and that is a correct reading in a product-led book, "assigned to you" and "known to you" are different things. 
 
 | Rating | What it means |
 |--------|---------------|

--- a/contents/handbook/cs-and-onboarding/lifecycle-csm.md
+++ b/contents/handbook/cs-and-onboarding/lifecycle-csm.md
@@ -8,6 +8,8 @@ showTitle: true
 
 When you start as a Technical CSM, you're assigned a book of business with ~30 accounts. Customer engagement falls into three stages.
 
+The stages line up with [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-sentiment), the rating you give your own relationship with an account. Stage 1 covers ratings 1 to 3, stage 2 is rating 4, and stage 3 is rating 5.
+
 ## Stage 1: Getting started
 
 See [getting started with customers](/handbook/cs-and-onboarding/getting-started-with-customers).

--- a/contents/handbook/cs-and-onboarding/lifecycle-csm.md
+++ b/contents/handbook/cs-and-onboarding/lifecycle-csm.md
@@ -8,7 +8,7 @@ showTitle: true
 
 When you start as a Technical CSM, you're assigned a book of business with ~30 accounts. Customer engagement falls into three stages.
 
-The stages line up with [CSM sentiment](/handbook/cs-and-onboarding/health-tracking#csm-sentiment), the rating you give your own relationship with an account. Stage 1 covers ratings 1 to 3, stage 2 is rating 4, and stage 3 is rating 5.
+The stages line up with [CSM relationship](/handbook/cs-and-onboarding/health-tracking#csm-relationship), the rating you give your own relationship with an account. Stage 1 covers ratings 1 to 3, stage 2 is rating 4, and stage 3 is rating 5.
 
 ## Stage 1: Getting started
 


### PR DESCRIPTION
## Changes

CSM relationship is a new account property in Customer analytics. A CSM sets it by hand on the accounts they own, to record the relationship they personally have with each account. It is subjective, and no data source writes to it.

This PR documents it in three places:

- **`health-tracking.md`** — a new "CSM relationship" section with the 1 to 5 scale and the rules for use. This page is the correct home, because it also defines the computed health score. The two measures are different, and the difference is easier to understand when one page shows both. The section says clearly that a large, healthy, fully self-serve account can correctly sit at 1.
- **`lifecycle-csm.md`** — one line that maps the three engagement stages onto the scale.
- **`getting-started-with-customers.md`** — one line in "Handover from Sales". On handover the new CSM starts again at 2, and does not keep the previous owner's rating.

**Why:** CS asked for a way for CSMs to record their own relationship with an account. In a product-led book, an account can be assigned to a CSM and still be fully self-serve, or can arrive through a warm handover from a colleague. The health score cannot show this, because it is computed from product and billing data. The field is live in Customer analytics, so the handbook has to explain what the ratings mean and who sets them.

The property was called "CSM sentiment" when this PR was opened. It is now named **CSM relationship** in Customer analytics, and the text here matches. The rating labels are unchanged.

## Open question for the reviewer

The stage names in `lifecycle-csm.md` describe the same progression as the scale, in different words. I kept the two vocabularies separate and linked them. Tell me if you prefer the ratings to reuse the stage names, and I will rename them in the product and here in the same change.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no page moved

Prettier reports no changes on the three files. I could not start the dev server, because this environment has no `node_modules` and cannot install them. Please use the Vercel preview build to check the pages. The only component in the new text is `PrivateLink`, which the same page already uses.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
