### PR TITLE
fix: measure scroll depth against the window scroll root

### DIFF
--- a/gatsby/onPreBootstrap.ts
+++ b/gatsby/onPreBootstrap.ts
@@ -70,6 +70,11 @@ posthog.init("${process.env.GATSBY_POSTHOG_API_KEY}", {
     ui_host: "${process.env.GATSBY_POSTHOG_UI_HOST}",
     ${assetHostConfig}capture_pageview: false,
     capture_pageleave: true,
+    // A windowed page scrolls inside its app window, not the document, so the default
+    // document scroll root reports "100% scrolled" for everyone. ScrollArea marks the
+    // viewport with data-scroll-root while that viewport is what scrolls, and 'html'
+    // keeps the default behavior for a page that scrolls the document instead.
+    scroll_root_selector: ['[data-scroll-root]', 'html'],
     persistence: 'localStorage+cookie',
     cookie_persisted_properties: ['prod_interest'],
     uuid_version:'v7',

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -110,7 +110,7 @@ type EditorActionButton = {
 }
 
 const ScrollWrapper = ({ scrollable, children }: { scrollable: boolean; children: React.ReactNode }) =>
-    scrollable ? <ScrollArea>{children}</ScrollArea> : <>{children}</>
+    scrollable ? <ScrollArea isScrollRoot>{children}</ScrollArea> : <>{children}</>
 
 const contentWidthOptions: ToggleOption[] = [
     {

--- a/src/components/RadixUI/ScrollArea.tsx
+++ b/src/components/RadixUI/ScrollArea.tsx
@@ -37,6 +37,8 @@ interface ScrollAreaProps {
     fadeX?: boolean
     style?: React.CSSProperties
     fullWidth?: boolean
+    /** Marks this viewport as the page's scroll root, so posthog-js measures scroll depth against it. */
+    isScrollRoot?: boolean
     viewportClasses?: string
     /** Ref to the scrolling viewport node — e.g. to persist/restore scroll position. */
     viewportRef?: React.Ref<HTMLDivElement>
@@ -50,6 +52,7 @@ const ScrollArea = ({
     fadeX = false,
     style,
     fullWidth = false,
+    isScrollRoot = false,
     viewportClasses = '',
     viewportRef,
 }: ScrollAreaProps) => {
@@ -65,11 +68,14 @@ const ScrollArea = ({
         }
     }, [scrollbars])
 
+    const scrollRootRef = React.useRef<HTMLDivElement | null>(null)
+
     // The horizontal fade needs its own ref on the viewport while still
     // honouring any `viewportRef` the caller passed.
     const setViewportRef = React.useCallback(
         (node: HTMLDivElement | null) => {
             fadeRef.current = node
+            scrollRootRef.current = node
             if (typeof viewportRef === 'function') {
                 viewportRef(node)
             } else if (viewportRef) {
@@ -79,6 +85,31 @@ const ScrollArea = ({
         },
         [viewportRef]
     )
+
+    // posthog-js measures scroll depth against the first element matching its
+    // `scroll_root_selector` and does no scrollability check of its own. A page renders
+    // either windowed (this viewport scrolls) or full page (the document scrolls), so only
+    // claim the marker while this viewport is the element that actually scrolls.
+    React.useEffect(() => {
+        const node = scrollRootRef.current
+        if (!isScrollRoot || !node) return
+
+        const sync = () => {
+            if (node.scrollHeight > node.clientHeight) {
+                node.setAttribute('data-scroll-root', '')
+            } else {
+                node.removeAttribute('data-scroll-root')
+            }
+        }
+
+        sync()
+        const observer = new ResizeObserver(sync)
+        observer.observe(node)
+        if (node.firstElementChild) {
+            observer.observe(node.firstElementChild)
+        }
+        return () => observer.disconnect()
+    }, [isScrollRoot, children])
 
     return (
         <RadixScrollArea.Root

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -1674,6 +1674,7 @@ function ReaderViewContent({
                     <div className="flex flex-1 min-h-0">
                         <ScrollArea
                             dataScheme="primary"
+                            isScrollRoot
                             className="flex-1 min-w-0 min-h-0 relative [mask-image:linear-gradient(to_bottom,transparent_0,black_2rem,black_calc(100%_-_2rem),transparent_100%)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_1rem,black_calc(100%_-_1rem),transparent_100%)]"
                         >
                             <article


### PR DESCRIPTION
## Changes

Scroll depth on posthog.com is measured against the wrong element, so the data it produces is not usable.

Pages open in an app window, and that window scrolls its own viewport. The document behind it does not scroll. posthog-js measures scroll depth against the document scroll root by default, so almost every page-leave on the homepage reports a full 100% scroll depth with a one-pixel scroll. Heatmap scroll depth reads the same measurement and has the same problem. As a result, we cannot tell a visitor who landed and read the page from a visitor who landed and left.

This change points the SDK at the element that scrolls:

- `ScrollArea` accepts an `isScrollRoot` prop. It puts a `data-scroll-root` attribute on its viewport, but only while that viewport is the element that actually scrolls. A `ResizeObserver` keeps the attribute in sync as content and window size change. This matters because posthog-js takes the first element that matches the selector and does no scrollability check of its own. A page that scrolls the document instead must not offer it a viewport that never moves.
- The `Editor` and `ReaderView` templates set `isScrollRoot` on the viewport that holds their content. Together they cover the homepage, docs, handbook, blog, tutorials, and customer pages.
- The generated SDK config sets `scroll_root_selector: ['[data-scroll-root]', 'html']`. The `html` fallback keeps today's behavior for a page that has no marked viewport, such as a `Presentation` page or a page that scrolls the document.

No visual change: the diff adds one data attribute and one SDK option, and changes no styles or layout.

### Why

Someone asked in Slack whether we can separate "landed on the homepage and clicked" from "landed on the homepage and scrolled". Clicks are available through autocapture. Scroll depth is captured, but the recorded value is a constant, so the second half of the question cannot be answered until the measurement is fixed.

### Verification

Checked on the dev server with a current Chromium (the bundled puppeteer Chromium is too old to support the `dvh` units the window shell needs, and it renders a document-scrolling page that does not occur in a real browser):

- `/`, `/customers`, and `/docs/feature-flags` at 1400px: exactly one marked scroll root, it holds the page content, it scrolls, and the document does not.
- `/` at 375px and 1024px: same result.
- The old Chromium case, where the document scrolls instead: the marker is correctly absent, so the SDK falls back to `html`.
- No new console errors. The dev server reports a pre-existing 404 for `/framework.js` and pre-existing SVG attribute warnings on all of these pages.

`pnpm format` was run on the changed files.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — checked on a local dev server (see Verification); the preview build still needs a look
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no page moved

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1789051455632489)*
