### PR TITLE
Replace CS and FDE SuperDay section with Customer Success SuperDay

### DIFF
--- a/contents/handbook/people/hiring-process/sales-cs-hiring.md
+++ b/contents/handbook/people/hiring-process/sales-cs-hiring.md
@@ -13,7 +13,6 @@ Our Sales and Customer Success teams look after customers paying $20k a year or 
  - Technical Account Managers focused on expansion from existing customers and closing new business from product-led leads.
  - Customer Success Managers focused on the retention of customers using all of our products already.
  - Onboarding Specialists focused on ensuring newer and smaller customers are set up for success with PostHog.
- - [Forward Deployed Engineers](/teams/forward-deployed-engineering) focused on getting embedded with customers to fill the gap between what PostHog does and what the customer needs.
 
 We've proven that [the way we do sales](/sales) works at a small scale, we are now growing the team in line with increased top-of-funnel growth for PostHog. Please check our [careers page](/careers) for our open roles. 
 
@@ -80,7 +79,7 @@ Overall, you should spend at least 80% of your time and energy on the task and l
 
 > In line with our [values](/handbook/values) and [culture](/handbook/company/culture), you might get short replies like "step on toes" or "bias for action".
 
-### CS and FDE hiring process
+### Customer Success hiring process
 
 #### Culture interview
 
@@ -94,21 +93,48 @@ The small team interview with the relevant team lead usually lasts 45 minutes.  
 
 In this 30-minute interview, you'll meet with [Simon](/community/profiles/28895), who will be trying to answer "Are they a good cultural fit for the Sales team at PostHog?".
 
-#### CS and FDE SuperDay
+#### Customer Success SuperDay
 
-The final stage of our interview process is what we call a PostHog [SuperDay](/handbook/people/hiring-process#posthog-superday). This is a paid full day of work, which we can flexibly arrange around your schedule.
+If you've been invited to a PostHog [SuperDay](/handbook/people/hiring-process#posthog-superday), here's what to expect and how to set yourself up for success.
 
-We will share the task with you at the start of the day. The task is representative of the work someone in this role at PostHog is doing, and it is always the same for each candidate, so we can make clear comparisons. It will typically involve doing actual PostHog work, e.g. prioritizing customers, doing a demo, etc.
+##### What the SuperDay looks like
 
-A CS and FDE SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences):_
+The SuperDay is a paid full day of work (1,000 USD). You'll receive some tasks at the start of your day and submit your work at the end. Whilst you won't be working with real customers (which would be risky!), the tasks are meant to be as representative as possible of a day in the life of a CSM at PostHog. Expect to spend the majority of your day on them.
 
-*   Kick-off session
-*   Meet with [Tim](/tim), who will be trying to answer "Would I buy from this person?"
-*   Meet with [Ben](/community/profiles/30205), who will be doing a culture and vibe check.
-*   Time to focus on the task, we can provide support via your personal Slack channel (use the channel, don't slide into people's DMs)
-*   Demo role-play with the team lead and [Simon](/community/profiles/28895)
-*   Meet a few members of our team for a quick chat
+Scheduled throughout the day, you'll also have:
 
-Overall, you should spend at least 80% of your time and energy on the task and less than 20% on meeting people, as we will base our decision on your output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems.
+*   A kick-off call (30 min) - a session with Dana or Phil to go over the task for the day!
+*   A product demo (30 min) - a session spent understanding your demoing style, your comfort with PostHog, and with ambiguous situations.
+*   A peer team interview (30 min) - a session dedicated to team members to get to know you, and for you to ask as many questions as you have!
+*   A short chat with a co-founder or exec - a brief conversation about culture and motivation.
+
+You'll also have access to a dedicated Slack channel with the team throughout the day. Use it - share progress, ask questions, surface blockers.
+
+##### How to prepare for the day
+
+*   Read the CS section of the handbook thoroughly. You will be expected to have opinions!
+*   Install and get familiar with PostHog - you'll be expected to have a good understanding of PostHog going into SuperDay.
+
+##### During the day
+
+*   Communicate proactively. Share progress updates and blockers in Slack. Ask clarifying questions early if something is ambiguous. Don't wait until you're stuck for hours.
+*   Divide your time between all of the tasks (don't finish the day rushing to complete one because you thought it wasn't important).
+*   Act as if you would with a real customer. We want to test how you engage with folks when you are their Customer Success Manager.
+
+##### What not to worry about
+
+*   Perfection. We don't expect you to finish everything to a super polished standard. We care about the quality of what you ship, the decisions you make, and how you work under constraints.
+*   Not knowing something. You're free to make as many assumptions as you need, as long as you keep a record of them. You're also very welcome to ask questions in the Slack channel, but make sure to trust your skills and gut!
+*   Getting stuck. Everyone gets stuck. What matters is what you do next. Ask questions. Try a different approach. Talk through what you're thinking.
 
 > In line with our [values](/handbook/values) and [culture](/handbook/company/culture), you might get short replies like "step on toes" or "bias for action".
