### PR TITLE
docs: optimizing queries steps and hourly rate limit note

### DIFF
--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -234,7 +234,48 @@ SELECT *
 FROM ca_events
 ```
 
-### 4. Name your queries for easier debugging
+### 4. Use `PREWHERE` to filter before wide columns are read
+
+Reading a property decodes the whole `properties` value for every row the query touches. A `WHERE` condition runs after that decode, even when it sits inside the subquery that does the scan. If you can express a selective filter on a real column of the `events` table, put it in `PREWHERE` so only matching rows are decoded.
+
+```sql
+-- ❌ Decodes properties for every event in the range, then filters
+WITH cohort AS (
+    SELECT DISTINCT $group_0 AS org FROM events
+    WHERE event = 'signed up' AND timestamp >= now() - INTERVAL 7 DAY
+),
+plans AS (
+    SELECT $group_0 AS org, argMin(properties.plan, timestamp) AS plan
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 7 DAY
+    GROUP BY $group_0
+)
+SELECT plan, count() FROM plans
+WHERE org IN (SELECT org FROM cohort)
+GROUP BY plan
+
+-- ✅ Decodes properties only for events from the cohort
+WITH cohort AS (
+    SELECT DISTINCT $group_0 AS org FROM events
+    WHERE event = 'signed up' AND timestamp >= now() - INTERVAL 7 DAY
+),
+plans AS (
+    SELECT $group_0 AS org, argMin(properties.plan, timestamp) AS plan
+    FROM events
+    PREWHERE $group_0 IN (SELECT org FROM cohort)
+    WHERE timestamp >= now() - INTERVAL 7 DAY
+    GROUP BY $group_0
+)
+SELECT plan, count() FROM plans GROUP BY plan
+```
+
+On a day of our own events, the second version read 6x fewer bytes and used 5x less CPU than the first. A few things to know:
+
+- `PREWHERE` only accepts real columns of `events`, such as `event`, `distinct_id`, `timestamp`, and `$group_0` through `$group_4`. `person_id` is not allowed because it is resolved through a join.
+- Moving the filter into the subquery's `WHERE` is not the same thing. ClickHouse still decodes the wide column for every row first, so bytes read stay the same and memory can go up.
+- It only helps when the filter skips most of the data. A filter that matches nearly every row costs extra: it adds a pass over the data, the `IN (...)` subquery is an extra scan, and writing `PREWHERE` yourself turns off ClickHouse's automatic `PREWHERE` for your remaining `WHERE` conditions. Compare bytes read under the results in the SQL editor, or in the [`query_log` table](/docs/data/query-log), before and after.
+
+### 5. Name your queries for easier debugging
 
 Always provide a meaningful `name` parameter for your queries. This helps you:
 
@@ -255,7 +296,7 @@ Bad names are generic and vague:
 - `test`
 - `data`
 
-### 5. Use keyset pagination instead of OFFSET
+### 6. Use keyset pagination instead of OFFSET
 
 `OFFSET` pagination is **not supported** for programmatic requests on `/query` and is currently rejected with HTTP 400 for personal API keys. If you're paginating to export data, **stop and use [batch exports](/docs/cdp/batch-exports) instead** – `/query` is not a supported export path.
 
@@ -271,6 +312,6 @@ SELECT * FROM events WHERE timestamp > '2024-01-01 12:34:56.789'
 ORDER BY timestamp LIMIT 1000;
 ```
 
-### 6. Other SQL optimizations
+### 7. Other SQL optimizations
 
-Options 1-5 make the most difference, but other generic SQL optimizations work too. See our [SQL docs](/docs/data-warehouse/sql) for commands, useful functions, and more to help you with this.
+Options 1-6 make the most difference, but other generic SQL optimizations work too. See our [SQL docs](/docs/data-warehouse/sql) for commands, useful functions, and more to help you with this.

