### PR TITLE
docs(push): release-dependent push open updates

### DIFF
--- a/contents/docs/workflows/push-notifications/react-native.mdx
+++ b/contents/docs/workflows/push-notifications/react-native.mdx
@@ -70,24 +70,17 @@ Registration and unregistration are durable. If the device is offline or the req
 
 ## Capturing opens
 
-For the opens automatic capture misses (locally-scheduled notifications on either platform, plus warm-start taps and foreground messages on Android), call the manual API:
+Taps on remote notifications are captured for you (see above). Automatic capture can't see locally-scheduled notifications, notifications you display yourself from a foreground message, or push delivered outside FCM on Android. Call the manual API only for those:
 
 ```react-native
-import messaging from '@react-native-firebase/messaging'
-import { Platform } from 'react-native'
-
-if (Platform.OS === 'android') {
-    messaging().onNotificationOpenedApp((message) => {
-        posthog.capturePushNotificationOpened({
-            title: message.notification?.title,
-            body: message.notification?.body,
-            payload: message.data,
-        })
-    })
-}
+posthog.capturePushNotificationOpened({
+    title: 'Your order shipped',
+    body: 'Track it in the app',
+    payload: { order_id: '1234' },
+})
 ```
 
-Only call it for opens automatic capture can't see itself, or the tap is counted twice.
+Don't wire this to `messaging().onNotificationOpenedApp` or `getInitialNotification()`. The SDK already captures those taps, and the manual call isn't deduplicated against them, so the open is counted twice. If you added an `onNotificationOpenedApp` handler for Android on an earlier plugin version, remove it when you upgrade to 2.6.0.
 
 The `$push_notification_opened` event includes `$notification_title` and `$notification_body` (plus `$notification_subtitle` on iOS), and `$notification_action` for action-button taps. Notification content is only captured for notifications sent by PostHog. Opens of other notifications are still captured, but without title or body.
 


### PR DESCRIPTION
## Changes

**Draft: every remaining item here waits on an SDK release. Do not merge before the release it names is published, since posthog.com deploys on merge.**

The corrections that are true *today*, independent of any pending release, moved to #20114 (ready for review): the React Native iOS cold-launch gap, the iOS 14 floor on all three iOS surfaces, the Android warm-start coverage plus the killed-process gap, the notification-delegate callout, the missing React Native troubleshooting row, and the stale `posthog-android 3.62.0` floor on the Flutter page.

What is left on this branch:

**`react-native.mdx` – "Capturing opens"**

Replaces "Only call it for opens automatic capture can't see itself, or the tap is counted twice" with an explicit "don't wire this to `messaging().onNotificationOpenedApp` / `getInitialNotification()`" warning, and tells anyone who followed the old advice to remove their handler.

This branch is based on `master` before #20114, so it still carries the snippet swap #20114 also makes. Rebase it once #20114 lands and the hunk reduces to the wording change.

## Still to write here, and what each waits on

