### PR TITLE
docs(session-replay): match network capture copy to the current settings UI

### DIFF
--- a/contents/docs/session-replay/_snippets/web-network.mdx
+++ b/contents/docs/session-replay/_snippets/web-network.mdx
@@ -4,21 +4,21 @@ export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/im
 
 PostHog can capture network requests that occur during the browser session, so you can see if your application is sending the expected requests and response, and check the effect of slow network requests or errors on the user experience.
 
-You can enable network recording from your [project settings](https://app.posthog.com/project/settings):
+You can turn on network capture in your [session replay settings](https://app.posthog.com/settings/project-replay#replay-network). Use the **Capture network requests** switch in the **Network capture** section:
 
 <ProductScreenshot
     imageLight={EnableSessionReplayLight} 
     imageDark={EnableSessionReplayDark}
-    alt="Enable network recording in your PostHog" 
+    alt="Turn on network capture in your session replay settings" 
     classes="rounded"
 />
 
-When enabled PostHog always captures:
+When network capture is on, PostHog always captures:
 
-* the network request URL, 
-* [performance information](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry) about the request,
+* the network request URL
+* [performance information](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry) about the request
 
-When request capture is enabled you can also enabled payload and body capture, this includes:
+To capture more than the timings, use the **Header capture** and **Body capture** switches in the **Network headers & payloads** section. These switches add:
 
 * the request method
 * the response code


### PR DESCRIPTION
## Changes

The web tab of [Network performance recording](https://posthog.com/docs/session-replay/network-recording) described a settings page that no longer exists. This PR corrects the text:

- The link now goes to the network capture section of the session replay settings, not the old project settings page.
- The switch names now match the app: **Capture network requests** in the **Network capture** section, and **Header capture** / **Body capture** in the **Network headers & payloads** section.
- Small copy fixes in the same paragraphs ("you can also enabled payload and body capture").

**Why:** a user asked whether the screenshots on this page still show the current UI. They do not — the app moved these switches into the session replay settings and renamed them.

**Screenshot still to do:** the embedded screenshot shows the old project settings page (left sidebar with Project / Organization / User groups, a `Capture network performance` switch, and a `NETWORK PAYLOADS` group). It needs a new capture of the **Network capture** and **Network headers & payloads** sections in light and dark mode. I cannot log in to a PostHog project from this environment to take it, so the image URLs are unchanged in this PR. The same image is also used by the web, Android, iOS, and Flutter installation snippets, so a replacement pair fixes five pages.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07TQR0V16U/p1789047066433209?thread_ts=1789047066.433209&cid=C07TQR0V16U)*