### PR TITLE
Skip off-screen merch cards from raster with content-visibility

### DIFF
--- a/src/templates/merch/ProductCard.tsx
+++ b/src/templates/merch/ProductCard.tsx
@@ -40,11 +40,6 @@ export function ProductCard(props: ProductCardProps): React.ReactElement {
     )
 
     return (
-        /**
-         * content-visibility keeps off-screen cards out of layout, paint and raster. Without it,
-         * a pinch-zoom expands the visual viewport, every lazy product image becomes eligible to
-         * decode at once, and iOS Safari kills the tab.
-         */
         <button
             className={`group px-2 pt-2 pb-1 border-[1.5px] rounded [content-visibility:auto] [contain-intrinsic-size:auto_300px] ${
                 selected ? 'border-blue bg-blue/10' : 'border-transparent'

--- a/src/templates/merch/ProductCard.tsx
+++ b/src/templates/merch/ProductCard.tsx
@@ -40,8 +40,13 @@ export function ProductCard(props: ProductCardProps): React.ReactElement {
     )
 
     return (
+        /**
+         * content-visibility keeps off-screen cards out of layout, paint and raster. Without it,
+         * a pinch-zoom expands the visual viewport, every lazy product image becomes eligible to
+         * decode at once, and iOS Safari kills the tab.
+         */
         <button
-            className={`group px-2 pt-2 pb-1 border-[1.5px] rounded ${
+            className={`group px-2 pt-2 pb-1 border-[1.5px] rounded [content-visibility:auto] [contain-intrinsic-size:auto_300px] ${
                 selected ? 'border-blue bg-blue/10' : 'border-transparent'
             } relative flex flex-col gap-2 ${className}`}
             key={product.shopifyId}


### PR DESCRIPTION
## Changes

The merch grid renders 52 product cards. Each card image loads lazily, and each `srcset` offers a 500w candidate. A phone is narrower than the 500px breakpoint in the `sizes` attribute, so the browser selects the 500w candidate for every card.

Lazy loading usually keeps most of those bitmaps off the heap. A pinch-zoom defeats it. The visual viewport expands to the full page, so every lazy image becomes eligible to decode at the same time, and WebKit re-rasterizes the page tiles at the new scale at the same moment. On iOS the tab can then exceed its memory limit, and Safari kills it. The user sees "A problem repeatedly occurred".

This change adds `content-visibility: auto` and `contain-intrinsic-size: auto 300px` to the product card. The browser then skips layout, paint and raster for off-screen cards at any zoom level, which caps the memory the grid can hold.

`content-visibility` is available in Safari 18 and later, and in Chrome. Older browsers ignore the property and render the card as before. The `auto` keyword in `contain-intrinsic-size` makes the browser remember the real card size after the first render, so the scroll position stays stable.

Refs #17108. That report is about the product modal, not the grid, so this change alone is not expected to close it. It lowers the memory the page holds while the modal is open.

## Screenshots

**Not included. This PR is blocked until someone adds them.**

I cannot render /merch in this environment. `gatsby/sourceNodes.ts` skips Shopify sourcing when `SHOPIFY_APP_PASSWORD` is absent, so `shopifyCollection` has no nodes and `src/pages/merch.tsx` returns `null`. That secret is not in `.env.development`, and I did not go looking for it.

Please add before/after images for a narrow window and a wide window, in light and dark mode, or tell me how to source the merch data locally.

## Before you open a PR

- `pnpm format`: run on the changed file. Prettier made no further changes.
- Dev server: started with `pnpm start`. I could not complete the page check, for the reason above.
- No page moved, so this PR needs no redirect and no `pnpm test-redirects` run.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BH6R0RDFX/p1788987980118409)*
