### PR TITLE
docs(tracing): mention posthog-node on the tracing docs landing page

### DIFF
--- a/src/pages/docs/distributed-tracing/index.tsx
+++ b/src/pages/docs/distributed-tracing/index.tsx
@@ -12,9 +12,11 @@ export const Content = () => {
                 <h2 className="mb-4">Overview</h2>
                 <div>
                     <p>
-                        PostHog Distributed Tracing works with the OpenTelemetry Protocol (OTLP). You don't need any
-                        vendor-specific SDKs. Use standard OpenTelemetry libraries to send spans to PostHog using your
-                        project token.
+                        PostHog Distributed Tracing works with the OpenTelemetry Protocol (OTLP). Use standard
+                        OpenTelemetry libraries to send spans to PostHog using your project token. On Node.js,{' '}
+                        <code>posthog-node</code> can also create and export spans itself, with no OpenTelemetry
+                        dependency – see the{' '}
+                        <Link to="/docs/distributed-tracing/installation/nodejs">Node.js guide</Link>.
                     </p>
                     <p>
                         Distributed tracing is currently in beta. Setup details may change before general availability.
@@ -28,7 +30,8 @@ export const Content = () => {
                     <ul>
                         <li>
                             <b>OpenTelemetry-compatible</b> - Use standard OpenTelemetry SDKs, no PostHog packages
-                            required. Works with any compatible client.
+                            required. Works with any compatible client, or with <code>posthog-node</code>'s own span
+                            API.
                         </li>
                         <li>
                             <b>Part of the observability suite</b> - Traces use the same OpenTelemetry ingestion as{' '}


### PR DESCRIPTION
## Changes

Follow-up to [#19837](https://github.com/PostHog/posthog.com/pull/19837), which documented `posthog-node`'s span API (shipped in `posthog-node` 5.52.0) on the Node library page and the tracing install guides, but missed the `/docs/distributed-tracing` landing page. That page still told readers they "don't need any vendor-specific SDKs" and described OpenTelemetry as the only route.

- **Overview** – keeps the OpenTelemetry route first, and adds that on Node.js `posthog-node` can create and export spans itself, linking the Node.js guide. Same framing `installation/index.mdx` already uses.
- **Why use** – the OpenTelemetry-compatible bullet also names `posthog-node`'s span API.

Out of scope, flagged for owners:
- [#19930](https://github.com/PostHog/posthog.com/pull/19930) (draft) edits the same file's `ReaderView` wrapper – different hunks, no conflict expected.
- `src/hooks/productData/traces.tsx` (product page) says "Built on OpenTelemetry: no proprietary SDK". Marketing copy, and #19930 rewrites that file, so it's left alone here.

Companion: [PostHog/posthog#99441](https://github.com/PostHog/posthog/pull/99441) fixes the same claim in the in-app tracing empty state; [PostHog/context-mill#391](https://github.com/PostHog/context-mill/pull/391) adds the agent-facing tracing skill that reads these pages.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/wizard-and-docs/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json` (no pages moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPLdjqTgK93WtVxnhx6aVr

