### PR TITLE
feat: add changed pages table to deploy preview comment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -148,6 +148,30 @@ jobs:
               id: timestamp-final
               run: echo "time=$(date -u +'%b %d, %Y %I:%M%p')" >> $GITHUB_OUTPUT
 
+            # Direct links to the pages this PR touched, so reviewers do not have to
+            # navigate to them from the preview root.
+            - name: List changed files
+              if: success()
+              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              with:
+                  script: |
+                      const files = await github.paginate(github.rest.pulls.listFiles, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.payload.pull_request.number,
+                        per_page: 100,
+                      });
+                      require('fs').writeFileSync('changed-files.txt', files.map((f) => f.filename).join('\n'));
+
+            - name: Build preview comment
+              if: success()
+              env:
+                  DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+                  UPDATED_AT: ${{ steps.timestamp-final.outputs.time }}
+                  CHANGED_FILES_PATH: changed-files.txt
+                  COMMENT_PATH: preview-comment.md
+              run: node scripts/preview/build-preview-comment.mjs
+
             - name: Comment on success
               if: success()
               uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
@@ -155,13 +179,7 @@ jobs:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-id: ${{ steps.comment.outputs.comment-id }}
                   edit-mode: replace
-                  body: |
-                      <!-- cloudflare-pages-preview -->
-                      ### Deploy preview
-
-                      | Status | Details | Updated (UTC) |
-                      |--------|---------|---------|
-                      | 🟢 **Ready** | [View preview](${{ steps.deploy.outputs.deployment-url }}) | ${{ steps.timestamp-final.outputs.time }} |
+                  body-path: preview-comment.md
 
             - name: Notify reviewer on successful builds (Inkeep PRs only)
               if: success() && contains(github.event.pull_request.user.login, 'inkeep')

--- a/scripts/preview/build-preview-comment.mjs
+++ b/scripts/preview/build-preview-comment.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Builds the body of the "Deploy preview" PR comment: the status table, plus a table of
+// direct links to the pages this PR touched. Never throws — if the changed-page lookup
+// fails for any reason, the status table still gets written on its own.
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..')
+const publicDir = path.join(repoRoot, 'public')
+
+const MARKER = '<!-- cloudflare-pages-preview -->'
+const PAGE_EXTENSIONS = new Set(['.md', '.mdx'])
+const MAX_ROWS = 25
+
+// contents/docs/foo.mdx -> /docs/foo, contents/docs/foo/index.mdx -> /docs/foo
+function toSlug(file) {
+    if (!file.startsWith('contents/')) {
+        return null
+    }
+    const extension = path.extname(file)
+    if (!PAGE_EXTENSIONS.has(extension)) {
+        return null
+    }
+    const slug = file.slice('contents'.length, -extension.length).replace(/\/index$/, '')
+    return slug === '' ? '/' : slug
+}
+
+// The build output is the source of truth for whether a slug is a real page. It filters out
+// partials, deleted files, and anything the content file does not turn into a page.
+function isBuiltPage(slug) {
+    return fs.existsSync(path.join(publicDir, slug === '/' ? '' : slug, 'index.html'))
+}
+
+function readTitle(file) {
+    try {
+        const frontmatter = fs.readFileSync(path.join(repoRoot, file), 'utf-8').match(/^---\r?\n([\s\S]*?)\r?\n---/)
+        const title = frontmatter?.[1].match(/^title:\s*(.+)$/m)?.[1].trim()
+        return title?.replace(/^['"]|['"]$/g, '').replace(/\|/g, '\\|') || null
+    } catch {
+        return null
+    }
+}
+
+function changedPages(changedFilesPath) {
+    const files = fs
+        .readFileSync(changedFilesPath, 'utf-8')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+    const pages = []
+    for (const file of files) {
+        const slug = toSlug(file)
+        if (slug && isBuiltPage(slug)) {
+            pages.push({ file, slug, title: readTitle(file) })
+        }
+    }
+    return pages.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+function pagesSection(deploymentUrl, changedFilesPath) {
+    if (!deploymentUrl || !changedFilesPath || !fs.existsSync(changedFilesPath)) {
+        return []
+    }
+    const pages = changedPages(changedFilesPath)
+    if (pages.length === 0) {
+        return []
+    }
+    const baseUrl = deploymentUrl.replace(/\/$/, '')
+    const lines = ['', '### Changed pages', '', '| Page | Source |', '| --- | --- |']
+    for (const { file, slug, title } of pages.slice(0, MAX_ROWS)) {
+        lines.push(`| [${title || slug}](${baseUrl}${slug}) | \`${file}\` |`)
+    }
+    if (pages.length > MAX_ROWS) {
+        lines.push('', `_${pages.length - MAX_ROWS} more changed pages are not listed._`)
+    }
+    return lines
+}
+
+function main() {
+    const { DEPLOYMENT_URL, UPDATED_AT, CHANGED_FILES_PATH, COMMENT_PATH } = process.env
+    const outPath = COMMENT_PATH || path.join(repoRoot, 'preview-comment.md')
+    const lines = [
+        MARKER,
+        '### Deploy preview',
+        '',
+        '| Status | Details | Updated (UTC) |',
+        '|--------|---------|---------|',
+        `| 🟢 **Ready** | [View preview](${DEPLOYMENT_URL}) | ${UPDATED_AT} |`,
+    ]
+    fs.writeFileSync(outPath, `${lines.join('\n')}\n`)
+
+    try {
+        const section = pagesSection(DEPLOYMENT_URL, CHANGED_FILES_PATH)
+        if (section.length > 0) {
+            fs.writeFileSync(outPath, `${[...lines, ...section].join('\n')}\n`)
+        }
+    } catch (error) {
+        console.error('Failed to list changed pages:', error)
+    }
+}
+
+main()

--- a/scripts/preview/build-preview-comment.mjs
+++ b/scripts/preview/build-preview-comment.mjs
@@ -37,7 +37,9 @@ function readTitle(file) {
     try {
         const frontmatter = fs.readFileSync(path.join(repoRoot, file), 'utf-8').match(/^---\r?\n([\s\S]*?)\r?\n---/)
         const title = frontmatter?.[1].match(/^title:\s*(.+)$/m)?.[1].trim()
-        return title?.replace(/^['"]|['"]$/g, '').replace(/\|/g, '\\|') || null
+        // Escapes the backslash first (one combined pass), then the characters that would
+        // otherwise break the table cell or the link text.
+        return title?.replace(/^['"]|['"]$/g, '').replace(/[\\|[\]]/g, '\\$&') || null
     } catch {
         return null
     }


### PR DESCRIPTION
## Changes

The deploy preview bot writes one comment with a status table. This PR adds a second table below it: one row for each page that the PR adds or changes, with a direct link into the preview deployment. Reviewers open the changed page with one click, instead of navigating to it from the preview root.

**Why:** it is difficult to find the pages that a PR touches from the preview root, especially in the docs and the handbook.

How it works:

- A new step lists the files of the pull request.
- `scripts/preview/build-preview-comment.mjs` maps each changed `contents/**/*.md(x)` file to its slug, and keeps only the slugs that have an `index.html` in the build output. The build output prevents links to partials, to deleted files, and to files that do not become a page.
- The script writes the full comment body. The status table is written first, thus a failure in the page lookup cannot remove the preview link.
- The table shows a maximum of 25 rows.

Example of the new table:

| Page | Source |
| --- | --- |
| [Feature flags](https://example.pages.dev/docs/feature-flags) | `contents/docs/feature-flags/index.mdx` |

@greptile

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
