### PR TITLE
Add Application metrics changelog and tool listing for alpha product

### DIFF
--- a/contents/docs/metrics/architecture.mdx
+++ b/contents/docs/metrics/architecture.mdx
@@ -2,7 +2,7 @@
 title: How metrics works
 ---
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams. The details on this page describe current behavior and may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. The details on this page describe current behavior and may change before general availability.
 
 This page explains what happens to a metric between your application and a chart: how ingestion works, what a series is, how aggregations are computed, and where the data lives. You don't need any of this to use metrics, but it helps when you're deciding what to instrument or debugging why a chart looks the way it does.
 

--- a/contents/docs/metrics/changelog.mdx
+++ b/contents/docs/metrics/changelog.mdx
@@ -1,0 +1,8 @@
+---
+title: Application metrics changelog
+hideRightSidebar: true
+---
+
+import { ProductChangelog } from 'components/Docs/ProductChangelog'
+
+<ProductChangelog product="Metrics" />

--- a/contents/docs/metrics/explore.mdx
+++ b/contents/docs/metrics/explore.mdx
@@ -2,7 +2,7 @@
 title: Use your metrics
 ---
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to open the views on this page. They reflect the current product and may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. The views on this page reflect the current product and may change before general availability.
 
 Once metrics are flowing, open [Metrics](https://app.posthog.com/metrics) in PostHog. The metrics scene has three tabs:
 

--- a/contents/docs/metrics/index.mdx
+++ b/contents/docs/metrics/index.mdx
@@ -2,9 +2,9 @@
 title: Application metrics
 ---
 
-<CalloutBox icon="IconFlask" title="Metrics is in private alpha" type="action">
+<CalloutBox icon="IconFlask" title="Metrics is in public alpha" type="action">
 
-The metrics viewer is only turned on for selected teams. You can send metrics now and they are stored against your project, but you won't be able to view them in PostHog until your team is added. Setup details, including the ingestion endpoint, may change before general availability.
+Metrics is in public alpha and available to everyone. You can send metrics now and explore them in PostHog. Setup details, including the ingestion endpoint, may change before general availability.
 
 </CalloutBox>
 

--- a/contents/docs/metrics/installation/docker.mdx
+++ b/contents/docs/metrics/installation/docker.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from "components/Docs/Steps";
 import MetricsNextSteps from "./_snippets/metrics-next-steps.mdx";
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details, including the ingestion endpoint, may change before general availability.
 
 If your services already expose Prometheus-format `/metrics` endpoints, the PostHog metrics agent scrapes them and forwards everything to PostHog. One `docker run`, no application changes.
 

--- a/contents/docs/metrics/installation/index.mdx
+++ b/contents/docs/metrics/installation/index.mdx
@@ -2,7 +2,7 @@
 title: Install metrics
 ---
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details, including the ingestion endpoint, may change before general availability.
 
 There are three ways to get metrics into PostHog:
 

--- a/contents/docs/metrics/installation/javascript.mdx
+++ b/contents/docs/metrics/installation/javascript.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details may change before general availability.
 
 If [posthog-js](/docs/libraries/js) is already running on your site, you can record metrics directly with the `posthog.metrics` API. No new packages, no extra authentication.
 

--- a/contents/docs/metrics/installation/kubernetes.mdx
+++ b/contents/docs/metrics/installation/kubernetes.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from "components/Docs/Steps";
 import MetricsNextSteps from "./_snippets/metrics-next-steps.mdx";
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details, including the ingestion endpoint, may change before general availability.
 
 If your Kubernetes workloads already expose Prometheus-format `/metrics` endpoints, the PostHog metrics agent scrapes them and forwards everything to PostHog. One `helm install`, no application changes.
 

--- a/contents/docs/metrics/installation/nodejs.mdx
+++ b/contents/docs/metrics/installation/nodejs.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details may change before general availability.
 
 The [posthog-node](/docs/libraries/node) SDK includes the `posthog.metrics` API, so you can record metrics with the same client you use for events and feature flags.
 

--- a/contents/docs/metrics/installation/other.mdx
+++ b/contents/docs/metrics/installation/other.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details, including the ingestion endpoint, may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details, including the ingestion endpoint, may change before general availability.
 
 PostHog's application metrics work with any OpenTelemetry-compatible client. If your app or infrastructure already exports OTLP metrics, point the exporter at PostHog. No PostHog packages required.
 

--- a/contents/docs/metrics/installation/python.mdx
+++ b/contents/docs/metrics/installation/python.mdx
@@ -7,7 +7,7 @@ showStepsToc: true
 import { Steps, Step } from 'components/Docs/Steps'
 import MetricsNextSteps from './_snippets/metrics-next-steps.mdx'
 
-> **Note:** Metrics is in private alpha and the viewer is only turned on for selected teams, so you may not be able to view metrics you send yet. Setup details may change before general availability.
+> **Note:** Metrics is in public alpha and available to everyone. Setup details may change before general availability.
 
 The [posthog-python](/docs/libraries/python) SDK includes the `posthog.metrics` API, so you can record metrics with the same client you use for events and feature flags.
 

--- a/contents/docs/metrics/start-here.mdx
+++ b/contents/docs/metrics/start-here.mdx
@@ -6,9 +6,9 @@ contentMaxWidthClass: max-w-5xl
 
 import { QuestLog, QuestLogItem } from "components/Docs/QuestLog";
 
-<CalloutBox icon="IconFlask" title="Metrics is in private alpha" type="action">
+<CalloutBox icon="IconFlask" title="Metrics is in public alpha" type="action">
 
-The metrics viewer is only turned on for selected teams. You can send metrics now and they are stored against your project, but you won't be able to view them in PostHog until your team is added. Setup details, including the ingestion endpoint, may change before general availability.
+Metrics is in public alpha and available to everyone. You can send metrics now and explore them in PostHog. Setup details, including the ingestion endpoint, may change before general availability.
 
 </CalloutBox>
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "update-sprite": "svg-sprite -s --symbol-dest src/components/productFeature/images/icons --symbol-sprite sprited-icons.svg src/components/productFeature/images/icons/*.svg",
         "test-redirects": "jest scripts",
         "test:bundle": "node --test scripts/bundle/check-eager-graph.test.mjs",
-        "test:navs": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/navs/activeMenu.test.ts src/navs/applicationMetrics.test.ts",
+        "test:navs": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/navs/activeMenu.test.ts src/navs/applicationMetrics.test.ts src/navs/applicationMetricsPresence.test.ts",
         "test:sdk-references": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/components/SdkReferences/utils.test.ts",
         "check-links-post-build": "node scripts/check-links-post-build.js",
         "check-src-links": "node scripts/check-src-links.js",

--- a/src/components/Docs/ProductChangelog.tsx
+++ b/src/components/Docs/ProductChangelog.tsx
@@ -36,6 +36,7 @@ const productConfigMap: Record<string, ProductConfig> = {
     'posthog ai': { topic: 'PostHog AI', teams: ['posthog ai'] },
     endpoints: { topic: 'endpoints' },
     logs: { topic: 'logs', teams: ['apm'] },
+    metrics: { topic: 'metrics', teams: ['apm'] },
     'customer analytics': { teams: ['customer analytics'] },
 }
 

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -89,6 +89,14 @@ export const tools = [
         aliases: ['Logging'],
     },
     {
+        handle: 'metrics',
+        name: 'Application metrics',
+        description: 'Send OpenTelemetry metrics to PostHog and analyze them.',
+        slug: 'metrics',
+        category: 'product_engineering',
+        status: 'alpha',
+    },
+    {
         handle: 'mcp_analytics',
         name: 'MCP Analytics',
         description: 'See how agents actually use your MCP server',

--- a/src/navs/applicationMetricsPresence.test.ts
+++ b/src/navs/applicationMetricsPresence.test.ts
@@ -12,7 +12,7 @@
  */
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
-import { readFileSync, existsSync } from 'node:fs'
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
@@ -67,5 +67,29 @@ describe('the application metrics tool', () => {
         const tools = readFileSync(join(here, '../data/tools.ts'), 'utf8')
         const entry = tools.match(/\{[^{}]*handle:\s*'metrics'[^{}]*\}/)?.[0] ?? ''
         assert.match(entry, /status:\s*'alpha'/, 'expected the metrics tool to carry an alpha status badge')
+    })
+})
+
+// Metrics is in public alpha with self-serve signup, so the docs must not tell
+// readers it is private or gated to selected teams.
+const metricsDocsDir = join(here, '../../contents/docs/metrics')
+const listMdx = (dir: string): string[] =>
+    readdirSync(dir).flatMap((entry) => {
+        const full = join(dir, entry)
+        if (statSync(full).isDirectory()) return listMdx(full)
+        return entry.endsWith('.mdx') ? [full] : []
+    })
+
+describe('the application metrics alpha wording', () => {
+    test('no metrics doc calls the alpha private or gated to selected teams', () => {
+        const offenders = listMdx(metricsDocsDir).filter((file) => {
+            const text = readFileSync(file, 'utf8')
+            return /private alpha/i.test(text) || /selected teams/i.test(text)
+        })
+        assert.deepEqual(
+            offenders.map((file) => file.replace(`${metricsDocsDir}/`, '')),
+            [],
+            'expected no "private alpha" / "selected teams" wording in the metrics docs'
+        )
     })
 })

