### PR TITLE
docs(proxy): say the managed reverse proxy removes cookies

### DIFF
--- a/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
+++ b/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
@@ -179,6 +179,14 @@ That said, the managed reverse proxy is designed so that **no request content is
 
 Once traffic reaches PostHog, it is ingested into the region you selected (EU or US Cloud). If strict EU-only termination at the edge is a hard requirement for your compliance posture, we recommend setting up a [self-hosted proxy](/docs/advanced/proxy) on infrastructure you control instead.
 
+### Does the managed reverse proxy forward my cookies to PostHog?
+
+No. The managed reverse proxy removes the `Cookie` header from every request before it forwards the request to PostHog. PostHog doesn't need your cookies, because ingestion authenticates with the project token in the request body.
+
+This matters because your proxy runs on a subdomain of your site. Cookies your site sets on the parent domain (for example, `.myapp.com`) also apply to `yoursubdomain.myapp.com`, so the browser can attach them to requests it sends to the proxy. `posthog-js` doesn't send cookies on its regular `fetch` and `XMLHttpRequest` requests. The browser does attach cookies to `sendBeacon` requests, though, and the SDK can use `sendBeacon` to send the last events when a page unloads. The proxy removes those cookies before the request leaves Cloudflare.
+
+To stop the browser from sending a cookie to your proxy at all, set that cookie without a `Domain` attribute or give it the `__Host-` prefix. The browser then sends it only to the exact host that set it.
+
 ### Is the managed reverse proxy HIPAA-compliant?
 
 No. The managed reverse proxy is not HIPAA-compliant and should not be used to process Protected Health Information (PHI). Any Business Associate Agreement (BAA) you have with PostHog does not apply to this feature.

--- a/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
+++ b/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
@@ -183,9 +183,7 @@ Once traffic reaches PostHog, it is ingested into the region you selected (EU or
 
 No. The managed reverse proxy removes the `Cookie` header from every request before it forwards the request to PostHog. PostHog doesn't need your cookies, because ingestion authenticates with the project token in the request body.
 
-This matters because your proxy runs on a subdomain of your site. Cookies your site sets on the parent domain (for example, `.myapp.com`) also apply to `yoursubdomain.myapp.com`, so the browser can attach them to requests it sends to the proxy. `posthog-js` doesn't send cookies on its regular `fetch` and `XMLHttpRequest` requests. The browser does attach cookies to `sendBeacon` requests, though, and the SDK can use `sendBeacon` to send the last events when a page unloads. The proxy removes those cookies before the request leaves Cloudflare.
-
-To stop the browser from sending a cookie to your proxy at all, set that cookie without a `Domain` attribute or give it the `__Host-` prefix. The browser then sends it only to the exact host that set it.
+Your proxy runs on a subdomain of your site, so the browser can send it cookies you set on the parent domain (for example, `.myapp.com`). To keep a cookie away from the proxy entirely, set it without a `Domain` attribute or use the `__Host-` prefix.
 
 ### Is the managed reverse proxy HIPAA-compliant?
 


### PR DESCRIPTION
## Changes

- The managed reverse proxy page does not say whether the proxy forwards browser cookies to PostHog. Customers who run the proxy on a subdomain of their site cannot find out if their own cookies reach us.
- A new FAQ entry says the proxy removes the `Cookie` header before it forwards each request.
- The entry notes that parent-domain cookies can reach the proxy, and how to keep a cookie away from it.
- The claim matches the deployed proxy worker code in both US and EU, which deletes `cookie` on every forwarding path.

Text only. No components or layout change.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`


