### PR TITLE
Tear down ai pricing estimate experiment

### DIFF
--- a/src/components/Pricing/AgentEstimateLink.tsx
+++ b/src/components/Pricing/AgentEstimateLink.tsx
@@ -29,15 +29,6 @@ const ASSISTANTS = [
 /** Matches the inline link treatment used across the pricing page. */
 const DEFAULT_LINK_CLASSES = 'font-semibold text-red dark:text-yellow underline'
 
-// Experiment 450022
-export const AI_PRICING_FLAG = 'ai-pricing'
-
-export const AI_PRICING_EXPERIMENT_VARIANTS = {
-    control: 'control',
-    inside_calculator: 'inside-calculator',
-    outside_calculator: 'outside-calculator',
-} as const
-
 interface AgentEstimateLinkProps {
     /** Which link was clicked, sent with `pricing_ai_estimate_opened`. */
     source: string

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -23,11 +23,7 @@ import { BROWSE_TOOLS_HANDLES } from 'constants/productNavigation'
 import qs from 'qs'
 import { getProductInputs, readProductInputs, priceProductInputs } from './calculatorURL'
 import usePostHog from 'hooks/usePostHog'
-import AgentEstimateLink, {
-    AI_PRICING_EXPERIMENT_VARIANTS,
-    AI_PRICING_FLAG,
-} from 'components/Pricing/AgentEstimateLink'
-import { RenderInClient } from 'components/RenderInClient'
+import AgentEstimateLink from 'components/Pricing/AgentEstimateLink'
 import { useApp } from '../../../context/App'
 import AllProductsRatesModal, { ALL_PRODUCTS_RATES_MODAL_KEY } from './AllProductsRatesModal'
 
@@ -928,18 +924,9 @@ export default function Tabbed() {
                         data-ai-estimate-placement="inside-calculator"
                     >
                         <CopyURLButton onClick={generateURL} />
-                        <RenderInClient
-                            render={() => {
-                                const variant = window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG)
-                                return variant === AI_PRICING_EXPERIMENT_VARIANTS.inside_calculator ? (
-                                    <AgentEstimateLink
-                                        source="calculator-total"
-                                        className="text-sm font-bold text-red dark:text-yellow"
-                                    />
-                                ) : (
-                                    <></>
-                                )
-                            }}
+                        <AgentEstimateLink
+                            source="calculator-total"
+                            className="text-sm font-bold text-red dark:text-yellow"
                         />
                     </div>
                 </div>

--- a/src/components/Pricing/Redesign/CalculatorReveal.tsx
+++ b/src/components/Pricing/Redesign/CalculatorReveal.tsx
@@ -4,11 +4,7 @@ import { motion, useReducedMotion } from 'framer-motion'
 import { Calculator } from 'components/Pricing/Test/Calculator'
 import { scrollToElement } from 'components/ScrollToElement'
 import usePostHog from 'hooks/usePostHog'
-import { RenderInClient } from 'components/RenderInClient'
-import AgentEstimateLink, {
-    AI_PRICING_EXPERIMENT_VARIANTS,
-    AI_PRICING_FLAG,
-} from 'components/Pricing/AgentEstimateLink'
+import AgentEstimateLink from 'components/Pricing/AgentEstimateLink'
 
 const PANEL_ID = 'calculator-panel'
 
@@ -75,26 +71,15 @@ export default function CalculatorReveal(): JSX.Element {
                 >
                     {open ? 'Hide the calculator' : "Calculate what you'd pay past it"}
                 </button>
-                <RenderInClient
-                    render={() => {
-                        return window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG) ===
-                            AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator ? (
-                            <>
-                                {' or '}
-                                <AgentEstimateLink
-                                    source={AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator}
-                                    label="get AI to do it for you"
-                                    popoverText={
-                                        open
-                                            ? `It's probably easier for you to close the calculator yourself... that said, AI can certainly help you estimate your bill. Try it out:`
-                                            : undefined
-                                    }
-                                />
-                            </>
-                        ) : (
-                            <></>
-                        )
-                    }}
+                {' or '}
+                <AgentEstimateLink
+                    source="outside-calculator"
+                    label="get AI to do it for you"
+                    popoverText={
+                        open
+                            ? `It's probably easier for you to close the calculator yourself... that said, AI can certainly help you estimate your bill. Try it out:`
+                            : undefined
+                    }
                 />
             </p>
 

--- a/src/components/Pricing/Redesign/CalculatorSection.tsx
+++ b/src/components/Pricing/Redesign/CalculatorSection.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 import { useLocation } from '@reach/router'
 import { Calculator } from 'components/Pricing/Test/Calculator'
 import { scrollToElement } from 'components/ScrollToElement'
-import AgentEstimateLink from 'components/Pricing/AgentEstimateLink'
 
 /**
  * The pricing calculator as a plain, always-visible section.
@@ -28,9 +27,6 @@ export default function CalculatorSection(): JSX.Element {
         // `my-0` loses to its `mb-12` in Tailwind's cascade regardless of class order, so it
         // takes a child selector to win on specificity.
         <div className="not-prose [&>section]:my-0 [&>section]:px-0">
-            <p className="text-[15px] text-secondary mb-6" data-ai-estimate-placement="outside-calculator">
-                Coming from another tool? <AgentEstimateLink source="outside-calculator" /> using your real usage there.
-            </p>
             <Calculator hideHeader id="" />
         </div>
     )

--- a/src/components/Pricing/Redesign/CalculatorSection.tsx
+++ b/src/components/Pricing/Redesign/CalculatorSection.tsx
@@ -2,11 +2,7 @@ import React, { useEffect } from 'react'
 import { useLocation } from '@reach/router'
 import { Calculator } from 'components/Pricing/Test/Calculator'
 import { scrollToElement } from 'components/ScrollToElement'
-import { RenderInClient } from 'components/RenderInClient'
-import AgentEstimateLink, {
-    AI_PRICING_EXPERIMENT_VARIANTS,
-    AI_PRICING_FLAG,
-} from 'components/Pricing/AgentEstimateLink'
+import AgentEstimateLink from 'components/Pricing/AgentEstimateLink'
 
 /**
  * The pricing calculator as a plain, always-visible section.
@@ -32,20 +28,9 @@ export default function CalculatorSection(): JSX.Element {
         // `my-0` loses to its `mb-12` in Tailwind's cascade regardless of class order, so it
         // takes a child selector to win on specificity.
         <div className="not-prose [&>section]:my-0 [&>section]:px-0">
-            <RenderInClient
-                render={() =>
-                    window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG) ===
-                    AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator ? (
-                        <p className="text-[15px] text-secondary mb-6" data-ai-estimate-placement="outside-calculator">
-                            Coming from another tool?{' '}
-                            <AgentEstimateLink source={AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator} /> using your
-                            real usage there.
-                        </p>
-                    ) : (
-                        <></>
-                    )
-                }
-            />
+            <p className="text-[15px] text-secondary mb-6" data-ai-estimate-placement="outside-calculator">
+                Coming from another tool? <AgentEstimateLink source="outside-calculator" /> using your real usage there.
+            </p>
             <Calculator hideHeader id="" />
         </div>
     )

--- a/src/components/Pricing/Redesign/README.md
+++ b/src/components/Pricing/Redesign/README.md
@@ -2,7 +2,7 @@
 
 Components for the pricing page, served on **`/pricing`**. The page that assembles them is `pages/pricing/index.tsx`.
 
-These components shipped behind the `pricing-page-redesign` experiment. The redesign is now the only pricing page. The calculator is always visible as its own section (`CalculatorSection`). The `ai-pricing` experiment controls the AI estimate entry point: `control` hides it, `inside-calculator` places it beside **Share estimate**, and `outside-calculator` places it above the calculator and in the **Estimating usage** guidance. Unknown or unavailable flag values hide the AI estimate links. The shared `AgentEstimateLink` popover retains the ChatGPT, Claude, and copy-prompt actions and their existing analytics events.
+These components shipped behind the `pricing-page-redesign` experiment. The redesign is now the only pricing page. The calculator is always visible as its own section (`CalculatorSection`). AI estimate links are always available above the calculator, beside **Share estimate**, and in the **Estimating usage** guidance. The shared `AgentEstimateLink` popover retains the ChatGPT, Claude, and copy-prompt actions and their existing analytics events.
 
 ## Why
 

--- a/src/components/Pricing/Redesign/README.md
+++ b/src/components/Pricing/Redesign/README.md
@@ -2,7 +2,7 @@
 
 Components for the pricing page, served on **`/pricing`**. The page that assembles them is `pages/pricing/index.tsx`.
 
-These components shipped behind the `pricing-page-redesign` experiment. The redesign is now the only pricing page. The calculator is always visible as its own section (`CalculatorSection`). AI estimate links are always available above the calculator, beside **Share estimate**, and in the **Estimating usage** guidance. The shared `AgentEstimateLink` popover retains the ChatGPT, Claude, and copy-prompt actions and their existing analytics events.
+These components shipped behind the `pricing-page-redesign` experiment. The redesign is now the only pricing page. The calculator is always visible as its own section (`CalculatorSection`). AI estimate links are always available beside **Share estimate** and in the **Estimating usage** guidance. The shared `AgentEstimateLink` popover retains the ChatGPT, Claude, and copy-prompt actions and their existing analytics events.
 
 ## Why
 

--- a/src/components/Pricing/Test/Calculator.tsx
+++ b/src/components/Pricing/Test/Calculator.tsx
@@ -5,11 +5,7 @@ import Link from 'components/Link'
 import Tooltip from 'components/Tooltip'
 import { graphql, useStaticQuery } from 'gatsby'
 import { IconCode, IconHandMoney, IconRocket } from '@posthog/icons'
-import AgentEstimateLink, {
-    AI_PRICING_EXPERIMENT_VARIANTS,
-    AI_PRICING_FLAG,
-} from 'components/Pricing/AgentEstimateLink'
-import { RenderInClient } from 'components/RenderInClient'
+import AgentEstimateLink from 'components/Pricing/AgentEstimateLink'
 
 // The sidebar sits inside a `not-prose` section, so prose's link styling doesn't reach it and
 // `Link` ships no styles of its own — inline links read as plain text without this. Matches the
@@ -216,24 +212,12 @@ export const Calculator = ({ hideHeader = false, id = 'calculator' }: Calculator
                         <SidebarList>
                             <SidebarListItem>
                                 Not sure what your volume looks like?{' '}
-                                <RenderInClient
-                                    placeholder={<>Add</>}
-                                    render={() =>
-                                        window.posthog?.getFeatureFlag?.(AI_PRICING_FLAG) ===
-                                        AI_PRICING_EXPERIMENT_VARIANTS.outside_calculator ? (
-                                            <>
-                                                <AgentEstimateLink
-                                                    label="Generate an AI estimate"
-                                                    source="pricing-page-estimating-usage"
-                                                />{' '}
-                                                or add
-                                            </>
-                                        ) : (
-                                            <>Add</>
-                                        )
-                                    }
+                                <AgentEstimateLink
+                                    label="Generate an AI estimate"
+                                    source="pricing-page-estimating-usage"
                                 />{' '}
-                                the tracking code to your site and check back in a few days – no credit card required.
+                                or add the tracking code to your site and check back in a few days – no credit card
+                                required.
                             </SidebarListItem>
                             <SidebarListItem>
                                 If something stupid happens and you get an unexpected bill (like if{' '}


### PR DESCRIPTION
## Changes

### New Calc UX
<img width="881" height="705" alt="image" src="https://github.com/user-attachments/assets/739d5533-6424-4bb6-8052-67563081fc91" />

### Old
<img width="883" height="655" alt="image" src="https://github.com/user-attachments/assets/faa2ce2a-3735-4154-9da5-8a5e19900a78" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
