### PR TITLE
docs(self-driving): point from a scout's filing methods to Slack delivery

### DIFF
--- a/contents/docs/self-driving/scouts.mdx
+++ b/contents/docs/self-driving/scouts.mdx
@@ -27,6 +27,8 @@ A scout runs on a schedule. Each run, it looks at one slice of your data, decide
 
 For the first two, the bar is the same: a structured finding with the evidence behind it and a suggested action. The difference is whether the scout has already done enough research to stand behind the finding as a single inbox item, or whether the pipeline should consolidate it with others first. Measurements are different: they aren't findings at all, just data, and they skip the inbox entirely.
 
+Those three are about *what* a scout files, not where the output ends up. Reports and signals land in your [inbox](/docs/self-driving/inbox) by default, and any scout can also send what it files to a Slack channel or a direct message – see [sending a scout's output to Slack](#sending-a-scouts-output-to-slack).
+
 A scout is **selective by design**. Holding something back is a decision it makes on purpose, not a gap – most runs close out having found nothing worth your attention, and that's the scout working. If you need every item in a stream handled with no judgement call in between, that's what a [signal source](/docs/self-driving/inbox/sources) is for, and the two are often best run together.
 
 A scout reads your data through the same [PostHog MCP](/docs/model-context-protocol) you can connect to Claude Code or Cursor, so it can see anything in PostHog out of the box – events, [data warehouse](/docs/data-warehouse) tables, insights, dashboards – with nothing to wire up per scout. Because any source you land in PostHog becomes queryable, a scout isn't limited to product analytics: a Slack channel, a billing system, or a support inbox synced to your warehouse is fair game too.


### PR DESCRIPTION
## Changes

One sentence added to **How a scout works**, after the paragraph that explains the three filing methods:

> Those three are about *what* a scout files, not where the output ends up. Reports and signals land in your inbox by default, and any scout can also send what it files to a Slack channel or a direct message – see sending a scout's output to Slack.

**Why.** The three methods in that table (file a report, emit a signal, record structured data) all end in the inbox or in the event stream, and per-scout Slack delivery is only described further down the page. A reader — or an agent — who stops after that table concludes a scout cannot reach Slack. That happened: an agent choosing how to deliver a recurring daily update to a channel eliminated a scout on exactly that reasoning, even though the destination is a supported per-scout setting.

No new capability is documented here; the [Slack section](https://posthog.com/docs/self-driving/scouts#sending-a-scouts-output-to-slack) and the settings-table row already exist. This only signposts them from the place readers form the wrong impression. Two open drafts propose adding that section (#18912, #18944) — the section has since landed on master, so both are superseded and can be closed.

No visual change beyond one paragraph of body text, so no screenshots.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — not done, no browser in this environment; the change is one paragraph of prose with two links whose targets (`/docs/self-driving/inbox` and the on-page `#sending-a-scouts-output-to-slack` heading) both exist in this repo.
- [x] If I moved a page, I added a redirect in `vercel.json` — no page moved.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1789029619162229?thread_ts=1789029619.162229&cid=C09SK2PAGKF)*
