### PR TITLE
Update engineering hiring: AI-pilled criterion and culture chat owner

### DIFF
--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -46,7 +46,7 @@ You should use <PrivateLink url="[https://github.com/Posthog-Interviews/superday
 
 #### Culture & motivation chat
 
-One of our co-founders or execs – [Tim](/tim) or [James](/james), depending on scheduling – will meet with the candidate for a short 15 min chat to dive deeper into culture and motivation. 
+A member of our [Blitzscale](/teams/blitzscale) team – Raquel, Ben, or Paul, depending on scheduling – will meet with the candidate for a 20-25 min chat to dive deeper into culture and motivation. 
 
 #### Engineering SuperDay
 
@@ -62,7 +62,7 @@ An engineering SuperDay usually looks like this (_there is a degree of flexibili
    * This will include:- the talent team, cofounders, exec, hiring lead, & the SuperDay buddy      
 *   Time to focus on the task
 *   An interview with the SuperDay buddy
-*   A chat with [James](/james), [Tim](/tim), or an exec, whoever they didn't meet with in the previous stage
+*   A chat with [James](/james), [Tim](/tim), or an exec
 *   Wrapping up – at the end of the work day, they'll send us what they've built, along with a summary
 
 Usually the Superday buddy will review the output, but they can ask other engineers for input when needed, and we'll get back to the candidate with our final decision ASAP (always within a few days).

--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -13,7 +13,8 @@ Engineers make up around 60% of our team, and we are almost always hiring for En
 
 Beyond the specific skills listed in the job description, we generally look for: 
 
-*   Experience with relevant technologies (Python or similar, React or similar, something to do with big data is a bonus)
+*   Able to pick up a new stack quickly
+    *   This matters more to us than experience with the exact technologies we use. Our [tech stack](/handbook/engineering/stack) is public, so candidates can see what they will work with. Experience with something to do with big data is a bonus.
     *   We don't care how many years of professional experience someone has, but depending on our current team structure we may be looking for more or less experienced people for a role - if that's the case, we will be explicit in the job spec.
 *   Has built something from scratch, ideally with minimal outside help
     *   They may have been the founder of a startup, or built an impressive side project. They may have also worked on a project at work where they were the only developer.
@@ -62,7 +63,7 @@ An engineering SuperDay usually looks like this (_there is a degree of flexibili
    * This will include:- the talent team, cofounders, exec, hiring lead, & the SuperDay buddy      
 *   Time to focus on the task
 *   An interview with the SuperDay buddy
-*   A chat with [James](/james), [Tim](/tim), or an exec
+*   A chat with an exec
 *   Wrapping up – at the end of the work day, they'll send us what they've built, along with a summary
 
 Usually the Superday buddy will review the output, but they can ask other engineers for input when needed, and we'll get back to the candidate with our final decision ASAP (always within a few days).

--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -19,6 +19,8 @@ Beyond the specific skills listed in the job description, we generally look for:
     *   They may have been the founder of a startup, or built an impressive side project. They may have also worked on a project at work where they were the only developer.
 *   Communication skills
     *   More so than other companies, all of our communication is written and public for the world to see. Good written communication is key.
+*   AI-pilled
+    *   They have built things agents actually use. More and more of what we ship is used by agents, not people, and building for them is genuinely different. We want someone who has done it and has the scars: an API an agent can drive, an MCP server, evals, or docs written for a machine. Side projects count.
 *   User-centric
     *   Our engineering team work very closely with our users - they do customer support, demos, and help with implementation. All potential engineers need to be excited by the prospect of getting to work directly with users.
 

--- a/contents/handbook/people/hiring-process/engineering-tech-screen.md
+++ b/contents/handbook/people/hiring-process/engineering-tech-screen.md
@@ -70,6 +70,6 @@ The best preparation is reflection. More concretely, here's what we recommend:
 
 We want this to feel like a working session. The interviewer is there to collaborate with you, ask follow-up questions, and sometimes push back on your ideas. If something isn't clear, ask. If you want to change direction, say so. The best interviews feel like a conversation between two engineers solving a problem together.
 
-If you pass the technical screen, you'll meet one of our co-founders or execs for a short culture and motivation chat, followed by a [PostHog SuperDay](/handbook/people/hiring-process/engineering-superday). You can read more about the [full interview process](/handbook/people/hiring-process).
+If you pass the technical screen, you'll meet a member of our Blitzscale team for a culture and motivation chat, followed by a [PostHog SuperDay](/handbook/people/hiring-process/engineering-superday). You can read more about the [full interview process](/handbook/people/hiring-process).
 
 Good luck – we're rooting for you.


### PR DESCRIPTION
## Changes

Three updates to the engineering hiring pages:

1. Adds an "AI-pilled" bullet to *What we are looking for in engineering hires*. The wording comes from the product engineer job ad, so the handbook agrees with what candidates read.
2. Replaces the "experience with relevant technologies" bullet with "able to pick up a new stack quickly". We care more about how fast a person learns a stack than about experience with the exact technologies we use, and the bullet now links to our public [tech stack](https://posthog.com/handbook/engineering/stack).
3. Corrects the *Culture & motivation chat* stage: it is a 20-25 min chat with a [Blitzscale](https://posthog.com/teams/blitzscale) team member (Raquel, Ben, or Paul), not a 15 min chat with a co-founder or exec. The candidate-facing tech screen page said the same thing, so it is corrected too. The SuperDay agenda no longer names a person for the exec chat, because candidates do not necessarily meet a specific one.

The three Blitzscale names are plain text, because no handbook profile link is confirmed for all three.

**Why:** A team member wanted to send the Engineering Hiring page to a candidate and was not sure that all of it is current. The AI-pilled criterion was missing, the stack bullet read as a hard requirement, and the culture chat stage was out of date.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no page moved)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09FJ89FVCK/p1789123799110839?thread_ts=1789123799.110839&cid=C09FJ89FVCK)*