### PR TITLE
Fix /teams/team-ben by keeping the /teams wildcard on the [slug] page

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -58,7 +58,9 @@ export const onCreatePage: GatsbyNode['onCreatePage'] = async ({ page, actions }
         page.matchPath = '/next-steps/*'
         createPage(page)
     }
-    if (page.path.match(/^\/teams\//) && !page.path.match(/^\/teams\/new/)) {
+    // Only the [slug] page needs the wildcard. A static page under /teams (/teams/new, /teams/team-ben)
+    // that also claims '/teams/*' loses the tie to [slug] at runtime, and the browser shows that team as missing.
+    if (page.path.match(/^\/teams\//) && page.component.match(/teams[\\/]\[slug\]\.tsx$/)) {
         page.matchPath = '/teams/*'
         createPage(page)
     }


### PR DESCRIPTION
## Changes

`/teams/team-ben` served the correct page, then replaced it with an error a moment later.

`onCreatePage` in `gatsby-node.ts` gave the `/teams/*` match path to every page under `/teams/`, so the static `team-ben` page and the client-only `[slug]` page both claimed the same wildcard. `[slug]` comes first in `match-paths.json`, and @gatsbyjs/reach-router breaks a tie in scores by array order, so `[slug]` won every `/teams` URL. On hydration the browser threw away the server-rendered Ben page, loaded `[slug]`, looked up a team with the slug `team-ben`, found none, and showed the error.

**Why:** the page is unreachable, and any future static page under `/teams/` would break the same way.

The fix gives the wildcard to the `[slug]` page only. Gatsby then adds an exact match path for each static page under `/teams/` (see `getMatchPaths` in `requires-writer`), and an exact path outranks a splat, so the static page wins. This is how `/teams`, `/teams/new`, and `/community/profiles/me` already work. It also removes the need for the `/teams/new` exception, so that exception is gone.

Evidence from the live bundle, before the fix:

```
{ "path": "/teams/new",       "matchPath": "/teams/new" }
{ "path": "/teams",           "matchPath": "/teams" }
{ "path": "/teams/[slug]",    "matchPath": "/teams/*" }   <- wins the tie
{ "path": "/teams/team-ben",  "matchPath": "/teams/*" }
```

No visual change: the Ben page markup is untouched, and the server-rendered HTML of the broken page already shows it in full. Please confirm on the preview build that `/teams/team-ben` stays on screen and that other team pages still route.

I could not install dependencies in my environment, so `pnpm start` and a production build did not run here. `prettier` reports no change to the diff.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C084WK1HU0P/p1788988772196639?thread_ts=1788988772.196639&cid=C084WK1HU0P)*
