### PR TITLE
chore(pocket-guides): Pin pocket guide contents in a sidebar

### DIFF
--- a/contents/pocket-guides/ai-observability/index.mdx
+++ b/contents/pocket-guides/ai-observability/index.mdx
@@ -26,11 +26,3 @@ Either way, they all assume your LLM calls already reach PostHog. If they don't 
 <Setup />
 
 </LeftPage>
-
-<RightPage>
-
-# Contents
-
-<Contents />
-
-</RightPage>

--- a/contents/pocket-guides/context-warehouse/index.mdx
+++ b/contents/pocket-guides/context-warehouse/index.mdx
@@ -24,11 +24,3 @@ Beginning to need more complex data modeling? Start with **Long-term
 modeling**. [Warehouse foundations](/pocket-guides/context-warehouse/warehouse-foundations) covers the view-vs-dbt decision every other Skill builds on.
 
 </LeftPage>
-
-<RightPage>
-
-# Contents
-
-<Contents />
-
-</RightPage>

--- a/contents/pocket-guides/self-driving/index.mdx
+++ b/contents/pocket-guides/self-driving/index.mdx
@@ -22,11 +22,3 @@ Already Self-driving? Use cases in the **Contents** are scouts you can add to
 your own product in one click.
 
 </LeftPage>
-
-<RightPage>
-
-# Contents
-
-<Contents />
-
-</RightPage>

--- a/contents/pocket-guides/session-replay/index.mdx
+++ b/contents/pocket-guides/session-replay/index.mdx
@@ -26,11 +26,3 @@ Every page assumes a PostHog SDK is in your app with recording switched on. If i
 <Frontispiece />
 
 </LeftPage>
-
-<RightPage>
-
-# Contents
-
-<Contents />
-
-</RightPage>

