### PR TITLE
chore(mcp-analytics): document installation with coding agents

### DIFF
--- a/contents/docs/mcp-analytics/install-with-agent.mdx
+++ b/contents/docs/mcp-analytics/install-with-agent.mdx
@@ -1,0 +1,54 @@
+---
+title: Install MCP analytics with your coding agent
+---
+
+Use your coding agent to add [MCP analytics](/docs/mcp-analytics) to an existing MCP server and verify its first tool call.
+Open the repository containing your server before starting.
+
+## Give your agent the installation task
+
+Replace the project ID and PostHog URL in this prompt, then paste it into your coding agent:
+
+```text
+Install PostHog MCP analytics in the MCP server in this repository.
+Read https://posthog.com/docs/mcp-analytics/installation.md and follow the instructions for this server's language, framework, and SDK version.
+
+Target project [PROJECT_ID] at [POSTHOG_URL]. Confirm the matching ingestion host and project token. Keep credentials in the repository's environment configuration and ask me for missing configuration.
+
+Locate the existing server entry point before editing. If no server is found, explain which directories you checked and ask me for the correct directory. Instrument this server; do not create a new server or install the PostHog MCP connector.
+
+Make the smallest necessary change, including flushing events correctly for this runtime. Run the relevant checks. Help me invoke an existing safe, read-only tool, then verify that its $mcp_tool_call arrives in the target project from the server you instrumented.
+
+Report the files changed and any remaining restart or deployment steps. If you cannot access PostHog to observe the event, give me verification steps and mark verification as pending.
+```
+
+Use `https://us.posthog.com` or `https://eu.posthog.com` for your region, or your self-hosted PostHog URL.
+Find the project ID in the URL when you open your project.
+Find your [project token](/docs/getting-started/project-token) in project settings.
+
+## Follow the matching installation instructions
+
+The agent should identify the server framework and installed SDK version before choosing an integration:
+
+- [TypeScript and JavaScript servers](/docs/mcp-analytics/installation.md), including `Server`, `McpServer`, and `mcp-handler`
+- [Python servers](/docs/mcp-analytics/installation.md#python)
+- [Custom dispatchers](/docs/mcp-analytics/custom-servers.md) without a standard server object
+
+Keep optional configuration out of the initial installation unless your application requires it.
+For capture controls, read [privacy and data capture](/docs/mcp-analytics/privacy.md).
+For event names and properties, read the [event reference](/docs/mcp-analytics/events.md).
+
+## Verify a tool call
+
+Restart or deploy the instrumented server as needed, then call an existing safe tool through your MCP client.
+Open the project you configured and inspect the call in MCP analytics or filter the activity feed for `$mcp_tool_call`.
+Check the tool name, server identity, and timestamp against the call you made.
+
+A successful package install or completed agent run does not confirm event delivery.
+An initialization event alone is also insufficient, and stateless clients may not send one.
+If the tool call does not appear, check the project token, ingestion host, active server entry point, and event flushing.
+
+The agent can verify events through an authenticated PostHog connection if you already have one.
+Otherwise, inspect the event in the UI and confirm the result yourself.
+
+For a compact list of references, use the [MCP analytics documentation index](/docs/mcp-analytics/llms.txt).

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -17,13 +17,23 @@ import WizardCommand from 'components/WizardCommand'
 - An MCP server built on either TypeScript SDK major — `@modelcontextprotocol/sdk` (v1) or `@modelcontextprotocol/{core,server,client}` (v2) — or either official Python MCP SDK major (`mcp>=1.26,<3`). jlowin's standalone `fastmcp` package is also supported. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2). (Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers).)
 - A PostHog [project token](/docs/getting-started/project-token) (`phc_…`)
 
-## AI wizard
+## Install with Wizard
 
-The fastest way to get set up is our wizard, which installs the package, adds your `posthog-node` client, and wires up the `instrument()` call for you (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt):
+Run Wizard from the repository containing your MCP server.
+The setup agent detects your framework and adds the analytics instrumentation:
 
 <WizardCommand command="mcp-analytics" />
 
-Prefer to set things up manually, or want to understand each piece? Follow the steps below.
+If the agent cannot find an MCP server, check that you opened the server repository and point it to the server entry point.
+After setup, invoke an existing tool and check for its `$mcp_tool_call` event in your PostHog project.
+
+## Install with your coding agent
+
+You can use your existing coding agent to [install and verify MCP analytics](/docs/mcp-analytics/install-with-agent).
+Give it the [Markdown installation guide](/docs/mcp-analytics/installation.md), your project ID, and your PostHog region.
+The [MCP analytics documentation index](/docs/mcp-analytics/llms.txt) links to the agent-readable references.
+
+For manual installation, follow the steps below.
 
 ## Install
 

--- a/contents/docs/mcp-analytics/installation.mdx
+++ b/contents/docs/mcp-analytics/installation.mdx
@@ -13,8 +13,8 @@ import WizardCommand from 'components/WizardCommand'
 
 ## Requirements
 
-- Node.js 20.20+ or 22.22+ (TypeScript/JavaScript), or Python 3.10+ — see [Python](#python) below
-- An MCP server built on either TypeScript SDK major — `@modelcontextprotocol/sdk` (v1) or `@modelcontextprotocol/{core,server,client}` (v2) — or either official Python MCP SDK major (`mcp>=1.26,<3`). jlowin's standalone `fastmcp` package is also supported. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2). (Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers).)
+- Node.js 20.20+ or 22.22+ (TypeScript/JavaScript), or Python 3.10+ – see [Python](#python) below
+- An MCP server built on either TypeScript SDK major – `@modelcontextprotocol/sdk` (v1) or `@modelcontextprotocol/{core,server,client}` (v2) – or either official Python MCP SDK major (`mcp>=1.26,<3`). jlowin's standalone `fastmcp` package is also supported. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2). (Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers).)
 - A PostHog [project token](/docs/getting-started/project-token) (`phc_…`)
 
 ## Install with Wizard
@@ -43,11 +43,11 @@ npm install @posthog/mcp posthog-node
 # or yarn add @posthog/mcp posthog-node
 ```
 
-You bring your own [`posthog-node`](/docs/libraries/node) client (the same pattern as [`@posthog/ai`](/docs/ai-engineering)) and pass it to `instrument()` as the required second argument. You own its lifecycle — call `posthog.shutdown()` or `posthog.flush()` yourself.
+You bring your own [`posthog-node`](/docs/libraries/node) client (the same pattern as [`@posthog/ai`](/docs/ai-engineering)) and pass it to `instrument()` as the required second argument. You own its lifecycle – call `posthog.shutdown()` or `posthog.flush()` yourself.
 
 ## Wrap your server
 
-`instrument(server, posthog, options?)` is the only function you need to call. The `posthog` client is a required positional argument; `options` is optional. It returns an analytics handle (used for [custom events](/docs/mcp-analytics/custom-events)). It's idempotent per server — calling it twice on the same server logs a warning and returns early.
+`instrument(server, posthog, options?)` is the only function you need to call. The `posthog` client is a required positional argument; `options` is optional. It returns an analytics handle (used for [custom events](/docs/mcp-analytics/custom-events)). It's idempotent per server – calling it twice on the same server logs a warning and returns early.
 
 ### Low-level `Server`
 
@@ -73,7 +73,7 @@ const analytics = instrument(server, posthog, {
 
 ### High-level `McpServer`
 
-If you use the typed `McpServer` wrapper, pass it in directly — the SDK will unwrap it and also install a proxy on `_registeredTools`, so any tool you register *after* `instrument()` is also wrapped:
+If you use the typed `McpServer` wrapper, pass it in directly – the SDK will unwrap it and also install a proxy on `_registeredTools`, so any tool you register *after* `instrument()` is also wrapped:
 
 <MultiLanguage>
 
@@ -120,12 +120,12 @@ server.registerTool("search_events", { /* ... */ }, async (args) => {
 
 </MultiLanguage>
 
-Everything past this point — options, callbacks, events — is identical on both majors. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2) for the two places they differ.
+Everything past this point – options, callbacks, events – is identical on both majors. See [MCP SDK v2](/docs/mcp-analytics/sdk-v2) for the two places they differ.
 
 ### Next.js / Vercel (`mcp-handler`)
 
 [`mcp-handler`](https://github.com/vercel/mcp-handler) gives you a standard `McpServer` in its setup
-callback, so you instrument it the same way — one line, before or after you register tools:
+callback, so you instrument it the same way – one line, before or after you register tools:
 
 ```ts
 import { createMcpHandler } from "mcp-handler"
@@ -155,10 +155,10 @@ export { handler as GET, handler as POST }
 
 On Vercel, `mcp-handler`'s streamable-HTTP transport is **stateless**: it spins up a fresh server per
 request and issues no `Mcp-Session-Id`, so there's no connection for the SDK to derive a shared
-`$session_id` from — left alone, every request lands in its own session.
+`$session_id` from – left alone, every request lands in its own session.
 
 The robust way to group is **by user**. Pass [`identify`](/docs/mcp-analytics/identifying-users) and
-return a `distinctId` from your auth (e.g. the OAuth subject) — that sets `distinct_id`, so a person's
+return a `distinctId` from your auth (e.g. the OAuth subject) – that sets `distinct_id`, so a person's
 calls group together no matter how many stateless requests they span, and it requires nothing from the
 client:
 
@@ -171,7 +171,7 @@ instrument(server, posthog, {
 For finer, per-conversation grouping you can also enable
 [`enableConversationId`](/docs/mcp-analytics/conversation-id): the SDK adds a `conversation_id`
 argument, generates one when the client doesn't send it, and asks the agent to echo it on later calls,
-correlating them via `$mcp_conversation_id`. It's **best-effort** — it works by appending a short
+correlating them via `$mcp_conversation_id`. It's **best-effort** – it works by appending a short
 instruction to the tool result, which a cooperative agent echoes but some clients ignore or treat as
 untrusted server content (the same wariness they apply to prompt injection). Use it when you control the
 client or that trade-off is acceptable; otherwise stick with `identify`.
@@ -187,12 +187,12 @@ This option requires `@posthog/mcp` 0.12.0 or later. It works on both protocol r
 #### Flushing
 
 `posthog-node` batches events, and a serverless function can freeze before they send. Flush at the end
-of the invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` to keep the runtime
+of the invocation – `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` to keep the runtime
 alive until it completes.
 
 ### NestJS (`@rekog/mcp-nest`)
 
-With [`@rekog/mcp-nest`](https://github.com/rekog-labs/MCP-Nest) you don't construct the server yourself — `McpModule.forRoot(...)` does, and you define tools with `@Tool()` decorators. Instrument it through the module's `serverMutator` hook using `instrumentMutator`, which returns the server for you:
+With [`@rekog/mcp-nest`](https://github.com/rekog-labs/MCP-Nest) you don't construct the server yourself – `McpModule.forRoot(...)` does, and you define tools with `@Tool()` decorators. Instrument it through the module's `serverMutator` hook using `instrumentMutator`, which returns the server for you:
 
 ```ts
 import { Module } from "@nestjs/common"
@@ -232,9 +232,9 @@ serverMutator: (server) => {
 
 ## Stateless and multi-pod servers
 
-A stateless server keeps nothing between requests — a fresh server instance each time, often on a different pod. Left alone, every request becomes its own `$session_id`, and `$mcp_client_name` / `$mcp_client_version` (only sent at `initialize`) go missing from every event after the handshake.
+A stateless server keeps nothing between requests – a fresh server instance each time, often on a different pod. Left alone, every request becomes its own `$session_id`, and `$mcp_client_name` / `$mcp_client_version` (only sent at `initialize`) go missing from every event after the handshake.
 
-The SDK handles this with no session store and no sticky routing. At `initialize` it mints the `Mcp-Session-Id` response header as a token carrying the session id and client metadata. Clients replay that header on every subsequent request, so any pod reads the same values back — nothing changes on the client side.
+The SDK handles this with no session store and no sticky routing. At `initialize` it mints the `Mcp-Session-Id` response header as a token carrying the session ID and client metadata. Clients replay that header on every subsequent request, so any pod reads the same values back – nothing changes on the client side.
 
 <CalloutBox icon="IconInfo" title="This applies to 2025-11-25 traffic" type="fyi">
 
@@ -277,7 +277,7 @@ if (body?.method === "initialize" && !req.headers[MCP_SESSION_HEADER]) {
 
 ### When you can't use a session token
 
-Some frameworks construct the transport for you and don't expose `enableJsonResponse`, and a client that ignores the header falls back to a generated session per request either way. In both cases, group by user with [`identify`](/docs/mcp-analytics/identifying-users) — `distinct_id` groups a person's calls however many requests they span, and it requires nothing from the client. [Conversation IDs](/docs/mcp-analytics/conversation-id) give finer, per-conversation grouping when the agent cooperates.
+Some frameworks construct the transport for you and don't expose `enableJsonResponse`, and a client that ignores the header falls back to a generated session per request either way. In both cases, group by user with [`identify`](/docs/mcp-analytics/identifying-users) – `distinct_id` groups a person's calls however many requests they span, and it requires nothing from the client. [Conversation IDs](/docs/mcp-analytics/conversation-id) give finer, per-conversation grouping when the agent cooperates.
 
 ## Python
 
@@ -287,12 +287,12 @@ A Python SDK ships inside the [`posthog`](/docs/libraries/python) package (the s
 pip install posthog
 ```
 
-`instrument()` needs the MCP SDK at runtime, but you already have it — you built your server with `mcp` or `fastmcp`, so it's treated as a peer dependency rather than bundled. Both official `mcp` majors are supported (`mcp>=1.26,<3`) and detected at runtime. MCP SDK 2.x support requires `posthog` 7.40.0 or later. jlowin's standalone `fastmcp` package is also supported. (`PostHogMCP` for custom dispatchers needs nothing beyond `posthog`.)
+`instrument()` needs the MCP SDK at runtime, but you already have it – you built your server with `mcp` or `fastmcp`, so it's treated as a peer dependency rather than bundled. Both official `mcp` majors are supported (`mcp>=1.26,<3`) and detected at runtime. MCP SDK 2.x support requires `posthog` 7.40.0 or later. jlowin's standalone `fastmcp` package is also supported. (`PostHogMCP` for custom dispatchers needs nothing beyond `posthog`.)
 
 `instrument(server, posthog_client, options?)` works with every common Python MCP server:
 
 - `FastMCP` and the low-level `Server` from the official [`modelcontextprotocol/python-sdk`](https://github.com/modelcontextprotocol/python-sdk) (the `mcp` package, 1.x)
-- `MCPServer` — FastMCP's new name on `mcp` 2.x — and the v2 low-level `Server`, see [MCP SDK v2](/docs/mcp-analytics/sdk-v2#python)
+- `MCPServer` – FastMCP's new name on `mcp` 2.x – and the v2 low-level `Server`, see [MCP SDK v2](/docs/mcp-analytics/sdk-v2#python)
 - [jlowin's standalone **FastMCP 2.0**](https://github.com/jlowin/fastmcp) (the separate `fastmcp` package)
 - `PostHogMCP` for custom dispatchers with no server object (see below)
 
@@ -307,7 +307,7 @@ posthog = Posthog(
 )
 server = FastMCP("my-server")
 
-# On MCP SDK 2.x, FastMCP was renamed — instrument() works the same:
+# On MCP SDK 2.x, FastMCP was renamed – instrument() works the same:
 # from mcp.server.mcpserver import MCPServer
 # server = MCPServer("my-server")
 
@@ -330,7 +330,7 @@ instrument(server, posthog, MCPAnalyticsOptions(
 ))
 ```
 
-`MCPAnalyticsOptions` fields (the TypeScript [Configuration](#configuration) table below uses camelCase — these are the Python names):
+`MCPAnalyticsOptions` fields (the TypeScript [Configuration](#configuration) table below uses camelCase – these are the Python names):
 
 | Option | Type | Default | What it does |
 |---|---|---|---|
@@ -339,15 +339,15 @@ instrument(server, posthog, MCPAnalyticsOptions(
 | `missing_capability_tool_name` | `str` | `"get_more_tools"` | Rename the virtual tool registered by `report_missing`. |
 | `enable_conversation_id` | `bool` | `False` | Inject an optional `conversation_id` argument to stitch calls. |
 | `enable_exception_autocapture` | `bool` | `True` | Emit a `$exception` sibling on failed tool calls. |
-| `identify` | `(request, extra) -> UserIdentity \| None` (sync or async) | — | Map a request to one of your users. |
-| `intent_fallback` | `(request, extra) -> str \| None` | — | Provide intent when the agent didn't pass `context`. |
-| `before_send` | `(event) -> event \| None` | — | Inspect/modify/drop each event before send. |
-| `event_properties` | `(request, extra) -> dict` | — | Properties merged onto every event. |
+| `identify` | `(request, extra) -> UserIdentity \| None` (sync or async) | – | Map a request to one of your users. |
+| `intent_fallback` | `(request, extra) -> str \| None` | – | Provide intent when the agent didn't pass `context`. |
+| `before_send` | `(event) -> event \| None` | – | Inspect/modify/drop each event before send. |
+| `event_properties` | `(request, extra) -> dict` | – | Properties merged onto every event. |
 | `logger` | `(message: str) -> None` | no-op | STDIO-safe log sink. |
 
 ### Stateless and multi-pod servers
 
-Same problem as [above](#stateless-and-multi-pod-servers) — a stateless deployment fragments `$session_id` and loses the client name/version after `initialize`. Python fixes it with the same self-encoded session token (minted onto the `Mcp-Session-Id` header, replayed by the client), but from an ASGI layer, so there's **no `enableJsonResponse` caveat** — JSON and SSE both work.
+Same problem as [above](#stateless-and-multi-pod-servers) – a stateless deployment fragments `$session_id` and loses the client name/version after `initialize`. Python fixes it with the same self-encoded session token (minted onto the `Mcp-Session-Id` header, replayed by the client), but from an ASGI layer, so there's **no `enableJsonResponse` caveat** – JSON and SSE both work.
 
 On a **FastMCP** server (official `mcp.server.fastmcp` or jlowin's `fastmcp` 2.0) it's zero-config: `instrument()` wraps the server's `streamable_http_app()` / `sse_app()` factories (which `run()` uses too), so just make the server stateless:
 
@@ -357,7 +357,7 @@ instrument(server, posthog)
 server.run(transport="streamable-http")  # or: app = server.streamable_http_app()
 ```
 
-When you build the ASGI app yourself — a low-level `Server`, or a custom [`PostHogMCP`](/docs/mcp-analytics/custom-servers) dispatcher — add the middleware to that app once:
+When you build the ASGI app yourself – a low-level `Server`, or a custom [`PostHogMCP`](/docs/mcp-analytics/custom-servers) dispatcher – add the middleware to that app once:
 
 ```python
 from posthog.mcp import PostHogMcpStatelessSessionMiddleware
@@ -367,7 +367,7 @@ app.add_middleware(PostHogMcpStatelessSessionMiddleware)
 
 ### Flushing on exit
 
-The `posthog` client batches events asynchronously and you own its lifecycle. On the `instrument()` path, auto-captured events are scheduled in the background — `await analytics.flush()` waits for in-flight events, then `posthog.flush()` / `posthog.shutdown()` sends them. Call this from your shutdown/`SIGTERM` handler so trailing events aren't dropped (see [`examples/mcp_analytics_demo.py`](https://github.com/PostHog/posthog-python/blob/main/examples/mcp_analytics_demo.py) for a runnable end-to-end example):
+The `posthog` client batches events asynchronously and you own its lifecycle. On the `instrument()` path, auto-captured events are scheduled in the background – `await analytics.flush()` waits for in-flight events, then `posthog.flush()` / `posthog.shutdown()` sends them. Call this from your shutdown/`SIGTERM` handler so trailing events aren't dropped (see [`examples/mcp_analytics_demo.py`](https://github.com/PostHog/posthog-python/blob/main/examples/mcp_analytics_demo.py) for a runnable end-to-end example):
 
 ```python
 analytics = instrument(server, posthog)
@@ -378,7 +378,7 @@ posthog.shutdown()        # flush + stop the posthog client
 
 ### Custom dispatchers (no server object to wrap)
 
-If you hand-rolled your own dispatcher, there's nothing for `instrument()` to patch. Use `PostHogMCP` instead — a `posthog` client subclass (needs nothing beyond `posthog`, no MCP SDK) that lets you build the events yourself: `capture_tool_call()`, `capture_initialize()`, `capture_tools_list()`, `capture_missing_capability()`, plus `prepare_tool_list()` and `prepare_tool_call()` for intent capture. Same events, same redaction and truncation as `instrument()`. See [Custom servers](/docs/mcp-analytics/custom-servers#python) for a full dispatcher example.
+If you hand-rolled your own dispatcher, there's nothing for `instrument()` to patch. Use `PostHogMCP` instead – a `posthog` client subclass (needs nothing beyond `posthog`, no MCP SDK) that lets you build the events yourself: `capture_tool_call()`, `capture_initialize()`, `capture_tools_list()`, `capture_missing_capability()`, plus `prepare_tool_list()` and `prepare_tool_call()` for intent capture. Same events, same redaction and truncation as `instrument()`. See [Custom servers](/docs/mcp-analytics/custom-servers#python) for a full dispatcher example.
 
 <CalloutBox icon="IconInfo" title="Python SDK is beta" type="fyi">
 
@@ -392,7 +392,7 @@ Self-reported model capture is currently TypeScript-only. Python doesn't inject 
 
 ## Configuration
 
-The `posthog` client is passed as the required second positional argument — not in this options object. `instrument()` accepts these options as an optional third argument:
+The `posthog` client is passed as the required second positional argument – not in this options object. `instrument()` accepts these options as an optional third argument:
 
 | Option | Type | Default | What it does |
 |---|---|---|---|
@@ -400,12 +400,12 @@ The `posthog` client is passed as the required second positional argument — no
 | `enableExceptionAutocapture` | `boolean` | `true` | When `false`, a failed tool call does not emit the `$exception` sibling event. |
 | `context` | `boolean \| { description: string }` | `true` | Inject a required `context` argument into every tool schema. See [Capturing agent intent](/docs/mcp-analytics/intent). |
 | `captureModel` | `boolean \| { description: string }` | `false` | Inject a required `llm_model` argument and capture the agent's self-reported model. Requires `@posthog/mcp` 0.12.0 or later. |
-| `intentFallback` | `(request, extra) => string \| Promise<string \| null \| undefined>` | — | Called when the agent didn't pass a `context` argument. See [Capturing agent intent](/docs/mcp-analytics/intent). |
+| `intentFallback` | `(request, extra) => string \| Promise<string \| null \| undefined>` | – | Called when the agent didn't pass a `context` argument. See [Capturing agent intent](/docs/mcp-analytics/intent). |
 | `enableConversationId` | `boolean` | `false` | Inject an optional `conversation_id` argument into every tool. See [Conversation IDs](/docs/mcp-analytics/conversation-id). |
 | `reportMissing` | `boolean` | `false` | Register the `get_more_tools` virtual tool. See [Missing capability](/docs/mcp-analytics/missing-capability). |
-| `identify` | `async (request, extra) => UserIdentity \| null \| UserIdentity` | — | Map an MCP request to one of your users. See [Identifying users](/docs/mcp-analytics/identifying-users). |
-| `beforeSend` | `(event) => event \| null \| undefined \| Promise<...>` | — | Runs on each fully-built PostHog payload right before send. Return the (possibly mutated) event to send it, or a nullish value to drop it. See [Privacy](/docs/mcp-analytics/privacy). |
-| `eventProperties` | `async (request, extra) => Record<string, unknown>` | — | Properties merged onto every event. See [Custom events and metadata](/docs/mcp-analytics/custom-events). |
+| `identify` | `async (request, extra) => UserIdentity \| null \| UserIdentity` | – | Map an MCP request to one of your users. See [Identifying users](/docs/mcp-analytics/identifying-users). |
+| `beforeSend` | `(event) => event \| null \| undefined \| Promise<...>` | – | Runs on each fully-built PostHog payload right before send. Return the (possibly mutated) event to send it, or a nullish value to drop it. See [Privacy](/docs/mcp-analytics/privacy). |
+| `eventProperties` | `async (request, extra) => Record<string, unknown>` | – | Properties merged onto every event. See [Custom events and metadata](/docs/mcp-analytics/custom-events). |
 
 ## Graceful shutdown
 
@@ -426,7 +426,7 @@ process.on("SIGTERM", async () => {
 
 If you only want to drain the queue without tearing the client down, call `posthog.flush()` instead.
 
-In serverless or edge environments where `SIGTERM` isn't reliable, flush explicitly at the end of each invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` on platforms that support it — rather than relying on a shutdown signal.
+In serverless or edge environments where `SIGTERM` isn't reliable, flush explicitly at the end of each invocation – `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` on platforms that support it – rather than relying on a shutdown signal.
 
 ## What happens after install
 

--- a/contents/docs/mcp-analytics/start-here.mdx
+++ b/contents/docs/mcp-analytics/start-here.mdx
@@ -76,7 +76,9 @@ icon="IconGraph"
 
 Run your MCP server and connect an agent to it (Claude Desktop, Cursor, Codex, or your own). Within seconds of the first tool call, PostHog receives `$mcp_tool_call` and `$mcp_tools_list` events. Clients using the `2025-11-25` revision also produce `$mcp_initialize`. The handshake-free `2026-07-28` revision doesn't have an initialize event.
 
-Open the [activity feed](https://us.posthog.com/project/2/activity) and filter for `event = $mcp_tool_call`. You should see one row per agent tool invocation, each with `$mcp_tool_name`, `$mcp_parameters`, `$mcp_response`, `$mcp_duration_ms`, and `$mcp_is_error`.
+Select the PostHog project you configured, open its activity feed, and filter for `event = $mcp_tool_call`.
+Confirm that the event came from the tool and server you just called.
+You should see one row per agent tool invocation, each with `$mcp_tool_name`, `$mcp_parameters`, `$mcp_response`, `$mcp_duration_ms`, and `$mcp_is_error`.
 
 <ProductScreenshot
 imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_activity_feed_light_197cb57f3c.png"

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -7413,6 +7413,12 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
+                    name: 'Install with your agent',
+                    url: '/docs/mcp-analytics/install-with-agent',
+                    icon: 'IconBook',
+                    color: 'blue',
+                },
+                {
                     name: 'MCP SDK v2',
                     url: '/docs/mcp-analytics/sdk-v2',
                     icon: 'IconCode',

--- a/static/docs/mcp-analytics/llms.txt
+++ b/static/docs/mcp-analytics/llms.txt
@@ -1,0 +1,21 @@
+# PostHog MCP analytics
+
+> Instrument an existing MCP server, verify real tool-call events, and analyze how agents use its tools.
+
+## Installation
+
+- [Install with a coding agent](https://posthog.com/docs/mcp-analytics/install-with-agent.md): Task instructions, project configuration, and first-call verification.
+- [Installation reference](https://posthog.com/docs/mcp-analytics/installation.md): Wizard and manual installation for TypeScript, JavaScript, and Python servers; runtime flushing requirements.
+- [Custom servers](https://posthog.com/docs/mcp-analytics/custom-servers.md): Capture calls from a custom dispatcher without a standard server object.
+
+## Verification and capture
+
+- [Getting started](https://posthog.com/docs/mcp-analytics/start-here.md): Inspect the first events in the selected project.
+- [Events and properties](https://posthog.com/docs/mcp-analytics/events.md): The $mcp_tool_call event and its properties.
+- [Privacy](https://posthog.com/docs/mcp-analytics/privacy.md): Control captured data.
+- [Conversation IDs](https://posthog.com/docs/mcp-analytics/conversation-id.md): Group calls across stateless requests.
+
+## Product
+
+- [MCP analytics overview](https://posthog.com/docs/mcp-analytics.md): Product capabilities and analysis surfaces.
+- [PostHog MCP connector](https://posthog.com/docs/model-context-protocol.md): Connect an agent to PostHog to query data. Installing this connector is a separate task from instrumenting a server.


### PR DESCRIPTION
## Changes

MCP server owners can give their coding agent a concrete installation task and verify its first captured tool call.

- Add a copyable prompt covering the existing server, project configuration, event flushing, and first-call verification.
- Add `/docs/mcp-analytics/llms.txt` with links to the Markdown installation and event references.
- Link agent installation from the installation page and the MCP analytics sidebar.
- Replace the getting-started link to a fixed project.
- Correct installation-guide punctuation reported by Vale; SDK instructions remain unchanged.

Validation: all three changed pages compile with MDX 2.3.0, pass Markdown lint, and the index links resolve to documentation sources.
The first preview build passed. The sidebar fix passes all 10 navigation tests, Prettier, ESLint, and Markdown lint.
The updated Cloudflare preview build passes, with zero Vale errors.
All three changed pages and `llms.txt` return HTTP 200 in the local dev server and the updated preview.
The agent guide stays in the MCP analytics sidebar at 640px and 1440px in light and dark mode.
The before/after browser comparison found no new console error messages; both previews report the same SVG, hydration, and missing-resource errors.
The eight navigation screenshots are captured; public upload approval is pending.
Companion [app PR](https://github.com/PostHog/posthog/pull/98668): project-specific installation prompts and setup measurement.

## Checklist

- [x] I've read the [content](https://posthog.com/handbook/content/posthog-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links outside the copyable agent prompt and `llms.txt`
- [x] I've checked the pages added or changed in the Cloudflare preview build
- [x] No pages moved; no redirects required

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex prepared and checked this change with Git, local MDX validation, navigation tests, and browser checks against the local dev server and Cloudflare preview.
Skills: `debugging-mcp-analytics`, `writing-user-facing-copy`, and `writing-pr-descriptions`.
The public diff contains product instructions and placeholder configuration only.
The search for open MCP agent documentation PRs found no duplicate.
No local CodeRabbit pass ran; that pass is paused.

