### PR TITLE
Add community questions to the support hero handbook

### DIFF
--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -152,23 +152,21 @@ The key principle: We want to be responsive to our open-source community when we
 
 ### Community questions and Discord
 
-Users on the free plan get community support only. Because of this, many questions and opinions about your product area appear on [Community questions](/questions) and in [Discord](/community), and not in PostHog Support.
+Users on the free plan get community support only. Because of this, many questions and opinions about your product area appear on [Community questions](/questions) and in Discord, and not in PostHog Support.
 
 This is not a ticket queue, and it is not a duty. Nobody has to reply. Look at it as a source of product feedback: it shows you what users ask, what confuses them, and what they say about your product area, in real time.
 
-If you have time between tickets, read your team's community posts. Try to spend less than 30 minutes a week. Most teams get one or two questions a week, sometimes none. Billing and configuration topics get more, and we are moving more troubleshooting questions to PostHog AI.
+If you have time between tickets, read your team's community posts. The goal is to spend less than 30 minutes a week. Most teams get one or two questions a week, sometimes none.
 
-#### Where your team's questions go
+#### Where to find posts relevant to your team
 
-Each question topic is subscribed to one or more teams. When a user asks a question, the question goes to the Slack channel of each subscribed team.
+Each post topic is subscribed to one or more teams. When a user makes a post, the post goes to the Slack channel of each subscribed team.
 
 To see which topics are mapped to your team, go to [community alerts](/community/alerts). Use that page also to find topics that have no team, and teams that have no Slack channel. A team with no Slack channel gets nothing, even when it is subscribed to a topic.
 
 #### What is a good reply?
 
-PostHog AI answers almost every question in about a minute, and community members answer many more. **A reply from PostHog AI or from another community member is frequently the correct answer for the user.** When this is true, you do not have to write an answer. To confirm that the answer is correct is sufficient, and it is a help to the user.
-
-Write an answer yourself when the given answer is wrong, or when the community and PostHog AI do not know the answer and the user cannot continue.
+**A reply from PostHog AI or from another community member is frequently the correct answer for the user.** When this is true, no need to reply—you can upvote the existing reply. If you want to chime in with something, check these [guidelines for answering questions](/handbook/community/questions).
 
 Paid tickets always have a higher priority than community questions.
 

--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -30,7 +30,7 @@ Each engineering team has its own list of tickets in PostHog support. Your view 
 
 Your job is simple: ship features and fixes, resolve ticket after ticket from your team's list, and respond to open-source PRs assigned to your team.
 
-There are three sources of tickets:
+There are four sources of tickets:
 
 1. In-app bug reports/feedback/support tickets sent from the [Support panel](https://us.posthog.com/home#panel=support).
 1. Slack or MS Teams threads that have been raised via @SupportHog in [customer support channels](/handbook/growth/sales/slack-channels).
@@ -149,6 +149,28 @@ If you find yourself overwhelmed, remember:
 - Teams aren't expected to handle unlimited PRs
 
 The key principle: We want to be responsive to our open-source community when we can, but not at the cost of our primary support responsibilities or team sustainability.
+
+### Community questions and Discord
+
+Users on the free plan get community support only. Because of this, many questions and opinions about your product area appear on [Community questions](/questions) and in [Discord](/community), and not in PostHog Support.
+
+This is not a ticket queue, and it is not a duty. Nobody has to reply. Look at it as a source of product feedback: it shows you what users ask, what confuses them, and what they say about your product area, in real time.
+
+If you have time between tickets, read your team's community posts. Try to spend less than 30 minutes a week. Most teams get one or two questions a week, sometimes none. Billing and configuration topics get more, and we are moving more troubleshooting questions to PostHog AI.
+
+#### Where your team's questions go
+
+Each question topic is subscribed to one or more teams. When a user asks a question, the question goes to the Slack channel of each subscribed team.
+
+To see which topics are mapped to your team, go to [community alerts](/community/alerts). Use that page also to find topics that have no team, and teams that have no Slack channel. A team with no Slack channel gets nothing, even when it is subscribed to a topic.
+
+#### What is a good reply?
+
+PostHog AI answers almost every question in about a minute, and community members answer many more. **A reply from PostHog AI or from another community member is frequently the correct answer for the user.** When this is true, you do not have to write an answer. To confirm that the answer is correct is sufficient, and it is a help to the user.
+
+Write an answer yourself when the given answer is wrong, or when the community and PostHog AI do not know the answer and the user cannot continue.
+
+Paid tickets always have a higher priority than community questions.
 
 ## What about SDK support?
 

--- a/contents/handbook/support/customer-support.md
+++ b/contents/handbook/support/customer-support.md
@@ -99,6 +99,12 @@ We very rarely receive messages from people wishing to make a legal claim agains
 
 Support =/= community - we consider them to be separate things.
 
+### Community questions and Discord
+
+Community is not support, but it is one of our best sources of product feedback. [Community questions](/questions) and Discord show what users ask and say about each product area, in real time.
+
+Questions are routed to team Slack channels by topic, so each team can see the posts about its own products. Support heroes are welcome to [read their team's community posts](/handbook/engineering/support-hero#community-questions-and-discord) when they have time, but it is not a requirement. PostHog AI and other community members answer most questions.
+
 ### Tutorials
 
 We want to help teams of all sizes learn how to ask the right product analytics questions to grow their product. To help, we create content in the form of [tutorials](/tutorials), [blog posts](/blog), and [videos](https://www.youtube.com/channel/UCn4mJ4kK5KVSvozJre645LA).


### PR DESCRIPTION
## Changes

Adds community questions and Discord to the support hero handbook page, as an **optional** part of the role.

**Why:** free-plan users get community support only, so a lot of feedback and real questions about each product area land on `/questions` and in Discord instead of in PostHog Support. Topic-to-team routing now works well enough that each team already has a queue in its own Slack channel, so the framing is worth writing down. This is deliberately not a new duty — it is a source of product feedback.

Key points in the new section:

- Not a ticket queue and not required. Paid tickets always come first.
- Target is under 30 minutes a week. Most teams see one or two questions a week, sometimes none.
- Questions are routed to team Slack channels by topic. `/community/alerts` shows which topics map to which team, and flags unmapped topics and teams with no Slack channel.
- A reply from PostHog AI or another community member is frequently the correct answer. Confirming it is enough. Write an answer yourself when the given answer is wrong, or when nobody knows and the user is blocked.

Also adds a short pointer from the customer support page (keeping the existing "support =/= community" distinction), and fixes "three sources of tickets" where four are listed.

Note: `/community/alerts` is moderator-only — non-moderators are redirected to `/questions`. Worth confirming that support heroes hold that role before this ships, or the link is a dead end for them.

*No visual changes — prose only, no navigation or component changes.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build — not run locally (no `node_modules` in this environment); please check the Vercel preview
- [x] If I moved a page, I added a redirect in `vercel.json` — not applicable, no pages moved

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