--- a/src/navs/applicationMetricsPresence.test.ts
+++ b/src/navs/applicationMetricsPresence.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Application metrics is a product in private alpha. It should appear wherever the
+ * other APM signals (logs, traces) appear so people can find it and see that it is
+ * in alpha. These tests pin the two pieces of that presence:
+ *
+ *   1. a docs changelog page, wired into productConfigMap and the docs nav
+ *      (scripts/check-product-changelogs.js enforces all three together)
+ *   2. a `metrics` tool entry so it surfaces in product/tool listings with an
+ *      alpha badge
+ *
+ * Run: pnpm test:navs
+ */
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { docsMenu } from './index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+interface NamedNode {
+    name?: string
+    url?: string
+    children?: NamedNode[]
+}
+
+const walk = (nodes?: NamedNode[]): NamedNode[] => (nodes ?? []).flatMap((node) => [node, ...walk(node.children)])
+
+const metricsSection = (docsMenu.children as NamedNode[]).find((section) => section.url === '/docs/metrics')
+
+describe('the application metrics changelog', () => {
+    test('has a docs changelog page', () => {
+        assert.ok(
+            existsSync(join(here, '../../contents/docs/metrics/changelog.mdx')),
+            'expected contents/docs/metrics/changelog.mdx to exist'
+        )
+    })
+
+    test('the page renders ProductChangelog for metrics', () => {
+        const page = readFileSync(join(here, '../../contents/docs/metrics/changelog.mdx'), 'utf8')
+        assert.match(page, /<ProductChangelog\s+product=["']Metrics["']/)
+    })
+
+    test('is linked from the metrics docs nav', () => {
+        const urls = walk([metricsSection as NamedNode]).map((node) => node.url)
+        assert.ok(
+            urls.includes('/docs/metrics/changelog'),
+            'expected /docs/metrics/changelog in the metrics docs nav section'
+        )
+    })
+
+    test('has a productConfigMap entry so it does not render the whole company changelog', () => {
+        const component = readFileSync(join(here, '../components/Docs/ProductChangelog.tsx'), 'utf8')
+        assert.match(component, /\bmetrics\s*:\s*\{[^}]*(topic|teams)/)
+    })
+})
+
+describe('the application metrics tool', () => {
+    test('has a metrics handle in src/data/tools.ts', () => {
+        const tools = readFileSync(join(here, '../data/tools.ts'), 'utf8')
+        assert.match(tools, /handle:\s*'metrics'/)
+    })
+
+    test('is badged as in alpha', () => {
+        const tools = readFileSync(join(here, '../data/tools.ts'), 'utf8')
+        const entry = tools.match(/\{[^{}]*handle:\s*'metrics'[^{}]*\}/)?.[0] ?? ''
+        assert.match(entry, /status:\s*'alpha'/, 'expected the metrics tool to carry an alpha status badge')
+    })
+})

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -8336,6 +8336,12 @@ export const docsMenu = {
                     icon: 'IconDatabase',
                     color: 'purple',
                 },
+                {
+                    name: 'Changelog',
+                    url: '/docs/metrics/changelog',
+                    icon: 'IconRocket',
+                    color: 'purple',
+                },
             ],
         },
         {


### PR DESCRIPTION
## Changes

Application metrics is in **public alpha** with self-serve signup. The docs existed but still described it as a private, gated alpha, and the product was not reflected anywhere people browse products or follow updates. This wires up the in-repo pieces and corrects the alpha wording:

- **Alpha wording** — update 11 docs pages from "private alpha… only turned on for selected teams" to "public alpha and available to everyone"
- **Changelog page** — add `contents/docs/metrics/changelog.mdx` rendering `<ProductChangelog product="Metrics" />`
- **Changelog filter** — add a `metrics` entry to `productConfigMap` (topic `metrics`, team `apm`) so the page filters the changelog feed instead of rendering the whole company changelog
- **Docs nav** — link the changelog from the metrics docs section
- **Tool listing** — add a `metrics` entry in `src/data/tools.ts` with an `alpha` status badge so it surfaces in product/tool listings

**Why:** the docs for application metrics existed but mislabeled the release as a private, invite-only alpha, and the product had no changelog surface or presence in product/tool listings — so people could not tell it is open to everyone or follow its updates.

Tests pin all of the above (red-green), including a wording test that fails if any metrics doc reintroduces "private alpha" / "selected teams". `check-product-changelogs` now covers 16 pages and all nav tests pass.

Note: the public roadmap item lives in Strapi and is created on the site, not in this repo, so it is out of scope here.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*