### PR TITLE
Keep "ships code" on one line in the hero body

### DIFF
--- a/src/components/Home/HeroCopy/variants.tsx
+++ b/src/components/Home/HeroCopy/variants.tsx
@@ -61,7 +61,6 @@ const BodyReviewAndMerge = () => (
 const BodyShipsCode = () => (
     <Paragraph>
         PostHog already has your <Highlight>analytics and errors</Highlight>. Now it{' '}
-        {/* A non-breaking space keeps the two words on one line, so the underline is one stroke. */}
         <Underline delay={900}>ships&nbsp;code</Underline> to help you build a better product.
     </Paragraph>
 )

--- a/src/components/Home/HeroCopy/variants.tsx
+++ b/src/components/Home/HeroCopy/variants.tsx
@@ -61,7 +61,8 @@ const BodyReviewAndMerge = () => (
 const BodyShipsCode = () => (
     <Paragraph>
         PostHog already has your <Highlight>analytics and errors</Highlight>. Now it{' '}
-        <Underline delay={900}>ships code</Underline> to help you build a better product.
+        {/* A non-breaking space keeps the two words on one line, so the underline is one stroke. */}
+        <Underline delay={900}>ships&nbsp;code</Underline> to help you build a better product.
     </Paragraph>
 )
 


### PR DESCRIPTION
## Changes

The `variant-3` hero body underlines the words "ships code". The underline annotation draws one stroke for each line of the phrase. At some window widths, the text breaks between the two words, so the phrase gets two short strokes: one at the end of the first line, and one at the start of the second. This looks like a defect.

A non-breaking space now joins the two words. The phrase can no longer break, so the underline is always one stroke, and both words move to the second line together. Widths that did not break the phrase, the other three copy variants, and the draw animation are all unchanged.

**Why:** the split underline on the homepage hero looked wrong, so the two words must stay on the same line at every width.

### Screenshots

#### Homepage hero body (`variant-3`)

| State | Before | After |
|---|---|---|
| Light, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/3506562d-48bf-4f48-b0f8-d83a3d2bd1d1.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/6a6ec8e1-1425-425d-ab12-669963ca729d.png" width="300"> |
| Light, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/9453400c-699f-4286-b740-ce465d43686c.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/fc00b940-6562-4b45-9be2-1a7825211c5c.png" width="300"> |
| Dark, narrow window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/101c98d6-b245-441e-aa98-b859ba4172cc.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/e1059ef1-e066-413e-b75a-65e0504a902c.png" width="300"> |
| Dark, wide window | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/47c303df-8a7d-4d3b-9b43-a0d992b9f5ec.png" width="300"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/3782970369f035414219f86b22a5ea5d69d32884/2026/09/e1b0e481-62c7-4e5a-82ec-f5e39bf6326c.png" width="300"> |

How to read the grid: the narrow window is 540 px, which is a width that breaks the phrase, so it shows the change. The wide window is 1440 px, which does not break the phrase, so it shows that nothing else moves. The `homepage-hero-copy` flag selects this variant, so the capture pointed the default variant at `variant-3` for the screenshots only. That change is not in the diff. No GIF: the change moves where the stroke is drawn, but the animation itself is the same.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

Other checks: `prettier` reports the changed file is clean. The local dev server shows no new console errors on the homepage (the two errors present are the same before and after the change).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1788858838790869?thread_ts=1788858838.790869&cid=C01V9AT7DK4)*
