### PR TITLE
docs(ingestion): clean up missing distinct ID example and root causes

### DIFF
--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -143,7 +143,7 @@ These warnings are raised when PostHog rejects a request as it arrives, before t
 
 Rejected events are dropped, and the warning is the only record of them: details carry identifiers and sizes (the SDK name and version, the endpoint, and an occurrence count) rather than event contents. To inspect a rejected payload, capture it at the sender – look for `400` responses to your ingestion endpoint in your browser's network tab, enable [debug mode](/docs/libraries/js/usage#debug-mode) with `posthog.debug()`, or log the event in a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook.
 
-Start with the `lib` and `lib_version` details. Warnings clustered on a single older SDK version point to an upgrade. When both read `unknown`, the request carried no `$lib` property, so no PostHog SDK sent it. Your project token is public and visible in your web app's source, so anything that finds it can post malformed events to your ingestion endpoint – crawlers, security scanners, and researchers probing your site all do. Check the sender before you look for a bug in your own instrumentation.
+Start with the `lib` and `lib_version` details. Warnings clustered on a single older SDK version point to an upgrade. When both read `unknown`, the request carried no `$lib` property, so no PostHog SDK sent it. Your project token is public and visible in your web app's source, so anything that finds it can post malformed events to your ingestion endpoint – crawlers, security scanners, and researchers probing your site, for example. Check the sender before you look for a bug in your own instrumentation.
 
 ### Discarded event with no distinct ID
 
