### PR TITLE
Fix broken calculator urls

### DIFF
--- a/contents/pricing/agent-estimates.md
+++ b/contents/pricing/agent-estimates.md
@@ -125,15 +125,17 @@ This is where estimates go wrong. Apply these rules and show your work.
 PostHog's pricing calculator at https://posthog.com/pricing accepts URL parameters and pre-fills itself. Build a link with only the products in scope:
 
 ```
-https://posthog.com/pricing?calculator=<primary_product>&<product>[volume]=<monthly_volume>&...
+https://posthog.com/pricing?calculator=<primary_product>&products=<comma_separated_product_types>&<product>[volume]=<monthly_volume>&...
 ```
 
-Valid product keys: `product_analytics`, `session_replay`, `feature_flags`, `surveys`, `error_tracking`, `data_warehouse`, `logs`, `ai_observability`. Experiments bill through `feature_flags`. Set `calculator=` to the product that matters most to the user, so the page opens on that tab.
+Valid product keys: `product_analytics`, `session_replay`, `feature_flags`, `surveys`, `error_tracking`, `data_warehouse`, `logs`, `ai_observability`. Experiments bill through `feature_flags`. Set `calculator=` to the product that matters most to the user, so the page opens on that tab. List every selected product in `products=`; this sets the exact selection and order. Use `products=` with an empty value for no products.
 
-Example – 12M events, 75K recordings, 3M flag requests:
+For Product analytics, set both `product_analytics[types][productAnalyticsEvents][volume]` (identified events) and `product_analytics[types][websiteAnalyticsEvents][volume]` (anonymous events). Do not send a combined analytics volume. Include explicit zeros; omitted inputs use the calculator defaults.
+
+Example – 9.6M identified events, 2.4M anonymous events, 75K recordings, 3M flag requests:
 
 ```
-https://posthog.com/pricing?calculator=product_analytics&product_analytics[volume]=12000000&session_replay[volume]=75000&feature_flags[volume]=3000000
+https://posthog.com/pricing?calculator=product_analytics&products=product_analytics,session_replay,feature_flags&product_analytics[types][productAnalyticsEvents][volume]=9600000&product_analytics[types][websiteAnalyticsEvents][volume]=2400000&session_replay[volume]=75000&feature_flags[volume]=3000000
 ```
 
 Append `&utm_campaign=agent-estimate` to the end of the link, after all volume parameters.

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -16,11 +16,12 @@ import ProductAnalyticsTab, {
     getTotalEnhancedPersonsVolume,
 } from './Tabs/ProductAnalytics'
 import ReplayVisionTab from './Tabs/ReplayVision'
-import PostHogDesktopTab from './Tabs/PostHogDesktop'
+import PostHogDesktopTab, { useDesktopPricing } from './Tabs/PostHogDesktop'
 import StandaloneAddonsTab from './Tabs/StandaloneAddonsTab'
 import { EXCLUDED_ADDON_TYPES } from '../../../constants/addons'
 import { BROWSE_TOOLS_HANDLES } from 'constants/productNavigation'
 import qs from 'qs'
+import { getProductInputs, readProductInputs, priceProductInputs } from './calculatorURL'
 import usePostHog from 'hooks/usePostHog'
 import AgentEstimateLink, {
     AI_PRICING_EXPERIMENT_VARIANTS,
@@ -285,18 +286,42 @@ const EmptyEstimate = ({ products, onAdd }) => {
     )
 }
 
