### PR TITLE
Let community members post in Builder-lounge forum topics

### DIFF
--- a/src/components/Inbox/index.tsx
+++ b/src/components/Inbox/index.tsx
@@ -124,7 +124,7 @@ const SidebarContent = ({
                             )
                         }
                     >
-                        Ask a question
+                        + New post
                     </OSButton>
                 </div>
             </div>
@@ -392,13 +392,14 @@ const AskAQuestion = ({ onSubmit }: { onSubmit: () => void }) => {
     const { closeWindow, setWindowTitle } = useApp()
 
     useEffect(() => {
-        setWindowTitle(appWindow, 'Ask a question')
+        setWindowTitle(appWindow, 'New post')
     }, [])
 
     return (
         <div data-scheme="secondary" className="bg-primary size-full p-4">
             <QuestionForm
                 showTopicSelector
+                buttonText={<span className="font-bold">Create post</span>}
                 onSubmit={(_values, _type, data) => {
                     onSubmit()
                     closeWindow(appWindow)

--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -65,11 +65,10 @@ export const Select = ({
 
     useEffect(() => {
         fetchTopicGroups().then((topicGroups) => {
-            const filteredGroups = topicGroups.filter((group) => group?.attributes?.label !== 'Off-topic')
-            setTopicGroups(filteredGroups)
+            setTopicGroups(topicGroups)
 
             // Flatten topic groups into options array with section headers
-            const flatOptions = filteredGroups
+            const flatOptions = topicGroups
                 .sort(
                     (a, b) =>
                         topicGroupsSorted.indexOf(a?.attributes?.label) -

--- a/src/components/Squeak/util/topicGroups.ts
+++ b/src/components/Squeak/util/topicGroups.ts
@@ -42,4 +42,4 @@ export const fetchTopicGroups = async () => {
     return topicGroups.json().then((topicGroups) => topicGroups.data)
 }
 
-export const topicGroupsSorted = ['Products', 'Platform', 'Data', 'Self-hosting', 'Other']
+export const topicGroupsSorted = ['Products', 'Product OS', 'Data', 'Self-hosting', 'Other', 'Off-topic']

--- a/src/components/Squeak/util/topicGroups.ts
+++ b/src/components/Squeak/util/topicGroups.ts
@@ -42,4 +42,4 @@ export const fetchTopicGroups = async () => {
     return topicGroups.json().then((topicGroups) => topicGroups.data)
 }
 
-export const topicGroupsSorted = ['Off-topic', 'Products', 'Product OS', 'Data', 'Self-hosting', 'Other']
+export const topicGroupsSorted = ['Builder-lounge', 'Products', 'Product OS', 'Data', 'Self-hosting', 'Other']

--- a/src/components/Squeak/util/topicGroups.ts
+++ b/src/components/Squeak/util/topicGroups.ts
@@ -42,4 +42,4 @@ export const fetchTopicGroups = async () => {
     return topicGroups.json().then((topicGroups) => topicGroups.data)
 }
 
-export const topicGroupsSorted = ['Products', 'Product OS', 'Data', 'Self-hosting', 'Other', 'Off-topic']
+export const topicGroupsSorted = ['Off-topic', 'Products', 'Product OS', 'Data', 'Self-hosting', 'Other']

--- a/src/navs/useTopicsNav.js
+++ b/src/navs/useTopicsNav.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { useUser } from 'hooks/useUser'
 import { IconSparkles, IconClock } from '@posthog/icons'
 
-const navSorted = ['Products', 'Data', 'Product OS', 'Self-hosting', 'Off-topic', 'Other']
+const navSorted = ['Off-topic', 'Products', 'Data', 'Product OS', 'Self-hosting', 'Other']
 
 export default function useTopicsNav() {
     const { topicGroups } = useStaticQuery(graphql`

--- a/src/navs/useTopicsNav.js
+++ b/src/navs/useTopicsNav.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { useUser } from 'hooks/useUser'
 import { IconSparkles, IconClock } from '@posthog/icons'
 
-const navSorted = ['Off-topic', 'Products', 'Data', 'Product OS', 'Self-hosting', 'Other']
+const navSorted = ['Builder-lounge', 'Products', 'Data', 'Product OS', 'Self-hosting', 'Other']
 
 export default function useTopicsNav() {
     const { topicGroups } = useStaticQuery(graphql`


### PR DESCRIPTION
## Changes

Community members could read `#introductions`, `#where-in-the-world`, and `#devrel`, but they could not post in them. The topic dropdown in the post form removed the whole group that holds them (named Off-topic, and renamed to Builder-lounge), and the topic is a required field, so people had to select a different topic (usually "Uncategorized"). They also could not correct it afterwards, because the topic selector on a question is only available to forum moderators. A moderator had to re-tag each post by hand.

**Why:** we want people to introduce themselves and to tell us where in the world they are, and we plan initiatives to increase these posts. So these topics must be postable.

Three small changes:

- `QuestionForm.tsx` no longer removes the group from the topic dropdown.
- The two hard-coded sort orders use the new group name, Builder-lounge. The group keeps this name in Strapi in a separate step. Until then, the old name is absent from both lists, which puts the group first — the position we want.
- The forum button says "+ New post" instead of "Ask a question", the window title says "New post", and the submit button in that window says "Create post". Not every post in these topics is a question. Other surfaces that use the question form keep their current text.
- The forum sidebar sorts the group above Products, to make the community topics more visible.
- The form sort order used `'Platform'`, but the group label is `'Product OS'`. The value never matched, so `indexOf` gave `-1` and the group sorted first. The list now uses the correct label, and includes `'Off-topic'` at the end.

The group is first in both the sidebar and the post form dropdown, to give conversational topics more visibility than product debugging topics.

**Note:** the group labels are hard-coded in `topicGroups.ts` and `useTopicsNav.js`. A group that gets a new label in Strapi needs the new value in these two lists, or it sorts to an unintended position. The topics themselves are not hard-coded: they come from Strapi, so a new topic needs no code change. A new topic has no icon until someone adds it to `topicIcons` in `TopicsTable.tsx`.

## Screenshots

Not attached — this environment has no browser and no installed dependencies, so I could not start the dev server. The change is visible in three places (the forum sidebar button and order, the topic dropdown, and the new post window). The Vercel preview build shows all three.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1789080899521789?thread_ts=1789080899.521789&cid=C01V9AT7DK4)*

