### PR TITLE
fix(docs): point billing links to the existing cost guide

### DIFF
--- a/contents/docs/cdp/transformations/downsampling-plugin.mdx
+++ b/contents/docs/cdp/transformations/downsampling-plugin.mdx
@@ -8,7 +8,7 @@ import FeedbackQuestions from "../_snippets/feedback-questions.mdx"
 import PostHogMaintained from "../_snippets/posthog-maintained.mdx"
 import { CalloutBox } from 'components/Docs/CalloutBox'
 
-Reduces the volume of events coming into PostHog by keeping only a percentage of them. Events that aren't kept are dropped before ingestion, which lowers both the amount of data stored and your [usage/billing](/docs/billing).
+Reduces the volume of events coming into PostHog by keeping only a percentage of them. Events that aren't kept are dropped before ingestion, which lowers both the amount of data stored and your [usage/billing](/docs/billing/estimating-usage-costs).
 
 This is useful when a high-traffic app sends far more events than you need, and you'd rather trade some completeness for lower cost or volume.
 

--- a/contents/docs/model-context-protocol/faq.mdx
+++ b/contents/docs/model-context-protocol/faq.mdx
@@ -17,7 +17,7 @@ The PostHog MCP server is a hosted [Model Context Protocol](https://modelcontext
 
 ### How much does it cost?
 
-Connecting to the MCP server and calling its MCP tools is free. Standard PostHog [usage and billing](/docs/billing) still apply to the underlying data your queries consume.
+Connecting to the MCP server and calling its MCP tools is free. Standard PostHog [usage and billing](/docs/billing/estimating-usage-costs) still apply to the underlying data your queries consume.
 
 Note that some MCP tools use LLMs internally, and usage of these MCP tools may be billed as PostHog AI spend. These AI-powered MCP tools are only available when [AI data processing is enabled](/docs/posthog-ai/allow-access) in your organization settings – when it's disabled, they're filtered out and not exposed to your MCP client.
 


### PR DESCRIPTION
## Executive summary

The downsampling guide and MCP FAQ link to `/docs/billing`, which has no Gatsby page. Change both links to `/docs/billing/estimating-usage-costs` so client-side navigation reaches an existing page.

Keep the existing Vercel redirect for direct visits to `/docs/billing`. This replaces #19736 without adding a billing overview page. The change affects two link destinations only.

## Validation

- Markdown lint passed for both changed files.
- Ran the Prettier formatter on both files. The repository's `.prettierignore` excludes MDX, so it made no changes.
- `git diff --check` passed.
- Checked tracked content and source files: no exact links to `/docs/billing` remain.
- Checked that the destination page exists and `vercel.json` matches `master`.
- Checked production: `/docs/billing` returns HTTP 308 to `/docs/billing/estimating-usage-costs`; the destination returns HTTP 200.
- Started `PORT=8013 pnpm start`. Local page and console checks remain incomplete: Gatsby reports `gatsby-source-ashby: Missing options.apiKey` and does not serve the pages. Paseo browser automation also timed out.
- Draft until page and console checks pass in a working environment or deploy preview.

No visible content, navigation menus, page paths, or redirect rules changed. Screenshots and redirect tests are not required for this link-only change.