@@ -151,11 +151,11 @@ Every event needs a `distinct_id` to attribute it to a person. PostHog reads the
 
 PostHog accepts a wide range of values here: numbers and objects are converted to strings, and literal strings like `"null"`, `"undefined"`, and `"anonymous"` are valid IDs. [Prefer real user IDs](/docs/getting-started/identify-users#2-use-unique-strings-for-distinct-ids) – placeholder values group unrelated users onto a single person, and merging them later raises [`cannot_merge_with_illegal_distinct_id`](#refused-to-merge-with-an-illegal-distinct-id).
 
-posthog-js blocks the obvious mistakes for you. `identify()` refuses `null`, `undefined`, an empty string, and the literal strings `"null"` and `"undefined"`. It logs `Unique user id has not been set in posthog.identify` and sends nothing, so a plain `identify()` call is rarely the source of this warning. Common causes include:
+Most PostHog SDKs block the obvious mistakes for you - for example in the posthog-js SDK, `identify()` refuses `null`, `undefined`, an empty string, and the literal strings `"null"` and `"undefined"`. It logs `Unique user id has not been set in posthog.identify` and sends nothing, so a plain `identify()` call is rarely the source of this warning. Common causes include:
 
 - **A `null` `bootstrap.distinctID`.** The ID comes from another system, such as a server-rendered page or a native app handover, and is sometimes `null`. Every event from that page load is unattributable.
 - **A layer that removes the ID in transit.** A [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook, a reverse proxy, or middleware can remove `distinct_id` after the SDK sets it.
-- **Requests that don't come from a PostHog SDK.** Hand-built calls to the [capture API](/docs/api/capture) have no client-side guard. A `lib` detail of `unknown` points at a sender outside your SDKs.
+- **Requests that don't come from a PostHog SDK.** Hand-built calls to the [capture API](/docs/api/capture) have no client-side guard. A `lib` detail of `unknown` points at a sender outside PostHog SDKs.
 
 Check where the ID comes from: your `bootstrap` value, or wherever you call `identify()`. Pass `bootstrap` only when you have an ID. An omitted `distinctID` or an empty string is safe – posthog-js generates an anonymous ID instead.
 

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -165,7 +165,7 @@ The `event` field was missing or empty, so there was no name to record the event
 
 ### Discarded session replay batches
 
-These warnings mean a chunk of a [session recording](/docs/session-replay) was dropped. The rest of the recording still exists, but that stretch is missing from it. If the dropped chunk carried the recording's only full snapshot, the player has no starting DOM to replay against and can't play the recording at all. All three usually point to an outdated SDK or a proxy that rewrites request bodies.
+These warnings mean a chunk of a [session recording](/docs/session-replay) was dropped. The rest of the recording still exists, but that stretch is missing from it. If the dropped chunk carried the recording's only full snapshot, the player has no starting DOM to replay against and can't play the recording at all.
 
 | Warning | Cause |
 | --- | --- |

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -46,13 +46,7 @@ List of ingestion warnings:
 Validation warnings, raised when PostHog rejects a request as it arrives:
 
 - [Discarded event with no distinct ID](#discarded-event-with-no-distinct-id)
-- [Discarded event whose distinct ID exceeds the size limit](#discarded-event-whose-distinct-id-exceeds-the-size-limit)
 - [Discarded event with no event name](#discarded-event-with-no-event-name)
-- [Discarded event whose name exceeds the length limit](#discarded-event-whose-name-exceeds-the-length-limit)
-- [Discarded event with an invalid timestamp](#discarded-event-with-an-invalid-timestamp)
-- [Discarded event with malformed properties](#discarded-event-with-malformed-properties)
-- [Discarded event with invalid capture options](#discarded-event-with-invalid-capture-options)
-- [Rejected batches](#rejected-batches)
 - [Discarded session replay batches](#discarded-session-replay-batches)
 - [Discarded AI events](#discarded-ai-events)
 
@@ -165,45 +159,9 @@ posthog-js blocks the obvious mistakes for you. `identify()` refuses `null`, `un
 
 Check where the ID comes from: your `bootstrap` value, or wherever you call `identify()`. Pass `bootstrap` only when you have an ID. An omitted `distinctID` or an empty string is safe — posthog-js generates an anonymous ID instead.
 
-### Discarded event whose distinct ID exceeds the size limit
-
-The `distinct_id` was longer than 200 characters. An ID this long is usually something else — a token, a session blob, or a serialized object — so update the `capture` or `identify` call to send a real user ID.
-
-Some capture endpoints shorten the ID and ingest the event instead. See [Ingested event after shortening its distinct ID](#ingested-event-after-shortening-its-distinct-id-to-the-200-character-limit).
-
 ### Discarded event with no event name
 
 The `event` field was missing or empty, so there was no name to record the event under. The usual cause is an empty variable at the `capture()` call site.
-
-### Discarded event whose name exceeds the length limit
-
-The event name was longer than 200 characters. Use short, stable identifiers like `user_signed_up`, and move any variable data (an ID, a URL, a message) into a property. This also keeps your event list easy to browse.
-
-### Discarded event with an invalid timestamp
-
-The event's `timestamp` couldn't be parsed. Send timestamps in [ISO 8601](/docs/data/timestamps) format.
-
-Some endpoints keep the event and substitute the server's time instead — see [Ignored an invalid timestamp](#ignored-an-invalid-timestamp-event-was-still-ingested). Which applies depends on the endpoint your SDK uses.
-
-### Discarded event with malformed properties
-
-The `properties` field wasn't a JSON object — commonly an array or a string. This most often means the properties were JSON-encoded twice, so check for a stray `JSON.stringify()` before the value reaches `capture()`.
-
-### Discarded event with invalid capture options
-
-The request's capture options were malformed. SDKs set these for you, so this points to a hand-built HTTP request — check it against the [capture API reference](/docs/api/capture).
-
-### Rejected batches
-
-These warnings apply to a whole request rather than a single event, so every event in the request is dropped together.
-
-| Warning | Cause |
-| --- | --- |
-| Rejected a request containing no events | The request body contained an empty batch, typically from a client that flushes on a timer with nothing queued. |
-| Rejected a batch with invalid metadata | The batch's envelope (the fields wrapping the events) was malformed. |
-| Rejected a batch containing an event with no UUID | An event in the batch was missing its UUID. |
-| Rejected a batch containing an event with an invalid UUID | An event's UUID wasn't valid. PostHog generates these for you — see [Refused to process event with invalid UUID](#refused-to-process-event-with-invalid-uuid). |
-| Rejected a batch containing duplicate event UUIDs | Two events in the batch shared a UUID, usually from a retry or queue flush re-sending events. |
 
 ### Discarded session replay batches
 

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -161,7 +161,7 @@ Check where the ID comes from: your `bootstrap` value, or wherever you call `ide
 
 ### Discarded event with no event name
 
-The `event` field was missing or empty, so there was no name to record the event under. The usual cause is an empty variable at the `capture()` call site. posthog-js only rejects a name that is missing or not a string, so `capture("")` reaches PostHog and is dropped here.
+The `event` field was missing or empty, so there was no name to record the event under.
 
 ### Discarded session replay batches
 

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -145,7 +145,7 @@ posthog.group("company", "company_id_in_your_db", "PostHog");
 
 ## Validation warnings
 
-These warnings are raised when PostHog rejects a request as it arrives, before the event enters the ingestion pipeline. Your SDK receives an HTTP `400` naming the problem, for example `event submitted without a distinct_id`. Requests are validated as a unit, so one malformed event can reject the whole batch — which is why a warning's event count can exceed the number of warnings.
+These warnings are raised when PostHog rejects a request as it arrives, before the event enters the ingestion pipeline. Your SDK receives an HTTP `400` naming the problem. Requests are validated as a unit, so one malformed event can reject the whole batch — which is why a warning's event count can exceed the number of warnings.
 
 Rejected events are dropped, and the warning is the only record of them: details carry identifiers and sizes (the SDK name and version, the endpoint, and an occurrence count) rather than event contents. To inspect a rejected payload, capture it at the sender — look for `400` responses to your capture host in your browser's network tab, enable [debug mode](/docs/libraries/js/usage#debug-mode) with `posthog.debug()`, or log the event in a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook.
 
@@ -157,20 +157,13 @@ Every event needs a `distinct_id` to attribute it to a person. PostHog reads the
 
 PostHog accepts a wide range of values here: numbers and objects are converted to strings, and literal strings like `"null"`, `"undefined"`, and `"anonymous"` are valid IDs. Prefer real user IDs — placeholder values group unrelated users onto a single person, and merging them later raises [`cannot_merge_with_illegal_distinct_id`](#refused-to-merge-with-an-illegal-distinct-id).
 
-The usual cause is an empty variable at the `capture()` call site:
+posthog-js blocks the obvious mistakes for you. `identify()` refuses `null`, `undefined`, an empty string, and the literal strings `"null"` and `"undefined"`. It logs `Unique user id has not been set in posthog.identify` and sends nothing, so a plain `identify()` call is rarely the source of this warning. Common causes include:
 
-- The ID passed to `capture()` or `identify()` is `undefined` or `null` because it hasn't loaded yet. Identify once your auth state resolves.
-- A [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook, reverse proxy, or middleware layer removes `distinct_id` on the way out.
-- `bootstrap.distinctID` comes from another system (a server-rendered page or a native app handover) and is sometimes `null`. Pass `bootstrap` only when you have an ID: a `null` is stored as-is, so that browser keeps sending unattributable events until its storage is cleared. Omitting `distinctID` or passing an empty string is safe — posthog-js generates an anonymous ID instead.
+- **A `null` `bootstrap.distinctID`.** The ID comes from another system, such as a server-rendered page or a native app handover, and is sometimes `null`. Every event from that page load is unattributable.
+- **A layer that removes the ID in transit.** A [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook, a reverse proxy, or middleware can remove `distinct_id` after the SDK sets it.
+- **Requests that don't come from a PostHog SDK.** Hand-built calls to the [capture API](/docs/api/capture) have no client-side guard. A `lib` detail of `unknown` points at a sender outside your SDKs.
 
-Validate the ID before capturing:
-
-```js
-// ✅ Identify once you have a real ID
-if (user?.id) {
-  posthog.identify(user.id)
-}
-```
+Check where the ID comes from: your `bootstrap` value, or wherever you call `identify()`. Pass `bootstrap` only when you have an ID. An omitted `distinctID` or an empty string is safe — posthog-js generates an anonymous ID instead.
 
 ### Discarded event whose distinct ID exceeds the size limit
 

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -141,15 +141,15 @@ posthog.group("company", "company_id_in_your_db", "PostHog");
 
 These warnings are raised when PostHog rejects a request as it arrives, before the event enters the ingestion pipeline. Your SDK receives an HTTP `400` naming the problem. Requests are validated as a unit, so one malformed event can reject the whole batch — which is why a warning's event count can exceed the number of warnings.
 
-Rejected events are dropped, and the warning is the only record of them: details carry identifiers and sizes (the SDK name and version, the endpoint, and an occurrence count) rather than event contents. To inspect a rejected payload, capture it at the sender — look for `400` responses to your capture host in your browser's network tab, enable [debug mode](/docs/libraries/js/usage#debug-mode) with `posthog.debug()`, or log the event in a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook.
+Rejected events are dropped, and the warning is the only record of them: details carry identifiers and sizes (the SDK name and version, the endpoint, and an occurrence count) rather than event contents. To inspect a rejected payload, capture it at the sender — look for `400` responses to your ingestion endpoint in your browser's network tab, enable [debug mode](/docs/libraries/js/usage#debug-mode) with `posthog.debug()`, or log the event in a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook.
 
-Start with the `lib` and `lib_version` details. Warnings clustered on a single older SDK version point to an upgrade. When both read `unknown`, the request carried no `$lib` property, which typically means traffic from outside a PostHog SDK — project API keys are public, so bots and scanners can generate these warnings independently of your code.
+Start with the `lib` and `lib_version` details. Warnings clustered on a single older SDK version point to an upgrade. When both read `unknown`, the request carried no `$lib` property, so no PostHog SDK sent it. Your project token is public and visible in your web app's source, so anything that finds it can post malformed events to your ingestion endpoint — crawlers, security scanners, and researchers probing your site all do. Check the sender before you look for a bug in your own instrumentation.
 
 ### Discarded event with no distinct ID
 
 Every event needs a `distinct_id` to attribute it to a person. PostHog reads the top-level `distinct_id` first, then falls back to `properties.distinct_id`, and drops the event when neither holds a usable value — when it's missing from both, `null`, empty, or only whitespace.
 
-PostHog accepts a wide range of values here: numbers and objects are converted to strings, and literal strings like `"null"`, `"undefined"`, and `"anonymous"` are valid IDs. Prefer real user IDs — placeholder values group unrelated users onto a single person, and merging them later raises [`cannot_merge_with_illegal_distinct_id`](#refused-to-merge-with-an-illegal-distinct-id).
+PostHog accepts a wide range of values here: numbers and objects are converted to strings, and literal strings like `"null"`, `"undefined"`, and `"anonymous"` are valid IDs. [Prefer real user IDs](/docs/getting-started/identify-users#2-use-unique-strings-for-distinct-ids) — placeholder values group unrelated users onto a single person, and merging them later raises [`cannot_merge_with_illegal_distinct_id`](#refused-to-merge-with-an-illegal-distinct-id).
 
 posthog-js blocks the obvious mistakes for you. `identify()` refuses `null`, `undefined`, an empty string, and the literal strings `"null"` and `"undefined"`. It logs `Unique user id has not been set in posthog.identify` and sends nothing, so a plain `identify()` call is rarely the source of this warning. Common causes include:
 
@@ -161,11 +161,11 @@ Check where the ID comes from: your `bootstrap` value, or wherever you call `ide
 
 ### Discarded event with no event name
 
-The `event` field was missing or empty, so there was no name to record the event under. The usual cause is an empty variable at the `capture()` call site.
+The `event` field was missing or empty, so there was no name to record the event under. The usual cause is an empty variable at the `capture()` call site. posthog-js only rejects a name that is missing or not a string, so `capture("")` reaches PostHog and is dropped here.
 
 ### Discarded session replay batches
 
-These warnings mean a chunk of a [session recording](/docs/session-replay) was dropped. The recording still exists, minus the part that chunk covered, so it may appear shorter than expected. All three usually point to an outdated SDK or a proxy that rewrites request bodies.
+These warnings mean a chunk of a [session recording](/docs/session-replay) was dropped. The rest of the recording still exists, but the dropped chunk leaves a gap: the player has no DOM mutations for that stretch, so playback can skip, show a stale page, or end early. All three usually point to an outdated SDK or a proxy that rewrites request bodies.
 
 | Warning | Cause |
 | --- | --- |

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -120,7 +120,7 @@ This indicates the `$heatmap_data` property was malformed, which is usually a si
 
 ## Discarded $groupidentify event with invalid $group_set
 
-PostHog discards `$groupidentify` events when the `$group_set` property is not a valid JSON object. The `$group_set` property must be a plain object containing the group properties you want to set — strings, numbers, booleans, and arrays are rejected.
+PostHog discards `$groupidentify` events when the `$group_set` property is not a valid JSON object. The `$group_set` property must be a plain object containing the group properties you want to set – strings, numbers, booleans, and arrays are rejected.
 
 To fix this, ensure `$group_set` is always a plain object when calling `posthog.group()` or sending `$groupidentify` events:
 
@@ -139,17 +139,17 @@ posthog.group("company", "company_id_in_your_db", "PostHog");
 
 ## Validation warnings
 
-These warnings are raised when PostHog rejects a request as it arrives, before the event enters the ingestion pipeline. Your SDK receives an HTTP `400` naming the problem. Requests are validated as a unit, so one malformed event can reject the whole batch — which is why a warning's event count can exceed the number of warnings.
+These warnings are raised when PostHog rejects a request as it arrives, before the event enters the ingestion pipeline. Your SDK receives an HTTP `400` naming the problem. Requests are validated as a unit, so one malformed event can reject the whole batch – which is why a warning's event count can exceed the number of warnings.
 
-Rejected events are dropped, and the warning is the only record of them: details carry identifiers and sizes (the SDK name and version, the endpoint, and an occurrence count) rather than event contents. To inspect a rejected payload, capture it at the sender — look for `400` responses to your ingestion endpoint in your browser's network tab, enable [debug mode](/docs/libraries/js/usage#debug-mode) with `posthog.debug()`, or log the event in a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook.
+Rejected events are dropped, and the warning is the only record of them: details carry identifiers and sizes (the SDK name and version, the endpoint, and an occurrence count) rather than event contents. To inspect a rejected payload, capture it at the sender – look for `400` responses to your ingestion endpoint in your browser's network tab, enable [debug mode](/docs/libraries/js/usage#debug-mode) with `posthog.debug()`, or log the event in a [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook.
 
-Start with the `lib` and `lib_version` details. Warnings clustered on a single older SDK version point to an upgrade. When both read `unknown`, the request carried no `$lib` property, so no PostHog SDK sent it. Your project token is public and visible in your web app's source, so anything that finds it can post malformed events to your ingestion endpoint — crawlers, security scanners, and researchers probing your site all do. Check the sender before you look for a bug in your own instrumentation.
+Start with the `lib` and `lib_version` details. Warnings clustered on a single older SDK version point to an upgrade. When both read `unknown`, the request carried no `$lib` property, so no PostHog SDK sent it. Your project token is public and visible in your web app's source, so anything that finds it can post malformed events to your ingestion endpoint – crawlers, security scanners, and researchers probing your site all do. Check the sender before you look for a bug in your own instrumentation.
 
 ### Discarded event with no distinct ID
 
-Every event needs a `distinct_id` to attribute it to a person. PostHog reads the top-level `distinct_id` first, then falls back to `properties.distinct_id`, and drops the event when neither holds a usable value — when it's missing from both, `null`, empty, or only whitespace.
+Every event needs a `distinct_id` to attribute it to a person. PostHog reads the top-level `distinct_id` first, then falls back to `properties.distinct_id`, and drops the event when neither holds a usable value – when it's missing from both, `null`, empty, or only whitespace.
 
-PostHog accepts a wide range of values here: numbers and objects are converted to strings, and literal strings like `"null"`, `"undefined"`, and `"anonymous"` are valid IDs. [Prefer real user IDs](/docs/getting-started/identify-users#2-use-unique-strings-for-distinct-ids) — placeholder values group unrelated users onto a single person, and merging them later raises [`cannot_merge_with_illegal_distinct_id`](#refused-to-merge-with-an-illegal-distinct-id).
+PostHog accepts a wide range of values here: numbers and objects are converted to strings, and literal strings like `"null"`, `"undefined"`, and `"anonymous"` are valid IDs. [Prefer real user IDs](/docs/getting-started/identify-users#2-use-unique-strings-for-distinct-ids) – placeholder values group unrelated users onto a single person, and merging them later raises [`cannot_merge_with_illegal_distinct_id`](#refused-to-merge-with-an-illegal-distinct-id).
 
 posthog-js blocks the obvious mistakes for you. `identify()` refuses `null`, `undefined`, an empty string, and the literal strings `"null"` and `"undefined"`. It logs `Unique user id has not been set in posthog.identify` and sends nothing, so a plain `identify()` call is rarely the source of this warning. Common causes include:
 
@@ -157,7 +157,7 @@ posthog-js blocks the obvious mistakes for you. `identify()` refuses `null`, `un
 - **A layer that removes the ID in transit.** A [`before_send`](/docs/libraries/js/usage#amending-or-sampling-events) hook, a reverse proxy, or middleware can remove `distinct_id` after the SDK sets it.
 - **Requests that don't come from a PostHog SDK.** Hand-built calls to the [capture API](/docs/api/capture) have no client-side guard. A `lib` detail of `unknown` points at a sender outside your SDKs.
 
-Check where the ID comes from: your `bootstrap` value, or wherever you call `identify()`. Pass `bootstrap` only when you have an ID. An omitted `distinctID` or an empty string is safe — posthog-js generates an anonymous ID instead.
+Check where the ID comes from: your `bootstrap` value, or wherever you call `identify()`. Pass `bootstrap` only when you have an ID. An omitted `distinctID` or an empty string is safe – posthog-js generates an anonymous ID instead.
 
 ### Discarded event with no event name
 
@@ -170,7 +170,7 @@ These warnings mean a chunk of a [session recording](/docs/session-replay) was d
 | Warning | Cause |
 | --- | --- |
 | Discarded a session replay batch with no `$session_id` | The batch didn't identify which session it belonged to. |
-| Discarded a session replay batch with an invalid `$session_id` | The `$session_id` was present but unusable — most often not a string. |
+| Discarded a session replay batch with an invalid `$session_id` | The `$session_id` was present but unusable – most often not a string. |
 | Discarded a session replay batch with no `$snapshot_data` | The batch carried no recording data. |
 
 ### Discarded AI events

--- a/contents/docs/data/ingestion-warnings.mdx
+++ b/contents/docs/data/ingestion-warnings.mdx
@@ -165,7 +165,7 @@ The `event` field was missing or empty, so there was no name to record the event
 
 ### Discarded session replay batches
 
-These warnings mean a chunk of a [session recording](/docs/session-replay) was dropped. The rest of the recording still exists, but the dropped chunk leaves a gap: the player has no DOM mutations for that stretch, so playback can skip, show a stale page, or end early. All three usually point to an outdated SDK or a proxy that rewrites request bodies.
+These warnings mean a chunk of a [session recording](/docs/session-replay) was dropped. The rest of the recording still exists, but that stretch is missing from it. If the dropped chunk carried the recording's only full snapshot, the player has no starting DOM to replay against and can't play the recording at all. All three usually point to an outdated SDK or a proxy that rewrites request bodies.
 
 | Warning | Cause |
 | --- | --- |


### PR DESCRIPTION
## Changes

Follow up to https://github.com/PostHog/posthog.com/pull/19539 which documented some more ingestion warnings (everything in `WARNING_TYPE_TO_DESCRIPTION` under a bad assumption they were all live right now). Some of these ingestion warnings are not in use right now. So, if these docs were read as a rulebook rather than a reference manual, unexpected behaviour could occur.

Additionally addresses some of @luke-belton's review comments posthumously added to that PR>

tl;dr is
* sneaky em-dashes dropped in favour of formatted en-dashes with spaces either side.
* calrified how the missing distinct ID issue can happen which was the root cause of the PR in the first place
* removed any unused warnings (bulk of the PR)
* clarified session replay warning, it can be more severe if the dropped chunk contains the full snapshot.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x]  Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
