### PR TITLE
docs: Document optional OAuth scopes

### DIFF
--- a/contents/docs/api/oauth.mdx
+++ b/contents/docs/api/oauth.mdx
@@ -139,7 +139,26 @@ We recommend adding a CIMD verification token to your metadata document. Create 
 
 ### Declare your scopes
 
-We also recommend declaring the OAuth scopes your app needs under `com.posthog.scopes` in your metadata document. This sets a scope ceiling, the maximum set of scopes any token for your app can carry, so a reviewer can see exactly what your app asks for. See [Declare OAuth scopes for your app](/docs/integrate/provisioning#declare-oauth-scopes-for-your-app-optional) for details.
+Declare the OAuth scopes your app needs in the `com.posthog` namespace of your metadata document:
+
+```json
+{
+  "com.posthog": {
+    "scopes": ["insight:read", "project:read"],
+    "optional_scopes": ["session_recording:read"]
+  }
+}
+```
+
+Every scope in `scopes` is required. People who authorize your app see these scopes locked on the consent screen. Put scopes for features they can decline in `optional_scopes`. They can then authorize your app without those features.
+
+Both lists form the scope ceiling, which is the maximum set of scopes a token for your app can carry. Each scope still requires user consent. Check the scopes in the token response before using a feature that needs an optional scope.
+
+`optional_scopes` requires a non-empty `scopes` list. PostHog drops scopes that people can't grant to CIMD clients. If PostHog drops every entry in `scopes`, it rejects the metadata document. An `optional_scopes` list that becomes empty remains valid.
+
+When PostHog first reads your metadata document, omitting `scopes` lets your app request any scope people can grant. During a metadata refresh, omitting either field keeps its stored value. Publish `"optional_scopes": []` to remove all optional scopes.
+
+Manage CIMD app scopes through the metadata document. You can't edit them in the PostHog admin UI. See [supported scopes](#supported-scopes) for the scopes your app can request.
 
 Have a question while integrating? [Reach out to us](/talk-to-a-human).
 

--- a/contents/docs/integrate/provisioning.mdx
+++ b/contents/docs/integrate/provisioning.mdx
@@ -184,45 +184,7 @@ Revocation clears the link on the next metadata refresh, so a leaked or stale to
 
 ### Declare OAuth scopes for your app (optional)
 
-You can declare which OAuth scopes your partner app needs by adding a `scopes` field inside the `com.posthog` namespace. This sets a scope ceiling – tokens issued to your app are limited to these scopes.
-
-```json
-{
-  "client_id": "https://yourapp.com/.well-known/posthog-client.json",
-  "client_name": "Your App Name",
-  "redirect_uris": ["https://yourapp.com/callbacks/posthog"],
-  "token_endpoint_auth_method": "none",
-  "grant_types": ["authorization_code"],
-  "response_types": ["code"],
-  "com.posthog": {
-    "provisioning": true,
-    "verification_token": "phvt_...",
-    "scopes": ["insight:read", "project:read", "person:read"]
-  }
-}
-```
-
-Only scopes a user can grant on the consent screen are accepted – see [available scopes](#available-scopes) for the full list. Any scope PostHog reserves for internal use, or doesn't recognize, is dropped. If every scope you declare is dropped (none are grantable), registration is rejected rather than falling back to an empty ceiling, so make sure at least one declared scope is on the available list.
-
-If `com.posthog.scopes` is omitted, your app can request any scope a user can grant. When present, the declared scopes are applied on both initial registration and every subsequent metadata refresh. A scope ceiling is a cap, not a grant – each scope still requires user consent at the authorization step.
-
-CIMD app scopes are managed via the metadata document and are read-only in the PostHog admin UI.
-
-#### Scopes a user can decline
-
-Everything in `scopes` is required, and the user sees it locked on the consent screen. If part of what you ask for is for a feature they may not want, put those scopes in `optional_scopes` instead. Those appear as declinable, and the user can approve the rest without them.
-
-```json
-"com.posthog": {
-  "provisioning": true,
-  "scopes": ["insight:read", "project:read"],
-  "optional_scopes": ["session_recording:read"]
-}
-```
-
-Your ceiling is both lists together, so a token can carry anything in either one, and never anything outside them. Check the scopes on the token you get back before using a feature that depends on a declinable scope, because the user may have said no to it.
-
-`optional_scopes` needs a non-empty `scopes` alongside it: an app offering extras has to declare the base they sit on top of. Both lists are filtered the same way, so an unrecognized or internal scope is dropped from either. Unlike `scopes`, an `optional_scopes` list that ends up empty is fine, and just means you offer no declinable extras.
+Provisioning apps use the same required and optional scope declarations as other CIMD clients. See [declare your OAuth scopes](/docs/api/oauth#declare-your-scopes) to set your app's scope ceiling and mark scopes that people can decline.
 
 ## API reference
 


### PR DESCRIPTION
## Problem

OAuth app developers can find `com.posthog.optional_scopes` only in the provisioning guide, even though all CIMD clients can use it.

## Changes

- The OAuth guide now explains both scope fields, which scopes PostHog drops, how refreshes work, and how to clear optional scopes.
- The provisioning guide links to the OAuth guide instead of repeating the same rules.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English.
- [x] Internal links use relative URLs.
- [x] I've checked the changed pages in the deploy preview.
- [x] This PR doesn't move a page, so it needs no redirect.

## 🤖 Agent context

- Codex wrote the documentation and checked it with `pr-ready`, `writing-pr-descriptions`, and `unambiguous-agent-text`.
