### PR TITLE
Handbook: security findings are the support hero's remit

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -104,6 +104,12 @@ Security vulnerabilities and other security related findings can be reported via
 
 For information about current and past security advisories and CVEs, see our [advisories & CVEs page](/handbook/company/security-advisories).
 
+## Fixing vulnerabilities in our own code
+
+Security findings in our own code are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a monthly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+
+Each team fixes the findings for the code it owns. The team's [support hero](/handbook/engineering/operations/support-hero#security-findings) picks these up alongside the normal support workload.
+
 ## Reporting phishing
 
 If you receive a phishing email/text/whatsapp, it's useful to report it to the security team so that they can make other employees aware. Take a screenshot and post it in `#phishing-attempts`. You may be asked to forward the email to [security-internal@posthog.com](mailto:security-internal@posthog.com) for further inspection.

--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -106,7 +106,7 @@ For information about current and past security advisories and CVEs, see our [ad
 
 ## Fixing vulnerabilities in our own code
 
-Security findings in our own code are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+We import security findings in our own code from the AI pentesting services we use, currently Veria Labs and Parameter. Findings are triaged automatically, and true positives are forwarded to the product team that owns the code. They are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and each team gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
 
 Each team fixes the findings for the code it owns. The team's [support hero](/handbook/engineering/operations/support-hero#security-findings) picks these up alongside the normal support workload.
 

--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -106,7 +106,7 @@ For information about current and past security advisories and CVEs, see our [ad
 
 ## Fixing vulnerabilities in our own code
 
-Security findings in our own code are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a monthly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+Security findings in our own code are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
 
 Each team fixes the findings for the code it owns. The team's [support hero](/handbook/engineering/operations/support-hero#security-findings) picks these up alongside the normal support workload.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -80,7 +80,7 @@ Papercuts are also routed to the Signals inbox, so before you start work, check 
 
 Vulnerabilities in code your team owns are also yours to fix, and the support hero is the person who picks them up alongside the normal support workload. Some findings are critical, so give them the same priority as a customer ticket.
 
-Findings for your team are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+Findings come from the AI pentesting services we use, currently Veria Labs and Parameter. They are triaged automatically, and the true positives go to the product team that owns the code. Your team's findings are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and your team also gets a weekly post in its Slack channel that lists them.
 
 Work through the findings for your team during your rotation. If you cannot finish one, hand it over to the next support hero. If you are not sure how serious a finding is, or how to fix it, ask in `#team-security`.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -80,7 +80,7 @@ Papercuts are also routed to the Signals inbox, so before you start work, check 
 
 Vulnerabilities in code your team owns are also yours to fix, and the support hero is the person who picks them up alongside the normal support workload. Some findings are critical, so give them the same priority as a customer ticket.
 
-Findings for your team are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a monthly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+Findings for your team are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
 
 Work through the findings for your team during your rotation. If you cannot finish one, hand it over to the next support hero. If you are not sure how serious a finding is, or how to fix it, ask in `#team-security`.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -35,6 +35,7 @@ There are three sources of tickets:
 1. In-app bug reports/feedback/support tickets sent from the [Support panel](https://us.posthog.com/home#panel=support).
 1. Slack or MS Teams threads that have been raised via @SupportHog in [customer support channels](/handbook/growth/sales/slack-channels).
 1. Reports in the `#papercuts` Slack channel that relate to your team's area.
+1. Security findings in code your team owns, tracked in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>.
 
 ### Answering tickets
 
@@ -74,6 +75,14 @@ Check the `#papercuts` Slack channel during your rotation and pick up any report
 - **React with ✅** once you've shipped a fix or improvement.
 
 Papercuts are also routed to the Signals inbox, so before you start work, check whether an auto-generated PR is already waiting – it may save you most of the effort.
+
+### Security findings
+
+Vulnerabilities in code your team owns are also yours to fix, and the support hero is the person who picks them up alongside the normal support workload. Some findings are critical, so give them the same priority as a customer ticket.
+
+Findings for your team are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>. Each team also gets a monthly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+
+Work through the findings for your team during your rotation. If you cannot finish one, hand it over to the next support hero. If you are not sure how serious a finding is, or how to fix it, ask in `#team-security`.
 
 ### Responding to external PRs
 


### PR DESCRIPTION
## Changes

- Support hero page: security findings in code a team owns are now listed as a source of tickets, with a new **Security findings** section that says the support hero picks them up alongside the normal support workload, points at security.posthog.dev, and mentions the weekly per-team Slack post.
- Company security page: a short **Fixing vulnerabilities in our own code** section that links to the support hero page.

## Why

The handbook did not say who fixes security findings in our own code. We now have security.posthog.dev and a weekly post in each team's channel, and the team's support hero is the right owner, so the handbook should say so.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08SCAZ52S3/p1788977154450149?thread_ts=1788977154.450149&cid=C08SCAZ52S3)*