-const CopyURLButton = ({ onClick }) => {
-    const [copied, setCopied] = useState(false)
-    const copyURL = () => {
-        onClick()
-        setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
+const CopyURLButton = ({ onClick }: { onClick: () => string }) => {
+    const [status, setStatus] = useState('')
+    const [fallbackURL, setFallbackURL] = useState('')
+    const timeout = useRef<ReturnType<typeof setTimeout>>()
+    useEffect(() => () => clearTimeout(timeout.current), [])
+    const copyURL = async () => {
+        const url = onClick()
+        clearTimeout(timeout.current)
+        try {
+            await navigator.clipboard.writeText(url)
+            setFallbackURL('')
+            setStatus('Link copied')
+            timeout.current = setTimeout(() => setStatus(''), 2000)
+        } catch {
+            setFallbackURL(url)
+            setStatus('Copy the link below to share your estimate.')
+        }
     }
-
     return (
-        <button className="text-sm font-bold text-red dark:text-yellow" onClick={copyURL}>
-            {copied ? 'Copied!' : 'Generate calculator URL'}
-        </button>
+        <div className="min-w-0 max-w-full">
+            <button type="button" className="text-sm font-bold text-red dark:text-yellow" onClick={copyURL}>
+                Share estimate
+            </button>
+            <span role="status" className="text-sm ml-2">
+                {status}
+            </span>
+            {fallbackURL && (
+                <input
+                    aria-label="Calculator share URL"
+                    readOnly
+                    value={fallbackURL}
+                    onFocus={(event) => event.currentTarget.select()}
+                    className="block w-full mt-2 p-2 text-sm bg-primary text-primary border border-primary rounded"
+                />
+            )}
+        </div>
     )
 }
 
@@ -306,7 +331,7 @@ export default function Tabbed() {
             nodes: [{ products: billingProducts }],
         },
     } = useStaticQuery(allProductsData)
-    const [analyticsData, setAnalyticsData] = useState(getDefaultAnalyticsData)
+    const [analyticsData, setAnalyticsData] = useState<Record<string, any>>(getDefaultAnalyticsData)
     const platform = billingProducts.find((product) => product.type === 'platform_and_support')
     const [activeType, setActiveType] = useState<string | null>(DEFAULT_PRODUCT_TYPES[0])
     const [selectedTypes, setSelectedTypes] = useState<string[]>(DEFAULT_PRODUCT_TYPES)
@@ -314,6 +339,8 @@ export default function Tabbed() {
     const [productSearch, setProductSearch] = useState('')
     const addProductRef = useRef(null)
     const { products: initialProducts, setVolume, setProduct } = useProducts()
+    const [urlRestored, setUrlRestored] = useState(false)
+    const { computeRate } = useDesktopPricing(selectedTypes.includes('posthog_code'))
     const { addWindow } = useApp()
     // Listed in the same order as the taskbar's "Browse tools" menu, so the tools appear where
     // people have already learned to look for them. Metered products missing from that curated
@@ -329,7 +356,12 @@ export default function Tabbed() {
                 (product) => !!product.unit && !product.hideFromPricingTableAndCalculator && !product.hideFromCalculator
             )
             .sort((a, b) => navOrder(a) - navOrder(b))
-    }, [initialProducts])
+            .map((product): any =>
+                product.type === 'posthog_code'
+                    ? { ...product, ...priceProductInputs(product, getProductInputs(product), computeRate) }
+                    : product
+            )
+    }, [initialProducts, computeRate])
     const selectedProducts = selectedTypes
         .map((type) => products.find((product) => product.type === type))
         .filter(Boolean)