--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -239,7 +239,7 @@ FROM ca_events
 Reading a property decodes the whole `properties` value for every row the query touches. A `WHERE` condition runs after that decode, even when it sits inside the subquery that does the scan. If you can express a selective filter on a real column of the `events` table, put it in `PREWHERE` so only matching rows are decoded.
 
 ```sql
--- ❌ Decodes properties for every event in the range, then filters
+-- Slow: decodes properties for every event in the range, then filters
 WITH cohort AS (
     SELECT DISTINCT $group_0 AS org FROM events
     WHERE event = 'signed up' AND timestamp >= now() - INTERVAL 7 DAY
@@ -254,7 +254,7 @@ SELECT plan, count() FROM plans
 WHERE org IN (SELECT org FROM cohort)
 GROUP BY plan
 
--- ✅ Decodes properties only for events from the cohort
+-- Fast: decodes properties only for events from the cohort
 WITH cohort AS (
     SELECT DISTINCT $group_0 AS org FROM events
     WHERE event = 'signed up' AND timestamp >= now() - INTERVAL 7 DAY
@@ -269,7 +269,31 @@ plans AS (
 SELECT plan, count() FROM plans GROUP BY plan
 ```
 
-### 5. Name your queries for easier debugging
+### 5. Look up people in the `persons` table, not through `events`
+
+Every event carries its person's properties, so it is tempting to fetch one person by filtering `events`. Without a time range, that scans the person's entire event history to return a single row, and a backend that does it per request can read petabytes a day.
+
+```sql
+-- Slow: scans every event the person ever sent
+SELECT any(person.properties) AS properties
+FROM events
+WHERE person.id = '<person_id>'
+
+-- Fast: reads one row from persons
+SELECT properties
+FROM persons
+WHERE id = '<person_id>'
+```
+
+If you have a distinct ID instead of a person ID, resolve it through `person_distinct_ids` and keep the filter on `persons.id`:
+
+```sql
+SELECT properties
+FROM persons
+WHERE id IN (SELECT person_id FROM person_distinct_ids WHERE distinct_id = '<distinct_id>')
+```
+
+### 6. Name your queries for easier debugging
 
 Always provide a meaningful `name` parameter for your queries. This helps you:
 
@@ -290,7 +314,7 @@ Bad names are generic and vague:
 - `test`
 - `data`
 
-### 6. Use keyset pagination instead of OFFSET
+### 7. Use keyset pagination instead of OFFSET
 
 `OFFSET` pagination is **not supported** for programmatic requests on `/query` and is currently rejected with HTTP 400 for personal API keys. If you're paginating to export data, **stop and use [batch exports](/docs/cdp/batch-exports) instead** – `/query` is not a supported export path.
 
@@ -306,6 +330,6 @@ SELECT * FROM events WHERE timestamp > '2024-01-01 12:34:56.789'
 ORDER BY timestamp LIMIT 1000;
 ```
 
-### 7. Other SQL optimizations
+### 8. Other SQL optimizations
 
-Options 1-6 make the most difference, but other generic SQL optimizations work too. See our [SQL docs](/docs/data-warehouse/sql) for commands, useful functions, and more to help you with this.
+Options 1-7 make the most difference, but other generic SQL optimizations work too. See our [SQL docs](/docs/data-warehouse/sql) for commands, useful functions, and more to help you with this.

--- a/contents/docs/_snippets/optimal-queries.mdx
+++ b/contents/docs/_snippets/optimal-queries.mdx
@@ -269,12 +269,6 @@ plans AS (
 SELECT plan, count() FROM plans GROUP BY plan
 ```
 
-On a day of our own events, the second version read 6x fewer bytes and used 5x less CPU than the first. A few things to know:
-
-- `PREWHERE` only accepts real columns of `events`, such as `event`, `distinct_id`, `timestamp`, and `$group_0` through `$group_4`. `person_id` is not allowed because it is resolved through a join.
-- Moving the filter into the subquery's `WHERE` is not the same thing. ClickHouse still decodes the wide column for every row first, so bytes read stay the same and memory can go up.
-- It only helps when the filter skips most of the data. A filter that matches nearly every row costs extra: it adds a pass over the data, the `IN (...)` subquery is an extra scan, and writing `PREWHERE` yourself turns off ClickHouse's automatic `PREWHERE` for your remaining `WHERE` conditions. Compare bytes read under the results in the SQL editor, or in the [`query_log` table](/docs/data/query-log), before and after.
-
 ### 5. Name your queries for easier debugging
 
 Always provide a meaningful `name` parameter for your queries. This helps you:

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -296,7 +296,7 @@ Some customers haven't been migrated to the above limit and are on an old limit 
 
 Queries made with a personal API key draw from an hourly read budget per project, and every query debits the bytes it read. The budget refills at 20 GB per hour for projects on the free plan and 200 GB per hour for projects in an organization with a paid plan, and unused budget accumulates for up to 24 hours (480 GB and 4.8 TB).
 
