### PR TITLE
docs(handbook): update website and design points of contact

### DIFF
--- a/contents/handbook/brand/approvals.md
+++ b/contents/handbook/brand/approvals.md
@@ -22,7 +22,7 @@ Not everything needs sign-off. Here's a rough guide:
 | Blog post, changelog, tweet                                  | No – but self-check against this guide                    |
 | Product UI copy, tooltips, empty states                      | No – but read out loud before shipping                    |
 
-When in doubt, ask in the `#design-review` Slack channel. Lottie and Cory are, for now, the only people who can approve work or otherwise. 
+When in doubt, ask in the `#design-review` Slack channel. Lottie is, for now, the only person who can approve work or otherwise. 
 
 ## Who owns what
 

--- a/contents/handbook/brand/art-requests.md
+++ b/contents/handbook/brand/art-requests.md
@@ -40,7 +40,7 @@ The Art & Brand Planning board uses automations to keep work moving. Each behavi
 
 To establish a clear connection between the task and the working file, designers will create a frame containing a link to the task. They should then add a link to that frame within the task for easy reference.
 
-Please give **two weeks notice** for new briefs — this is the preferred minimum, and more time is always better. For reference, the team receives roughly 25-30 new art requests a month, so new briefs are rarely picked up the day they land. A **one-week turnaround is only possible for actual emergencies.** If your request is a genuine emergency, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie and/or Daniel.
+Please give **two weeks notice** for new briefs — this is the preferred minimum, and more time is always better. For reference, the team receives roughly 25-30 new art requests a month, so new briefs are rarely picked up the day they land. A **one-week turnaround is only possible for actual emergencies.** If your request is a genuine emergency, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie, Heidi and/or Daniel.
 
 If you need to chase for an update on a request, the best place to do it is a comment on the issue itself, not a Slack DM. Comments keep the context with the brief, notify the assigned artist, and the team triages from the project board.
 

--- a/contents/handbook/brand/art-requests.md
+++ b/contents/handbook/brand/art-requests.md
@@ -40,7 +40,7 @@ The Art & Brand Planning board uses automations to keep work moving. Each behavi
 
 To establish a clear connection between the task and the working file, designers will create a frame containing a link to the task. They should then add a link to that frame within the task for easy reference.
 
