### PR TITLE
Handbook: name SecurityHog and prioritize critical findings

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -106,9 +106,9 @@ For information about current and past security advisories and CVEs, see our [ad
 
 ## Fixing vulnerabilities in our own code
 
-We import security findings in our own code from the AI pentesting services we use, currently Veria Labs and Parameter. Findings are triaged automatically, and true positives are forwarded to the product team that owns the code. They are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and each team gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+We import security findings in our own code from the AI pentesting services we use, currently Veria Labs and Parameter. Findings are triaged automatically, and true positives are forwarded to the product team that owns the code. They are collected in SecurityHog, at <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and each team gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
 
-Each team fixes the findings for the code it owns. The team's [support hero](/handbook/engineering/operations/support-hero#security-findings) picks these up alongside the normal support workload.
+Each team fixes the findings for the code it owns. The team's [support hero](/handbook/engineering/operations/support-hero#security-findings) picks these up alongside the normal support workload. Critical and high severity findings must be fixed as soon as possible.
 
 ## Reporting phishing
 

--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -106,7 +106,7 @@ For information about current and past security advisories and CVEs, see our [ad
 
 ## Fixing vulnerabilities in our own code
 
-We import security findings in our own code from the AI pentesting services we use, currently Veria Labs and Parameter. Findings are triaged automatically, and true positives are forwarded to the product team that owns the code. They are collected in SecurityHog, at <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and each team gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
+We import security findings in our own code from the AI pentesting services we use, currently Veria Labs and Parameter. Findings are triaged automatically, and true positives are forwarded to the product team that owns the code. They are collected in <PrivateLink url="https://security.posthog.dev">SecurityHog</PrivateLink>, and each team gets a weekly post in its Slack channel that lists the vulnerabilities found in the code it owns.
 
 Each team fixes the findings for the code it owns. The team's [support hero](/handbook/engineering/operations/support-hero#security-findings) picks these up alongside the normal support workload. Critical and high severity findings must be fixed as soon as possible.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -78,9 +78,9 @@ Papercuts are also routed to the Signals inbox, so before you start work, check 
 
 ### Security findings
 
-Vulnerabilities in code your team owns are also yours to fix, and the support hero is the person who picks them up alongside the normal support workload. Some findings are critical, so give them the same priority as a customer ticket.
+Vulnerabilities in code your team owns are also yours to fix, and the support hero is the person who picks them up alongside the normal support workload. Give critical and high severity findings the same priority as a customer ticket, and fix them as soon as you can.
 
-Findings come from the AI pentesting services we use, currently Veria Labs and Parameter. They are triaged automatically, and the true positives go to the product team that owns the code. Your team's findings are collected in <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and your team also gets a weekly post in its Slack channel that lists them.
+Findings come from the AI pentesting services we use, currently Veria Labs and Parameter. They are triaged automatically, and the true positives go to the product team that owns the code. Your team's findings are collected in SecurityHog, at <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and your team also gets a weekly post in its Slack channel that lists them.
 
 Work through the findings for your team during your rotation. If you cannot finish one, hand it over to the next support hero. If you are not sure how serious a finding is, or how to fix it, ask in `#team-security`.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -80,7 +80,7 @@ Papercuts are also routed to the Signals inbox, so before you start work, check 
 
 Vulnerabilities in code your team owns are also yours to fix, and the support hero is the person who picks them up alongside the normal support workload. Give critical and high severity findings the same priority as a customer ticket, and fix them as soon as you can.
 
-Findings come from the AI pentesting services we use, currently Veria Labs and Parameter. They are triaged automatically, and the true positives go to the product team that owns the code. Your team's findings are collected in SecurityHog, at <PrivateLink url="https://security.posthog.dev">security.posthog.dev</PrivateLink>, and your team also gets a weekly post in its Slack channel that lists them.
+Findings come from the AI pentesting services we use, currently Veria Labs and Parameter. They are triaged automatically, and the true positives go to the product team that owns the code. Your team's findings are collected in <PrivateLink url="https://security.posthog.dev">SecurityHog</PrivateLink>, and your team also gets a weekly post in its Slack channel that lists them.
 
 Work through the findings for your team during your rotation. If you cannot finish one, hand it over to the next support hero. If you are not sure how serious a finding is, or how to fix it, ask in `#team-security`.
 


### PR DESCRIPTION
## Changes

Follow-up to #20046, which is already merged:

- The security findings service is called **SecurityHog** — both the support hero page and the company security page now say so alongside the security.posthog.dev link.
- Critical and high severity findings must be fixed as soon as possible.

## Why

The service got a name after the first PR merged, and the handbook did not say that severity changes how fast a finding must be fixed.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (n/a — no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08SCAZ52S3/p1788977154450149?thread_ts=1788977154.450149&cid=C08SCAZ52S3)*