+
+##### A note on AI tools
+
+You can use AI tools during the day - we know this is how many Customer Success Managers work. There is a line between using AI effectively and overusing it; we want to test that out as well.
+
+##### What comes next
+
+After the SuperDay, everyone involved will leave their feedback. We aim to get back to you with a decision within 48 hours.
+
+If you've made it this far, good luck - we're rooting for you!

--- a/contents/handbook/people/hiring-process/sales-cs-hiring.md
+++ b/contents/handbook/people/hiring-process/sales-cs-hiring.md
@@ -99,7 +99,7 @@ If you've been invited to a PostHog [SuperDay](/handbook/people/hiring-process#p
 
 ##### What the SuperDay looks like
 
-The SuperDay is a paid full day of work (1,000 USD). You'll receive some tasks at the start of your day and submit your work at the end. Whilst you won't be working with real customers (which would be risky!), the tasks are meant to be as representative as possible of a day in the life of a CSM at PostHog. Expect to spend the majority of your day on them.
+The SuperDay is a paid full day of work (1,000 USD). You'll receive some tasks at the start of your day and submit your work at the end. While you won't be working with real customers (which would be risky!), the tasks are meant to be as representative as possible of a day in the life of a CSM at PostHog. Expect to spend the majority of your day on them.
 
 Scheduled throughout the day, you'll also have:
 
@@ -112,7 +112,7 @@ You'll also have access to a dedicated Slack channel with the team throughout th
 
 ##### How to prepare for the day
 
-*   Read the CS section of the handbook thoroughly. You will be expected to have opinions!
+*   Read the [CS section of the handbook](/handbook/cs-and-onboarding/customer-success) thoroughly. You will be expected to have opinions!
 *   Install and get familiar with PostHog - you'll be expected to have a good understanding of PostHog going into SuperDay.
 
 ##### During the day

--- a/contents/handbook/people/hiring-process/sales-cs-hiring.md
+++ b/contents/handbook/people/hiring-process/sales-cs-hiring.md
@@ -13,6 +13,7 @@ Our Sales and Customer Success teams look after customers paying $20k a year or 
  - Technical Account Managers focused on expansion from existing customers and closing new business from product-led leads.
  - Customer Success Managers focused on the retention of customers using all of our products already.
  - Onboarding Specialists focused on ensuring newer and smaller customers are set up for success with PostHog.
+ - [Forward Deployed Engineers](/teams/forward-deployed-engineering) focused on getting embedded with customers to fill the gap between what PostHog does and what the customer needs.
 
 We've proven that [the way we do sales](/sales) works at a small scale, we are now growing the team in line with increased top-of-funnel growth for PostHog. Please check our [careers page](/careers) for our open roles. 
 


### PR DESCRIPTION
## Changes

This is a content-only change to `contents/handbook/people/hiring-process/sales-cs-hiring.md`.

**Why:** the SuperDay stage no longer covers Forward Deployed Engineer candidates, and the Customer Success SuperDay copy is out of date. Candidates read this page to prepare, so it must describe the day they will actually get.

- Renamed the heading "CS and FDE hiring process" to "Customer Success hiring process".
- Replaced the "CS and FDE SuperDay" section with a new "Customer Success SuperDay" section, supplied by the section owner. It gives the pay, the schedule of calls, how to prepare, what to do during the day, what not to worry about, the position on AI tools, and what comes next.
- The list of team roles is unchanged, and still includes Forward Deployed Engineers. The role gives context about the broader team, even though the hiring process below it is Customer Success only.

The new section keeps the formatting of the page: `####` for the stage heading, `#####` for the sub-sections, `*` list items, and a block quote for the note about short replies. All internal links are relative URLs: the values page, the culture page, and the [Customer Success overview](/handbook/cs-and-onboarding/customer-success), which is the target of "Read the CS section of the handbook".

One thing for the reviewer: the anchor changes from `#cs-and-fde-superday` to `#customer-success-superday`. No page in this repository links to the old anchor, but a link in an email or a document outside the repository will break.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page was moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ALSU1UJ5C/p1788954265614749)*