### PR TITLE
Prevent asking Max in Builder-lounge posts

### DIFF
--- a/src/components/Squeak/components/Question.tsx
+++ b/src/components/Squeak/components/Question.tsx
@@ -479,6 +479,9 @@ export function Question(props: QuestionProps) {
     const slugs = questionData?.attributes?.slugs
     const isQuestionAuthor = questionData?.attributes.profile?.data?.id === user?.profile?.id
     const publishedAt = questionData?.attributes?.publishedAt
+    const isBuilderLounge = questionData.attributes.topics?.data?.some((topic) =>
+        topic.attributes.label?.startsWith('#')
+    )
 
     return (
         <CurrentQuestionContext.Provider
@@ -632,6 +635,7 @@ export function Question(props: QuestionProps) {
                         </div>
                         <Replies expanded={expanded} setExpanded={setExpanded} isInForum={isInForum} />
                         {maxQuestions.map((question, index) => {
+                            if (!question.manual && isBuilderLounge) return null
                             return (
                                 <AskMax
                                     key={`ask-max-${index}`}


### PR DESCRIPTION
## Changes

- Skips asking Max if tag starts with `#` (Builder-lounge posts)