-Once it is exhausted, queries return a `429` response with the code `api_queries_budget_exceeded` and a `Retry-After` header. The wait is never longer than an hour. Every `/query` response made with a personal API key includes `X-PostHog-Query-Bytes-Read` and `X-PostHog-Query-Budget-Remaining-Bytes`; for asynchronous queries, the same headers arrive on the poll response once the query completes.
+Once it is exhausted, queries return a `429` response with the code `api_queries_budget_exceeded` and a `Retry-After` header. Every `/query` response made with a personal API key includes `X-PostHog-Query-Bytes-Read` and `X-PostHog-Query-Budget-Remaining-Bytes`; for asynchronous queries, the same headers arrive on the poll response once the query completes.
 
 Cached results still work while the budget is exhausted. Queries made in the PostHog app are not affected.
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -292,13 +292,15 @@ If the project's concurrency quota is exhausted, we put the query in queue and w
 Some customers haven't been migrated to the above limit and are on an old limit of 120 queries/hour.
 </CalloutBox>
 
-### Free plan data limit
+### Hourly read budget
 
-Organizations without a paid plan can read up to 50 TB of data per calendar month across all API queries. Past that, queries return a `402` response with the code `api_queries_quota_exceeded` and a message that shows your usage and when the allowance resets (the start of the next month, UTC).
+Queries made with a personal API key draw from an hourly read budget per project, and every query debits the bytes it read. The budget refills at 20 GB per hour for projects on the free plan and 200 GB per hour for projects in an organization with a paid plan, and unused budget accumulates for up to 24 hours (480 GB and 4.8 TB).
 
-Cached results still work while you are over the limit. Queries made in the PostHog app are not affected.
+Once it is exhausted, queries return a `429` response with the code `api_queries_budget_exceeded` and a `Retry-After` header. The wait is never longer than an hour. Every `/query` response made with a personal API key includes `X-PostHog-Query-Bytes-Read` and `X-PostHog-Query-Budget-Remaining-Bytes`; for asynchronous queries, the same headers arrive on the poll response once the query completes.
 
