### PR TITLE
Add 'go to {route}' action on Spotlight search

### DIFF
--- a/src/components/SpotlightSearch/README.md
+++ b/src/components/SpotlightSearch/README.md
@@ -39,6 +39,10 @@ Keep search behavior and selection ordering in `index.tsx`. Extracted components
 
 Actions appear for short matching queries. One-shot actions close the palette, while actions with `keepOpen` can be repeated. Add an action by providing an id, label, icon, keywords, `perform`, and optional `keepOpen` value.
 
+### Direct routes
+
+When the query matches a site-local path, Spotlight puts a `Go to` row first. The regex requires a leading `/` and rejects protocol-relative URLs (`//`), whitespace, and backslashes. Query strings and fragments are allowed. The row opens the supplied path in a new window without checking that Gatsby created the route.
+
 ### Ask AI suggestion
 
 Queries of four or more words promote an Ask AI row. A settled query with no Algolia results does the same, so users can hand the question to Max chat. This handoff does not use Inkeep vector search.

--- a/src/components/SpotlightSearch/SuggestionList.tsx
+++ b/src/components/SpotlightSearch/SuggestionList.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IconFilter, IconSparkles } from '@posthog/icons'
+import { IconArrowRight, IconFilter, IconSparkles } from '@posthog/icons'
 import KeyboardShortcut from 'components/KeyboardShortcut'
 import type { SpotlightAction } from './actions'
 import { configForType } from './categories'
@@ -12,6 +12,7 @@ type SuggestionListProps = {
     selectedIndex: number
     itemRefs: React.MutableRefObject<(HTMLLIElement | null)[]>
     onSelectIndex: (index: number) => void
+    onGoToRoute: (path: string) => void
     onRunAction: (action: SpotlightAction) => void
     onAskAI: () => void
     onApplyFilter: (type: string) => void
@@ -31,6 +32,7 @@ export default function SuggestionList({
     selectedIndex,
     itemRefs,
     onSelectIndex,
+    onGoToRoute,
     onRunAction,
     onAskAI,
     onApplyFilter,
@@ -45,6 +47,22 @@ export default function SuggestionList({
                     ref: (element: HTMLLIElement | null) => (itemRefs.current[index] = element),
                     selected: selectedIndex === index,
                     onActive: () => onSelectIndex(index),
+                }
+
+                if (item.kind === 'route') {
+                    return (
+                        <SpotlightRow
+                            key="route"
+                            {...rowProps}
+                            icon={<IconArrowRight />}
+                            onSelect={() => onGoToRoute(item.path)}
+                            trailing={<SuggestionHint action="go" />}
+                        >
+                            <p className="m-0 min-w-0 truncate text-[15px] text-primary">
+                                Go to <span className="font-semibold">{item.path}</span>
+                            </p>
+                        </SpotlightRow>
+                    )
                 }
 
                 if (item.kind === 'action') {

--- a/src/components/SpotlightSearch/index.tsx
+++ b/src/components/SpotlightSearch/index.tsx
@@ -93,6 +93,7 @@ function SpotlightSearchContent({
 
     const actions = useSpotlightActions()
     const matchedActions = matchActions(query, actions)
+    const route = /^\/(?!\/)(?![\s\S]*[\s\\])/.test(query) ? query : null
 
     const suggestedFilter = useMemo(() => (activeFilter ? null : matchCategory(query)), [query, activeFilter])
 
@@ -133,8 +134,9 @@ function SpotlightSearchContent({
     const suggestAskAI = queryWordCount >= 4 || (queryWordCount > 0 && !loading && !hasResults)
 
     // Flat list in rendered order (suggestion rows first), for keyboard
-    // navigation: actions → ask AI → filter → results
+    // navigation: direct route → actions → ask AI → filter → results
     const navItems: NavItem[] = [
+        ...(route ? [{ kind: 'route' as const, path: route }] : []),
         ...matchedActions.map((action) => ({ kind: 'action' as const, action })),
         ...(suggestAskAI ? [{ kind: 'ask-ai' as const }] : []),
         ...(suggestedFilter ? [{ kind: 'filter' as const, type: suggestedFilter }] : []),
@@ -163,6 +165,11 @@ function SpotlightSearchContent({
         })
         close()
         navigate(result.url, { state: { newWindow: true } })
+    }
+
+    const openRoute = (path: string) => {
+        close()
+        navigate(path, { state: { newWindow: true } })
     }
 
     const applyFilter = (type: string, { keepQuery = false }: { keepQuery?: boolean } = {}) => {
@@ -217,7 +224,9 @@ function SpotlightSearchContent({
     }
 
     const selectItem = (item: NavItem) => {
-        if (item.kind === 'action') {
+        if (item.kind === 'route') {
+            openRoute(item.path)
+        } else if (item.kind === 'action') {
             runAction(item.action)
         } else if (item.kind === 'ask-ai') {
             askAI()
@@ -452,6 +461,7 @@ function SpotlightSearchContent({
                                                                     selectedIndex={selectedIndex}
                                                                     itemRefs={itemRefs}
                                                                     onSelectIndex={setSelectedIndex}
+                                                                    onGoToRoute={openRoute}
                                                                     onRunAction={runAction}
                                                                     onAskAI={askAI}
                                                                     onApplyFilter={applyFilter}

--- a/src/components/SpotlightSearch/types.ts
+++ b/src/components/SpotlightSearch/types.ts
@@ -21,6 +21,7 @@ export type ResultGroup = {
 }
 
 export type SuggestionItem =
+    | { kind: 'route'; path: string }
     | { kind: 'action'; action: SpotlightAction }
     | { kind: 'ask-ai' }
     | { kind: 'filter'; type: string }


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