--- a/src/components/Explorer/index.tsx
+++ b/src/components/Explorer/index.tsx
@@ -24,6 +24,8 @@ interface ExplorerProps {
     rightSidebarContent?: React.ReactNode | AccordionItem[]
     children?: React.ReactNode
     fullScreen?: boolean
+    /** Let the standard app-window background show through the content. */
+    transparent?: boolean
     showTitle?: boolean
     padding?: boolean
     headerBarOptions?: string[]
@@ -79,6 +81,7 @@ export default function Explorer({
     rightSidebarContent,
     children,
     fullScreen = false,
+    transparent = false,
     showTitle = true,
     padding = true,
     headerBarOptions,
@@ -204,7 +207,7 @@ export default function Explorer({
                     <main
                         data-app="Explorer"
                         data-scheme="primary"
-                        className="@container flex-1 bg-primary relative h-full"
+                        className={`@container flex-1 relative h-full ${transparent ? '' : 'bg-primary'}`}
                     >
                         {fullScreen ? (
                             children

--- a/src/components/PocketGuides/Action.tsx
+++ b/src/components/PocketGuides/Action.tsx
@@ -157,7 +157,7 @@ export function ActionBar({
     const trackCtaClick = () => posthog?.capture('pocket_guide_interaction', { kind, guide, placement: 'pinned_bar' })
 
     return (
-        <div className="flex items-center gap-3 border-t border-primary bg-primary px-6 py-3">
+        <div className="flex items-center gap-3 px-6 py-3">
             <span className="min-w-0 flex-1 truncate text-sm text-secondary">{title}</span>
             <OSButton asLink to={href} external variant="primary" size="sm" onClick={trackCtaClick}>
                 {cta.label}

--- a/src/components/PocketGuides/BookPage.tsx
+++ b/src/components/PocketGuides/BookPage.tsx
@@ -76,6 +76,8 @@ export default function BookPage({ slug, body }: BookPageProps): JSX.Element | n
             headerBarOptions={[]}
             // fullScreen: the book fits the window and its page owns its scroll.
             fullScreen
+            // Like the docs reader, show the standard app-window surface behind the page.
+            transparent
             // The window itself is the page – no desk. The viewport selector re-pins the height fullScreen drops.
             className="[&_.app-scroll-viewport>div>div]:h-full"
         >

--- a/src/components/PocketGuides/BookReader.tsx
+++ b/src/components/PocketGuides/BookReader.tsx
@@ -325,7 +325,7 @@ export default function BookReader({
                     </div>
                 </div>
                 {actionBar && (
-                    <div className="shrink-0 border-t border-primary">
+                    <div className="m-4 shrink-0 rounded-md border border-primary">
                         <div className="mx-auto w-full max-w-[52rem] @3xl:max-w-[56rem]">{actionBar}</div>
                     </div>
                 )}

--- a/src/components/PocketGuides/BookReader.tsx
+++ b/src/components/PocketGuides/BookReader.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import usePostHog from '../../hooks/usePostHog'
 import { motion, useReducedMotion } from 'framer-motion'
 
-import { IconBook, IconChevronLeft, IconChevronRight, IconList } from '@posthog/icons'
+import { IconBook, IconChevronLeft, IconChevronRight, IconHome, IconList } from '@posthog/icons'
 
 import Link from 'components/Link'
 
@@ -21,9 +21,9 @@ interface BookReaderProps {
     actionBar?: React.ReactNode
     prev?: { url: string; label: string }
     next?: { url: string; label: string }
-    /** The contents popover's entries, one per page you can turn to. */
+    /** The contents entries, one per page you can turn to. */
     tabs?: BookTab[]
-    /** The way out – an edge tab and a foot link, so leaving the book is always one click. */
+    /** The way out – a sidebar control and a foot link. */
     shelf?: { url: string; label: string }
     /** Where you are, printed in the foot line. Front matter is unnumbered. */
     position?: { page?: number; total: number }
@@ -35,7 +35,7 @@ interface BookReaderProps {
 
 type Panel = 'contents' | 'type' | null
 
-/** The reading-size control, inside the Aa pop-out. */
+/** The reading-size control, shared by the sidebar and compact Aa pop-out. */
 function BookControls({
     fontSize,
     sizes,
@@ -140,9 +140,8 @@ function PageTurnZone({
 }
 
 /**
- * The e-reader: the window itself is the page. Reading controls are book tabs on the page's
- * left edge – small handles that belong to the page, not a toolbar. Left, because that's where
- * readers expect navigation, and their popovers open over the page instead of off the window.
+ * The e-reader: contents and controls stay beside the scrolling page in wide windows.
+ * Narrow windows keep the compact book tabs and popovers to leave room for the page.
  */
 export default function BookReader({
     children,
@@ -177,11 +176,51 @@ export default function BookReader({
             active ? 'bg-primary text-primary' : 'bg-accent text-secondary hover:text-primary dark:bg-accent-dark'
         }`
 
+    const readingSizeControls = fontSize && onFontSize && fontSizes && (
+        <BookControls
+            fontSize={fontSize}
+            sizes={fontSizes}
+            onStep={(delta) => {
+                posthog?.capture('pocket_guide_interaction', { kind: 'font_size_step', delta })
+                onFontSize(delta)
+            }}
+        />
+    )
+
     return (
-        <div className="relative flex h-full min-h-0 w-full flex-col bg-primary">
+        <div className="relative flex h-full min-h-0 w-full flex-col @4xl:flex-row">
+            <aside
+                aria-label="Pocket guide sidebar"
+                className="m-4 mr-0 hidden min-h-0 w-64 shrink-0 flex-col overflow-hidden rounded-md border border-primary @4xl:flex"
+            >
+                {tabs && tabs.length > 0 && (
+                    <nav aria-label="Pocket guide contents" className="min-h-0 flex-1 overflow-y-auto">
+                        <ContentsList tabs={tabs} />
+                    </nav>
+                )}
+                {(shelf || readingSizeControls) && (
+                    <div
+                        role="group"
+                        aria-label="Controls"
+                        className="flex shrink-0 items-center justify-between gap-3 border-t border-primary px-3 py-2"
+                    >
+                        {shelf && (
+                            <Link
+                                to={shelf.url}
+                                title={shelf.label}
+                                className="flex h-7 items-center gap-1.5 rounded px-1.5 text-xs text-secondary no-underline hover:bg-accent hover:text-primary"
+                            >
+                                <IconHome className="size-4" />
+                                Home
+                            </Link>
+                        )}
+                        {readingSizeControls}
+                    </div>
+                )}
+            </aside>
             {/* Book tabs: in-flow above the page on narrow containers (floating tabs would sit
                 on the text), attached to the left edge at reading widths. */}
-            <div className="relative z-30 flex shrink-0 flex-row items-center gap-1 px-4 pt-3 @3xl:absolute @3xl:left-0 @3xl:top-6 @3xl:flex-col @3xl:items-start @3xl:p-0">
+            <div className="relative z-30 flex shrink-0 flex-row items-center gap-1 px-4 pt-3 @3xl:absolute @3xl:left-0 @3xl:top-6 @3xl:flex-col @3xl:items-start @3xl:p-0 @4xl:hidden">
                 {shelf && (
                     <Link to={shelf.url} aria-label={shelf.label} title={shelf.label} className={edgeTabClasses()}>
                         <IconBook className="size-4" />
@@ -227,75 +266,70 @@ export default function BookReader({
                     <div className="absolute left-4 top-full mt-1 rounded-md border border-primary bg-primary p-3 shadow-xl @3xl:left-9 @3xl:top-0 @3xl:mt-0">
                         <div className="flex items-center justify-between gap-4">
                             <span className="text-xs font-semibold text-secondary">Font size</span>
-                            <BookControls
-                                fontSize={fontSize}
-                                sizes={fontSizes}
-                                onStep={(delta) => {
-                                    posthog?.capture('pocket_guide_interaction', { kind: 'font_size_step', delta })
-                                    onFontSize(delta)
-                                }}
-                            />
+                            {readingSizeControls}
                         </div>
                     </div>
                 )}
             </div>
 
-            <div className="relative min-h-0 flex-1 bg-white dark:bg-accent">
-                {prev && <PageTurnZone to={prev.url} label={prev.label} direction="prev" />}
-                {next && <PageTurnZone to={next.url} label={next.label} direction="next" />}
-                <div className="h-full overflow-y-auto">
-                    {/* min-h-full + mt-auto: on a short page the nav pins to the page's
+            <div className="@container flex min-h-0 min-w-0 flex-1 flex-col">
+                <div className="relative min-h-0 flex-1">
+                    {prev && <PageTurnZone to={prev.url} label={prev.label} direction="prev" />}
+                    {next && <PageTurnZone to={next.url} label={next.label} direction="next" />}
+                    <div className="h-full overflow-y-auto">
+                        {/* min-h-full + mt-auto: on a short page the nav pins to the page's
                         foot instead of floating mid-page above empty paper. */}
-                    <div className="mx-auto flex min-h-full w-full max-w-[52rem] flex-col @3xl:max-w-[56rem]">
-                        <div style={{ fontSize }}>{children}</div>
-                        <nav
-                            aria-label="Pocket guide pages"
-                            className="mt-auto flex items-baseline justify-between gap-4 px-5 pb-8 text-sm @xl:px-12"
-                        >
-                            {prev ? (
-                                <Link
-                                    to={prev.url}
-                                    wrapperClassName="min-w-0 truncate"
-                                    className="text-secondary hover:text-primary"
-                                >
-                                    ‹ {prev.label}
-                                </Link>
-                            ) : (
-                                <span />
-                            )}
-                            <span className="flex shrink-0 items-baseline gap-3">
-                                {/* On the front matter the prev turn already IS the shelf – one link is plenty. */}
-                                {shelf && prev?.url !== shelf.url && (
-                                    <Link to={shelf.url} className="text-secondary hover:text-primary">
-                                        All guides
+                        <div className="mx-auto flex min-h-full w-full max-w-[52rem] flex-col @3xl:max-w-[56rem]">
+                            <div style={{ fontSize }}>{children}</div>
+                            <nav
+                                aria-label="Pocket guide pages"
+                                className="mt-auto flex items-baseline justify-between gap-4 px-5 pb-8 text-sm @xl:px-12"
+                            >
+                                {prev ? (
+                                    <Link
+                                        to={prev.url}
+                                        wrapperClassName="min-w-0 truncate"
+                                        className="text-secondary hover:text-primary"
+                                    >
+                                        ‹ {prev.label}
                                     </Link>
+                                ) : (
+                                    <span />
                                 )}
-                                {position?.page && (
-                                    <span className="tabular-nums text-secondary">
-                                        p. {position.page} of {position.total}
-                                    </span>
+                                <span className="flex shrink-0 items-baseline gap-3">
+                                    {/* On the front matter the prev turn already IS the shelf – one link is plenty. */}
+                                    {shelf && prev?.url !== shelf.url && (
+                                        <Link to={shelf.url} className="text-secondary hover:text-primary">
+                                            All guides
+                                        </Link>
+                                    )}
+                                    {position?.page && (
+                                        <span className="tabular-nums text-secondary">
+                                            p. {position.page} of {position.total}
+                                        </span>
+                                    )}
+                                </span>
+                                {next ? (
+                                    <Link
+                                        to={next.url}
+                                        wrapperClassName="min-w-0 truncate text-right"
+                                        className="text-secondary hover:text-primary"
+                                    >
+                                        {next.label} ›
+                                    </Link>
+                                ) : (
+                                    <span />
                                 )}
-                            </span>
-                            {next ? (
-                                <Link
-                                    to={next.url}
-                                    wrapperClassName="min-w-0 truncate text-right"
-                                    className="text-secondary hover:text-primary"
-                                >
-                                    {next.label} ›
-                                </Link>
-                            ) : (
-                                <span />
-                            )}
-                        </nav>
+                            </nav>
+                        </div>
                     </div>
                 </div>
+                {actionBar && (
+                    <div className="shrink-0 border-t border-primary">
+                        <div className="mx-auto w-full max-w-[52rem] @3xl:max-w-[56rem]">{actionBar}</div>
+                    </div>
+                )}
             </div>
-            {actionBar && (
-                <div className="shrink-0 border-t border-primary">
-                    <div className="mx-auto w-full max-w-[52rem] @3xl:max-w-[56rem]">{actionBar}</div>
-                </div>
-            )}
         </div>
     )
 }

--- a/src/components/PocketGuides/README.md
+++ b/src/components/PocketGuides/README.md
@@ -87,7 +87,6 @@ after the prose.
 | `<Watches />` | The signal sources from this page's `watches` frontmatter |
 | `<Enable />` | The scout CTA – one click to add this page's scout |
 | `<Action />` | The CTA for volumes whose answer isn't a scout, from `pocketGuideCta:` frontmatter |
-| `<Contents />` | The contents list, built from the book itself |
 | `<SeeAlso>` | A print footnote at the foot of the column |
 | `<Term name="scout">` | An orange dotted-underline definition with a hover card |
 
@@ -98,8 +97,9 @@ Headings map to the book's type scale: `#` is the page title, `##` a small-caps 
 Every page is one linear scroll. `ReaderWrapper` (ReaderWrapper.tsx) re-orders the compiled
 elements by their `mdxType` and `n` props at render time: each figure is embedded after the
 first block that cites it via `<SeeFig>`, and a figure nobody cites prints at the end of the
-page. One exception: a figure-less page authored as two pages – the volume's front matter –
-renders `<LeftPage>` and `<RightPage>` as two columns at reading widths.
+page. Landing-page introductions render in one column in both the standalone reader and docs'
+Learn surface. Contents navigation belongs to each surface's sidebar, so introductory MDX does
+not include a separate contents page.
 
 The hover markers and their hint line show at reading widths only – below ~672px of container
 width they're hidden (there is no hover on touch), so a figure's caption has to carry it alone
@@ -142,10 +142,15 @@ shows after the `.mdx` file itself changes (or `pnpm clean`).
 
 ## The reader UI
 
-- **`BookReader`** – the window itself is the page, no inner frame and no toolbar: reading
-  controls are book tabs on the page's left edge (shelf link, a Contents popover, an Aa
-  reading-size control), a centered reading column, click-to-turn page margins, and a foot line
-  with prev/next turns, "All guides" (except where prev already is the shelf), and "p. N of M".
+- **`BookReader`** – wide windows pin the Contents panel on the left, with a compact Home and
+  reading-size control bar. `BookPage` uses Explorer's `transparent` option so the standard
+  frosted app-window background shows through, as it does in the docs reader. The sidebar
+  has no separate background or shadow, so it shares that same surface.
+  The page scrolls independently, and long contents
+  lists scroll within the sidebar. Below `@4xl`, compact book tabs keep the Contents and Aa
+  popovers. The reading column has its own container queries, click-to-turn page margins, and
+  a foot line with prev/next turns, "All guides" (except where prev already is the shelf), and
+  "p. N of M".
 - **One model drives everything.** `bookModel.tsx`'s `useBookPages(volumeId)` reads every page's
   `pocketGuideOrder` and produces that volume's reading order; the bar, contents, and page turns all
   derive from it. Front matter is unnumbered; arabic numbering starts at the page after it, so
@@ -161,12 +166,12 @@ shows after the `.mdx` file itself changes (or `pnpm clean`).
 | `Book.tsx` | The volume as a coloured spine for the `/docs` library column, plus the `BookShelf` it sits in |
 | `VolumeCard.tsx` | One volume pitched as a card: cover, pitch, button. Shared by the docs pages and `/self-driving` |
 | `GuidesForProduct.tsx` | Looks up the volume for a docs slug and renders a `VolumeCard`. Renders nothing when there is none |
-| `BookReader.tsx` | The full-window page: edge book tabs, popovers, turn zones, foot nav |
+| `BookReader.tsx` | The full-window page: pinned sidebar, compact book tabs, turn zones, foot nav |
 | `BookPage.tsx` | Renders one MDX page into the reader |
 | `bookComponents.tsx` | Assembles the MDX vocabulary from the files below |
 | `ReaderWrapper.tsx` | The figure-interleaving MDX wrapper + LeftPage/RightPage markers |
 | `figures.tsx` | Fig and every `<XxxFigure>` exhibit |
-| `bookPieces.tsx` | SeeFig, Eyebrow, Watches, Enable, Contents, SeeAlso, prose styling |
+| `bookPieces.tsx` | SeeFig, Eyebrow, Watches, Enable, SeeAlso, prose styling |
 | `Action.tsx` | The non-scout CTA and its pinned bar, from `pocketGuideCta:` frontmatter |
 | `terms.tsx` | The book's vocabulary – `<Term>` and every hover-card definition |
 | `bookContext.tsx` | EntryProvider + useEntry/useTemplate (page data for figures) |

--- a/src/components/PocketGuides/ReaderWrapper.tsx
+++ b/src/components/PocketGuides/ReaderWrapper.tsx
@@ -63,21 +63,7 @@ export default function ReaderWrapper({ children }: { children: React.ReactNode 
     })
 
     const emitted = new Set<number>()
-    const stream: React.ReactNode[] = []
-
-    // A figure-less page authored as two prose pages – the volume's front matter – keeps its
-    // two-page character as two columns at reading widths, instead of one tall stack.
-    if (figures.size === 0 && preface.length > 0 && prose.length > 0) {
-        stream.push(
-            <div key="front-matter" className="@3xl:grid @3xl:grid-cols-2 @3xl:items-start @3xl:gap-12">
-                <div>{preface}</div>
-                <div>{prose}</div>
-            </div>
-        )
-        prose = []
-    } else {
-        stream.push(...preface)
-    }
+    const stream: React.ReactNode[] = [...preface]
 
     for (const block of prose) {
         stream.push(block)

--- a/src/components/PocketGuides/bookComponents.tsx
+++ b/src/components/PocketGuides/bookComponents.tsx
@@ -25,7 +25,7 @@ import {
     TraceFigure,
     TriggerGroupFigure,
 } from './figures'
-import { Contents, Enable, Eyebrow, Frontispiece, SeeAlso, SeeFig, Watches, proseComponents } from './bookPieces'
+import { Enable, Eyebrow, Frontispiece, SeeAlso, SeeFig, Watches, proseComponents } from './bookPieces'
 import { AskAI, CTA, ScannerTemplate, ViewRecording, ViewRecordings } from './UIButton'
 
 export { EntryProvider } from './bookContext'
@@ -66,7 +66,6 @@ export const bookMdxComponents = {
     Callout,
     ProductVideo,
     Setup,
-    Contents,
     SeeAlso,
     ViewRecordings,
     ViewRecording,

--- a/src/components/PocketGuides/bookModel.tsx
+++ b/src/components/PocketGuides/bookModel.tsx
@@ -27,8 +27,6 @@ export interface BookPageEntry {
     /** Arabic page number. Front matter is unnumbered, the way print leaves it. */
     page?: number
     isFrontMatter: boolean
-    /** Groups the Contents list into named sections. Undefined pages print in one flat list. */
-    section?: string
     /** Rich use case data (report, scout, watches), when this page is a use case. */
     template?: InboxTemplate
     /** The page's one action, when it isn't a scout – see bookPieces' `<Action />`. */
@@ -67,7 +65,6 @@ export function useBookPages(volumeId: string): BookPageEntry[] {
                         title
                         shortTitle
                         pocketGuideOrder
-                        section
                         pocketGuideCta {
                             kind
                             label
@@ -108,7 +105,6 @@ export function useBookPages(volumeId: string): BookPageEntry[] {
                     shortTitle: node.frontmatter.shortTitle || node.frontmatter.title,
                     order,
                     isFrontMatter: order === 0,
-                    section: node.frontmatter.section || undefined,
                     template: byUrl.get(url),
                     cta: node.frontmatter.pocketGuideCta || undefined,
                 }

--- a/src/components/PocketGuides/bookPieces.tsx
+++ b/src/components/PocketGuides/bookPieces.tsx
@@ -8,7 +8,7 @@ import EnableScout from 'components/SelfDrivingInbox/EnableScout'
 import { productSource } from 'components/SelfDrivingInbox/sources'
 
 import { useEntry, useTemplate } from './bookContext'
-import { BookPageEntry, learnChapterPath, normalizeUrl, volumeIdFromUrl } from './bookModel'
+import { learnChapterPath, normalizeUrl, volumeIdFromUrl } from './bookModel'
 import { volumeArt } from './volumeArt'
 
 /** Inline cue to a figure, color only – bold read larger than the surrounding text. */
@@ -74,79 +74,6 @@ export function Enable(): JSX.Element | null {
         return null
     }
     return <EnableScout scout={template.scout} requires={template.requires} templateTitle={template.templateTitle} />
-}
-
-/** One page's row: a link, a dotted leader, and its folio number. */
-function ContentsRow({ page, basePath }: { page: BookPageEntry; basePath?: string }): JSX.Element {
-    // Inside the Learn tab the contents keep the reader in the tab; the standalone reader's
-    // pages are their own routes.
-    const to = basePath ? learnChapterPath(basePath, page) : page.url
-    return (
-        <li className="flex items-baseline gap-2">
-            <Link to={to} wrapperClassName="min-w-0" className="text-[1em] text-primary hover:underline">
-                {page.title}
-            </Link>
-            {/* The dotted leader, so the row reads as a ToC line. */}
-            <span aria-hidden="true" className="min-w-6 flex-1 border-b border-dotted border-primary opacity-50" />
-            <span className="shrink-0 text-[0.9em] tabular-nums text-secondary">
-                {String(page.page).padStart(2, '0')}
-            </span>
-        </li>
-    )
-}
-
-/**
- * The contents list, built from the book itself. Groups into named sections when pages declare
- * a `section` in frontmatter (consecutive by reading order); a book where no page does prints
- * the same single flat list as before.
- */
-export function Contents(): JSX.Element | null {
-    const book = useEntry()
-    if (!book) {
-        return null
-    }
-    const pages = book.pages.filter((page) => !page.isFrontMatter)
-
-    if (pages.every((page) => !page.section)) {
-        return (
-            <ul className="m-0 list-none space-y-3 p-0">
-                {pages.map((page) => (
-                    <ContentsRow key={page.url} page={page} basePath={book.basePath} />
-                ))}
-            </ul>
-        )
-    }
-
-    // Group consecutive pages sharing a section – reading order already sorted them.
-    const groups: { section?: string; pages: BookPageEntry[] }[] = []
-    for (const page of pages) {
-        const current = groups[groups.length - 1]
-        if (current && current.section === page.section) {
-            current.pages.push(page)
-        } else {
-            groups.push({ section: page.section, pages: [page] })
-        }
-    }
-
-    return (
-        <div className="space-y-6">
-            {groups.map((group, i) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <div key={group.section ?? i}>
-                    {group.section && (
-                        <p className="m-0 mb-2 text-[0.8em] font-bold uppercase tracking-wide text-secondary">
-                            {group.section}
-                        </p>
-                    )}
-                    <ul className="m-0 list-none space-y-3 p-0">
-                        {group.pages.map((page) => (
-                            <ContentsRow key={page.url} page={page} basePath={book.basePath} />
-                        ))}
-                    </ul>
-                </div>
-            ))}
-        </div>
-    )
 }
 
 /** A print footnote: short rule, small type, at the foot of the text column. */

--- a/src/components/SelfDrivingInbox/EnableScout.tsx
+++ b/src/components/SelfDrivingInbox/EnableScout.tsx
@@ -23,7 +23,7 @@ export function EnableScoutBar({ scout, templateTitle }: Pick<EnableScoutProps, 
         })
 
     return (
-        <div className="flex items-center gap-3 border-t border-primary bg-primary px-6 py-3">
+        <div className="flex items-center gap-3 px-6 py-3">
             <span className="min-w-0 flex-1 truncate text-sm text-secondary">
                 <span className="font-mono text-[13px] text-primary">{scout?.name || templateTitle}</span>
             </span>


### PR DESCRIPTION
## Changes

Keep pocket-guide contents visible in a left sidebar, with a compact Home and font-size control bar. Narrow windows keep the existing contents menu.

Use the standard window background and show introductions in one column on both pocket-guide and docs Learn pages. Remove duplicate contents and the unused layout code.

after
<img width="2606" height="1430" alt="CleanShot 2026-09-09 at 16 01 07@2x" src="https://github.com/user-attachments/assets/bab943d6-3ba1-4dea-9f57-ea5dc804cdc7" />

<img width="2530" height="1430" alt="CleanShot 2026-09-10 at 10 08 54 AM@2x" src="https://github.com/user-attachments/assets/0882a8d4-05ee-4045-8015-7c8cf990b1a5" />


<details>
<summary>PR tour</summary>

- `BookReader`: pinned sidebar, shared font controls, and separate article scrolling.
- `Explorer` and `BookPage`: optional transparent content background, enabled for pocket guides only.
- Four introduction pages, `ReaderWrapper`, `bookPieces`, `bookComponents`, and `bookModel`: remove body contents, the two-column layout, and unused contents code and data. Update the README.

</details>

<details>
<summary>Reviewer's guide</summary>

The dev server compiled successfully. Formatting, ESLint, and Markdown lint passed during commit.

Automated tests, a complete wide/narrow and light/dark visual check, and before/after captures were not run; visual testing was left to the author. Check sidebar scrolling, font controls, and Learn introductions in the preview.

</details>
