### PR TITLE
docs(api/capture): fix invalid JSON and missing imports in code samples

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -35,6 +35,9 @@ curl -v -L --header "Content-Type: application/json" -d '{
 ```
 
 ```python
+import json
+import requests
+
 url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
@@ -294,7 +297,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "$group_key": "<company_name>",
     "$group_set": {
       "name": "<company_name>",
-      "subscription": "premium"
+     "subscription": "premium",
       "date_joined": "[optional timestamp in ISO 8601 format]"
     }
   }


### PR DESCRIPTION
## Changes

Two code samples on the capture API page fail when copied as published.

1. Group identify, curl. The JSON body is missing a comma after "subscription": "premium", so the body is not valid JSON and the capture endpoint rejects it. The Python sample in the same section already has the comma.

2. Single event, Python. The first Python sample calls requests.post and json.dumps with no imports, so it fails immediately with NameError. The Node sample beside it imports node-fetch, and the Python sample in the Group identify section already imports both json and requests. This one just missed them.

Both fixes make the samples consistent with the working examples elsewhere on the same page. One file, code blocks only, no prose changes.
Checklist
 I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
 Words are spelled using American English
 Use relative URLs for internal links
 I've checked the pages added or changed in the Vercel preview build
 If I moved a page, I added a redirect in vercel.json

The preview box is unticked because the preview build is created when this PR opens. I will check the rendered page and tick it.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