| Page / claim | Change to make | Waits on |
| --- | --- | --- |
| `android.mdx`: "`PostHog.capturePushNotificationOpened` below isn't deduplicated." | A repeat of a PostHog push (same `invocation_id` / `action_id`) within 5 minutes is skipped, first report wins. Pushes with no PostHog payload are still never deduplicated. | **posthog-android 3.65.0** (PostHog/posthog-android#783). `main` already released 3.64.0 with an unrelated minor, so #783 ships as 3.65.0, not 3.64.0. |
| `react-native.mdx`: the "isn't deduplicated" wording on this branch | Same first-report-wins rule, once the plugin pins a native version that has it. | An **`@posthog/react-native-plugin`** release bumping both pins: `com.posthog:posthog-android` 3.63.1 → 3.65.0 (PostHog/posthog-js#4919) and `posthog_ios_version` 3.73.3 → 3.75.0. |
| `flutter.mdx`: "the manual call isn't deduplicated against them, so the open is counted twice." | Same first-report-wins rule. | A **`posthog_flutter`** release whose floors clear both fixes. 5.41.0 declares `posthog-android [3.64.0,4.0.0)` and `PostHog >= 3.74.0`, so it would resolve the fixes but does not require them – PostHog/posthog-flutter#578 raises the floors. |
| `react-native.mdx`: iOS open coverage | A tap that cold-launches the app is captured (with the plugin version named, and the iOS 14 qualifier #20114 adds). | An **`@posthog/react-native-plugin`** release with PostHog/posthog-js#4921. `main` has no `prewarmPushNotificationOpenCapture()` call today. |
| `react-native.mdx`: "Opting out" | **The one that turns actively wrong, not just stale.** After #4921 the iOS launch hook runs before any JS, so `capturePushNotificationOpened: false` alone no longer disables it; `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED` = `false` in `Info.plist` (Expo: `ios.infoPlist`) is also required. | An **`@posthog/react-native-plugin`** release with PostHog/posthog-js#4921. |
| `ios.mdx` troubleshooting: "In a cross-platform host … call `PostHogSDK.prewarmPushNotificationOpenCapture()` … The PostHog Flutter plugin already does this for you." | Add the React Native plugin to the list of hosts that already do it, so a JavaScript host doesn't wire up something it already has. | An **`@posthog/react-native-plugin`** release with PostHog/posthog-js#4921. |
| `react-native.mdx`: killed-process guidance | The Expo config plugin patches `MainActivity` by default, `patchMainActivityNewIntent: false` opts out, and a bare React Native app that never runs `expo prebuild` must add `setIntent(intent)` before `super.onNewIntent(intent)` by hand. #20114 documents the gap; this documents the fix. | **`posthog-react-native`** / the plugin with PostHog/posthog-js#4929 (draft). |
| `ios.mdx`: "Capturing opens" | Optional parity note: state the same first-report-wins skip once iOS has it. Nothing on the page is false without it. | **posthog-ios 3.75.0** (PostHog/posthog-ios#828, draft). |

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

## Related PRs

One push-open capture effort across the mobile SDKs: count every notification tap exactly once, and stop losing taps the SDK starts too late to see.

| PR | What it does | Blocked by |
| --- | --- | --- |
| PostHog/posthog-android#783 | Core: capture each PostHog push open once, whichever path reports it (ships as 3.65.0) | – |
| PostHog/posthog-ios#828 | Same rule on iOS, so both platforms behave identically (ships as 3.75.0) | – |
| PostHog/posthog-js#4921 | React Native on iOS: capture a tap that launches the app | – |
| PostHog/posthog-js#4929 | React Native on Android: capture a tap lost when the process was killed but the task stayed in recents | – |
| PostHog/posthog-flutter#579 | Flutter: replay a tap that arrives before the SDK is set up, instead of relying on `firebase_messaging` | – |
| PostHog/posthog-js#4919 | React Native plugin: take the core dedupe, drop the plugin-level copy | posthog-android 3.65.0 |
| PostHog/posthog-flutter#578 | Flutter plugin: take the core dedupe, drop the plugin-level copy | posthog-android 3.65.0 |
| PostHog/posthog.com#20114 | Docs corrections that are wrong today, independent of any release | – |
| **PostHog/posthog.com#20102** (this PR) | Docs for the release-dependent behavior changes | the SDK releases above |

**Merge order:** posthog-android#783 and posthog-ios#828 first, then their releases. #4921, #4929 and #579 are independent and can go any time. #4919 and #578 go green once posthog-android 3.65.0 is published. Docs: #20114 can go now; #20102 last, after the releases.

**Earlier work this builds on:** PostHog/posthog-android#753, PostHog/posthog-ios#792, PostHog/posthog-js#4858, PostHog/posthog-flutter#556, PostHog/posthog-flutter#557, PostHog/posthog.com#19905.