-To remove the limit, [subscribe to a paid plan](/pricing). PostHog is pay-as-you-go with no monthly minimum, and access is restored within moments of subscribing. Trials also lift the limit while active.
+Cached results still work while the budget is exhausted. Queries made in the PostHog app are not affected.
+
+For the larger budget, [subscribe to a paid plan](/pricing). PostHog is pay-as-you-go with no monthly minimum, and trials count as paid while active. To read less per query, see [writing performant queries](#writing-performant-queries) above.
 
 ## Further reading
 

--- a/contents/docs/sql/optimizing-queries.mdx
+++ b/contents/docs/sql/optimizing-queries.mdx
@@ -10,4 +10,10 @@ availability:
 
 import OptimalQueries from '../_snippets/optimal-queries.mdx'
 
+<CalloutBox icon="IconWarning" type="caution" title="Hourly read limit on API queries">
+
+Since September 9, 2026, queries made with a personal API key draw from an hourly read budget per project. The budget refills at 20 GB per hour for projects on the free plan and 200 GB per hour for projects in an organization with a paid plan, and unused budget accumulates for up to 24 hours (480 GB and 4.8 TB). A query is never cut off partway: the one that exhausts the budget completes, and further API queries return a `429` with a `Retry-After` header until enough budget refills, at most an hour later. Each response carries `X-PostHog-Query-Bytes-Read` and `X-PostHog-Query-Budget-Remaining-Bytes` so you can see what a query cost. Queries run in the PostHog app are not affected. The advice below reduces the bytes a query reads.
+
+</CalloutBox>
+
 <OptimalQueries />

--- a/contents/docs/sql/optimizing-queries.mdx
+++ b/contents/docs/sql/optimizing-queries.mdx
@@ -12,7 +12,7 @@ import OptimalQueries from '../_snippets/optimal-queries.mdx'
 
 <CalloutBox icon="IconWarning" type="caution" title="Hourly read limit on API queries">
 
-Since September 9, 2026, queries made with a personal API key draw from an hourly read budget per project. The budget refills at 20 GB per hour for projects on the free plan and 200 GB per hour for projects in an organization with a paid plan, and unused budget accumulates for up to 24 hours (480 GB and 4.8 TB). A query is never cut off partway: the one that exhausts the budget completes, and further API queries return a `429` with a `Retry-After` header until enough budget refills, at most an hour later. Each response carries `X-PostHog-Query-Bytes-Read` and `X-PostHog-Query-Budget-Remaining-Bytes` so you can see what a query cost. Queries run in the PostHog app are not affected. The advice below reduces the bytes a query reads.
+Since September 9, 2026, queries made with a personal API key draw from an hourly read budget per project. The budget refills at 20 GB per hour for projects on the free plan and 200 GB per hour for projects in an organization with a paid plan, and unused budget accumulates for up to 24 hours (480 GB and 4.8 TB). Once it is exhausted, API queries return a `429` with a `Retry-After` header until enough budget refills, at most an hour later. Each response carries `X-PostHog-Query-Bytes-Read` and `X-PostHog-Query-Budget-Remaining-Bytes` so you can see what a query cost. Queries run in the PostHog app are not affected. The advice below reduces the bytes a query reads.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Adds two sections to `contents/docs/_snippets/optimal-queries.mdx`, which renders on `/docs/sql/optimizing-queries`, `/docs/data-warehouse/query`, and `/docs/api/queries`. Later sections are renumbered.

- **4. Use `PREWHERE` to filter before wide columns are read** – a cohort CTE plus a scan CTE that reads a property, with the cohort filter placed in `PREWHERE` on `$group_0`.
- **5. Look up people in the `persons` table, not through `events`** – the `SELECT any(person.properties) FROM events WHERE person.id = ...` pattern from the query-performance thread on 2026-08-26 (no time bound, so it scans the person's whole event history; one backend was reading ~2 PB/day this way), replaced with a `persons WHERE id = ...` lookup and a distinct-id variant that filters `persons.id IN (SELECT person_id FROM person_distinct_ids WHERE distinct_id = ...)`. The rewrite in PostHog/posthog#88919 targets the same shape but is not merged, so the docs stand on their own.

Also adds a caution callout at the top of `/docs/sql/optimizing-queries` about the hourly read budget on personal API key queries (PostHog/posthog#95375, enforced since 2026-09-09): 20 GB/hour free, 200 GB/hour paid, 24 hours of capacity, `429` with `Retry-After`, cost headers on responses. The "Free plan data limit" section on `/docs/api/queries`, which described the monthly 50 TB quota and its `402` that the same PR deleted, is replaced with an "Hourly read budget" section.

The `PREWHERE` section documents the fix from the team-data-tools thread on 2026-09-02 (a query that hit the memory limit and got circuit-broken), generalized to a minimal example.

## Why PREWHERE and not "filter inside the subquery"

Measured on one day of project 2 events, same results for all shapes, stats from the `query_log` table:

| Shape | Duration | Bytes read | Peak memory | CPU |
| --- | --- | --- | --- | --- |
| Cohort filter on the outer query | 4.0 s | 3.11 TB | 2.4 GB | 129 s |
| Cohort filter inside the CTE as `WHERE` | 3.2 s | 2.64 TB | 6.4 GB | 170 s |
| Cohort filter inside the CTE as `PREWHERE` | 1.3 s | 0.49 TB | 2.9 GB | 26 s |
| Dense `PREWHERE` (every org active that day) | 10.7 s | 3.19 TB | 4.2 GB | 244 s |

The doc keeps only the example; the measurements above are the justification. Not always a win: dense filters read slightly more (the last row), filters on non-real columns do not help (`person_id` is rejected with error 182), the `IN (...)` subquery is an extra scan, and an explicit `PREWHERE` disables ClickHouse's automatic promotion of the remaining `WHERE` conditions (`MergeTreeWhereOptimizer` returns early when a PREWHERE exists; the analyzer path is gated by `optimize_prewhere_after_pushdown`, default off).

For the persons section, the natural distinct-id shape `SELECT person.properties FROM person_distinct_ids WHERE distinct_id = ...` timed out at 60 s even for a placeholder id (the `person` join deduplicates the whole persons table), while the `persons.id IN (subquery)` form returns instantly because the persons table promotes `id` filters into its dedup subquery. Only the fast form is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RubgfyZjB81BshzwWn7Unr