@@ -389,53 +421,88 @@ export default function Tabbed() {
 
     const generateURL = () => {
         const params = {
-            ...(activeProduct && { calculator: activeProduct.type }),
+            calculator: activeType ?? '',
+            products: selectedTypes.join(','),
+            ...Object.fromEntries(
+                selectedProducts.map((product) => [product.type, getProductInputs(product, analyticsData)])
+            ),
+            addons: Object.fromEntries(productAddons.map((addon) => [addon.type, addon.checked])),
+            platform: Object.fromEntries(
+                platformAddons
+                    .filter((addon) => !addon.legacy_product && addon.type !== 'enterprise')
+                    .map((addon) => [addon.type, addon.checked])
+            ),
         }
-        selectedProducts.forEach((product) => {
-            if (product.volume) {
-                params[product.type] = { volume: product.volume }
-                if (product.type === 'product_analytics') {
-                    const types = {}
-                    Object.keys(analyticsData).forEach((type) => {
-                        const volume = analyticsData[type].volume
-                        if (volume) {
-                            types[type] = { volume: analyticsData[type].volume }
-                        }
-                    })
-                    params['product_analytics'].types = types
-                }
-            }
-        })
-        const URL = `${window.location.origin}${window.location.pathname}?${qs.stringify(params, {
+        return `${window.location.origin}${window.location.pathname}?${qs.stringify(params, {
             encodeValuesOnly: true,
         })}`
-        navigator.clipboard.writeText(URL)
     }
 
     useEffect(() => {
-        const urlParams = new URLSearchParams(window.location.search)
-        const params = qs.parse(urlParams.toString())
-        const { calculator, ...volumeParams } = params
-
-        const volumeTypes = Object.keys(volumeParams).filter((type) =>
-            products.some((product) => product.type === type)
+        const params = qs.parse(window.location.search, { ignoreQueryPrefix: true })
+        const selected =
+            typeof params.products === 'string'
+                ? Array.from(
+                      new Set<string>(
+                          params.products.split(',').filter((type) => products.some((product) => product.type === type))
+                      )
+                  )
+                : selectedTypes
+        setSelectedTypes(selected)
+        setActiveType(
+            params.calculator === PLATFORM_PACKAGES_TYPE
+                ? PLATFORM_PACKAGES_TYPE
+                : selected.includes(params.calculator as string)
+                ? (params.calculator as string)
+                : selected[0] ?? null
         )
-        const typesFromUrl = [calculator, ...volumeTypes].filter((type) =>
-            products.some((product) => product.type === type)
-        )
-        if (typesFromUrl.length > 0) {
-            setSelectedTypes((current) => [...current, ...typesFromUrl.filter((type) => !current.includes(type))])
-            if (calculator && products.some((product) => product.type === calculator)) {
-                setActiveType(calculator)
+        let restoredAnalytics = analyticsData
+        const restoredProducts = products.map((product) => {
+            const inputs = readProductInputs(params[product.type], getProductInputs(product, analyticsData))
+            if (product.type === 'product_analytics') {
+                restoredAnalytics = Object.fromEntries(
+                    Object.entries(analyticsData).map(([key, value]) => [
+                        key,
+                        { ...value, volume: inputs.types[key].volume },
+                    ])
+                )
+                setAnalyticsData(restoredAnalytics)
             }
-        }
-
-        volumeTypes.forEach((type) => {
-            setVolume(type, volumeParams[type].volume)
+            const override = priceProductInputs(product, inputs, computeRate)
+            setProduct(product.handle, override)
+            return { ...product, ...override }
         })
-
+        setProductAddons((addons) =>
+            addons.map((addon) => {
+                const checked = params.addons?.[addon.type] === 'true'
+                const product = restoredProducts.find((product) =>
+                    product.billingData?.addons?.some((item: any) => item.type === addon.type)
+                )
+                const billingAddon = product?.billingData?.addons?.find((item: any) => item.type === addon.type)
+                const volume =
+                    addon.type === 'group_analytics'
+                        ? getTotalEnhancedPersonsVolume(restoredAnalytics)
+                        : product?.volume
+                return {
+                    ...addon,
+                    checked,
+                    totalCost: checked
+                        ? calculatePrice(volume, billingAddon?.plans.find((plan: any) => plan.tiers)?.tiers).total
+                        : 0,
+                }
+            })
+        )
+        setPlatformAddons((addons) =>
+            addons.map((addon) => ({
+                ...addon,
+                checked:
+                    !addon.legacy_product && addon.type !== 'enterprise' && params.platform?.[addon.type] === 'true',
+            }))
+        )
+        // Mount tabs after restoration so their local defaults cannot overwrite URL inputs.
+        setUrlRestored(true)
         const el = document.getElementById('calculator')
-        if (el && products.some((product) => volumeTypes.includes(product.type))) {
+        if (el && products.some((product) => params[product.type])) {
             const y = el.getBoundingClientRect().top + window.scrollY - (window.innerWidth > 767 ? 108 : 57)
             window.scrollTo({ top: y, behavior: 'smooth' })
         }
@@ -496,6 +563,13 @@ export default function Tabbed() {
         const product = products.find((item) => item.type === type)
         if (product) {
             setVolume(product.handle, 0)
+            setProduct(product.handle, {
+                addons: undefined,
+                model: undefined,
+                observations: undefined,
+                hours: undefined,
+                modelSpend: undefined,
+            })
             const addonTypes = new Set((product.billingData?.addons || []).map((addon) => addon.type))
             setProductAddons((addons) =>
                 addons.map((addon) => (addonTypes.has(addon.type) ? { ...addon, checked: false, totalCost: 0 } : addon))
@@ -807,16 +881,18 @@ export default function Tabbed() {
                                 </div>
                             </div>
 
-                            <TabContent
-                                key={activeProduct.type}
-                                addons={productAddons}
-                                setAddons={setProductAddons}
-                                activeProduct={activeProduct}
-                                setVolume={setVolume}
-                                setProduct={setProduct}
-                                analyticsData={analyticsData}
-                                setAnalyticsData={setAnalyticsData}
-                            />
+                            {urlRestored && (
+                                <TabContent
+                                    key={activeProduct.type}
+                                    addons={productAddons}
+                                    setAddons={setProductAddons}
+                                    activeProduct={activeProduct}
+                                    setVolume={setVolume}
+                                    setProduct={setProduct}
+                                    analyticsData={analyticsData}
+                                    setAnalyticsData={setAnalyticsData}
+                                />
+                            )}
                         </div>
                     )}
 
@@ -847,7 +923,8 @@ export default function Tabbed() {
                     </div>
                     {/* Two ways to leave with an estimate: a link to this one, or a prompt that builds
                         one from what the visitor already pays for elsewhere. Same row, same weight. */}
-                    <div className="flex flex-wrap items-center justify-between gap-2 mt-2 pr-2 md:pr-0">
+                    <div className="flex flex-wrap items-center justify-between gap-2 mt-2">
+                        <CopyURLButton onClick={generateURL} />
                         <RenderInClient
                             render={() => {
                                 const variant = window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG)

--- a/src/components/Pricing/PricingCalculator/Tabs/PostHogDesktop.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/PostHogDesktop.tsx
@@ -54,9 +54,7 @@ export default function PostHogDesktopTab({
     )
 
     const [hours, setHours] = useState(activeProduct.hours ?? 0)
-    const [modelSpend, setModelSpend] = useState(
-        activeProduct.modelSpend ?? (activeProduct.volume ?? 0) / CREDITS_PER_USD
-    )
+    const [modelSpend, setModelSpend] = useState(activeProduct.modelSpend)
 
     const computeSpend = hours * computeRate
     const computeCredits = Math.round(computeSpend * CREDITS_PER_USD)

--- a/src/components/Pricing/PricingCalculator/Tabs/PostHogDesktop.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/PostHogDesktop.tsx
@@ -29,6 +29,14 @@ const fetchPricing = async (url: string): Promise<PricingResponse> => {
     return response.json() as Promise<PricingResponse>
 }
 
+export const useDesktopPricing = (enabled = true) => {
+    const { data: pricing } = useSWR<PricingResponse>(enabled ? '/api/posthog-desktop-pricing' : null, fetchPricing)
+    return {
+        computeRate: hourlyComputeUsd(pricing?.compute ?? PUBLISHED_COMPUTE_RATE_CARD),
+        isPublishedRate: !pricing?.compute,
+    }
+}
+
 export default function PostHogDesktopTab({
     activeProduct,
     setProduct,
@@ -37,8 +45,7 @@ export default function PostHogDesktopTab({
     setProduct: (handle: string, data: any) => void
     [key: string]: any
 }): JSX.Element {
-    const { data: pricing, error } = useSWR<PricingResponse>('/api/posthog-desktop-pricing', fetchPricing)
-    const pricingSettled = pricing !== undefined || error !== undefined
+    const { computeRate, isPublishedRate } = useDesktopPricing()
 
     const creditTiers = useMemo(() => activeProduct?.billingData?.plans.find((plan: any) => plan.tiers)?.tiers, [])
     const freeCredits = useMemo(
@@ -46,34 +53,20 @@ export default function PostHogDesktopTab({
         [creditTiers]
     )
 
-    const liveCompute = pricing?.compute ?? null
-    const computeRate = hourlyComputeUsd(liveCompute ?? PUBLISHED_COMPUTE_RATE_CARD)
-    const isPublishedRate = liveCompute === null
-
-    const [hours, setHours] = useState(0)
-    const [modelSpend, setModelSpend] = useState<number | null>(null)
+    const [hours, setHours] = useState(activeProduct.hours ?? 0)
+    const [modelSpend, setModelSpend] = useState(
+        activeProduct.modelSpend ?? (activeProduct.volume ?? 0) / CREDITS_PER_USD
+    )
 
     const computeSpend = hours * computeRate
     const computeCredits = Math.round(computeSpend * CREDITS_PER_USD)
-    const modelCredits = modelSpend === null ? 0 : Math.round(modelSpend * CREDITS_PER_USD)
+    const modelCredits = Math.round(modelSpend * CREDITS_PER_USD)
     const credits = computeCredits + modelCredits
     const { total, costByTier } = useMemo(() => calculatePrice(credits, creditTiers), [credits, creditTiers])
 
     useEffect(() => {
-        if (!pricingSettled || modelSpend !== null) return
-        const external = Number(activeProduct.volume)
-        const restored = Number.isFinite(external) && external > 0 ? (external - computeCredits) / CREDITS_PER_USD : 0
-        setModelSpend(Math.max(0, restored))
-    }, [pricingSettled])
-
-    useEffect(() => {
-        if (modelSpend === null) return
-        setProduct('posthog_code', { cost: total, volume: credits, costByTier })
-    }, [total, credits, modelSpend === null])
-
-    if (modelSpend === null) {
-        return <div className="h-64 bg-accent border border-primary rounded-md animate-pulse" />
-    }
+        setProduct('posthog_code', { cost: total, volume: credits, costByTier, hours, modelSpend })
+    }, [total, credits, hours, modelSpend])
 
     const freeUsd = freeCredits / CREDITS_PER_USD
 

--- a/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
@@ -2,7 +2,6 @@ import { IconInfo } from '@posthog/icons'
 import { PricingTiers } from 'components/Pricing/Plans'
 import { calculatePrice } from 'components/Pricing/PricingCalculator/calculatorLogic'
 import React, { useEffect, useMemo, useState } from 'react'
-import qs from 'qs'
 import Tooltip from 'components/Tooltip'
 import { Addons } from '../Tabbed'
 import UsageSliderRow, { UsageSliderHeader } from '../UsageSliderRow'
@@ -193,26 +192,11 @@ export default function ProductAnalyticsTab({
     }
 
     useEffect(() => {
-        const totalAnalyticsCost = getTotalAnalyticsCost(analyticsData)
+        const totalAnalyticsCost = getTotalAnalyticsCost(priceAnalyticsData(analyticsData))
         const totalAnalyticsVolume = getTotalAnalyticsVolume(analyticsData)
         const { costByTier } = calculatePrice(totalAnalyticsVolume, productAnalyticsTiers)
         setProduct('product_analytics', { cost: totalAnalyticsCost, volume: totalAnalyticsVolume, costByTier })
     }, [analyticsData])
-
-    useEffect(() => {
-        const urlParams = new URLSearchParams(window.location.search)
-        const volumes = qs.parse(urlParams.toString())
-        if (volumes['product_analytics']?.types) {
-            Object.keys(volumes['product_analytics'].types).forEach((subtype) => {
-                const volume = volumes['product_analytics'].types[subtype]?.volume
-                if (volume) {
-                    setAnalyticsVolume(subtype, Number(volume))
-                }
-            })
-            return
-        }
-        setAnalyticsData((data) => priceAnalyticsData(data))
-    }, [])
 
     return (
         <div className="@container">

--- a/src/components/Pricing/PricingCalculator/Tabs/ReplayVision.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/ReplayVision.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import PricingEstimator, { MODELS, estimateReplayVisionPricing } from 'components/ReplayVision/PricingEstimator'
+import PricingEstimator, {
+    MODELS,
+    MAX_OBSERVATIONS,
+    estimateReplayVisionPricing,
+} from 'components/ReplayVision/PricingEstimator'
 
 /*
  * Replay Vision's tab in the /pricing calculator. Registered in `productTabs`
@@ -7,9 +11,8 @@ import PricingEstimator, { MODELS, estimateReplayVisionPricing } from 'component
  * model-selector estimator as /replay-vision/pricing, but driven by the billing
  * API's credit tiers and synced into the shared calculator state.
  *
- * Denominations: the UI works in observations; shared state (`product.volume`,
- * the tab-list subtotal, the generated calculator URL) stays in credits – the
- * billing unit – so `setVolume` restores and `calculatePrice` agree with us.
+ * The product override retains the model and observations for sharing and tab switches.
+ * Volume remains the derived credit amount used for billing.
  */
 export default function ReplayVisionTab({
     activeProduct,
@@ -23,11 +26,12 @@ export default function ReplayVisionTab({
     // subtotal cannot disagree. Empty deps: the tab remounts per tab switch
     // (`key={activeProduct.type}` in TabContent).
     const creditTiers = useMemo(() => activeProduct?.billingData?.plans.find((plan: any) => plan.tiers)?.tiers, [])
-    const [modelKey, setModelKey] = useState(MODELS[0].key)
-    // Seed from the shared credit volume so the estimate survives tab switches
-    // (the productData default of 2,500 credits reads as 500 observations on Standard).
-    const [observations, setObservations] = useState(() =>
-        Math.round((Number(activeProduct.volume) || 0) / MODELS[0].creditsPerObservation)
+    const [modelKey, setModelKey] = useState(activeProduct.model ?? MODELS[0].key)
+    // Restore saved inputs, or derive the initial observations from the product's default credits.
+    const [observations, setObservations] = useState(
+        () =>
+            activeProduct.observations ??
+            Math.round((Number(activeProduct.volume) || 0) / MODELS[0].creditsPerObservation)
     )
 
     const estimate = estimateReplayVisionPricing({ observations, modelKey, creditTiers })
@@ -36,19 +40,14 @@ export default function ReplayVisionTab({
     // so listing it would loop the effect.
     useEffect(() => {
         if (!estimate) return
-        setProduct('replay_vision', { cost: estimate.cost, volume: estimate.credits, costByTier: estimate.costByTier })
+        setProduct('replay_vision', {
+            cost: estimate.cost,
+            volume: estimate.credits,
+            costByTier: estimate.costByTier,
+            model: modelKey,
+            observations,
+        })
     }, [estimate?.cost, estimate?.credits, estimate?.model.key])
-
-    // Adopt a volume written from outside the tab – Tabbed's mount effect restores
-    // `?replay_vision[volume]=N` (credits) via setVolume after this component mounts.
-    // Converges: once observations match, the next run sees equal credits and bails.
-    useEffect(() => {
-        if (!estimate) return
-        const external = Number(activeProduct.volume)
-        if (Number.isFinite(external) && external > 0 && external !== estimate.credits) {
-            setObservations(Math.round(external / estimate.model.creditsPerObservation))
-        }
-    }, [activeProduct.volume])
 
     if (!estimate) return null
 
@@ -63,7 +62,7 @@ export default function ReplayVisionTab({
                 modelKey={modelKey}
                 observations={observations}
                 onModelKeyChange={setModelKey}
-                onObservationsChange={setObservations}
+                onObservationsChange={(value) => setObservations(Math.min(value, MAX_OBSERVATIONS))}
             />
         </div>
     )

--- a/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/StandaloneAddonsTab.tsx
@@ -56,7 +56,7 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
     const [addonData, setAddonData] = useState(
         () =>
             activeProduct.addonSliders?.map((addon) => ({
-                volume: addon.volume ?? addon.sliderConfig?.min ?? 0,
+                volume: activeProduct.addons?.[addon.key]?.volume ?? addon.volume ?? addon.sliderConfig?.min ?? 0,
                 cost: 0,
                 costByTier: [],
             })) || []
@@ -111,18 +111,22 @@ export default function StandaloneAddonsTab({ activeProduct, setVolume, setProdu
         )
     }, [addonBillingData])
 
+    const addonVolumes = addonData.map((addon) => addon.volume).join(',')
     useEffect(() => {
         if (mainBillingTiers) {
             const { costByTier } = calculatePrice(billedMainVolume, mainBillingTiers)
             setProduct(activeProduct.handle, {
                 cost: totalCost,
                 volume: mainVolume,
+                addons: Object.fromEntries(
+                    addonBillingData.map((addon, index) => [addon.key, { volume: addonData[index].volume }])
+                ),
                 costByTier,
             })
         }
         // Omit setProduct: it is a new function every render and would retrigger this
         // effect, rebuild addonBillingData, and race a just-clicked volume.
-    }, [totalCost, mainVolume, billedMainVolume, mainBillingTiers, activeProduct.handle])
+    }, [totalCost, mainVolume, billedMainVolume, mainBillingTiers, activeProduct.handle, addonVolumes])
 
     // Cost is derived from billedMainVolume in the effect above — the cost SliderRow reports only
     // covers its own volume, which undercounts when an add-on meters through the main product.

--- a/src/components/Pricing/PricingCalculator/UsageSliderRow.tsx
+++ b/src/components/Pricing/PricingCalculator/UsageSliderRow.tsx
@@ -55,7 +55,7 @@ export default function UsageSliderRow({
     const [draft, setDraft] = useState<string | null>(null)
     const displayValue = draft ?? `${inputPrefix ?? ''}${formatCompact(value)}`
 
-    const emit = (next: number) => onChange(snapToMark(next, marks))
+    const emit = (next: number) => onChange(inputPrefix === '$' ? next : snapToMark(next, marks))
 
     const handleLogChange = (next: number) => {
         const rounded = Math.round(sliderCurve(next))
@@ -64,7 +64,8 @@ export default function UsageSliderRow({
 
     const commitDraft = () => {
         if (draft === null) return
-        emit(parseCompact(draft))
+        const next = parseCompact(draft)
+        if (next !== value) emit(next)
         setDraft(null)
     }
 
@@ -103,16 +104,17 @@ export default function UsageSliderRow({
             </div>
             <input
                 type="text"
+                aria-label={label}
                 className={`${
                     inputPrefix ? 'w-16' : 'w-14'
                 } bg-transparent text-center font-bold text-sm border border-light dark:border-dark rounded-md py-1 px-1.5 focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark ml-auto`}
                 value={displayValue}
-                onFocus={() => setDraft(displayValue)}
+                onFocus={() => setDraft(`${inputPrefix ?? ''}${value}`)}
                 onChange={(e) => setDraft(e.target.value)}
                 onBlur={commitDraft}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter') {
-                        ;(e.target as HTMLInputElement).blur()
+                        e.currentTarget.blur()
                     }
                 }}
             />

--- a/src/components/Pricing/PricingCalculator/UsageSliderRow.tsx
+++ b/src/components/Pricing/PricingCalculator/UsageSliderRow.tsx
@@ -55,7 +55,7 @@ export default function UsageSliderRow({
     const [draft, setDraft] = useState<string | null>(null)
     const displayValue = draft ?? `${inputPrefix ?? ''}${formatCompact(value)}`
 
-    const emit = (next: number) => onChange(inputPrefix === '$' ? next : snapToMark(next, marks))
+    const emit = (next: number) => onChange(snapToMark(next, marks))
 
     const handleLogChange = (next: number) => {
         const rounded = Math.round(sliderCurve(next))

--- a/src/components/Pricing/PricingCalculator/calculatorURL.ts
+++ b/src/components/Pricing/PricingCalculator/calculatorURL.ts
@@ -57,7 +57,7 @@ export const priceProductInputs = (product: any, inputs: ProductInputs, computeR
     let volume = inputs.volume ?? 0
     let extraCost = 0
     let parentVolume = 0
-    if (inputs.types) {
+    if (product.type === 'product_analytics') {
         volume = Object.values(inputs.types).reduce((sum: number, value: any) => sum + value.volume, 0)
         const enhancedTiers = product.billingData?.addons
             .find((addon: any) => addon.type === 'enhanced_persons')
@@ -72,7 +72,7 @@ export const priceProductInputs = (product: any, inputs: ProductInputs, computeR
         extraCost += calculatePrice(addonVolume, addonTiers).total
         if (addon.countsTowardParentVolume) parentVolume += addonVolume
     }
-    if (inputs.model !== undefined) {
+    if (product.type === 'replay_vision') {
         const estimate = estimateReplayVisionPricing({
             observations: inputs.observations,
             modelKey: inputs.model,
@@ -85,7 +85,7 @@ export const priceProductInputs = (product: any, inputs: ProductInputs, computeR
             costByTier: estimate?.costByTier ?? [],
         }
     }
-    if (inputs.hours !== undefined)
+    if (product.type === 'posthog_code')
         volume = Math.round(inputs.hours * computeRate * 100) + Math.round(inputs.modelSpend * 100)
     const price = calculatePrice(volume + parentVolume, tiers)
     return { ...inputs, volume, cost: product.billedWith ? 0 : price.total + extraCost, costByTier: price.costByTier }

--- a/src/components/Pricing/PricingCalculator/calculatorURL.ts
+++ b/src/components/Pricing/PricingCalculator/calculatorURL.ts
@@ -1,0 +1,92 @@
+import { calculatePrice } from './calculatorLogic'
+import { MODELS, MAX_OBSERVATIONS, estimateReplayVisionPricing } from '../../ReplayVision/PricingEstimator'
+
+type ProductInputs = Record<string, any>
+
+/** The editable fields only; prices and billing metadata never come from the URL. */
+export const getProductInputs = (product: any, analyticsData: ProductInputs = {}): ProductInputs => {
+    if (product.type === 'product_analytics')
+        return {
+            types: Object.fromEntries(
+                Object.entries(analyticsData).map(([key, data]) => [key, { volume: data.volume }])
+            ),
+        }
+    if (product.type === 'replay_vision')
+        return {
+            model: product.model ?? MODELS[0].key,
+            observations: product.observations ?? Math.round((product.volume ?? 0) / MODELS[0].creditsPerObservation),
+        }
+    if (product.type === 'posthog_code')
+        return { hours: product.hours ?? 0, modelSpend: product.modelSpend ?? (product.volume ?? 0) / 100 }
+    return {
+        volume: product.volume ?? product.freeLimit ?? product.slider?.min ?? 0,
+        ...(product.addonSliders && {
+            addons: Object.fromEntries(
+                product.addonSliders.map((addon: any) => [
+                    addon.key,
+                    {
+                        volume: product.addons?.[addon.key]?.volume ?? addon.volume ?? addon.sliderConfig?.min ?? 0,
+                    },
+                ])
+            ),
+        }),
+    }
+}
+
+/** Walk known fields to reject unknown keys, invalid numbers, and duplicate parameters. */
+export const readProductInputs = (source: any, defaults: ProductInputs): ProductInputs =>
+    Object.fromEntries(
+        Object.entries(defaults).map(([key, fallback]) => {
+            const value = source?.[key]
+            if (typeof fallback === 'object') return [key, readProductInputs(value, fallback)]
+            if (key === 'model') return [key, MODELS.some((model) => model.key === value) ? value : fallback]
+            const number = typeof value === 'string' && value.trim() ? Number(value) : NaN
+            if (!Number.isFinite(number) || number < 0 || number > Number.MAX_SAFE_INTEGER) return [key, fallback]
+            return [
+                key,
+                key === 'modelSpend'
+                    ? Math.round(number * 100) / 100
+                    : Math.round(Math.min(number, key === 'observations' ? MAX_OBSERVATIONS : Number.MAX_SAFE_INTEGER)),
+            ]
+        })
+    )
+
+/** Seed costs for unopened tabs using the same pricing functions as their controls. */
+export const priceProductInputs = (product: any, inputs: ProductInputs, computeRate: number) => {
+    const tiers = product.billingData?.plans.find((plan: any) => plan.tiers)?.tiers
+    let volume = inputs.volume ?? 0
+    let extraCost = 0
+    let parentVolume = 0
+    if (inputs.types) {
+        volume = Object.values(inputs.types).reduce((sum: number, value: any) => sum + value.volume, 0)
+        const enhancedTiers = product.billingData?.addons
+            .find((addon: any) => addon.type === 'enhanced_persons')
+            ?.plans.find((plan: any) => plan.tiers)?.tiers
+        extraCost = calculatePrice(inputs.types.productAnalyticsEvents.volume, enhancedTiers).total
+    }
+    for (const addon of product.addonSliders || []) {
+        const addonVolume = inputs.addons[addon.key].volume
+        const addonTiers = product.billingData?.addons
+            .find((item: any) => item.type === addon.key)
+            ?.plans.find((plan: any) => plan.tiers)?.tiers
+        extraCost += calculatePrice(addonVolume, addonTiers).total
+        if (addon.countsTowardParentVolume) parentVolume += addonVolume
+    }
+    if (inputs.model !== undefined) {
+        const estimate = estimateReplayVisionPricing({
+            observations: inputs.observations,
+            modelKey: inputs.model,
+            creditTiers: tiers,
+        })
+        return {
+            ...inputs,
+            volume: estimate?.credits ?? 0,
+            cost: estimate?.cost ?? 0,
+            costByTier: estimate?.costByTier ?? [],
+        }
+    }
+    if (inputs.hours !== undefined)
+        volume = Math.round(inputs.hours * computeRate * 100) + Math.round(inputs.modelSpend * 100)
+    const price = calculatePrice(volume + parentVolume, tiers)
+    return { ...inputs, volume, cost: product.billedWith ? 0 : price.total + extraCost, costByTier: price.costByTier }
+}


### PR DESCRIPTION
## Changes

Previously, generated calculator urls didn't generate properly as there were a few products (product analytics, session reply, and posthog desktop) that have a pricing scheme that differ from the others. Attempting to use these products in a shared URL would promptly break it.

This PR properly ties the state for these components to the url and moves some of their bespoke attributes into the shared calculator data model. It also adds back the link generation under the "Share estimate" button

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>