### PR TITLE
Add desktop drag select

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -180,7 +180,73 @@ function Desktop() {
     })
     const [navVisible, setNavVisible] = useState(false)
     const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+    const dragBoxRef = useRef<HTMLDivElement>(null)
     const { addToast } = useToast()
+
+    useEffect(() => {
+        const box = dragBoxRef.current
+        if (!box) return
+        let drag: { x: number; y: number; pointerId: number; target: Element } | null = null
+
+        const stopDrag = () => {
+            const previous = drag
+            drag = null
+            box.style.transitionProperty = 'opacity'
+            box.style.opacity = '0'
+            if (previous?.target.hasPointerCapture(previous.pointerId)) {
+                previous.target.releasePointerCapture(previous.pointerId)
+            }
+        }
+        const startDrag = (event: PointerEvent) => {
+            if (event.pointerType !== 'mouse' || event.button !== 0 || !event.isPrimary) return
+            const target = event.target
+            if (!(target instanceof Element)) return
+            // Empty space can belong to the window layer or the desktop icon lists.
+            const isBackground = target.matches(
+                '[data-app="WindowList"], [data-app="DesktopViewport"], [data-app="Desktop"]'
+            )
+            const isIconList = target.matches('ul') && target.closest('[data-app="Desktop"]')
+            if (!isBackground && !isIconList) return
+
+            event.preventDefault()
+            box.style.display = 'none'
+            box.style.transitionProperty = 'none'
+            box.style.opacity = '1'
+            drag = { x: event.clientX, y: event.clientY, pointerId: event.pointerId, target }
+            target.setPointerCapture(event.pointerId)
+        }
+        const moveDrag = (event: PointerEvent) => {
+            if (!drag || event.pointerId !== drag.pointerId) return
+            if (!(event.buttons & 1)) return stopDrag()
+            // Update only the decorative box, without re-rendering the desktop on each move.
+            Object.assign(box.style, {
+                display: 'block',
+                left: `${Math.min(drag.x, event.clientX)}px`,
+                top: `${Math.min(drag.y, event.clientY)}px`,
+                width: `${Math.abs(event.clientX - drag.x)}px`,
+                height: `${Math.abs(event.clientY - drag.y)}px`,
+            })
+        }
+        const endDrag = (event: PointerEvent) => {
+            if (event.pointerId === drag?.pointerId) stopDrag()
+        }
+
+        document.addEventListener('pointerdown', startDrag)
+        document.addEventListener('pointermove', moveDrag)
+        document.addEventListener('pointerup', endDrag)
+        document.addEventListener('pointercancel', endDrag)
+        document.addEventListener('lostpointercapture', endDrag)
+        window.addEventListener('blur', stopDrag)
+        return () => {
+            document.removeEventListener('pointerdown', startDrag)
+            document.removeEventListener('pointermove', moveDrag)
+            document.removeEventListener('pointerup', endDrag)
+            document.removeEventListener('pointercancel', endDrag)
+            document.removeEventListener('lostpointercapture', endDrag)
+            window.removeEventListener('blur', stopDrag)
+            stopDrag()
+        }
+    }, [])
 
     useEffect(() => {
         return () => {
@@ -336,6 +402,12 @@ function Desktop() {
                             </ul>
                         </div>
                     </nav>
+                    <div
+                        ref={dragBoxRef}
+                        data-desktop-drag-box
+                        aria-hidden="true"
+                        className="fixed hidden pointer-events-none rounded-md border border-blue bg-blue/10 duration-200 ease-out motion-reduce:duration-0"
+                    />
                 </div>
                 {!compact && (
                     <Screensaver


### PR DESCRIPTION
## Changes

Adds the most worthless feature ever: dragging on the desktop background for a nice blue selection box to appear.

Does trying to select things like desktop icons do anything? Absolutely not.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
