### PR TITLE
Replace DuckDB mentions with Trino in marketing/nav copy

### DIFF
--- a/contents/handbook/growth/sales/why-buy-posthog.md
+++ b/contents/handbook/growth/sales/why-buy-posthog.md
@@ -84,6 +84,6 @@ Using PostHog's [CDP](/cdp) lets you aggregate data from multiple technologies a
 
 The product marketing team has created sales enablement materials, covering some product information and general objection handling for specific products. These exist as Google Docs as they are living documents, but are listed below. 
 
-- [Managed data warehouse (DuckDB)](https://docs.google.com/document/d/19P0SajrkCf7IS0jJEh08y5kqKANEGPq5S6ZqTpyFKts/edit?usp=sharing)
+- [Managed data warehouse (Trino)](https://docs.google.com/document/d/19P0SajrkCf7IS0jJEh08y5kqKANEGPq5S6ZqTpyFKts/edit?usp=sharing)
 
 If there are additional products you'd like to see this sort of material for, let the team know in the **#team-marketing** Slack channel.  

--- a/contents/teams/data-tools/objectives.mdx
+++ b/contents/teams/data-tools/objectives.mdx
@@ -10,7 +10,7 @@ What we’ll ship:
 
 - Python notebooks for customers
 - Polished markdown-first notebook UX
-- Better integration with HogQL, DuckDB, external DBs, and visualizations
+- Better integration with HogQL, Trino, external DBs, and visualizations
 - AI agents can create/edit notebooks directly (great MCP support)
 - Publicly shareable notebooks
 

--- a/src/hooks/productData/data_warehouse.tsx
+++ b/src/hooks/productData/data_warehouse.tsx
@@ -13,7 +13,7 @@ export const dataWarehouse = {
     color: 'purple',
     colorSecondary: 'lilac',
     seo: {
-        title: 'Managed DuckDB warehouse - PostHog',
+        title: 'Managed Warehouse - PostHog',
         description:
             'A managed data warehouse that unifies your product context with any source – so agents can query all of it and act on it to make your product self-driving.',
     },

--- a/src/hooks/useCustomerDataInfrastructureNavigation.tsx
+++ b/src/hooks/useCustomerDataInfrastructureNavigation.tsx
@@ -27,7 +27,7 @@ export const customerDataInfrastructureNav = {
             name: 'Data tools',
         },
         {
-            name: 'Managed DuckDB warehouse',
+            name: 'Managed Warehouse',
             url: '/context-warehouse/managed-warehouse',
         },
         {

--- a/src/pages/context-warehouse/business-intelligence.tsx
+++ b/src/pages/context-warehouse/business-intelligence.tsx
@@ -81,7 +81,7 @@ export default function BusinessIntelligence(): JSX.Element {
                         <Link to="https://hex.tech/" external>
                             Hex
                         </Link>{' '}
-                        directly to your PostHog DuckDB warehouse.
+                        directly to your PostHog Trino warehouse.
                     </p>
                 </div>
 

--- a/src/pages/context-warehouse/data-modeling.tsx
+++ b/src/pages/context-warehouse/data-modeling.tsx
@@ -38,7 +38,7 @@ export default function DataModeling(): JSX.Element {
                         <Link to="https://www.getdbt.com/" external>
                             dbt
                         </Link>{' '}
-                        to your PostHog DuckDB warehouse.
+                        to your PostHog Trino warehouse.
                     </p>
                 </div>
 

--- a/src/pages/context-warehouse/index.tsx
+++ b/src/pages/context-warehouse/index.tsx
@@ -476,14 +476,14 @@ const faqItems = [
             <>
                 <p>
                     Natively. Warehouse data can power cohorts used in experiments and flags. Pipeline data flows
-                    directly into analytics. DuckDB queries run on the same dataset your dashboards use. There's no
+                    directly into analytics. Trino queries run on the same dataset your dashboards use. There's no
                     separate sync to set up.
                 </p>
                 {/* On a light card in both themes, since the diagram has no dark variant. */}
                 <div className="not-prose mt-4 overflow-hidden rounded-md border border-primary bg-white p-4">
                     <CloudinaryImage
                         src={ARCHITECTURE_DIAGRAM}
-                        alt="Warehouse sources and PostHog product events feed the context warehouse – an S3 data lake partitioned per org, a DuckLake catalog, and a single-tenant DuckDB in a Firecracker MicroVM – which in turn serves the Postgres wire protocol, analytics and experiments, AI agents, and endpoints"
+                        alt="Warehouse sources and PostHog product events feed the context warehouse – an S3 data lake partitioned per org, a DuckLake catalog, and a single-tenant Trino in a Firecracker MicroVM – which in turn serves the Postgres wire protocol, analytics and experiments, AI agents, and endpoints"
                         className="!block w-full"
                         imgClassName="!block w-full"
                     />

--- a/src/pages/context-warehouse/managed-warehouse.tsx
+++ b/src/pages/context-warehouse/managed-warehouse.tsx
@@ -249,11 +249,11 @@ export default function ManagedWarehouse(): JSX.Element {
                 </div>
 
                 <h2 className="!mt-10 @2xl/reader-content-container:!mt-12">
-                    Built on DuckDB. Enterprise-ready on top.
+                    Built on Trino. Enterprise-ready on top.
                 </h2>
                 <p>
-                    <Link to="https://duckdb.org/" external={true}>
-                        DuckDB
+                    <Link to="https://trino.io/" external={true}>
+                        Trino
                     </Link>{' '}
                     runs analytical queries fast, on hardware most teams already have. Here's what we built on top of it
                     to get it ready for production:

--- a/src/pages/context-warehouse/sql-editor.tsx
+++ b/src/pages/context-warehouse/sql-editor.tsx
@@ -47,8 +47,8 @@ const sqlEditorFeatures: SQLEditorFeature[] = [
         comingSoon: true,
     },
     {
-        title: 'DuckDB syntax support',
-        description: 'Full support for DuckDB SQL syntax and functions when connected to a managed DuckDB warehouse',
+        title: 'Trino syntax support',
+        description: 'Full support for Trino SQL syntax and functions when connected to a managed Trino warehouse',
         comingSoon: true,
     },
     {

--- a/src/pages/context-warehouse/warehouse-native.tsx
+++ b/src/pages/context-warehouse/warehouse-native.tsx
@@ -116,12 +116,12 @@ export default function WarehouseNative(): JSX.Element {
 
                 <h2>What does this mean for the future?</h2>
                 <p>
-                    PostHog is building a managed warehouse based on DuckDB in addition to the current ClickHouse-based
+                    PostHog is building a managed warehouse based on Trino in addition to the current ClickHouse-based
                     warehouse. The focus is on expanding what integrates with our integrated warehouse, making it easier
                     to use PostHog as your primary data platform without needing to stitch together multiple tools. If
                     you&apos;re interested in finding out more, we suggest{' '}
                     <Link to="/context-warehouse/managed-warehouse">
-                        joining the waitlist for the managed DuckDB warehouse
+                        joining the waitlist for the managed Trino warehouse
                     </Link>
                     .
                 </p>


### PR DESCRIPTION
## Summary
- Swaps DuckDB references for Trino on marketing pages, the site nav, and the sales handbook, updating the one external link (`duckdb.org` → `https://trino.io/`) accordingly
- The nav label and SEO title are simplified to "Managed Warehouse" rather than naming either engine, per request
- Deliberately **excludes** the blog and the technical docs pages under `contents/docs/data-warehouse/managed-warehouse/` (`index.mdx`, `connect.mdx`, `performance-tuning.mdx`) — those describe literal DuckDB-specific SQL syntax (`DESCRIBE`, `QUALIFY`, `ASOF` joins), config keys (`duckgres.worker_cpu`), and a real SQL function (`duckdb_settings()`). Renaming those to Trino would make the docs describe behavior that doesn't exist, so they're left as-is pending confirmation of whether this reflects an actual engine migration
- Also left alone: the MotherDuck section of `/compare/best-data-warehouses-for-developers` (factual statement about a third-party product) and internal code identifiers (the `DuckDBWaitlistSurvey` component name, `managed-duckdb-data-warehouse` feature flag)

## Note for reviewers
On `src/pages/context-warehouse/index.tsx`, the FAQ architecture-diagram alt text now says "Trino" but the diagram image itself still visually shows DuckDB — the two are now inconsistent until the diagram asset is updated or replaced.

## Test plan
- [ ] Confirm no remaining unintended DuckDB references in the changed files
- [ ] Verify pages render correctly with updated copy (`/context-warehouse/managed-warehouse`, `/context-warehouse/warehouse-native`, `/context-warehouse/business-intelligence`, `/context-warehouse/data-modeling`, `/context-warehouse/sql-editor`, `/context-warehouse`)
- [ ] Confirm the diagram alt-text/image mismatch noted above is acceptable or gets addressed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)