### PR TITLE
test: check the deploy preview changed pages table (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,5 @@ We <3 contributions big and small. In priority order (although everything is app
     - Read more [detailed instructions in our manual](https://posthog.com/handbook/engineering/posthog-com/developing-the-website)
     - For basic edits, go to the file in GitHub and click the edit button (pencil icon)
 - Open [an issue](https://github.com/PostHog/posthog.com/issues/new) or [content idea](https://github.com/PostHog/posthog.com/issues/new?assignees=andyvan-ph&labels=content&template=blog-post-idea-template.md&title=%7BContent+type%7D+-+%7Btitle%7D)
+
+<!-- Test edit: a file out of contents/ must not get a row. Do not merge. -->

--- a/contents/_includes/example-table.mdx
+++ b/contents/_includes/example-table.mdx
@@ -9,3 +9,5 @@
 | Multivariate testing        | <Check color="red" />                 | <Check />        |
 | Data warehouse integrations | <Check color="red" />                 | <Close />        |
 | Ad-blocker resistant        | <Check color="red" />                 | <Close />        |
+
+{/* Test edit: a partial has no page of its own, thus it must not get a row. Do not merge. */}

--- a/contents/docs/feature-flags/index.mdx
+++ b/contents/docs/feature-flags/index.mdx
@@ -111,3 +111,5 @@ Your flags are a [signal source](/docs/self-driving/inbox/sources) for [Self-dri
 Most flag findings go to a human rather than a pull request – whether a dead flag check was deliberate cleanup or a broken deploy is a judgment call, so the report lands in your inbox with no repository attached. Only the obvious code changes, like removing the dead check behind a ghost flag, auto-open a draft PR for you to review and merge.
 
 You create and roll out flags in the [PostHog web app](/docs/feature-flags/surfaces/web-app), and review the Self-driving work in [PostHog Desktop](/docs/feature-flags/surfaces/desktop) or the [Self-driving inbox](/docs/self-driving/inbox). See the [Self-driving docs](/docs/self-driving) for the full picture.
+
+{/* Test edit for the deploy preview "Changed pages" table. Do not merge. */}

--- a/contents/docs/glossary.mdx
+++ b/contents/docs/glossary.mdx
@@ -376,3 +376,5 @@ Year-on-Year. Normally this is used to track your performance from one year to t
 ## Z 
 
 > We couldn't think of anything which begins with a Z. If you can think of something which should go here, let us know by [making a GitHub issue](https://github.com/PostHog) or join [our community page](/posts).
+
+{/* Test edit for the deploy preview "Changed pages" table. Do not merge. */}


### PR DESCRIPTION
## Changes

**Do not merge. Do not review.** This pull request is a test of the "Changed pages" table that [#20063](https://github.com/PostHog/posthog.com/pull/20063) added to the deploy preview comment. Close it after the check.

It adds a hidden comment to four files. The comments make no visible change to any page.

**Why:** the table is built in GitHub Actions from the file list of the pull request and from the build output. Only a real pull request can show that it works.

What each file checks:

| File | Expected result |
| --- | --- |
| `contents/docs/feature-flags/index.mdx` | A row that links to `/docs/feature-flags` (the folder index slug form) |
| `contents/docs/glossary.mdx` | A row that links to `/docs/glossary` (the flat file slug form) |
| `contents/_includes/example-table.mdx` | No row. A partial has no page of its own. |
| `README.md` | No row. The file is out of `contents/`. |

Both rows must show the frontmatter title ("Feature flags" and "Glossary"), not the slug.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
