### PR TITLE
Add back ai estimates

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -923,12 +923,15 @@ export default function Tabbed() {
                     </div>
                     {/* Two ways to leave with an estimate: a link to this one, or a prompt that builds
                         one from what the visitor already pays for elsewhere. Same row, same weight. */}
-                    <div className="flex flex-wrap items-center justify-between gap-2 mt-2">
+                    <div
+                        className="flex flex-wrap items-center justify-between gap-2 mt-2"
+                        data-ai-estimate-placement="inside-calculator"
+                    >
                         <CopyURLButton onClick={generateURL} />
                         <RenderInClient
                             render={() => {
                                 const variant = window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG)
-                                return variant && variant !== AI_PRICING_EXPERIMENT_VARIANTS.control ? (
+                                return variant === AI_PRICING_EXPERIMENT_VARIANTS.inside_calculator ? (
                                     <AgentEstimateLink
                                         source="calculator-total"
                                         className="text-sm font-bold text-red dark:text-yellow"

--- a/src/components/Pricing/Redesign/CalculatorSection.tsx
+++ b/src/components/Pricing/Redesign/CalculatorSection.tsx
@@ -2,6 +2,11 @@ import React, { useEffect } from 'react'
 import { useLocation } from '@reach/router'
 import { Calculator } from 'components/Pricing/Test/Calculator'
 import { scrollToElement } from 'components/ScrollToElement'
+import { RenderInClient } from 'components/RenderInClient'
+import AgentEstimateLink, {
+    AI_PRICING_EXPERIMENT_VARIANTS,
+    AI_PRICING_FLAG,
+} from 'components/Pricing/AgentEstimateLink'
 
 /**
  * The pricing calculator as a plain, always-visible section.
@@ -27,6 +32,20 @@ export default function CalculatorSection(): JSX.Element {
         // `my-0` loses to its `mb-12` in Tailwind's cascade regardless of class order, so it
         // takes a child selector to win on specificity.
         <div className="not-prose [&>section]:my-0 [&>section]:px-0">
+            <RenderInClient
+                render={() =>
+                    window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG) ===
+                    AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator ? (
+                        <p className="text-[15px] text-secondary mb-6" data-ai-estimate-placement="outside-calculator">
+                            Coming from another tool?{' '}
+                            <AgentEstimateLink source={AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator} /> using your
+                            real usage there.
+                        </p>
+                    ) : (
+                        <></>
+                    )
+                }
+            />
             <Calculator hideHeader id="" />
         </div>
     )

--- a/src/components/Pricing/Redesign/README.md
+++ b/src/components/Pricing/Redesign/README.md
@@ -2,7 +2,7 @@
 
 Components for the pricing page, served on **`/pricing`**. The page that assembles them is `pages/pricing/index.tsx`.
 
-These components shipped behind the `pricing-page-redesign` experiment. The redesign is now the only pricing page. The calculator is always visible as its own section (`CalculatorSection`). Nothing here reads a feature flag.
+These components shipped behind the `pricing-page-redesign` experiment. The redesign is now the only pricing page. The calculator is always visible as its own section (`CalculatorSection`). The `ai-pricing` experiment controls the AI estimate entry point: `control` hides it, `inside-calculator` places it beside **Share estimate**, and `outside-calculator` places it above the calculator and in the **Estimating usage** guidance. Unknown or unavailable flag values hide the AI estimate links. The shared `AgentEstimateLink` popover retains the ChatGPT, Claude, and copy-prompt actions and their existing analytics events.
 
 ## Why
 

--- a/src/components/Pricing/Test/Calculator.tsx
+++ b/src/components/Pricing/Test/Calculator.tsx
@@ -215,8 +215,25 @@ export const Calculator = ({ hideHeader = false, id = 'calculator' }: Calculator
                         <h4 className="text-lg mb-2">Estimating usage</h4>
                         <SidebarList>
                             <SidebarListItem>
-                                Not sure what your volume looks like? Add the tracking code to your site and check back
-                                in a few days – no credit card required.
+                                Not sure what your volume looks like?{' '}
+                                <RenderInClient
+                                    placeholder={<>Add</>}
+                                    render={() =>
+                                        window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG) ===
+                                        AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator ? (
+                                            <>
+                                                <AgentEstimateLink
+                                                    label="Generate an AI estimate"
+                                                    source="pricing-page-estimating-usage"
+                                                />{' '}
+                                                or add
+                                            </>
+                                        ) : (
+                                            <>Add</>
+                                        )
+                                    }
+                                />{' '}
+                                the tracking code to your site and check back in a few days – no credit card required.
                             </SidebarListItem>
                             <SidebarListItem>
                                 If something stupid happens and you get an unexpected bill (like if{' '}
@@ -232,24 +249,6 @@ export const Calculator = ({ hideHeader = false, id = 'calculator' }: Calculator
                                 </Link>{' '}
                                 to help!
                             </SidebarListItem>
-                            <RenderInClient
-                                render={() => {
-                                    const variant = window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG)
-                                    return variant && variant !== AI_PRICING_EXPERIMENT_VARIANTS.control ? (
-                                        <SidebarListItem>
-                                            Coming from another tool?{' '}
-                                            <AgentEstimateLink
-                                                label="Create an estimate"
-                                                source="pricing-page-estimating-usage"
-                                                className={sidebarLinkClasses}
-                                            />{' '}
-                                            using your real usage there.
-                                        </SidebarListItem>
-                                    ) : (
-                                        <></>
-                                    )
-                                }}
-                            />
                         </SidebarList>
                     </div>
                 </div>


### PR DESCRIPTION
## Changes

AI estimates are back and better than ever (they work now since calc urls are fixed)

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>