### PR TITLE
fix(handbook): working guide link and QR tool in speaker guide

### DIFF
--- a/contents/handbook/marketing/speaker-guide.md
+++ b/contents/handbook/marketing/speaker-guide.md
@@ -80,7 +80,8 @@ If you’re pre-recording your demo, [\#team-youtube](https://posthog.slack.com/
 A few principles for building out slides:
 
 * Before the slides, start on paper or in a notes app and build out your talk outline  
-* PostHog talks use our [standard slide template](https://www.figma.com/slides/buiAgxPjrzpuZyvilFJadI/PH-slide-deck-template?node-id=1-20157&t=ZtCfzbtzRzwfVTry-0) in Figma. [Here’s a guide](https://share.zight.com/kpu21RG9) on how to use it.   
+* PostHog talks use our [standard slide template](https://www.figma.com/slides/buiAgxPjrzpuZyvilFJadI/PH-slide-deck-template?node-id=1-20157&t=ZtCfzbtzRzwfVTry-0) in Figma. [Here’s a guide](https://drive.google.com/file/d/1hZ556swZrKE7guOZipFh-N3kWD_MsVYU/view?usp=sharing) on how to use it.   
+* Adding a QR code to a slide? Make it with our own [QR code generator](https://qr-mogging.hosthog.dev/).   
 * Code on slides: use a large font (24pt minimum), a dark background, and only show the lines that matter. If you're pasting a full file, you've already lost.  
 * One idea per slide. If you're writing full sentences, you're writing speaker notes, not a slide. If applicable, allow memes to replace text.   
 * If a slide doesn't support the one true thing you identified in step 3, cut it.  


### PR DESCRIPTION
## Changes

- The "how to use the slide template" guide in step 5 now opens for everyone. It pointed at a Zight share that had passed its view limit, and now points at the Drive copy of the same video.
- Step 5 also links our own QR code generator, so speakers making a QR code for their deck have a tool to hand.

Text-only change to one handbook page, no screenshots needed.

## Why

Speakers found the guide video dead when they clicked it, and the QR code advice later on the page named no tool.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1764784314234079?thread_ts=1764784314.234079&cid=C02E3BKC78F)*