### PR TITLE
docs: fix typo and set expectations on dashboard widget coverage

### DIFF
--- a/contents/docs/product-analytics/dashboards.mdx
+++ b/contents/docs/product-analytics/dashboards.mdx
@@ -298,9 +298,11 @@ Dashboard widgets are an early access feature. Subscribe on the early access fea
 
 Widgets let you add live content from other PostHog products directly to your dashboards. Unlike insights, widgets display real-time lists of events, issues, or recordings instead of charts and metrics.
 
-This means your dashboards can be now be the one stop for everything you care about for your project.
+This means your dashboards can now be the one stop for everything you care about in your project.
 
 To add a widget, click the **Add...** dropdown button and select a widget from the available groups.
+
+Widgets don't cover every product yet. If what you want isn't in the list, add it as an insight tile instead. For example, open a [web analytics](/docs/web-analytics) tile as a new insight, save it, then add that insight to your dashboard.
 
 #### Activity widget
 


### PR DESCRIPTION
## Changes

Two small edits to the **Adding widgets** section of the dashboards doc.

- Fix a typo: "can be now be" now reads "can now be".
- Add one sentence that says widgets don't cover every product yet, and points readers at the insight tile route (with web analytics as the example).

**Why:** a user on the widgets early access asked for web analytics widgets, and said they didn't want to build separate insights for that content. The doc currently says dashboards "can be now be the one stop for everything you care about", so readers expect coverage the catalog doesn't have. Feature requests for the missing widgets are [PostHog/posthog#97772](https://github.com/PostHog/posthog/issues/97772) and [PostHog/posthog#97773](https://github.com/PostHog/posthog/issues/97773); this PR just makes the doc honest in the meantime.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