-Please give **two weeks notice** for new briefs — this is the preferred minimum, and more time is always better. For reference, the team receives roughly 25-30 new art requests a month, so new briefs are rarely picked up the day they land. A **one-week turnaround is only possible for actual emergencies.** If your request is a genuine emergency, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie, Daniel, and/or [Cory](/community/profiles/30200).
+Please give **two weeks notice** for new briefs — this is the preferred minimum, and more time is always better. For reference, the team receives roughly 25-30 new art requests a month, so new briefs are rarely picked up the day they land. A **one-week turnaround is only possible for actual emergencies.** If your request is a genuine emergency, please share your request issue in [#team-graphics channel](https://posthog.slack.com/archives/C0AU440KS6P) and mention Lottie and/or Daniel.
 
 If you need to chase for an update on a request, the best place to do it is a comment on the issue itself, not a Slack DM. Comments keep the context with the brief, notify the assigned artist, and the team triages from the project board.
 

--- a/contents/handbook/brand/visual-identity.md
+++ b/contents/handbook/brand/visual-identity.md
@@ -174,7 +174,7 @@ PostHog uses three icon styles for different purposes:
 | icons8 sticker pack                         | Stickers and casual contexts |
 | OS-style icons                              | Website desktop              |
 
-Cory cares a little too much about icon glyphs. Icons should be intentional.
+We care a little too much about icon glyphs. Icons should be intentional.
 
 - When an icon is accompanies by a label, the icon should be complimentary.
 - When an icon is used without text, they should be clear enough to stand on their own.

--- a/contents/handbook/community/profiles.mdx
+++ b/contents/handbook/community/profiles.mdx
@@ -19,7 +19,7 @@ We also use data from these profiles in other areas of the site:
 
 ## Creating a profile for a new team member
 
-To reduce the onboarding steps, Lottie or Cory can help create a profile for a new team member. To do this:
+To reduce the onboarding steps, Lottie or the <SmallTeam slug="website" /> can help create a profile for a new team member. To do this:
 
 1. On [posthog.com/questions](http://posthog.com/questions)…
     1. Create an account with their `@posthog.com` email

--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -195,9 +195,9 @@ We mainly use Google Docs to capture internal information like meeting notes or 
 
 Please avoid using presentations for internal use. They are a poor substitute for a discussion on an issue. They lack the depth, and don't add enough context to enable asynchronous work.
 
-When giving a talk which requires a presentation, use [Pitch](https://pitch.com) to build your slides. (It offers more control over design than Google Slides.) They also have a [desktop app](https://pitch.com/download). We don't (yet) have templates configured, but you can draw from existing slides in other presentations - just copy/paste into your own presentation and modify accordingly. If you'd like assistance with slide design (or using Pitch), talk to Cory.
+When giving a talk which requires a presentation, use [Pitch](https://pitch.com) to build your slides. (It offers more control over design than Google Slides.) They also have a [desktop app](https://pitch.com/download). We don't (yet) have templates configured, but you can draw from existing slides in other presentations - just copy/paste into your own presentation and modify accordingly. If you'd like assistance with slide design (or using Pitch), ask in the `#team-graphics` Slack channel.
 
-James (H) and Cory are admins on the Pitch account. Because Pitch charges per seat, we remove users who only need periodic access but can easily re-add when needed.
+James (H) is an admin on the Pitch account. Because Pitch charges per seat, we remove users who only need periodic access but can easily re-add when needed.
 
 ### Email
 

--- a/contents/handbook/content/newsletter.md
+++ b/contents/handbook/content/newsletter.md
@@ -72,7 +72,7 @@ These aren’t rules, just things that have worked well in the past. They provid
 
 - **Be opinionated:** Sitting on the fence isn't interesting. It's ok for people to disagree with you, so avoid too much hedging.
 
-- **Use graphics and charts:** These are great ways for explaining complex ideas and make for great social content. Create bad version and ask Cory to help you make it better.
+- **Use graphics and charts:** These are great ways for explaining complex ideas and make for great social content. Create bad version and ask the <SmallTeam slug="graphics" /> to help you make it better.
 
 - **Be fun and lighthearted:** We're writing about building software, not internet safety. Throw in jokes and memes occasionally. Again, footnotes and captions can be useful here.
 

--- a/contents/handbook/content/posthog-style-guide.md
+++ b/contents/handbook/content/posthog-style-guide.md
@@ -198,7 +198,7 @@ When [embedding YouTube videos](/handbook/engineering/posthog-com/markdown#embed
 
 #### Wistia
 
-<TeamMember name="Cory Watilo" photo /> or <TeamMember name="Jordo Dibb" photo /> can upload videos to Wistia. It's best to also have a thumbnail image which can be uploaded to Wistia as well. Videos can be embedded on the site using our <a href="/handbook/engineering/posthog-com/markdown#embedding-wistia-videos">Wistia component</a>.
+<TeamMember name="Jordo Dibb" photo /> can upload videos to Wistia. It's best to also have a thumbnail image which can be uploaded to Wistia as well. Videos can be embedded on the site using our <a href="/handbook/engineering/posthog-com/markdown#embedding-wistia-videos">Wistia component</a>.
 
 ### Best practices for images and videos
 

--- a/contents/handbook/engineering/posthog-com/add-team-member.mdx
+++ b/contents/handbook/engineering/posthog-com/add-team-member.mdx
@@ -36,6 +36,6 @@ Once notified in `#portraits` that the illustration is ready...
 
 ## Notes
 
-- If the new team member lives in a country we haven't hired from before, we'll need to add a new flag sticker for their country. Ask <TeamMember name="Cory Watilo" photo /> to do this.
+- If the new team member lives in a country we haven't hired from before, we'll need to add a new flag sticker for their country. Ask the <SmallTeam slug="website" /> in the `#posthogdotcom` Slack channel to do this.
 - We'll use the team member's public photo by default
 - They have an option to ask the <SmallTeam slug="website" /> to use a different photo, but if they don't, we'll roll with the public photo

--- a/contents/handbook/engineering/posthog-com/markdown.mdx
+++ b/contents/handbook/engineering/posthog-com/markdown.mdx
@@ -893,13 +893,13 @@ Private links will always open in a new browser tab.
 
 ## Mention a team member
 
-Use this component to mention a team member in a post. It will link to their community profile and appears like this: <TeamMember name="Cory Watilo" />
+Use this component to mention a team member in a post. It will link to their community profile and appears like this: <TeamMember name="Eli Kinsey" />
 
 ```
-<TeamMember name="Cory Watilo" />
+<TeamMember name="Eli Kinsey" />
 ```
 
-There's also a `photo` parameter which will inline their photo next to their name like this: <TeamMember name="Cory Watilo" photo />
+There's also a `photo` parameter which will inline their photo next to their name like this: <TeamMember name="Eli Kinsey" photo />
 
 ## Mention a small team
 

--- a/contents/handbook/engineering/posthog-com/overview.mdx
+++ b/contents/handbook/engineering/posthog-com/overview.mdx
@@ -8,7 +8,7 @@ If you're new here, you might be interested in reading <Link href="/blog/why-os"
 
 | What | Who |
 | ---------------------- | ---------------------------------------------------------------------------- |
-| Design & copy | <TeamMember name="Cory Watilo" photo /> |
+| Design & copy | <SmallTeam slug="website" /> |
 | Technical architecture | <TeamMember name="Eli Kinsey" photo /> |
 | Graphic design | <TeamMember name="Lottie Coxon" photo /> |
 | Docs | <SmallTeam slug="wizard-and-docs" /> |

--- a/contents/handbook/engineering/posthog-com/presentations.mdx
+++ b/contents/handbook/engineering/posthog-com/presentations.mdx
@@ -12,7 +12,7 @@ They can be used to tailor content for:
 -   the needs of a specific company
 -   an individual
 
-> This is an MVP and ultimately needs to be refactored a bit. Check with <TeamMember name="Cory Watilo" /> if you'd like to use this feature.
+> This is an MVP and ultimately needs to be refactored a bit. Check with the <SmallTeam slug="website" /> if you'd like to use this feature.
 
 The example below shows a presentation that is personalized for a particular company and includes the person within PostHog assigned to that account.
 

--- a/contents/handbook/marketing/index.md
+++ b/contents/handbook/marketing/index.md
@@ -106,7 +106,7 @@ Beyond PostHog's company [mission and strategy](/handbook/why-does-posthog-exist
 
 - **Paid ads:** We run a lot of paid ads on Google and others. It is fuel for everything else we are doing. We want to be good at this, but do it in a way unique to PostHog. We're not throwing everything at the wall and seeing what sticks. We have a minimum brand bar we need to hit.
 
-- **Graphics:** We're not the most visually focused team, but creating visuals and animations is a great way to communicate complex ideas. They also make for excellent content. Create a basic version and get the design pros (Cory, Lottie) to help.
+- **Graphics:** We're not the most visually focused team, but creating visuals and animations is a great way to communicate complex ideas. They also make for excellent content. Create a basic version and get the design pros on the <SmallTeam slug="graphics" /> to help.
 
 - **Developer influencers:** We [sponsor creators](/handbook/marketing/influencers) like Theo and Fireship to drive awareness and signups to PostHog. Many of the influencers we sponsor don't work out, but the ones that work drive great results. 
 

--- a/contents/handbook/marketing/ownership.md
+++ b/contents/handbook/marketing/ownership.md
@@ -100,13 +100,13 @@ Speak to <TeamMember name="Joe Martin" />, <TeamMember name="Cleo Lant" />, or <
 <details>
 <summary>A customer has an issue with merch</summary>
 
-Please share in the #merch channel. <TeamMember name="Kendal Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
+Please share in the #merch channel. <TeamMember name="Kendal Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Eli Kinsey" /> and <TeamMember name="Ian Matson" /> own the storefront.
 </details>
 
 <details>
 <summary>I have a question / problem / suggestion for the website</summary>
 
-The website is owned by <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" />. Generally, the best place to ask is the `#posthogdotcom` Slack channel.
+The website is owned by <TeamMember name="Eli Kinsey" /> and <TeamMember name="Ian Matson" />. Generally, the best place to ask is the `#posthogdotcom` Slack channel.
 
 For larger pieces of work — a new product page, a significant copy overhaul — read [Working with the website team](/handbook/marketing/working-with-website) for the process to follow.
 </details>

--- a/contents/handbook/marketing/working-with-website.md
+++ b/contents/handbook/marketing/working-with-website.md
@@ -6,7 +6,9 @@ showTitle: true
 
 The website is owned by <TeamMember name="Eli Kinsey" /> and <TeamMember name="Ian Matson" />. For general questions or quick updates, the best place to start is the `#posthogdotcom` Slack channel.
 
-For most pieces of work, like blog posts and copy updates, you can ship without needing a review from the website team. However, for larger pieces of work — a new product page, a significant copy overhaul, a new landing page — there's a more structured process to follow.
+Before you make a change, read [Should I open an issue or a PR?](/handbook/engineering/posthog-com/issue-or-pr). It is the full guidance on which changes you can ship yourself and which ones the website team builds. In short: content changes go in a pull request, everything else goes in an issue.
+
+For larger pieces of work — a new product page, a significant copy overhaul, a new landing page — there's a more structured process to follow.
 
 > **Why can't I vibecode?** You can, but vibecoded stuff tends to be harder for the website team to review and has a tendency to not work well with some existing systems.
 
@@ -18,7 +20,7 @@ Start with words, not designs. Write out the full copy, structure, and any speci
 
 **2. Submit it to the website team as a GitHub issue**
 
-Open an issue in the [posthog.com repo](https://github.com/PostHog/posthog.com) using the Website Request template and link your Google Doc. Include:
+Open an issue in the [posthog.com repo](https://github.com/PostHog/posthog.com) using the [website request template](https://github.com/PostHog/posthog.com/issues/new?template=website-request.md) and link your Google Doc. Include:
 
 - A brief description of what you're trying to achieve and why
 - A link to your Google Doc 
@@ -33,7 +35,7 @@ Once the issue is picked up, the website team will build the page. They'll open 
 
 Review the PR, leave comments, and iterate from there. This is the right moment to give design and layout feedback — not before, when things are still just ideas.
 
-> **Curious about your request?** The [website project board](https://github.com/orgs/PostHog/projects/195/) tracks all their tasks. 
+> **Curious about your request?** Issues get triaged onto the [website project board](https://github.com/orgs/PostHog/projects/131), which tracks all of the team's tasks. 
 
 ## Why this process
 

--- a/contents/handbook/marketing/working-with-website.md
+++ b/contents/handbook/marketing/working-with-website.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-The website is owned by <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" />. For general questions or quick updates, the best place to start is the `#posthogdotcom` Slack channel.
+The website is owned by <TeamMember name="Eli Kinsey" /> and <TeamMember name="Ian Matson" />. For general questions or quick updates, the best place to start is the `#posthogdotcom` Slack channel.
 
 For most pieces of work, like blog posts and copy updates, you can ship without needing a review from the website team. However, for larger pieces of work — a new product page, a significant copy overhaul, a new landing page — there's a more structured process to follow.
 

--- a/contents/handbook/people/hiring-process/design-hiring.md
+++ b/contents/handbook/people/hiring-process/design-hiring.md
@@ -31,7 +31,7 @@ This is our standard first round culture interview with the People & Ops team.
 
 The [technical interview](/handbook/people/hiring-process#interview-2) round is a 2-part interview, lasting up to 90 minutes in total.
 
-The first half of the interview will be with the hiring manager and 1 or 2 team members, and it will focus on your Product and Design thinking. You can expect questions around your typical design process and how you prioritize. 
+The first half of the interview will be with the team lead and 1 or 2 team members, and it will focus on your Product and Design thinking. You can expect questions around your typical design process and how you prioritize. 
 
 The second part of the interview will be a portfolio interview, where you will meet a few other members of the team. You will present a deep dive into your portfolio, covering the end-to-end process from strategy to design to impact.
 
@@ -41,7 +41,7 @@ The final stage of our interview process is the PostHog [SuperDay](/handbook/peo
 
 A Design SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences):_
 
-*   Kick-off session with the hiring manager
+*   Kick-off session with the team lead
 *   Meet the founders - Tim and James
 *   Time to focus on the task - we can provide support via your personal Slack channel
 *   On days when we have company wide meetings, we will invite you along to that and give you a chance to introduce yourself. On days without company-wide meetings, we will arrange for you to meet a few members of our team for a casual lunch/coffee break

--- a/contents/handbook/people/hiring-process/design-hiring.md
+++ b/contents/handbook/people/hiring-process/design-hiring.md
@@ -31,7 +31,7 @@ This is our standard first round culture interview with the People & Ops team.
 
 The [technical interview](/handbook/people/hiring-process#interview-2) round is a 2-part interview, lasting up to 90 minutes in total.
 
-The first half of the interview will be with [Cory](/cory) and 1 or 2 team members, and it will focus on your Product and Design thinking. You can expect questions around your typical design process and how you prioritize. 
+The first half of the interview will be with the hiring manager and 1 or 2 team members, and it will focus on your Product and Design thinking. You can expect questions around your typical design process and how you prioritize. 
 
 The second part of the interview will be a portfolio interview, where you will meet a few other members of the team. You will present a deep dive into your portfolio, covering the end-to-end process from strategy to design to impact.
 
@@ -41,7 +41,7 @@ The final stage of our interview process is the PostHog [SuperDay](/handbook/peo
 
 A Design SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences):_
 
-*   Kick-off session with [Cory](/cory)(Lead Designer)
+*   Kick-off session with the hiring manager
 *   Meet the founders - Tim and James
 *   Time to focus on the task - we can provide support via your personal Slack channel
 *   On days when we have company wide meetings, we will invite you along to that and give you a chance to introduce yourself. On days without company-wide meetings, we will arrange for you to meet a few members of our team for a casual lunch/coffee break


### PR DESCRIPTION
## Changes

A former team member is still listed as the DRI or point of contact on several handbook pages. This updates those pages to the current owners, so readers contact people who can help.

- Website and merch storefront ownership now says Eli Kinsey and Ian Matson ([working with the website team](/handbook/marketing/working-with-website), [ownership](/handbook/marketing/ownership)).
- Requests that go to a team, not a person, now point at the Website Team or Team Graphics (add a team member, presentations, community profiles, newsletter graphics, marketing graphics, Pitch slide design).
- Design hiring rounds now say "the hiring manager".
- Component examples in the markdown guide use a current team member.
- "Working with the website team" now links to [Should I open an issue or a PR?](/handbook/engineering/posthog-com/issue-or-pr), which holds the current guidance. It also links the website request template and uses the same project board as that page, which removes a contradiction.

History stays as it is. Quotes, blog posts, the Dive Club interview link, and the credits page keep their original attribution.

Two lines need a check from a human, because the replacement owner is not documented anywhere:
- `brand/approvals.md` now says Lottie is the only approver.
- `company/communication.md` now says James (H) is the Pitch account admin.

Content-only change: no components changed, so there is nothing visual to screenshot. Prettier does not run on Markdown in this repo, and the dev server was not started because `node_modules` is not installed in this environment.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B4Q92EZGD/p1789050738396639)*